### PR TITLE
fix: time zone inconsistency & right panel flash on record click

### DIFF
--- a/apps/dsa-web/src/pages/HomePage.tsx
+++ b/apps/dsa-web/src/pages/HomePage.tsx
@@ -111,6 +111,8 @@ const HomePage: React.FC = () => {
       }
     }
 
+    // page is always 1 when reset=true, regardless of currentPageRef; the ref
+    // is only used for load-more (reset=false) to get the next page number.
     const page = reset ? 1 : currentPageRef.current + 1;
 
     try {
@@ -213,6 +215,7 @@ const HomePage: React.FC = () => {
       }
     } catch (err) {
       console.error('Failed to fetch report:', err);
+      setStoreError(err instanceof Error ? err.message : '报告加载失败');
     }
   };
 

--- a/apps/dsa-web/src/utils/format.ts
+++ b/apps/dsa-web/src/utils/format.ts
@@ -31,10 +31,15 @@ export const toDateInputValue = (date: Date): string => {
   return `${year}-${month}-${day}`;
 };
 
+/**
+ * Returns the date N days ago as YYYY-MM-DD in Asia/Shanghai timezone.
+ * Consistent with getTodayInShanghai() so both ends of the date range
+ * are expressed in the same timezone as the backend.
+ */
 export const getRecentStartDate = (days: number): string => {
   const date = new Date();
   date.setDate(date.getDate() - days);
-  return toDateInputValue(date);
+  return new Intl.DateTimeFormat('en-CA', { timeZone: 'Asia/Shanghai' }).format(date);
 };
 
 /**


### PR DESCRIPTION
## PR Type

- [x] fix
- [ ] feat
- [ ] refactor
- [ ] docs
- [ ] chore
- [ ] test

## Background And Problem

请描述当前问题、影响范围与触发场景。

The history list fetchHistory used new Date() + 1 day as endDate to work around today's records being missed. This was a known hack left as a TODO comment.

## Scope Of Change

请列出本 PR 修改的模块和文件范围。

1. Fix timezone inconsistency (utils/format.ts)
Added getTodayInShanghai() using the Intl.DateTimeFormat API with timeZone Asia/Shanghai. The backend stores and filters created_at in server local time (Asia/Shanghai); passing today's date in the same timezone makes the endDate semantically correct and timezone-safe regardless of the browser's locale. Removed the +1 day workaround.

2. Prevent history list full-reset on record click (pages/HomePage.tsx)
fetchHistory previously listed selectedReport, currentPage, and historyItems.length as useCallback deps. Clicking any record updated selectedReport, causing fetchHistory to get a new reference, which triggered the initial-load useEffect and reset the entire list — scroll position was lost and the list was re-fetched from page 1. Fixed by giving fetchHistory stable empty deps and reading those three values through refs that are synced inline on every render.

3. Eliminate right-panel flash on record click (pages/HomePage.tsx)
handleHistoryClick called setIsLoadingReport(true) before fetching, which blanked out the visible report and showed a spinner on every click. Fixed by keeping the current report visible during the fetch and only swapping once the new data arrives. The spinner is now reserved for the initial page load where there is no report to show. Added a request-ID guard to handle rapid successive clicks correctly.

## Issue Link

必须填写以下之一：
- `Fixes #<issue_number>`
- `Refs #<issue_number>`
- 无 Issue 时说明原因与验收标准

## Verification Commands And Results

请填写你实际执行过的命令和关键结果（不要只写“已测试”）：

```bash
# example
./scripts/ci_gate.sh
python -m pytest -m "not network"
```

关键输出/结论：

## Compatibility And Risk

请说明兼容性影响、潜在风险（如无请写 `None`）。

## Rollback Plan

请至少写一句可执行的回滚方案（必填）。

Revert.

## Checklist

- [ ] 我已确认本 PR 有明确动机和业务价值
- [ ] 我已提供可复现的验证命令与结果
- [ ] 我已评估兼容性与风险
- [ ] 我已提供回滚方案
- [ ] 若涉及用户可见变更，我已同步更新 `README.md` 与 `docs/CHANGELOG.md`
