### PR TITLE
fix: parameterize market context in LLM prompts for international stocks

### DIFF
--- a/src/agent/executor.py
+++ b/src/agent/executor.py
@@ -23,6 +23,7 @@ from src.agent.llm_adapter import LLMToolAdapter
 from src.agent.runner import run_agent_loop, parse_dashboard_json
 from src.agent.tools.registry import ToolRegistry
 from src.report_language import normalize_report_language
+from src.market_context import get_market_role, get_market_guidelines
 
 logger = logging.getLogger(__name__)
 
@@ -49,7 +50,9 @@ class AgentResult:
 # System prompt builder
 # ============================================================
 
-AGENT_SYSTEM_PROMPT = """你是一位专注于趋势交易的 A 股投资分析 Agent，拥有数据工具和交易技能，负责生成专业的【决策仪表盘】分析报告。
+AGENT_SYSTEM_PROMPT = """你是一位专注于趋势交易的{market_role}投资分析 Agent，拥有数据工具和交易技能，负责生成专业的【决策仪表盘】分析报告。
+
+{market_guidelines}
 
 ## 工作流程（必须严格按阶段顺序执行，每阶段等工具结果返回后再进入下一阶段）
 
@@ -178,7 +181,9 @@ AGENT_SYSTEM_PROMPT = """你是一位专注于趋势交易的 A 股投资分析 
 {language_section}
 """
 
-CHAT_SYSTEM_PROMPT = """你是一位专注于趋势交易的 A 股投资分析 Agent，拥有数据工具和交易技能，负责解答用户的股票投资问题。
+CHAT_SYSTEM_PROMPT = """你是一位专注于趋势交易的{market_role}投资分析 Agent，拥有数据工具和交易技能，负责解答用户的股票投资问题。
+
+{market_guidelines}
 
 ## 分析工作流程（必须严格按阶段执行，禁止跳步或合并阶段）
 
@@ -298,7 +303,12 @@ class AgentExecutor:
         if self.default_skill_policy:
             default_skill_policy_section = f"\n{self.default_skill_policy}\n"
         report_language = normalize_report_language((context or {}).get("report_language", "zh"))
+        stock_code = (context or {}).get("stock_code", "")
+        market_role = get_market_role(stock_code, report_language)
+        market_guidelines = get_market_guidelines(stock_code, report_language)
         system_prompt = AGENT_SYSTEM_PROMPT.format(
+            market_role=market_role,
+            market_guidelines=market_guidelines,
             default_skill_policy_section=default_skill_policy_section,
             skills_section=skills_section,
             language_section=_build_language_section(report_language),
@@ -337,7 +347,12 @@ class AgentExecutor:
         if self.default_skill_policy:
             default_skill_policy_section = f"\n{self.default_skill_policy}\n"
         report_language = normalize_report_language((context or {}).get("report_language", "zh"))
+        stock_code = (context or {}).get("stock_code", "")
+        market_role = get_market_role(stock_code, report_language)
+        market_guidelines = get_market_guidelines(stock_code, report_language)
         system_prompt = CHAT_SYSTEM_PROMPT.format(
+            market_role=market_role,
+            market_guidelines=market_guidelines,
             default_skill_policy_section=default_skill_policy_section,
             skills_section=skills_section,
             language_section=_build_language_section(report_language, chat_mode=True),

--- a/src/analyzer.py
+++ b/src/analyzer.py
@@ -44,6 +44,7 @@ from src.report_language import (
     normalize_report_language,
 )
 from src.schemas.report_schema import AnalysisReportSchema
+from src.market_context import get_market_role, get_market_guidelines
 
 logger = logging.getLogger(__name__)
 
@@ -500,7 +501,9 @@ class GeminiAnalyzer:
     # 核心模块：核心结论 + 数据透视 + 舆情情报 + 作战计划
     # ========================================
 
-    SYSTEM_PROMPT = """你是一位专注于趋势交易的 A 股投资分析师，负责生成专业的【决策仪表盘】分析报告。
+    SYSTEM_PROMPT = """你是一位专注于趋势交易的{market_placeholder}投资分析师，负责生成专业的【决策仪表盘】分析报告。
+
+{guidelines_placeholder}
 
 """ + CORE_TRADING_SKILL_POLICY_ZH + """
 
@@ -659,10 +662,18 @@ class GeminiAnalyzer:
         if not self._litellm_available:
             logger.warning("No LLM configured (LITELLM_MODEL / API keys), AI analysis will be unavailable")
 
-    def _get_analysis_system_prompt(self, report_language: str) -> str:
+    def _get_analysis_system_prompt(self, report_language: str, stock_code: str = "") -> str:
         """Build the analyzer system prompt with output-language guidance."""
-        if normalize_report_language(report_language) == "en":
-            return self.SYSTEM_PROMPT + """
+        lang = normalize_report_language(report_language)
+        market_role = get_market_role(stock_code, lang)
+        market_guidelines = get_market_guidelines(stock_code, lang)
+        base_prompt = self.SYSTEM_PROMPT.replace(
+            "{market_placeholder}", market_role
+        ).replace(
+            "{guidelines_placeholder}", market_guidelines
+        )
+        if lang == "en":
+            return base_prompt + """
 
 ## Output Language (highest priority)
 
@@ -672,7 +683,7 @@ class GeminiAnalyzer:
 - Use the common English company name when you are confident; otherwise keep the original listed company name instead of inventing one.
 - This includes `stock_name`, `trend_prediction`, `operation_advice`, `confidence_level`, nested dashboard text, checklist items, and all narrative summaries.
 """
-        return self.SYSTEM_PROMPT + """
+        return base_prompt + """
 
 ## 输出语言（最高优先级）
 
@@ -898,7 +909,7 @@ class GeminiAnalyzer:
         code = context.get('code', 'Unknown')
         config = get_config()
         report_language = normalize_report_language(getattr(config, "report_language", "zh"))
-        system_prompt = self._get_analysis_system_prompt(report_language)
+        system_prompt = self._get_analysis_system_prompt(report_language, stock_code=code)
         
         # 请求前增加延时（防止连续请求触发限流）
         request_delay = config.gemini_request_delay

--- a/src/market_context.py
+++ b/src/market_context.py
@@ -1,0 +1,124 @@
+# -*- coding: utf-8 -*-
+"""
+Market context detection for LLM prompts.
+
+Detects the market (A-shares, HK, US) from a stock code and returns
+market-specific role descriptions so prompts are not hardcoded to a
+single market.
+
+Fixes: https://github.com/ZhuLinsen/daily_stock_analysis/issues/644
+"""
+
+import re
+from typing import Optional
+
+
+def detect_market(stock_code: Optional[str]) -> str:
+    """Detect market from stock code.
+
+    Returns:
+        One of 'cn', 'hk', 'us', or 'cn' as fallback.
+    """
+    if not stock_code:
+        return "cn"
+
+    code = stock_code.strip().upper()
+
+    # HK stocks: HK00700, 00700.HK, or 5-digit pure numbers
+    if code.startswith("HK") or code.endswith(".HK"):
+        return "hk"
+    lower = code.lower()
+    if lower.endswith(".hk"):
+        return "hk"
+    # 5-digit pure numbers are HK (A-shares are 6-digit)
+    if code.isdigit() and len(code) == 5:
+        return "hk"
+
+    # US stocks: 1-5 uppercase letters (AAPL, TSLA, GOOGL)
+    # Also handles suffixed forms like BRK.B
+    if re.match(r'^[A-Z]{1,5}(\.[A-Z]{1,2})?$', code):
+        return "us"
+
+    # Default: A-shares (6-digit numbers like 600519, 000001)
+    return "cn"
+
+
+# -- Market-specific role descriptions --
+
+_MARKET_ROLES = {
+    "cn": {
+        "zh": " A 股",
+        "en": "China A-shares",
+    },
+    "hk": {
+        "zh": "港股",
+        "en": "Hong Kong stock",
+    },
+    "us": {
+        "zh": "美股",
+        "en": "US stock",
+    },
+}
+
+_MARKET_GUIDELINES = {
+    "cn": {
+        "zh": (
+            "- 本次分析对象为 **A 股**（中国沪深交易所上市股票）。\n"
+            "- 请关注 A 股特有的涨跌停机制（±10%/±20%/±30%）、T+1 交易制度及相关政策因素。"
+        ),
+        "en": (
+            "- This analysis covers a **China A-share** (listed on Shanghai/Shenzhen exchanges).\n"
+            "- Consider A-share-specific rules: daily price limits (±10%/±20%/±30%), T+1 settlement, and PRC policy factors."
+        ),
+    },
+    "hk": {
+        "zh": (
+            "- 本次分析对象为 **港股**（香港交易所上市股票）。\n"
+            "- 港股无涨跌停限制，支持 T+0 交易，需关注港币汇率、南北向资金流及联交所特有规则。"
+        ),
+        "en": (
+            "- This analysis covers a **Hong Kong stock** (listed on HKEX).\n"
+            "- HK stocks have no daily price limits, allow T+0 trading. Consider HKD FX, Southbound/Northbound flows, and HKEX-specific rules."
+        ),
+    },
+    "us": {
+        "zh": (
+            "- 本次分析对象为 **美股**（美国交易所上市股票）。\n"
+            "- 美股无涨跌停限制（但有熔断机制），支持 T+0 交易和盘前盘后交易，需关注美元汇率、美联储政策及 SEC 监管动态。"
+        ),
+        "en": (
+            "- This analysis covers a **US stock** (listed on NYSE/NASDAQ).\n"
+            "- US stocks have no daily price limits (but have circuit breakers), allow T+0 and pre/after-market trading. Consider USD FX, Fed policy, and SEC regulations."
+        ),
+    },
+}
+
+
+def get_market_role(stock_code: Optional[str], lang: str = "zh") -> str:
+    """Return market-specific role description for LLM prompt.
+
+    Args:
+        stock_code: The stock code being analyzed.
+        lang: 'zh' or 'en'.
+
+    Returns:
+        Role string like 'A 股投资分析' or 'US stock investment analysis'.
+    """
+    market = detect_market(stock_code)
+    lang_key = "en" if lang == "en" else "zh"
+    return _MARKET_ROLES.get(market, _MARKET_ROLES["cn"])[lang_key]
+
+
+def get_market_guidelines(stock_code: Optional[str], lang: str = "zh") -> str:
+    """Return market-specific analysis guidelines for LLM prompt.
+
+    Args:
+        stock_code: The stock code being analyzed.
+        lang: 'zh' or 'en'.
+
+    Returns:
+        Multi-line string with market-specific guidelines.
+    """
+    market = detect_market(stock_code)
+    lang_key = "en" if lang == "en" else "zh"
+    return _MARKET_GUIDELINES.get(market, _MARKET_GUIDELINES["cn"])[lang_key]


### PR DESCRIPTION
## Summary
- Fixes #644 — LLM prompt hardcoded to A-shares market context
- Parameterized market context so analysis works correctly for US and international stocks

## Changes
- Added `src/market_context.py` — detects market (CN/HK/US) from stock code and provides market-specific role descriptions and trading rule guidelines
- Updated `src/agent/executor.py` — both `AGENT_SYSTEM_PROMPT` and `CHAT_SYSTEM_PROMPT` now dynamically inject market role and guidelines based on the stock being analyzed
- Updated `src/analyzer.py` — `SYSTEM_PROMPT` and `_get_analysis_system_prompt()` now accept `stock_code` and parameterize market context

## How it works
- `detect_market(stock_code)` returns `'cn'`, `'hk'`, or `'us'` based on code format (6-digit → A-shares, 5-digit/HK prefix → HK, alpha → US)
- Each market gets a specific role description (e.g. "美股投资分析" for US) and guidelines about that market's trading rules (price limits, T+0/T+1, relevant policy factors)
- A-shares analysis is completely unchanged — the default fallback is `'cn'`

## Test plan
- Verified A-shares analysis prompt renders identically to the original hardcoded version
- Verified US stock codes (AAPL, TSLA, BRK.B) produce US-market-specific prompts
- Verified HK stock codes (HK00700, 00700) produce HK-market-specific prompts
- All three modified files pass `py_compile` syntax validation