### PR TITLE
fix: restore report details copy button

### DIFF
--- a/apps/dsa-web/src/components/report/ReportDetails.tsx
+++ b/apps/dsa-web/src/components/report/ReportDetails.tsx
@@ -45,7 +45,7 @@ export const ReportDetails: React.FC<ReportDetailsProps> = ({
         <button
           type="button"
           onClick={() => copyToClipboard(jsonStr)}
-          className="home-accent-link absolute top-2 right-2 text-xs text-muted-text"
+          className="home-accent-link absolute top-2 right-2 z-10 text-xs text-muted-text"
         >
           {copied ? text.copied : text.copy}
         </button>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### 修复
+
+- 🧾 **Web 报告透明度区复制按钮层级修复**（#749）— `ReportDetails` 中“原始分析结果 / 分析快照”的复制按钮补齐可点击层级，避免被下方 JSON 内容覆盖后出现按钮可见但无法点击的问题。
+
 ## [3.9.0] - 2026-03-20
 
 ### 发布亮点


### PR DESCRIPTION
## PR Type

- [x] fix
- [ ] feat
- [ ] refactor
- [ ] docs
- [ ] chore
- [ ] test

## Background And Problem

Web report details rendered a visible copy button for raw analysis JSON / context snapshot, but the button could not be clicked reliably because it could be covered by the JSON content layer. This affected the transparency/traceability panel in the Web UI.

## Scope Of Change

- `apps/dsa-web/src/components/report/ReportDetails.tsx`
- `docs/CHANGELOG.md`

## Issue Link

- `Fixes #749`

## Verification Commands And Results

```bash
cd apps/dsa-web && npm run lint
cd apps/dsa-web && npm run build
```

关键输出/结论 / Key output & conclusion:
- `npm run lint` passed
- `npm run build` passed
- Production build completed successfully for the web app

## Compatibility And Risk

Compatibility impact: None expected. This only raises the copy button z-index in the report details panel.

Potential risks:
- This change fixes click-layering only. It does not change browser clipboard permission behavior in insecure contexts.

## Rollback Plan

Revert the `z-10` addition in `apps/dsa-web/src/components/report/ReportDetails.tsx` and remove the matching `docs/CHANGELOG.md` entry.

## EXTRACT_PROMPT Change (if applicable)

Not applicable.

## Checklist

- [x] 本 PR 有明确动机和业务价值 / This PR has a clear motivation and value
- [x] 已提供可复现的验证命令与结果 / Reproducible verification commands and results are included
- [x] 已评估兼容性与风险 / Compatibility and risk have been assessed
- [x] 已提供回滚方案 / A rollback plan is provided
- [x] 若涉及用户可见变更，已同步更新相关文档与 `docs/CHANGELOG.md`；若未更新 `README.md`，已说明原因与文档落点 / If user-visible changes are included, the relevant docs and `docs/CHANGELOG.md` are updated; if `README.md` is not updated, the reason and documentation location are explained

补充说明：
- `README.md` 未更新，因为本次仅为局部 Web 交互修复，不涉及入门、运行、部署或核心能力说明；变更已记录在 `docs/CHANGELOG.md`。