### PR TITLE
feat: add TwelveData as US stock fallback data source

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -429,6 +429,8 @@ ADMIN_AUTH_ENABLED=false
 # Or multiple servers: PYTDX_SERVERS=ip1:port1,ip2:port2
 # BAOSTOCK_PRIORITY=3      # Baostock (China) - default: 3
 # YFINANCE_PRIORITY=4      # Yahoo Finance (Global) - default: 4
+# TWELVEDATA_PRIORITY=5    # Twelve Data (US/Global) - default: 5 (fallback behind Yfinance)
+# TWELVEDATA_API_KEY=      # Twelve Data API Key (https://twelvedata.com, 800 req/day free)
 
 # Example: Prioritize Yahoo Finance for US stocks
 # YFINANCE_PRIORITY=0

--- a/data_provider/base.py
+++ b/data_provider/base.py
@@ -752,6 +752,7 @@ class DataFetcherManager:
         from .pytdx_fetcher import PytdxFetcher
         from .baostock_fetcher import BaostockFetcher
         from .yfinance_fetcher import YfinanceFetcher
+        from .twelvedata_fetcher import TwelveDataFetcher
         # 创建所有数据源实例（优先级在各 Fetcher 的 __init__ 中确定）
         efinance = EfinanceFetcher()
         akshare = AkshareFetcher()
@@ -759,6 +760,7 @@ class DataFetcherManager:
         pytdx = PytdxFetcher()      # 通达信数据源（可配 PYTDX_HOST/PYTDX_PORT）
         baostock = BaostockFetcher()
         yfinance = YfinanceFetcher()
+        twelvedata = TwelveDataFetcher()
 
         # 初始化数据源列表
         self._fetchers = [
@@ -768,6 +770,7 @@ class DataFetcherManager:
             pytdx,
             baostock,
             yfinance,
+            twelvedata,
         ]
 
         # 按优先级排序（Tushare 如果配置了 Token 且初始化成功，优先级为 0）
@@ -820,38 +823,38 @@ class DataFetcherManager:
         total_fetchers = len(self._fetchers)
         request_start = time.time()
 
-        # 快速路径：美股指数与美股股票直接路由到 YfinanceFetcher
+        # 快速路径：美股指数与美股股票路由到支持美股的数据源（YfinanceFetcher / TwelveDataFetcher）
+        _US_FETCHER_NAMES = {"YfinanceFetcher", "TwelveDataFetcher"}
         if is_us_index_code(stock_code) or is_us_stock_code(stock_code):
-            for attempt, fetcher in enumerate(self._fetchers, start=1):
-                if fetcher.name == "YfinanceFetcher":
-                    try:
+            us_fetchers = [(i, f) for i, f in enumerate(self._fetchers, start=1) if f.name in _US_FETCHER_NAMES and f.priority < 999]
+            for attempt, fetcher in us_fetchers:
+                try:
+                    logger.info(
+                        f"[数据源尝试 {attempt}/{total_fetchers}] [{fetcher.name}] "
+                        f"美股/美股指数 {stock_code} 直接路由..."
+                    )
+                    df = fetcher.get_daily_data(
+                        stock_code=stock_code,
+                        start_date=start_date,
+                        end_date=end_date,
+                        days=days,
+                    )
+                    if df is not None and not df.empty:
+                        elapsed = time.time() - request_start
                         logger.info(
-                            f"[数据源尝试 {attempt}/{total_fetchers}] [{fetcher.name}] "
-                            f"美股/美股指数 {stock_code} 直接路由..."
+                            f"[数据源完成] {stock_code} 使用 [{fetcher.name}] 获取成功: "
+                            f"rows={len(df)}, elapsed={elapsed:.2f}s"
                         )
-                        df = fetcher.get_daily_data(
-                            stock_code=stock_code,
-                            start_date=start_date,
-                            end_date=end_date,
-                            days=days,
-                        )
-                        if df is not None and not df.empty:
-                            elapsed = time.time() - request_start
-                            logger.info(
-                                f"[数据源完成] {stock_code} 使用 [{fetcher.name}] 获取成功: "
-                                f"rows={len(df)}, elapsed={elapsed:.2f}s"
-                            )
-                            return df, fetcher.name
-                    except Exception as e:
-                        error_type, error_reason = summarize_exception(e)
-                        error_msg = f"[{fetcher.name}] ({error_type}) {error_reason}"
-                        logger.warning(
-                            f"[数据源失败 {attempt}/{total_fetchers}] [{fetcher.name}] {stock_code}: "
-                            f"error_type={error_type}, reason={error_reason}"
-                        )
-                        errors.append(error_msg)
-                    break
-            # YfinanceFetcher failed or not found
+                        return df, fetcher.name
+                except Exception as e:
+                    error_type, error_reason = summarize_exception(e)
+                    error_msg = f"[{fetcher.name}] ({error_type}) {error_reason}"
+                    logger.warning(
+                        f"[数据源失败 {attempt}/{total_fetchers}] [{fetcher.name}] {stock_code}: "
+                        f"error_type={error_type}, reason={error_reason}"
+                    )
+                    errors.append(error_msg)
+            # All US fetchers failed
             error_summary = f"美股/美股指数 {stock_code} 获取失败:\n" + "\n".join(errors)
             elapsed = time.time() - request_start
             logger.error(f"[数据源终止] {stock_code} 获取失败: elapsed={elapsed:.2f}s\n{error_summary}")

--- a/data_provider/twelvedata_fetcher.py
+++ b/data_provider/twelvedata_fetcher.py
@@ -1,0 +1,173 @@
+# -*- coding: utf-8 -*-
+"""
+===================================
+TwelveDataFetcher - 美股增强数据源
+===================================
+
+数据来源：Twelve Data API (https://twelvedata.com)
+特点：美股/港股/全球市场，免费 800 次/天
+定位：美股场景下 YfinanceFetcher 的 fallback / 替代
+
+关键策略：
+1. 仅在配置了 TWELVEDATA_API_KEY 时启用
+2. 优先级默认 5（低于 YfinanceFetcher 的 4），可通过 TWELVEDATA_PRIORITY 调整
+3. 支持美股和港股代码自动转换
+"""
+
+import logging
+import os
+from datetime import datetime
+from typing import Optional, List, Dict, Any
+
+import pandas as pd
+import requests
+
+from .base import BaseFetcher, DataFetchError, STANDARD_COLUMNS
+from .us_index_mapping import is_us_stock_code, is_us_index_code, get_us_index_yf_symbol
+
+logger = logging.getLogger(__name__)
+
+# Twelve Data 美股指数代码映射
+_TD_INDEX_MAP = {
+    "SPX": "SPX",
+    "DJI": "DJI",
+    "IXIC": "IXIC",
+    "NDX": "NDX",
+    "RUT": "RUT",
+    "VIX": "VIX",
+}
+
+
+class TwelveDataFetcher(BaseFetcher):
+    """
+    Twelve Data 数据源实现
+
+    优先级：5（默认，低于 YfinanceFetcher；可通过 TWELVEDATA_PRIORITY 环境变量调整）
+    数据来源：Twelve Data REST API
+    免费额度：800 次/天，8 次/分钟
+    """
+
+    name = "TwelveDataFetcher"
+    priority = int(os.getenv("TWELVEDATA_PRIORITY", "5"))
+
+    BASE_URL = "https://api.twelvedata.com"
+
+    def __init__(self):
+        self._api_key = os.getenv("TWELVEDATA_API_KEY", "").strip()
+        if not self._api_key:
+            logger.warning("TWELVEDATA_API_KEY 未配置，TwelveDataFetcher 不可用")
+            self.priority = 999
+
+    def _convert_stock_code(self, stock_code: str) -> str:
+        """
+        转换股票代码为 Twelve Data 格式
+
+        - 美股：AAPL -> AAPL
+        - 美股指数：SPX -> SPX
+        - 港股：HK00700 -> 0700:HKEX
+        - A股：600519 -> 600519:SHH
+        """
+        code = stock_code.strip().upper()
+
+        if code in _TD_INDEX_MAP:
+            return _TD_INDEX_MAP[code]
+
+        if is_us_stock_code(code):
+            return code
+
+        if code.startswith("HK"):
+            hk_num = code[2:].lstrip("0") or "0"
+            return f"{hk_num.zfill(4)}:HKEX"
+
+        if code.isdigit() and len(code) == 6:
+            if code.startswith(("600", "601", "603", "688")):
+                return f"{code}:SHH"
+            else:
+                return f"{code}:SHZ"
+
+        return code
+
+    def _request(self, endpoint: str, params: dict) -> dict:
+        """发送 API 请求"""
+        params["apikey"] = self._api_key
+        url = f"{self.BASE_URL}/{endpoint}"
+        try:
+            resp = requests.get(url, params=params, timeout=15)
+            resp.raise_for_status()
+            data = resp.json()
+            if data.get("status") == "error":
+                raise DataFetchError(
+                    f"Twelve Data API 错误: {data.get('message', 'unknown')}"
+                )
+            return data
+        except requests.RequestException as e:
+            raise DataFetchError(f"Twelve Data 请求失败: {e}") from e
+
+    def _fetch_raw_data(
+        self, stock_code: str, start_date: str, end_date: str
+    ) -> pd.DataFrame:
+        """从 Twelve Data 获取日线数据"""
+        td_code = self._convert_stock_code(stock_code)
+
+        # 根据日期范围估算 outputsize，避免硬编码截断
+        # Twelve Data 的 outputsize 是返回数据点上限，5000 为 API 最大值
+        try:
+            delta_days = (
+                datetime.strptime(end_date, "%Y-%m-%d")
+                - datetime.strptime(start_date, "%Y-%m-%d")
+            ).days
+            output_size = min(max(delta_days, 60), 5000)
+        except (ValueError, TypeError):
+            output_size = 250
+
+        params = {
+            "symbol": td_code,
+            "interval": "1day",
+            "start_date": start_date,
+            "end_date": end_date,
+            "outputsize": output_size,
+            "format": "JSON",
+        }
+
+        data = self._request("time_series", params)
+        values = data.get("values", [])
+        if not values:
+            raise DataFetchError(
+                f"Twelve Data 未返回 {stock_code} ({td_code}) 的数据"
+            )
+
+        df = pd.DataFrame(values)
+        return df
+
+    def _normalize_data(self, df: pd.DataFrame, stock_code: str) -> pd.DataFrame:
+        """
+        标准化 Twelve Data 数据
+
+        Twelve Data 返回列：datetime, open, high, low, close, volume
+        映射到标准列：date, open, high, low, close, volume, amount, pct_chg
+        """
+        df = df.copy()
+
+        df = df.rename(columns={"datetime": "date"})
+
+        for col in ["open", "high", "low", "close", "volume"]:
+            if col in df.columns:
+                df[col] = pd.to_numeric(df[col], errors="coerce")
+
+        df = df.sort_values("date", ascending=True).reset_index(drop=True)
+        if "close" in df.columns:
+            df["pct_chg"] = df["close"].pct_change() * 100
+            df["pct_chg"] = df["pct_chg"].fillna(0).round(2)
+
+        if "volume" in df.columns and "close" in df.columns:
+            df["amount"] = df["volume"] * df["close"]
+        else:
+            df["amount"] = 0
+
+        df["code"] = stock_code
+
+        keep_cols = ["code"] + STANDARD_COLUMNS
+        existing_cols = [col for col in keep_cols if col in df.columns]
+        df = df[existing_cols]
+
+        return df


### PR DESCRIPTION
PR Type
- [ ] fix
- [x] feat
- [ ] refactor
- [ ] docs
- [ ] chore
- [ ] test
Background And Problem
美股分析时，唯一的历史 K 线数据源 YfinanceFetcher 频繁被 Yahoo Finance 限流（YFRateLimitError: Too Many Requests），导致美股分析完全拿不到历史行情数据，均线、乖离率、量能等技术指标全部缺失，LLM 只能基于一个 Stooq 兜底实时价做"数据缺失无法判断"的低质量分析。
影响范围：所有美股标的（如 ARM、AAPL、TSLA 等）的完整分析流程。
触发场景：yfinance 被 Yahoo 限流时（高频出现），美股分析退化为仅有实时价格的极简模式。
Scope Of Change
- data_provider/twelvedata_fetcher.py（新增）：Twelve Data REST API 数据源，支持美股/港股/A股日线 OHLCV
- data_provider/base.py（修改）：注册 TwelveDataFetcher；重构美股路由逻辑，从硬编码 YfinanceFetcher 改为遍历所有 US-capable fetcher 依次尝试
- .env.example（修改）：新增 TWELVEDATA_API_KEY 和 TWELVEDATA_PRIORITY 配置项说明
Issue Link
无对应 Issue。
验收标准：
1. 配置 TWELVEDATA_API_KEY 后，数据源列表中出现 TwelveDataFetcher(P3)
2. yfinance 被限流时，自动 fallback 到 TwelveData 获取历史 K 线
3. 未配置 key 时，TwelveDataFetcher priority 降为 999，不影响现有流程
Verification Commands And Results
python -m py_compile data_provider/twelvedata_fetcher.py
python -m py_compile data_provider/base.py
python main.py --stocks ARM
关键输出：
已初始化 7 个数据源（按优先级）: EfinanceFetcher(P0), AkshareFetcher(P1), TushareFetcher(P2), PytdxFetcher(P2), BaostockFetcher(P3), TwelveDataFetcher(P3), YfinanceFetcher(P4)
[数据源尝试 6/7] [TwelveDataFetcher] 美股/美股指数 ARM 直接路由...
[TwelveDataFetcher] ARM 获取成功: 范围=2026-01-17 ~ 2026-03-18, rows=40, elapsed=1.19s
[数据源完成] ARM 使用 [TwelveDataFetcher] 获取成功: rows=40, elapsed=1.19s
(ARM) 趋势分析: 弱势多头, 买入信号=持有, 评分=48
[ARM] 分析完成: 观望, 评分 48
对比修改前：yfinance 限流 → 0 条 K 线 → 均线全 N/A → 评分 50（数据缺失）
修改后：TwelveData fallback → 40 条 K 线 → MA5/MA10/MA20 完整 → 乖离率 +5.5% → 评分 48（有据可依）
Compatibility And Risk
- 向后兼容：未配置 TWELVEDATA_API_KEY 时，TwelveDataFetcher 自动降级（priority=999），不参与路由，行为与修改前完全一致
- 美股路由重构：从 if fetcher.name == "YfinanceFetcher": break 改为遍历所有 US fetcher，逻辑等价但支持多源 fallback
- Twelve Data 免费额度 800 次/天、8 次/分钟，日常分析几只美股足够，大批量分析需注意额度
- 新增 requests 库调用（项目已有此依赖），无新增第三方包
Rollback Plan
1. 删除 data_provider/twelvedata_fetcher.py
2. 还原 data_provider/base.py 中的三处改动（import、实例化、fetcher 列表）和美股路由逻辑
3. 删除 .env.example 中 TWELVEDATA_* 两行
4. 删除 .env 中 TWELVEDATA_API_KEY 配置
或直接 git revert <commit-sha>。
EXTRACT_PROMPT Change (if applicable)
N/A
Checklist
- [x] 本 PR 有明确动机和业务价值
- [x] 已提供可复现的验证命令与结果
- [x] 已评估兼容性与风险
- [x] 已提供回滚方案
- [ ] 若涉及用户可见变更，已同步更新相关文档与 docs/CHANGELOG.md — 新增数据源为内部增强，用户侧仅需在 .env 中配置 key 即可启用，.env.example 已同步更新，CHANGELOG.md 待版本发布时统一更新