### PR TITLE
fix: StockTrendAnalyzer 因 raw_data 缺失未执行 (Issue #357)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,6 +11,10 @@
 - **Web 登录认证重构**：移除 `ADMIN_PASSWORD`、`ADMIN_PASSWORD_HASH`，改用 `ADMIN_AUTH_ENABLED` 开关 + 文件凭证。启用后首次访问在网页设置初始密码，支持「系统设置 > 修改密码」和 CLI `python -m src.auth reset_password` 重置。
 
 ### 修复
+- 🐛 **StockTrendAnalyzer 从未执行** (Issue #357)
+  - 根因：`get_analysis_context` 仅返回 2 天数据且无 `raw_data`，pipeline 中 `raw_data in context` 始终为 False
+  - 修复：Step 3 直接调用 `get_data_range` 获取 90 日历天（约 60 交易日）历史数据用于趋势分析
+  - 改善：趋势分析失败时用 `logger.warning(..., exc_info=True)` 记录完整 traceback
 - 🐛 **BOT 与 WEB UI 股票代码大小写统一** (Issue #355)
   - BOT `/analyze` 与 WEB UI 触发分析的股票代码统一为大写（如 `aapl` → `AAPL`）
   - 新增 `canonical_stock_code()`，在 BOT、API、Config、CLI、task_queue 入口处规范化


### PR DESCRIPTION
## 背景与问题

`StockTrendAnalyzer` 类（约 800 行代码）自部署以来从未被实际执行。根因是 `get_analysis_context()` 返回的 context 中不包含 `raw_data` 字段，导致 pipeline 中检查 `raw_data` 的条件始终为 false，趋势分析逻辑被完全跳过。由于外层 try/except 静默吞掉了异常，问题一直未被发现。

此问题在 #355 的调查过程中被发现。

Fixes #357

## 变更范围

| 文件 | 改动 |
|------|------|
| `src/core/pipeline.py` | Step 3 趋势分析：不再依赖 `get_analysis_context` 的 `raw_data`，直接调用 `get_data_range` 获取 90 日历天（约 60 交易日）历史数据；异常日志增加 `exc_info=True` 记录完整 traceback |
| `docs/CHANGELOG.md` | 新增修复条目 |

## 验证方式

- `python -m py_compile src/core/pipeline.py` 通过
- `./test.sh syntax` 通过
- `pytest tests/test_stock_analyzer_bias.py tests/test_get_latest_data.py` 全部通过

## 兼容性与回滚

- 无破坏性变更
- 回滚：撤销上述文件改动即可