### PR TITLE
fix: handle MultiIndex columns from new yfinance versions

### DIFF
--- a/data_provider/yfinance_fetcher.py
+++ b/data_provider/yfinance_fetcher.py
@@ -164,10 +164,20 @@ class YfinanceFetcher(BaseFetcher):
         yfinance 返回的列名：
         Open, High, Low, Close, Volume（索引是日期）
         
+        注意：新版 yfinance 返回 MultiIndex 列名，如 ('Close', 'AMD')
+        需要先扁平化列名再进行处理
+        
         需要映射到标准列名：
         date, open, high, low, close, volume, amount, pct_chg
         """
         df = df.copy()
+        
+        # 处理 MultiIndex 列名（新版 yfinance 返回格式）
+        # 例如: ('Close', 'AMD') -> 'Close'
+        if isinstance(df.columns, pd.MultiIndex):
+            logger.debug(f"检测到 MultiIndex 列名，进行扁平化处理")
+            # 取第一级列名（Price level: Close, High, Low, etc.）
+            df.columns = df.columns.get_level_values(0)
         
         # 重置索引，将日期从索引变为列
         df = df.reset_index()


### PR DESCRIPTION
## Problem

New versions of yfinance return MultiIndex columns like `('Close', 'AMD')` instead of simple column names like `'Close'`. This causes errors when YfinanceFetcher tries to process the DataFrame:

```
[YfinanceFetcher] 获取 AMD 失败: arg must be a list, tuple, 1-d array, or Series
```

Or:

```
Cannot set a DataFrame with multiple columns to the single column pct_chg
```

## Solution

Flatten MultiIndex columns before processing by extracting the first level (Price level: Close, High, Low, etc.):

```python
# Handle MultiIndex columns (new yfinance format)
if isinstance(df.columns, pd.MultiIndex):
    df.columns = df.columns.get_level_values(0)
```

## Testing

Before fix:
```
[YfinanceFetcher] 获取 AMD 失败: arg must be a list, tuple, 1-d array, or Series
```

After fix:
```
⚪ **AMD** (AMD)
**Recommendation:** 观望
**Sentiment Score:** 42/100
...
MA20: 231.44 (correct price!)
```

Fixes #209