### PR TITLE
feat(telegram): 支持发送消息到子话题

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -79,6 +79,7 @@ SERPAPI_API_KEYS=your_serpapi_key_here
 #
 # TELEGRAM_BOT_TOKEN=123456789:ABCdefGHIjklMNOpqrsTUVwxyz
 # TELEGRAM_CHAT_ID=123456789
+# TELEGRAM_MESSAGE_THREAD_ID=2780
 #
 # 【方式四】邮件推送（只需 2 项配置，SMTP 自动识别）
 # 支持 QQ邮箱、163邮箱、Gmail、Outlook 等主流邮箱

--- a/.github/workflows/daily_analysis.yml
+++ b/.github/workflows/daily_analysis.yml
@@ -90,6 +90,7 @@ jobs:
           # 方式三：Telegram
           TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
           TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID }}
+          TELEGRAM_MESSAGE_THREAD_ID: ${{ secrets.TELEGRAM_MESSAGE_THREAD_ID }}
           
           # 方式四：邮件
           EMAIL_SENDER: ${{ vars.EMAIL_SENDER || secrets.EMAIL_SENDER }}

--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@
 | `FEISHU_WEBHOOK_URL` | 飞书 Webhook URL | 可选 |
 | `TELEGRAM_BOT_TOKEN` | Telegram Bot Token（@BotFather 获取） | 可选 |
 | `TELEGRAM_CHAT_ID` | Telegram Chat ID | 可选 |
+| `TELEGRAM_MESSAGE_THREAD_ID` | Telegram Topic ID (用于发送到子话题) | 可选 |
 | `EMAIL_SENDER` | 发件人邮箱（如 `xxx@qq.com`） | 可选 |
 | `EMAIL_PASSWORD` | 邮箱授权码（非登录密码） | 可选 |
 | `EMAIL_RECEIVERS` | 收件人邮箱（多个用逗号分隔，留空则发给自己） | 可选 |

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -353,6 +353,7 @@ git push -u origin main
 | `FEISHU_WEBHOOK_URL` | 飞书机器人 Webhook | 可选* |
 | `TELEGRAM_BOT_TOKEN` | Telegram Bot Token | 可选* |
 | `TELEGRAM_CHAT_ID` | Telegram Chat ID | 可选* |
+| `TELEGRAM_MESSAGE_THREAD_ID` | Telegram Topic ID | 可选* |
 | `EMAIL_SENDER` | 发件人邮箱 | 可选* |
 | `EMAIL_PASSWORD` | 邮箱授权码 | 可选* |
 | `CUSTOM_WEBHOOK_URLS` | 自定义 Webhook（多个逗号分隔） | 可选* |

--- a/docs/README_CHT.md
+++ b/docs/README_CHT.md
@@ -90,6 +90,7 @@
 |------------|------|:----:|
 | `TELEGRAM_BOT_TOKEN` | Telegram Bot Token（@BotFather 獲取） | 可選 |
 | `TELEGRAM_CHAT_ID` | Telegram Chat ID | 可選 |
+| `TELEGRAM_MESSAGE_THREAD_ID` | Telegram Topic ID (用於發送到子話題) | 可選 |
 | `DISCORD_WEBHOOK_URL` | Discord Webhook URL | 可選 |
 | `DISCORD_BOT_TOKEN` | Discord Bot Token（與 Webhook 二選一） | 可選 |
 | `DISCORD_CHANNEL_ID` | Discord Channel ID（使用 Bot 時需要） | 可選 |

--- a/docs/README_EN.md
+++ b/docs/README_EN.md
@@ -90,6 +90,7 @@ Go to your forked repo → `Settings` → `Secrets and variables` → `Actions` 
 |------------|------|:----:|
 | `TELEGRAM_BOT_TOKEN` | Telegram Bot Token (Get from @BotFather) | Optional |
 | `TELEGRAM_CHAT_ID` | Telegram Chat ID | Optional |
+| `TELEGRAM_MESSAGE_THREAD_ID` | Telegram Topic ID (For sending to topics) | Optional |
 | `DISCORD_WEBHOOK_URL` | Discord Webhook URL | Optional |
 | `DISCORD_BOT_TOKEN` | Discord Bot Token (choose one with Webhook) | Optional |
 | `DISCORD_CHANNEL_ID` | Discord Channel ID (required when using Bot) | Optional |

--- a/docs/full-guide.md
+++ b/docs/full-guide.md
@@ -70,6 +70,7 @@ daily_stock_analysis/
 | `FEISHU_WEBHOOK_URL` | 飞书 Webhook URL | 可选 |
 | `TELEGRAM_BOT_TOKEN` | Telegram Bot Token（@BotFather 获取） | 可选 |
 | `TELEGRAM_CHAT_ID` | Telegram Chat ID | 可选 |
+| `TELEGRAM_MESSAGE_THREAD_ID` | Telegram Topic ID (用于发送到子话题) | 可选 |
 | `DISCORD_WEBHOOK_URL` | Discord Webhook URL（[创建方法](https://support.discord.com/hc/en-us/articles/228383668)） | 可选 |
 | `DISCORD_BOT_TOKEN` | Discord Bot Token（与 Webhook 二选一） | 可选 |
 | `DISCORD_CHANNEL_ID` | Discord Channel ID（使用 Bot 时需要） | 可选 |
@@ -154,6 +155,7 @@ daily_stock_analysis/
 | `FEISHU_WEBHOOK_URL` | 飞书机器人 Webhook URL | 可选 |
 | `TELEGRAM_BOT_TOKEN` | Telegram Bot Token | 可选 |
 | `TELEGRAM_CHAT_ID` | Telegram Chat ID | 可选 |
+| `TELEGRAM_MESSAGE_THREAD_ID` | Telegram Topic ID | 可选 |
 | `DISCORD_WEBHOOK_URL` | Discord Webhook URL | 可选 |
 | `DISCORD_BOT_TOKEN` | Discord Bot Token（与 Webhook 二选一） | 可选 |
 | `DISCORD_CHANNEL_ID` | Discord Channel ID（使用 Bot 时需要） | 可选 |
@@ -386,6 +388,7 @@ crontab -e
 2. 获取 Bot Token
 3. 获取 Chat ID（可通过 @userinfobot）
 4. 设置 `TELEGRAM_BOT_TOKEN` 和 `TELEGRAM_CHAT_ID`
+5. (可选) 如需发送到 Topic，设置 `TELEGRAM_MESSAGE_THREAD_ID` (从 Topic 链接末尾获取)
 
 ### 邮件
 

--- a/src/config.py
+++ b/src/config.py
@@ -79,6 +79,7 @@ class Config:
     # Telegram 配置（需要同时配置 Bot Token 和 Chat ID）
     telegram_bot_token: Optional[str] = None  # Bot Token（@BotFather 获取）
     telegram_chat_id: Optional[str] = None  # Chat ID
+    telegram_message_thread_id: Optional[str] = None  # Topic ID (Message Thread ID) for groups
     
     # 邮件配置（只需邮箱和授权码，SMTP 自动识别）
     email_sender: Optional[str] = None  # 发件人邮箱
@@ -336,6 +337,7 @@ class Config:
             feishu_webhook_url=os.getenv('FEISHU_WEBHOOK_URL'),
             telegram_bot_token=os.getenv('TELEGRAM_BOT_TOKEN'),
             telegram_chat_id=os.getenv('TELEGRAM_CHAT_ID'),
+            telegram_message_thread_id=os.getenv('TELEGRAM_MESSAGE_THREAD_ID'),
             email_sender=os.getenv('EMAIL_SENDER'),
             email_password=os.getenv('EMAIL_PASSWORD'),
             email_receivers=[r.strip() for r in os.getenv('EMAIL_RECEIVERS', '').split(',') if r.strip()],


### PR DESCRIPTION
## 变更类型

- [ ] 🐛 Bug 修复
- [x] ✨ 新功能
- [x] 📝 文档更新
- [ ] 🎨 代码优化/重构
- [ ] ⚡ 性能优化
- [x] 🔧 配置/构建相关

## 变更描述

本次 PR 新增了对 Telegram 群组子话题（Topic/Message Thread）通知的支持。

主要变更包括：
1.  **配置增强**：在 `src/config.py` 中新增 `TELEGRAM_MESSAGE_THREAD_ID` 配置项，用于指定消息发送的目标话题 ID。
2.  **功能实现**：修改 `src/notification.py` 中的 Telegram 发送逻辑（`_send_telegram_message` 和 `_send_telegram_chunked`），在调用 Telegram API 时透传 `message_thread_id` 参数。
3.  **文档同步**：同步更新了所有涉及配置的文档，包括 `README.md`、`DEPLOY.md`、`full-guide.md` 以及 GitHub Actions workflow 配置文件，补充了新环境变量的说明。

## 测试说明

描述如何测试这些变更：

1.  **环境配置**：在 `.env` 文件中配置 Telegram 相关的环境变量：
    ```env
    TELEGRAM_BOT_TOKEN=your_bot_token
    TELEGRAM_CHAT_ID=your_chat_id
    TELEGRAM_MESSAGE_THREAD_ID=your_topic_id  # 新增配置，填入目标 Topic 的 ID
    ```
2.  **运行测试**：执行本地测试脚本或运行主程序 `python main.py` 触发通知发送。
3.  **验证结果**：
    *   检查 Telegram 客户端，确认消息是否准确发送到了指定的 Topic 中。
    *   移除 `TELEGRAM_MESSAGE_THREAD_ID` 配置后再次测试，确认消息回退到默认行为（发送到普通群组或 General 话题）。

## 检查清单

- [x] 代码符合项目规范
- [x] 已添加必要的注释/文档
- [x] 已在本地测试通过
- [x] 已更新相关文档（如需要）

## 截图（如适用）

<img width="1170" height="1130" alt="image" src="https://github.com/user-attachments/assets/7bf079d7-0e39-4c2a-835e-37b344e6d9e6" />

## 其他说明

此功能对于使用 Telegram Supergroup 进行消息分类管理的场景非常有用，可以将股票分析报告定向推送到特定的讨论话题中，避免打扰主频道的讨论。

