### PR TITLE
[fix]. 筹码结构 LLM 未填写时兜底补全 Issue #589

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 ### Added
 - 📊 **LLM cost tracking** — all LLM calls (analysis, agent, market review) are recorded in the `llm_usage` table; new `GET /api/v1/usage/summary?period=today|month|all` endpoint returns aggregated token usage broken down by call type and model
 ### Fixed
+- 🐛 **筹码结构 LLM 未填写时兜底补全** (#589) — DeepSeek 等模型未正确填写 `chip_structure` 时，自动用数据源已获取的筹码数据补全，保证各模型展示一致；普通分析与 Agent 模式均生效
 - 🐛 **历史报告狙击点位显示原始文本** (#452) — 历史详情页现优先展示 `raw_result.dashboard.battle_plan.sniper_points` 中的原始字符串，避免 `analysis_history` 数值列把区间、说明文字或复杂点位压缩成单个数字；保留原有数值列作为回退
 
 ### Changed

--- a/src/analyzer.py
+++ b/src/analyzer.py
@@ -12,6 +12,7 @@ A股自选股智能分析系统 - AI分析层
 
 import json
 import logging
+import math
 import time
 from dataclasses import dataclass
 from typing import Optional, Dict, Any, List, Tuple
@@ -89,6 +90,92 @@ def apply_placeholder_fill(result: "AnalysisResult", missing_fields: List[str]) 
             if "sniper_points" not in result.dashboard["battle_plan"]:
                 result.dashboard["battle_plan"]["sniper_points"] = {}
             result.dashboard["battle_plan"]["sniper_points"]["stop_loss"] = "待补充"
+
+
+# ---------- chip_structure fallback (Issue #589) ----------
+
+_CHIP_KEYS: tuple = ("profit_ratio", "avg_cost", "concentration", "chip_health")
+
+
+def _is_value_placeholder(v: Any) -> bool:
+    """True if value is empty or placeholder (N/A, 数据缺失, etc.)."""
+    if v is None:
+        return True
+    if isinstance(v, (int, float)) and v == 0:
+        return True
+    s = str(v).strip().lower()
+    return s in ("", "n/a", "na", "数据缺失", "未知")
+
+
+def _safe_float(v: Any, default: float = 0.0) -> float:
+    """Safely convert to float; return default on failure. Private helper for chip fill."""
+    if v is None:
+        return default
+    if isinstance(v, (int, float)):
+        try:
+            return default if math.isnan(float(v)) else float(v)
+        except (ValueError, TypeError):
+            return default
+    try:
+        return float(str(v).strip())
+    except (TypeError, ValueError):
+        return default
+
+
+def _derive_chip_health(profit_ratio: float, concentration_90: float) -> str:
+    """Derive chip_health from profit_ratio and concentration_90."""
+    if profit_ratio >= 0.9:
+        return "警惕"  # 获利盘极高
+    if concentration_90 >= 0.25:
+        return "警惕"  # 筹码分散
+    if concentration_90 < 0.15 and 0.3 <= profit_ratio < 0.9:
+        return "健康"  # 集中且获利比例适中
+    return "一般"
+
+
+def _build_chip_structure_from_data(chip_data: Any) -> Dict[str, Any]:
+    """Build chip_structure dict from ChipDistribution or dict."""
+    if hasattr(chip_data, "profit_ratio"):
+        pr = _safe_float(chip_data.profit_ratio)
+        ac = chip_data.avg_cost
+        c90 = _safe_float(chip_data.concentration_90)
+    else:
+        d = chip_data if isinstance(chip_data, dict) else {}
+        pr = _safe_float(d.get("profit_ratio"))
+        ac = d.get("avg_cost")
+        c90 = _safe_float(d.get("concentration_90"))
+    chip_health = _derive_chip_health(pr, c90)
+    return {
+        "profit_ratio": f"{pr:.1%}",
+        "avg_cost": ac if (ac is not None and _safe_float(ac) != 0.0) else "N/A",
+        "concentration": f"{c90:.2%}",
+        "chip_health": chip_health,
+    }
+
+
+def fill_chip_structure_if_needed(result: "AnalysisResult", chip_data: Any) -> None:
+    """When chip_data exists, fill chip_structure placeholder fields from chip_data (in-place)."""
+    if not result or not chip_data:
+        return
+    try:
+        if not result.dashboard:
+            result.dashboard = {}
+        dash = result.dashboard
+        # Use `or {}` rather than setdefault so that an explicit `null` from LLM is also replaced
+        dp = dash.get("data_perspective") or {}
+        dash["data_perspective"] = dp
+        cs = dp.get("chip_structure") or {}
+        filled = _build_chip_structure_from_data(chip_data)
+        # Start from a copy of cs to preserve any extra keys the LLM may have added
+        merged = dict(cs)
+        for k in _CHIP_KEYS:
+            if _is_value_placeholder(merged.get(k)):
+                merged[k] = filled[k]
+        if merged != cs:
+            dp["chip_structure"] = merged
+            logger.info("[chip_structure] Filled placeholder chip fields from data source (Issue #589)")
+    except Exception as e:
+        logger.warning("[chip_structure] Fill failed, skipping: %s", e)
 
 
 def get_stock_name_multi_source(

--- a/src/core/pipeline.py
+++ b/src/core/pipeline.py
@@ -25,7 +25,7 @@ from src.config import get_config, Config
 from src.storage import get_db
 from data_provider import DataFetcherManager
 from data_provider.realtime_types import ChipDistribution
-from src.analyzer import GeminiAnalyzer, AnalysisResult
+from src.analyzer import GeminiAnalyzer, AnalysisResult, fill_chip_structure_if_needed
 from src.data.stock_mapping import STOCK_NAME_MAP
 from src.notification import NotificationService, NotificationChannel
 from src.search_service import SearchService
@@ -322,6 +322,10 @@ class StockAnalysisPipeline:
                 result.current_price = realtime_data.get('price')
                 result.change_pct = realtime_data.get('change_pct')
 
+            # Step 7.6: chip_structure fallback (Issue #589)
+            if result and chip_data:
+                fill_chip_structure_if_needed(result, chip_data)
+
             # Step 8: 保存分析历史记录
             if result:
                 try:
@@ -547,6 +551,10 @@ class StockAnalysisPipeline:
                         "[LLM完整性] integrity_mode=agent_weak 必填字段缺失 %s，已占位补全",
                         missing,
                     )
+            # chip_structure fallback (Issue #589), before save_analysis_history
+            if result and chip_data:
+                fill_chip_structure_if_needed(result, chip_data)
+
             resolved_stock_name = result.name if result and result.name else stock_name
 
             # 保存新闻情报到数据库（Agent 工具结果仅用于 LLM 上下文，未持久化，Fixes #396）

--- a/tests/test_chip_structure_fallback.py
+++ b/tests/test_chip_structure_fallback.py
@@ -1,0 +1,245 @@
+# -*- coding: utf-8 -*-
+"""
+===================================
+Chip structure fallback tests (Issue #589)
+===================================
+
+Tests for fill_chip_structure_if_needed and related helpers.
+"""
+
+import sys
+import unittest
+from unittest.mock import MagicMock
+
+try:
+    import litellm  # noqa: F401
+except ModuleNotFoundError:
+    sys.modules["litellm"] = MagicMock()
+
+from data_provider.realtime_types import ChipDistribution
+from src.analyzer import (
+    AnalysisResult,
+    fill_chip_structure_if_needed,
+    _is_value_placeholder,
+    _derive_chip_health,
+    _build_chip_structure_from_data,
+)
+
+
+class TestIsValuePlaceholder(unittest.TestCase):
+    """Tests for _is_value_placeholder."""
+
+    def test_none_is_placeholder(self) -> None:
+        self.assertTrue(_is_value_placeholder(None))
+
+    def test_zero_is_placeholder(self) -> None:
+        self.assertTrue(_is_value_placeholder(0))
+        self.assertTrue(_is_value_placeholder(0.0))
+
+    def test_empty_string_is_placeholder(self) -> None:
+        self.assertTrue(_is_value_placeholder(""))
+        self.assertTrue(_is_value_placeholder("   "))
+
+    def test_na_variants_are_placeholder(self) -> None:
+        self.assertTrue(_is_value_placeholder("N/A"))
+        self.assertTrue(_is_value_placeholder("n/a"))
+        self.assertTrue(_is_value_placeholder("NA"))
+        self.assertTrue(_is_value_placeholder("na"))
+
+    def test_data_missing_is_placeholder(self) -> None:
+        self.assertTrue(_is_value_placeholder("数据缺失"))
+        self.assertTrue(_is_value_placeholder("未知"))
+
+    def test_valid_values_not_placeholder(self) -> None:
+        self.assertFalse(_is_value_placeholder(0.5))
+        self.assertFalse(_is_value_placeholder("50%"))
+        self.assertFalse(_is_value_placeholder("67.5%"))
+        self.assertFalse(_is_value_placeholder(25.6))
+        self.assertFalse(_is_value_placeholder("健康"))
+
+
+class TestDeriveChipHealth(unittest.TestCase):
+    """Tests for _derive_chip_health."""
+
+    def test_high_profit_ratio_returns_jingti(self) -> None:
+        self.assertEqual(_derive_chip_health(0.95, 0.10), "警惕")
+        self.assertEqual(_derive_chip_health(0.9, 0.05), "警惕")
+
+    def test_high_concentration_returns_jingti(self) -> None:
+        self.assertEqual(_derive_chip_health(0.5, 0.30), "警惕")
+        self.assertEqual(_derive_chip_health(0.3, 0.25), "警惕")
+
+    def test_concentrated_moderate_profit_returns_jiankang(self) -> None:
+        self.assertEqual(_derive_chip_health(0.5, 0.10), "健康")
+        self.assertEqual(_derive_chip_health(0.6, 0.12), "健康")
+        self.assertEqual(_derive_chip_health(0.3, 0.14), "健康")
+
+    def test_otherwise_returns_yiban(self) -> None:
+        self.assertEqual(_derive_chip_health(0.2, 0.20), "一般")
+        self.assertEqual(_derive_chip_health(0.5, 0.18), "一般")
+
+
+class TestBuildChipStructureFromData(unittest.TestCase):
+    """Tests for _build_chip_structure_from_data."""
+
+    def test_from_chip_distribution(self) -> None:
+        chip = ChipDistribution(
+            code="600519",
+            profit_ratio=0.567,
+            avg_cost=1850.5,
+            concentration_90=0.12,
+        )
+        out = _build_chip_structure_from_data(chip)
+        self.assertEqual(out["profit_ratio"], "56.7%")
+        self.assertEqual(out["avg_cost"], 1850.5)
+        self.assertEqual(out["concentration"], "12.00%")
+        self.assertEqual(out["chip_health"], "健康")
+
+    def test_from_dict(self) -> None:
+        d = {"profit_ratio": 0.9, "avg_cost": 100.0, "concentration_90": 0.08}
+        out = _build_chip_structure_from_data(d)
+        self.assertEqual(out["profit_ratio"], "90.0%")
+        self.assertEqual(out["avg_cost"], 100.0)
+        self.assertEqual(out["concentration"], "8.00%")
+        self.assertEqual(out["chip_health"], "警惕")
+
+    def test_dict_with_string_values(self) -> None:
+        d = {"profit_ratio": "0.5", "avg_cost": "25.6", "concentration_90": "0.15"}
+        out = _build_chip_structure_from_data(d)
+        self.assertEqual(out["profit_ratio"], "50.0%")
+        self.assertEqual(out["avg_cost"], "25.6")  # raw value preserved
+        self.assertEqual(out["concentration"], "15.00%")
+
+    def test_avg_cost_zero_shows_na(self) -> None:
+        chip = ChipDistribution(code="600519", profit_ratio=0.5, avg_cost=0.0, concentration_90=0.1)
+        out = _build_chip_structure_from_data(chip)
+        self.assertEqual(out["avg_cost"], "N/A")
+
+    def test_avg_cost_none_shows_na(self) -> None:
+        d = {"profit_ratio": 0.5, "avg_cost": None, "concentration_90": 0.1}
+        out = _build_chip_structure_from_data(d)
+        self.assertEqual(out["avg_cost"], "N/A")
+
+
+class TestFillChipStructureIfNeeded(unittest.TestCase):
+    """Tests for fill_chip_structure_if_needed."""
+
+    def _make_result(self, dashboard: dict = None) -> AnalysisResult:
+        return AnalysisResult(
+            code="600519",
+            name="贵州茅台",
+            trend_prediction="看多",
+            sentiment_score=70,
+            operation_advice="持有",
+            analysis_summary="稳健",
+            decision_type="hold",
+            dashboard=dashboard,
+        )
+
+    def _make_chip(self) -> ChipDistribution:
+        return ChipDistribution(
+            code="600519",
+            profit_ratio=0.67,
+            avg_cost=1850.0,
+            concentration_90=0.11,
+        )
+
+    def test_no_modification_when_chip_data_none(self) -> None:
+        result = self._make_result(dashboard={"data_perspective": {"chip_structure": {}}})
+        fill_chip_structure_if_needed(result, None)
+        self.assertEqual(result.dashboard["data_perspective"]["chip_structure"], {})
+
+    def test_no_modification_when_result_none(self) -> None:
+        chip = self._make_chip()
+        fill_chip_structure_if_needed(None, chip)
+        # No crash
+
+    def test_full_fill_when_cs_all_empty(self) -> None:
+        result = self._make_result(
+            dashboard={"data_perspective": {"chip_structure": {"profit_ratio": 0, "avg_cost": 0, "concentration": 0, "chip_health": ""}}}
+        )
+        chip = self._make_chip()
+        fill_chip_structure_if_needed(result, chip)
+        cs = result.dashboard["data_perspective"]["chip_structure"]
+        self.assertEqual(cs["profit_ratio"], "67.0%")
+        self.assertEqual(cs["avg_cost"], 1850.0)
+        self.assertEqual(cs["concentration"], "11.00%")
+        self.assertEqual(cs["chip_health"], "健康")
+
+    def test_merge_fill_partial_placeholder(self) -> None:
+        result = self._make_result(
+            dashboard={
+                "data_perspective": {
+                    "chip_structure": {"profit_ratio": "65.0%", "avg_cost": 0, "concentration": 0, "chip_health": ""}
+                }
+            }
+        )
+        chip = self._make_chip()
+        fill_chip_structure_if_needed(result, chip)
+        cs = result.dashboard["data_perspective"]["chip_structure"]
+        self.assertEqual(cs["profit_ratio"], "65.0%")  # LLM value kept
+        self.assertEqual(cs["avg_cost"], 1850.0)  # filled from chip
+        self.assertEqual(cs["concentration"], "11.00%")  # filled from chip
+        self.assertEqual(cs["chip_health"], "健康")  # filled from chip
+
+    def test_dashboard_none_initialized(self) -> None:
+        result = self._make_result(dashboard=None)
+        chip = self._make_chip()
+        fill_chip_structure_if_needed(result, chip)
+        self.assertIsNotNone(result.dashboard)
+        cs = result.dashboard["data_perspective"]["chip_structure"]
+        self.assertEqual(cs["profit_ratio"], "67.0%")
+        self.assertEqual(cs["chip_health"], "健康")
+
+    def test_no_overwrite_valid_llm_values(self) -> None:
+        result = self._make_result(
+            dashboard={
+                "data_perspective": {
+                    "chip_structure": {
+                        "profit_ratio": "70.0%",
+                        "avg_cost": 1900.0,
+                        "concentration": "10.00%",
+                        "chip_health": "健康",
+                    }
+                }
+            }
+        )
+        chip = self._make_chip()
+        fill_chip_structure_if_needed(result, chip)
+        cs = result.dashboard["data_perspective"]["chip_structure"]
+        self.assertEqual(cs["profit_ratio"], "70.0%")
+        self.assertEqual(cs["avg_cost"], 1900.0)
+        self.assertEqual(cs["concentration"], "10.00%")
+        self.assertEqual(cs["chip_health"], "健康")
+
+    def test_data_perspective_null_handled(self) -> None:
+        """When LLM returns data_perspective: null, fill should still work."""
+        result = self._make_result(
+            dashboard={"data_perspective": None, "core_conclusion": {"one_sentence": "观望"}}
+        )
+        chip = self._make_chip()
+        fill_chip_structure_if_needed(result, chip)
+        self.assertIsNotNone(result.dashboard["data_perspective"])
+        cs = result.dashboard["data_perspective"]["chip_structure"]
+        self.assertEqual(cs["profit_ratio"], "67.0%")
+
+    def test_extra_keys_in_chip_structure_preserved(self) -> None:
+        """Extra keys added by LLM in chip_structure must not be dropped."""
+        result = self._make_result(
+            dashboard={
+                "data_perspective": {
+                    "chip_structure": {
+                        "profit_ratio": 0,
+                        "avg_cost": 0,
+                        "concentration": 0,
+                        "chip_health": "",
+                        "custom_note": "LLM added this",
+                    }
+                }
+            }
+        )
+        chip = self._make_chip()
+        fill_chip_structure_if_needed(result, chip)
+        cs = result.dashboard["data_perspective"]["chip_structure"]
+        self.assertEqual(cs["profit_ratio"], "67.0%")
+        self.assertEqual(cs["custom_note"], "LLM added this")


### PR DESCRIPTION
## PR Type

- [x] fix
- [ ] feat
- [ ] refactor
- [ ] docs
- [ ] chore
- [ ] test

## Background And Problem

**背景与问题**：DeepSeek 等部分 LLM 模型未正确填写 `dashboard.data_perspective.chip_structure`（获利比例、平均成本、集中度、筹码健康度），导致报告中筹码信息显示「数据缺失」或占位值（0、N/A）。Gemini 能正确填写，造成不同模型展示不一致。

**根因**：模型对 prompt 中 chip_structure 输出格式的遵循程度不同，非数据获取问题。

**影响范围**：使用 DeepSeek 等未正确填写 chip_structure 的模型分析 A 股时，用户无法看到筹码分布数据。

## Scope Of Change

**变更范围**：

| 文件 | 变更 |
|------|------|
| `src/analyzer.py` | 新增 `_is_value_placeholder`、`_safe_float`、`_derive_chip_health`、`_build_chip_structure_from_data`、`fill_chip_structure_if_needed`；`import math` |
| `src/core/pipeline.py` | 顶部 import `fill_chip_structure_if_needed`；普通分析路径 Step 7.6、Agent 路径各增加一处调用 |
| `docs/CHANGELOG.md` | [Unreleased] 下新增 Fix 条目 |
| `tests/test_chip_structure_fallback.py` | 新建，23 个单测 |

**设计要点**：不修改 `check_content_integrity` / `apply_placeholder_fill`，在 pipeline 层独立补全；按字段合并（仅对占位字段用 chip_data 填充，保留 LLM 已正确填写的字段）；`chip_data` 为 None（美股/ETF）时直接 return，无副作用。

## Issue Link

Fixes #589

## Verification Commands And Results

```bash
# 语法与单测
.venv/bin/python -m unittest tests.test_chip_structure_fallback tests.test_report_integrity -v
```

**关键输出**：
```
Ran 31 tests in 0.001s
OK
```

chip_structure 相关 23 个测试覆盖：`_is_value_placeholder`、`_derive_chip_health`、`_build_chip_structure_from_data`、`fill_chip_structure_if_needed`（含 `data_perspective: null`、extra keys 保留等边界）。

## Compatibility And Risk

**兼容性**：向后兼容。`chip_data` 为 None 时不做任何处理；LLM 已正确填写的 chip_structure 字段不会被覆盖。

**潜在风险**：无。补全逻辑有 try/except 包裹，失败时打 warning 并跳过，不中断 pipeline。

## Rollback Plan

回滚方案：`git revert <commit>` 或回退该 PR 合并的 commit，恢复 analyzer 与 pipeline 原有逻辑即可。无数据迁移或配置变更。

## Checklist

- [x] 我已确认本 PR 有明确动机和业务价值
- [x] 我已提供可复现的验证命令与结果
- [x] 我已评估兼容性与风险
- [x] 我已提供回滚方案
- [x] 若涉及用户可见变更，我已同步更新 `README.md` 与 `docs/CHANGELOG.md`（本次为内部修复，已更新 CHANGELOG）
