### PR TITLE
refactor(webui): 实现API错误精细化分类与统一展示组件

### DIFF
--- a/apps/dsa-web/src/App.tsx
+++ b/apps/dsa-web/src/App.tsx
@@ -6,6 +6,7 @@ import SettingsPage from './pages/SettingsPage';
 import LoginPage from './pages/LoginPage';
 import NotFoundPage from './pages/NotFoundPage';
 import ChatPage from './pages/ChatPage';
+import { ApiErrorAlert } from './components/common';
 import { AuthProvider, useAuth } from './contexts/AuthContext';
 import './App.css';
 
@@ -144,7 +145,9 @@ const AppContent: React.FC = () => {
     if (loadError) {
         return (
             <div className="flex min-h-screen flex-col items-center justify-center gap-4 bg-base px-4">
-                <p className="text-sm text-red-400">无法连接到服务器，请检查后端是否正常运行。</p>
+                <div className="w-full max-w-lg">
+                    <ApiErrorAlert error={loadError}/>
+                </div>
                 <button
                     type="button"
                     className="btn-primary"

--- a/apps/dsa-web/src/api/agent.ts
+++ b/apps/dsa-web/src/api/agent.ts
@@ -1,8 +1,14 @@
 import apiClient from './index';
+import { createApiError, isApiRequestError, parseApiError } from './error';
 
 export interface ChatRequest {
   message: string;
   skills?: string[];
+}
+
+export interface ChatStreamRequest extends ChatRequest {
+  session_id?: string;
+  context?: unknown;
 }
 
 export interface ChatResponse {
@@ -58,5 +64,48 @@ export const agentApi = {
   },
   async deleteChatSession(sessionId: string): Promise<void> {
     await apiClient.delete(`/api/v1/agent/chat/sessions/${sessionId}`);
+  },
+  async chatStream(payload: ChatStreamRequest): Promise<Response> {
+    try {
+      const response = await fetch('/api/v1/agent/chat/stream', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload),
+      });
+
+      if (response.ok) {
+        return response;
+      }
+
+      const contentType = response.headers.get('content-type') || '';
+      let responseData: unknown = null;
+      if (contentType.includes('application/json')) {
+        responseData = await response.json().catch(() => null);
+      } else {
+        responseData = await response.text().catch(() => null);
+      }
+
+      const parsed = parseApiError({
+        response: {
+          status: response.status,
+          statusText: response.statusText,
+          data: responseData,
+        },
+      });
+      throw createApiError(parsed, {
+        response: {
+          status: response.status,
+          statusText: response.statusText,
+          data: responseData,
+        },
+      });
+    } catch (error: unknown) {
+      if (isApiRequestError(error)) {
+        throw error;
+      }
+
+      const parsed = parseApiError(error);
+      throw createApiError(parsed, { cause: error });
+    }
   },
 };

--- a/apps/dsa-web/src/api/error.ts
+++ b/apps/dsa-web/src/api/error.ts
@@ -1,0 +1,451 @@
+import axios from 'axios';
+
+export type ApiErrorCategory =
+  | 'agent_disabled'
+  | 'missing_params'
+  | 'llm_not_configured'
+  | 'model_tool_incompatible'
+  | 'invalid_tool_call'
+  | 'upstream_llm_400'
+  | 'upstream_timeout'
+  | 'upstream_network'
+  | 'local_connection_failed'
+  | 'http_error'
+  | 'unknown';
+
+export interface ParsedApiError {
+  title: string;
+  message: string;
+  rawMessage: string;
+  status?: number;
+  category: ApiErrorCategory;
+}
+
+type ResponseLike = {
+  status?: number;
+  data?: unknown;
+  statusText?: string;
+};
+
+type ErrorCarrier = {
+  response?: ResponseLike;
+  code?: string;
+  message?: string;
+  parsedError?: ParsedApiError;
+  cause?: unknown;
+};
+
+type CreateParsedApiErrorOptions = {
+  title: string;
+  message: string;
+  rawMessage?: string;
+  status?: number;
+  category?: ApiErrorCategory;
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+function pickString(...values: unknown[]): string | null {
+  for (const value of values) {
+    if (typeof value === 'string' && value.trim()) {
+      return value.trim();
+    }
+  }
+  return null;
+}
+
+function stringifyValue(value: unknown): string | null {
+  if (value === null || value === undefined) {
+    return null;
+  }
+
+  if (typeof value === 'string') {
+    return value.trim() || null;
+  }
+
+  if (typeof value === 'number' || typeof value === 'boolean') {
+    return String(value);
+  }
+
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return String(value);
+  }
+}
+
+function getResponse(error: unknown): ResponseLike | undefined {
+  if (!isRecord(error)) {
+    return undefined;
+  }
+
+  const response = (error as ErrorCarrier).response;
+  return response && typeof response === 'object' ? response : undefined;
+}
+
+function getErrorCode(error: unknown): string | undefined {
+  return isRecord(error) && typeof (error as ErrorCarrier).code === 'string'
+    ? (error as ErrorCarrier).code
+    : undefined;
+}
+
+function getErrorMessage(error: unknown): string | null {
+  if (typeof error === 'string') {
+    return error.trim() || null;
+  }
+
+  if (error instanceof Error && error.message.trim()) {
+    return error.message.trim();
+  }
+
+  if (isRecord(error) && typeof (error as ErrorCarrier).message === 'string') {
+    const message = (error as ErrorCarrier).message?.trim();
+    return message || null;
+  }
+
+  return null;
+}
+
+function getCauseMessage(error: unknown): string | null {
+  if (!isRecord(error)) {
+    return null;
+  }
+
+  return getErrorMessage((error as ErrorCarrier).cause);
+}
+
+function buildMatchText(parts: Array<string | undefined | null>): string {
+  return parts
+    .filter((part): part is string => typeof part === 'string' && part.trim().length > 0)
+    .join(' | ')
+    .toLowerCase();
+}
+
+function includesAny(haystack: string, needles: string[]): boolean {
+  return needles.some((needle) => haystack.includes(needle.toLowerCase()));
+}
+
+function extractValidationDetail(detail: unknown): string | null {
+  if (!Array.isArray(detail)) {
+    return null;
+  }
+
+  const parts = detail
+    .map((item) => {
+      if (!isRecord(item)) {
+        return stringifyValue(item);
+      }
+
+      const location = Array.isArray(item.loc)
+        ? item.loc.map((segment) => String(segment)).join('.')
+        : null;
+      const message = pickString(item.msg, item.message, item.error);
+      if (!location && !message) {
+        return stringifyValue(item);
+      }
+      return [location, message].filter(Boolean).join(': ');
+    })
+    .filter((entry): entry is string => Boolean(entry));
+
+  return parts.length > 0 ? parts.join('; ') : null;
+}
+
+export function extractErrorPayloadText(data: unknown): string | null {
+  if (typeof data === 'string') {
+    return data.trim() || null;
+  }
+
+  if (Array.isArray(data)) {
+    return extractValidationDetail(data) ?? stringifyValue(data);
+  }
+
+  if (!isRecord(data)) {
+    return stringifyValue(data);
+  }
+
+  const detail = data.detail;
+  if (isRecord(detail)) {
+    return (
+      pickString(detail.message, detail.error)
+      ?? extractValidationDetail(detail.detail)
+      ?? stringifyValue(detail)
+    );
+  }
+
+  return (
+    pickString(
+      detail,
+      data.message,
+      data.error,
+      data.title,
+      data.reason,
+      data.description,
+      data.msg,
+    )
+    ?? extractValidationDetail(detail)
+    ?? stringifyValue(data)
+  );
+}
+
+export function createParsedApiError(options: CreateParsedApiErrorOptions): ParsedApiError {
+  return {
+    title: options.title,
+    message: options.message,
+    rawMessage: options.rawMessage?.trim() || options.message,
+    status: options.status,
+    category: options.category ?? 'unknown',
+  };
+}
+
+export function isParsedApiError(value: unknown): value is ParsedApiError {
+  return isRecord(value)
+    && typeof value.title === 'string'
+    && typeof value.message === 'string'
+    && typeof value.rawMessage === 'string'
+    && typeof value.category === 'string';
+}
+
+export function isApiRequestError(
+  value: unknown,
+): value is Error & ErrorCarrier & { parsedError: ParsedApiError } {
+  return value instanceof Error
+    && isRecord(value)
+    && isParsedApiError((value as ErrorCarrier).parsedError);
+}
+
+export function formatParsedApiError(parsed: ParsedApiError): string {
+  if (!parsed.title.trim()) {
+    return parsed.message;
+  }
+  if (parsed.title === parsed.message) {
+    return parsed.title;
+  }
+  return `${parsed.title}：${parsed.message}`;
+}
+
+export function getParsedApiError(error: unknown): ParsedApiError {
+  if (isParsedApiError(error)) {
+    return error;
+  }
+  if (isRecord(error) && isParsedApiError((error as ErrorCarrier).parsedError)) {
+    return (error as ErrorCarrier).parsedError as ParsedApiError;
+  }
+  return parseApiError(error);
+}
+
+export function createApiError(
+  parsed: ParsedApiError,
+  extra: { response?: ResponseLike; code?: string; cause?: unknown } = {},
+): Error & ErrorCarrier & { status?: number; category: ApiErrorCategory; rawMessage: string } {
+  const apiError = new Error(formatParsedApiError(parsed)) as Error & ErrorCarrier & {
+    status?: number;
+    category: ApiErrorCategory;
+    rawMessage: string;
+  };
+  apiError.name = 'ApiRequestError';
+  apiError.parsedError = parsed;
+  apiError.response = extra.response;
+  apiError.code = extra.code;
+  apiError.status = parsed.status;
+  apiError.category = parsed.category;
+  apiError.rawMessage = parsed.rawMessage;
+  if (extra.cause !== undefined) {
+    apiError.cause = extra.cause;
+  }
+  return apiError;
+}
+
+export function attachParsedApiError(error: unknown): ParsedApiError {
+  const parsed = parseApiError(error);
+  if (isRecord(error)) {
+    const carrier = error as ErrorCarrier;
+    carrier.parsedError = parsed;
+  }
+  if (error instanceof Error) {
+    error.name = 'ApiRequestError';
+    error.message = formatParsedApiError(parsed);
+  }
+  return parsed;
+}
+
+export function isLocalConnectionFailure(error: unknown): boolean {
+  return parseApiError(error).category === 'local_connection_failed';
+}
+
+export function parseApiError(error: unknown): ParsedApiError {
+  const response = getResponse(error);
+  const status = response?.status;
+  const payloadText = extractErrorPayloadText(response?.data);
+  const errorMessage = getErrorMessage(error);
+  const causeMessage = getCauseMessage(error);
+  const code = getErrorCode(error);
+  const rawMessage = pickString(payloadText, response?.statusText, errorMessage, causeMessage, code)
+    ?? '请求未成功完成，请稍后重试。';
+  const matchText = buildMatchText([rawMessage, errorMessage, causeMessage, code, response?.statusText]);
+
+  if (includesAny(matchText, ['agent mode is not enabled', 'agent_mode'])) {
+    return createParsedApiError({
+      title: 'Agent 模式未开启',
+      message: '当前功能依赖 Agent 模式，请先开启后再重试。',
+      rawMessage,
+      status,
+      category: 'agent_disabled',
+    });
+  }
+
+  const hasStockCodeField = includesAny(matchText, ['stock_code', 'stock_codes']);
+  const hasMissingParamText = includesAny(matchText, ['必须提供 stock_code 或 stock_codes', 'missing', 'required']);
+  if (hasStockCodeField && hasMissingParamText) {
+    return createParsedApiError({
+      title: '请求缺少必要参数',
+      message: '请先补充股票代码或必要输入后再试。',
+      rawMessage,
+      status,
+      category: 'missing_params',
+    });
+  }
+
+  const noConfiguredLlm = (
+    includesAny(matchText, ['all llm models failed']) && includesAny(matchText, ['last error: none'])
+  ) || includesAny(matchText, [
+    'no llm configured',
+    'litellm_model not configured',
+    'ai analysis will be unavailable',
+  ]);
+  if (noConfiguredLlm) {
+    return createParsedApiError({
+      title: '系统没有配置可用的 LLM 模型',
+      message: '请先在系统设置中配置主模型、可用渠道或相关 API Key 后再重试。',
+      rawMessage,
+      status,
+      category: 'llm_not_configured',
+    });
+  }
+
+  if (includesAny(matchText, [
+    'tool call',
+    'function call',
+    'does not support tools',
+    'tools is not supported',
+    'reasoning',
+  ])) {
+    return createParsedApiError({
+      title: '当前模型不兼容工具调用',
+      message: '当前模型不适合 Agent / 工具调用场景，请更换支持工具调用的模型后重试。',
+      rawMessage,
+      status,
+      category: 'model_tool_incompatible',
+    });
+  }
+
+  if (includesAny(matchText, [
+    'thought_signature',
+    'missing function',
+    'missing tool',
+    'invalid tool call',
+    'invalid function call',
+  ])) {
+    return createParsedApiError({
+      title: '上游模型返回的数据结构不完整',
+      message: '上游模型返回的工具调用结构不符合要求，请更换模型或关闭相关推理模式后重试。',
+      rawMessage,
+      status,
+      category: 'invalid_tool_call',
+    });
+  }
+
+  if (includesAny(matchText, ['timeout', 'timed out', 'read timeout', 'connect timeout']) || code === 'ECONNABORTED') {
+    return createParsedApiError({
+      title: '连接上游服务超时',
+      message: '服务端访问外部依赖时超时，请稍后重试，或检查当前网络与代理设置。',
+      rawMessage,
+      status,
+      category: 'upstream_timeout',
+    });
+  }
+
+  if (
+    status === 502
+    || status === 503
+    || includesAny(matchText, [
+      'dns',
+      'enotfound',
+      'name or service not known',
+      'temporary failure in name resolution',
+      'proxy',
+      'tunnel',
+      '502',
+      '503',
+    ])
+  ) {
+    return createParsedApiError({
+      title: '服务端无法访问外部依赖',
+      message: '页面已连接到本地服务，但本地服务访问外部模型或数据接口失败，请检查代理、DNS 或出网配置。',
+      rawMessage,
+      status,
+      category: 'upstream_network',
+    });
+  }
+
+  const hasLlmProviderHint = includesAny(matchText, [
+    'bad request',
+    'chat/completions',
+    'generativelanguage',
+    'openai',
+    'gemini',
+  ]);
+  if ((status === 400 || includesAny(matchText, ['bad request'])) && hasLlmProviderHint) {
+    return createParsedApiError({
+      title: '上游模型接口拒绝了当前请求',
+      message: '本地服务正常，但上游模型接口拒绝了请求，请检查模型名称、参数格式或工具调用兼容性。',
+      rawMessage,
+      status,
+      category: 'upstream_llm_400',
+    });
+  }
+
+  const localConnectionFailed = !response && (
+    includesAny(matchText, ['fetch failed', 'failed to fetch', 'network error', 'connection refused', 'econnrefused'])
+    || code === 'ERR_NETWORK'
+    || code === 'ECONNREFUSED'
+  );
+  if (localConnectionFailed) {
+    return createParsedApiError({
+      title: '无法连接到本地服务',
+      message: '浏览器当前无法连接到本地 Web 服务，请检查服务是否启动、监听地址是否正确、端口是否开放。',
+      rawMessage,
+      status,
+      category: 'local_connection_failed',
+    });
+  }
+
+  if (payloadText || status) {
+    return createParsedApiError({
+      title: '请求失败',
+      message: payloadText ?? `请求未成功完成（HTTP ${status}）。`,
+      rawMessage,
+      status,
+      category: 'http_error',
+    });
+  }
+
+  return createParsedApiError({
+    title: '请求失败',
+    message: rawMessage,
+    rawMessage,
+    status,
+    category: 'unknown',
+  });
+}
+
+export function toApiErrorMessage(error: unknown, fallback = '请求未成功完成，请稍后重试。'): string {
+  const parsed = getParsedApiError(error);
+  const message = formatParsedApiError(parsed);
+  return message.trim() || fallback;
+}
+
+export function isAxiosApiError(error: unknown): boolean {
+  return axios.isAxiosError(error);
+}

--- a/apps/dsa-web/src/api/index.ts
+++ b/apps/dsa-web/src/api/index.ts
@@ -1,5 +1,6 @@
 import axios from 'axios';
 import { API_BASE_URL } from '../utils/constants';
+import { attachParsedApiError } from './error';
 
 const apiClient = axios.create({
   baseURL: API_BASE_URL,
@@ -20,6 +21,7 @@ apiClient.interceptors.response.use(
         window.location.assign(`/login?redirect=${redirect}`);
       }
     }
+    attachParsedApiError(error);
     return Promise.reject(error);
   }
 );

--- a/apps/dsa-web/src/api/systemConfig.ts
+++ b/apps/dsa-web/src/api/systemConfig.ts
@@ -1,4 +1,5 @@
 import apiClient from './index';
+import { createParsedApiError, getParsedApiError, type ParsedApiError } from './error';
 import { toCamelCase } from './utils';
 import type {
   SystemConfigConflictResponse,
@@ -11,30 +12,39 @@ import type {
   ValidateSystemConfigResponse,
 } from '../types/systemConfig';
 
-type ApiErrorPayload = {
-  error?: string;
-  message?: string;
-  issues?: unknown;
-  current_config_version?: string;
-};
-
 export class SystemConfigValidationError extends Error {
   issues: SystemConfigValidationErrorResponse['issues'];
+  parsedError: ParsedApiError;
 
-  constructor(message: string, issues: SystemConfigValidationErrorResponse['issues']) {
+  constructor(message: string, issues: SystemConfigValidationErrorResponse['issues'], parsedError?: ParsedApiError) {
     super(message);
     this.name = 'SystemConfigValidationError';
     this.issues = issues;
+    this.parsedError = parsedError ?? createParsedApiError({
+      title: '配置校验失败',
+      message,
+      rawMessage: message,
+      status: 400,
+      category: 'http_error',
+    });
   }
 }
 
 export class SystemConfigConflictError extends Error {
   currentConfigVersion?: string;
+  parsedError: ParsedApiError;
 
-  constructor(message: string, currentConfigVersion?: string) {
+  constructor(message: string, currentConfigVersion?: string, parsedError?: ParsedApiError) {
     super(message);
     this.name = 'SystemConfigConflictError';
     this.currentConfigVersion = currentConfigVersion;
+    this.parsedError = parsedError ?? createParsedApiError({
+      title: '配置版本冲突',
+      message,
+      rawMessage: message,
+      status: 409,
+      category: 'http_error',
+    });
   }
 }
 
@@ -57,15 +67,6 @@ function toSnakeValidatePayload(payload: ValidateSystemConfigRequest): Record<st
       value: item.value,
     })),
   };
-}
-
-function extractApiMessage(error: unknown, fallback: string): string {
-  if (!error || typeof error !== 'object' || !('response' in error)) {
-    return fallback;
-  }
-
-  const response = (error as { response?: { data?: ApiErrorPayload } }).response;
-  return response?.data?.message || fallback;
 }
 
 export const systemConfigApi = {
@@ -97,28 +98,31 @@ export const systemConfigApi = {
       );
       return toCamelCase<UpdateSystemConfigResponse>(response.data);
     } catch (error: unknown) {
+      const parsed = getParsedApiError(error);
       if (error && typeof error === 'object' && 'response' in error) {
         const status = (error as { response?: { status?: number } }).response?.status;
-        const payloadData = (error as { response?: { data?: ApiErrorPayload } }).response?.data;
+        const payloadData = (error as { response?: { data?: unknown } }).response?.data;
 
         if (status === 400) {
           const validationError = toCamelCase<SystemConfigValidationErrorResponse>(payloadData ?? {});
           throw new SystemConfigValidationError(
-            validationError.message || '配置校验失败',
+            parsed.message || validationError.message || '配置校验失败',
             validationError.issues || [],
+            parsed,
           );
         }
 
         if (status === 409) {
           const conflict = toCamelCase<SystemConfigConflictResponse>(payloadData ?? {});
           throw new SystemConfigConflictError(
-            conflict.message || '配置版本冲突',
+            parsed.message || conflict.message || '配置版本冲突',
             conflict.currentConfigVersion,
+            parsed,
           );
         }
       }
 
-      throw new Error(extractApiMessage(error, '更新系统配置失败'));
+      throw error;
     }
   },
 };

--- a/apps/dsa-web/src/components/common/ApiErrorAlert.tsx
+++ b/apps/dsa-web/src/components/common/ApiErrorAlert.tsx
@@ -1,0 +1,41 @@
+import type React from 'react';
+import type { ParsedApiError } from '../../api/error';
+
+interface ApiErrorAlertProps {
+  error: ParsedApiError;
+  className?: string;
+  actionLabel?: string;
+  onAction?: () => void;
+}
+
+export const ApiErrorAlert: React.FC<ApiErrorAlertProps> = ({
+  error,
+  className = '',
+  actionLabel,
+  onAction,
+}) => {
+  const showDetails = error.rawMessage.trim() && error.rawMessage.trim() !== error.message.trim();
+
+  return (
+    <div
+      className={`rounded-xl border border-red-500/35 bg-red-500/10 px-4 py-3 text-red-200 ${className}`}
+      role="alert"
+    >
+      <p className="text-sm font-semibold">{error.title}</p>
+      <p className="mt-1 text-xs opacity-90">{error.message}</p>
+      {showDetails ? (
+        <details className="mt-3 rounded-lg border border-white/8 bg-black/15 px-3 py-2">
+          <summary className="cursor-pointer text-xs text-red-100/90">查看详情</summary>
+          <pre className="mt-2 whitespace-pre-wrap break-words text-[11px] leading-5 text-red-100/85">
+            {error.rawMessage}
+          </pre>
+        </details>
+      ) : null}
+      {actionLabel && onAction ? (
+        <button type="button" className="mt-3 btn-secondary !px-3 !py-1.5 !text-xs" onClick={onAction}>
+          {actionLabel}
+        </button>
+      ) : null}
+    </div>
+  );
+};

--- a/apps/dsa-web/src/components/common/index.ts
+++ b/apps/dsa-web/src/components/common/index.ts
@@ -3,6 +3,7 @@ export * from './Card';
 export * from './EyeToggleIcon';
 export * from './Loading';
 export * from './Drawer';
+export * from './ApiErrorAlert';
 export * from './Collapsible';
 export * from './ScoreGauge';
 export * from './JsonViewer';

--- a/apps/dsa-web/src/components/report/ReportNews.tsx
+++ b/apps/dsa-web/src/components/report/ReportNews.tsx
@@ -1,6 +1,9 @@
 import type React from 'react';
 import { useState, useEffect, useCallback } from 'react';
+import type { ParsedApiError } from '../../api/error';
+import { getParsedApiError } from '../../api/error';
 import { Card } from '../common';
+import { ApiErrorAlert } from '../common';
 import { historyApi } from '../../api/history';
 import type { NewsIntelItem } from '../../types/analysis';
 
@@ -15,7 +18,7 @@ interface ReportNewsProps {
 export const ReportNews: React.FC<ReportNewsProps> = ({ recordId, limit = 20 }) => {
   const [isLoading, setIsLoading] = useState(false);
   const [items, setItems] = useState<NewsIntelItem[]>([]);
-  const [error, setError] = useState<string | null>(null);
+  const [error, setError] = useState<ParsedApiError | null>(null);
 
   const fetchNews = useCallback(async () => {
     if (!recordId) return;
@@ -26,7 +29,7 @@ export const ReportNews: React.FC<ReportNewsProps> = ({ recordId, limit = 20 }) 
       const response = await historyApi.getNews(recordId, limit);
       setItems(response.items || []);
     } catch (err) {
-      setError(err instanceof Error ? err.message : '加载资讯失败');
+      setError(getParsedApiError(err));
     } finally {
       setIsLoading(false);
     }
@@ -67,16 +70,11 @@ export const ReportNews: React.FC<ReportNewsProps> = ({ recordId, limit = 20 }) 
       </div>
 
       {error && !isLoading && (
-        <div className="flex items-center justify-between gap-3 p-3 rounded-lg bg-danger/10 border border-danger/20 text-xs text-danger">
-          <span>{error}</span>
-          <button
-            type="button"
-            onClick={fetchNews}
-            className="text-xs text-cyan hover:text-white transition-colors"
-          >
-            重试
-          </button>
-        </div>
+        <ApiErrorAlert
+          error={error}
+          actionLabel="重试"
+          onAction={() => void fetchNews()}
+        />
       )}
 
       {isLoading && !error && (

--- a/apps/dsa-web/src/components/settings/ChangePasswordCard.tsx
+++ b/apps/dsa-web/src/components/settings/ChangePasswordCard.tsx
@@ -1,7 +1,9 @@
 import type React from 'react';
 import { useState } from 'react';
+import type { ParsedApiError } from '../../api/error';
+import { isParsedApiError } from '../../api/error';
 import { useAuth } from '../../hooks';
-import { EyeToggleIcon } from '../common';
+import { ApiErrorAlert, EyeToggleIcon } from '../common';
 import { SettingsAlert } from './SettingsAlert';
 
 export const ChangePasswordCard: React.FC = () => {
@@ -13,7 +15,7 @@ export const ChangePasswordCard: React.FC = () => {
   const [showNew, setShowNew] = useState(false);
   const [showConfirm, setShowConfirm] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
-  const [error, setError] = useState<string | null>(null);
+  const [error, setError] = useState<string | ParsedApiError | null>(null);
   const [success, setSuccess] = useState(false);
 
   const handleSubmit = async (e: React.FormEvent) => {
@@ -157,9 +159,11 @@ export const ChangePasswordCard: React.FC = () => {
           </div>
         </div>
 
-        {error ? (
-          <SettingsAlert title="修改失败" message={error} variant="error" className="!mt-3" />
-        ) : null}
+        {error
+          ? isParsedApiError(error)
+            ? <ApiErrorAlert error={error} className="!mt-3" />
+            : <SettingsAlert title="修改失败" message={error} variant="error" className="!mt-3" />
+          : null}
         {success ? (
           <p className="text-xs text-green-500">密码已修改成功</p>
         ) : null}

--- a/apps/dsa-web/src/components/settings/ImageStockExtractor.tsx
+++ b/apps/dsa-web/src/components/settings/ImageStockExtractor.tsx
@@ -1,5 +1,8 @@
 import type React from 'react';
 import { useCallback, useState } from 'react';
+import type { ParsedApiError } from '../../api/error';
+import { createParsedApiError, getParsedApiError } from '../../api/error';
+import { ApiErrorAlert } from '../common';
 import { stocksApi } from '../../api/stocks';
 import { systemConfigApi, SystemConfigConflictError } from '../../api/systemConfig';
 
@@ -24,7 +27,7 @@ export const ImageStockExtractor: React.FC<ImageStockExtractorProps> = ({
   const [codes, setCodes] = useState<string[]>([]);
   const [isExtracting, setIsExtracting] = useState(false);
   const [isMerging, setIsMerging] = useState(false);
-  const [error, setError] = useState<string | null>(null);
+  const [error, setError] = useState<ParsedApiError | null>(null);
   const [isDragging, setIsDragging] = useState(false);
 
   const parseCurrentList = useCallback(() => {
@@ -38,11 +41,19 @@ export const ImageStockExtractor: React.FC<ImageStockExtractorProps> = ({
     async (file: File) => {
       const ext = '.' + (file.name.split('.').pop() ?? '').toLowerCase();
       if (!ALLOWED_EXT.includes(ext)) {
-        setError('仅支持 JPG、PNG、WebP、GIF 格式');
+        setError(createParsedApiError({
+          title: '文件格式不支持',
+          message: '仅支持 JPG、PNG、WebP、GIF 格式。',
+          category: 'unknown',
+        }));
         return;
       }
       if (file.size > MAX_SIZE) {
-        setError('图片不超过 5MB');
+        setError(createParsedApiError({
+          title: '图片尺寸超出限制',
+          message: '图片大小不能超过 5MB。',
+          category: 'unknown',
+        }));
         return;
       }
 
@@ -52,13 +63,7 @@ export const ImageStockExtractor: React.FC<ImageStockExtractorProps> = ({
         const res = await stocksApi.extractFromImage(file);
         setCodes(res.codes ?? []);
       } catch (e) {
-        const err = e && typeof e === 'object' ? e as { code?: string; response?: { data?: { message?: string }; status?: number } } : null;
-        const resp = err?.response ?? null;
-        const msg = resp?.data?.message ?? null;
-        let fallback = '识别失败，请重试';
-        if (resp?.status === 429) fallback = '请求过于频繁，请稍后再试';
-        else if (err?.code === 'ECONNABORTED') fallback = '请求超时，请检查网络后重试';
-        setError(msg || fallback);
+        setError(getParsedApiError(e));
         setCodes([]);
       } finally {
         setIsExtracting(false);
@@ -103,7 +108,11 @@ export const ImageStockExtractor: React.FC<ImageStockExtractorProps> = ({
   const mergeToWatchlist = useCallback(async () => {
     if (codes.length === 0) return;
     if (!configVersion) {
-      setError('请先加载配置后再合并');
+      setError(createParsedApiError({
+        title: '配置尚未加载',
+        message: '请先加载配置后再合并。',
+        category: 'unknown',
+      }));
       return;
     }
     const current = parseCurrentList();
@@ -124,9 +133,15 @@ export const ImageStockExtractor: React.FC<ImageStockExtractorProps> = ({
     } catch (e) {
       if (e instanceof SystemConfigConflictError) {
         onMerged();
-        setError('配置已更新，请再次点击「合并到自选股」');
+        setError(createParsedApiError({
+          title: '配置已发生变化',
+          message: '配置已更新，请再次点击“合并到自选股”。',
+          rawMessage: e.parsedError.rawMessage,
+          status: e.parsedError.status,
+          category: e.parsedError.category,
+        }));
       } else {
-        setError(e instanceof Error ? e.message : '合并保存失败');
+        setError(getParsedApiError(e));
       }
     } finally {
       setIsMerging(false);
@@ -167,9 +182,7 @@ export const ImageStockExtractor: React.FC<ImageStockExtractorProps> = ({
       </div>
 
       {error ? (
-        <div className="mb-3 rounded-lg border border-red-500/30 bg-red-500/10 px-3 py-2 text-sm text-red-400">
-          {error}
-        </div>
+        <ApiErrorAlert error={error} className="mb-3" />
       ) : null}
 
       {codes.length > 0 ? (

--- a/apps/dsa-web/src/components/settings/LLMChannelEditor.tsx
+++ b/apps/dsa-web/src/components/settings/LLMChannelEditor.tsx
@@ -1,6 +1,8 @@
 import { useState, useMemo, useCallback } from 'react';
 import type React from 'react';
-import { EyeToggleIcon } from '../common';
+import type { ParsedApiError } from '../../api/error';
+import { getParsedApiError } from '../../api/error';
+import { ApiErrorAlert, EyeToggleIcon } from '../common';
 import { systemConfigApi } from '../../api/systemConfig';
 
 /** Well-known channel presets for quick-add dropdown. */
@@ -146,7 +148,9 @@ export const LLMChannelEditor: React.FC<LLMChannelEditorProps> = ({
 
   const [channels, setChannels] = useState<ChannelConfig[]>(initialChannels);
   const [isSaving, setIsSaving] = useState(false);
-  const [saveMessage, setSaveMessage] = useState<{ type: 'success' | 'error'; text: string } | null>(null);
+  const [saveMessage, setSaveMessage] = useState<
+    { type: 'success'; text: string } | { type: 'error'; error: ParsedApiError } | null
+  >(null);
   const [visibleKeys, setVisibleKeys] = useState<Record<number, boolean>>({});
   const [isCollapsed, setIsCollapsed] = useState(initialChannels.length === 0);
   const [addPreset, setAddPreset] = useState('aihubmix');
@@ -217,8 +221,7 @@ export const LLMChannelEditor: React.FC<LLMChannelEditorProps> = ({
       setSaveMessage({ type: 'success', text: '渠道配置已保存' });
       onSaved();
     } catch (error: unknown) {
-      const msg = error instanceof Error ? error.message : '保存失败';
-      setSaveMessage({ type: 'error', text: msg });
+      setSaveMessage({ type: 'error', error: getParsedApiError(error) });
     } finally {
       setIsSaving(false);
     }
@@ -386,11 +389,9 @@ export const LLMChannelEditor: React.FC<LLMChannelEditorProps> = ({
           )}
 
           {saveMessage && (
-            <p
-              className={`text-xs ${saveMessage.type === 'success' ? 'text-green-400' : 'text-red-400'}`}
-            >
-              {saveMessage.text}
-            </p>
+            saveMessage.type === 'success'
+              ? <p className="text-xs text-green-400">{saveMessage.text}</p>
+              : <ApiErrorAlert error={saveMessage.error} />
           )}
         </div>
       )}

--- a/apps/dsa-web/src/contexts/AuthContext.tsx
+++ b/apps/dsa-web/src/contexts/AuthContext.tsx
@@ -1,5 +1,6 @@
 import type React from 'react';
 import { createContext, useCallback, useContext, useEffect, useState } from 'react';
+import { createParsedApiError, getParsedApiError, type ParsedApiError } from '../api/error';
 import { authApi } from '../api/auth';
 
 type AuthContextValue = {
@@ -8,32 +9,31 @@ type AuthContextValue = {
   passwordSet: boolean;
   passwordChangeable: boolean;
   isLoading: boolean;
-  loadError: string | null;
-  login: (password: string, passwordConfirm?: string) => Promise<{ success: boolean; error?: string }>;
+  loadError: ParsedApiError | null;
+  login: (password: string, passwordConfirm?: string) => Promise<{ success: boolean; error?: ParsedApiError }>;
   changePassword: (
     currentPassword: string,
     newPassword: string,
     newPasswordConfirm: string
-  ) => Promise<{ success: boolean; error?: string }>;
+  ) => Promise<{ success: boolean; error?: ParsedApiError }>;
   logout: () => Promise<void>;
   refreshStatus: () => Promise<void>;
 };
 
 const AuthContext = createContext<AuthContextValue | null>(null);
 
-function extractLoginError(err: unknown): string {
-  const axiosErr =
-    err && typeof err === 'object' && 'response' in err
-      ? (err as { response?: { status?: number; data?: { message?: string } } })
-      : null;
-  if (axiosErr) {
-    if (axiosErr.response?.status === 429) {
-      return '尝试次数过多，请稍后再试';
-    }
-    const serverMsg = axiosErr.response?.data?.message;
-    return serverMsg || '密码错误';
+function extractLoginError(err: unknown): ParsedApiError {
+  const parsed = getParsedApiError(err);
+  if (parsed.status === 429) {
+    return createParsedApiError({
+      title: '登录尝试过于频繁',
+      message: '尝试次数过多，请稍后再试。',
+      rawMessage: parsed.rawMessage,
+      status: parsed.status,
+      category: parsed.category,
+    });
   }
-  return '登录失败';
+  return parsed;
 }
 
 export function AuthProvider({ children }: { children: React.ReactNode }) {
@@ -42,7 +42,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   const [passwordSet, setPasswordSet] = useState(false);
   const [passwordChangeable, setPasswordChangeable] = useState(false);
   const [isLoading, setIsLoading] = useState(true);
-  const [loadError, setLoadError] = useState<string | null>(null);
+  const [loadError, setLoadError] = useState<ParsedApiError | null>(null);
 
   const fetchStatus = useCallback(async () => {
     setIsLoading(true);
@@ -54,7 +54,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       setPasswordSet(status.passwordSet ?? false);
       setPasswordChangeable(status.passwordChangeable ?? false);
     } catch (err) {
-      setLoadError(err instanceof Error ? err.message : 'Failed to load auth status');
+      setLoadError(getParsedApiError(err));
       setAuthEnabled(false);
       setLoggedIn(false);
       setPasswordSet(false);
@@ -72,7 +72,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     async (
       password: string,
       passwordConfirm?: string
-    ): Promise<{ success: boolean; error?: string }> => {
+    ): Promise<{ success: boolean; error?: ParsedApiError }> => {
       try {
         await authApi.login(password, passwordConfirm);
         setLoggedIn(true);
@@ -89,17 +89,12 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       currentPassword: string,
       newPassword: string,
       newPasswordConfirm: string
-    ): Promise<{ success: boolean; error?: string }> => {
+    ): Promise<{ success: boolean; error?: ParsedApiError }> => {
       try {
         await authApi.changePassword(currentPassword, newPassword, newPasswordConfirm);
         return { success: true };
       } catch (err: unknown) {
-        const axiosErr =
-          err && typeof err === 'object' && 'response' in err
-            ? (err as { response?: { data?: { message?: string } } })
-            : null;
-        const msg = axiosErr?.response?.data?.message || '修改失败';
-        return { success: false, error: msg };
+        return { success: false, error: getParsedApiError(err) };
       }
     },
     []

--- a/apps/dsa-web/src/hooks/useSystemConfig.ts
+++ b/apps/dsa-web/src/hooks/useSystemConfig.ts
@@ -1,4 +1,5 @@
 import { useCallback, useMemo, useState } from 'react';
+import { createParsedApiError, getParsedApiError, type ParsedApiError } from '../api/error';
 import { systemConfigApi, SystemConfigConflictError, SystemConfigValidationError } from '../api/systemConfig';
 import type {
   ConfigValidationIssue,
@@ -8,8 +9,11 @@ import type {
 } from '../types/systemConfig';
 
 type ToastState = {
-  type: 'success' | 'error';
+  type: 'success';
   message: string;
+} | {
+  type: 'error';
+  error: ParsedApiError;
 } | null;
 
 type RetryAction = 'load' | 'save' | null;
@@ -40,13 +44,6 @@ function sortItemsByOrder(items: SystemConfigItem[]): SystemConfigItem[] {
     }
     return a.key.localeCompare(b.key);
   });
-}
-
-function getReadableError(error: unknown, fallback: string): string {
-  if (error instanceof Error && error.message) {
-    return error.message;
-  }
-  return fallback;
 }
 
 function isMultiValueSchema(schema: SystemConfigItem['schema'] | undefined): boolean {
@@ -81,8 +78,8 @@ export function useSystemConfig() {
   // Request state
   const [isLoading, setIsLoading] = useState(false);
   const [isSaving, setIsSaving] = useState(false);
-  const [loadError, setLoadError] = useState<string | null>(null);
-  const [saveError, setSaveError] = useState<string | null>(null);
+  const [loadError, setLoadError] = useState<ParsedApiError | null>(null);
+  const [saveError, setSaveError] = useState<ParsedApiError | null>(null);
   const [retryAction, setRetryAction] = useState<RetryAction>(null);
 
   const mergedItems = useMemo(() => {
@@ -201,7 +198,7 @@ export function useSystemConfig() {
       applyServerPayload(config.items, config.configVersion, config.maskToken);
       setToast(null);
     } catch (error: unknown) {
-      setLoadError(getReadableError(error, '加载系统配置失败'));
+      setLoadError(getParsedApiError(error));
       setRetryAction('load');
     } finally {
       setIsLoading(false);
@@ -259,7 +256,12 @@ export function useSystemConfig() {
       setValidationIssues(validateResult.issues || []);
 
       if (!validateResult.valid) {
-        setSaveError('配置校验未通过，请先修正表单错误。');
+        setSaveError(createParsedApiError({
+          title: '配置校验未通过',
+          message: '请先修正表单错误后再保存。',
+          rawMessage: '配置校验未通过，请先修正表单错误。',
+          category: 'http_error',
+        }));
         setRetryAction('save');
         return {
           success: false,
@@ -286,14 +288,20 @@ export function useSystemConfig() {
     } catch (error: unknown) {
       if (error instanceof SystemConfigValidationError) {
         setValidationIssues(error.issues);
-        setSaveError(error.message || '配置校验失败');
+        setSaveError(error.parsedError);
       } else if (error instanceof SystemConfigConflictError) {
-        setSaveError(`${error.message}，请先重新加载配置。`);
+        setSaveError(createParsedApiError({
+          title: '配置版本冲突',
+          message: `${error.message}，请先重新加载配置。`,
+          rawMessage: error.parsedError.rawMessage,
+          status: error.parsedError.status,
+          category: error.parsedError.category,
+        }));
       } else {
-        setSaveError(getReadableError(error, '保存配置失败'));
+        setSaveError(getParsedApiError(error));
       }
 
-      setToast({ type: 'error', message: '配置保存失败。' });
+      setToast({ type: 'error', error: getParsedApiError(error) });
       setRetryAction('save');
       return { success: false, message: '保存失败' };
     } finally {

--- a/apps/dsa-web/src/pages/BacktestPage.tsx
+++ b/apps/dsa-web/src/pages/BacktestPage.tsx
@@ -1,7 +1,9 @@
 import type React from 'react';
 import { useState, useEffect, useCallback } from 'react';
 import { backtestApi } from '../api/backtest';
-import { Card, Badge, Pagination } from '../components/common';
+import type { ParsedApiError } from '../api/error';
+import { getParsedApiError } from '../api/error';
+import { ApiErrorAlert, Card, Badge, Pagination } from '../components/common';
 import type {
   BacktestResultItem,
   BacktestRunResponse,
@@ -113,7 +115,8 @@ const BacktestPage: React.FC = () => {
   const [forceRerun, setForceRerun] = useState(false);
   const [isRunning, setIsRunning] = useState(false);
   const [runResult, setRunResult] = useState<BacktestRunResponse | null>(null);
-  const [runError, setRunError] = useState<string | null>(null);
+  const [runError, setRunError] = useState<ParsedApiError | null>(null);
+  const [pageError, setPageError] = useState<ParsedApiError | null>(null);
 
   // Results state
   const [results, setResults] = useState<BacktestResultItem[]>([]);
@@ -135,8 +138,10 @@ const BacktestPage: React.FC = () => {
       setResults(response.items);
       setTotalResults(response.total);
       setCurrentPage(response.page);
+      setPageError(null);
     } catch (err) {
       console.error('Failed to fetch backtest results:', err);
+      setPageError(getParsedApiError(err));
     } finally {
       setIsLoadingResults(false);
     }
@@ -155,8 +160,10 @@ const BacktestPage: React.FC = () => {
       } else {
         setStockPerf(null);
       }
+      setPageError(null);
     } catch (err) {
       console.error('Failed to fetch performance:', err);
+      setPageError(getParsedApiError(err));
     } finally {
       setIsLoadingPerf(false);
     }
@@ -197,7 +204,7 @@ const BacktestPage: React.FC = () => {
       fetchResults(1, codeFilter.trim() || undefined, evalWindowDays);
       fetchPerformance(codeFilter.trim() || undefined, evalWindowDays);
     } catch (err) {
-      setRunError(err instanceof Error ? err.message : 'Backtest failed');
+      setRunError(getParsedApiError(err));
     } finally {
       setIsRunning(false);
     }
@@ -307,7 +314,7 @@ const BacktestPage: React.FC = () => {
           </div>
         )}
         {runError && (
-          <p className="mt-2 text-xs text-danger">{runError}</p>
+          <ApiErrorAlert error={runError} className="mt-2 max-w-4xl" />
         )}
       </header>
 
@@ -336,6 +343,9 @@ const BacktestPage: React.FC = () => {
 
         {/* Right content - Results table */}
         <section className="flex-1 overflow-y-auto">
+          {pageError ? (
+            <ApiErrorAlert error={pageError} className="mb-3" />
+          ) : null}
           {isLoadingResults ? (
             <div className="flex flex-col items-center justify-center h-64">
               <div className="w-10 h-10 border-3 border-cyan/20 border-t-cyan rounded-full animate-spin" />

--- a/apps/dsa-web/src/pages/ChatPage.tsx
+++ b/apps/dsa-web/src/pages/ChatPage.tsx
@@ -3,6 +3,14 @@ import { useSearchParams } from 'react-router-dom';
 import Markdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import { agentApi } from '../api/agent';
+import {
+  createParsedApiError,
+  getParsedApiError,
+  isApiRequestError,
+  isParsedApiError,
+  type ParsedApiError,
+} from '../api/error';
+import { ApiErrorAlert } from '../components/common';
 import { generateUUID } from '../utils/uuid';
 import type { StrategyInfo, ChatSessionItem } from '../api/agent';
 import { historyApi } from '../api/history';
@@ -64,6 +72,7 @@ const ChatPage: React.FC = () => {
   const [selectedStrategy, setSelectedStrategy] = useState<string>('bull_trend');
   const [progressSteps, setProgressSteps] = useState<ProgressStep[]>([]);
   const [showStrategyDesc, setShowStrategyDesc] = useState<string | null>(null);
+  const [chatError, setChatError] = useState<ParsedApiError | null>(null);
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const initialFollowUpHandled = useRef(false);
 
@@ -213,6 +222,7 @@ const ChatPage: React.FC = () => {
     setInput('');
     setLoading(true);
     setProgressSteps([]);
+    setChatError(null);
 
     const currentSessionId = sessionIdRef.current;
 
@@ -240,20 +250,7 @@ const ChatPage: React.FC = () => {
     }
 
     try {
-      const response = await fetch('/api/v1/agent/chat/stream', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(payload),
-      });
-
-      if (!response.ok) {
-        const errData = await response.json().catch(() => ({}));
-        const detail = (errData as { detail?: string }).detail || `HTTP ${response.status}`;
-        if (response.status === 400 && String(detail).includes('not enabled')) {
-          throw new Error('⚠️ Agent 模式未启用，请在 .env 中设置 AGENT_MODE=true 并重启服务。');
-        }
-        throw new Error(`❌ 服务端错误: ${detail}`);
-      }
+      const response = await agentApi.chatStream(payload);
 
       const reader = response.body!.getReader();
       const decoder = new TextDecoder();
@@ -275,17 +272,28 @@ const ChatPage: React.FC = () => {
             if (event.type === 'done') {
               const doneEvent = event as unknown as { type: string; success: boolean; content?: string; error?: string };
               if (doneEvent.success === false) {
-                throw new Error(`❌ 分析失败: ${doneEvent.error || doneEvent.content || '大模型调用出错，请检查 API Key 配置'}`);
+                const parsedStreamError = getParsedApiError(
+                  doneEvent.error || doneEvent.content || '大模型调用出错，请检查 API Key 配置',
+                );
+                throw createParsedApiError({
+                  title: '问股执行失败',
+                  message: parsedStreamError.message,
+                  rawMessage: parsedStreamError.rawMessage,
+                  status: parsedStreamError.status,
+                  category: parsedStreamError.category,
+                });
               }
               finalContent = doneEvent.content ?? '';
             } else if (event.type === 'error') {
-              throw new Error(`❌ 分析出错: ${event.message}`);
+              throw getParsedApiError(event.message || '分析出错');
             } else {
               currentProgressSteps.push(event);
               setProgressSteps((prev) => [...prev, event]);
             }
           } catch (parseErr: unknown) {
-            if ((parseErr as Error).message?.startsWith('❌')) throw parseErr;
+            if (isParsedApiError(parseErr) || isApiRequestError(parseErr)) {
+              throw parseErr;
+            }
           }
         }
       }
@@ -302,15 +310,7 @@ const ChatPage: React.FC = () => {
         },
       ]);
     } catch (error: unknown) {
-      const errMsg = (error as Error).message;
-      const displayMsg =
-        errMsg?.startsWith('⚠️') || errMsg?.startsWith('❌')
-          ? errMsg
-          : `抱歉，发生了错误: ${errMsg || '未知错误'}`;
-      setMessages((prev) => [
-        ...prev,
-        { id: (Date.now() + 1).toString(), role: 'assistant', content: displayMsg },
-      ]);
+      setChatError(getParsedApiError(error));
     } finally {
       setLoading(false);
       setProgressSteps([]);
@@ -638,6 +638,9 @@ const ChatPage: React.FC = () => {
 
         {/* Input area */}
         <div className="p-4 md:p-6 border-t border-white/5 bg-black/20 relative z-20">
+          {chatError ? (
+            <ApiErrorAlert error={chatError} className="mb-3" />
+          ) : null}
           {/* Strategy radio selector with descriptions */}
           {strategies.length > 0 && (
             <div className="mb-3 flex flex-wrap gap-x-5 gap-y-2 items-start">

--- a/apps/dsa-web/src/pages/HomePage.tsx
+++ b/apps/dsa-web/src/pages/HomePage.tsx
@@ -1,6 +1,8 @@
 import type React from 'react';
 import { useState, useEffect, useCallback, useRef } from 'react';
 import { useNavigate } from 'react-router-dom';
+import { ApiErrorAlert } from '../components/common';
+import { getParsedApiError } from '../api/error';
 import type { HistoryItem, AnalysisReport, TaskInfo } from '../types/analysis';
 import { historyApi } from '../api/history';
 import { analysisApi, DuplicateTaskError } from '../api/analysis';
@@ -17,7 +19,11 @@ import { useTaskStream } from '../hooks';
  * 顶部输入 + 左侧历史 + 右侧报告
  */
 const HomePage: React.FC = () => {
-  const { setLoading, setError: setStoreError } = useAnalysisStore();
+  const {
+    error: analysisError,
+    setLoading,
+    setError: setStoreError,
+  } = useAnalysisStore();
   const navigate = useNavigate();
 
   // 输入状态
@@ -82,7 +88,7 @@ const HomePage: React.FC = () => {
     onTaskFailed: (task) => {
       updateTask(task);
       // 显示错误提示
-      setStoreError(task.error || '分析失败');
+      setStoreError(getParsedApiError(task.error || '分析失败'));
       // 延迟移除任务
       setTimeout(() => removeTask(task.taskId), 5000);
     },
@@ -150,20 +156,23 @@ const HomePage: React.FC = () => {
         setIsLoadingReport(true);
         try {
           const report = await historyApi.getDetail(firstItem.id);
+          setStoreError(null);
           setSelectedReport(report);
         } catch (err) {
           console.error('Failed to fetch first report:', err);
+          setStoreError(getParsedApiError(err));
         } finally {
           setIsLoadingReport(false);
         }
       }
     } catch (err) {
       console.error('Failed to fetch history:', err);
+      setStoreError(getParsedApiError(err));
     } finally {
       setIsLoadingHistory(false);
       setIsLoadingMore(false);
     }
-  }, [pageSize]);
+  }, [pageSize, setStoreError]);
 
   // 加载更多历史记录
   const handleLoadMore = useCallback(() => {
@@ -211,11 +220,12 @@ const HomePage: React.FC = () => {
       const report = await historyApi.getDetail(recordId);
       // Ignore result if a newer click has already been issued.
       if (requestId === analysisRequestIdRef.current) {
+        setStoreError(null);
         setSelectedReport(report);
       }
     } catch (err) {
       console.error('Failed to fetch report:', err);
-      setStoreError(err instanceof Error ? err.message : '报告加载失败');
+      setStoreError(getParsedApiError(err));
     }
   };
 
@@ -257,7 +267,7 @@ const HomePage: React.FC = () => {
           // 显示重复任务错误
           setDuplicateError(`股票 ${err.stockCode} 正在分析中，请等待完成`);
         } else {
-          setStoreError(err instanceof Error ? err.message : '分析失败');
+          setStoreError(getParsedApiError(err));
         }
       }
     } finally {
@@ -370,6 +380,12 @@ const HomePage: React.FC = () => {
 
       {/* 右侧报告详情 */}
       <section className="md:col-start-4 md:row-start-2 flex-1 overflow-y-auto overflow-x-auto px-3 md:px-0 md:pl-1 min-w-0 min-h-0">
+        {analysisError ? (
+          <ApiErrorAlert
+            error={analysisError}
+            className="mb-3"
+          />
+        ) : null}
         {isLoadingReport ? (
           <div className="flex flex-col items-center justify-center h-full">
             <div className="w-10 h-10 border-3 border-cyan/20 border-t-cyan rounded-full animate-spin" />

--- a/apps/dsa-web/src/pages/LoginPage.tsx
+++ b/apps/dsa-web/src/pages/LoginPage.tsx
@@ -1,6 +1,9 @@
 import type React from 'react';
 import { useState } from 'react';
+import { ApiErrorAlert } from '../components/common';
 import { useNavigate, useSearchParams } from 'react-router-dom';
+import type { ParsedApiError } from '../api/error';
+import { isParsedApiError } from '../api/error';
 import { useAuth } from '../hooks';
 import { SettingsAlert } from '../components/settings';
 
@@ -15,7 +18,7 @@ const LoginPage: React.FC = () => {
   const [password, setPassword] = useState('');
   const [passwordConfirm, setPasswordConfirm] = useState('');
   const [isSubmitting, setIsSubmitting] = useState(false);
-  const [error, setError] = useState<string | null>(null);
+  const [error, setError] = useState<string | ParsedApiError | null>(null);
 
   const isFirstTime = !passwordSet;
 
@@ -90,14 +93,18 @@ const LoginPage: React.FC = () => {
             </div>
           ) : null}
 
-          {error ? (
-            <SettingsAlert
-              title={isFirstTime ? '设置失败' : '登录失败'}
-              message={error}
-              variant="error"
-              className="!mt-3"
-            />
-          ) : null}
+          {error
+            ? isParsedApiError(error)
+              ? <ApiErrorAlert error={error} className="!mt-3" />
+              : (
+                <SettingsAlert
+                  title={isFirstTime ? '设置失败' : '登录失败'}
+                  message={error}
+                  variant="error"
+                  className="!mt-3"
+                />
+              )
+            : null}
 
           <button
             type="submit"

--- a/apps/dsa-web/src/pages/SettingsPage.tsx
+++ b/apps/dsa-web/src/pages/SettingsPage.tsx
@@ -1,6 +1,7 @@
 import type React from 'react';
 import { useEffect } from 'react';
 import { useAuth, useSystemConfig } from '../hooks';
+import { ApiErrorAlert } from '../components/common';
 import {
   ChangePasswordCard,
   ImageStockExtractor,
@@ -91,10 +92,9 @@ const SettingsPage: React.FC = () => {
         </div>
 
         {saveError ? (
-          <SettingsAlert
+          <ApiErrorAlert
             className="mt-3"
-            title="保存失败"
-            message={saveError}
+            error={saveError}
             actionLabel={retryAction === 'save' ? '重试保存' : undefined}
             onAction={retryAction === 'save' ? () => void retry() : undefined}
           />
@@ -102,9 +102,8 @@ const SettingsPage: React.FC = () => {
       </header>
 
       {loadError ? (
-        <SettingsAlert
-          title="加载设置失败"
-          message={loadError}
+        <ApiErrorAlert
+          error={loadError}
           actionLabel={retryAction === 'load' ? '重试加载' : '重新加载'}
           onAction={() => void retry()}
           className="mb-4"
@@ -196,11 +195,9 @@ const SettingsPage: React.FC = () => {
 
       {toast ? (
         <div className="fixed bottom-5 right-5 z-50 w-[320px] max-w-[calc(100vw-24px)]">
-          <SettingsAlert
-            title={toast.type === 'success' ? '操作成功' : '操作失败'}
-            message={toast.message}
-            variant={toast.type === 'success' ? 'success' : 'error'}
-          />
+          {toast.type === 'success'
+            ? <SettingsAlert title="操作成功" message={toast.message} variant="success" />
+            : <ApiErrorAlert error={toast.error} />}
         </div>
       ) : null}
     </div>

--- a/apps/dsa-web/src/stores/analysisStore.ts
+++ b/apps/dsa-web/src/stores/analysisStore.ts
@@ -1,11 +1,12 @@
 import { create } from 'zustand';
+import type { ParsedApiError } from '../api/error';
 import type { AnalysisResult, AnalysisReport } from '../types/analysis';
 
 interface AnalysisState {
   // 分析状态
   isLoading: boolean;
   result: AnalysisResult | null;
-  error: string | null;
+  error: ParsedApiError | null;
 
   // 历史报告视图
   isHistoryView: boolean;
@@ -14,7 +15,7 @@ interface AnalysisState {
   // Actions
   setLoading: (loading: boolean) => void;
   setResult: (result: AnalysisResult | null) => void;
-  setError: (error: string | null) => void;
+  setError: (error: ParsedApiError | null) => void;
   setHistoryReport: (report: AnalysisReport | null) => void;
   reset: () => void;
   resetToAnalysis: () => void;

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+- 🐛 **Web UI API error classification** — frontend no longer treats every HTTP 400 as the same “server/network” failure. It now prioritizes backend error text, distinguishes Agent disabled / missing params / model-tool incompatibility / upstream LLM 400 / upstream timeout or egress failure / local connection failure, and only shows local listen-address hints when the browser cannot reach the local service.
+
 ## [3.4.9] - 2026-03-06
 
 ### Added


### PR DESCRIPTION
## PR Type

- [X] fix
- [X] refactor

## Background And Problem

本 PR 修复 Web UI 的接口报错展示逻辑，避免前端把所有 HTTP 400 都渲染成同一种泛化的“服务端错误”或“网络错误”。

此前前端存在两个主要问题：

1. 不同页面各自用 `err.message` 或页面内 fallback 字符串处理错误，逻辑分散。
2. HTTP 400 经常被统一显示为同一种错误，导致后端真实错误原因被掩盖，并且在本地服务明明可用时，错误地提示监听地址、端口或服务未启动。

本 PR 将错误解析与展示收敛到公共逻辑，并确保只有浏览器真正连不上本地 API 时，才提示本地服务连接问题。


## Scope Of Change

已将统一错误解析/展示接入以下主要入口：

- 设置页与系统配置保存/加载
- 登录与修改密码
- 首页分析、历史记录、报告加载
- 回测页面
- 问股页面
- 图片识别入口
- 资讯加载入口
- 全局鉴权初始化错误提示

## Issue Link

必须填写以下之一：
- 无 Issue 
说明：遇到错误能准确展示后端传递的信息与说明；

## 核心代码变更

### 1. 新增统一错误解析模块
- `apps/dsa-web/src/api/error.ts`
- 新增 `ParsedApiError`、`parseApiError()`、`isApiRequestError()` 等公共逻辑
- 统一输出：
  - `title`
  - `message`
  - `rawMessage`
  - `status`
  - `category`

### 2. 新增统一错误展示组件
- `apps/dsa-web/src/components/common/ApiErrorAlert.tsx`
- 统一展示：
  - 标题
  - 说明
  - “查看详情”折叠区（原始错误 `rawMessage`）

### 3. 请求层统一接入
- `apps/dsa-web/src/api/index.ts`
  - axios 响应拦截器在抛错前附加解析后的错误信息
- `apps/dsa-web/src/api/agent.ts`
  - Agent 流式 `fetch()` 路径接入统一错误包装与分类逻辑

### 4. 主要页面/入口接入
涉及以下前端入口：
- `apps/dsa-web/src/pages/ChatPage.tsx`
- `apps/dsa-web/src/pages/HomePage.tsx`
- `apps/dsa-web/src/pages/BacktestPage.tsx`
- `apps/dsa-web/src/pages/SettingsPage.tsx`
- `apps/dsa-web/src/pages/LoginPage.tsx`
- `apps/dsa-web/src/contexts/AuthContext.tsx`
- `apps/dsa-web/src/hooks/useSystemConfig.ts`
- `apps/dsa-web/src/components/settings/ImageStockExtractor.tsx`
- `apps/dsa-web/src/components/settings/LLMChannelEditor.tsx`
- `apps/dsa-web/src/components/settings/ChangePasswordCard.tsx`
- `apps/dsa-web/src/components/report/ReportNews.tsx`

## 本次错误分类能力
本 PR 已支持区分：
- Agent 未开启
- 缺少必要参数
- 系统没有配置可用的 LLM 模型
- 模型不兼容工具调用
- 上游返回不完整 tool-call / function-call 结构
- 上游 LLM 400
- 上游超时
- 上游 DNS / 代理 / 出网失败
- 本地连接失败
- 其他 HTTP / 未知错误

## 统一规则
- 优先显示后端返回的具体错误信息
- 保留“查看详情”区域展示原始错误
- HTTP 400 默认不再提示监听地址/端口问题
- 只有真正无法连接本地服务时，才提示本地服务未启动或监听异常

## Verification Commands And Results

已在 `apps/dsa-web` 目录执行：

```bash
npm run build
npm run lint
```
上述命令均已通过。


## Compatibility And Risk

请说明兼容性影响、潜在风险（如无请写 `None`）。

可能会影响部分错误展示；

## Rollback Plan

回滚本 PR 即可恢复此前页面各自处理错误的行为。

## Checklist

- [X] 我已确认本 PR 有明确动机和业务价值
- [X] 我已提供可复现的验证命令与结果
- [X] 我已评估兼容性与风险
- [X ] 我已提供回滚方案
- [X] 若涉及用户可见变更，我已同步更新   `docs/CHANGELOG.md`

------
![Snipaste_2026-03-07_11-21-33](https://github.com/user-attachments/assets/d5c77b1d-4972-4bbd-ba67-f86076b1eef9)
