### PR TITLE
[Feature] 增加交易日判断 #373

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,6 +19,8 @@ TUSHARE_TOKEN=your_tushare_token_here
 # SCHEDULE_TIME=18:00
 # 启动时是否立即运行一次（默认 true）
 # SCHEDULE_RUN_IMMEDIATELY=false
+# 交易日检查：默认 true，非交易日跳过执行；设为 false 或使用 --force-run 可强制执行（Issue #373）
+# TRADING_DAY_CHECK_ENABLED=true
 
 # ===================================
 # AI 模型配置（多选一，至少配置一个）

--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@
 | `AGENT_MODE` | 开启 Agent 策略问股模式（`true`/`false`，默认 false） | 可选 |
 | `AGENT_MAX_STEPS` | Agent 最大推理步数（默认 10） | 可选 |
 | `AGENT_STRATEGY_DIR` | 自定义策略目录（默认内置 `strategies/`） | 可选 |
+| `TRADING_DAY_CHECK_ENABLED` | 交易日检查（默认 `true`）：非交易日跳过执行；设为 `false` 或使用 `--force-run` 强制执行 | 可选 |
 
 #### 3. 启用 Actions
 
@@ -150,7 +151,7 @@
 
 #### 完成
 
-默认每个**工作日 18:00（北京时间）**自动执行，也可手动触发
+默认每个**工作日 18:00（北京时间）**自动执行，也可手动触发。默认非交易日（含 A/H/US 节假日）不执行；可使用 `TRADING_DAY_CHECK_ENABLED=false` 或 `--force-run` 强制执行。
 
 ### 方式二：本地运行 / Docker 部署
 

--- a/data_provider/__init__.py
+++ b/data_provider/__init__.py
@@ -31,7 +31,7 @@
 
 from .base import BaseFetcher, DataFetcherManager
 from .efinance_fetcher import EfinanceFetcher
-from .akshare_fetcher import AkshareFetcher
+from .akshare_fetcher import AkshareFetcher, is_hk_stock_code
 from .tushare_fetcher import TushareFetcher
 from .pytdx_fetcher import PytdxFetcher
 from .baostock_fetcher import BaostockFetcher
@@ -49,6 +49,7 @@ __all__ = [
     'YfinanceFetcher',
     'is_us_index_code',
     'is_us_stock_code',
+    'is_hk_stock_code',
     'get_us_index_yf_symbol',
     'US_INDEX_MAPPING',
 ]

--- a/data_provider/akshare_fetcher.py
+++ b/data_provider/akshare_fetcher.py
@@ -130,6 +130,21 @@ def _is_hk_code(stock_code: str) -> bool:
     return code.isdigit() and len(code) == 5
 
 
+def is_hk_stock_code(stock_code: str) -> bool:
+    """
+    Public API: determine if a stock code is a Hong Kong stock.
+
+    Delegates to _is_hk_code for internal compatibility.
+
+    Args:
+        stock_code: Stock code (e.g. '00700', 'hk00700')
+
+    Returns:
+        True if HK stock, False otherwise
+    """
+    return _is_hk_code(stock_code)
+
+
 def _is_us_code(stock_code: str) -> bool:
     """
     判断代码是否为美股股票（不包括美股指数）。

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,13 @@
 ## [Unreleased]
 
 ### 新增（#minor）
+- 📅 **交易日判断**（Issue #373）
+  - 默认非交易日不执行分析，按 A 股 / 港股 / 美股各自交易日历区分
+  - 混合持仓时，每只股票只在其市场开市日分析，休市股票当日跳过
+  - 全部相关市场休市时，整体跳过执行（不启动 pipeline、不发推送）
+  - 依赖 `exchange-calendars`（A 股 XSHG、港股 XHKG、美股 XNYS）
+  - 配置项：`TRADING_DAY_CHECK_ENABLED`（默认 `true`）
+  - 覆盖方式：`--force-run` 或 `TRADING_DAY_CHECK_ENABLED=false`
 - 🤖 **Agent 策略问股**（全链路，#367）
   - **API**：新增 `/api/v1/agent/strategies`（获取策略列表）与 `/api/v1/agent/chat/stream`（SSE 流式对话）
   - **核心**：`src/agent/`（AgentExecutor ReAct 循环、LLMToolAdapter 多厂商适配、ConversationManager 会话持久化、ToolRegistry 工具注册）

--- a/docs/full-guide.md
+++ b/docs/full-guide.md
@@ -228,6 +228,7 @@ daily_stock_analysis/
 | `MAX_WORKERS` | 并发线程数 | `3` |
 | `MARKET_REVIEW_ENABLED` | 启用大盘复盘 | `true` |
 | `MARKET_REVIEW_REGION` | 大盘复盘市场区域：cn(A股)、us(美股)、both(两者)，us 适合仅关注美股的用户 | `cn` |
+| `TRADING_DAY_CHECK_ENABLED` | 交易日检查：默认 `true`，非交易日跳过执行；设为 `false` 或使用 `--force-run` 可强制执行（Issue #373） | `true` |
 | `SCHEDULE_ENABLED` | 启用定时任务 | `false` |
 | `SCHEDULE_TIME` | 定时执行时间 | `18:00` |
 | `LOG_DIR` | 日志目录 | `./logs` |
@@ -357,6 +358,7 @@ python main.py --stocks 600519,300750 # 指定股票
 python main.py --dry-run              # 仅获取数据，不 AI 分析
 python main.py --no-notify            # 不发送推送
 python main.py --schedule             # 定时任务模式
+python main.py --force-run            # 非交易日也强制执行（Issue #373）
 python main.py --debug                # 调试模式（详细日志）
 python main.py --workers 5            # 指定并发数
 ```
@@ -408,6 +410,7 @@ python main.py --schedule --no-run-immediately
 | `SCHEDULE_ENABLED` | 是否启用定时任务 | `false` | `true` |
 | `SCHEDULE_TIME` | 每日执行时间 (HH:MM) | `18:00` | `09:30` |
 | `SCHEDULE_RUN_IMMEDIATELY` | 启动服务时是否立即运行一次 | `true` | `false` |
+| `TRADING_DAY_CHECK_ENABLED` | 交易日检查：非交易日跳过执行；设为 `false` 可强制执行 | `true` | `false` |
 
 例如在 Docker 中配置：
 
@@ -415,6 +418,14 @@ python main.py --schedule --no-run-immediately
 # 设置启动时不立即分析
 docker run -e SCHEDULE_ENABLED=true -e SCHEDULE_RUN_IMMEDIATELY=false ...
 ```
+
+#### 交易日判断（Issue #373）
+
+默认根据自选股市场（A 股 / 港股 / 美股）和 `MARKET_REVIEW_REGION` 判断是否为交易日：
+- 使用 `exchange-calendars` 区分 A 股 / 港股 / 美股各自的交易日历（含节假日）
+- 混合持仓时，每只股票只在其市场开市日分析，休市股票当日跳过
+- 全部相关市场均为非交易日时，整体跳过执行（不启动 pipeline、不发推送）
+- 覆盖方式：`TRADING_DAY_CHECK_ENABLED=false` 或 命令行 `--force-run`
 
 #### 使用 Crontab
 

--- a/main.py
+++ b/main.py
@@ -42,7 +42,7 @@ import time
 import uuid
 from datetime import datetime, timezone, timedelta
 from pathlib import Path
-from typing import List, Optional
+from typing import List, Optional, Tuple
 
 from data_provider.base import canonical_stock_code
 from src.core.pipeline import StockAnalysisPipeline
@@ -135,6 +135,12 @@ def parse_arguments() -> argparse.Namespace:
     )
 
     parser.add_argument(
+        '--force-run',
+        action='store_true',
+        help='跳过交易日检查，强制执行全量分析（Issue #373）'
+    )
+
+    parser.add_argument(
         '--webui',
         action='store_true',
         help='启动 Web 管理界面'
@@ -208,6 +214,48 @@ def parse_arguments() -> argparse.Namespace:
     return parser.parse_args()
 
 
+def _compute_trading_day_filter(
+    config: Config,
+    args: argparse.Namespace,
+    stock_codes: List[str],
+) -> Tuple[List[str], Optional[str], bool]:
+    """
+    Compute filtered stock list and effective market review region (Issue #373).
+
+    Returns:
+        (filtered_codes, effective_region, should_skip_all)
+        - effective_region None = use config default (check disabled)
+        - effective_region '' = all relevant markets closed, skip market review
+        - should_skip_all: skip entire run when no stocks and no market review to run
+    """
+    force_run = getattr(args, 'force_run', False)
+    if force_run or not getattr(config, 'trading_day_check_enabled', True):
+        return (stock_codes, None, False)
+
+    from src.core.trading_calendar import (
+        get_market_for_stock,
+        get_open_markets_today,
+        compute_effective_region,
+    )
+
+    open_markets = get_open_markets_today()
+    filtered_codes = []
+    for code in stock_codes:
+        mkt = get_market_for_stock(code)
+        if mkt in open_markets or mkt is None:
+            filtered_codes.append(code)
+
+    if config.market_review_enabled and not getattr(args, 'no_market_review', False):
+        effective_region = compute_effective_region(
+            getattr(config, 'market_review_region', 'cn') or 'cn', open_markets
+        )
+    else:
+        effective_region = None
+
+    should_skip_all = (not filtered_codes) and (effective_region or '') == ''
+    return (filtered_codes, effective_region, should_skip_all)
+
+
 def run_full_analysis(
     config: Config,
     args: argparse.Namespace,
@@ -219,6 +267,21 @@ def run_full_analysis(
     这是定时任务调用的主函数
     """
     try:
+        # Issue #373: Trading day filter (per-stock, per-market)
+        effective_codes = stock_codes if stock_codes is not None else config.stock_list
+        filtered_codes, effective_region, should_skip = _compute_trading_day_filter(
+            config, args, effective_codes
+        )
+        if should_skip:
+            logger.info(
+                "今日所有相关市场均为非交易日，跳过执行。可使用 --force-run 强制执行。"
+            )
+            return
+        if set(filtered_codes) != set(effective_codes):
+            skipped = set(effective_codes) - set(filtered_codes)
+            logger.info("今日休市股票已跳过: %s", skipped)
+        stock_codes = filtered_codes
+
         # 命令行参数 --single-notify 覆盖配置（#55）
         if getattr(args, 'single_notify', False):
             config.single_stock_notify = True
@@ -254,20 +317,29 @@ def run_full_analysis(
 
         # Issue #128: 分析间隔 - 在个股分析和大盘分析之间添加延迟
         analysis_delay = getattr(config, 'analysis_delay', 0)
-        if analysis_delay > 0 and config.market_review_enabled and not args.no_market_review:
+        if (
+            analysis_delay > 0
+            and config.market_review_enabled
+            and not args.no_market_review
+            and effective_region != ''
+        ):
             logger.info(f"等待 {analysis_delay} 秒后执行大盘复盘（避免API限流）...")
             time.sleep(analysis_delay)
 
         # 2. 运行大盘复盘（如果启用且不是仅个股模式）
         market_report = ""
-        if config.market_review_enabled and not args.no_market_review:
-            # 只调用一次，并获取结果
+        if (
+            config.market_review_enabled
+            and not args.no_market_review
+            and effective_region != ''
+        ):
             review_result = run_market_review(
                 notifier=pipeline.notifier,
                 analyzer=pipeline.analyzer,
                 search_service=pipeline.search_service,
                 send_notification=not args.no_notify,
-                merge_notification=merge_notification
+                merge_notification=merge_notification,
+                override_region=effective_region,
             )
             # 如果有结果，赋值给 market_report 用于后续飞书文档生成
             if review_result:
@@ -523,6 +595,21 @@ def main() -> int:
             from src.notification import NotificationService
             from src.search_service import SearchService
 
+            # Issue #373: Trading day check for market-review-only mode.
+            # Do NOT use _compute_trading_day_filter here: that helper checks
+            # config.market_review_enabled, which would wrongly block an
+            # explicit --market-review invocation when the flag is disabled.
+            effective_region = None
+            if not getattr(args, 'force_run', False) and getattr(config, 'trading_day_check_enabled', True):
+                from src.core.trading_calendar import get_open_markets_today, compute_effective_region as _compute_region
+                open_markets = get_open_markets_today()
+                effective_region = _compute_region(
+                    getattr(config, 'market_review_region', 'cn') or 'cn', open_markets
+                )
+                if effective_region == '':
+                    logger.info("今日大盘复盘相关市场均为非交易日，跳过执行。可使用 --force-run 强制执行。")
+                    return 0
+
             logger.info("模式: 仅大盘复盘")
             notifier = NotificationService()
 
@@ -551,7 +638,8 @@ def main() -> int:
                 notifier=notifier,
                 analyzer=analyzer,
                 search_service=search_service,
-                send_notification=not args.no_notify
+                send_notification=not args.no_notify,
+                override_region=effective_region,
             )
             return 0
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@ python-dotenv>=1.0.0        # 环境变量配置管理
 tenacity>=8.2.0             # 重试机制（指数退避）
 sqlalchemy>=2.0.0           # ORM数据库操作
 schedule>=1.2.0             # 定时任务调度
+exchange-calendars>=4.5.0   # 交易日历（A股/港股/美股，Issue #373）
 
 # 数据源依赖（多源策略，按优先级排序）
 efinance>=0.5.5             # Priority 0: 东方财富数据源（最高优先级）https://github.com/Micro-sheep/efinance

--- a/src/config.py
+++ b/src/config.py
@@ -202,6 +202,8 @@ class Config:
     market_review_enabled: bool = True        # 是否启用大盘复盘
     # 大盘复盘市场区域：cn(A股)、us(美股)、both(两者)，us 适合仅关注美股的用户
     market_review_region: str = "cn"
+    # 交易日检查：默认启用，非交易日跳过执行；设为 false 或 --force-run 可强制执行（Issue #373）
+    trading_day_check_enabled: bool = True
 
     # === 实时行情增强数据配置 ===
     # 实时行情开关（关闭后使用历史收盘价进行分析）
@@ -476,6 +478,7 @@ class Config:
             market_review_region=cls._parse_market_review_region(
                 os.getenv('MARKET_REVIEW_REGION', 'cn')
             ),
+            trading_day_check_enabled=os.getenv('TRADING_DAY_CHECK_ENABLED', 'true').lower() != 'false',
             webui_enabled=os.getenv('WEBUI_ENABLED', 'false').lower() == 'true',
             webui_host=os.getenv('WEBUI_HOST', '127.0.0.1'),
             webui_port=int(os.getenv('WEBUI_PORT', '8000')),

--- a/src/core/market_review.py
+++ b/src/core/market_review.py
@@ -29,7 +29,8 @@ def run_market_review(
     analyzer: Optional[GeminiAnalyzer] = None,
     search_service: Optional[SearchService] = None,
     send_notification: bool = True,
-    merge_notification: bool = False
+    merge_notification: bool = False,
+    override_region: Optional[str] = None,
 ) -> Optional[str]:
     """
     执行大盘复盘分析
@@ -40,13 +41,18 @@ def run_market_review(
         search_service: 搜索服务（可选）
         send_notification: 是否发送通知
         merge_notification: 是否合并推送（跳过本次推送，由 main 层合并个股+大盘后统一发送，Issue #190）
+        override_region: 覆盖 config 的 market_review_region（Issue #373 交易日过滤后有效子集）
 
     Returns:
         复盘报告文本
     """
     logger.info("开始执行大盘复盘分析...")
     config = get_config()
-    region = getattr(config, 'market_review_region', 'cn') or 'cn'
+    region = (
+        override_region
+        if override_region is not None
+        else (getattr(config, 'market_review_region', 'cn') or 'cn')
+    )
     if region not in ('cn', 'us', 'both'):
         region = 'cn'
 

--- a/src/core/trading_calendar.py
+++ b/src/core/trading_calendar.py
@@ -1,0 +1,145 @@
+# -*- coding: utf-8 -*-
+"""
+===================================
+交易日历模块 (Issue #373)
+===================================
+
+职责：
+1. 按市场（A股/港股/美股）判断当日是否为交易日
+2. 按市场时区取“今日”日期，避免服务器 UTC 导致日期错误
+3. 支持 per-stock 过滤：只分析当日开市市场的股票
+
+依赖：exchange-calendars（可选，不可用时 fail-open）
+"""
+
+import logging
+from datetime import date, datetime
+from typing import Optional, Set
+
+logger = logging.getLogger(__name__)
+
+# Exchange-calendars availability
+_XCALS_AVAILABLE = False
+try:
+    import exchange_calendars as xcals
+    _XCALS_AVAILABLE = True
+except ImportError:
+    logger.warning(
+        "exchange-calendars not installed; trading day check disabled. "
+        "Run: pip install exchange-calendars"
+    )
+
+# Market -> exchange code (exchange-calendars)
+MARKET_EXCHANGE = {"cn": "XSHG", "hk": "XHKG", "us": "XNYS"}
+
+# Market -> IANA timezone for "today"
+MARKET_TIMEZONE = {
+    "cn": "Asia/Shanghai",
+    "hk": "Asia/Hong_Kong",
+    "us": "America/New_York",
+}
+
+
+def get_market_for_stock(code: str) -> Optional[str]:
+    """
+    Infer market region for a stock code.
+
+    Returns:
+        'cn' | 'hk' | 'us' | None (None = unrecognized, fail-open: treat as open)
+    """
+    if not code or not isinstance(code, str):
+        return None
+    code = (code or "").strip().upper()
+
+    from data_provider import is_us_stock_code, is_us_index_code, is_hk_stock_code
+
+    if is_us_stock_code(code) or is_us_index_code(code):
+        return "us"
+    if is_hk_stock_code(code):
+        return "hk"
+    # A-share: 6-digit numeric
+    if code.isdigit() and len(code) == 6:
+        return "cn"
+    return None
+
+
+def is_market_open(market: str, check_date: date) -> bool:
+    """
+    Check if the given market is open on the given date.
+
+    Fail-open: returns True if exchange-calendars unavailable or date out of range.
+
+    Args:
+        market: 'cn' | 'hk' | 'us'
+        check_date: Date to check
+
+    Returns:
+        True if trading day (or fail-open), False otherwise
+    """
+    if not _XCALS_AVAILABLE:
+        return True
+    ex = MARKET_EXCHANGE.get(market)
+    if not ex:
+        return True
+    try:
+        cal = xcals.get_calendar(ex)
+        session = datetime(check_date.year, check_date.month, check_date.day)
+        return cal.is_session(session)
+    except Exception as e:
+        logger.warning("trading_calendar.is_market_open fail-open: %s", e)
+        return True
+
+
+def get_open_markets_today() -> Set[str]:
+    """
+    Get markets that are open today (by each market's local timezone).
+
+    Returns:
+        Set of market keys ('cn', 'hk', 'us') that are trading today
+    """
+    if not _XCALS_AVAILABLE:
+        return {"cn", "hk", "us"}
+    result: Set[str] = set()
+    from zoneinfo import ZoneInfo
+    for mkt, tz_name in MARKET_TIMEZONE.items():
+        try:
+            tz = ZoneInfo(tz_name)
+            today = datetime.now(tz).date()
+            if is_market_open(mkt, today):
+                result.add(mkt)
+        except Exception as e:
+            logger.warning("get_open_markets_today fail-open for %s: %s", mkt, e)
+            result.add(mkt)
+    return result
+
+
+def compute_effective_region(
+    config_region: str, open_markets: Set[str]
+) -> Optional[str]:
+    """
+    Compute effective market review region given config and open markets.
+
+    Args:
+        config_region: From MARKET_REVIEW_REGION ('cn' | 'us' | 'both')
+        open_markets: Markets open today
+
+    Returns:
+        None: caller uses config default (check disabled)
+        '': all relevant markets closed, skip market review
+        'cn' | 'us' | 'both': effective subset for today
+    """
+    if config_region not in ("cn", "us", "both"):
+        config_region = "cn"
+    if config_region == "cn":
+        return "cn" if "cn" in open_markets else ""
+    if config_region == "us":
+        return "us" if "us" in open_markets else ""
+    # both
+    parts = []
+    if "cn" in open_markets:
+        parts.append("cn")
+    if "us" in open_markets:
+        parts.append("us")
+    if not parts:
+        return ""
+    return "both" if len(parts) == 2 else parts[0]


### PR DESCRIPTION
Fixes #373

## 背景与问题

Issue #373 提议增加交易日判断功能：默认在非交易日不执行分析，并区分 A 股、港股、美股的交易日历。

## 变更范围

- **新增模块**：`src/core/trading_calendar.py`  
  使用 `exchange-calendars` 按市场（A/HK/US）判断当日是否为交易日，支持按各市场时区取「今日」日期。

- **主流程**：`main.py`  
  - 在 `run_full_analysis` 与 `--market-review` 模式下增加交易日检查
  - 新增 `--force-run` 参数用于跳过检查、强制执行
  - 个股按市场 per-stock 过滤：仅分析当日开市的股票

- **配置**：`src/config.py`、`.env.example`  
  - 新增 `TRADING_DAY_CHECK_ENABLED`（默认 `true`）

- **数据层**：`data_provider/akshare_fetcher.py`、`data_provider/__init__.py`  
  - 新增公开接口 `is_hk_stock_code`，供交易日历模块识别港股代码

- **大盘复盘**：`src/core/market_review.py`  
  - 新增 `override_region` 参数，支持交易日过滤后的有效区域覆盖

- **依赖**：`requirements.txt`  
  - 新增 `exchange-calendars>=4.5.0`

- **文档**：`docs/CHANGELOG.md`、`docs/full-guide.md`、`README.md`  
  - 补充交易日判断说明、配置项与 CLI 用法

## 验证方式与结果

```bash
# 语法检查
python -m py_compile main.py src/core/trading_calendar.py
flake8 src/core/trading_calendar.py main.py --max-line-length=120

# 功能验证（exchange-calendars 未安装时 fail-open）
python -c "
from src.core.trading_calendar import get_market_for_stock, compute_effective_region, get_open_markets_today
assert get_market_for_stock('600519') == 'cn'
assert get_market_for_stock('00700') == 'hk'
assert get_market_for_stock('AAPL') == 'us'
print('OK')
"
```

## 兼容性与破坏性变更

- **无破坏性变更**：默认启用交易日检查，非交易日跳过执行；可通过 `TRADING_DAY_CHECK_ENABLED=false` 或 `--force-run` 保持原有行为。
- **fail-open**：若未安装 `exchange-calendars` 或检查异常，则默认视为交易日，不阻塞执行。

## 回滚方案

将 `TRADING_DAY_CHECK_ENABLED` 设为 `false` 或使用 `--force-run` 即可恢复「每天执行」的旧行为，无需回退代码。