### PR TITLE
feat: configurable data fetcher priority via environment variables

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -195,3 +195,21 @@ WEBUI_ENABLED=false
 WEBUI_HOST=127.0.0.1
 # WebUI 监听端口（默认 8000）
 WEBUI_PORT=8000
+
+# ===========================================
+# Data Fetcher Priority Configuration
+# ===========================================
+# Lower number = higher priority (tried first)
+# Default priorities: efinance(0) > akshare(1) > tushare/pytdx(2) > baostock(3) > yfinance(4)
+# For US stocks, set YFINANCE_PRIORITY=0 to use Yahoo Finance first
+
+# EFINANCE_PRIORITY=0      # EastMoney (China) - default: 0
+# AKSHARE_PRIORITY=1       # AkShare (China) - default: 1
+# TUSHARE_PRIORITY=2       # Tushare Pro (China) - default: 2
+# PYTDX_PRIORITY=2         # Tongdaxin (China) - default: 2
+# BAOSTOCK_PRIORITY=3      # Baostock (China) - default: 3
+# YFINANCE_PRIORITY=4      # Yahoo Finance (Global) - default: 4
+
+# Example: Prioritize Yahoo Finance for US stocks
+# YFINANCE_PRIORITY=0
+# EFINANCE_PRIORITY=99

--- a/data_provider/akshare_fetcher.py
+++ b/data_provider/akshare_fetcher.py
@@ -24,6 +24,7 @@ AkshareFetcher - 主数据源 (Priority 1)
 """
 
 import logging
+import os
 import random
 import time
 from dataclasses import dataclass, field
@@ -171,7 +172,7 @@ class AkshareFetcher(BaseFetcher):
     """
     
     name = "AkshareFetcher"
-    priority = 1
+    priority = int(os.getenv("AKSHARE_PRIORITY", "1"))
     
     def __init__(self, sleep_min: float = 2.0, sleep_max: float = 5.0):
         """

--- a/data_provider/baostock_fetcher.py
+++ b/data_provider/baostock_fetcher.py
@@ -29,6 +29,7 @@ from tenacity import (
 )
 
 from .base import BaseFetcher, DataFetchError, STANDARD_COLUMNS
+import os
 
 logger = logging.getLogger(__name__)
 
@@ -52,7 +53,7 @@ class BaostockFetcher(BaseFetcher):
     """
     
     name = "BaostockFetcher"
-    priority = 3
+    priority = int(os.getenv("BAOSTOCK_PRIORITY", "3"))
     
     def __init__(self):
         """初始化 BaostockFetcher"""

--- a/data_provider/efinance_fetcher.py
+++ b/data_provider/efinance_fetcher.py
@@ -21,6 +21,7 @@ EfinanceFetcher - 优先数据源 (Priority 0)
 """
 
 import logging
+import os
 import random
 import time
 from dataclasses import dataclass, field
@@ -148,7 +149,7 @@ class EfinanceFetcher(BaseFetcher):
     """
     
     name = "EfinanceFetcher"
-    priority = 0  # 最高优先级，排在 AkshareFetcher 之前
+    priority = int(os.getenv("EFINANCE_PRIORITY", "0"))  # 最高优先级，排在 AkshareFetcher 之前
     
     def __init__(self, sleep_min: float = 1.5, sleep_max: float = 3.0):
         """

--- a/data_provider/pytdx_fetcher.py
+++ b/data_provider/pytdx_fetcher.py
@@ -29,6 +29,7 @@ from tenacity import (
 )
 
 from .base import BaseFetcher, DataFetchError, STANDARD_COLUMNS
+import os
 
 logger = logging.getLogger(__name__)
 
@@ -53,7 +54,7 @@ class PytdxFetcher(BaseFetcher):
     """
     
     name = "PytdxFetcher"
-    priority = 2
+    priority = int(os.getenv("PYTDX_PRIORITY", "2"))
     
     # 默认通达信行情服务器列表
     DEFAULT_HOSTS = [

--- a/data_provider/tushare_fetcher.py
+++ b/data_provider/tushare_fetcher.py
@@ -30,6 +30,7 @@ from tenacity import (
 
 from .base import BaseFetcher, DataFetchError, RateLimitError, STANDARD_COLUMNS
 from src.config import get_config
+import os
 
 logger = logging.getLogger(__name__)
 
@@ -52,7 +53,7 @@ class TushareFetcher(BaseFetcher):
     """
     
     name = "TushareFetcher"
-    priority = 2  # 默认优先级，会在 __init__ 中根据配置动态调整
+    priority = int(os.getenv("TUSHARE_PRIORITY", "2"))  # 默认优先级，会在 __init__ 中根据配置动态调整
 
     def __init__(self, rate_limit_per_minute: int = 80):
         """

--- a/data_provider/yfinance_fetcher.py
+++ b/data_provider/yfinance_fetcher.py
@@ -28,6 +28,7 @@ from tenacity import (
 )
 
 from .base import BaseFetcher, DataFetchError, STANDARD_COLUMNS
+import os
 
 logger = logging.getLogger(__name__)
 
@@ -51,7 +52,7 @@ class YfinanceFetcher(BaseFetcher):
     """
     
     name = "YfinanceFetcher"
-    priority = 4
+    priority = int(os.getenv("YFINANCE_PRIORITY", "4"))
     
     def __init__(self):
         """初始化 YfinanceFetcher"""


### PR DESCRIPTION
## Problem

Currently, data fetcher priorities are hardcoded in the class definitions. This makes it difficult for users to customize which data source is tried first without modifying the code.

For example, when analyzing US stocks from an overseas server, users might want Yahoo Finance to be tried first instead of Chinese data sources.

## Solution

Add environment variable support for all data fetcher priorities:

| Env Variable | Default | Data Source |
|--------------|---------|-------------|
| `EFINANCE_PRIORITY` | 0 | EastMoney (China) |
| `AKSHARE_PRIORITY` | 1 | AkShare (China) |
| `TUSHARE_PRIORITY` | 2 | Tushare Pro (China) |
| `PYTDX_PRIORITY` | 2 | Tongdaxin (China) |
| `BAOSTOCK_PRIORITY` | 3 | Baostock (China) |
| `YFINANCE_PRIORITY` | 4 | Yahoo Finance (Global) |

Lower number = higher priority (tried first).

## Usage Examples

**For US stocks (prioritize Yahoo Finance):**
```bash
YFINANCE_PRIORITY=0 EFINANCE_PRIORITY=99 python analyze_stock.py AMD
```

**Or in .env file:**
```
YFINANCE_PRIORITY=0
EFINANCE_PRIORITY=99
```

## Changes

- Modified all 6 fetcher classes to read priority from environment variables
- Updated `.env.example` with documentation
- Backward compatible: defaults match current hardcoded values