### PR TITLE
fix: 优化手动触发分析，支持选择精简报告or完整报告

### DIFF
--- a/enums.py
+++ b/enums.py
@@ -1,0 +1,45 @@
+# -*- coding: utf-8 -*-
+"""
+===================================
+枚举类型定义
+===================================
+
+集中管理系统中使用的枚举类型，提供类型安全和代码可读性。
+"""
+
+from enum import Enum
+
+
+class ReportType(str, Enum):
+    """
+    报告类型枚举
+    
+    用于 API 触发分析时选择推送的报告格式。
+    继承 str 使其可以直接与字符串比较和序列化。
+    """
+    SIMPLE = "simple"  # 精简报告：使用 generate_single_stock_report
+    FULL = "full"      # 完整报告：使用 generate_dashboard_report
+    
+    @classmethod
+    def from_str(cls, value: str) -> "ReportType":
+        """
+        从字符串安全地转换为枚举值
+        
+        Args:
+            value: 字符串值
+            
+        Returns:
+            对应的枚举值，无效输入返回默认值 SIMPLE
+        """
+        try:
+            return cls(value.lower().strip())
+        except (ValueError, AttributeError):
+            return cls.SIMPLE
+    
+    @property
+    def display_name(self) -> str:
+        """获取用于显示的名称"""
+        return {
+            ReportType.SIMPLE: "精简报告",
+            ReportType.FULL: "完整报告",
+        }.get(self, "精简报告")

--- a/web/handlers.py
+++ b/web/handlers.py
@@ -25,6 +25,7 @@ from typing import Dict, Any, TYPE_CHECKING
 
 from web.services import get_config_service, get_analysis_service
 from web.templates import render_config_page
+from enums import ReportType
 
 if TYPE_CHECKING:
     from http.server import BaseHTTPRequestHandler
@@ -182,9 +183,13 @@ class ApiHandler:
                 status=HTTPStatus.BAD_REQUEST
             )
         
+        # 获取报告类型参数（默认精简报告）
+        report_type_str = query.get("report_type", ["simple"])[0]
+        report_type = ReportType.from_str(report_type_str)
+        
         # 提交异步分析任务
         try:
-            result = self.analysis_service.submit_analysis(code)
+            result = self.analysis_service.submit_analysis(code, report_type=report_type)
             return JsonResponse(result)
         except Exception as e:
             logger.error(f"[ApiHandler] 提交分析任务失败: {e}")

--- a/web/templates.py
+++ b/web/templates.py
@@ -233,6 +233,24 @@ button:active {
     white-space: nowrap;
 }
 
+.report-select {
+    padding: 0.75rem 0.5rem;
+    border: 1px solid var(--border);
+    border-radius: 0.5rem;
+    font-size: 0.8rem;
+    background: white;
+    color: var(--text);
+    cursor: pointer;
+    min-width: 110px;
+    transition: border-color 0.2s, box-shadow 0.2s;
+}
+
+.report-select:focus {
+    outline: none;
+    border-color: var(--primary);
+    box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.1);
+}
+
 .btn-analysis {
     background-color: var(--success);
 }
@@ -617,6 +635,7 @@ def render_config_page(
     const codeInput = document.getElementById('analysis_code');
     const submitBtn = document.getElementById('analysis_btn');
     const taskList = document.getElementById('task_list');
+    const reportTypeSelect = document.getElementById('report_type');
     
     // 任务管理
     const tasks = new Map(); // taskId -> {task, pollCount}
@@ -723,6 +742,7 @@ def render_config_page(
                 '<div class="task-meta">' +
                     '<span>⏱ ' + formatTime(task.start_time) + '</span>' +
                     '<span>⏳ ' + calcDuration(task.start_time, task.end_time) + '</span>' +
+                    '<span>' + (task.report_type === 'full' ? '📊完整' : '📝精简') + '</span>' +
                 '</div>' +
             '</div>' +
             resultHtml +
@@ -839,7 +859,8 @@ def render_config_page(
         submitBtn.disabled = true;
         submitBtn.textContent = '提交中...';
         
-        fetch('/analysis?code=' + encodeURIComponent(code))
+        const reportType = reportTypeSelect.value;
+        fetch('/analysis?code=' + encodeURIComponent(code) + '&report_type=' + encodeURIComponent(reportType))
             .then(response => response.json())
             .then(data => {
                 if (data.success) {
@@ -848,7 +869,8 @@ def render_config_page(
                         task: {
                             code: code,
                             status: 'running',
-                            start_time: new Date().toISOString()
+                            start_time: new Date().toISOString(),
+                            report_type: reportType
                         },
                         pollCount: 0
                     });
@@ -904,6 +926,10 @@ def render_config_page(
               maxlength="8"
               autocomplete="off"
           />
+          <select id="report_type" class="report-select" title="选择报告类型">
+            <option value="simple">📝 精简报告</option>
+            <option value="full">📊 完整报告</option>
+          </select>
           <button type="button" id="analysis_btn" class="btn-analysis" onclick="submitAnalysis()" disabled>
             🚀 分析
           </button>


### PR DESCRIPTION
## 变更类型

- [ ] 🐛 Bug 修复
- [ ] ✨ 新功能
- [ ] 📝 文档更新
- [x] 🎨 代码优化
- [ ] ⚡ 性能优化
- [ ] 🔧 配置/构建相关

## 变更描述



## 关联 Issue
fixes  #85 

## 测试说明

描述如何测试这些变更：

启动项目
`python main.py --webui-only`

打开 WebUI（默认 http://127.0.0.1:8000/ 或你运行的端口），在“股票代码”输入框输入合法代码（如 600519），选择“📝 精简报告”，点击“🚀 分析”或按回车。
预期：按钮变“提交中…”，任务列表出现新任务，状态从运行中变为完成；任务卡片右下显示“精简”。配置的通知渠道将推送精简报告
重复一次，选择“📊 完整报告”。
预期：任务卡片显示“完整”；后台日志应记录使用完整报告格式，配置的通知渠道将推送精简报告
## 检查清单

- [x] 代码符合项目规范
- [x] 已添加必要的注释/文档
- [x] 已在本地测试通过
- [x] 已更新相关文档（如需要）

## 截图（如适用）

<img width="525" height="883" alt="image" src="https://github.com/user-attachments/assets/2be97b87-8ab0-4ea2-b5e2-de95e7583a06" />

## 其他说明

其他需要说明的内容。
