### PR TITLE
[fix]  狙击点位解析错误 Issue #488

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+- 🐛 **狙击点位解析错误** — 理想买入/二次买入等字段在无「元」字时误提取括号内技术指标数字（如 MA5/10→10.0、M20→20.0）；现先截去第一个括号后内容再提取，修复 #488
+
 ## [3.4.9] - 2026-03-06
 
 ### Added

--- a/src/storage.py
+++ b/src/storage.py
@@ -1235,12 +1235,19 @@ class DatabaseManager:
                 except ValueError:
                     pass
 
-        # 兜底：无"元"字时（如 "102.10-103.00（MA5附近）"），
-        # 提取最后一个非 MA 前缀的数字
+        # 兜底：无"元"字时，先截去第一个括号后的内容，避免误提取括号内技术指标数字
+        # 例如 "1.52-1.53 (回踩MA5/10附近)" → 仅在 "1.52-1.53 " 中搜索
+        paren_pos = len(text)
+        for paren_char in ('(', '（'):
+            pos = text.find(paren_char)
+            if pos != -1:
+                paren_pos = min(paren_pos, pos)
+        search_text = text[:paren_pos].strip() or text  # 括号前为空时降级用全文
+
         valid_numbers = []
-        for m in re.finditer(r"\d+(?:\.\d+)?", text):
+        for m in re.finditer(r"\d+(?:\.\d+)?", search_text):
             start_idx = m.start()
-            if start_idx >= 2 and text[start_idx-2:start_idx].upper() == "MA":
+            if start_idx >= 2 and search_text[start_idx-2:start_idx].upper() == "MA":
                 continue
             valid_numbers.append(m.group())
         if valid_numbers:

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -52,5 +52,14 @@ class TestStorage(unittest.TestCase):
         self.assertIsNone(DatabaseManager._parse_sniper_value("没有数字"))
         self.assertIsNone(DatabaseManager._parse_sniper_value("MA5但没有元"))
 
+        # 7. 回归：括号内技术指标数字不应被提取
+        self.assertNotEqual(DatabaseManager._parse_sniper_value("1.52-1.53 (回踩MA5/10附近)"), 10.0)
+        self.assertNotEqual(DatabaseManager._parse_sniper_value("1.55-1.56(MA5/M20支撑)"), 20.0)
+        self.assertNotEqual(DatabaseManager._parse_sniper_value("1.49-1.50(MA60附近企稳)"), 60.0)
+        # 验证正确值在区间内
+        self.assertIn(DatabaseManager._parse_sniper_value("1.52-1.53 (回踩MA5/10附近)"), [1.52, 1.53])
+        self.assertIn(DatabaseManager._parse_sniper_value("1.55-1.56(MA5/M20支撑)"), [1.55, 1.56])
+        self.assertIn(DatabaseManager._parse_sniper_value("1.49-1.50(MA60附近企稳)"), [1.49, 1.50])
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## 背景与问题

Fixes #488

狙击点位（理想买入、二次买入等）在展示时出现解析错误：原始分析结果中的价格区间（如 `1.52-1.53 (回踩MA5/10附近)`）被错误解析为 `10.0`，或 `1.55-1.56(MA5/M20支撑)` 被解析为 `20.0`。

根因：`_parse_sniper_value` 在无「元」字时的兜底逻辑对完整字符串取「最后一个非 MA 前缀的数字」，误提取了括号内技术指标数字（MA5/**10**、**M20**）。

## 变更范围

- `src/storage.py`：兜底提取前先截去第一个括号后的内容，仅在括号前部分搜索数字
- `tests/test_storage.py`：新增 Issue #488 回归用例
- `docs/CHANGELOG.md`：记录修复

## 验证方式

```bash
python -m pytest tests/test_storage.py -v
```

## 兼容性

无破坏性变更，仅修正解析逻辑。历史已存错误值不迁移，新分析将正确。