### PR TITLE
fix: BOT 与 WEB UI 股票代码大小写统一 (Issue #355)

### DIFF
--- a/api/v1/endpoints/analysis.py
+++ b/api/v1/endpoints/analysis.py
@@ -43,6 +43,7 @@ from api.v1.schemas.history import (
     ReportStrategy,
     ReportDetails,
 )
+from data_provider.base import canonical_stock_code
 from src.config import Config
 from src.services.task_queue import (
     get_task_queue,
@@ -115,7 +116,8 @@ def trigger_analysis(
             }
         )
 
-    # 去重
+    # 统一大小写后去重，确保 ['aapl', 'AAPL'] 被识别为同一股票（Issue #355）
+    stock_codes = [canonical_stock_code(c) for c in stock_codes]
     stock_codes = list(dict.fromkeys(stock_codes))
     stock_code = stock_codes[0]  # 当前只处理第一个
 

--- a/bot/commands/analyze.py
+++ b/bot/commands/analyze.py
@@ -13,6 +13,7 @@ from typing import List, Optional
 
 from bot.commands.base import BotCommand
 from bot.models import BotMessage, BotResponse
+from data_provider.base import canonical_stock_code
 
 logger = logging.getLogger(__name__)
 
@@ -66,7 +67,7 @@ class AnalyzeCommand(BotCommand):
     
     def execute(self, message: BotMessage, args: List[str]) -> BotResponse:
         """执行分析命令"""
-        code = args[0].lower()
+        code = canonical_stock_code(args[0])
         
         # 检查是否需要完整报告（默认精简，传 full/完整/详细 切换）
         report_type = "simple"

--- a/data_provider/base.py
+++ b/data_provider/base.py
@@ -74,6 +74,23 @@ def normalize_stock_code(stock_code: str) -> str:
     return code
 
 
+def canonical_stock_code(code: str) -> str:
+    """
+    Return the canonical (uppercase) form of a stock code.
+
+    This is a display/storage layer concern, distinct from normalize_stock_code
+    which strips exchange prefixes. Apply at system input boundaries to ensure
+    consistent case across BOT, WEB UI, API, and CLI paths (Issue #355).
+
+    Examples:
+        'aapl'    -> 'AAPL'
+        'AAPL'    -> 'AAPL'
+        '600519'  -> '600519'  (digits are unchanged)
+        'hk00700' -> 'HK00700'
+    """
+    return (code or "").strip().upper()
+
+
 class DataFetchError(Exception):
     """数据获取异常基类"""
     pass

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,6 +11,10 @@
 - **Web 登录认证重构**：移除 `ADMIN_PASSWORD`、`ADMIN_PASSWORD_HASH`，改用 `ADMIN_AUTH_ENABLED` 开关 + 文件凭证。启用后首次访问在网页设置初始密码，支持「系统设置 > 修改密码」和 CLI `python -m src.auth reset_password` 重置。
 
 ### 修复
+- 🐛 **BOT 与 WEB UI 股票代码大小写统一** (Issue #355)
+  - BOT `/analyze` 与 WEB UI 触发分析的股票代码统一为大写（如 `aapl` → `AAPL`）
+  - 新增 `canonical_stock_code()`，在 BOT、API、Config、CLI、task_queue 入口处规范化
+  - 历史记录与任务去重逻辑可正确识别同一股票（大小写不再影响）
 - 修复美股（如 ADBE）技术指标矛盾：akshare 美股复权数据异常，统一美股历史数据源为 YFinance（Issue #311）
 - 🐛 **美股指数实时行情与日线数据** (Issue #273)
   - 修复 SPX、DJI、IXIC、NDX、VIX、RUT 等美股指数无法获取实时行情的问题

--- a/main.py
+++ b/main.py
@@ -44,6 +44,7 @@ from datetime import datetime, timezone, timedelta
 from pathlib import Path
 from typing import List, Optional
 
+from data_provider.base import canonical_stock_code
 from src.core.pipeline import StockAnalysisPipeline
 from src.core.market_review import run_market_review
 
@@ -446,10 +447,10 @@ def main() -> int:
     for warning in warnings:
         logger.warning(warning)
 
-    # 解析股票列表
+    # 解析股票列表（统一为大写 Issue #355）
     stock_codes = None
     if args.stocks:
-        stock_codes = [code.strip() for code in args.stocks.split(',') if code.strip()]
+        stock_codes = [canonical_stock_code(c) for c in args.stocks.split(',') if (c or "").strip()]
         logger.info(f"使用命令行指定的股票列表: {stock_codes}")
 
     # === 处理 --webui / --webui-only 参数，映射到 --serve / --serve-only ===

--- a/src/config.py
+++ b/src/config.py
@@ -337,12 +337,12 @@ class Config:
                 os.environ['https_proxy'] = https_proxy
 
         
-        # 解析自选股列表（逗号分隔）
+        # 解析自选股列表（逗号分隔，统一为大写 Issue #355）
         stock_list_str = os.getenv('STOCK_LIST', '')
         stock_list = [
-            code.strip() 
-            for code in stock_list_str.split(',') 
-            if code.strip()
+            (c or "").strip().upper()
+            for c in stock_list_str.split(',')
+            if (c or "").strip()
         ]
         
         # 如果没有配置，使用默认的示例股票
@@ -594,12 +594,12 @@ class Config:
             stock_list_str = os.getenv('STOCK_LIST', '')
 
         stock_list = [
-            code.strip()
-            for code in stock_list_str.split(',')
-            if code.strip()
+            (c or "").strip().upper()
+            for c in stock_list_str.split(',')
+            if (c or "").strip()
         ]
 
-        if not stock_list:        
+        if not stock_list:
             stock_list = ['000001']
 
         self.stock_list = stock_list

--- a/src/services/task_queue.py
+++ b/src/services/task_queue.py
@@ -26,6 +26,8 @@ from typing import Optional, Dict, Set, List, Callable, Any, TYPE_CHECKING
 if TYPE_CHECKING:
     from asyncio import Queue as AsyncQueue
 
+from data_provider.base import canonical_stock_code
+
 logger = logging.getLogger(__name__)
 
 
@@ -215,6 +217,7 @@ class AnalysisTaskQueue:
         Raises:
             DuplicateTaskError: 股票正在分析中
         """
+        stock_code = canonical_stock_code(stock_code)
         with self._data_lock:
             # 检查重复
             if stock_code in self._analyzing_stocks:


### PR DESCRIPTION
## 背景与问题

BOT 触发分析的股票代码为小写（如 `aapl`），而 WEB UI 的为大写（如 `AAPL`），导致：
- 历史记录中同一只股票出现两种写法
- API 路径的任务去重依赖 `stock_code` 完全匹配，大小写不统一会导致防重复逻辑失效

Fixes #355

## 变更范围

| 文件 | 改动 |
|------|------|
| `data_provider/base.py` | 新增 `canonical_stock_code()` |
| `bot/commands/analyze.py` | `args[0].lower()` → `args[0].strip().upper()` |
| `src/config.py` | Config.load() 与 refresh_stock_list() 中股票代码统一为大写 |
| `api/v1/endpoints/analysis.py` | stock_codes 去重后应用 `canonical_stock_code` |
| `src/services/task_queue.py` | submit_task() 入口处对 stock_code 规范化 |
| `main.py` | CLI `--stocks` 解析时应用 `canonical_stock_code` |
| `docs/CHANGELOG.md` | 新增修复条目 |

## 验证方式

- `./test.sh syntax` 已通过
- BOT: `/analyze aapl` → 历史记录显示 `AAPL`
- WEB UI: 输入 `aapl` → 历史记录显示 `AAPL`

## 兼容性与回滚

- 无破坏性变更
- 回滚：撤销上述文件改动即可，无数据库变更