### PR TITLE
fix: split oversized PushPlus notifications

### DIFF
--- a/src/notification_sender/pushplus_sender.py
+++ b/src/notification_sender/pushplus_sender.py
@@ -6,11 +6,13 @@ PushPlus 发送提醒服务
 1. 通过 PushPlus API 发送 PushPlus 消息
 """
 import logging
+import time
 from typing import Optional
 from datetime import datetime
 import requests
 
 from src.config import Config
+from src.formatters import chunk_content_by_max_bytes
 
 
 logger = logging.getLogger(__name__)
@@ -27,6 +29,7 @@ class PushplusSender:
         """
         self._pushplus_token = getattr(config, 'pushplus_token', None)
         self._pushplus_topic = getattr(config, 'pushplus_topic', None)
+        self._pushplus_max_bytes = getattr(config, 'pushplus_max_bytes', 20000)
         
     def send_to_pushplus(self, content: str, title: Optional[str] = None) -> bool:
         """
@@ -57,42 +60,76 @@ class PushplusSender:
             logger.warning("PushPlus Token 未配置，跳过推送")
             return False
 
-        # PushPlus API 端点
         api_url = "http://www.pushplus.plus/send"
 
-        # 处理消息标题
         if title is None:
             date_str = datetime.now().strftime('%Y-%m-%d')
             title = f"📈 股票分析报告 - {date_str}"
 
         try:
-            payload = {
-                "token": self._pushplus_token,
-                "title": title,
-                "content": content,
-                "template": "markdown"  # 使用 Markdown 格式
-            }
+            content_bytes = len(content.encode('utf-8'))
+            if content_bytes > self._pushplus_max_bytes:
+                logger.info(
+                    "PushPlus 消息内容超长(%s字节/%s字符)，将分批发送",
+                    content_bytes,
+                    len(content),
+                )
+                return self._send_pushplus_chunked(
+                    api_url,
+                    content,
+                    title,
+                    self._pushplus_max_bytes,
+                )
 
-            # 群组推送（配置了 PUSHPLUS_TOPIC 时推给群组所有人）
-            if self._pushplus_topic:
-                payload["topic"] = self._pushplus_topic
-
-            response = requests.post(api_url, json=payload, timeout=10)
-
-            if response.status_code == 200:
-                result = response.json()
-                if result.get('code') == 200:
-                    logger.info("PushPlus 消息发送成功")
-                    return True
-                else:
-                    error_msg = result.get('msg', '未知错误')
-                    logger.error(f"PushPlus 返回错误: {error_msg}")
-                    return False
-            else:
-                logger.error(f"PushPlus 请求失败: HTTP {response.status_code}")
-                return False
-
+            return self._send_pushplus_message(api_url, content, title)
         except Exception as e:
             logger.error(f"发送 PushPlus 消息失败: {e}")
             return False
-   
+
+    def _send_pushplus_message(self, api_url: str, content: str, title: str) -> bool:
+        payload = {
+            "token": self._pushplus_token,
+            "title": title,
+            "content": content,
+            "template": "markdown",
+        }
+
+        if self._pushplus_topic:
+            payload["topic"] = self._pushplus_topic
+
+        response = requests.post(api_url, json=payload, timeout=10)
+
+        if response.status_code == 200:
+            result = response.json()
+            if result.get('code') == 200:
+                logger.info("PushPlus 消息发送成功")
+                return True
+
+            error_msg = result.get('msg', '未知错误')
+            logger.error(f"PushPlus 返回错误: {error_msg}")
+            return False
+
+        logger.error(f"PushPlus 请求失败: HTTP {response.status_code}")
+        return False
+
+    def _send_pushplus_chunked(self, api_url: str, content: str, title: str, max_bytes: int) -> bool:
+        """分批发送长 PushPlus 消息，给 JSON payload 预留空间。"""
+        budget = max(1000, max_bytes - 1500)
+        chunks = chunk_content_by_max_bytes(content, budget, add_page_marker=True)
+        total_chunks = len(chunks)
+        success_count = 0
+
+        logger.info(f"PushPlus 分批发送：共 {total_chunks} 批")
+
+        for i, chunk in enumerate(chunks):
+            chunk_title = f"{title} ({i+1}/{total_chunks})" if total_chunks > 1 else title
+            if self._send_pushplus_message(api_url, chunk, chunk_title):
+                success_count += 1
+                logger.info(f"PushPlus 第 {i+1}/{total_chunks} 批发送成功")
+            else:
+                logger.error(f"PushPlus 第 {i+1}/{total_chunks} 批发送失败")
+
+            if i < total_chunks - 1:
+                time.sleep(1)
+
+        return success_count == total_chunks

--- a/tests/test_notification.py
+++ b/tests/test_notification.py
@@ -285,6 +285,27 @@ class TestNotificationServiceSendToMethods(unittest.TestCase):
         self.assertTrue(ok)
         mock_post.assert_called_once()
 
+    @mock.patch("src.notification_sender.pushplus_sender.time.sleep")
+    @mock.patch("src.notification.get_config")
+    @mock.patch("requests.post")
+    def test_send_to_pushplus_via_notification_service_requires_chunking(
+        self,
+        mock_post: mock.MagicMock,
+        mock_get_config: mock.MagicMock,
+        _mock_sleep: mock.MagicMock,
+    ):
+        cfg = _make_config(pushplus_token="TOKEN")
+        mock_get_config.return_value = cfg
+        mock_post.return_value = _make_response(200, {"code": 200})
+
+        service = NotificationService()
+        self.assertIn(NotificationChannel.PUSHPLUS, service.get_available_channels())
+
+        ok = service.send("A" * 25000)
+
+        self.assertTrue(ok)
+        self.assertGreaterEqual(mock_post.call_count, 2)
+
     @mock.patch("src.notification.get_config")
     @mock.patch("requests.post")
     def test_send_to_serverchan3_via_notification_service(

--- a/tests/test_notification_sender.py
+++ b/tests/test_notification_sender.py
@@ -310,6 +310,18 @@ class TestPushplusSender(unittest.TestCase):
         result = sender.send_to_pushplus("hello")
         self.assertTrue(result)
 
+    @mock.patch("src.notification_sender.pushplus_sender.time.sleep")
+    @mock.patch("src.notification_sender.pushplus_sender.requests.post")
+    def test_send_long_message_chunks_pushplus_requests(self, mock_post, _mock_sleep):
+        mock_post.return_value = _response(200, {"code": 200})
+        cfg = _config(pushplus_token="TOKEN")
+        sender = PushplusSender(cfg)
+
+        result = sender.send_to_pushplus("A" * 25000)
+
+        self.assertTrue(result)
+        self.assertGreaterEqual(mock_post.call_count, 2)
+
 
 class TestServerchan3Sender(unittest.TestCase):
     """Unit tests for Serverchan3Sender."""


### PR DESCRIPTION
## PR Type

- [x] fix
- [ ] feat
- [ ] refactor
- [ ] docs
- [ ] chore
- [ ] test

## Background And Problem

- split oversized PushPlus markdown payloads before sending so large reports no longer fail at the PushPlus 20k limit
- reuse the existing byte-aware chunking helper with page markers and per-part titles
- add focused regression coverage for direct PushPlus sends and NotificationService PushPlus sends

- targeted pytest collection is blocked locally because the host Python is missing the optional `markdown2` dependency imported by `src.formatters`

## Scope Of Change

- split oversized PushPlus markdown payloads before sending so large reports no longer fail at the PushPlus 20k limit
- reuse the existing byte-aware chunking helper with page markers and per-part titles
- add focused regression coverage for direct PushPlus sends and NotificationService PushPlus sends

## Issue Link

Fixes #489

## Verification Commands And Results

```bash
python3 -m py_compile src/notification_sender/pushplus_sender.py tests/test_notification_sender.py tests/test_notification.py
PushplusSender.send_to_pushplus('A' * 25000)
git diff --check
```

关键输出/结论：
- focused mocked chunk-send validation script (`PushplusSender.send_to_pushplus('A' * 25000)` => multiple requests)

## Compatibility And Risk

Low risk; the patch is limited to the described area and keeps existing behavior as fallback where noted.

## Rollback Plan

Revert this PR to restore the previous behavior.

## Checklist

- [x] 我已确认本 PR 有明确动机和业务价值
- [x] 我已提供可复现的验证命令与结果
- [x] 我已评估兼容性与风险
- [x] 我已提供回滚方案
- [ ] 若涉及用户可见变更，我已同步更新 `README.md` 与 `docs/CHANGELOG.md`

## example

Pending honest fill-in.
