### PR TITLE
fix: 启动时config.py检测通知渠道，在已配置自定义渠道情况下仍然提示未配置问题

### DIFF
--- a/config.py
+++ b/config.py
@@ -283,11 +283,12 @@ class Config:
         
         # 检查通知配置
         has_notification = (
-            self.wechat_webhook_url or 
+            self.wechat_webhook_url or
             self.feishu_webhook_url or
             (self.telegram_bot_token and self.telegram_chat_id) or
             (self.email_sender and self.email_password) or
-            (self.pushover_user_key and self.pushover_api_token)
+            (self.pushover_user_key and self.pushover_api_token) or
+            (self.custom_webhook_urls and self.custom_webhook_bearer_token)
         )
         if not has_notification:
             warnings.append("提示：未配置通知渠道，将不发送推送通知")


### PR DESCRIPTION
## 变更类型

- [x] 🐛 Bug 修复

## 变更描述

启动时config.py检测通知渠道，在已配置自定义渠道情况下仍然提示未配置问题。

## 关联 Issue

无

## 测试说明

描述如何测试这些变更：

1. 应用启动时检测

## 检查清单

- [x] 代码符合项目规范
- [x] 已在本地测试通过

## 截图（如适用）

无

## 其他说明

无
