### PR TITLE
fix: Conditionally add proxy in test env

### DIFF
--- a/test_env.py
+++ b/test_env.py
@@ -20,8 +20,15 @@ A股自选股智能分析系统 - 环境验证测试
 
 """
 import os
-os.environ["http_proxy"] = "http://127.0.0.1:10809"
-os.environ["https_proxy"] = "http://127.0.0.1:10809"
+# Proxy config - controlled by USE_PROXY env var, off by default.
+# Set USE_PROXY=true in .env if you need a local proxy (e.g. mainland China).
+# GitHub Actions always skips this regardless of USE_PROXY.
+if os.getenv("GITHUB_ACTIONS") != "true" and os.getenv("USE_PROXY", "false").lower() == "true":
+    proxy_host = os.getenv("PROXY_HOST", "127.0.0.1")
+    proxy_port = os.getenv("PROXY_PORT", "10809")
+    proxy_url = f"http://{proxy_host}:{proxy_port}"
+    os.environ["http_proxy"] = proxy_url
+    os.environ["https_proxy"] = proxy_url
 
 import argparse
 import logging


### PR DESCRIPTION
## PR Type

- [x] fix
- [ ] feat
- [ ] refactor
- [ ] docs
- [ ] chore
- [ ] test

## Background And Problem

请描述当前问题、影响范围与触发场景。

In current `test_env.py`, it unconditionally add proxy in all test env, which cause test_llm to hang endlessly. The in-function socket check bypasses HTTP proxy env vars (raw TCP), so it falsely reported "network OK" before the Gemini SDK call hung on the dead proxy.

Fix: Reuse `USE_PROXY` to add proxy conditionally. Developers outside China leave `USE_PROXY` unset and get a direct connection; mainland developers set USE_PROXY=true in their `.env`.

## Scope Of Change

请列出本 PR 修改的模块和文件范围。

## Issue Link

必须填写以下之一：
- `Fixes #<issue_number>`
- `Refs #<issue_number>`
- 无 Issue 时说明原因与验收标准

## Verification Commands And Results

请填写你实际执行过的命令和关键结果（不要只写“已测试”）：

```bash
# example
./scripts/ci_gate.sh
python -m pytest -m "not network"
```

关键输出/结论：

## Compatibility And Risk

请说明兼容性影响、潜在风险（如无请写 `None`）。

Backward compatible.

## Rollback Plan

请至少写一句可执行的回滚方案（必填）。

Revert.

## Checklist

- [ ] 我已确认本 PR 有明确动机和业务价值
- [ ] 我已提供可复现的验证命令与结果
- [ ] 我已评估兼容性与风险
- [ ] 我已提供回滚方案
- [ ] 若涉及用户可见变更，我已同步更新 `README.md` 与 `docs/CHANGELOG.md`
