### PR TITLE
fix: 统一美股数据源为 YFinance，修复"ADBE技术指标存在矛盾" (Issue #311)

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@
 | 行情数据 | AkShare、Tushare、Pytdx、Baostock、YFinance |
 | 新闻搜索 | Tavily、SerpAPI、Bocha、Brave |
 
+> 注：美股历史数据与实时行情统一使用 YFinance，确保复权一致性
+
 ### 内置交易纪律
 
 | 规则 | 说明 |

--- a/data_provider/akshare_fetcher.py
+++ b/data_provider/akshare_fetcher.py
@@ -234,7 +234,7 @@ class AkshareFetcher(BaseFetcher):
         从 Akshare 获取原始数据
         
         根据代码类型自动选择 API：
-        - 美股：使用 ak.stock_us_daily()
+        - 美股：不支持，抛出异常由 YfinanceFetcher 处理（Issue #311）
         - 港股：使用 ak.stock_hk_hist()
         - ETF 基金：使用 ak.fund_etf_hist_em()
         - 普通 A 股：使用 ak.stock_zh_a_hist()
@@ -248,7 +248,11 @@ class AkshareFetcher(BaseFetcher):
         """
         # 根据代码类型选择不同的获取方法
         if _is_us_code(stock_code):
-            return self._fetch_us_data(stock_code, start_date, end_date)
+            # 美股：akshare 的 stock_us_daily 接口复权存在已知问题（参见 Issue #311）
+            # 交由 YfinanceFetcher 处理，确保复权价格一致
+            raise DataFetchError(
+                f"AkshareFetcher 不支持美股 {stock_code}，请使用 YfinanceFetcher 获取正确的复权价格"
+            )
         elif _is_hk_code(stock_code):
             return self._fetch_hk_data(stock_code, start_date, end_date)
         elif _is_etf_code(stock_code):

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,7 @@
 ## [Unreleased]
 
 ### 修复
+- 修复美股（如 ADBE）技术指标矛盾：akshare 美股复权数据异常，统一美股历史数据源为 YFinance（Issue #311）
 - 🐛 **美股指数实时行情与日线数据** (Issue #273)
   - 修复 SPX、DJI、IXIC、NDX、VIX、RUT 等美股指数无法获取实时行情的问题
   - 新增 `us_index_mapping` 模块，将用户输入（如 SPX）映射为 Yahoo Finance 符号（如 ^GSPC）

--- a/docs/full-guide.md
+++ b/docs/full-guide.md
@@ -560,6 +560,7 @@ PUSHOVER_API_TOKEN=your_api_token
 ### YFinance
 - 免费，无需配置
 - 支持美股/港股数据
+- 美股历史数据与实时行情均统一使用 YFinance，以避免 akshare 美股复权异常导致的技术指标错误
 
 ---
 

--- a/docs/full-guide_EN.md
+++ b/docs/full-guide_EN.md
@@ -487,6 +487,7 @@ System defaults to AkShare (free), also supports other data sources:
 ### YFinance
 - Free, no configuration needed
 - Supports US/HK stock data
+- US stock historical and real-time data both use YFinance exclusively to avoid technical indicator errors from akshare's US stock adjustment issues
 
 ---
 


### PR DESCRIPTION
## 问题

ADBE 等美股的当日收盘价异常（约为当前价一半），导致 MA5、MA10 等技术指标计算错误。

原因：akshare 的 `stock_us_daily(adjust="qfq")` 复权处理存在已知问题（参考 akfamily/akshare#4998），历史数据与实时行情来自不同数据源，复权基准不一致。

## 变更范围

- **data_provider/akshare_fetcher.py**：美股直接抛出 DataFetchError，交由 YfinanceFetcher 处理
- **docs**：更新 full-guide、README、CHANGELOG

## 验证方式

```bash
python -c "
from data_provider.base import DataFetcherManager
mgr = DataFetcherManager()
df, source = mgr.get_daily_data('ADBE', days=5)
print(f'数据源: {source}')"  # 预期: YfinanceFetcher
```

## 兼容性

A 股、港股、ETF 行为不变，无架构改动。