### PR TITLE
fix(docker): respect WEBUI_PORT from .env file (fixes #221)

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -31,7 +31,7 @@ x-common: &common
     # 注意：容器内如果绑定到 127.0.0.1，宿主机端口映射将无法访问 WebUI。
     # 即使 .env 里设置了 WEBUI_HOST=127.0.0.1，这里也会强制覆盖。
     - WEBUI_HOST=0.0.0.0
-    - WEBUI_PORT=8000
+    # WEBUI_PORT 从 .env 文件读取，无需在此硬编码
 
     # 代理设置（如果需要）
     # - http_proxy=http://host.docker.internal:10809
@@ -61,4 +61,4 @@ services:
     container_name: stock-webui
     command: ["python", "main.py", "--webui-only"]
     ports:
-      - "8000:8000"
+      - "${WEBUI_PORT:-8000}:${WEBUI_PORT:-8000}"


### PR DESCRIPTION
  - Remove hardcoded WEBUI_PORT=8000 from docker-compose.yml environment
  - Use variable substitution in port mapping with default fallback
  - WEBUI_PORT is now properly read from .env file

## 变更类型

- [ ] 🐛 Bug 修复
- [ ] ✨ 新功能
- [ ] 📝 文档更新
- [ ] 🎨 代码优化/重构
- [ ] ⚡ 性能优化
- [ ] 🔧 配置/构建相关

## 变更描述

简要描述这个 PR 做了什么。

## 关联 Issue

关联的 Issue 编号（如有）：fixes #

## 测试说明

描述如何测试这些变更：

1. 步骤一
2. 步骤二
3. ...

## 检查清单

- [ ] 代码符合项目规范
- [ ] 已添加必要的注释/文档
- [ ] 已在本地测试通过
- [ ] 已更新相关文档（如需要）

## 截图（如适用）

如有 UI 变更，请附上截图。

## 其他说明

其他需要说明的内容。
