### PR TITLE
feat(web): 重构WebUI添加历史报告功能和多个页面路由

### DIFF
--- a/web/router.py
+++ b/web/router.py
@@ -288,8 +288,26 @@ def create_default_router() -> Router:
     router.register(
         "/", "GET",
         lambda q: page_handler.handle_index(),
-        "配置首页"
+        "服务首页"
     )
+    
+    router.register(
+        "/stock-analysis", "GET",
+        lambda q: page_handler.handle_stock_analysis(),
+        "个股分析"
+    )
+    
+    router.register(
+        "/history", "GET",
+        lambda q: page_handler.handle_history(),
+        "历史报告"
+    )
+    
+    # router.register(
+    #     "/stock-picker", "GET",
+    #     lambda q: page_handler.handle_stock_picker(),
+    #     "选股助手"
+    # )
     
     router.register(
         "/update", "POST",
@@ -320,6 +338,19 @@ def create_default_router() -> Router:
         "/task", "GET",
         lambda q: api_handler.handle_task_status(q),
         "查询任务状态"
+    )
+    
+    # === 历史报告 API 路由 ===
+    router.register(
+        "/api/history/dates", "GET",
+        lambda q: api_handler.handle_history_dates(q),
+        "获取可用的历史报告日期列表"
+    )
+    
+    router.register(
+        "/api/history/report", "GET",
+        lambda q: api_handler.handle_history_report(q),
+        "获取指定日期的历史报告"
     )
     
     # === Bot Webhook 路由 ===

--- a/web/services.py
+++ b/web/services.py
@@ -314,6 +314,306 @@ class AnalysisService:
 
 
 # ============================================================
+# 历史报告服务
+# ============================================================
+
+import os
+import re
+import json
+from pathlib import Path
+from datetime import datetime, date
+from typing import List, Dict, Any, Optional, Tuple
+
+
+class HistoryReportService:
+    """
+    历史报告服务
+    
+    负责：
+    1. 从 reports 目录读取已生成的报告文件
+    2. 解析报告内容，提取结构化数据
+    3. 提供按日期查询报告接口
+    """
+    
+    def __init__(self, reports_dir: Optional[str] = None):
+        """
+        初始化历史报告服务
+        
+        Args:
+            reports_dir: 报告目录路径（默认项目根目录下的 reports）
+        """
+        if reports_dir:
+            self.reports_dir = Path(reports_dir)
+        else:
+            # 默认使用项目根目录下的 reports
+            self.reports_dir = Path(__file__).parent.parent / 'reports'
+    
+    def get_available_dates(self) -> List[str]:
+        """
+        获取所有可用的报告日期列表
+        
+        Returns:
+            日期字符串列表（格式：YYYY-MM-DD），按日期降序排列
+        """
+        dates = set()
+        
+        if not self.reports_dir.exists():
+            return []
+        
+        # 匹配 report_YYYYMMDD.md 和 market_review_YYYYMMDD.md 文件
+        report_pattern = re.compile(r'report_(\d{8})\.md')
+        market_pattern = re.compile(r'market_review_(\d{8})\.md')
+        
+        for file in self.reports_dir.iterdir():
+            if file.is_file():
+                # 检查个股报告
+                match = report_pattern.match(file.name)
+                if match:
+                    date_str = match.group(1)
+                    formatted_date = f"{date_str[:4]}-{date_str[4:6]}-{date_str[6:]}"
+                    dates.add(formatted_date)
+                    continue
+                
+                # 检查大盘复盘报告
+                match = market_pattern.match(file.name)
+                if match:
+                    date_str = match.group(1)
+                    formatted_date = f"{date_str[:4]}-{date_str[4:6]}-{date_str[6:]}"
+                    dates.add(formatted_date)
+        
+        # 按日期降序排列
+        return sorted(list(dates), reverse=True)
+    
+    def get_report_by_date(self, target_date: str) -> Optional[Dict[str, Any]]:
+        """
+        获取指定日期的完整报告数据
+        
+        Args:
+            target_date: 目标日期（格式：YYYY-MM-DD）
+            
+        Returns:
+            报告数据字典，包含 marketReview 和 decisions
+        """
+        # 转换日期格式
+        date_obj = datetime.strptime(target_date, '%Y-%m-%d')
+        date_str_compact = date_obj.strftime('%Y%m%d')
+        
+        # 构建文件路径
+        report_file = self.reports_dir / f'report_{date_str_compact}.md'
+        market_file = self.reports_dir / f'market_review_{date_str_compact}.md'
+        
+        result = {
+            'date': target_date,
+            'marketReview': None,
+            'decisions': []
+        }
+        
+        # 读取大盘复盘
+        if market_file.exists():
+            result['marketReview'] = self._parse_market_review(market_file.read_text(encoding='utf-8'))
+        
+        # 读取个股决策报告
+        if report_file.exists():
+            result['decisions'] = self._parse_stock_report(report_file.read_text(encoding='utf-8'))
+        
+        # 如果没有任何报告数据，返回 None
+        if result['marketReview'] is None and not result['decisions']:
+            return None
+        
+        return result
+    
+    def _parse_market_review(self, content: str) -> Optional[Dict[str, str]]:
+        """
+        解析大盘复盘报告内容
+        
+        Args:
+            content: Markdown 格式的报告内容
+            
+        Returns:
+            解析后的市场复盘数据
+        """
+        sections = {
+            'summary': '',
+            'indexComment': '',
+            'capitalFlow': '',
+            'hotTopics': '',
+            'outlook': '',
+            'riskWarning': ''
+        }
+        
+        # 使用正则表达式提取各部分内容
+        # 市场总结 - 一、市场总结
+        summary_match = re.search(r'### 一、市场总结\s*\n([^#]+?)(?=###|$)', content)
+        if summary_match:
+            sections['summary'] = summary_match.group(1).strip()
+        
+        # 指数点评 - 二、指数点评
+        index_match = re.search(r'### 二、指数点评\s*\n([^#]+?)(?=###|$)', content)
+        if index_match:
+            sections['indexComment'] = index_match.group(1).strip()
+        
+        # 资金动向 - 三、资金动向
+        capital_match = re.search(r'### 三、资金动向\s*\n([^#]+?)(?=###|$)', content)
+        if capital_match:
+            sections['capitalFlow'] = capital_match.group(1).strip()
+        
+        # 热点解读 - 四、热点解读
+        hot_match = re.search(r'### 四、热点解读\s*\n([^#]+?)(?=###|$)', content)
+        if hot_match:
+            sections['hotTopics'] = hot_match.group(1).strip()
+        
+        # 后市展望 - 五、后市展望
+        outlook_match = re.search(r'### 五、后市展望\s*\n([^#]+?)(?=###|$)', content)
+        if outlook_match:
+            sections['outlook'] = outlook_match.group(1).strip()
+        
+        # 风险提示 - 六、风险提示
+        risk_match = re.search(r'### 六、风险提示\s*\n([^#]+?)(?=###|$)', content)
+        if risk_match:
+            sections['riskWarning'] = risk_match.group(1).strip()
+        
+        return sections if any(sections.values()) else None
+    
+    def _parse_stock_report(self, content: str) -> List[Dict[str, Any]]:
+        """
+        解析个股分析报告内容
+        
+        Args:
+            content: Markdown 格式的报告内容
+            
+        Returns:
+            个股决策列表
+        """
+        decisions = []
+        
+        # 提取报告摘要中的统计信息
+        summary_match = re.search(r'> 共分析 \*\*(\d+)\*\* 只.*🟢买入:(\d+).*🟡观望:(\d+).*🔴卖出:(\d+)', content)
+        
+        # 使用finditer找到所有股票部分
+        # 模式：## [emoji] 股票名称 (代码)
+        # 注意：股票名称中可能包含空格，代码在括号中
+        # 匹配到行尾，使用多行模式
+        stock_pattern = r'^##\s+([💚⚪🔴])\s+(.+)$'
+        
+        matches = list(re.finditer(stock_pattern, content, re.MULTILINE))
+        
+        for i, match in enumerate(matches):
+            emoji = match.group(1)
+            header_line = match.group(2).strip()
+            
+            # 提取股票名称和代码
+            # header_line 格式: "股票名称 (代码)" 或 "股票名称(代码)"
+            # 从右往左找最后一个括号，避免股票名称中有括号
+            if '(' in header_line and ')' in header_line:
+                # 找到最后一个 '(' 和对应的 ')'
+                code_start = header_line.rfind('(')
+                code_end = header_line.rfind(')')
+                if code_start < code_end:
+                    name = header_line[:code_start].strip()
+                    code = header_line[code_start + 1:code_end].strip()
+                else:
+                    continue
+            else:
+                continue
+            
+            # 获取该股票的内容（从当前匹配位置到下一个匹配位置或文件结束）
+            start_pos = match.end()
+            if i + 1 < len(matches):
+                section_content = content[start_pos:matches[i + 1].start()]
+            else:
+                section_content = content[start_pos:]
+            
+            decision = self._parse_single_stock_content(name, code, emoji, section_content)
+            if decision:
+                decisions.append(decision)
+        
+        return decisions
+    
+    def _parse_single_stock_content(self, name: str, code: str, signal_emoji: str, section: str) -> Optional[Dict[str, Any]]:
+        """
+        解析单个股票的分析内容
+        
+        Args:
+            name: 股票名称
+            code: 股票代码
+            signal_emoji: 信号emoji（💚买入/⚪观望/🔴卖出）
+            section: 单个股票的分析内容
+            
+        Returns:
+            解析后的股票决策数据
+        """
+        
+        # 根据 emoji 判断信号类型
+        signal_map = {
+            '💚': 'buy',
+            '⚪': 'watch',
+            '🔴': 'sell'
+        }
+        signal = signal_map.get(signal_emoji, 'watch')
+        
+        # 提取评分
+        score_match = re.search(r'评分[:\s]*(\d+)', section)
+        score = int(score_match.group(1)) if score_match else 50
+        
+        # 提取当前价
+        price_match = re.search(r'当前价\s*\|\s*([\d.]+)', section)
+        price = float(price_match.group(1)) if price_match else 0.0
+        
+        # 提取乖离率
+        bias_match = re.search(r'乖离率\([^)]+\)\s*\|\s*([+-]?[\d.]+)%', section)
+        bias = float(bias_match.group(1)) if bias_match else 0.0
+        
+        # 提取趋势强度
+        trend_match = re.search(r'趋势强度[:\s]*(\d+)', section)
+        trend = int(trend_match.group(1)) if trend_match else 50
+        
+        # 提取决策指令（一句话决策）
+        decision_match = re.search(r'> \*\*一句话决策\*\*[:：]\s*([^\n]+)', section)
+        if not decision_match:
+            decision_match = re.search(r'一句话决策[:\s]*([^\n]+)', section)
+        decision = decision_match.group(1).strip() if decision_match else ''
+        
+        # 提取基本面要点
+        fundamentals = []
+        # 从重要信息速览中提取
+        sentiment_match = re.search(r'\*\*💭 舆情情绪\*\*[:：]\s*([^\n]+)', section)
+        if sentiment_match:
+            fundamentals.append(f"舆情: {sentiment_match.group(1).strip()}")
+        
+        expectation_match = re.search(r'\*\*📊 业绩预期\*\*[:：]\s*([^\n]+)', section)
+        if expectation_match:
+            fundamentals.append(f"业绩: {expectation_match.group(1).strip()}")
+        
+        # 提取最新动态
+        news_match = re.search(r'\*\*📢 最新动态\*\*[:：]\s*([^\n]+)', section)
+        if news_match:
+            fundamentals.append(f"动态: {news_match.group(1).strip()}")
+        
+        # 如果没有提取到基本面信息，使用默认信息
+        if not fundamentals:
+            fundamentals = ['暂无详细基本面数据']
+        
+        # 提取操作建议（空仓者建议）
+        suggestion_match = re.search(r'\| 🆕 \*\*空仓者\*\* \|\s*([^\|]+?)\s*\|', section)
+        if not suggestion_match:
+            suggestion_match = re.search(r'空仓者.*建议[:：]\s*([^\n]+)', section)
+        suggestion = suggestion_match.group(1).strip() if suggestion_match else '建议观望，等待机会。'
+        
+        return {
+            'code': code,
+            'name': name,
+            'signal': signal,
+            'score': score,
+            'price': price,
+            'bias': bias,
+            'trend': trend,
+            'decision': decision,
+            'fundamentals': fundamentals,
+            'suggestion': suggestion
+        }
+
+
+# ============================================================
 # 便捷函数
 # ============================================================
 
@@ -325,3 +625,8 @@ def get_config_service() -> ConfigService:
 def get_analysis_service() -> AnalysisService:
     """获取分析服务单例"""
     return AnalysisService.get_instance()
+
+
+def get_history_report_service() -> HistoryReportService:
+    """获取历史报告服务实例"""
+    return HistoryReportService()

--- a/web/templates.py
+++ b/web/templates.py
@@ -8,608 +8,290 @@ Web 模板层 - HTML 页面生成
 1. 生成 HTML 页面
 2. 管理 CSS 样式
 3. 提供可复用的页面组件
+
+技术栈：原生 HTML + Tailwind CSS + Alpine.js
 """
 
 from __future__ import annotations
 
 import html
+import os
 from typing import Optional
 
 
 # ============================================================
-# CSS 样式定义
+# 模板目录配置
 # ============================================================
 
-BASE_CSS = """
-:root {
-    --primary: #2563eb;
-    --primary-hover: #1d4ed8;
-    --bg: #f8fafc;
-    --card: #ffffff;
-    --text: #1e293b;
-    --text-light: #64748b;
-    --border: #e2e8f0;
-    --success: #10b981;
-    --error: #ef4444;
-    --warning: #f59e0b;
-}
-
-* {
-    box-sizing: border-box;
-}
-
-body {
-    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
-    background-color: var(--bg);
-    color: var(--text);
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    min-height: 100vh;
-    margin: 0;
-    padding: 20px;
-}
-
-.container {
-    background: var(--card);
-    padding: 2rem;
-    border-radius: 1rem;
-    box-shadow: 0 4px 6px -1px rgb(0 0 0 / 0.1), 0 2px 4px -2px rgb(0 0 0 / 0.1);
-    width: 100%;
-    max-width: 500px;
-}
-
-h2 {
-    margin-top: 0;
-    color: var(--text);
-    font-size: 1.5rem;
-    font-weight: 700;
-    display: flex;
-    align-items: center;
-    gap: 0.5rem;
-}
-
-.subtitle {
-    color: var(--text-light);
-    font-size: 0.875rem;
-    margin-bottom: 2rem;
-    line-height: 1.5;
-}
-
-.code-badge {
-    background: #f1f5f9;
-    padding: 0.2rem 0.4rem;
-    border-radius: 0.25rem;
-    font-family: monospace;
-    color: var(--primary);
-}
-
-.form-group {
-    margin-bottom: 1.5rem;
-}
-
-label {
-    display: block;
-    margin-bottom: 0.5rem;
-    font-weight: 500;
-    color: var(--text);
-}
-
-textarea, input[type="text"] {
-    width: 100%;
-    padding: 0.75rem;
-    border: 1px solid var(--border);
-    border-radius: 0.5rem;
-    font-family: monospace;
-    font-size: 0.875rem;
-    line-height: 1.5;
-    resize: vertical;
-    transition: border-color 0.2s, box-shadow 0.2s;
-}
-
-textarea:focus, input[type="text"]:focus {
-    outline: none;
-    border-color: var(--primary);
-    box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.1);
-}
-
-button {
-    background-color: var(--primary);
-    color: white;
-    border: none;
-    padding: 0.75rem 1.5rem;
-    border-radius: 0.5rem;
-    font-weight: 500;
-    cursor: pointer;
-    transition: all 0.2s;
-    width: 100%;
-    font-size: 1rem;
-}
-
-button:hover {
-    background-color: var(--primary-hover);
-    transform: translateY(-1px);
-}
-
-button:active {
-    transform: translateY(0);
-}
-
-.btn-secondary {
-    background-color: var(--text-light);
-}
-
-.btn-secondary:hover {
-    background-color: var(--text);
-}
-
-.footer {
-    margin-top: 2rem;
-    padding-top: 1rem;
-    border-top: 1px solid var(--border);
-    color: var(--text-light);
-    font-size: 0.75rem;
-    text-align: center;
-}
-
-/* Toast Notification */
-.toast {
-    position: fixed;
-    bottom: 20px;
-    left: 50%;
-    transform: translateX(-50%) translateY(100px);
-    background: white;
-    border-left: 4px solid var(--success);
-    padding: 1rem 1.5rem;
-    border-radius: 0.5rem;
-    box-shadow: 0 10px 15px -3px rgb(0 0 0 / 0.1);
-    display: flex;
-    align-items: center;
-    gap: 0.75rem;
-    transition: transform 0.3s cubic-bezier(0.175, 0.885, 0.32, 1.275);
-    opacity: 0;
-    z-index: 1000;
-}
-
-.toast.show {
-    transform: translateX(-50%) translateY(0);
-    opacity: 1;
-}
-
-.toast.error {
-    border-left-color: var(--error);
-}
-
-.toast.warning {
-    border-left-color: var(--warning);
-}
-
-/* Helper classes */
-.text-muted {
-    font-size: 0.75rem;
-    color: var(--text-light);
-    margin-top: 0.5rem;
-}
-
-.mt-2 { margin-top: 0.5rem; }
-.mt-4 { margin-top: 1rem; }
-.mb-2 { margin-bottom: 0.5rem; }
-.mb-4 { margin-bottom: 1rem; }
-
-/* Section divider */
-.section-divider {
-    margin: 2rem 0;
-    border: none;
-    border-top: 1px solid var(--border);
-}
-
-/* Analysis section */
-.analysis-section {
-    margin-top: 1.5rem;
-    padding-top: 1.5rem;
-    border-top: 1px solid var(--border);
-}
-
-.analysis-section h3 {
-    font-size: 1.1rem;
-    font-weight: 600;
-    margin-bottom: 1rem;
-    color: var(--text);
-}
-
-.input-group {
-    display: flex;
-    gap: 0.5rem;
-}
-
-.input-group input {
-    flex: 1;
-    resize: none;
-}
-
-.input-group button {
-    width: auto;
-    padding: 0.75rem 1.25rem;
-    white-space: nowrap;
-}
-
-.report-select {
-    padding: 0.75rem 0.5rem;
-    border: 1px solid var(--border);
-    border-radius: 0.5rem;
-    font-size: 0.8rem;
-    background: white;
-    color: var(--text);
-    cursor: pointer;
-    min-width: 110px;
-    transition: border-color 0.2s, box-shadow 0.2s;
-}
-
-.report-select:focus {
-    outline: none;
-    border-color: var(--primary);
-    box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.1);
-}
-
-.btn-analysis {
-    background-color: var(--success);
-}
-
-.btn-analysis:hover {
-    background-color: #059669;
-}
-
-.btn-analysis:disabled {
-    background-color: var(--text-light);
-    cursor: not-allowed;
-    transform: none;
-}
-
-/* Result box */
-.result-box {
-    margin-top: 1rem;
-    padding: 1rem;
-    border-radius: 0.5rem;
-    font-size: 0.875rem;
-    display: none;
-}
-
-.result-box.show {
-    display: block;
-}
-
-.result-box.success {
-    background-color: #ecfdf5;
-    border: 1px solid #a7f3d0;
-    color: #065f46;
-}
-
-.result-box.error {
-    background-color: #fef2f2;
-    border: 1px solid #fecaca;
-    color: #991b1b;
-}
-
-.result-box.loading {
-    background-color: #eff6ff;
-    border: 1px solid #bfdbfe;
-    color: #1e40af;
-}
-
-.spinner {
-    display: inline-block;
-    width: 14px;
-    height: 14px;
-    border: 2px solid currentColor;
-    border-right-color: transparent;
-    border-radius: 50%;
-    animation: spin 0.75s linear infinite;
-    margin-right: 0.5rem;
-    vertical-align: middle;
-}
-
-@keyframes spin {
-    to { transform: rotate(360deg); }
-}
-
-/* Task List Container */
-.task-list {
-    display: flex;
-    flex-direction: column;
-    gap: 0.5rem;
-    max-height: 400px;
-    overflow-y: auto;
-}
-
-.task-list:empty::after {
-    content: '暂无任务';
-    display: block;
-    text-align: center;
-    color: var(--text-light);
-    font-size: 0.8rem;
-    padding: 1rem;
-}
-
-/* Task Card - Compact */
-.task-card {
-    display: flex;
-    align-items: center;
-    gap: 0.75rem;
-    padding: 0.6rem 0.75rem;
-    background: var(--bg);
-    border-radius: 0.5rem;
-    border: 1px solid var(--border);
-    font-size: 0.8rem;
-    transition: all 0.2s;
-}
-
-.task-card:hover {
-    border-color: var(--primary);
-    box-shadow: 0 2px 4px rgba(0,0,0,0.05);
-}
-
-.task-card.running {
-    border-color: var(--primary);
-    background: linear-gradient(135deg, #eff6ff 0%, #f8fafc 100%);
-}
-
-.task-card.completed {
-    border-color: var(--success);
-    background: linear-gradient(135deg, #ecfdf5 0%, #f8fafc 100%);
-}
-
-.task-card.failed {
-    border-color: var(--error);
-    background: linear-gradient(135deg, #fef2f2 0%, #f8fafc 100%);
-}
-
-/* Task Status Icon */
-.task-status {
-    width: 28px;
-    height: 28px;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    border-radius: 50%;
-    flex-shrink: 0;
-    font-size: 0.9rem;
-}
-
-.task-card.running .task-status {
-    background: var(--primary);
-    color: white;
-}
-
-.task-card.completed .task-status {
-    background: var(--success);
-    color: white;
-}
-
-.task-card.failed .task-status {
-    background: var(--error);
-    color: white;
-}
-
-.task-card.pending .task-status {
-    background: var(--border);
-    color: var(--text-light);
-}
-
-/* Task Main Info */
-.task-main {
-    flex: 1;
-    min-width: 0;
-    display: flex;
-    flex-direction: column;
-    gap: 0.15rem;
-}
-
-.task-title {
-    display: flex;
-    align-items: center;
-    gap: 0.5rem;
-    font-weight: 600;
-    color: var(--text);
-}
-
-.task-title .code {
-    font-family: monospace;
-    background: rgba(0,0,0,0.05);
-    padding: 0.1rem 0.3rem;
-    border-radius: 0.25rem;
-}
-
-.task-title .name {
-    color: var(--text-light);
-    font-weight: 400;
-    font-size: 0.75rem;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-}
-
-.task-meta {
-    display: flex;
-    gap: 0.75rem;
-    font-size: 0.7rem;
-    color: var(--text-light);
-}
-
-.task-meta span {
-    display: flex;
-    align-items: center;
-    gap: 0.2rem;
-}
-
-/* Task Result Badge */
-.task-result {
-    display: flex;
-    flex-direction: column;
-    align-items: flex-end;
-    gap: 0.15rem;
-    flex-shrink: 0;
-}
-
-.task-advice {
-    font-weight: 600;
-    font-size: 0.75rem;
-    padding: 0.15rem 0.4rem;
-    border-radius: 0.25rem;
-    background: var(--primary);
-    color: white;
-}
-
-.task-advice.buy { background: #059669; }
-.task-advice.sell { background: #dc2626; }
-.task-advice.hold { background: #d97706; }
-.task-advice.wait { background: #6b7280; }
-
-.task-score {
-    font-size: 0.7rem;
-    color: var(--text-light);
-}
-
-/* Task Actions */
-.task-actions {
-    display: flex;
-    gap: 0.25rem;
-    flex-shrink: 0;
-}
-
-.task-btn {
-    width: 24px;
-    height: 24px;
-    padding: 0;
-    border-radius: 0.25rem;
-    background: transparent;
-    color: var(--text-light);
-    font-size: 0.75rem;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-}
-
-.task-btn:hover {
-    background: rgba(0,0,0,0.05);
-    color: var(--text);
-    transform: none;
-}
-
-/* Spinner in task */
-.task-card .spinner {
-    width: 12px;
-    height: 12px;
-    border-width: 1.5px;
-    margin: 0;
-}
-
-/* Empty state hint */
-.task-hint {
-    text-align: center;
-    padding: 0.75rem;
-    color: var(--text-light);
-    font-size: 0.75rem;
-    background: var(--bg);
-    border-radius: 0.375rem;
-}
-
-/* Task detail expand */
-.task-detail {
-    display: none;
-    padding: 0.5rem 0.75rem;
-    padding-left: 3rem;
-    background: rgba(0,0,0,0.02);
-    border-radius: 0 0 0.5rem 0.5rem;
-    margin-top: -0.5rem;
-    font-size: 0.75rem;
-    border: 1px solid var(--border);
-    border-top: none;
-}
-
-.task-detail.show {
-    display: block;
-}
-
-.task-detail-row {
-    display: flex;
-    justify-content: space-between;
-    padding: 0.25rem 0;
-}
-
-.task-detail-row .label {
-    color: var(--text-light);
-}
-
-.task-detail-summary {
-    margin-top: 0.5rem;
-    padding: 0.5rem;
-    background: white;
-    border-radius: 0.25rem;
-    line-height: 1.4;
-}
-"""
+TEMPLATES_DIR = os.path.join(os.path.dirname(__file__), "templates")
 
 
 # ============================================================
-# 页面模板
+# 模板渲染函数
 # ============================================================
 
-def render_base(
-    title: str,
-    content: str,
-    extra_css: str = "",
-    extra_js: str = ""
-) -> str:
+def render_template(template_name: str, **context) -> str:
     """
-    渲染基础 HTML 模板
+    渲染模板文件
     
     Args:
-        title: 页面标题
-        content: 页面内容 HTML
-        extra_css: 额外的 CSS 样式
-        extra_js: 额外的 JavaScript
+        template_name: 模板文件名 (如 "index.html")
+        **context: 模板变量
+        
+    Returns:
+        渲染后的 HTML 字符串
     """
-    return f"""<!doctype html>
-<html lang="zh-CN">
-<head>
-  <meta charset="utf-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>{html.escape(title)}</title>
-  <style>{BASE_CSS}{extra_css}</style>
-</head>
-<body>
-  {content}
-  {extra_js}
-</body>
-</html>"""
+    template_path = os.path.join(TEMPLATES_DIR, template_name)
+    
+    try:
+        with open(template_path, "r", encoding="utf-8") as f:
+            template_content = f.read()
+    except FileNotFoundError:
+        return f"<!-- Template not found: {template_name} -->"
+    except Exception as e:
+        return f"<!-- Error loading template {template_name}: {e} -->"
+    
+    # 处理模板继承 ({% extends %})
+    if "{% extends" in template_content:
+        template_content = _process_extends(template_content, **context)
+    
+    # 处理包含 ({% include %})
+    template_content = _process_includes(template_content, **context)
+    
+    # 处理块 ({% block %})
+    template_content = _process_blocks(template_content, **context)
+    
+    # 处理变量 ({{ var }})
+    template_content = _process_variables(template_content, **context)
+    
+    # 处理条件 ({% if %})
+    template_content = _process_conditionals(template_content, **context)
+    
+    # 处理默认值过滤器 (|default())
+    template_content = _process_default_filters(template_content, **context)
+    
+    return template_content
 
 
-def render_toast(message: str, toast_type: str = "success") -> str:
+def _process_extends(template_content: str, **context) -> str:
+    """处理模板继承"""
+    import re
+    
+    extends_match = re.search(r'{%\s*extends\s*["\'](.+?)["\']\s*%}', template_content)
+    if not extends_match:
+        return template_content
+    
+    parent_name = extends_match.group(1)
+    parent_path = os.path.join(TEMPLATES_DIR, parent_name)
+    
+    try:
+        with open(parent_path, "r", encoding="utf-8") as f:
+            parent_content = f.read()
+    except FileNotFoundError:
+        return template_content
+    
+    # 提取子模板中的块内容
+    child_blocks = {}
+    block_pattern = r'{%\s*block\s+(\w+)\s*%}(.*?){%\s*endblock\s*%}'
+    for match in re.finditer(block_pattern, template_content, re.DOTALL):
+        block_name = match.group(1)
+        block_content = match.group(2)
+        child_blocks[block_name] = block_content
+    
+    # 替换父模板中的块
+    def replace_block(match):
+        block_name = match.group(1)
+        if block_name in child_blocks:
+            return child_blocks[block_name]
+        return match.group(2)  # 保留父模板的默认内容
+    
+    parent_content = re.sub(block_pattern, replace_block, parent_content, flags=re.DOTALL)
+    
+    return parent_content
+
+
+def _process_includes(template_content: str, **context) -> str:
+    """处理包含指令"""
+    import re
+    
+    include_pattern = r'{%\s*include\s*["\'](.+?)["\']\s*%}'
+    
+    def replace_include(match):
+        include_name = match.group(1)
+        include_path = os.path.join(TEMPLATES_DIR, include_name)
+        
+        try:
+            with open(include_path, "r", encoding="utf-8") as f:
+                return f.read()
+        except FileNotFoundError:
+            return f"<!-- Include not found: {include_name} -->"
+    
+    return re.sub(include_pattern, replace_include, template_content)
+
+
+def _process_blocks(template_content: str, **context) -> str:
+    """处理块定义 (移除块标记)"""
+    import re
+    
+    # 移除 {% block %} 和 {% endblock %} 标记
+    template_content = re.sub(r'{%\s*block\s+\w+\s*%}', '', template_content)
+    template_content = re.sub(r'{%\s*endblock\s*%}', '', template_content)
+    
+    return template_content
+
+
+def _process_variables(template_content: str, **context) -> str:
+    """处理模板变量"""
+    import re
+    
+    def replace_var(match):
+        var_expr = match.group(1).strip()
+        
+        # 处理过滤器
+        if "|" in var_expr:
+            var_name, filters = var_expr.split("|", 1)
+            var_name = var_name.strip()
+            value = context.get(var_name, "")
+            
+            # 应用过滤器
+            for filter_expr in filters.split("|"):
+                filter_expr = filter_expr.strip()
+                if filter_expr == "default(\"\")" or filter_expr.startswith("default("):
+                    if not value:
+                        default_match = re.search(r'default\(["\']?(.*?)["\']?\)', filter_expr)
+                        value = default_match.group(1) if default_match else ""
+                elif filter_expr == "e" or filter_expr == "escape":
+                    value = html.escape(str(value))
+            return str(value)
+        
+        # 简单变量
+        value = context.get(var_expr, "")
+        return html.escape(str(value)) if value else ""
+    
+    return re.sub(r'{{\s*(.+?)\s*}}', replace_var, template_content)
+
+
+def _process_conditionals(template_content: str, **context) -> str:
+    """处理条件语句"""
+    import re
+    
+    # 简单的 if/endif 处理
+    if_pattern = r'{%\s*if\s+(.+?)\s*%}(.*?){%\s*endif\s*%}'
+    
+    def replace_if(match):
+        condition = match.group(1).strip()
+        content = match.group(2)
+        
+        # 支持简单的变量存在性检查
+        if condition.startswith("not "):
+            var_name = condition[4:].strip()
+            if context.get(var_name):
+                return ""
+            return content
+        else:
+            var_name = condition
+            if context.get(var_name):
+                return content
+            return ""
+    
+    return re.sub(if_pattern, replace_if, template_content, flags=re.DOTALL)
+
+
+def _process_default_filters(template_content: str, **context) -> str:
+    """处理默认值过滤器"""
+    import re
+    
+    # 处理 {{ var|default("value") }}
+    pattern = r'{{\s*(\w+)\s*\|\s*default\(["\']?(.*?)["\']?\)\s*}}'
+    
+    def replace_default(match):
+        var_name = match.group(1)
+        default_value = match.group(2)
+        value = context.get(var_name)
+        return html.escape(str(value)) if value else default_value
+    
+    return re.sub(pattern, replace_default, template_content)
+
+
+# ============================================================
+# 页面渲染函数
+# ============================================================
+
+def render_index_page(
+    stock_list: str = "",
+    env_filename: str = ".env"
+) -> bytes:
     """
-    渲染 Toast 通知
+    渲染服务首页
     
     Args:
-        message: 通知消息
-        toast_type: 类型 (success, error, warning)
+        stock_list: 自选股列表
+        env_filename: 环境文件名
+        
+    Returns:
+        HTML 字节内容
     """
-    icon_map = {
-        "success": "✅",
-        "error": "❌",
-        "warning": "⚠️"
-    }
-    icon = icon_map.get(toast_type, "ℹ️")
-    type_class = f" {toast_type}" if toast_type != "success" else ""
+    html_content = render_template(
+        "index.html",
+        page_name="index",
+        stock_list=stock_list,
+        env_filename=env_filename
+    )
+    return html_content.encode("utf-8")
+
+
+def render_stock_analysis_page(
+    stock_list: str = "",
+    env_filename: str = ".env",
+    message: Optional[str] = None
+) -> bytes:
+    """
+    渲染个股分析页面
     
-    return f"""
-    <div id="toast" class="toast show{type_class}">
-        <span class="icon">{icon}</span> {html.escape(message)}
-    </div>
-    <script>
-        setTimeout(() => {{
-            document.getElementById('toast').classList.remove('show');
-        }}, 3000);
-    </script>
+    Args:
+        stock_list: 自选股列表
+        env_filename: 环境文件名
+        message: 提示消息
+        
+    Returns:
+        HTML 字节内容
     """
+    html_content = render_template(
+        "stock_analysis.html",
+        page_name="stock_analysis",
+        stock_list=stock_list,
+        env_filename=env_filename,
+        message=message
+    )
+    return html_content.encode("utf-8")
+
+
+def render_history_page() -> bytes:
+    """
+    渲染历史报告页面
+    
+    Returns:
+        HTML 字节内容
+    """
+    html_content = render_template(
+        "history.html",
+        page_name="history"
+    )
+    return html_content.encode("utf-8")
+
+
+def render_stock_picker_page() -> bytes:
+    """
+    渲染选股助手页面
+    
+    Returns:
+        HTML 字节内容
+    """
+    html_content = render_template(
+        "stock_picker.html",
+        page_name="stock_picker"
+    )
+    return html_content.encode("utf-8")
 
 
 def render_config_page(
@@ -618,362 +300,17 @@ def render_config_page(
     message: Optional[str] = None
 ) -> bytes:
     """
-    渲染配置页面
+    渲染配置页面 (兼容旧接口，重定向到个股分析页面)
     
     Args:
         stock_list: 当前自选股列表
         env_filename: 环境文件名
         message: 可选的提示消息
+        
+    Returns:
+        HTML 字节内容
     """
-    safe_value = html.escape(stock_list)
-    toast_html = render_toast(message) if message else ""
-    
-    # 分析组件的 JavaScript - 支持多任务
-    analysis_js = """
-<script>
-(function() {
-    const codeInput = document.getElementById('analysis_code');
-    const submitBtn = document.getElementById('analysis_btn');
-    const taskList = document.getElementById('task_list');
-    const reportTypeSelect = document.getElementById('report_type');
-    
-    // 任务管理
-    const tasks = new Map(); // taskId -> {task, pollCount}
-    let pollInterval = null;
-    const MAX_POLL_COUNT = 120; // 6 分钟超时：120 * 3000ms = 360000ms
-    const POLL_INTERVAL_MS = 3000;
-    const MAX_TASKS_DISPLAY = 10;
-    
-    // 允许输入数字和字母和点（支持港股 HKxxxxx 格式 美股AAPL/BRK.B）
-    codeInput.addEventListener('input', function(e) {
-        // 转大写，只保留字母和数字和点
-        this.value = this.value.toUpperCase().replace(/[^A-Z0-9.]/g, '');
-        if (this.value.length > 8) {
-            this.value = this.value.slice(0, 8);
-        }
-        updateButtonState();
-    });
-    
-    // 回车提交
-    codeInput.addEventListener('keypress', function(e) {
-        if (e.key === 'Enter') {
-            e.preventDefault();
-            if (!submitBtn.disabled) {
-                submitAnalysis();
-            }
-        }
-    });
-    
-    // 更新按钮状态 - 支持 A股(6位数字) 或 港股(HK+5位数字)
-    function updateButtonState() {
-        const code = codeInput.value.trim();
-        const isAStock = /^\\d{6}$/.test(code);           // A股: 600519
-        const isHKStock = /^HK\\d{5}$/.test(code);        // 港股: HK00700
-        const isUSStock =  /^[A-Z]{1,5}(\.[A-Z]{1,2})?$/.test(code); // 美股: AAPL
-
-        submitBtn.disabled = !(isAStock || isHKStock || isUSStock);
-    }
-    
-    // 格式化时间
-    function formatTime(isoString) {
-        if (!isoString) return '-';
-        const date = new Date(isoString);
-        return date.toLocaleTimeString('zh-CN', {hour: '2-digit', minute: '2-digit', second: '2-digit'});
-    }
-    
-    // 计算耗时
-    function calcDuration(start, end) {
-        if (!start) return '-';
-        const startTime = new Date(start).getTime();
-        const endTime = end ? new Date(end).getTime() : Date.now();
-        const seconds = Math.floor((endTime - startTime) / 1000);
-        if (seconds < 60) return seconds + 's';
-        const minutes = Math.floor(seconds / 60);
-        const remainSec = seconds % 60;
-        return minutes + 'm' + remainSec + 's';
-    }
-    
-    // 获取建议样式类
-    function getAdviceClass(advice) {
-        if (!advice) return '';
-        if (advice.includes('买') || advice.includes('加仓')) return 'buy';
-        if (advice.includes('卖') || advice.includes('减仓')) return 'sell';
-        if (advice.includes('持有')) return 'hold';
-        return 'wait';
-    }
-    
-    // 渲染单个任务卡片
-    function renderTaskCard(taskId, taskData) {
-        const task = taskData.task || {};
-        const status = task.status || 'pending';
-        const code = task.code || taskId.split('_')[0];
-        const result = task.result || {};
-        
-        let statusIcon = '⏳';
-        let statusText = '等待中';
-        if (status === 'running') { statusIcon = '<span class="spinner"></span>'; statusText = '分析中'; }
-        else if (status === 'completed') { statusIcon = '✓'; statusText = '完成'; }
-        else if (status === 'failed') { statusIcon = '✗'; statusText = '失败'; }
-        
-        let resultHtml = '';
-        if (status === 'completed' && result.operation_advice) {
-            const adviceClass = getAdviceClass(result.operation_advice);
-            resultHtml = '<div class="task-result">' +
-                '<span class="task-advice ' + adviceClass + '">' + result.operation_advice + '</span>' +
-                '<span class="task-score">' + (result.sentiment_score || '-') + '分</span>' +
-                '</div>';
-        } else if (status === 'failed') {
-            resultHtml = '<div class="task-result"><span class="task-advice sell">失败</span></div>';
-        }
-        
-        let detailHtml = '';
-        if (status === 'completed') {
-            detailHtml = '<div class="task-detail" id="detail_' + taskId + '">' +
-                '<div class="task-detail-row"><span class="label">趋势</span><span>' + (result.trend_prediction || '-') + '</span></div>' +
-                (result.analysis_summary ? '<div class="task-detail-summary">' + result.analysis_summary.substring(0, 100) + '...</div>' : '') +
-                '</div>';
-        }
-        
-        return '<div class="task-card ' + status + '" id="task_' + taskId + '" onclick="toggleDetail(\\''+taskId+'\\')">' +
-            '<div class="task-status">' + statusIcon + '</div>' +
-            '<div class="task-main">' +
-                '<div class="task-title">' +
-                    '<span class="code">' + code + '</span>' +
-                    '<span class="name">' + (result.name || code) + '</span>' +
-                '</div>' +
-                '<div class="task-meta">' +
-                    '<span>⏱ ' + formatTime(task.start_time) + '</span>' +
-                    '<span>⏳ ' + calcDuration(task.start_time, task.end_time) + '</span>' +
-                    '<span>' + (task.report_type === 'full' ? '📊完整' : '📝精简') + '</span>' +
-                '</div>' +
-            '</div>' +
-            resultHtml +
-            '<div class="task-actions">' +
-                '<button class="task-btn" onclick="event.stopPropagation();removeTask(\\''+taskId+'\\')">×</button>' +
-            '</div>' +
-        '</div>' + detailHtml;
-    }
-    
-    // 渲染所有任务
-    function renderAllTasks() {
-        if (tasks.size === 0) {
-            taskList.innerHTML = '<div class="task-hint">💡 输入股票代码开始分析</div>';
-            return;
-        }
-        
-        let html = '';
-        const sortedTasks = Array.from(tasks.entries())
-            .sort((a, b) => (b[1].task?.start_time || '').localeCompare(a[1].task?.start_time || ''));
-        
-        sortedTasks.slice(0, MAX_TASKS_DISPLAY).forEach(([taskId, taskData]) => {
-            html += renderTaskCard(taskId, taskData);
-        });
-        
-        if (sortedTasks.length > MAX_TASKS_DISPLAY) {
-            html += '<div class="task-hint">... 还有 ' + (sortedTasks.length - MAX_TASKS_DISPLAY) + ' 个任务</div>';
-        }
-        
-        taskList.innerHTML = html;
-    }
-    
-    // 切换详情显示
-    window.toggleDetail = function(taskId) {
-        const detail = document.getElementById('detail_' + taskId);
-        if (detail) {
-            detail.classList.toggle('show');
-        }
-    };
-    
-    // 移除任务
-    window.removeTask = function(taskId) {
-        tasks.delete(taskId);
-        renderAllTasks();
-        checkStopPolling();
-    };
-    
-    // 轮询所有运行中的任务
-    function pollAllTasks() {
-        let hasRunning = false;
-        
-        tasks.forEach((taskData, taskId) => {
-            const status = taskData.task?.status;
-            if (status === 'running' || status === 'pending' || !status) {
-                hasRunning = true;
-                taskData.pollCount = (taskData.pollCount || 0) + 1;
-                
-                if (taskData.pollCount > MAX_POLL_COUNT) {
-                    taskData.task = taskData.task || {};
-                    taskData.task.status = 'failed';
-                    taskData.task.error = '轮询超时';
-                    return;
-                }
-                
-                fetch('/task?id=' + encodeURIComponent(taskId))
-                    .then(r => r.json())
-                    .then(data => {
-                        if (data.success && data.task) {
-                            taskData.task = data.task;
-                            renderAllTasks();
-                        }
-                    })
-                    .catch(() => {});
-            }
-        });
-        
-        if (!hasRunning) {
-            checkStopPolling();
-        }
-    }
-    
-    // 检查是否需要停止轮询
-    function checkStopPolling() {
-        let hasRunning = false;
-        tasks.forEach((taskData) => {
-            const status = taskData.task?.status;
-            if (status === 'running' || status === 'pending' || !status) {
-                hasRunning = true;
-            }
-        });
-        
-        if (!hasRunning && pollInterval) {
-            clearInterval(pollInterval);
-            pollInterval = null;
-        }
-    }
-    
-    // 开始轮询
-    function startPolling() {
-        if (!pollInterval) {
-            pollInterval = setInterval(pollAllTasks, POLL_INTERVAL_MS);
-        }
-    }
-    
-    // 提交分析
-    window.submitAnalysis = function() {
-        const code = codeInput.value.trim();
-        const isAStock = /^\d{6}$/.test(code);
-        const isHKStock = /^HK\d{5}$/.test(code);
-        const isUSStock = /^[A-Z]{1,5}(\.[A-Z]{1,2})?$/.test(code);
-
-        if (!(isAStock || isHKStock || isUSStock)) {
-            return;
-        }
-        
-        submitBtn.disabled = true;
-        submitBtn.textContent = '提交中...';
-
-        const reportType = reportTypeSelect.value;
-        fetch('/analysis?code=' + encodeURIComponent(code) + '&report_type=' + encodeURIComponent(reportType))
-            .then(response => response.json())
-            .then(data => {
-                if (data.success) {
-                    const taskId = data.task_id;
-                    tasks.set(taskId, {
-                        task: {
-                            code: code,
-                            status: 'running',
-                            start_time: new Date().toISOString(),
-                            report_type: reportType
-                        },
-                        pollCount: 0
-                    });
-                    
-                    renderAllTasks();
-                    startPolling();
-                    codeInput.value = '';
-                    
-                    // 立即轮询一次
-                    setTimeout(() => {
-                        fetch('/task?id=' + encodeURIComponent(taskId))
-                            .then(r => r.json())
-                            .then(d => {
-                                if (d.success && d.task) {
-                                    tasks.get(taskId).task = d.task;
-                                    renderAllTasks();
-                                }
-                            });
-                    }, 500);
-                } else {
-                    alert('提交失败: ' + (data.error || '未知错误'));
-                }
-            })
-            .catch(error => {
-                alert('请求失败: ' + error.message);
-            })
-            .finally(() => {
-                submitBtn.disabled = false;
-                submitBtn.textContent = '🚀 分析';
-                updateButtonState();
-            });
-    };
-    
-    // 初始化
-    updateButtonState();
-    renderAllTasks();
-})();
-</script>
-"""
-    
-    content = f"""
-  <div class="container">
-    <h2>📈 A股/港股/美股分析</h2>
-    
-    <!-- 快速分析区域 -->
-    <div class="analysis-section" style="margin-top: 0; padding-top: 0; border-top: none;">
-      <div class="form-group" style="margin-bottom: 0.75rem;">
-        <div class="input-group">
-          <input 
-              type="text" 
-              id="analysis_code" 
-              placeholder="A股 600519 / 港股 HK00700 / 美股 AAPL"
-              maxlength="8"
-              autocomplete="off"
-          />
-          <select id="report_type" class="report-select" title="选择报告类型">
-            <option value="simple">📝 精简报告</option>
-            <option value="full">📊 完整报告</option>
-          </select>
-          <button type="button" id="analysis_btn" class="btn-analysis" onclick="submitAnalysis()" disabled>
-            🚀 分析
-          </button>
-        </div>
-      </div>
-      
-      <!-- 任务列表 -->
-      <div id="task_list" class="task-list"></div>
-    </div>
-    
-    <hr class="section-divider">
-    
-    <!-- 自选股配置区域 -->
-    <form method="post" action="/update">
-      <div class="form-group">
-        <label for="stock_list">📋 自选股列表 <span class="code-badge">{html.escape(env_filename)}</span></label>
-        <p>仅用于本地环境 (127.0.0.1) • 安全修改 .env 配置</p>
-        <textarea 
-            id="stock_list" 
-            name="stock_list" 
-            rows="4" 
-            placeholder="例如: 600519, 000001 (逗号或换行分隔)"
-        >{safe_value}</textarea>
-      </div>
-      <button type="submit">💾 保存</button>
-    </form>
-    
-    <div class="footer">
-      <p>API: <code>/health</code> · <code>/analysis?code=xxx</code> · <code>/tasks</code></p>
-    </div>
-  </div>
-  
-  {toast_html}
-  {analysis_js}
-"""
-    
-    page = render_base(
-        title="A/H股自选配置 | WebUI",
-        content=content
-    )
-    return page.encode("utf-8")
+    return render_stock_analysis_page(stock_list, env_filename, message)
 
 
 def render_error_page(
@@ -988,20 +325,123 @@ def render_error_page(
         status_code: HTTP 状态码
         message: 错误消息
         details: 详细信息
+        
+    Returns:
+        HTML 字节内容
     """
-    details_html = f"<p class='text-muted'>{html.escape(details)}</p>" if details else ""
-    
-    content = f"""
-  <div class="container" style="text-align: center;">
-    <h2>😵 {status_code}</h2>
-    <p>{html.escape(message)}</p>
-    {details_html}
-    <a href="/" style="color: var(--primary); text-decoration: none;">← 返回首页</a>
-  </div>
+    html_content = f"""<!DOCTYPE html>
+<html lang="zh-CN" class="dark">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>错误 {status_code} - Alpha Quant</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+    <script>
+        tailwind.config = {{
+            darkMode: 'class',
+            theme: {{
+                extend: {{
+                    colors: {{
+                        'geek-bg': '#0f172a',
+                        'geek-card': '#1e293b',
+                        'geek-border': '#334155',
+                        'accent': '#6366f1',
+                    }}
+                }}
+            }}
+        }}
+    </script>
+    <style>
+        body {{ background-color: #020617; color: #cbd5e1; min-height: 100vh; }}
+    </style>
+</head>
+<body class="flex items-center justify-center">
+    <div class="text-center p-8">
+        <div class="inline-flex items-center justify-center p-4 bg-red-500/10 border border-red-500/30 rounded-2xl mb-6">
+            <i class="fa-solid fa-triangle-exclamation text-red-400 text-4xl"></i>
+        </div>
+        <h1 class="text-4xl font-bold text-white mb-4">{status_code}</h1>
+        <p class="text-xl text-slate-400 mb-2">{html.escape(message)}</p>
+        {f'<p class="text-sm text-slate-500 mb-6">{html.escape(details)}</p>' if details else ''}
+        <a href="/" class="inline-flex items-center px-6 py-3 bg-accent hover:bg-accent/80 text-white font-semibold rounded-lg transition-all">
+            <i class="fa-solid fa-arrow-left mr-2"></i>
+            返回首页
+        </a>
+    </div>
+</body>
+</html>"""
+    return html_content.encode("utf-8")
+
+
+# ============================================================
+# 向后兼容
+# ============================================================
+
+# 保留旧的 BASE_CSS 常量以兼容可能的引用
+BASE_CSS = """
+/* Legacy CSS - 已迁移到 Tailwind CSS */
+:root {{
+    --primary: #6366f1;
+    --geek-bg: #0f172a;
+    --geek-card: #1e293b;
+    --geek-border: #334155;
+}}
 """
+
+
+def render_base(
+    title: str,
+    content: str,
+    extra_css: str = "",
+    extra_js: str = ""
+) -> str:
+    """
+    渲染基础 HTML 模板 (向后兼容)
     
-    page = render_base(
-        title=f"错误 {status_code}",
-        content=content
-    )
-    return page.encode("utf-8")
+    注意: 新代码应使用 render_template() 函数
+    """
+    return f"""<!doctype html>
+<html lang="zh-CN" class="dark">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>{html.escape(title)}</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+  <style>
+    body {{ background-color: #020617; color: #cbd5e1; }}
+    {extra_css}
+  </style>
+</head>
+<body>
+  {content}
+  {extra_js}
+</body>
+</html>"""
+
+
+def render_toast(message: str, toast_type: str = "success") -> str:
+    """
+    渲染 Toast 通知 (向后兼容)
+    """
+    icon_map = {
+        "success": "✅",
+        "error": "❌",
+        "warning": "⚠️"
+    }
+    icon = icon_map.get(toast_type, "ℹ️")
+    color_class = "green" if toast_type == "success" else "red" if toast_type == "error" else "yellow"
+    
+    return f"""
+    <div id="toast" class="fixed bottom-4 left-1/2 -translate-x-1/2 bg-slate-800 border-l-4 border-{color_class}-500 text-white px-6 py-3 rounded shadow-lg flex items-center gap-3 z-50">
+        <span>{icon}</span>
+        <span>{html.escape(message)}</span>
+    </div>
+    <script>
+        setTimeout(() => {{
+            const toast = document.getElementById('toast');
+            if (toast) toast.remove();
+        }}, 3000);
+    </script>
+    """

--- a/web/templates/base.html
+++ b/web/templates/base.html
@@ -1,0 +1,181 @@
+<!DOCTYPE html>
+<html lang="zh-CN" class="dark" x-data="{ currentPage: '{{ page_name }}' }">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{% block title %}Daily Stock Analysis{% endblock %}</title>
+    
+    <!-- Tailwind CSS -->
+    <script src="https://cdn.tailwindcss.com"></script>
+    <!-- FontAwesome -->
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+    <!-- Google Fonts -->
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;600;700&family=JetBrains+Mono:wght@400;700&display=swap" rel="stylesheet">
+    <!-- Alpine.js -->
+    <script defer src="https://cdn.jsdelivr.net/npm/alpinejs@3.x.x/dist/cdn.min.js"></script>
+    
+    <script>
+        tailwind.config = {
+            darkMode: 'class',
+            theme: {
+                extend: {
+                    colors: {
+                        'geek-bg': '#0f172a',
+                        'geek-card': '#1e293b',
+                        'geek-border': '#334155',
+                        'signal-buy': '#10b981',
+                        'signal-watch': '#94a3b8',
+                        'signal-sell': '#f43f5e',
+                        'accent': '#6366f1',
+                    },
+                    fontFamily: {
+                        sans: ['Inter', 'sans-serif'],
+                        mono: ['JetBrains Mono', 'monospace'],
+                    }
+                }
+            }
+        }
+    </script>
+    <style>
+        body {
+            background-color: #020617;
+            color: #cbd5e1;
+            min-height: 100vh;
+        }
+        /* Custom Scrollbar */
+        ::-webkit-scrollbar {
+            width: 8px;
+            height: 8px;
+        }
+        ::-webkit-scrollbar-track {
+            background: #0f172a; 
+        }
+        ::-webkit-scrollbar-thumb {
+            background: #334155; 
+            border-radius: 4px;
+        }
+        ::-webkit-scrollbar-thumb:hover {
+            background: #475569; 
+        }
+        .glass-panel {
+            background: rgba(30, 41, 59, 0.7);
+            backdrop-filter: blur(10px);
+            border: 1px solid rgba(255, 255, 255, 0.05);
+        }
+        .nav-link {
+            @apply flex items-center space-x-2 px-4 py-2 rounded-lg text-sm font-medium transition-all duration-200;
+        }
+        .nav-link:hover {
+            @apply bg-slate-800 text-white;
+        }
+        .nav-link.active {
+            @apply bg-accent/20 text-accent border border-accent/50;
+        }
+    </style>
+    {% block extra_css %}{% endblock %}
+</head>
+<body class="antialiased">
+    <!-- Navigation Header -->
+    <header class="sticky top-0 z-50 glass-panel border-b border-geek-border shadow-lg">
+        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+            <div class="flex items-center justify-between h-16">
+                <!-- Logo -->
+                <div class="flex items-center space-x-3">
+                    <div class="bg-accent/10 border border-accent/50 p-2 rounded-lg">
+                        <i class="fa-solid fa-chart-line text-accent text-xl"></i>
+                    </div>
+                    <div>
+                        <h1 class="font-bold text-white text-lg tracking-wide">Daily Stock Analysis</h1>
+                        <p class="text-[10px] text-slate-400 font-mono">每日股票分析系统</p>
+                    </div>
+                </div>
+
+                <!-- Navigation Links -->
+                <nav class="hidden md:flex items-center space-x-10">
+                    <a href="/" 
+                       :class="currentPage === 'index' ? 'active' : ''"
+                       class="nav-link">
+                        <i class="fa-solid fa-house"></i>
+                        <span>首页</span>
+                    </a>
+                    <a href="/stock-analysis" 
+                       :class="currentPage === 'stock_analysis' ? 'active' : ''"
+                       class="nav-link">
+                        <i class="fa-solid fa-magnifying-glass-chart"></i>
+                        <span>个股分析</span>
+                    </a>
+                    <a href="/history" 
+                       :class="currentPage === 'history' ? 'active' : ''"
+                       class="nav-link">
+                        <i class="fa-solid fa-clock-rotate-left"></i>
+                        <span>历史报告</span>
+                    </a>
+                    <!-- <a href="/stock-picker"
+                       :class="currentPage === 'stock_picker' ? 'active' : ''"
+                       class="nav-link">
+                        <i class="fa-solid fa-filter"></i>
+                        <span>选股助手</span>
+                    </a> -->
+                </nav>
+
+                <!-- Right Side -->
+                <div class="flex items-center space-x-4">
+                    <div class="flex items-center space-x-2 text-xs text-slate-500 font-mono">
+                        <span class="relative flex h-2 w-2">
+                            <span class="animate-ping absolute inline-flex h-full w-full rounded-full bg-green-400 opacity-75"></span>
+                            <span class="relative inline-flex rounded-full h-2 w-2 bg-green-500"></span>
+                        </span>
+                        <span class="hidden sm:inline text-green-400">ONLINE</span>
+                    </div>
+                    <div class="h-8 w-8 rounded-full bg-slate-800 border border-slate-700 flex items-center justify-center text-slate-400 cursor-pointer hover:bg-slate-700 hover:text-white transition-colors">
+                        <i class="fa-solid fa-user"></i>
+                    </div>
+                </div>
+            </div>
+        </div>
+        
+        <!-- Mobile Navigation -->
+        <div class="md:hidden border-t border-geek-border">
+            <div class="max-w-7xl mx-auto px-4 py-2 flex justify-around">
+                <a href="/" class="flex flex-col items-center p-2 text-xs" :class="currentPage === 'index' ? 'text-accent' : 'text-slate-400'">
+                    <i class="fa-solid fa-house mb-1"></i>
+                    <span>首页</span>
+                </a>
+                <a href="/stock-analysis" class="flex flex-col items-center p-2 text-xs" :class="currentPage === 'stock_analysis' ? 'text-accent' : 'text-slate-400'">
+                    <i class="fa-solid fa-magnifying-glass-chart mb-1"></i>
+                    <span>分析</span>
+                </a>
+                <a href="/history" class="flex flex-col items-center p-2 text-xs" :class="currentPage === 'history' ? 'text-accent' : 'text-slate-400'">
+                    <i class="fa-solid fa-clock-rotate-left mb-1"></i>
+                    <span>历史</span>
+                </a>
+                <!-- <a href="/stock-picker" class="flex flex-col items-center p-2 text-xs" :class="currentPage === 'stock_picker' ? 'text-accent' : 'text-slate-400'">
+                    <i class="fa-solid fa-filter mb-1"></i>
+                    <span>选股</span>
+                </a> -->
+            </div>
+        </div>
+    </header>
+
+    <!-- Main Content -->
+    <main class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-6">
+        {% block content %}{% endblock %}
+    </main>
+
+    <!-- Footer -->
+    <footer class="border-t border-geek-border mt-auto">
+        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-4">
+            <div class="flex flex-col md:flex-row items-center justify-between text-xs text-slate-500">
+                <p>Daily Stock Analysis &copy; 2026 - 每日股票分析系统</p>
+                <div class="flex items-center space-x-4 mt-2 md:mt-0">
+                    <span>API: <code class="bg-slate-800 px-1 py-0.5 rounded">/health</code></span>
+                    <span><code class="bg-slate-800 px-1 py-0.5 rounded">/analysis</code></span>
+                    <span><code class="bg-slate-800 px-1 py-0.5 rounded">/tasks</code></span>
+                </div>
+            </div>
+        </div>
+    </footer>
+
+    {% block extra_js %}{% endblock %}
+</body>
+</html>

--- a/web/templates/history.html
+++ b/web/templates/history.html
@@ -1,0 +1,338 @@
+{% extends "base.html" %}
+
+{% block title %}历史报告 - Daily Stock Analysis{% endblock %}
+
+{% block content %}
+<!-- Main Container with Alpine.js Data -->
+<div x-data="{
+    selectedDate: new Date().toISOString().split('T')[0],
+    loading: false,
+    reportData: null,
+    error: null,
+    availableDates: [],
+    currentView: 'market',
+    
+    async init() {
+        await this.loadAvailableDates();
+        await this.loadReport();
+    },
+    
+    async loadAvailableDates() {
+        try {
+            const response = await fetch('/api/history/dates');
+            const result = await response.json();
+            if (result.success && result.dates.length > 0) {
+                this.availableDates = result.dates;
+                this.selectedDate = result.dates[0];
+            }
+        } catch (e) {
+            console.error('加载可用日期失败:', e);
+        }
+    },
+    
+    async loadReport() {
+        this.loading = true;
+        this.error = null;
+        this.reportData = null;
+        
+        try {
+            const response = await fetch(`/api/history/report?date=${this.selectedDate}`);
+            const result = await response.json();
+            
+            if (!response.ok) {
+                this.error = result.error || '加载报告失败';
+                this.loading = false;
+                return;
+            }
+            
+            if (result.success && result.data) {
+                this.reportData = result.data;
+            } else {
+                this.error = result.error || '未找到该日期的报告';
+            }
+        } catch (e) {
+            this.error = '网络错误，请稍后重试';
+            console.error('加载报告失败:', e);
+        } finally {
+            this.loading = false;
+        }
+    },
+    
+    getSignalColor(signal) {
+        const colors = {
+            buy: 'bg-green-500/20 text-green-400 border-green-500/30',
+            watch: 'bg-slate-700 text-slate-300 border-slate-600',
+            sell: 'bg-red-500/20 text-red-400 border-red-500/30'
+        };
+        return colors[signal] || colors.watch;
+    },
+    
+    getSignalText(signal) {
+        const texts = {
+            buy: '🟢 强烈买入',
+            watch: '⚪ 观望',
+            sell: '🔴 卖出'
+        };
+        return texts[signal] || texts.watch;
+    }
+}" x-init="init()">
+
+    <!-- Header Section -->
+    <div class="mb-8">
+        <h1 class="text-2xl font-bold text-white flex items-center mb-2">
+            <i class="fa-solid fa-clock-rotate-left mr-3 text-emerald-500"></i>
+            历史报告查看
+        </h1>
+        <p class="text-slate-400">
+            查看过往的市场复盘与个股分析报告
+        </p>
+    </div>
+
+    <!-- Date Selector -->
+    <div class="bg-geek-card rounded-xl border border-geek-border p-6 mb-8">
+        <div class="flex flex-col md:flex-row items-center gap-4">
+            <div class="flex items-center space-x-3 bg-slate-800/50 p-2 rounded-lg border border-slate-700/50">
+                <span class="text-xs text-slate-400 font-bold uppercase">报告日期:</span>
+                <select 
+                    x-model="selectedDate"
+                    @change="loadReport()"
+                    class="bg-transparent text-white text-sm font-mono focus:outline-none cursor-pointer min-w-[140px]">
+                    <template x-for="date in availableDates" :key="date">
+                        <option :value="date" x-text="date" class="bg-slate-800"></option>
+                    </template>
+                </select>
+                <span x-show="availableDates.length === 0" class="text-slate-500 text-sm">暂无历史报告</span>
+            </div>
+            <button 
+                @click="loadReport()"
+                :disabled="loading || availableDates.length === 0"
+                class="px-6 py-2 bg-accent hover:bg-accent/80 disabled:bg-slate-700 text-white text-sm font-bold rounded-lg transition-all flex items-center">
+                <i class="fa-solid fa-rotate mr-2" :class="loading ? 'fa-spin' : ''"></i>
+                <span x-text="loading ? '加载中...' : '刷新'"></span>
+            </button>
+        </div>
+        
+        <!-- Error Message -->
+        <div x-show="error" x-transition class="mt-4 p-4 bg-red-500/10 border border-red-500/30 rounded-lg">
+            <div class="flex items-center text-red-400">
+                <i class="fa-solid fa-circle-exclamation mr-2"></i>
+                <span x-text="error"></span>
+            </div>
+        </div>
+    </div>
+
+    <!-- Report Content -->
+    <div x-show="reportData" x-transition>
+        <!-- View Switcher -->
+        <div class="flex items-center justify-center mb-8">
+            <div class="flex items-center space-x-2 bg-slate-800/50 p-1.5 rounded-lg border border-slate-700/50">
+                <button 
+                    @click="currentView = 'market'"
+                    :class="currentView === 'market' ? 'bg-accent text-white border-accent' : 'text-slate-400 hover:text-white border-transparent'"
+                    class="px-4 py-2 rounded-md text-sm font-medium border transition-all flex items-center">
+                    <i class="fa-solid fa-earth-asia mr-2"></i> 大盘复盘
+                </button>
+                <button 
+                    @click="currentView = 'strategy'"
+                    :class="currentView === 'strategy' ? 'bg-accent text-white border-accent' : 'text-slate-400 hover:text-white border-transparent'"
+                    class="px-4 py-2 rounded-md text-sm font-medium border transition-all flex items-center">
+                    <i class="fa-solid fa-crosshairs mr-2"></i> 决策建议
+                </button>
+            </div>
+        </div>
+
+        <!-- Market Review View -->
+        <div x-show="currentView === 'market'" x-transition class="space-y-6">
+            <div class="flex items-center justify-between">
+                <h2 class="text-xl font-bold text-white flex items-center">
+                    <i class="fa-solid fa-earth-asia mr-3 text-blue-500"></i>
+                    大盘复盘
+                    <span class="ml-3 text-sm font-normal text-slate-400" x-text="reportData?.date"></span>
+                </h2>
+            </div>
+
+            <!-- No Market Review Data -->
+            <div x-show="!reportData?.marketReview" class="p-8 text-center bg-geek-card rounded-xl border border-geek-border">
+                <i class="fa-solid fa-folder-open text-4xl text-slate-600 mb-4"></i>
+                <p class="text-slate-400">该日期暂无大盘复盘数据</p>
+            </div>
+
+            <div x-show="reportData?.marketReview" class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+                <!-- Market Summary -->
+                <div class="bg-geek-card rounded-xl border border-geek-border p-6 hover:border-accent transition-colors duration-300">
+                    <div class="flex items-center mb-4 text-accent">
+                        <i class="fa-solid fa-list-check text-lg"></i>
+                        <h3 class="ml-2 font-bold uppercase tracking-wider text-sm">市场总结</h3>
+                    </div>
+                    <p class="text-sm leading-relaxed text-slate-300" x-text="reportData?.marketReview?.summary || '暂无数据'"></p>
+                </div>
+
+                <!-- Index Comment -->
+                <div class="bg-geek-card rounded-xl border border-geek-border p-6 hover:border-accent transition-colors duration-300">
+                    <div class="flex items-center mb-4 text-blue-400">
+                        <i class="fa-solid fa-chart-simple text-lg"></i>
+                        <h3 class="ml-2 font-bold uppercase tracking-wider text-sm">指数点评</h3>
+                    </div>
+                    <p class="text-sm leading-relaxed text-slate-300" x-text="reportData?.marketReview?.indexComment || '暂无数据'"></p>
+                </div>
+
+                <!-- Capital Flow -->
+                <div class="bg-geek-card rounded-xl border border-geek-border p-6 hover:border-accent transition-colors duration-300">
+                    <div class="flex items-center mb-4 text-emerald-400">
+                        <i class="fa-solid fa-money-bill-transfer text-lg"></i>
+                        <h3 class="ml-2 font-bold uppercase tracking-wider text-sm">资金动向</h3>
+                    </div>
+                    <p class="text-sm leading-relaxed text-slate-300" x-text="reportData?.marketReview?.capitalFlow || '暂无数据'"></p>
+                </div>
+
+                <!-- Hot Topics -->
+                <div class="bg-geek-card rounded-xl border border-geek-border p-6 hover:border-accent transition-colors duration-300 lg:col-span-2">
+                    <div class="flex items-center mb-4 text-orange-400">
+                        <i class="fa-solid fa-fire text-lg"></i>
+                        <h3 class="ml-2 font-bold uppercase tracking-wider text-sm">热点解读</h3>
+                    </div>
+                    <p class="text-sm leading-relaxed text-slate-300" x-text="reportData?.marketReview?.hotTopics || '暂无数据'"></p>
+                </div>
+
+                <!-- Outlook & Risk -->
+                <div class="space-y-6">
+                    <div class="bg-geek-card rounded-xl border border-geek-border p-5 border-l-4 border-l-indigo-500">
+                        <h3 class="font-bold text-white mb-2 text-sm flex items-center">
+                            <i class="fa-solid fa-binoculars mr-2"></i> 后市展望
+                        </h3>
+                        <p class="text-xs text-slate-400 leading-relaxed" x-text="reportData?.marketReview?.outlook || '暂无数据'"></p>
+                    </div>
+
+                    <div class="bg-geek-card rounded-xl border border-geek-border p-5 border-l-4 border-l-red-500 bg-red-900/10">
+                        <h3 class="font-bold text-red-400 mb-2 text-sm flex items-center">
+                            <i class="fa-solid fa-triangle-exclamation mr-2"></i> 风险提示
+                        </h3>
+                        <p class="text-xs text-slate-400 leading-relaxed" x-text="reportData?.marketReview?.riskWarning || '暂无数据'"></p>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <!-- Strategy View -->
+        <div x-show="currentView === 'strategy'" x-transition class="space-y-6">
+            <div class="flex items-center justify-between">
+                <h2 class="text-xl font-bold text-white flex items-center">
+                    <i class="fa-solid fa-crosshairs mr-3 text-green-500"></i>
+                    决策建议
+                </h2>
+                <div class="flex space-x-2 text-xs font-mono font-bold" x-show="reportData?.decisions?.length > 0">
+                    <span class="px-2 py-1 rounded bg-green-500/20 text-green-400 border border-green-500/30">
+                        买入: <span x-text="reportData?.decisions?.filter(d => d.signal === 'buy').length || 0"></span>
+                    </span>
+                    <span class="px-2 py-1 rounded bg-slate-700 text-slate-300 border border-slate-600">
+                        观望: <span x-text="reportData?.decisions?.filter(d => d.signal === 'watch').length || 0"></span>
+                    </span>
+                    <span class="px-2 py-1 rounded bg-red-500/20 text-red-400 border border-red-500/30">
+                        卖出: <span x-text="reportData?.decisions?.filter(d => d.signal === 'sell').length || 0"></span>
+                    </span>
+                </div>
+            </div>
+
+            <!-- No Decisions Data -->
+            <div x-show="!reportData?.decisions || reportData?.decisions?.length === 0" class="p-8 text-center bg-geek-card rounded-xl border border-geek-border">
+                <i class="fa-solid fa-clipboard-list text-4xl text-slate-600 mb-4"></i>
+                <p class="text-slate-400">该日期暂无决策建议数据</p>
+            </div>
+
+            <div class="space-y-6">
+                <template x-for="(stock, index) in reportData?.decisions" :key="stock.code">
+                    <div class="bg-geek-card rounded-xl border overflow-hidden transition-all hover:border-slate-500"
+                         :class="stock.signal === 'buy' ? 'border-green-500/50 shadow-lg shadow-green-900/10' : 'border-geek-border'">
+                        <!-- Header -->
+                        <div class="p-6 border-b border-geek-border flex flex-col md:flex-row md:items-center justify-between gap-4"
+                             :class="stock.signal === 'buy' ? 'bg-green-500/5' : 'bg-slate-800/50'">
+                            <div class="flex items-center">
+                                <div class="h-12 w-12 rounded-lg flex items-center justify-center mr-4 border"
+                                     :class="stock.signal === 'buy' ? 'bg-green-500/20 text-green-400 border-green-500/30' : 'bg-slate-700 text-slate-400 border-slate-600'">
+                                    <i class="fa-solid text-xl" :class="stock.signal === 'buy' ? 'fa-arrow-trend-up' : 'fa-eye'"></i>
+                                </div>
+                                <div>
+                                    <h3 class="text-2xl font-bold text-white">
+                                        <span x-text="stock.name"></span>
+                                        <span class="text-lg text-slate-500 font-mono ml-2" x-text="'(' + stock.code + ')'"></span>
+                                    </h3>
+                                    <div class="flex items-center gap-3 mt-1">
+                                        <span class="text-xs font-bold px-2 py-0.5 rounded border" 
+                                              :class="getSignalColor(stock.signal)"
+                                              x-text="getSignalText(stock.signal)"></span>
+                                        <span class="text-xs font-mono text-slate-400">评分: <span class="text-white" x-text="stock.score"></span></span>
+                                    </div>
+                                </div>
+                            </div>
+                            <div class="bg-black/40 rounded-lg p-4 border md:max-w-md w-full"
+                                 :class="stock.signal === 'buy' ? 'border-green-500/20' : 'border-geek-border'">
+                                <h4 class="text-xs uppercase text-slate-500 mb-1 font-bold">决策指令</h4>
+                                <p class="font-mono text-sm border-l-2 pl-3"
+                                   :class="stock.signal === 'buy' ? 'text-green-400 border-green-500' : 'text-slate-300 border-slate-500'"
+                                   x-text="stock.decision"></p>
+                            </div>
+                        </div>
+
+                        <!-- Content -->
+                        <div class="grid grid-cols-1 lg:grid-cols-3 divide-y lg:divide-y-0 lg:divide-x divide-geek-border">
+                            <!-- Fundamentals -->
+                            <div class="p-6 space-y-6">
+                                <div>
+                                    <h4 class="text-xs uppercase tracking-wider text-slate-500 font-bold mb-3">基本面</h4>
+                                    <ul class="space-y-3 text-sm">
+                                        <template x-for="item in stock.fundamentals" :key="item">
+                                            <li class="flex items-start">
+                                                <i class="fa-solid fa-comment-dots mt-1 mr-2 text-blue-400"></i>
+                                                <span class="text-slate-300" x-text="item"></span>
+                                            </li>
+                                        </template>
+                                    </ul>
+                                </div>
+                            </div>
+
+                            <!-- Data -->
+                            <div class="p-6 space-y-6">
+                                <div>
+                                    <h4 class="text-xs uppercase tracking-wider text-slate-500 font-bold mb-3">数据透视</h4>
+                                    <div class="grid grid-cols-2 gap-4 mb-4">
+                                        <div class="bg-slate-900 p-3 rounded border border-geek-border">
+                                            <div class="text-xs text-slate-500">当前价</div>
+                                            <div class="text-lg font-mono text-white" x-text="stock.price"></div>
+                                        </div>
+                                        <div class="bg-slate-900 p-3 rounded border border-geek-border">
+                                            <div class="text-xs text-slate-500">乖离率</div>
+                                            <div class="text-lg font-mono" 
+                                                 :class="stock.bias > 0 ? 'text-green-400' : 'text-red-400'"
+                                                 x-text="(stock.bias > 0 ? '+' : '') + stock.bias + '%'"></div>
+                                        </div>
+                                    </div>
+                                    <div class="space-y-1 text-xs font-mono">
+                                        <div class="w-full bg-slate-700 h-1.5 rounded-full overflow-hidden">
+                                            <div class="h-1.5 rounded-full transition-all duration-500"
+                                                 :class="stock.trend > 70 ? 'bg-green-500' : stock.trend > 40 ? 'bg-yellow-500' : 'bg-red-500'"
+                                                 :style="'width: ' + stock.trend + '%'"></div>
+                                        </div>
+                                        <div class="text-right" 
+                                             :class="stock.trend > 70 ? 'text-green-500' : stock.trend > 40 ? 'text-yellow-500' : 'text-red-500'"
+                                             x-text="'趋势强度: ' + stock.trend + '%'"></div>
+                                    </div>
+                                </div>
+                            </div>
+
+                            <!-- Suggestion -->
+                            <div class="p-6 bg-slate-800/30">
+                                <h4 class="text-xs uppercase tracking-wider text-slate-500 font-bold mb-3">操作建议</h4>
+                                <div class="p-3 bg-slate-900 rounded border border-geek-border text-sm">
+                                    <span class="block text-slate-500 font-bold mb-1">🆕 空仓者</span>
+                                    <p class="text-slate-300" x-text="stock.suggestion"></p>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </template>
+            </div>
+        </div>
+    </div>
+
+</div>
+{% endblock %}

--- a/web/templates/index.html
+++ b/web/templates/index.html
@@ -1,0 +1,449 @@
+{% extends "base.html" %}
+
+{% block title %}Daily Stock Analysis - 服务首页{% endblock %}
+
+{% block content %}
+<!-- Hero Section -->
+<div class="text-center py-12 md:py-16">
+    <div class="inline-flex items-center justify-center p-3 bg-accent/10 border border-accent/30 rounded-2xl mb-6">
+        <i class="fa-solid fa-robot text-accent text-3xl"></i>
+    </div>
+    <h1 class="text-3xl md:text-5xl font-bold text-white mb-4">
+        智能量化分析平台
+    </h1>
+    <p class="text-slate-400 text-lg max-w-2xl mx-auto mb-8">
+        基于 AI 的股票分析与决策支持系统，支持 A股、港股、美股多市场分析
+    </p>
+    <div class="flex flex-col sm:flex-row items-center justify-center gap-4">
+        <a href="/stock-analysis" class="px-8 py-3 bg-accent hover:bg-accent/80 text-white font-semibold rounded-lg transition-all flex items-center space-x-2 shadow-lg shadow-accent/20">
+            <i class="fa-solid fa-magnifying-glass-chart"></i>
+            <span>开始分析</span>
+        </a>
+        <a href="/history" class="px-8 py-3 bg-slate-800 hover:bg-slate-700 text-white font-semibold rounded-lg transition-all flex items-center space-x-2 border border-geek-border">
+            <i class="fa-solid fa-clock-rotate-left"></i>
+            <span>查看历史</span>
+        </a>
+    </div>
+</div>
+
+<!-- Feature Cards -->
+<div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6 mt-8">
+    <!-- Feature 1: 个股分析 -->
+    <a href="/stock-analysis" class="group bg-geek-card rounded-xl border border-geek-border p-6 hover:border-accent transition-all duration-300 hover:shadow-lg hover:shadow-accent/10">
+        <div class="flex items-center justify-between mb-4">
+            <div class="h-12 w-12 rounded-lg bg-blue-500/20 flex items-center justify-center text-blue-400 group-hover:bg-blue-500/30 transition-colors">
+                <i class="fa-solid fa-magnifying-glass-chart text-xl"></i>
+            </div>
+            <i class="fa-solid fa-arrow-right text-slate-600 group-hover:text-accent transition-colors"></i>
+        </div>
+        <h3 class="text-lg font-bold text-white mb-2">个股分析</h3>
+        <p class="text-sm text-slate-400">
+            支持 A股(6位代码)、港股(HK+5位)、美股(字母代码)的实时分析与决策建议
+        </p>
+    </a>
+
+    <!-- Feature 2: 历史报告 -->
+    <a href="/history" class="group bg-geek-card rounded-xl border border-geek-border p-6 hover:border-accent transition-all duration-300 hover:shadow-lg hover:shadow-accent/10">
+        <div class="flex items-center justify-between mb-4">
+            <div class="h-12 w-12 rounded-lg bg-emerald-500/20 flex items-center justify-center text-emerald-400 group-hover:bg-emerald-500/30 transition-colors">
+                <i class="fa-solid fa-clock-rotate-left text-xl"></i>
+            </div>
+            <i class="fa-solid fa-arrow-right text-slate-600 group-hover:text-accent transition-colors"></i>
+        </div>
+        <h3 class="text-lg font-bold text-white mb-2">历史报告</h3>
+        <p class="text-sm text-slate-400">
+            查看过往的市场复盘与个股分析报告，支持按日期检索与回溯
+        </p>
+    </a>
+
+    <!-- Feature 3: 选股助手 -->
+    <a href="/stock-picker" class="group bg-geek-card rounded-xl border border-geek-border p-6 hover:border-accent transition-all duration-300 hover:shadow-lg hover:shadow-accent/10">
+        <div class="flex items-center justify-between mb-4">
+            <div class="h-12 w-12 rounded-lg bg-purple-500/20 flex items-center justify-center text-purple-400 group-hover:bg-purple-500/30 transition-colors">
+                <i class="fa-solid fa-filter text-xl"></i>
+            </div>
+            <i class="fa-solid fa-arrow-right text-slate-600 group-hover:text-accent transition-colors"></i>
+        </div>
+        <h3 class="text-lg font-bold text-white mb-2">选股助手</h3>
+        <p class="text-sm text-slate-400">
+            基于多因子模型的智能选股工具，帮助发现潜在投资机会
+        </p>
+        <span class="inline-block mt-3 px-2 py-1 text-xs bg-slate-700 text-slate-300 rounded">开发中</span>
+    </a>
+
+    <!-- Feature 4: API 接口 -->
+    <div class="group bg-geek-card rounded-xl border border-geek-border p-6 hover:border-accent transition-all duration-300" x-data="{ showApiModal: false }">
+        <div class="flex items-center justify-between mb-4">
+            <div class="h-12 w-12 rounded-lg bg-orange-500/20 flex items-center justify-center text-orange-400 group-hover:bg-orange-500/30 transition-colors">
+                <i class="fa-solid fa-code text-xl"></i>
+            </div>
+            <button @click="showApiModal = true" class="text-slate-500 hover:text-accent transition-colors" title="查看任务">
+                <i class="fa-solid fa-list-ul"></i>
+            </button>
+        </div>
+        <h3 class="text-lg font-bold text-white mb-2">API 接口</h3>
+        <p class="text-sm text-slate-400 mb-3">
+            提供 RESTful API 供外部系统集成与自动化调用
+        </p>
+        <div class="space-y-1 text-xs font-mono">
+            <code class="block bg-slate-900 px-2 py-1 rounded text-slate-400">GET /health</code>
+            <code class="block bg-slate-900 px-2 py-1 rounded text-slate-400">GET /analysis?code=xxx</code>
+            <code class="block bg-slate-900 px-2 py-1 rounded text-slate-400">GET /tasks</code>
+        </div>
+
+        <!-- Task Query Modal -->
+        <div x-show="showApiModal" 
+             x-transition:enter="transition ease-out duration-300"
+             x-transition:enter-start="opacity-0"
+             x-transition:enter-end="opacity-100"
+             x-transition:leave="transition ease-in duration-200"
+             x-transition:leave-start="opacity-100"
+             x-transition:leave-end="opacity-0"
+             class="fixed inset-0 z-50 overflow-y-auto"
+             style="display: none;">
+            <div class="flex items-center justify-center min-h-screen px-4">
+                <div class="fixed inset-0 bg-black/70 backdrop-blur-sm" @click="showApiModal = false"></div>
+                <div class="relative bg-geek-card rounded-xl border border-geek-border shadow-2xl max-w-4xl w-full max-h-[80vh] overflow-hidden"
+                     x-data="taskModalData()"
+                     x-init="fetchTasks()">
+                    <div class="flex items-center justify-between p-6 border-b border-geek-border">
+                        <h3 class="text-xl font-bold text-white flex items-center">
+                            <i class="fa-solid fa-list-check mr-3 text-accent"></i>
+                            任务查询
+                        </h3>
+                        <button @click="showApiModal = false" class="text-slate-400 hover:text-white transition-colors">
+                            <i class="fa-solid fa-xmark text-xl"></i>
+                        </button>
+                    </div>
+                    
+                    <div class="p-6 overflow-y-auto max-h-[60vh]">
+                        <!-- Search -->
+                        <div class="flex gap-4 mb-6">
+                            <div class="flex-1">
+                                <input 
+                                    type="text" 
+                                    x-model="searchCode"
+                                    placeholder="搜索股票代码..."
+                                    class="w-full bg-slate-900 border border-geek-border rounded-lg px-4 py-2 text-white placeholder-slate-500 focus:outline-none focus:border-accent font-mono"
+                                >
+                            </div>
+                            <select x-model="filterStatus" class="bg-slate-900 border border-geek-border rounded-lg px-4 py-2 text-white focus:outline-none focus:border-accent">
+                                <option value="">全部状态</option>
+                                <option value="running">分析中</option>
+                                <option value="completed">已完成</option>
+                                <option value="failed">失败</option>
+                            </select>
+                            <button @click="fetchTasks()" class="bg-accent hover:bg-accent/80 text-white px-4 py-2 rounded-lg transition-colors">
+                                <i class="fa-solid fa-rotate" :class="loading ? 'fa-spin' : ''"></i>
+                            </button>
+                        </div>
+
+                        <!-- Task List -->
+                        <div class="space-y-3">
+                            <template x-if="loading">
+                                <div class="text-center py-12 text-slate-400">
+                                    <i class="fa-solid fa-circle-notch fa-spin text-3xl mb-4"></i>
+                                    <p>加载中...</p>
+                                </div>
+                            </template>
+                            <template x-if="!loading && filteredTasks.length === 0">
+                                <div class="text-center py-12 text-slate-400">
+                                    <i class="fa-solid fa-inbox text-3xl mb-4 opacity-50"></i>
+                                    <p>暂无匹配的任务</p>
+                                </div>
+                            </template>
+                            <template x-for="task in filteredTasks" :key="task.task_id">
+                                <div class="bg-slate-900/50 rounded-lg border border-geek-border p-4 hover:border-slate-500 transition-colors cursor-pointer"
+                                     @click="selectedTask = selectedTask === task.task_id ? null : task.task_id">
+                                    <div class="flex items-center justify-between">
+                                        <div class="flex items-center space-x-4">
+                                            <div class="h-10 w-10 rounded-lg flex items-center justify-center"
+                                                 :class="{
+                                                     'bg-blue-500/20 text-blue-400': task.status === 'running',
+                                                     'bg-green-500/20 text-green-400': task.status === 'completed',
+                                                     'bg-red-500/20 text-red-400': task.status === 'failed',
+                                                     'bg-slate-700 text-slate-400': task.status === 'pending'
+                                                 }">
+                                                <i class="fa-solid" :class="{
+                                                    'fa-spinner fa-spin': task.status === 'running',
+                                                    'fa-check': task.status === 'completed',
+                                                    'fa-xmark': task.status === 'failed',
+                                                    'fa-clock': task.status === 'pending'
+                                                }"></i>
+                                            </div>
+                                            <div>
+                                                <div class="flex items-center space-x-2">
+                                                    <span class="font-mono font-bold text-white" x-text="task.code || task.task_id.split('_')[0]"></span>
+                                                    <span class="text-xs px-2 py-0.5 rounded" 
+                                                          :class="task.report_type === 'full' ? 'bg-purple-500/20 text-purple-400' : 'bg-blue-500/20 text-blue-400'"
+                                                          x-text="task.report_type === 'full' ? '完整' : '精简'"></span>
+                                                </div>
+                                                <div class="text-xs text-slate-500 mt-1" x-text="formatTime(task.start_time)"></div>
+                                            </div>
+                                        </div>
+                                        <div class="flex items-center space-x-3">
+                                            <template x-if="task.result && task.result.operation_advice">
+                                                <span class="px-2 py-1 text-xs rounded font-medium"
+                                                      :class="{
+                                                          'bg-green-500/20 text-green-400': task.result.operation_advice.includes('买'),
+                                                          'bg-red-500/20 text-red-400': task.result.operation_advice.includes('卖'),
+                                                          'bg-yellow-500/20 text-yellow-400': task.result.operation_advice.includes('持有'),
+                                                          'bg-slate-700 text-slate-300': !task.result.operation_advice.includes('买') && !task.result.operation_advice.includes('卖') && !task.result.operation_advice.includes('持有')
+                                                      }"
+                                                      x-text="task.result.operation_advice">
+                                                </span>
+                                            </template>
+                                            <i class="fa-solid fa-chevron-down text-slate-500 transition-transform" :class="selectedTask === task.task_id ? 'rotate-180' : ''"></i>
+                                        </div>
+                                    </div>
+                                    <!-- Expanded Details -->
+                                    <div x-show="selectedTask === task.task_id" x-collapse class="mt-4 pt-4 border-t border-geek-border">
+                                        <div class="grid grid-cols-2 gap-4 text-sm">
+                                            <div>
+                                                <span class="text-slate-500">任务ID:</span>
+                                                <span class="text-slate-300 font-mono ml-2" x-text="task.task_id"></span>
+                                            </div>
+                                            <div>
+                                                <span class="text-slate-500">状态:</span>
+                                                <span class="ml-2" :class="{
+                                                    'text-blue-400': task.status === 'running',
+                                                    'text-green-400': task.status === 'completed',
+                                                    'text-red-400': task.status === 'failed'
+                                                }" x-text="task.status === 'running' ? '分析中' : task.status === 'completed' ? '已完成' : task.status === 'failed' ? '失败' : '等待中'"></span>
+                                            </div>
+                                            <div x-show="task.result && task.result.sentiment_score">
+                                                <span class="text-slate-500">情绪评分:</span>
+                                                <span class="text-white ml-2" x-text="task.result.sentiment_score + '分'"></span>
+                                            </div>
+                                            <div x-show="task.result && task.result.trend_prediction">
+                                                <span class="text-slate-500">趋势预测:</span>
+                                                <span class="text-white ml-2" x-text="task.result.trend_prediction"></span>
+                                            </div>
+                                        </div>
+                                        <div x-show="task.result && task.result.analysis_summary" class="mt-3 p-3 bg-slate-950 rounded-lg">
+                                            <div class="text-xs text-slate-500 mb-1">分析摘要</div>
+                                            <div class="text-sm text-slate-300" x-text="task.result.analysis_summary"></div>
+                                        </div>
+                                        <div x-show="task.error" class="mt-3 p-3 bg-red-900/20 border border-red-500/30 rounded-lg">
+                                            <div class="text-xs text-red-400 mb-1">错误信息</div>
+                                            <div class="text-sm text-red-300" x-text="task.error"></div>
+                                        </div>
+                                    </div>
+                                </div>
+                            </template>
+                        </div>
+                    </div>
+                    
+                    <div class="p-4 border-t border-geek-border bg-slate-800/30 flex justify-between items-center">
+                        <span class="text-sm text-slate-400" x-text="'共 ' + filteredTasks.length + ' 个任务'"></span>
+                        <button @click="showApiModal = false" class="bg-slate-700 hover:bg-slate-600 text-white px-4 py-2 rounded-lg transition-colors">
+                            关闭
+                        </button>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <script>
+        function taskModalData() {
+            return {
+                tasks: [],
+                loading: true,
+                searchCode: '',
+                filterStatus: '',
+                selectedTask: null,
+                
+                get filteredTasks() {
+                    return this.tasks.filter(task => {
+                        const code = (task.code || task.task_id.split('_')[0]).toUpperCase();
+                        const matchCode = code.includes(this.searchCode.toUpperCase());
+                        const matchStatus = !this.filterStatus || task.status === this.filterStatus;
+                        return matchCode && matchStatus;
+                    });
+                },
+                
+                async fetchTasks() {
+                    this.loading = true;
+                    try {
+                        const response = await fetch('/tasks?limit=50');
+                        const data = await response.json();
+                        if (data.success && data.tasks) {
+                            this.tasks = data.tasks;
+                        }
+                    } catch (e) {
+                        console.error('Failed to fetch tasks:', e);
+                    } finally {
+                        this.loading = false;
+                    }
+                },
+                
+                formatTime(isoString) {
+                    if (!isoString) return '-';
+                    const date = new Date(isoString);
+                    return date.toLocaleString('zh-CN', { month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit' });
+                }
+            };
+        }
+        </script>
+    </div>
+</div>
+
+<!-- Quick Stats Section -->
+<div class="mt-12 grid grid-cols-1 md:grid-cols-3 gap-6" x-data="{ 
+    stats: { 
+        totalAnalyzed: 0, 
+        todayTasks: 0, 
+        successRate: 0 
+    },
+    async fetchStats() {
+        try {
+            const response = await fetch('/tasks?limit=100');
+            const data = await response.json();
+            if (data.success && data.tasks) {
+                this.stats.totalAnalyzed = data.tasks.length;
+                const today = new Date().toISOString().split('T')[0];
+                this.stats.todayTasks = data.tasks.filter(t => t.start_time && t.start_time.startsWith(today)).length;
+                const completed = data.tasks.filter(t => t.status === 'completed').length;
+                this.stats.successRate = data.tasks.length > 0 ? Math.round((completed / data.tasks.length) * 100) : 0;
+            }
+        } catch (e) {
+            console.error('Failed to fetch stats:', e);
+        }
+    }
+}" x-init="fetchStats()">
+    <div class="bg-geek-card rounded-xl border border-geek-border p-6 flex items-center space-x-4">
+        <div class="h-14 w-14 rounded-xl bg-accent/10 flex items-center justify-center text-accent">
+            <i class="fa-solid fa-chart-pie text-2xl"></i>
+        </div>
+        <div>
+            <p class="text-slate-400 text-sm">总分析次数</p>
+            <p class="text-2xl font-bold text-white font-mono" x-text="stats.totalAnalyzed">-</p>
+        </div>
+    </div>
+    <div class="bg-geek-card rounded-xl border border-geek-border p-6 flex items-center space-x-4">
+        <div class="h-14 w-14 rounded-xl bg-green-500/10 flex items-center justify-center text-green-400">
+            <i class="fa-solid fa-calendar-day text-2xl"></i>
+        </div>
+        <div>
+            <p class="text-slate-400 text-sm">今日任务</p>
+            <p class="text-2xl font-bold text-white font-mono" x-text="stats.todayTasks">-</p>
+        </div>
+    </div>
+    <div class="bg-geek-card rounded-xl border border-geek-border p-6 flex items-center space-x-4">
+        <div class="h-14 w-14 rounded-xl bg-blue-500/10 flex items-center justify-center text-blue-400">
+            <i class="fa-solid fa-check-circle text-2xl"></i>
+        </div>
+        <div>
+            <p class="text-slate-400 text-sm">成功率</p>
+            <p class="text-2xl font-bold text-white font-mono" x-text="stats.successRate + '%'">-</p>
+        </div>
+    </div>
+</div>
+
+<!-- Recent Tasks Section -->
+<div class="mt-12" x-data="{
+    tasks: [],
+    loading: true,
+    async fetchTasks() {
+        try {
+            const response = await fetch('/tasks?limit=5');
+            const data = await response.json();
+            if (data.success && data.tasks) {
+                this.tasks = data.tasks.slice(0, 5);
+            }
+        } catch (e) {
+            console.error('Failed to fetch tasks:', e);
+        } finally {
+            this.loading = false;
+        }
+    },
+    formatTime(isoString) {
+        if (!isoString) return '-';
+        const date = new Date(isoString);
+        return date.toLocaleString('zh-CN', { month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit' });
+    },
+    getStatusColor(status) {
+        const colors = { running: 'text-blue-400', completed: 'text-green-400', failed: 'text-red-400', pending: 'text-slate-400' };
+        return colors[status] || 'text-slate-400';
+    },
+    getStatusIcon(status) {
+        const icons = { running: 'fa-spinner fa-spin', completed: 'fa-check', failed: 'fa-xmark', pending: 'fa-clock' };
+        return icons[status] || 'fa-clock';
+    }
+}" x-init="fetchTasks()">
+    <div class="flex items-center justify-between mb-6">
+        <h2 class="text-xl font-bold text-white flex items-center">
+            <i class="fa-solid fa-list-check mr-3 text-accent"></i>
+            最近分析任务
+        </h2>
+        <a href="/stock-analysis" class="text-sm text-accent hover:text-accent/80 flex items-center">
+            查看全部 <i class="fa-solid fa-arrow-right ml-1"></i>
+        </a>
+    </div>
+
+    <div class="bg-geek-card rounded-xl border border-geek-border overflow-hidden">
+        <div class="overflow-x-auto">
+            <table class="w-full">
+                <thead class="bg-slate-800/50 border-b border-geek-border">
+                    <tr>
+                        <th class="px-6 py-3 text-left text-xs font-medium text-slate-400 uppercase tracking-wider">股票代码</th>
+                        <th class="px-6 py-3 text-left text-xs font-medium text-slate-400 uppercase tracking-wider">状态</th>
+                        <th class="px-6 py-3 text-left text-xs font-medium text-slate-400 uppercase tracking-wider">报告类型</th>
+                        <th class="px-6 py-3 text-left text-xs font-medium text-slate-400 uppercase tracking-wider">开始时间</th>
+                        <th class="px-6 py-3 text-left text-xs font-medium text-slate-400 uppercase tracking-wider">操作建议</th>
+                    </tr>
+                </thead>
+                <tbody class="divide-y divide-geek-border">
+                    <template x-if="loading">
+                        <tr>
+                            <td colspan="5" class="px-6 py-8 text-center text-slate-400">
+                                <i class="fa-solid fa-circle-notch fa-spin mr-2"></i> 加载中...
+                            </td>
+                        </tr>
+                    </template>
+                    <template x-if="!loading && tasks.length === 0">
+                        <tr>
+                            <td colspan="5" class="px-6 py-8 text-center text-slate-400">
+                                <i class="fa-solid fa-inbox mr-2"></i> 暂无分析任务
+                            </td>
+                        </tr>
+                    </template>
+                    <template x-for="task in tasks" :key="task.task_id">
+                        <tr class="hover:bg-slate-800/30 transition-colors">
+                            <td class="px-6 py-4 whitespace-nowrap">
+                                <span class="font-mono font-medium text-white" x-text="task.code || task.task_id.split('_')[0]"></span>
+                            </td>
+                            <td class="px-6 py-4 whitespace-nowrap">
+                                <span class="flex items-center" :class="getStatusColor(task.status)">
+                                    <i class="fa-solid mr-2" :class="getStatusIcon(task.status)"></i>
+                                    <span x-text="task.status === 'running' ? '分析中' : task.status === 'completed' ? '已完成' : task.status === 'failed' ? '失败' : '等待中'"></span>
+                                </span>
+                            </td>
+                            <td class="px-6 py-4 whitespace-nowrap">
+                                <span class="text-sm text-slate-300" x-text="task.report_type === 'full' ? '完整报告' : '精简报告'"></span>
+                            </td>
+                            <td class="px-6 py-4 whitespace-nowrap text-sm text-slate-400" x-text="formatTime(task.start_time)"></td>
+                            <td class="px-6 py-4 whitespace-nowrap">
+                                <template x-if="task.result && task.result.operation_advice">
+                                    <span class="px-2 py-1 text-xs rounded font-medium"
+                                          :class="{
+                                              'bg-green-500/20 text-green-400': task.result.operation_advice.includes('买'),
+                                              'bg-red-500/20 text-red-400': task.result.operation_advice.includes('卖'),
+                                              'bg-yellow-500/20 text-yellow-400': task.result.operation_advice.includes('持有'),
+                                              'bg-slate-700 text-slate-300': !task.result.operation_advice.includes('买') && !task.result.operation_advice.includes('卖') && !task.result.operation_advice.includes('持有')
+                                          }"
+                                          x-text="task.result.operation_advice">
+                                    </span>
+                                </template>
+                                <template x-if="!task.result || !task.result.operation_advice">
+                                    <span class="text-slate-500">-</span>
+                                </template>
+                            </td>
+                        </tr>
+                    </template>
+                </tbody>
+            </table>
+        </div>
+    </div>
+</div>
+{% endblock %}

--- a/web/templates/stock_analysis.html
+++ b/web/templates/stock_analysis.html
@@ -1,0 +1,373 @@
+{% extends "base.html" %}
+
+{% block title %}个股分析 - Daily Stock Analysis{% endblock %}
+
+{% block content %}
+<!-- Header Section -->
+<div class="mb-8">
+    <h1 class="text-2xl font-bold text-white flex items-center mb-2">
+        <i class="fa-solid fa-magnifying-glass-chart mr-3 text-blue-500"></i>
+        个股分析
+    </h1>
+    <p class="text-slate-400">
+        输入股票代码进行实时分析，支持 A股、港股、美股
+    </p>
+</div>
+
+<!-- Analysis Input Section -->
+<div class="bg-geek-card rounded-xl border border-geek-border p-6 mb-8" x-data="{
+    code: '',
+    reportType: 'simple',
+    loading: false,
+    tasks: [],
+    MAX_TASKS: 10,
+    
+    init() {
+        this.loadTasks();
+        this.startPolling();
+    },
+    
+    validateCode() {
+        const code = this.code.trim().toUpperCase();
+        const isAStock = /^\d{6}$/.test(code);
+        const isHKStock = /^HK\d{5}$/.test(code);
+        const isUSStock = /^[A-Z]{1,5}(\.[A-Z]{1,2})?$/.test(code);
+        return isAStock || isHKStock || isUSStock;
+    },
+    
+    getCodeType() {
+        const code = this.code.trim().toUpperCase();
+        if (/^\d{6}$/.test(code)) return 'A股';
+        if (/^HK\d{5}$/.test(code)) return '港股';
+        if (/^[A-Z]{1,5}(\.[A-Z]{1,2})?$/.test(code)) return '美股';
+        return '';
+    },
+    
+    async submitAnalysis() {
+        if (!this.validateCode() || this.loading) return;
+        
+        this.loading = true;
+        const code = this.code.trim().toUpperCase();
+        
+        try {
+            const response = await fetch(`/analysis?code=${encodeURIComponent(code)}&report_type=${this.reportType}`);
+            const data = await response.json();
+            
+            if (data.success) {
+                this.tasks.unshift({
+                    task_id: data.task_id,
+                    code: code,
+                    status: 'running',
+                    start_time: new Date().toISOString(),
+                    report_type: this.reportType,
+                    result: null
+                });
+                this.tasks = this.tasks.slice(0, this.MAX_TASKS);
+                this.saveTasks();
+                this.code = '';
+            } else {
+                alert('提交失败: ' + (data.error || '未知错误'));
+            }
+        } catch (error) {
+            alert('请求失败: ' + error.message);
+        } finally {
+            this.loading = false;
+        }
+    },
+    
+    startPolling() {
+        setInterval(() => this.pollTasks(), 3000);
+    },
+    
+    async pollTasks() {
+        const runningTasks = this.tasks.filter(t => t.status === 'running' || t.status === 'pending');
+        
+        for (const task of runningTasks) {
+            try {
+                const response = await fetch(`/task?id=${encodeURIComponent(task.task_id)}`);
+                const data = await response.json();
+                
+                if (data.success && data.task) {
+                    const index = this.tasks.findIndex(t => t.task_id === task.task_id);
+                    if (index !== -1) {
+                        this.tasks[index] = { ...this.tasks[index], ...data.task };
+                        this.saveTasks();
+                    }
+                }
+            } catch (e) {
+                console.error('Poll error:', e);
+            }
+        }
+    },
+    
+    saveTasks() {
+        localStorage.setItem('analysis_tasks', JSON.stringify(this.tasks.slice(0, this.MAX_TASKS)));
+    },
+    
+    loadTasks() {
+        try {
+            const saved = localStorage.getItem('analysis_tasks');
+            if (saved) {
+                this.tasks = JSON.parse(saved);
+            }
+        } catch (e) {
+            console.error('Load tasks error:', e);
+        }
+    },
+    
+    removeTask(taskId) {
+        this.tasks = this.tasks.filter(t => t.task_id !== taskId);
+        this.saveTasks();
+    },
+    
+    clearCompleted() {
+        this.tasks = this.tasks.filter(t => t.status === 'running' || t.status === 'pending');
+        this.saveTasks();
+    },
+    
+    formatTime(isoString) {
+        if (!isoString) return '-';
+        const date = new Date(isoString);
+        return date.toLocaleTimeString('zh-CN', { hour: '2-digit', minute: '2-digit', second: '2-digit' });
+    },
+    
+    calcDuration(start, end) {
+        if (!start) return '-';
+        const startTime = new Date(start).getTime();
+        const endTime = end ? new Date(end).getTime() : Date.now();
+        const seconds = Math.floor((endTime - startTime) / 1000);
+        if (seconds < 60) return seconds + 's';
+        const minutes = Math.floor(seconds / 60);
+        const remainSec = seconds % 60;
+        return minutes + 'm' + remainSec + 's';
+    },
+    
+    getAdviceClass(advice) {
+        if (!advice) return 'bg-slate-700 text-slate-300';
+        if (advice.includes('买') || advice.includes('加仓')) return 'bg-green-500/20 text-green-400 border border-green-500/30';
+        if (advice.includes('卖') || advice.includes('减仓')) return 'bg-red-500/20 text-red-400 border border-red-500/30';
+        if (advice.includes('持有')) return 'bg-yellow-500/20 text-yellow-400 border border-yellow-500/30';
+        return 'bg-slate-700 text-slate-300 border border-slate-600';
+    }
+}">
+    <div class="flex flex-col md:flex-row gap-4 mb-6">
+        <div class="flex-1">
+            <label class="block text-sm font-medium text-slate-400 mb-2">股票代码</label>
+            <div class="relative">
+                <input 
+                    type="text" 
+                    x-model="code"
+                    @input="code = code.toUpperCase().replace(/[^A-Z0-9.]/g, '').slice(0, 8)"
+                    @keydown.enter.prevent="submitAnalysis()"
+                    placeholder="A股 600519 / 港股 HK00700 / 美股 AAPL"
+                    class="w-full bg-slate-900 border border-geek-border rounded-lg px-4 py-3 text-white placeholder-slate-500 focus:outline-none focus:border-accent focus:ring-1 focus:ring-accent font-mono"
+                >
+                <div class="absolute right-3 top-1/2 -translate-y-1/2 text-xs text-slate-500" x-show="getCodeType()" x-text="getCodeType()"></div>
+            </div>
+            <p class="mt-2 text-xs text-slate-500">
+                <i class="fa-solid fa-circle-info mr-1"></i>
+                A股: 6位数字 | 港股: HK+5位数字 | 美股: 1-5位字母
+            </p>
+        </div>
+        <div class="md:w-48">
+            <label class="block text-sm font-medium text-slate-400 mb-2">报告类型</label>
+            <select x-model="reportType" class="w-full bg-slate-900 border border-geek-border rounded-lg px-4 py-3 text-white focus:outline-none focus:border-accent focus:ring-1 focus:ring-accent">
+                <option value="simple">📝 精简报告</option>
+                <option value="full">📊 完整报告</option>
+            </select>
+        </div>
+        <div class="md:w-40 flex items-center">
+            <button 
+                @click="submitAnalysis()"
+                :disabled="!validateCode() || loading"
+                class="w-full bg-accent hover:bg-accent/80 disabled:bg-slate-700 disabled:cursor-not-allowed text-white font-semibold rounded-lg px-4 py-3 transition-all flex items-center justify-center space-x-2">
+                <i class="fa-solid fa-rocket" :class="loading ? 'fa-spin' : ''"></i>
+                <span x-text="loading ? '提交中...' : '开始分析'"></span>
+            </button>
+        </div>
+    </div>
+
+    <!-- Task List -->
+    <div class="border-t border-geek-border pt-6">
+        <div class="flex items-center justify-between mb-4">
+            <h3 class="text-lg font-semibold text-white">
+                <i class="fa-solid fa-list-check mr-2 text-accent"></i>
+                分析任务
+                <span class="ml-2 text-sm text-slate-400 font-normal" x-text="tasks.length + '/' + MAX_TASKS"></span>
+            </h3>
+            <button 
+                @click="clearCompleted()"
+                x-show="tasks.some(t => t.status === 'completed' || t.status === 'failed')"
+                class="text-sm text-slate-400 hover:text-white transition-colors">
+                <i class="fa-solid fa-broom mr-1"></i> 清理已完成
+            </button>
+        </div>
+
+        <div class="space-y-3">
+            <template x-if="tasks.length === 0">
+                <div class="text-center py-12 text-slate-500">
+                    <i class="fa-solid fa-clipboard-list text-4xl mb-3 opacity-50"></i>
+                    <p>暂无分析任务，输入股票代码开始分析</p>
+                </div>
+            </template>
+
+            <template x-for="task in tasks" :key="task.task_id">
+                <div class="bg-slate-900/50 rounded-lg border border-geek-border p-4 transition-all"
+                     :class="{
+                         'border-blue-500/30': task.status === 'running',
+                         'border-green-500/30': task.status === 'completed',
+                         'border-red-500/30': task.status === 'failed'
+                     }">
+                    <div class="flex items-center justify-between">
+                        <div class="flex items-center space-x-4">
+                            <!-- Status Icon -->
+                            <div class="h-10 w-10 rounded-lg flex items-center justify-center"
+                                 :class="{
+                                     'bg-blue-500/20 text-blue-400': task.status === 'running',
+                                     'bg-green-500/20 text-green-400': task.status === 'completed',
+                                     'bg-red-500/20 text-red-400': task.status === 'failed',
+                                     'bg-slate-700 text-slate-400': task.status === 'pending'
+                                 }">
+                                <i class="fa-solid" :class="{
+                                    'fa-spinner fa-spin': task.status === 'running',
+                                    'fa-check': task.status === 'completed',
+                                    'fa-xmark': task.status === 'failed',
+                                    'fa-clock': task.status === 'pending'
+                                }"></i>
+                            </div>
+                            
+                            <!-- Task Info -->
+                            <div>
+                                <div class="flex items-center space-x-2">
+                                    <span class="font-mono font-bold text-white text-lg" x-text="task.code"></span>
+                                    <span class="text-xs text-slate-400" x-text="task.report_type === 'full' ? '完整报告' : '精简报告'"></span>
+                                </div>
+                                <div class="flex items-center space-x-4 text-xs text-slate-500 mt-1">
+                                    <span><i class="fa-regular fa-clock mr-1"></i> <span x-text="formatTime(task.start_time)"></span></span>
+                                    <span><i class="fa-solid fa-hourglass-half mr-1"></i> <span x-text="calcDuration(task.start_time, task.end_time)"></span></span>
+                                </div>
+                            </div>
+                        </div>
+
+                        <!-- Result -->
+                        <div class="flex items-center space-x-3">
+                            <template x-if="task.status === 'completed' && task.result">
+                                <div class="text-right">
+                                    <span class="inline-block px-3 py-1 rounded text-sm font-medium" 
+                                          :class="getAdviceClass(task.result.operation_advice)"
+                                          x-text="task.result.operation_advice || '无建议'"></span>
+                                    <div class="text-xs text-slate-500 mt-1" x-text="'评分: ' + (task.result.sentiment_score || '-') + '分'"></div>
+                                </div>
+                            </template>
+                            <template x-if="task.status === 'failed'">
+                                <span class="px-3 py-1 rounded text-sm font-medium bg-red-500/20 text-red-400 border border-red-500/30">分析失败</span>
+                            </template>
+                            <button @click="removeTask(task.task_id)" class="text-slate-500 hover:text-red-400 transition-colors p-2">
+                                <i class="fa-solid fa-trash"></i>
+                            </button>
+                        </div>
+                    </div>
+
+                    <!-- Expanded Details -->
+                    <template x-if="task.status === 'completed' && task.result">
+                        <div class="mt-4 pt-4 border-t border-geek-border grid grid-cols-1 md:grid-cols-3 gap-4">
+                            <div class="bg-slate-900 rounded-lg p-3">
+                                <div class="text-xs text-slate-500 mb-1">趋势预测</div>
+                                <div class="text-sm text-white" x-text="task.result.trend_prediction || '-'"></div>
+                            </div>
+                            <div class="bg-slate-900 rounded-lg p-3">
+                                <div class="text-xs text-slate-500 mb-1">关键价位</div>
+                                <div class="text-sm text-white font-mono" x-text="task.result.key_levels || '-'"></div>
+                            </div>
+                            <div class="bg-slate-900 rounded-lg p-3">
+                                <div class="text-xs text-slate-500 mb-1">风险等级</div>
+                                <div class="text-sm text-white" x-text="task.result.risk_level || '-'"></div>
+                            </div>
+                            <div class="md:col-span-3 bg-slate-900 rounded-lg p-3" x-show="task.result.analysis_summary">
+                                <div class="text-xs text-slate-500 mb-1">分析摘要</div>
+                                <div class="text-sm text-slate-300 leading-relaxed" x-text="task.result.analysis_summary"></div>
+                            </div>
+                        </div>
+                    </template>
+                </div>
+            </template>
+        </div>
+    </div>
+</div>
+
+<!-- Stock List Configuration -->
+<div class="bg-geek-card rounded-xl border border-geek-border p-6" x-data="{
+    stockList: '{{ stock_list|default("") }}',
+    saving: false,
+    message: '',
+    messageType: 'success',
+    
+    async saveConfig() {
+        this.saving = true;
+        this.message = '';
+        
+        try {
+            const formData = new URLSearchParams();
+            formData.append('stock_list', this.stockList);
+            
+            const response = await fetch('/update', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+                body: formData
+            });
+            
+            if (response.ok) {
+                this.message = '保存成功';
+                this.messageType = 'success';
+                setTimeout(() => this.message = '', 3000);
+            } else {
+                throw new Error('保存失败');
+            }
+        } catch (error) {
+            this.message = '保存失败: ' + error.message;
+            this.messageType = 'error';
+        } finally {
+            this.saving = false;
+        }
+    }
+}">
+    <div class="flex items-center justify-between mb-4">
+        <h3 class="text-lg font-semibold text-white">
+            <i class="fa-solid fa-gear mr-2 text-slate-400"></i>
+            自选股配置
+            <span class="ml-2 text-xs font-normal text-slate-500 bg-slate-800 px-2 py-0.5 rounded">{{ env_filename }}</span>
+        </h3>
+    </div>
+    
+    <div class="mb-4">
+        <textarea 
+            x-model="stockList"
+            rows="4"
+            placeholder="输入股票代码，用逗号或换行分隔，例如: 600519, 000001, HK00700"
+            class="w-full bg-slate-900 border border-geek-border rounded-lg px-4 py-3 text-white placeholder-slate-500 focus:outline-none focus:border-accent focus:ring-1 focus:ring-accent font-mono text-sm"
+        ></textarea>
+        <p class="mt-2 text-xs text-slate-500">
+            <i class="fa-solid fa-shield-halved mr-1"></i>
+            仅用于本地环境 (127.0.0.1) 安全修改 .env 配置
+        </p>
+    </div>
+    
+    <div class="flex items-center justify-between">
+        <button 
+            @click="saveConfig()"
+            :disabled="saving"
+            class="bg-slate-700 hover:bg-slate-600 disabled:bg-slate-800 text-white font-medium rounded-lg px-6 py-2 transition-all flex items-center space-x-2">
+            <i class="fa-solid" :class="saving ? 'fa-spinner fa-spin' : 'fa-save'"></i>
+            <span x-text="saving ? '保存中...' : '保存配置'"></span>
+        </button>
+        
+        <div x-show="message" 
+             x-transition
+             :class="messageType === 'success' ? 'text-green-400' : 'text-red-400'"
+             class="flex items-center text-sm">
+            <i class="fa-solid mr-2" :class="messageType === 'success' ? 'fa-check-circle' : 'fa-circle-exclamation'"></i>
+            <span x-text="message"></span>
+        </div>
+    </div>
+</div>
+{% endblock %}

--- a/web/templates/stock_picker.html
+++ b/web/templates/stock_picker.html
@@ -1,0 +1,103 @@
+{% extends "base.html" %}
+
+{% block title %}选股助手 - Daily Stock Analysis{% endblock %}
+
+{% block content %}
+<!-- Header Section -->
+<div class="mb-8">
+    <h1 class="text-2xl font-bold text-white flex items-center mb-2">
+        <i class="fa-solid fa-filter mr-3 text-purple-500"></i>
+        选股助手
+    </h1>
+    <p class="text-slate-400">
+        基于多因子模型的智能选股工具，帮助发现潜在投资机会
+    </p>
+</div>
+
+<!-- Coming Soon Banner -->
+<div class="bg-gradient-to-r from-purple-900/20 to-blue-900/20 rounded-xl border border-purple-500/30 p-12 text-center">
+    <div class="inline-flex items-center justify-center p-4 bg-purple-500/10 border border-purple-500/30 rounded-2xl mb-6">
+        <i class="fa-solid fa-rocket text-purple-400 text-4xl"></i>
+    </div>
+    <h2 class="text-3xl font-bold text-white mb-4">即将推出</h2>
+    <p class="text-slate-400 text-lg max-w-2xl mx-auto mb-8">
+        选股助手功能正在开发中，将提供基于技术指标、基本面数据和市场情绪的多维度选股筛选工具。
+    </p>
+    
+    <!-- Feature Preview -->
+    <div class="grid grid-cols-1 md:grid-cols-3 gap-6 max-w-4xl mx-auto mt-12">
+        <div class="bg-geek-card rounded-lg border border-geek-border p-6 text-left">
+            <div class="h-10 w-10 rounded-lg bg-blue-500/20 flex items-center justify-center text-blue-400 mb-4">
+                <i class="fa-solid fa-chart-line text-xl"></i>
+            </div>
+            <h3 class="font-bold text-white mb-2">技术指标筛选</h3>
+            <p class="text-sm text-slate-400">
+                基于均线排列、MACD、RSI、布林带等技术指标进行股票筛选
+            </p>
+        </div>
+        
+        <div class="bg-geek-card rounded-lg border border-geek-border p-6 text-left">
+            <div class="h-10 w-10 rounded-lg bg-green-500/20 flex items-center justify-center text-green-400 mb-4">
+                <i class="fa-solid fa-building text-xl"></i>
+            </div>
+            <h3 class="font-bold text-white mb-2">基本面分析</h3>
+            <p class="text-sm text-slate-400">
+                根据市盈率、市净率、ROE、营收增长等财务指标筛选优质标的
+            </p>
+        </div>
+        
+        <div class="bg-geek-card rounded-lg border border-geek-border p-6 text-left">
+            <div class="h-10 w-10 rounded-lg bg-orange-500/20 flex items-center justify-center text-orange-400 mb-4">
+                <i class="fa-solid fa-brain text-xl"></i>
+            </div>
+            <h3 class="font-bold text-white mb-2">AI 智能推荐</h3>
+            <p class="text-sm text-slate-400">
+                结合市场情绪、资金流向和机器学习模型生成个性化推荐
+            </p>
+        </div>
+    </div>
+    
+    <!-- Notification Signup -->
+    <div class="mt-12 max-w-md mx-auto">
+        <p class="text-sm text-slate-500 mb-4">订阅更新通知，功能上线时第一时间知晓</p>
+        <div class="flex gap-2">
+            <input 
+                type="email" 
+                placeholder="输入您的邮箱"
+                disabled
+                class="flex-1 bg-slate-900 border border-geek-border rounded-lg px-4 py-3 text-white placeholder-slate-500 opacity-50 cursor-not-allowed"
+            >
+            <button 
+                disabled
+                class="bg-purple-600 hover:bg-purple-500 disabled:bg-slate-700 disabled:cursor-not-allowed text-white font-semibold rounded-lg px-6 py-3 transition-all opacity-50">
+                订阅
+            </button>
+        </div>
+    </div>
+</div>
+
+<!-- Alternative Actions -->
+<div class="mt-8 grid grid-cols-1 md:grid-cols-2 gap-6">
+    <a href="/stock-analysis" class="bg-geek-card rounded-xl border border-geek-border p-6 hover:border-accent transition-all flex items-center group">
+        <div class="h-14 w-14 rounded-xl bg-accent/10 flex items-center justify-center text-accent mr-4 group-hover:bg-accent/20 transition-colors">
+            <i class="fa-solid fa-magnifying-glass-chart text-2xl"></i>
+        </div>
+        <div>
+            <h3 class="font-bold text-white text-lg">个股分析</h3>
+            <p class="text-sm text-slate-400">分析特定股票的实时数据与趋势</p>
+        </div>
+        <i class="fa-solid fa-arrow-right ml-auto text-slate-600 group-hover:text-accent transition-colors"></i>
+    </a>
+    
+    <a href="/history" class="bg-geek-card rounded-xl border border-geek-border p-6 hover:border-accent transition-all flex items-center group">
+        <div class="h-14 w-14 rounded-xl bg-emerald-500/10 flex items-center justify-center text-emerald-400 mr-4 group-hover:bg-emerald-500/20 transition-colors">
+            <i class="fa-solid fa-clock-rotate-left text-2xl"></i>
+        </div>
+        <div>
+            <h3 class="font-bold text-white text-lg">历史报告</h3>
+            <p class="text-sm text-slate-400">查看过往的市场复盘与分析记录</p>
+        </div>
+        <i class="fa-solid fa-arrow-right ml-auto text-slate-600 group-hover:text-accent transition-colors"></i>
+    </a>
+</div>
+{% endblock %}


### PR DESCRIPTION
## 变更类型

- [ ] 🐛 Bug 修复
- [x] ✨ 新功能
- [ ] 📝 文档更新
- [x] 🎨 代码优化/重构
- [ ] ⚡ 性能优化
- [ ] 🔧 配置/构建相关

## 变更描述

- 新增历史报告服务HistoryReportService，支持读取和解析报告文件
- 添加个股分析、历史报告等新页面路由
- 实现历史报告API接口，支持获取日期列表和指定日期报告
- 更新首页跳转到服务首页，并修改更新后跳转到个股分析页面
- 新增render_index_page等模板渲染函数



## 关联 Issue

关联的 Issue 编号（如有）：fixes #

## 测试说明

描述如何测试这些变更：

1. 启动 webui 服务 `python main.py --webui-only`
2. 访问 http://127.0.0.1:8000/ 

## 检查清单

- [x] 代码符合项目规范
- [x] 已添加必要的注释/文档
- [x] 已在本地测试通过
- [ ] 已更新相关文档（如需要）

## 截图（如适用）

<img width="1597" height="1290" alt="image" src="https://github.com/user-attachments/assets/39535707-29fb-459c-a121-3b9779715e18" />

<img width="1445" height="1184" alt="image" src="https://github.com/user-attachments/assets/6b35d820-f900-4449-97f5-9d6f0a3d437c" />

<img width="1432" height="1229" alt="image" src="https://github.com/user-attachments/assets/7c547df9-0aab-4b16-9123-d16725518212" />

<img width="1396" height="585" alt="image" src="https://github.com/user-attachments/assets/a09ae579-e615-4236-a8a4-a84c8ca7808f" />

## 其他说明

其他需要说明的内容。
