### PR TITLE
修复深市指数数据获取异常 & 暂时禁用北向资金模块（北向资金数据已停止公布）

### DIFF
--- a/market_analyzer.py
+++ b/market_analyzer.py
@@ -128,7 +128,7 @@ class MarketAnalyzer:
         self._get_sector_rankings(overview)
         
         # 4. 获取北向资金（可选）
-        self._get_north_flow(overview)
+        # self._get_north_flow(overview)
         
         return overview
     
@@ -245,26 +245,26 @@ class MarketAnalyzer:
         except Exception as e:
             logger.error(f"[大盘] 获取板块涨跌榜失败: {e}")
     
-    def _get_north_flow(self, overview: MarketOverview):
-        """获取北向资金流入"""
-        try:
-            logger.info("[大盘] 获取北向资金...")
+    # def _get_north_flow(self, overview: MarketOverview):
+    #     """获取北向资金流入"""
+    #     try:
+    #         logger.info("[大盘] 获取北向资金...")
             
-            # 获取北向资金数据
-            df = ak.stock_hsgt_north_net_flow_in_em(symbol="北上")
+    #         # 获取北向资金数据
+    #         df = ak.stock_hsgt_north_net_flow_in_em(symbol="北上")
             
-            if df is not None and not df.empty:
-                # 取最新一条数据
-                latest = df.iloc[-1]
-                if '当日净流入' in df.columns:
-                    overview.north_flow = float(latest['当日净流入']) / 1e8  # 转为亿元
-                elif '净流入' in df.columns:
-                    overview.north_flow = float(latest['净流入']) / 1e8
+    #         if df is not None and not df.empty:
+    #             # 取最新一条数据
+    #             latest = df.iloc[-1]
+    #             if '当日净流入' in df.columns:
+    #                 overview.north_flow = float(latest['当日净流入']) / 1e8  # 转为亿元
+    #             elif '净流入' in df.columns:
+    #                 overview.north_flow = float(latest['净流入']) / 1e8
                     
-                logger.info(f"[大盘] 北向资金净流入: {overview.north_flow:.2f}亿")
+    #             logger.info(f"[大盘] 北向资金净流入: {overview.north_flow:.2f}亿")
                 
-        except Exception as e:
-            logger.warning(f"[大盘] 获取北向资金失败: {e}")
+    #     except Exception as e:
+    #         logger.warning(f"[大盘] 获取北向资金失败: {e}")
     
     def search_market_news(self) -> List[Dict]:
         """


### PR DESCRIPTION
## 变更类型

- [X ] 🐛 Bug 修复
- [ ] ✨ 新功能
- [ ] 📝 文档更新
- [X ] 🎨 代码优化/重构
- [ ] ⚡ 性能优化
- [ ] 🔧 配置/构建相关

## 变更描述

简要描述这个 PR 做了什么。

本 PR 主要包含以下两点修改：

修复深市指数获取失败问题：修正了 market_analyzer.py 中获取深证成指（Shenzhen Component Index）的数据逻辑

禁用北向资金获取逻辑：注释了 _get_north_flow 的调用。2024年8月19日之后，交易所不再披露北向资金的“实时买入/卖出成交额” 这一变化。

关联的 Issue 编号（如有）：fixes #

## 测试说明

描述如何测试这些变更：

1. 步骤一
2. 步骤二
3. ...

## 检查清单

- [ ] 代码符合项目规范
- [ ] 已添加必要的注释/文档
- [ ] 已在本地测试通过
- [ ] 已更新相关文档（如需要）

## 截图（如适用）

如有 UI 变更，请附上截图。

## 其他说明

其他需要说明的内容。
