### PR TITLE
fix: Agent Reasoning 400 修复 & LiteLLM Proxy 接入 (fixes #409)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -85,6 +85,15 @@ GEMINI_TEMPERATURE=0.7
 # 思考模式：deepseek-reasoner、deepseek-r1、qwq 等模型自动识别，无需配置；
 # deepseek-chat 需显式启用，系统按模型名自动处理。
 
+# 【方案五】使用 LiteLLM Proxy（统一多模型、自动 reasoning 透传）
+# 适用场景：同时使用多个模型 / 通过代理访问 Gemini 3 等 Reasoning 模型
+# 前置：先启动 LiteLLM Proxy：litellm --config litellm_config.yaml
+# ⚠️ 警告：使用本方案时，必须清空 AIHUBMIX_KEY、GEMINI_API_KEY、ANTHROPIC_API_KEY
+#          否则系统优先走原生 SDK，绕过 LiteLLM
+# OPENAI_BASE_URL=http://localhost:4000/v1
+# OPENAI_API_KEY=sk-litellm-proxy-local   # 22字符，满足项目校验 (>=8)
+# OPENAI_MODEL=gemini/gemini-3-pro-preview
+
 # 搜索引擎配置（用于获取股票新闻）
 # Tavily API Keys（支持多个，逗号分隔）
 TAVILY_API_KEYS=your_tavily_key_here

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@
 
 | 类型 | 支持 |
 |------|------|
-| AI 模型 | [AIHubMix](https://aihubmix.com/?aff=CfMq)、Gemini（免费）、OpenAI 兼容、DeepSeek、通义千问、Claude、Ollama |
+| AI 模型 | [AIHubMix](https://aihubmix.com/?aff=CfMq)、Gemini（免费）、OpenAI 兼容、DeepSeek、通义千问、Claude、Ollama、LiteLLM Proxy |
 | 行情数据 | AkShare、Tushare、Pytdx、Baostock、YFinance |
 | 新闻搜索 | Tavily、SerpAPI、Bocha、Brave |
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -33,6 +33,11 @@
   - **兼容性**：`AGENT_MODE` 默认 false，不影响现有非 Agent 模式；回滚只需将 `AGENT_MODE` 设为 false
 - ⚙️ **Agent 工具链能力增强**
   - 扩展 `analysis_tools` 与 `data_tools`，优化策略问股的工具调用链路与分析覆盖
+- 📡 **LiteLLM Proxy 接入**
+  - 支持通过 LiteLLM Proxy 统一路由 Gemini、DeepSeek、Claude 等模型，自动处理 Reasoning 模型透传
+  - 新增 `docs/LITELLM_PROXY_SETUP.md` 接入指南、`litellm_config.yaml.example` 示例配置
+  - `.env` 方案五：`OPENAI_BASE_URL` + `OPENAI_API_KEY` + `OPENAI_MODEL` 指向 Proxy
+  - OpenAI 兼容 API Key 长度校验放宽为 `>= 8`，支持 LiteLLM 本地开发常用短 Key
 
 ### 修复（#patch）
 - 🐛 **支持 DeepSeek 思考模式**（Issue #379）
@@ -40,6 +45,10 @@
   - 修复：`llm_adapter._call_openai` 解析并透传 `reasoning_content`；`executor` 在 assistant_msg 中写入该字段
   - 按模型名自动识别：`deepseek-reasoner`、`deepseek-r1`、`qwq` 等自动返回 reasoning_content，不发送 extra_body；`deepseek-chat` 需显式启用，系统自动处理
   - 兼容性：非 DeepSeek 提供商不受影响；用户无需配置，无破坏性变更
+- 🐛 **Agent Reasoning 400 修复**（Fixes #409）
+  - 根因：Gemini 3、DeepSeek 等 Reasoning 模型在工具调用响应中返回 `thought_signature`，多轮对话未回传导致代理返回 400
+  - 修复：`llm_adapter._call_openai` 解析并透传 `provider_specific_fields.thought_signature`；`executor` 在 assistant_msg 的 tool_calls 中写入该字段
+  - 兼容性：非 Reasoning 模型不受影响；与 LiteLLM Proxy 及其他 OpenAI 兼容代理兼容
 - 🐛 **Agent 模式下报告页「相关资讯」为空**（Issue #396）
   - 根因：Agent 工具结果仅用于 LLM 上下文，未写入 `news_intel`，前端 `GET /api/v1/history/{query_id}/news` 查询不到数据
   - 修复：在 `_analyze_with_agent` 中 Agent 运行结束后，调用 `search_stock_news` 并持久化（仅 1 次 API 调用，与 Agent 工具逻辑一致，无额外延迟）
@@ -75,6 +84,8 @@
 ### 文档（#skip）
 - 📝 **Agent 文档补充**
   - 更新 `README.md`、`docs/README_EN.md`、`docs/README_CHT.md` 与 changelog，补充策略问股使用说明与测试说明
+- 📝 **LiteLLM Proxy 文档**
+  - 更新 `docs/full-guide.md`、`README.md`、`.env.example`，补充 LiteLLM Proxy 配置说明与冲突警告
 
 ## [3.2.11] - 2026-02-23
 

--- a/docs/LITELLM_PROXY_SETUP.md
+++ b/docs/LITELLM_PROXY_SETUP.md
@@ -1,0 +1,104 @@
+# LiteLLM Proxy 接入指南
+
+通过 LiteLLM Proxy 可在单一 OpenAI 兼容接口后统一路由 Gemini、DeepSeek、Claude 等模型，并自动处理 Reasoning 模型（Gemini 3 等）的 `thought_signature` 透传，避免多轮工具调用 400 错误。
+
+## 适用场景
+
+- 同时使用多个模型，通过一个 Base URL 切换
+- 通过代理访问 Gemini 3 等 Reasoning 模型，避免 400 错误
+- 本地开发时统一管理各厂商 API Key
+
+## 安装
+
+```bash
+pip install 'litellm[proxy]'
+```
+
+或使用 Docker：
+
+```bash
+docker run -p 4000:4000 ghcr.io/berriai/litellm:main-latest --config /path/to/litellm_config.yaml
+```
+
+## 配置与启动
+
+1. 复制示例配置到项目根目录：
+
+   ```bash
+   cp litellm_config.yaml.example litellm_config.yaml
+   ```
+
+2. 编辑 `litellm_config.yaml`，填入各厂商 API Key 对应的环境变量名（如 `os.environ/GEMINI_API_KEY`），并确保这些环境变量在启动 LiteLLM 时已设置。
+
+3. 启动 LiteLLM Proxy：
+
+   ```bash
+   litellm --config litellm_config.yaml
+   ```
+
+   默认监听 `http://localhost:4000`。
+
+## 项目侧 .env 配置
+
+在项目 `.env` 中配置以下变量，使本系统通过 LiteLLM Proxy 访问模型：
+
+```bash
+# 【方案五】使用 LiteLLM Proxy
+OPENAI_BASE_URL=http://localhost:4000/v1
+OPENAI_API_KEY=sk-litellm-proxy-local   # 22 字符，满足项目校验 (>=8)；无认证时可用此值
+OPENAI_MODEL=gemini/gemini-3-pro-preview
+```
+
+### 关键警告
+
+**必须清空或注释以下变量**，否则系统优先走原生 SDK，绕过 LiteLLM Proxy：
+
+- `AIHUBMIX_KEY` — 若配置，`openai_base_url` 会默认指向 aihubmix，覆盖 LiteLLM
+- `GEMINI_API_KEY` — 若配置，`LLMToolAdapter` 优先使用 Gemini 原生 SDK
+- `ANTHROPIC_API_KEY` — 若配置，会优先使用 Anthropic 原生 SDK
+
+系统 Provider 优先级为：**Gemini > Anthropic > OpenAI 兼容**。使用 LiteLLM Proxy 时，仅保留 `OPENAI_BASE_URL` + `OPENAI_API_KEY` + `OPENAI_MODEL`，确保请求走 `_call_openai` 路径。
+
+## 模型名格式
+
+LiteLLM 使用 `{provider}/{model}` 格式，例如：
+
+| 模型           | OPENAI_MODEL 值              |
+|----------------|-----------------------------|
+| Gemini 3 Pro   | `gemini/gemini-3-pro-preview` |
+| Gemini 3 Flash | `gemini/gemini-3-flash-preview` |
+| DeepSeek Chat  | `deepseek/deepseek-chat`     |
+| DeepSeek R1    | `deepseek/deepseek-r1`       |
+| OpenAI GPT-4o  | `openai/gpt-4o`             |
+
+`litellm_config.yaml` 中的 `model_name` 需与 `.env` 中 `OPENAI_MODEL` 一致。
+
+## OPENAI_API_KEY 说明
+
+- 项目要求 API Key 长度 `>= 8`（满足 LiteLLM 本地开发常用短 Key）
+- 无认证模式：可使用 `sk-litellm-proxy-local`（22 字符）
+- 有认证模式：在 LiteLLM 配置中设置 `master_key`，项目 `.env` 中 `OPENAI_API_KEY` 填该值
+
+## 常见问题
+
+### 端口冲突
+
+默认 4000 端口被占用时，可指定：
+
+```bash
+litellm --config litellm_config.yaml --port 4001
+```
+
+项目 `.env` 中 `OPENAI_BASE_URL` 需对应修改为 `http://localhost:4001/v1`。
+
+### 400 错误（多轮工具调用）
+
+若仍出现 400，请确认：
+
+1. 项目已应用 Agent Reasoning 400 修复（`thought_signature` 透传）
+2. `litellm_config.yaml` 中已设置 `litellm_settings.drop_params: true`
+3. 未同时配置 `GEMINI_API_KEY` 等原生 Key，否则请求不会经过 LiteLLM
+
+### 网络与 Docker
+
+LiteLLM 与项目同机时使用 `localhost`；若 LiteLLM 在 Docker 中、项目在宿主机，使用 `http://localhost:4000/v1`；若项目也在 Docker，使用 `http://host.docker.internal:4000/v1` 或 Docker 网络内服务名。

--- a/docs/full-guide.md
+++ b/docs/full-guide.md
@@ -612,6 +612,15 @@ OPENAI_MODEL=deepseek-chat
 # 思考模式：deepseek-reasoner、deepseek-r1、qwq 等自动识别；deepseek-chat 系统按模型名自动启用
 ```
 
+### LiteLLM Proxy（统一多模型网关）
+
+通过 LiteLLM Proxy 可在一个 OpenAI 兼容接口后统一路由 Gemini、DeepSeek、Claude 等模型，并自动处理 Reasoning 模型（Gemini 3 等）的 `thought_signature` 透传，避免多轮工具调用 400 错误。
+
+详见 [LiteLLM Proxy 接入指南](LITELLM_PROXY_SETUP.md)。
+
+> ⚠️ 使用 LiteLLM Proxy 时须清空 `GEMINI_API_KEY`、`ANTHROPIC_API_KEY`、`AIHUBMIX_KEY`，
+> 仅保留 `OPENAI_BASE_URL` + `OPENAI_API_KEY` + `OPENAI_MODEL`，否则系统优先走原生 SDK 绕过 Proxy。
+
 ### 调试模式
 
 ```bash

--- a/litellm_config.yaml.example
+++ b/litellm_config.yaml.example
@@ -1,0 +1,28 @@
+# LiteLLM Proxy 示例配置
+# 复制为 litellm_config.yaml 并填入环境变量
+# 启动: litellm --config litellm_config.yaml
+
+litellm_settings:
+  drop_params: true  # 关键：删除非标字段，防止 OpenAI 官方报错
+
+model_list:
+  - model_name: gemini/gemini-3-pro-preview
+    litellm_params:
+      model: gemini/gemini-3-pro-preview
+      api_key: os.environ/GEMINI_API_KEY
+  - model_name: gemini/gemini-3-flash-preview
+    litellm_params:
+      model: gemini/gemini-3-flash-preview
+      api_key: os.environ/GEMINI_API_KEY
+  - model_name: deepseek/deepseek-chat
+    litellm_params:
+      model: deepseek/deepseek-chat
+      api_key: os.environ/DEEPSEEK_API_KEY
+  - model_name: deepseek/deepseek-r1
+    litellm_params:
+      model: deepseek/deepseek-r1
+      api_key: os.environ/DEEPSEEK_API_KEY
+  - model_name: openai/gpt-4o
+    litellm_params:
+      model: openai/gpt-4o
+      api_key: os.environ/OPENAI_API_KEY_DIRECT

--- a/src/agent/executor.py
+++ b/src/agent/executor.py
@@ -457,7 +457,12 @@ class AgentExecutor:
                     "role": "assistant",
                     "content": response.content,
                     "tool_calls": [
-                        {"id": tc.id, "name": tc.name, "arguments": tc.arguments}
+                        {
+                            "id": tc.id,
+                            "name": tc.name,
+                            "arguments": tc.arguments,
+                            **({"thought_signature": tc.thought_signature} if tc.thought_signature is not None else {}),
+                        }
                         for tc in response.tool_calls
                     ],
                 }

--- a/src/agent/llm_adapter.py
+++ b/src/agent/llm_adapter.py
@@ -28,6 +28,7 @@ class ToolCall:
     id: str
     name: str
     arguments: Dict[str, Any]
+    thought_signature: Optional[str] = None
 
 
 @dataclass
@@ -149,7 +150,7 @@ class LLMToolAdapter:
 
         # OpenAI
         openai_key = config.openai_api_key
-        if openai_key and not openai_key.startswith("your_") and len(openai_key) > 10:
+        if openai_key and not openai_key.startswith("your_") and len(openai_key) >= 8:
             try:
                 from openai import OpenAI
                 client_kwargs = {"api_key": openai_key}
@@ -381,14 +382,18 @@ class LLMToolAdapter:
                 # Reconstruct assistant message with tool_calls
                 openai_tc = []
                 for tc in msg["tool_calls"]:
-                    openai_tc.append({
+                    tc_dict = {
                         "id": tc.get("id", str(uuid.uuid4())[:8]),
                         "type": "function",
                         "function": {
                             "name": tc["name"],
                             "arguments": json.dumps(tc["arguments"]),
                         }
-                    })
+                    }
+                    sig = tc.get("thought_signature")
+                    if sig is not None:
+                        tc_dict["provider_specific_fields"] = {"thought_signature": sig}
+                    openai_tc.append(tc_dict)
                 openai_msg = {
                     "role": "assistant",
                     "content": msg.get("content"),
@@ -432,10 +437,21 @@ class LLMToolAdapter:
                         args = json.loads(tc.function.arguments)
                     except json.JSONDecodeError:
                         args = {"raw": tc.function.arguments}
+                # Extract thought_signature: stored in __pydantic_extra__ as provider_specific_fields
+                psf = getattr(tc, 'provider_specific_fields', None)
+                if psf is not None:
+                    sig = psf.get('thought_signature') if isinstance(psf, dict) else getattr(psf, 'thought_signature', None)
+                else:
+                    func_psf = getattr(tc.function, 'provider_specific_fields', None)
+                    if func_psf is not None:
+                        sig = func_psf.get('thought_signature') if isinstance(func_psf, dict) else getattr(func_psf, 'thought_signature', None)
+                    else:
+                        sig = getattr(tc, 'thought_signature', None)
                 tool_calls.append(ToolCall(
                     id=tc.id,
                     name=tc.function.name,
                     arguments=args,
+                    thought_signature=sig,
                 ))
 
         usage = {}

--- a/src/analyzer.py
+++ b/src/analyzer.py
@@ -604,7 +604,7 @@ class GeminiAnalyzer:
         openai_key_valid = (
             config.openai_api_key and
             not config.openai_api_key.startswith('your_') and
-            len(config.openai_api_key) > 10
+            len(config.openai_api_key) >= 8
         )
 
         if not openai_key_valid:

--- a/src/services/image_stock_extractor.py
+++ b/src/services/image_stock_extractor.py
@@ -121,7 +121,7 @@ def _parse_codes_from_text(text: str) -> List[str]:
 
 def _is_key_valid(key: Optional[str]) -> bool:
     """检查 API Key 是否有效（非占位符）。"""
-    return bool(key and not key.startswith("your_") and len(key) > 10)
+    return bool(key and not key.startswith("your_") and len(key) >= 8)
 
 
 def _select_vision_provider() -> str:


### PR DESCRIPTION
## PR Type

- [x] fix
- [x] feat

## Background And Problem

**问题**：Gemini 3、DeepSeek 等 Reasoning 模型在 Agent 多轮工具调用场景下，通过 OpenAI 兼容代理（如 LiteLLM Proxy、liaobots.work）调用时返回 400 Bad Request。

**根因**：这些模型在 tool call 响应中返回 `thought_signature`，多轮对话时需将该字段回传；项目此前未解析和透传该字段，导致代理校验失败。

**影响**：使用 Reasoning 模型 + OpenAI 兼容代理的 Agent 用户无法完成多轮工具调用。

## Scope Of Change

- `src/agent/llm_adapter.py`：ToolCall 新增 `thought_signature`；解析响应中的 `provider_specific_fields.thought_signature`；请求构造时回传该字段
- `src/agent/executor.py`：assistant_msg 的 tool_calls 中写入 `thought_signature`
- `src/analyzer.py`、`src/services/image_stock_extractor.py`：OpenAI 兼容 API Key 长度校验放宽为 `>= 8`（支持 LiteLLM 本地短 Key）
- `docs/LITELLM_PROXY_SETUP.md`：新增 LiteLLM Proxy 接入指南
- `litellm_config.yaml.example`：新增示例配置
- `.env.example`：方案五（LiteLLM Proxy）说明
- `docs/full-guide.md`、`README.md`、`docs/CHANGELOG.md`：文档同步

## Issue Link

Fixes #409
Refs #421

## Verification Commands And Results

```bash
./test.sh syntax
python -m py_compile src/agent/llm_adapter.py src/agent/executor.py
flake8 src/agent/ --max-line-length=120
```

关键结论：语法与风格检查通过。建议使用 LiteLLM Proxy + Gemini 3 进行多轮工具调用回归验证。

## Compatibility And Risk

- **兼容性**：非 Reasoning 模型不受影响；Gemini/Anthropic 原生 SDK 路径仅忽略 tool_calls 中的额外键
- **风险**：API Key 长度放宽（>10 → ≥8）仅影响 OpenAI 兼容路由，真实 Key 均远超 8 位，影响可忽略

## Rollback Plan

将 `AGENT_MODE` 设为 `false` 可禁用 Agent；或回退本 PR 提交。
