### PR TITLE
fix: add explicit project name to docker-compose

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -7,6 +7,7 @@
 #   FastAPI模式: docker-compose -f ./docker/docker-compose.yml up -d server
 #   同时启动: docker-compose -f ./docker/docker-compose.yml up -d analyzer server
 
+name: daily-stock-analysis
 version: '3.8'
 
 x-common: &common


### PR DESCRIPTION
## Summary
- 为 `docker-compose.yml` 添加显式 `name: daily-stock-analysis`，避免多项目共用 `docker/` 目录时 Docker Compose 默认使用相同 project name 导致的孤儿容器警告

## Problem
当多个项目的 compose 文件都放在 `docker/` 目录下时，Docker Compose 默认以目录名 `docker` 作为 project name，导致不同项目的容器互相被识别为 orphan containers。

## Test plan
- [x] 运行 `docker-compose -f docker/docker-compose.yml up -d server`，确认不再出现 orphan container 警告
- [x] 运行 `docker compose ls`，确认 project name 显示为 `daily-stock-analysis`