### PR TITLE
fix: solve dependency error.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -45,3 +45,5 @@ discord.py>=2.0.0              # Discord 机器人开发库
 
 # Web Content Extraction
 newspaper3k>=0.2.8          # Article extraction
+
+lxml_html_clean>=0.4.3


### PR DESCRIPTION
## 变更类型

- [ ✔] 🐛 Bug 修复

## 变更描述

新增 lxml_html_clean>=0.4.3 依赖解决 github  workflow 运行报错。

```
Traceback (most recent call last):
  File "/home/runner/work/daily_stock_analysis/daily_stock_analysis/main.py", line 50, in <module>
    from src.core.pipeline import StockAnalysisPipeline
  File "/home/runner/work/daily_stock_analysis/daily_stock_analysis/src/core/pipeline.py", line 26, in <module>
    from src.search_service import SearchService
  File "/home/runner/work/daily_stock_analysis/daily_stock_analysis/src/search_service.py", line 23, in <module>
    from newspaper import Article, Config
  File "/opt/hostedtoolcache/Python/3.11.14/x64/lib/python3.11/site-packages/newspaper/__init__.py", line 10, in <module>
    from .api import (build, build_article, fulltext, hot, languages,
  File "/opt/hostedtoolcache/Python/3.11.14/x64/lib/python3.11/site-packages/newspaper/api.py", line 14, in <module>
    from .article import Article
  File "/opt/hostedtoolcache/Python/3.11.14/x64/lib/python3.11/site-packages/newspaper/article.py", line 15, in <module>
    from . import network
  File "/opt/hostedtoolcache/Python/3.11.14/x64/lib/python3.11/site-packages/newspaper/network.py", line 14, in <module>
    from .configuration import Configuration
  File "/opt/hostedtoolcache/Python/3.11.14/x64/lib/python3.11/site-packages/newspaper/configuration.py", line 15, in <module>
    from .parsers import Parser
  File "/opt/hostedtoolcache/Python/3.11.14/x64/lib/python3.11/site-packages/newspaper/parsers.py", line 12, in <module>
    import lxml.html.clean
  File "/opt/hostedtoolcache/Python/3.11.14/x64/lib/python3.11/site-packages/lxml/html/clean.py", line 18, in <module>
    raise ImportError(
ImportError: lxml.html.clean module is now a separate project lxml_html_clean.
Install lxml[html_clean] or lxml_html_clean directly.
```
