### PR TITLE
feat: 添加 SearXNG 免费搜索引擎作为后备选项

### DIFF
--- a/config.py
+++ b/config.py
@@ -58,6 +58,7 @@ class Config:
     bocha_api_keys: List[str] = field(default_factory=list)  # Bocha API Keys
     tavily_api_keys: List[str] = field(default_factory=list)  # Tavily API Keys
     serpapi_keys: List[str] = field(default_factory=list)  # SerpAPI Keys
+    searxng_url: Optional[str] = None  # SearXNG 实例 URL（免费后备搜索引擎）
     
     # === 通知配置（可同时配置多个，全部推送）===
     
@@ -197,6 +198,7 @@ class Config:
             bocha_api_keys=bocha_api_keys,
             tavily_api_keys=tavily_api_keys,
             serpapi_keys=serpapi_keys,
+            searxng_url=os.getenv('SEARXNG_URL'),
             wechat_webhook_url=os.getenv('WECHAT_WEBHOOK_URL'),
             feishu_webhook_url=os.getenv('FEISHU_WEBHOOK_URL'),
             telegram_bot_token=os.getenv('TELEGRAM_BOT_TOKEN'),


### PR DESCRIPTION
- 新增 SearXNGSearchProvider 类，支持 SearXNG 聚合搜索
- 当未配置 Tavily/SerpAPI 时自动启用 SearXNG
- 添加 SEARXNG_URL 环境变量配置支持
- 无需 API Key，完全免费，适合零成本部署

## 配置说明

在 .env 文件中添加（可选）：
\`\`\`bash
# SearXNG 搜索引擎 URL（可选，默认使用内置公开实例）
SEARXNG_URL=http://search.XXXXX.com:8888/
\`\`\`

如果不配置 SEARXNG_URL，系统将使用默认的公开实例。
也可以使用自建的 SearXNG 实例。

主要变更:
- search_service.py: 新增 SearXNGSearchProvider 类
- search_service.py: SearchService.__init__() 添加 searxng_url 参数
- search_service.py: 当没有其他搜索引擎时自动添加 SearXNG
- config.py: 添加 searxng_url 配置字段

## 变更类型

- [ ] 🐛 Bug 修复
- [ ] ✨ 新功能
- [ ] 📝 文档更新
- [ ] 🎨 代码优化/重构
- [ ] ⚡ 性能优化
- [ ] 🔧 配置/构建相关

## 变更描述

简要描述这个 PR 做了什么。

## 关联 Issue

关联的 Issue 编号（如有）：fixes #

## 测试说明

描述如何测试这些变更：

1. 步骤一
2. 步骤二
3. ...

## 检查清单

- [ ] 代码符合项目规范
- [ ] 已添加必要的注释/文档
- [ ] 已在本地测试通过
- [ ] 已更新相关文档（如需要）

## 截图（如适用）

如有 UI 变更，请附上截图。

## 其他说明

其他需要说明的内容。
