### PR TITLE
fixbug： pass searxng_base_urls to SearchService in pipeline init

### DIFF
--- a/src/core/pipeline.py
+++ b/src/core/pipeline.py
@@ -90,6 +90,7 @@ class StockAnalysisPipeline:
             brave_keys=self.config.brave_api_keys,
             serpapi_keys=self.config.serpapi_keys,
             minimax_keys=self.config.minimax_api_keys,
+            searxng_base_urls=self.config.searxng_base_urls,
             news_max_age_days=self.config.news_max_age_days,
             news_strategy_profile=getattr(self.config, "news_strategy_profile", "short"),
         )


### PR DESCRIPTION
PR Type
- [x] fix
Background And Problem
StockAnalysisPipeline 初始化 SearchService 时遗漏了 searxng_base_urls 参数，导致即使在 .env 中正确配置了 SEARXNG_BASE_URLS，搜索服务仍然无法启用 SearXNG 实例。
表现为日志输出 搜索服务未启用（未配置 API Key），新闻搜索功能完全不可用。当用户未配置任何付费搜索引擎 API Key、仅依赖自建 SearXNG 时，该 bug 会导致所有股票分析缺失舆情情报。
Scope Of Change
- src/core/pipeline.py：SearchService() 初始化调用处，补传 searxng_base_urls=self.config.searxng_base_urls
Issue Link
无对应 Issue。验收标准：配置 SEARXNG_BASE_URLS 后运行分析，日志应显示 已配置 SearXNG 搜索，共 N 个实例 且搜索服务状态为已启用。
Verification Commands And Results
python -m py_compile src/core/pipeline.py
python main.py --stocks ARM
关键输出：
修复前：
搜索服务未启用（未配置 API Key）
股票ARM(ARM) 搜索服务不可用，跳过情报搜索
修复后：
已配置 SearXNG 搜索，共 1 个实例
搜索服务已启用 (Tavily/SerpAPI)
股票ARM(ARM) 开始多维度情报搜索...
[SearXNG] 搜索 '股票ARM ARM latest news events' 成功，返回 6 条结果，耗时 3.01s
Compatibility And Risk
None。仅新增一个已有参数的透传，searxng_base_urls 默认为空列表，未配置时行为不变。
Rollback Plan
还原 src/core/pipeline.py 中 SearchService() 调用处删除 searxng_base_urls=self.config.searxng_base_urls 一行即可。
EXTRACT_PROMPT Change (if applicable)
N/A
Checklist
- [x] 本 PR 有明确动机和业务价值
- [x] 已提供可复现的验证命令与结果
- [x] 已评估兼容性与风险
- [x] 已提供回滚方案
- [ ] 若涉及用户可见变更，已同步更新相关文档与 docs/CHANGELOG.md — 本次为内部 bug 修复，不涉及用户可见的配置项或 API 变更，SEARXNG_BASE_URLS 在 .env.example 中已有说明，无需额外文档更新