### PR TITLE
feat: stock-to-email group routing (Fix #268)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -93,6 +93,13 @@ BRAVE_API_KEYS=your_brave_key_here
 # EMAIL_PASSWORD=your_email_auth_code
 # EMAIL_RECEIVERS=receiver@example.com  # 可选，留空则发给自己
 #
+# 【方式四扩展】股票分组发往不同邮箱（Issue #268，可选）
+# 配置后，不同股票组的报告发送到对应邮箱；大盘复盘发往所有配置邮箱
+# STOCK_GROUP_1=600519,300750
+# EMAIL_GROUP_1=user1@example.com
+# STOCK_GROUP_2=002594,AAPL
+# EMAIL_GROUP_2=user2@example.com
+#
 # 【方式五】自定义 Webhook（支持多个，逗号分隔）
 # 适用于：钉钉、Discord、Slack、Bark、自建服务等任意支持 POST JSON 的 Webhook
 # 系统会自动识别常见服务并使用对应格式

--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@
 | `EMAIL_PASSWORD` | 邮箱授权码（非登录密码） | 可选 |
 | `EMAIL_RECEIVERS` | 收件人邮箱（多个用逗号分隔，留空则发给自己） | 可选 |
 | `EMAIL_SENDER_NAME` | 邮件发件人显示名称（默认：daily_stock_analysis股票分析助手） | 可选 |
+| `STOCK_GROUP_N` / `EMAIL_GROUP_N` | 股票分组发往不同邮箱（如 `STOCK_GROUP_1=600519,300750` `EMAIL_GROUP_1=user1@example.com`） | 可选 |
 | `PUSHPLUS_TOKEN` | PushPlus Token（[获取地址](https://www.pushplus.plus)，国内推送服务） | 可选 |
 | `SERVERCHAN3_SENDKEY` | Server酱³ Sendkey（[获取地址](https://sc3.ft07.com/)，手机APP推送服务） | 可选 |
 | `CUSTOM_WEBHOOK_URLS` | 自定义 Webhook（支持钉钉等，多个用逗号分隔） | 可选 |

--- a/bot/commands/market.py
+++ b/bot/commands/market.py
@@ -107,7 +107,7 @@ class MarketCommand(BotCommand):
             if review_report:
                 # 推送结果
                 report_content = f"🎯 **大盘复盘**\n\n{review_report}"
-                notifier.send(report_content)
+                notifier.send(report_content, email_send_to_all=True)
                 logger.info("[MarketCommand] 大盘复盘完成并已推送")
             else:
                 logger.warning("[MarketCommand] 大盘复盘返回空结果")

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,13 @@
 格式基于 [Keep a Changelog](https://keepachangelog.com/zh-CN/1.0.0/)，
 版本号遵循 [Semantic Versioning](https://semver.org/lang/zh-CN/)。
 
+## [Unreleased]
+
+### 新增
+- 📧 **股票分组发往不同邮箱** (Issue #268)
+  - 支持 `STOCK_GROUP_N` + `EMAIL_GROUP_N` 配置，不同股票组报告发送到对应邮箱
+  - 大盘复盘发往所有配置的邮箱
+
 ## [3.0.5] - 2026-02-08
 
 ### 修复

--- a/docs/full-guide.md
+++ b/docs/full-guide.md
@@ -168,6 +168,7 @@ daily_stock_analysis/
 | `EMAIL_PASSWORD` | 邮箱授权码（非登录密码） | 可选 |
 | `EMAIL_RECEIVERS` | 收件人邮箱（逗号分隔，留空发给自己） | 可选 |
 | `EMAIL_SENDER_NAME` | 发件人显示名称 | 可选 |
+| `STOCK_GROUP_N` / `EMAIL_GROUP_N` | 股票分组发往不同邮箱（Issue #268），如 `STOCK_GROUP_1=600519,300750` 与 `EMAIL_GROUP_1=user1@example.com` 配对 | 可选 |
 | `CUSTOM_WEBHOOK_URLS` | 自定义 Webhook（逗号分隔） | 可选 |
 | `CUSTOM_WEBHOOK_BEARER_TOKEN` | 自定义 Webhook Bearer Token | 可选 |
 | `PUSHOVER_USER_KEY` | Pushover 用户 Key | 可选 |
@@ -413,6 +414,16 @@ crontab -e
 - QQ 邮箱：smtp.qq.com:465
 - 163 邮箱：smtp.163.com:465
 - Gmail：smtp.gmail.com:587
+
+**股票分组发往不同邮箱**（Issue #268，可选）：
+配置 `STOCK_GROUP_N` 与 `EMAIL_GROUP_N` 可实现不同股票组的报告发送到不同邮箱，例如多人共享分析时互不干扰。大盘复盘会发往所有配置的邮箱。
+
+```bash
+STOCK_GROUP_1=600519,300750
+EMAIL_GROUP_1=user1@example.com
+STOCK_GROUP_2=002594,AAPL
+EMAIL_GROUP_2=user2@example.com
+```
 
 ### 自定义 Webhook
 

--- a/src/core/market_review.py
+++ b/src/core/market_review.py
@@ -67,7 +67,7 @@ def run_market_review(
                 # 添加标题
                 report_content = f"🎯 大盘复盘\n\n{review_report}"
                 
-                success = notifier.send(report_content)
+                success = notifier.send(report_content, email_send_to_all=True)
                 if success:
                     logger.info("大盘复盘推送成功")
                 else:

--- a/src/core/pipeline.py
+++ b/src/core/pipeline.py
@@ -14,6 +14,7 @@ A股自选股智能分析系统 - 核心分析流水线
 import logging
 import time
 import uuid
+from collections import defaultdict
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from datetime import date
 from typing import List, Dict, Any, Optional, Tuple
@@ -568,7 +569,7 @@ class StockAnalysisPipeline:
                             report_content = self.notifier.generate_single_stock_report(result)
                             logger.info(f"[{code}] 使用精简报告格式")
                         
-                        if self.notifier.send(report_content):
+                        if self.notifier.send(report_content, email_stock_codes=[code]):
                             logger.info(f"[{code}] 单股推送成功")
                         else:
                             logger.warning(f"[{code}] 单股推送失败")
@@ -736,6 +737,7 @@ class StockAnalysisPipeline:
 
                 # 其他渠道：发完整报告（避免自定义 Webhook 被 wechat 截断逻辑污染）
                 non_wechat_success = False
+                stock_email_groups = getattr(self.config, 'stock_email_groups', []) or []
                 for channel in channels:
                     if channel == NotificationChannel.WECHAT:
                         continue
@@ -744,7 +746,31 @@ class StockAnalysisPipeline:
                     elif channel == NotificationChannel.TELEGRAM:
                         non_wechat_success = self.notifier.send_to_telegram(report) or non_wechat_success
                     elif channel == NotificationChannel.EMAIL:
-                        non_wechat_success = self.notifier.send_to_email(report) or non_wechat_success
+                        if stock_email_groups:
+                            code_to_emails: Dict[str, Optional[List[str]]] = {}
+                            for r in results:
+                                if r.code not in code_to_emails:
+                                    emails = []
+                                    for stocks, emails_list in stock_email_groups:
+                                        if r.code in stocks:
+                                            emails.extend(emails_list)
+                                    code_to_emails[r.code] = list(dict.fromkeys(emails)) if emails else None
+                            emails_to_results: Dict[Optional[Tuple], List] = defaultdict(list)
+                            for r in results:
+                                recs = code_to_emails.get(r.code)
+                                key = tuple(recs) if recs else None
+                                emails_to_results[key].append(r)
+                            for key, group_results in emails_to_results.items():
+                                grp_report = self.notifier.generate_dashboard_report(group_results)
+                                if key is None:
+                                    non_wechat_success = self.notifier.send_to_email(grp_report) or non_wechat_success
+                                else:
+                                    non_wechat_success = (
+                                        self.notifier.send_to_email(grp_report, receivers=list(key))
+                                        or non_wechat_success
+                                    )
+                        else:
+                            non_wechat_success = self.notifier.send_to_email(report) or non_wechat_success
                     elif channel == NotificationChannel.CUSTOM:
                         non_wechat_success = self.notifier.send_to_custom(report) or non_wechat_success
                     elif channel == NotificationChannel.PUSHPLUS:


### PR DESCRIPTION
## 功能描述
不同股票组的分析报告发送到不同邮箱。

## 实现
- 配置 `STOCK_GROUP_N` + `EMAIL_GROUP_N`（如 STOCK_GROUP_1=600519,300750 与 EMAIL_GROUP_1=user1@example.com）
- 汇总/单股模式下按组路由邮件
- 大盘复盘发往所有配置邮箱

Fixes #268