### PR TITLE
fix: Agent 模式下报告页「相关资讯」为空 (Fixes #396)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -28,6 +28,10 @@
   - 扩展 `analysis_tools` 与 `data_tools`，优化策略问股的工具调用链路与分析覆盖
 
 ### 修复（#patch）
+- 🐛 **Agent 模式下报告页「相关资讯」为空**（Issue #396）
+  - 根因：Agent 工具结果仅用于 LLM 上下文，未写入 `news_intel`，前端 `GET /api/v1/history/{query_id}/news` 查询不到数据
+  - 修复：在 `_analyze_with_agent` 中 Agent 运行结束后，调用 `search_stock_news` 并持久化（仅 1 次 API 调用，与 Agent 工具逻辑一致，无额外延迟）
+  - 兼容性：无破坏性变更，Agent 模式下报告页「相关资讯」可正常展示
 - 🐛 **修复 HTTP 非安全上下文下 /chat 页面黑屏**（Issue #377）
   - `crypto.randomUUID()` 仅在 HTTPS/localhost 安全上下文中可用，通过 `http://IP:port` 访问时页面崩溃黑屏
   - 新增 `apps/dsa-web/src/utils/uuid.ts`，提供带 fallback 的 `generateUUID()` 工具函数


### PR DESCRIPTION
## 背景与问题

Issue #396 反馈：分析股票后，报告页「相关资讯」区域为空，HTTP 和 HTTPS 下均空。

用户日志显示 Agent 已成功调用 `search_stock_news` 并返回 5 条结果，但前端 `GET /api/v1/history/{query_id}/news` 查询不到数据。

## 根因

Agent 模式下，`_analyze_with_agent` 路径不调用 `save_news_intel`。Agent 工具（`search_stock_news`）的返回结果仅用于 LLM 上下文，未持久化到 `news_intel` 表，导致前端无法通过 `query_id` 查询到新闻情报。

## 变更范围

- `src/core/pipeline.py`：在 `_analyze_with_agent` 中 Agent 运行结束后，调用 `search_stock_news` 并持久化到 `news_intel`
- `docs/CHANGELOG.md`：补充修复说明

## 修复方式

使用 `search_stock_news`（与 Agent 工具调用逻辑一致），仅 1 次 API 调用，无 `search_comprehensive_intel` 的 5 次调用与 0.5s×5 延迟。

## 验证方式

1. 启用 Agent 模式（`AGENT_MODE=true` 或配置 `AGENT_SKILLS`）
2. 触发股票分析
3. 分析完成后查看报告页「相关资讯」区域，应显示新闻列表

## 兼容性

无破坏性变更，Agent 模式下报告页「相关资讯」可正常展示。

Fixes #396