### PR TITLE
fix: ETF realtime quotes, market data fallback, WeCom chunking, and CI simplification

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,19 +1,9 @@
 # CI 流程 - Pull Request 自动检测
-# 当有 PR 提交或推送到 main 分支时自动运行
+# 仅在 PR 运行，main 分支由 docker-publish 执行发布构建
 
 name: CI
 
 on:
-  push:
-    branches: [main]
-    paths:
-      - '**.py'
-      - 'requirements.txt'
-      - 'pyproject.toml'
-      - 'setup.cfg'
-      - '.github/workflows/**'
-      - 'Dockerfile'
-      - 'docker-compose.yml'
   pull_request:
     branches: [main]
     paths:
@@ -24,6 +14,10 @@ on:
       - '.github/workflows/**'
       - 'Dockerfile'
       - 'docker-compose.yml'
+
+concurrency:
+  group: ci-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   # ==================== 核心检查（必须通过）====================

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -12,6 +12,10 @@ on:
       - 'LICENSE'
       - '.gitignore'
 
+concurrency:
+  group: docker-publish-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build-and-push:
     runs-on: ubuntu-latest

--- a/data_provider/akshare_fetcher.py
+++ b/data_provider/akshare_fetcher.py
@@ -1367,56 +1367,94 @@ class AkshareFetcher(BaseFetcher):
 
     def get_market_stats(self) -> Optional[Dict[str, Any]]:
         """
-        获取市场涨跌统计 (东财接口)
+        获取市场涨跌统计
+
+        数据源优先级：
+        1. 东财接口 (ak.stock_zh_a_spot_em)
+        2. 新浪接口 (ak.stock_zh_a_spot)
         """
         import akshare as ak
+
+        # 优先东财接口
         try:
             self._set_random_user_agent()
             self._enforce_rate_limit()
 
-            # 获取全部A股实时行情
+            logger.info("[API调用] ak.stock_zh_a_spot_em() 获取市场统计...")
             df = ak.stock_zh_a_spot_em()
-
             if df is not None and not df.empty:
-                change_col = '涨跌幅'
-                if change_col in df.columns:
-                    # 转换为数值
-                    df[change_col] = pd.to_numeric(df[change_col], errors='coerce')
-
-                    stats = {
-                        'up_count': len(df[df[change_col] > 0]),
-                        'down_count': len(df[df[change_col] < 0]),
-                        'flat_count': len(df[df[change_col] == 0]),
-                        'limit_up_count': len(df[df[change_col] >= 9.9]),
-                        'limit_down_count': len(df[df[change_col] <= -9.9]),
-                        'total_amount': 0.0
-                    }
-
-                    # 计算两市成交额
-                    amount_col = '成交额'
-                    if amount_col in df.columns:
-                        df[amount_col] = pd.to_numeric(df[amount_col], errors='coerce')
-                        stats['total_amount'] = df[amount_col].sum() / 1e8  # 转为亿元
-
-                    return stats
-            return None
-
+                return self._calc_market_stats(df, change_col='涨跌幅', amount_col='成交额')
         except Exception as e:
-            logger.error(f"[Akshare] 获取市场统计失败: {e}")
+            logger.warning(f"[Akshare] 东财接口获取市场统计失败: {e}，尝试新浪接口")
+
+        # 东财失败后，尝试新浪接口
+        try:
+            self._set_random_user_agent()
+            self._enforce_rate_limit()
+
+            logger.info("[API调用] ak.stock_zh_a_spot() 获取市场统计(新浪)...")
+            df = ak.stock_zh_a_spot()
+            if df is not None and not df.empty:
+                change_col = None
+                for col in ['change_percent', 'changepercent', '涨跌幅', 'trade_ratio']:
+                    if col in df.columns:
+                        change_col = col
+                        break
+
+                amount_col = None
+                for col in ['amount', '成交额', 'trade_amount']:
+                    if col in df.columns:
+                        amount_col = col
+                        break
+
+                if change_col:
+                    return self._calc_market_stats(df, change_col=change_col, amount_col=amount_col)
+        except Exception as e:
+            logger.error(f"[Akshare] 新浪接口获取市场统计也失败: {e}")
+
+        return None
+
+    def _calc_market_stats(
+        self,
+        df: pd.DataFrame,
+        change_col: str,
+        amount_col: Optional[str] = None
+    ) -> Optional[Dict[str, Any]]:
+        """从行情 DataFrame 计算涨跌统计。"""
+        if change_col not in df.columns:
             return None
+
+        df[change_col] = pd.to_numeric(df[change_col], errors='coerce')
+        stats = {
+            'up_count': len(df[df[change_col] > 0]),
+            'down_count': len(df[df[change_col] < 0]),
+            'flat_count': len(df[df[change_col] == 0]),
+            'limit_up_count': len(df[df[change_col] >= 9.9]),
+            'limit_down_count': len(df[df[change_col] <= -9.9]),
+            'total_amount': 0.0,
+        }
+        if amount_col and amount_col in df.columns:
+            df[amount_col] = pd.to_numeric(df[amount_col], errors='coerce')
+            stats['total_amount'] = df[amount_col].sum() / 1e8
+        return stats
 
     def get_sector_rankings(self, n: int = 5) -> Optional[Tuple[List[Dict], List[Dict]]]:
         """
-        获取板块涨跌榜 (东财接口)
+        获取板块涨跌榜
+
+        数据源优先级：
+        1. 东财接口 (ak.stock_board_industry_name_em)
+        2. 新浪接口 (ak.stock_sector_spot)
         """
         import akshare as ak
+
+        # 优先东财接口
         try:
             self._set_random_user_agent()
             self._enforce_rate_limit()
 
-            # 获取行业板块行情
+            logger.info("[API调用] ak.stock_board_industry_name_em() 获取板块排行...")
             df = ak.stock_board_industry_name_em()
-
             if df is not None and not df.empty:
                 change_col = '涨跌幅'
                 if change_col in df.columns:
@@ -1430,7 +1468,6 @@ class AkshareFetcher(BaseFetcher):
                         for _, row in top.iterrows()
                     ]
 
-                    # 跌幅前n
                     bottom = df.nsmallest(n, change_col)
                     bottom_sectors = [
                         {'name': row['板块名称'], 'change_pct': row[change_col]}
@@ -1438,10 +1475,49 @@ class AkshareFetcher(BaseFetcher):
                     ]
 
                     return top_sectors, bottom_sectors
-            return None
-
         except Exception as e:
-            logger.error(f"[Akshare] 获取板块排行失败: {e}")
+            logger.warning(f"[Akshare] 东财接口获取板块排行失败: {e}，尝试新浪接口")
+
+        # 东财失败后，尝试新浪接口
+        try:
+            self._set_random_user_agent()
+            self._enforce_rate_limit()
+
+            logger.info("[API调用] ak.stock_sector_spot() 获取板块排行(新浪)...")
+            df = ak.stock_sector_spot(indicator='新浪行业')
+            if df is None or df.empty:
+                return None
+
+            change_col = None
+            for col in ['涨跌幅', 'change_pct', '涨幅']:
+                if col in df.columns:
+                    change_col = col
+                    break
+
+            name_col = None
+            for col in ['板块', '板块名称', 'label', 'name']:
+                if col in df.columns:
+                    name_col = col
+                    break
+
+            if not change_col or not name_col:
+                return None
+
+            df[change_col] = pd.to_numeric(df[change_col], errors='coerce')
+            df = df.dropna(subset=[change_col])
+            top = df.nlargest(n, change_col)
+            bottom = df.nsmallest(n, change_col)
+            top_sectors = [
+                {'name': str(row[name_col]), 'change_pct': float(row[change_col])}
+                for _, row in top.iterrows()
+            ]
+            bottom_sectors = [
+                {'name': str(row[name_col]), 'change_pct': float(row[change_col])}
+                for _, row in bottom.iterrows()
+            ]
+            return top_sectors, bottom_sectors
+        except Exception as e:
+            logger.error(f"[Akshare] 新浪接口获取板块排行也失败: {e}")
             return None
 
 

--- a/data_provider/efinance_fetcher.py
+++ b/data_provider/efinance_fetcher.py
@@ -27,7 +27,7 @@ import re
 import time
 from dataclasses import dataclass, field
 from datetime import datetime
-from typing import Optional, Dict, Any, List
+from typing import Optional, Dict, Any, List, Tuple
 
 import pandas as pd
 import requests  # 引入 requests 以捕获异常
@@ -106,6 +106,13 @@ USER_AGENTS = [
 # 缓存实时行情数据（避免重复请求）
 # TTL 设为 10 分钟 (600秒)：批量分析场景下避免重复拉取
 _realtime_cache: Dict[str, Any] = {
+    'data': None,
+    'timestamp': 0,
+    'ttl': 600  # 10分钟缓存有效期
+}
+
+# ETF 实时行情缓存（与股票分开缓存）
+_etf_realtime_cache: Dict[str, Any] = {
     'data': None,
     'timestamp': 0,
     'ttl': 600  # 10分钟缓存有效期
@@ -441,11 +448,12 @@ class EfinanceFetcher(BaseFetcher):
         
         return df
     
-    def get_realtime_quote(self, stock_code: str) -> Optional[EfinanceRealtimeQuote]:
+    def get_realtime_quote(self, stock_code: str) -> Optional[UnifiedRealtimeQuote]:
         """
         获取实时行情数据
         
         数据来源：ef.stock.get_realtime_quotes()
+        ETF 数据源：ef.stock.get_realtime_quotes(['ETF'])
         
         Args:
             stock_code: 股票代码
@@ -453,6 +461,10 @@ class EfinanceFetcher(BaseFetcher):
         Returns:
             UnifiedRealtimeQuote 对象，获取失败返回 None
         """
+        # ETF 需要单独请求 ETF 实时行情接口
+        if _is_etf_code(stock_code):
+            return self._get_etf_realtime_quote(stock_code)
+
         import efinance as ef
         circuit_breaker = get_realtime_circuit_breaker()
         source_key = "efinance"
@@ -549,6 +561,262 @@ class EfinanceFetcher(BaseFetcher):
         except Exception as e:
             logger.error(f"[API错误] 获取 {stock_code} 实时行情(efinance)失败: {e}")
             circuit_breaker.record_failure(source_key, str(e))
+            return None
+
+    def _get_etf_realtime_quote(self, stock_code: str) -> Optional[UnifiedRealtimeQuote]:
+        """
+        获取 ETF 实时行情
+
+        efinance 默认实时接口仅返回股票数据，ETF 需要显式传入 ['ETF']。
+        """
+        import efinance as ef
+        circuit_breaker = get_realtime_circuit_breaker()
+        source_key = "efinance_etf"
+
+        if not circuit_breaker.is_available(source_key):
+            logger.warning(f"[熔断] 数据源 {source_key} 处于熔断状态，跳过")
+            return None
+
+        try:
+            current_time = time.time()
+            if (
+                _etf_realtime_cache['data'] is not None and
+                current_time - _etf_realtime_cache['timestamp'] < _etf_realtime_cache['ttl']
+            ):
+                df = _etf_realtime_cache['data']
+                cache_age = int(current_time - _etf_realtime_cache['timestamp'])
+                logger.debug(f"[缓存命中] ETF实时行情(efinance) - 缓存年龄 {cache_age}s/{_etf_realtime_cache['ttl']}s")
+            else:
+                self._set_random_user_agent()
+                self._enforce_rate_limit()
+
+                logger.info("[API调用] ef.stock.get_realtime_quotes(['ETF']) 获取ETF实时行情...")
+                import time as _time
+                api_start = _time.time()
+                df = ef.stock.get_realtime_quotes(['ETF'])
+                api_elapsed = _time.time() - api_start
+
+                if df is not None and not df.empty:
+                    logger.info(f"[API返回] ETF 实时行情成功: {len(df)} 条, 耗时 {api_elapsed:.2f}s")
+                    circuit_breaker.record_success(source_key)
+                else:
+                    logger.warning(f"[API返回] ETF 实时行情为空, 耗时 {api_elapsed:.2f}s")
+                    df = pd.DataFrame()
+
+                _etf_realtime_cache['data'] = df
+                _etf_realtime_cache['timestamp'] = current_time
+
+            if df is None or df.empty:
+                logger.warning(f"[实时行情] ETF实时行情数据为空(efinance)，跳过 {stock_code}")
+                return None
+
+            code_col = '股票代码' if '股票代码' in df.columns else 'code'
+            code_series = df[code_col].astype(str).str.zfill(6)
+            target_code = str(stock_code).strip().zfill(6)
+            row = df[code_series == target_code]
+            if row.empty:
+                logger.warning(f"[API返回] 未找到 ETF {stock_code} 的实时行情(efinance)")
+                return None
+
+            row = row.iloc[0]
+            name_col = '股票名称' if '股票名称' in df.columns else 'name'
+            price_col = '最新价' if '最新价' in df.columns else 'price'
+            pct_col = '涨跌幅' if '涨跌幅' in df.columns else 'pct_chg'
+            chg_col = '涨跌额' if '涨跌额' in df.columns else 'change'
+            vol_col = '成交量' if '成交量' in df.columns else 'volume'
+            amt_col = '成交额' if '成交额' in df.columns else 'amount'
+            turn_col = '换手率' if '换手率' in df.columns else 'turnover_rate'
+            amp_col = '振幅' if '振幅' in df.columns else 'amplitude'
+            high_col = '最高' if '最高' in df.columns else 'high'
+            low_col = '最低' if '最低' in df.columns else 'low'
+            open_col = '开盘' if '开盘' in df.columns else 'open'
+
+            quote = UnifiedRealtimeQuote(
+                code=target_code,
+                name=str(row.get(name_col, '')),
+                source=RealtimeSource.EFINANCE,
+                price=safe_float(row.get(price_col)),
+                change_pct=safe_float(row.get(pct_col)),
+                change_amount=safe_float(row.get(chg_col)),
+                volume=safe_int(row.get(vol_col)),
+                amount=safe_float(row.get(amt_col)),
+                turnover_rate=safe_float(row.get(turn_col)),
+                amplitude=safe_float(row.get(amp_col)),
+                high=safe_float(row.get(high_col)),
+                low=safe_float(row.get(low_col)),
+                open_price=safe_float(row.get(open_col)),
+            )
+
+            logger.info(
+                f"[ETF实时行情-efinance] {target_code} {quote.name}: "
+                f"价格={quote.price}, 涨跌={quote.change_pct}%, 换手率={quote.turnover_rate}%"
+            )
+            return quote
+        except Exception as e:
+            logger.error(f"[API错误] 获取 ETF {stock_code} 实时行情(efinance)失败: {e}")
+            circuit_breaker.record_failure(source_key, str(e))
+            return None
+
+    def get_main_indices(self) -> Optional[List[Dict[str, Any]]]:
+        """
+        获取主要指数实时行情 (efinance)
+        """
+        import efinance as ef
+
+        indices_map = {
+            '000001': ('上证指数', 'sh000001'),
+            '399001': ('深证成指', 'sz399001'),
+            '399006': ('创业板指', 'sz399006'),
+            '000688': ('科创50', 'sh000688'),
+            '000016': ('上证50', 'sh000016'),
+            '000300': ('沪深300', 'sh000300'),
+        }
+
+        try:
+            self._set_random_user_agent()
+            self._enforce_rate_limit()
+
+            logger.info("[API调用] ef.stock.get_realtime_quotes(['沪深系列指数']) 获取指数行情...")
+            import time as _time
+            api_start = _time.time()
+            df = ef.stock.get_realtime_quotes(['沪深系列指数'])
+            api_elapsed = _time.time() - api_start
+
+            if df is None or df.empty:
+                logger.warning(f"[API返回] 指数行情为空, 耗时 {api_elapsed:.2f}s")
+                return None
+
+            logger.info(f"[API返回] 指数行情成功: {len(df)} 条, 耗时 {api_elapsed:.2f}s")
+            code_col = '股票代码' if '股票代码' in df.columns else 'code'
+            code_series = df[code_col].astype(str).str.zfill(6)
+
+            results: List[Dict[str, Any]] = []
+            for code, (name, full_code) in indices_map.items():
+                row = df[code_series == code]
+                if row.empty:
+                    continue
+                item = row.iloc[0]
+
+                price_col = '最新价' if '最新价' in df.columns else 'price'
+                pct_col = '涨跌幅' if '涨跌幅' in df.columns else 'pct_chg'
+                chg_col = '涨跌额' if '涨跌额' in df.columns else 'change'
+                open_col = '开盘' if '开盘' in df.columns else 'open'
+                high_col = '最高' if '最高' in df.columns else 'high'
+                low_col = '最低' if '最低' in df.columns else 'low'
+                vol_col = '成交量' if '成交量' in df.columns else 'volume'
+                amt_col = '成交额' if '成交额' in df.columns else 'amount'
+                amp_col = '振幅' if '振幅' in df.columns else 'amplitude'
+
+                current = safe_float(item.get(price_col, 0))
+                change_amount = safe_float(item.get(chg_col, 0))
+
+                results.append({
+                    'code': full_code,
+                    'name': name,
+                    'current': current,
+                    'change': change_amount,
+                    'change_pct': safe_float(item.get(pct_col, 0)),
+                    'open': safe_float(item.get(open_col, 0)),
+                    'high': safe_float(item.get(high_col, 0)),
+                    'low': safe_float(item.get(low_col, 0)),
+                    'prev_close': current - change_amount if current or change_amount else 0,
+                    'volume': safe_float(item.get(vol_col, 0)),
+                    'amount': safe_float(item.get(amt_col, 0)),
+                    'amplitude': safe_float(item.get(amp_col, 0)),
+                })
+
+            if results:
+                logger.info(f"[efinance] 获取到 {len(results)} 个指数行情")
+            return results if results else None
+        except Exception as e:
+            logger.error(f"[efinance] 获取指数行情失败: {e}")
+            return None
+
+    def get_market_stats(self) -> Optional[Dict[str, Any]]:
+        """
+        获取市场涨跌统计 (efinance)
+        """
+        import efinance as ef
+
+        try:
+            self._set_random_user_agent()
+            self._enforce_rate_limit()
+
+            current_time = time.time()
+            if (
+                _realtime_cache['data'] is not None and
+                current_time - _realtime_cache['timestamp'] < _realtime_cache['ttl']
+            ):
+                df = _realtime_cache['data']
+            else:
+                logger.info("[API调用] ef.stock.get_realtime_quotes() 获取市场统计...")
+                df = ef.stock.get_realtime_quotes()
+                _realtime_cache['data'] = df
+                _realtime_cache['timestamp'] = current_time
+
+            if df is None or df.empty:
+                logger.warning("[API返回] 市场统计数据为空")
+                return None
+
+            change_col = '涨跌幅' if '涨跌幅' in df.columns else 'pct_chg'
+            amount_col = '成交额' if '成交额' in df.columns else 'amount'
+            if change_col not in df.columns:
+                return None
+
+            df[change_col] = pd.to_numeric(df[change_col], errors='coerce')
+            stats = {
+                'up_count': len(df[df[change_col] > 0]),
+                'down_count': len(df[df[change_col] < 0]),
+                'flat_count': len(df[df[change_col] == 0]),
+                'limit_up_count': len(df[df[change_col] >= 9.9]),
+                'limit_down_count': len(df[df[change_col] <= -9.9]),
+                'total_amount': 0.0,
+            }
+            if amount_col in df.columns:
+                df[amount_col] = pd.to_numeric(df[amount_col], errors='coerce')
+                stats['total_amount'] = df[amount_col].sum() / 1e8
+            return stats
+        except Exception as e:
+            logger.error(f"[efinance] 获取市场统计失败: {e}")
+            return None
+
+    def get_sector_rankings(self, n: int = 5) -> Optional[Tuple[List[Dict], List[Dict]]]:
+        """
+        获取板块涨跌榜 (efinance)
+        """
+        import efinance as ef
+
+        try:
+            self._set_random_user_agent()
+            self._enforce_rate_limit()
+
+            logger.info("[API调用] ef.stock.get_realtime_quotes(['行业板块']) 获取板块行情...")
+            df = ef.stock.get_realtime_quotes(['行业板块'])
+            if df is None or df.empty:
+                logger.warning("[efinance] 板块行情数据为空")
+                return None
+
+            change_col = '涨跌幅' if '涨跌幅' in df.columns else 'pct_chg'
+            name_col = '股票名称' if '股票名称' in df.columns else 'name'
+            if change_col not in df.columns or name_col not in df.columns:
+                return None
+
+            df[change_col] = pd.to_numeric(df[change_col], errors='coerce')
+            df = df.dropna(subset=[change_col])
+            top = df.nlargest(n, change_col)
+            bottom = df.nsmallest(n, change_col)
+
+            top_sectors = [
+                {'name': str(row[name_col]), 'change_pct': float(row[change_col])}
+                for _, row in top.iterrows()
+            ]
+            bottom_sectors = [
+                {'name': str(row[name_col]), 'change_pct': float(row[change_col])}
+                for _, row in bottom.iterrows()
+            ]
+            return top_sectors, bottom_sectors
+        except Exception as e:
+            logger.error(f"[efinance] 获取板块排行失败: {e}")
             return None
     
     def get_base_info(self, stock_code: str) -> Optional[Dict[str, Any]]:


### PR DESCRIPTION
- efinance: add an ETF-specific endpoint `get_realtime_quotes(['ETF'])` to fix empty ETF realtime quotes
- efinance: add implementations for `get_main_indices`, `get_market_stats`, and `get_sector_rankings`
- akshare: add Sina fallback for `get_market_stats` and `get_sector_rankings`
- akshare: extract shared `_calc_market_stats` helper
- notification: cap WeCom `text` messages at 2000 bytes and reserve 50 bytes per chunk for pagination markers
- ci: remove `push` trigger and keep `pull_request` only to avoid duplicate builds after merge
- ci/docker-publish: add a `concurrency` group to cancel redundant builds

Fixes #241
Fixes #244


可以，下面这版你可以直接贴到 PR 描述里：

## 变更类型

- [x] 🐛 Bug 修复
- [ ] ✨ 新功能
- [ ] 📝 文档更新
- [x] 🎨 代码优化/重构
- [ ] ⚡ 性能优化
- [x] 🔧 配置/构建相关

## 变更描述

本 PR 主要修复 ETF 实时行情缺失问题，并增强市场数据与通知链路的稳定性：

- `efinance`：新增 ETF 专用实时行情接口调用 `get_realtime_quotes(['ETF'])`，修复 ETF 实时数据为空问题
- `efinance`：补齐 `get_main_indices`、`get_market_stats`、`get_sector_rankings`
- `akshare`：`get_market_stats`、`get_sector_rankings` 增加新浪接口降级逻辑
- `akshare`：提取 `_calc_market_stats` 公共方法，减少重复逻辑
- `notification`：企业微信 `text` 类型按 2000 字节限制分片，并预留 50 字节给分页标记，降低超长发送失败概率
- `CI`：移除 `push` 触发，仅保留 `pull_request`
- `docker-publish`：新增 `concurrency`，取消同分支冗余构建

## 关联 Issue

Fixes #241  
Fixes #244

## 测试说明

1. 安装依赖：`pip install -r requirements.txt pytest`
2. 运行回归：`pytest -q test_*.py`
3. 运行语法检查：`python3 -m py_compile data_provider/efinance_fetcher.py data_provider/akshare_fetcher.py src/notification.py`
4. 手工验证 ETF：`python3 main.py --stocks 563230 --no-market-review --dry-run --no-notify`
5. 手工验证市场复盘：`python3 main.py --market-review --dry-run --no-notify`
6. 手工验证企业微信 text 分片：构造超长消息并确认分片推送成功且带分页标记

当前本地状态：
- 已完成第 3 步（通过）
- 第 1/2/4/5/6 步待在完整依赖环境执行

## 检查清单

- [x] 代码符合项目规范
- [x] 已添加必要的注释/文档
- [ ] 已在本地测试通过
- [ ] 已更新相关文档（如需要）

## 截图（如适用）

无 UI 变更，不适用。

## 其他说明

本 PR 同时优化了 CI 触发策略，避免 `main` 合并后出现重复构建，减少不必要的 CI 资源消耗。