### PR TITLE
feat: 添加东财接口补丁可配置开关

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -307,3 +307,6 @@ WEBUI_PORT=8000
 
 # 是否启用筹码分布（该接口不稳定，云端部署建议关闭）
 # ENABLE_CHIP_DISTRIBUTION=true
+
+# 是否启用东财请求接口补丁（东财接口无法成功请求时，可尝试开启）
+# ENABLE_EASTMONEY_PATCH=false

--- a/data_provider/akshare_fetcher.py
+++ b/data_provider/akshare_fetcher.py
@@ -41,6 +41,7 @@ from tenacity import (
 )
 
 from patch.eastmoney_patch import eastmoney_patch
+from src.config import get_config
 from .base import BaseFetcher, DataFetchError, RateLimitError, STANDARD_COLUMNS
 from .realtime_types import (
     UnifiedRealtimeQuote, ChipDistribution, RealtimeSource,
@@ -187,7 +188,9 @@ class AkshareFetcher(BaseFetcher):
         self.sleep_min = sleep_min
         self.sleep_max = sleep_max
         self._last_request_time: Optional[float] = None
-        eastmoney_patch()
+        # 东财补丁开启才执行打补丁操作
+        if get_config().enable_eastmoney_patch:
+            eastmoney_patch()
     
     def _set_random_user_agent(self) -> None:
         """

--- a/data_provider/efinance_fetcher.py
+++ b/data_provider/efinance_fetcher.py
@@ -40,6 +40,7 @@ from tenacity import (
 )
 
 from patch.eastmoney_patch import eastmoney_patch
+from src.config import get_config
 from .base import BaseFetcher, DataFetchError, RateLimitError, STANDARD_COLUMNS
 from .realtime_types import (
     UnifiedRealtimeQuote, RealtimeSource,
@@ -183,7 +184,9 @@ class EfinanceFetcher(BaseFetcher):
         self.sleep_min = sleep_min
         self.sleep_max = sleep_max
         self._last_request_time: Optional[float] = None
-        eastmoney_patch()
+        # 东财补丁开启才执行打补丁操作
+        if get_config().enable_eastmoney_patch:
+            eastmoney_patch()
     
     def _set_random_user_agent(self) -> None:
         """

--- a/patch/eastmoney_patch.py
+++ b/patch/eastmoney_patch.py
@@ -134,14 +134,16 @@ def _get_nid(user_agent):
             _cache.expire_at = now + _cache.ttl
             return nid
         except requests.exceptions.RequestException as e:
-            logger.warning(f"请求东方财富授权接口失败: {e}")  # 使用 logger 替换 print
+            logger.warning(f"请求东方财富授权接口失败: {e}")
             _cache.data = None
-            _cache.expire_at = 0  # 立即失效，以便下次重试
+            # 该接口请求失败时，方案可能已失效，后续大概率会继续失败，因无法成功获取，下次会继续请求，设置较长过期时间，可避免频繁请求
+            _cache.expire_at = now + 5 * 60
             return None
         except (KeyError, json.JSONDecodeError) as e:
             logger.warning(f"解析东方财富授权接口响应失败: {e}")
             _cache.data = None
-            _cache.expire_at = 0
+            # 该接口请求失败时，方案可能已失效，后续大概率会继续失败，因无法成功获取，下次会继续请求，设置较长过期时间，可避免频繁请求
+            _cache.expire_at = now + 5 * 60
             return None
 
 

--- a/src/config.py
+++ b/src/config.py
@@ -195,6 +195,8 @@ class Config:
     enable_realtime_quote: bool = True
     # 筹码分布开关（该接口不稳定，云端部署建议关闭）
     enable_chip_distribution: bool = True
+    # 东财接口补丁开关
+    enable_eastmoney_patch: bool = False
     # 实时行情数据源优先级（逗号分隔）
     # 推荐顺序：tencent > akshare_sina > efinance > akshare_em > tushare
     # - tencent: 腾讯财经，有量比/换手率/市盈率等，单股查询稳定（推荐）
@@ -472,6 +474,8 @@ class Config:
             # 实时行情增强数据配置
             enable_realtime_quote=os.getenv('ENABLE_REALTIME_QUOTE', 'true').lower() == 'true',
             enable_chip_distribution=os.getenv('ENABLE_CHIP_DISTRIBUTION', 'true').lower() == 'true',
+            # 东财接口补丁开关
+            enable_eastmoney_patch=os.getenv('ENABLE_EASTMONEY_PATCH', 'false').lower() == 'true',
             # 实时行情数据源优先级：
             # - tencent: 腾讯财经，有量比/换手率/PE/PB等，单股查询稳定（推荐）
             # - akshare_sina: 新浪财经，基本行情稳定，但无量比


### PR DESCRIPTION
东财接口请求补丁不是必要补丁，仅在东财接口无法正常请求情况下的优化功能，且方案存在失效可能，强制开启对系统性能存在一定的影响。此提交增加补丁功能开关，将是否开启权限交还用户，仅在用户配置为开启时生效。

## 变更类型

- [ ] 🐛 Bug 修复
- [ ] ✨ 新功能
- [ ] 📝 文档更新
- [x] 🎨 代码优化/重构
- [ ] ⚡ 性能优化
- [ ] 🔧 配置/构建相关

## 变更描述

- 新增环境变量 ENABLE_EASTMONEY_PATCH（默认 false）不开启东财补丁
- 在Config类中新增enable_eastmoney_patch配置项，默认关闭
- 修改AkshareFetcher和EfinanceFetcher，根据配置决定是否应用东财补丁
- 优化eastmoney_patch.py中的缓存策略（接口 https://anonflow2.eastmoney.com/backend/api/webreport 请求失败后，后续请求有大概率继续失败，原有逻辑将缓存失效会导致后续接口请求前一直请求该接口，影响系统性能）
- 更新.env.example添加ENABLE_EASTMONEY_PATCH配置说明

## 关联 Issue

无

## 测试说明

1. ENABLE_EASTMONEY_PATCH变量设置为true，补丁生效，设置为false，补丁失效

## 检查清单

- [x] 代码符合项目规范
- [x] 已添加必要的注释/文档
- [x] 已在本地测试通过
- [x] 已更新相关文档（如需要）
