### PR TITLE
fix: 修复 ARCH_ARGS 空数组导致的 unbound variable 错误

### DIFF
--- a/scripts/build-desktop-macos.sh
+++ b/scripts/build-desktop-macos.sh
@@ -40,7 +40,11 @@ if [[ -n "${MAC_ARCH}" ]]; then
 fi
 
 echo "Building macOS target arch: ${MAC_ARCH:-default}"
-npx electron-builder --mac dmg "${ARCH_ARGS[@]}"
+if [[ ${#ARCH_ARGS[@]} -gt 0 ]]; then
+  npx electron-builder --mac dmg "${ARCH_ARGS[@]}"
+else
+  npx electron-builder --mac dmg
+fi
 popd >/dev/null
 
 echo "Desktop build completed."


### PR DESCRIPTION
在 set -u 模式下，空数组 '${ARCH_ARGS[@]}' 会触发 unbound variable 错误。添加数组长度检查，仅在
  ARCH_ARGS 非空时传递参数。

  ## PR Type

  - [x] fix
  - [ ] feat
  - [ ] refactor
  - [ ] docs
  - [ ] chore
  - [ ] test

  ## Background And Problem

  在 `scripts/build-desktop-macos.sh` 中使用了 `set -euo pipefail`，当 `MAC_ARCH`
  环境变量未设置时，`ARCH_ARGS` 数组为空。在 `set -u` 模式下，引用空数组 `"${ARCH_ARGS[@]}"` 会触发
  `unbound variable` 错误，导致构建脚本无法正常执行。

  ## Scope Of Change

  - `scripts/build-desktop-macos.sh`: 添加数组长度判断，仅在 `ARCH_ARGS` 非空时传递参数

  ## Issue Link

  无 Issue（问题在本地构建时发现并修复）

  ## Verification Commands And Results

  ```bash
  # 未设置 MAC_ARCH 时构建（修复前会报错）
  cd scripts && ./build-desktop-macos.sh

  # 构建成功
  ./build-desktop-macos.sh
  # ...
  # • building block map  blockMapFile=dist/Daily Stock Analysis-0.1.0-arm64.dmg.blockmap
  # Desktop build completed.

  关键输出/结论：修复后脚本在默认配置下（不设置 DSA_MAC_ARCH）可正常完成构建，生成 DMG 安装包。

  Compatibility And Risk

  None - 仅修改脚本逻辑，不影响已有功能；设置 DSA_MAC_ARCH=x64/arm64 时行为与之前一致。

  Rollback Plan

  git revert <commit-hash>

  或手动将 scripts/build-desktop-macos.sh 第 43-47 行恢复为：
  npx electron-builder --mac dmg "${ARCH_ARGS[@]}"

  Checklist

  - 我已确认本 PR 有明确动机和业务价值
  - 我已提供可复现的验证命令与结果
  - 我已评估兼容性与风险
  - 我已提供回滚方案
  - 若涉及用户可见变更，我已同步更新 README.md 与 docs/CHANGELOG.md