### PR TITLE
feat(email): render normal HTML emails as dashboards

### DIFF
--- a/src/notification_sender/email_renderer.py
+++ b/src/notification_sender/email_renderer.py
@@ -1,0 +1,284 @@
+# -*- coding: utf-8 -*-
+"""
+Dedicated HTML renderer for normal email notifications.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from html import escape
+import re
+from typing import List, Optional
+
+import markdown2
+
+
+_TITLE_RE = re.compile(r"^#\s+(.+)$", re.MULTILINE)
+_DATE_RE = re.compile(r"(\d{4}-\d{2}-\d{2})")
+_SUMMARY_RE = re.compile(
+    r"共分析\s*\*{0,2}(?P<total>\d+)\*{0,2}\s*只股票\s*\|\s*"
+    r"🟢买入:(?P<buy>\d+)\s*🟡(?:观望|持有):(?P<hold>\d+)\s*🔴卖出:(?P<sell>\d+)"
+)
+_SUMMARY_ROW_RE = re.compile(
+    r"^[^\n]*\*\*(?P<name>.+?)\((?P<code>\d{6})\)\*\*:\s*"
+    r"(?P<advice>[^|]+?)\s*\|\s*评分\s*(?P<score>\d+)\s*\|\s*(?P<trend>.+)$",
+    re.MULTILINE,
+)
+
+
+@dataclass
+class DashboardStats:
+    total: int
+    buy: int
+    hold: int
+    sell: int
+
+
+@dataclass
+class StockSummaryRow:
+    name: str
+    code: str
+    advice: str
+    score: str
+    trend: str
+
+
+def _extract_title(markdown_text: str) -> str:
+    match = _TITLE_RE.search(markdown_text)
+    return match.group(1).strip() if match else "股票分析报告"
+
+
+def _extract_report_date(title: str) -> str:
+    match = _DATE_RE.search(title)
+    return match.group(1) if match else ""
+
+
+def _extract_stats(markdown_text: str) -> Optional[DashboardStats]:
+    match = _SUMMARY_RE.search(markdown_text)
+    if not match:
+        return None
+    return DashboardStats(
+        total=int(match.group("total")),
+        buy=int(match.group("buy")),
+        hold=int(match.group("hold")),
+        sell=int(match.group("sell")),
+    )
+
+
+def _extract_summary_rows(markdown_text: str) -> List[StockSummaryRow]:
+    rows: List[StockSummaryRow] = []
+    for match in _SUMMARY_ROW_RE.finditer(markdown_text):
+        rows.append(
+            StockSummaryRow(
+                name=match.group("name").strip(),
+                code=match.group("code").strip(),
+                advice=match.group("advice").strip(),
+                score=match.group("score").strip(),
+                trend=match.group("trend").strip(),
+            )
+        )
+    return rows
+
+
+def _render_stats(stats: Optional[DashboardStats]) -> str:
+    if not stats:
+        return ""
+
+    metrics = (
+        ("分析股票", str(stats.total)),
+        ("买入", str(stats.buy)),
+        ("观望", str(stats.hold)),
+        ("卖出", str(stats.sell)),
+    )
+    cards = "".join(
+        f"""
+        <div class="metric-card">
+            <div class="metric-label">{escape(label)}</div>
+            <div class="metric-value">{escape(value)}</div>
+        </div>
+        """
+        for label, value in metrics
+    )
+    return f'<div class="metrics">{cards}</div>'
+
+
+def _render_summary_table(rows: List[StockSummaryRow]) -> str:
+    if not rows:
+        return ""
+
+    body_rows = "".join(
+        f"""
+        <tr>
+            <td>{escape(row.name)}</td>
+            <td>{escape(row.code)}</td>
+            <td>{escape(row.score)}</td>
+            <td>{escape(row.trend)}</td>
+            <td>{escape(row.advice)}</td>
+        </tr>
+        """
+        for row in rows
+    )
+    return f"""
+    <section class="summary-card">
+        <h2>股票总结</h2>
+        <table>
+            <thead>
+                <tr>
+                    <th>股票</th>
+                    <th>代码</th>
+                    <th>评分</th>
+                    <th>趋势</th>
+                    <th>建议</th>
+                </tr>
+            </thead>
+            <tbody>
+                {body_rows}
+            </tbody>
+        </table>
+    </section>
+    """
+
+
+def render_email_dashboard(markdown_text: str) -> str:
+    """
+    Render a dashboard-style HTML document for normal email delivery.
+    """
+    title = _extract_title(markdown_text)
+    report_date = _extract_report_date(title)
+    stats = _extract_stats(markdown_text)
+    rows = _extract_summary_rows(markdown_text)
+    body_html = markdown2.markdown(
+        markdown_text,
+        extras=["tables", "fenced-code-blocks", "break-on-newline", "cuddled-lists"],
+    )
+
+    stats_html = _render_stats(stats)
+    summary_table_html = _render_summary_table(rows)
+    date_html = f'<p class="hero-subtitle">{escape(report_date)}</p>' if report_date else ""
+
+    return f"""
+    <!DOCTYPE html>
+    <html>
+    <head>
+        <meta charset="utf-8">
+        <style>
+            body {{
+                margin: 0;
+                padding: 24px;
+                background: #eef2f7;
+                color: #162033;
+                font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif;
+            }}
+            .email-shell {{
+                max-width: 920px;
+                margin: 0 auto;
+            }}
+            .hero {{
+                padding: 28px 32px;
+                border-radius: 24px;
+                background: linear-gradient(135deg, #0f172a, #1d4ed8);
+                color: #f8fafc;
+                box-shadow: 0 18px 40px rgba(15, 23, 42, 0.18);
+            }}
+            .hero h1 {{
+                margin: 0;
+                font-size: 28px;
+                line-height: 1.2;
+            }}
+            .hero-subtitle {{
+                margin: 10px 0 0;
+                font-size: 14px;
+                color: rgba(248, 250, 252, 0.82);
+            }}
+            .metrics {{
+                display: grid;
+                grid-template-columns: repeat(4, minmax(0, 1fr));
+                gap: 12px;
+                margin: 18px 0 0;
+            }}
+            .metric-card,
+            .summary-card,
+            .body-card {{
+                background: #ffffff;
+                border-radius: 20px;
+                box-shadow: 0 12px 30px rgba(15, 23, 42, 0.08);
+            }}
+            .metric-card {{
+                padding: 18px 20px;
+            }}
+            .metric-label {{
+                font-size: 13px;
+                color: #64748b;
+            }}
+            .metric-value {{
+                margin-top: 6px;
+                font-size: 24px;
+                font-weight: 700;
+                color: #0f172a;
+            }}
+            .summary-card,
+            .body-card {{
+                margin-top: 20px;
+                padding: 24px 28px;
+            }}
+            h2 {{
+                margin: 0 0 16px;
+                font-size: 20px;
+                color: #0f172a;
+            }}
+            table {{
+                width: 100%;
+                border-collapse: collapse;
+                font-size: 14px;
+            }}
+            th,
+            td {{
+                padding: 12px 14px;
+                border-bottom: 1px solid #e2e8f0;
+                text-align: left;
+            }}
+            th {{
+                color: #475569;
+                font-size: 12px;
+                letter-spacing: 0.04em;
+                text-transform: uppercase;
+            }}
+            .body-card h1,
+            .body-card h2,
+            .body-card h3 {{
+                color: #0f172a;
+            }}
+            .body-card p,
+            .body-card li,
+            .body-card blockquote {{
+                color: #334155;
+                line-height: 1.7;
+            }}
+            .body-card blockquote {{
+                margin: 12px 0;
+                padding: 12px 16px;
+                border-left: 4px solid #2563eb;
+                background: #eff6ff;
+                border-radius: 12px;
+            }}
+            .body-card hr {{
+                border: 0;
+                border-top: 1px solid #e2e8f0;
+                margin: 24px 0;
+            }}
+        </style>
+    </head>
+    <body>
+        <div class="email-shell">
+            <section class="hero">
+                <h1>{escape(title)}</h1>
+                {date_html}
+            </section>
+            {stats_html}
+            {summary_table_html}
+            <section class="body-card">
+                {body_html}
+            </section>
+        </div>
+    </body>
+    </html>
+    """

--- a/src/notification_sender/email_sender.py
+++ b/src/notification_sender/email_sender.py
@@ -16,7 +16,7 @@ from email.utils import formataddr
 import smtplib
 
 from src.config import Config
-from src.formatters import markdown_to_html_document
+from src.notification_sender.email_renderer import render_email_dashboard
 
 
 logger = logging.getLogger(__name__)
@@ -133,8 +133,7 @@ class EmailSender:
                 date_str = datetime.now().strftime('%Y-%m-%d')
                 subject = f"📈 股票智能分析报告 - {date_str}"
             
-            # 将 Markdown 转换为简单 HTML
-            html_content = markdown_to_html_document(content)
+            html_content = render_email_dashboard(content)
             
             # 构建邮件
             msg = MIMEMultipart('alternative')

--- a/tests/test_email_dashboard_renderer.py
+++ b/tests/test_email_dashboard_renderer.py
@@ -1,0 +1,58 @@
+# -*- coding: utf-8 -*-
+"""
+Tests for the dedicated HTML email dashboard renderer.
+"""
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from src.notification_sender.email_renderer import render_email_dashboard
+
+
+SAMPLE_DASHBOARD_MARKDOWN = """# 🎯 2026-03-09 决策仪表盘
+
+> 共分析 **2** 只股票 | 🟢买入:1 🟡观望:1 🔴卖出:0
+
+## 📊 分析结果摘要
+
+🟢 **宁德时代(300750)**: 买入 | 评分 88 | 趋势向上
+🟡 **贵州茅台(600519)**: 持有 | 评分 61 | 高位震荡
+
+---
+
+## 🟢 宁德时代 (300750)
+
+### 📌 核心结论
+
+**🟢 买入** | 趋势向上
+
+> **一句话决策**: 回踩 MA5 附近可分批布局。
+"""
+
+MARKET_REVIEW_MARKDOWN = """# 📈 市场复盘
+
+今日市场延续震荡修复，量能温和放大。
+
+## 核心观察
+
+- 北向资金回流
+- 科技成长相对强势
+"""
+
+
+def test_render_email_dashboard_extracts_summary_table():
+    html = render_email_dashboard(SAMPLE_DASHBOARD_MARKDOWN)
+
+    assert "股票总结" in html
+    assert "宁德时代" in html
+    assert "300750" in html
+    assert "回踩 MA5 附近可分批布局" in html
+
+
+def test_render_email_dashboard_without_stock_rows_preserves_body():
+    html = render_email_dashboard(MARKET_REVIEW_MARKDOWN)
+
+    assert "市场复盘" in html
+    assert "量能温和放大" in html
+    assert "股票总结" not in html

--- a/tests/test_notification_sender.py
+++ b/tests/test_notification_sender.py
@@ -172,11 +172,49 @@ class TestFeishuSender(unittest.TestCase):
 class TestEmailSender(unittest.TestCase):
     """Unit tests for EmailSender (config and receiver logic; send path covered via service)."""
 
+    _dashboard_markdown = """# 🎯 2026-03-09 决策仪表盘
+
+> 共分析 **1** 只股票 | 🟢买入:1 🟡观望:0 🔴卖出:0
+
+## 📊 分析结果摘要
+
+🟢 **宁德时代(300750)**: 买入 | 评分 88 | 趋势向上
+
+---
+
+## 🟢 宁德时代 (300750)
+
+### 📌 核心结论
+
+> **一句话决策**: 回踩 MA5 附近可分批布局。
+"""
+
     def test_send_returns_false_when_not_configured(self):
         cfg = _config()
         sender = EmailSender(cfg)
         result = sender.send_to_email("body")
         self.assertFalse(result)
+
+    @mock.patch("smtplib.SMTP_SSL")
+    def test_send_to_email_uses_email_dashboard_renderer_for_html_part(self, mock_smtp_ssl):
+        cfg = _config(
+            email_sender="a@qq.com",
+            email_password="p",
+            email_receivers=["b@qq.com"],
+        )
+        sender = EmailSender(cfg)
+
+        result = sender.send_to_email(self._dashboard_markdown)
+
+        self.assertTrue(result)
+        server = mock_smtp_ssl.return_value
+        server.send_message.assert_called_once()
+        message = server.send_message.call_args[0][0]
+        html_part = message.get_payload()[1]
+        html = html_part.get_payload(decode=True).decode("utf-8")
+        self.assertIn("股票总结", html)
+        self.assertIn("宁德时代", html)
+        self.assertIn("300750", html)
 
     def test_get_receivers_for_stocks_no_groups_returns_default(self):
         cfg = _config(


### PR DESCRIPTION
## PR Type

- [ ] fix
- [x] feat
- [ ] refactor
- [ ] docs
- [ ] chore
- [ ] test

## Background And Problem

普通 HTML email 通知当前复用通用 Markdown -> HTML 渲染链路，内容虽然完整，但缺少适合邮件阅读的 dashboard 摘要结构。需要在不影响 inline-image email 和其他通知渠道的前提下，仅增强 `EmailSender.send_to_email()` 的 HTML part 展示效果。

## Scope Of Change

- 新增 `src/notification_sender/email_renderer.py`
- 修改 `src/notification_sender/email_sender.py`
- 新增 `tests/test_email_dashboard_renderer.py`
- 修改 `tests/test_notification_sender.py`
- 本 PR 不包含 `README.md`、`docs/CHANGELOG.md` 或 `docs/plans/*` 变更

## Issue Link

无 Issue；验收标准：
- 普通 HTML email 使用专用 dashboard renderer
- plain-text email part、inline-image email、其他通知渠道行为不变
- `pytest -q` 全量通过

## Verification Commands And Results

请填写你实际执行过的命令和关键结果（不要只写“已测试”）：

```bash
/Users/zane/Documents/Self/Project/cursor_project/daily_stock_analysis/.venv/bin/pytest tests/test_email_dashboard_renderer.py tests/test_notification_sender.py -q
/Users/zane/Documents/Self/Project/cursor_project/daily_stock_analysis/.venv/bin/pytest tests/test_email_dashboard_renderer.py tests/test_notification_sender.py tests/test_notification.py tests/test_pipeline_notification_image_routing.py -q
/Users/zane/Documents/Self/Project/cursor_project/daily_stock_analysis/.venv/bin/pytest -q
```

关键输出/结论：
- 全量测试通过：`372 passed, 31 warnings`
- `tests/test_pipeline_notification_image_routing.py` 继续通过，说明 inline-image email 路径未被影响
- 分支当前 diff 仅包含 4 个代码/测试文件：
  - `src/notification_sender/email_renderer.py`
  - `src/notification_sender/email_sender.py`
  - `tests/test_email_dashboard_renderer.py`
  - `tests/test_notification_sender.py`

## Compatibility And Risk

- 兼容性影响：仅普通 HTML email 的 HTML MIME part 渲染结果发生变化
- 风险：Markdown 结构提取依赖现有 dashboard/summary 格式；对非股票类内容已保留 fallback，仅渲染样式外壳与完整正文
- 其他渠道（企业微信、飞书、Telegram、自定义 webhook）和 inline-image email 不受影响

## Rollback Plan

回滚本 PR 即可恢复到原先通用 Markdown HTML 渲染链路。

## Checklist

- [x] 我已确认本 PR 有明确动机和业务价值
- [x] 我已提供可复现的验证命令与结果
- [x] 我已评估兼容性与风险
- [x] 我已提供回滚方案
- [ ] 若涉及用户可见变更，我已同步更新 `README.md` 与 `docs/CHANGELOG.md`
