### PR TITLE
fix: upgrade GitHub Actions official actions for Node 24 compatibility

### DIFF
--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -26,7 +26,7 @@ jobs:
       contents: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
       frontend: ${{ steps.filter.outputs.frontend }}
     steps:
       - name: 📥 Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: 🧭 Filter paths
         id: filter
         uses: dorny/paths-filter@v3
@@ -30,9 +30,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 📥 Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: 🐍 Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.11'
           cache: 'pip'
@@ -50,7 +50,7 @@ jobs:
     needs: [backend-gate]
     steps:
       - name: 📥 Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: 🐳 Build image
         run: |
           docker build -t stock-analysis:test -f docker/Dockerfile .
@@ -79,9 +79,9 @@ jobs:
         working-directory: apps/dsa-web
     steps:
       - name: 📥 Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: 🟢 Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '20'
           cache: 'npm'

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -13,7 +13,7 @@ jobs:
       contents: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 

--- a/.github/workflows/daily_analysis.yml
+++ b/.github/workflows/daily_analysis.yml
@@ -39,10 +39,10 @@ jobs:
         run: sleep $((RANDOM % 60))  # 随机延迟0-60秒启动
       
       - name: 检出代码
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       
       - name: 设置 Python 环境
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.11'
           cache: 'pip'
@@ -244,7 +244,7 @@ jobs:
           fi
       
       - name: 上传分析报告
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         if: always()
         with:
           name: analysis-reports-${{ github.run_number }}

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -23,7 +23,7 @@ jobs:
     env:
       RELEASE_TAG: ${{ github.event_name == 'workflow_dispatch' && inputs.release_tag || github.ref_name }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
@@ -37,12 +37,12 @@ jobs:
             git checkout "${RELEASE_TAG}"
           fi
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.12'
           cache: 'pip'
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: '20'
           cache: 'npm'
@@ -77,7 +77,7 @@ jobs:
           Copy-Item -Path $installerExe.FullName -Destination $exeTarget -Force
           Compress-Archive -Path $winUnpacked -DestinationPath $zipTarget -CompressionLevel Optimal -Force
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v6
         with:
           name: desktop-windows-${{ env.RELEASE_TAG }}
           path: |
@@ -100,7 +100,7 @@ jobs:
     env:
       RELEASE_TAG: ${{ github.event_name == 'workflow_dispatch' && inputs.release_tag || github.ref_name }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
@@ -114,12 +114,12 @@ jobs:
             git checkout "${RELEASE_TAG}"
           fi
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.12'
           cache: 'pip'
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: '20'
           cache: 'npm'
@@ -128,7 +128,7 @@ jobs:
             apps/dsa-desktop/package-lock.json
 
       - name: Cache Electron binaries
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/Library/Caches/electron
           key: electron-macos-${{ matrix.arch }}-${{ hashFiles('apps/dsa-desktop/package-lock.json') }}
@@ -155,7 +155,7 @@ jobs:
           mkdir -p dist/release-assets
           cp "$dmg_file" "dist/release-assets/daily-stock-analysis-macos-${{ matrix.arch }}-${RELEASE_TAG}.dmg"
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v6
         with:
           name: desktop-macos-${{ matrix.arch }}-${{ env.RELEASE_TAG }}
           path: dist/release-assets/*.dmg
@@ -169,7 +169,7 @@ jobs:
     env:
       RELEASE_TAG: ${{ github.event_name == 'workflow_dispatch' && inputs.release_tag || github.ref_name }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Validate release tag and extract changelog
         id: changelog
@@ -185,7 +185,7 @@ jobs:
           # Write changelog content + install instructions to file
           echo "$BODY" > /tmp/release_body.md
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v7
         with:
           pattern: desktop-*
           path: dist/release-assets

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -24,7 +24,7 @@ jobs:
       id-token: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
@@ -41,7 +41,7 @@ jobs:
             echo "Using event ref: ${GITHUB_REF_NAME}"
           fi
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.11'
           cache: 'pip'

--- a/.github/workflows/ghcr-dockerhub.yml
+++ b/.github/workflows/ghcr-dockerhub.yml
@@ -26,7 +26,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/.github/workflows/network-smoke.yml
+++ b/.github/workflows/network-smoke.yml
@@ -16,10 +16,10 @@ jobs:
       contents: read
     steps:
       - name: 📥 Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: 🐍 Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.11'
           cache: 'pip'
@@ -44,7 +44,7 @@ jobs:
 
       - name: 📤 Upload smoke logs
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: network-smoke-logs-${{ github.run_number }}
           path: |

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -47,7 +47,7 @@ jobs:
     
     steps:
       - name: 📥 检出代码
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
           fetch-depth: 0
@@ -91,7 +91,7 @@ jobs:
     
     steps:
       - name: 📥 检出代码
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
           fetch-depth: 0
@@ -100,7 +100,7 @@ jobs:
         run: git fetch origin ${{ github.base_ref || 'main' }}:refs/remotes/origin/${{ github.base_ref || 'main' }}
       
       - name: 🐍 设置 Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.11'
           cache: 'pip'
@@ -197,7 +197,7 @@ jobs:
     steps:
       # 先检出主分支（获取最新的 .github/scripts）
       - name: 📥 检出主分支脚本
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ github.event.repository.default_branch }}
           sparse-checkout: |
@@ -207,7 +207,7 @@ jobs:
       
       # 再检出 PR 代码（用于 diff 分析）
       - name: 📥 检出 PR 代码
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
           fetch-depth: 0
@@ -218,7 +218,7 @@ jobs:
         run: git fetch origin ${{ github.base_ref || 'main' }}:refs/remotes/origin/${{ github.base_ref || 'main' }}
       
       - name: 🐍 设置 Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.11'
       
@@ -243,7 +243,7 @@ jobs:
         run: python ../main-scripts/.github/scripts/ai_review.py
       
       - name: 📤 上传审查结果
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         if: always()
         with:
           name: ai-review-result
@@ -257,11 +257,11 @@ jobs:
     
     steps:
       - name: 📥 检出代码
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       
       - name: 🏷️ 添加标签
         if: github.event_name == 'pull_request_target'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const { data: files } = await github.rest.pulls.listFiles({
@@ -338,12 +338,12 @@ jobs:
     
     steps:
       - name: 📥 检出代码
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
       
       - name: 📥 下载 AI 审查结果
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         if: needs.ai-review.result == 'success'
         continue-on-error: true
         with:
@@ -354,7 +354,7 @@ jobs:
         env:
           AUTO_CHECK_RESULT: ${{ needs.auto-check.result }}
           AI_REVIEW_RESULT: ${{ needs.ai-review.result }}
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const fs = require('fs');

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -21,7 +21,7 @@ jobs:
     
     steps:
       - name: 🏷️ 标记并关闭过期内容
-        uses: actions/stale@v9
+        uses: actions/stale@v10
         with:
           # ===== Issue 配置 =====
           days-before-issue-stale: 7


### PR DESCRIPTION
## PR Type

- [x] fix
- [ ] feat
- [ ] refactor
- [ ] docs
- [ ] chore
- [ ] test

## Background And Problem

GitHub 已公告弃用 Node.js 20 运行时，并将在 2026-06-02 默认改为使用 Node.js 24 执行 JavaScript actions。当前仓库多个 workflow 仍引用旧版本 GitHub 官方 actions，打包/CI 日志已出现 Node.js 20 deprecation warning。

根因是这些 workflow 仍使用基于旧 Node 运行时的 action 主版本，例如 `actions/checkout@v4`、`actions/setup-node@v4`、`actions/setup-python@v5`、`actions/upload-artifact@v4` 等。

本 PR 的修复点是统一升级到 GitHub 官方已发布的 Node 24 兼容版本，保持现有 workflow 逻辑和项目构建 Node 版本不变。

## Scope Of Change

本 PR 仅修改 `.github/workflows/` 下的 GitHub Actions workflow：

- 升级 `checkout` / `setup-node` / `setup-python` / `cache` / `upload-artifact`
- 同步升级 `download-artifact` / `github-script` / `stale`
- 未调整 job 结构、触发条件、构建命令和项目业务代码

## Issue Link

Fixes #664

## Verification Commands And Results

请填写你实际执行过的命令和关键结果（不要只写“已测试”）：

```bash
ruby -e 'require "yaml"; Dir[".github/workflows/*.yml"].sort.each { |f| YAML.load_file(f); puts "OK #{f}" }'
git diff --check -- .github/workflows
rg -n "actions/checkout@v4|actions/setup-node@v4|actions/setup-python@v5|actions/cache@v4|actions/upload-artifact@v4|actions/download-artifact@v4|actions/github-script@v7|actions/stale@v9" .github/workflows -g '*.yml'
```

关键输出/结论：

- 所有 `.github/workflows/*.yml` 均可被 YAML 解析
- `git diff --check` 无格式错误
- `rg` 无输出，说明旧版 action 引用已清理
- `./scripts/ci_gate.sh` 未执行；本次为 workflow 配置改动，已使用更贴近改动面的本地校验代替

## Compatibility And Risk

主要风险：

- 若后续使用 self-hosted runner，需要确认 runner 版本满足新版 action 的最低要求
- 本 PR 只处理 GitHub 官方 actions；若仍有 Node 20 告警，可能来自第三方 actions，需要后续单独排查

兼容性说明：

- 未改项目构建使用的 `node-version: '20'`
- 仅升级 GitHub 官方 actions 的运行时兼容版本

## Rollback Plan

如升级后出现 workflow 兼容性问题，可直接回退本 PR，将相关 actions 主版本恢复到升级前版本。

## EXTRACT_PROMPT 变更（如适用）

不适用。

## Checklist

- [x] 我已确认本 PR 有明确动机和业务价值
- [x] 我已提供可复现的验证命令与结果
- [x] 我已评估兼容性与风险
- [x] 我已提供回滚方案
- [x] 若涉及用户可见变更，我已同步更新 `README.md` 与 `docs/CHANGELOG.md`
