### PR TITLE
feat: add Novita AI as an LLM provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -46,6 +46,10 @@ GEMINI_API_KEY=
 # DeepSeek（https://platform.deepseek.com）
 # DEEPSEEK_API_KEY=
 
+# Novita AI（https://novita.ai）
+# OpenAI 兼容接口，支持 Kimi-K2.5、GLM-5、MiniMax 等模型
+# NOVITA_API_KEY=
+
 # AIHubmix 聚合（https://aihubmix.com/?aff=CfMq）
 # 一个 Key 用 GPT/Claude/Gemini/GLM/Qwen 等模型，无需科学上网
 # AIHUBMIX_KEY=

--- a/litellm_config.example.yaml
+++ b/litellm_config.example.yaml
@@ -28,6 +28,26 @@ model_list:
         chat_template_kwargs:
           enable_thinking: true
 
+  # --- Novita AI (OpenAI 兼容，支持 Kimi-K2.5 / GLM-5 / MiniMax 等) ---
+  # 文档：https://novita.ai/docs/api-reference/llm-openai-compatible
+  - model_name: openai/moonshotai/kimi-k2.5
+    litellm_params:
+      model: openai/moonshotai/kimi-k2.5
+      api_key: "os.environ/NOVITA_API_KEY"
+      api_base: https://api.novita.ai/openai
+
+  - model_name: openai/zai-org/glm-5
+    litellm_params:
+      model: openai/zai-org/glm-5
+      api_key: "os.environ/NOVITA_API_KEY"
+      api_base: https://api.novita.ai/openai
+
+  - model_name: openai/minimax/minimax-m2.5
+    litellm_params:
+      model: openai/minimax/minimax-m2.5
+      api_key: "os.environ/NOVITA_API_KEY"
+      api_base: https://api.novita.ai/openai
+
   # --- AIHubmix (OpenAI 兼容，一个 Key 使用多种模型) ---
   - model_name: openai/gpt-4o-mini
     litellm_params:

--- a/src/config.py
+++ b/src/config.py
@@ -460,6 +460,7 @@ class Config:
     anthropic_api_keys: List[str] = field(default_factory=list)
     openai_api_keys: List[str] = field(default_factory=list)
     deepseek_api_keys: List[str] = field(default_factory=list)
+    novita_api_keys: List[str] = field(default_factory=list)
 
     # Legacy single-key fields (kept for backward compatibility; gemini_api_keys[0] when set)
     gemini_api_key: Optional[str] = None
@@ -902,6 +903,14 @@ class Config:
             if _single_deepseek:
                 deepseek_api_keys = [_single_deepseek]
 
+        # NOVITA_API_KEYS > NOVITA_API_KEY (OpenAI-compatible endpoint: https://api.novita.ai/openai)
+        _novita_keys_raw = os.getenv('NOVITA_API_KEYS', '')
+        novita_api_keys = [k.strip() for k in _novita_keys_raw.split(',') if k.strip()]
+        if not novita_api_keys:
+            _single_novita = os.getenv('NOVITA_API_KEY', '').strip()
+            if _single_novita:
+                novita_api_keys = [_single_novita]
+
         # LITELLM_MODEL: explicit config takes precedence; else infer from available keys
         litellm_model = os.getenv('LITELLM_MODEL', '').strip()
         if not litellm_model:
@@ -914,6 +923,8 @@ class Config:
                 litellm_model = f'anthropic/{_anthropic_model_name}'
             elif deepseek_api_keys:
                 litellm_model = 'deepseek/deepseek-chat'
+            elif novita_api_keys:
+                litellm_model = 'openai/moonshotai/kimi-k2.5'
             elif openai_api_keys:
                 # For openai-compatible models, add prefix only if not already prefixed
                 if '/' not in _openai_model_name:
@@ -963,6 +974,7 @@ class Config:
                     'https://aihubmix.com/v1' if os.getenv('AIHUBMIX_KEY') else None
                 ),
                 deepseek_api_keys,
+                novita_api_keys,
             )
             if llm_model_list:
                 llm_models_source = "legacy_env"
@@ -1078,6 +1090,7 @@ class Config:
             anthropic_api_keys=anthropic_api_keys,
             openai_api_keys=openai_api_keys,
             deepseek_api_keys=deepseek_api_keys,
+            novita_api_keys=novita_api_keys,
             gemini_api_key=os.getenv('GEMINI_API_KEY'),
             gemini_model=os.getenv('GEMINI_MODEL', 'gemini-3-flash-preview'),
             gemini_model_fallback=os.getenv('GEMINI_MODEL_FALLBACK', 'gemini-2.5-flash'),
@@ -1519,6 +1532,7 @@ class Config:
         openai_keys: List[str],
         openai_base_url: Optional[str],
         deepseek_keys: Optional[List[str]] = None,
+        novita_keys: Optional[List[str]] = None,
     ) -> List[Dict[str, Any]]:
         """Build Router model_list from legacy per-provider keys (backward compat).
 
@@ -1566,6 +1580,18 @@ class Config:
                     'litellm_params': {
                         'model': '__legacy_deepseek__',
                         'api_key': k,
+                    },
+                })
+
+        # Novita AI keys (OpenAI-compatible endpoint)
+        for k in (novita_keys or []):
+            if k and len(k) >= 8:
+                model_list.append({
+                    'model_name': '__legacy_novita__',
+                    'litellm_params': {
+                        'model': '__legacy_novita__',
+                        'api_key': k,
+                        'api_base': 'https://api.novita.ai/openai',
                     },
                 })
 

--- a/tests/test_llm_channel_config.py
+++ b/tests/test_llm_channel_config.py
@@ -295,5 +295,63 @@ class LLMChannelConfigTestCase(unittest.TestCase):
         )
 
 
+    @patch("src.config.setup_env")
+    @patch.object(Config, "_parse_litellm_yaml", return_value=[])
+    def test_novita_api_key_sets_model_and_api_base(self, _mock_parse_yaml, _mock_setup_env) -> None:
+        """NOVITA_API_KEY should populate novita_api_keys, set litellm_model, and embed api_base."""
+        env = {
+            "NOVITA_API_KEY": "nv-test-key-1234",
+        }
+
+        with patch.dict(os.environ, env, clear=True):
+            config = Config._load_from_env()
+
+        self.assertEqual(config.novita_api_keys, ["nv-test-key-1234"])
+        self.assertEqual(config.litellm_model, "openai/moonshotai/kimi-k2.5")
+        params = config.llm_model_list[0]["litellm_params"]
+        self.assertEqual(params["api_key"], "nv-test-key-1234")
+        self.assertEqual(params["api_base"], "https://api.novita.ai/openai")
+
+    @patch("src.config.setup_env")
+    @patch.object(Config, "_parse_litellm_yaml", return_value=[])
+    def test_novita_api_keys_multi_creates_multiple_deployments(self, _mock_parse_yaml, _mock_setup_env) -> None:
+        """NOVITA_API_KEYS (comma-separated) should create one Router deployment per key."""
+        env = {
+            "NOVITA_API_KEYS": "nv-key-one,nv-key-two",
+        }
+
+        with patch.dict(os.environ, env, clear=True):
+            config = Config._load_from_env()
+
+        self.assertEqual(config.novita_api_keys, ["nv-key-one", "nv-key-two"])
+        novita_entries = [
+            e for e in config.llm_model_list
+            if e.get("model_name") == "__legacy_novita__"
+        ]
+        self.assertEqual(len(novita_entries), 2)
+        for entry in novita_entries:
+            self.assertEqual(entry["litellm_params"]["api_base"], "https://api.novita.ai/openai")
+
+    @patch("src.config.setup_env")
+    @patch.object(Config, "_parse_litellm_yaml", return_value=[])
+    def test_novita_channel_via_llm_channels(self, _mock_parse_yaml, _mock_setup_env) -> None:
+        """Novita configured as a named LLM_CHANNELS entry should resolve to openai protocol."""
+        env = {
+            "LLM_CHANNELS": "novita",
+            "LLM_NOVITA_BASE_URL": "https://api.novita.ai/openai",
+            "LLM_NOVITA_API_KEY": "nv-channel-key",
+            "LLM_NOVITA_MODELS": "moonshotai/kimi-k2.5",
+        }
+
+        with patch.dict(os.environ, env, clear=True):
+            config = Config._load_from_env()
+
+        self.assertEqual(config.llm_models_source, "llm_channels")
+        params = config.llm_model_list[0]["litellm_params"]
+        self.assertEqual(params["api_key"], "nv-channel-key")
+        self.assertEqual(params["api_base"], "https://api.novita.ai/openai")
+        self.assertIn("moonshotai/kimi-k2.5", params["model"])
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

- Adds **Novita AI** as a new LLM provider via its OpenAI-compatible endpoint (`https://api.novita.ai/openai`)
- Follows the same three-tier config pattern used by all existing providers (legacy env vars, `LLM_CHANNELS`, or `LITELLM_CONFIG` YAML)
- Default model: `moonshotai/kimi-k2.5` (selected when only `NOVITA_API_KEY` is set)

## Changes

**`src/config.py`**
- New `novita_api_keys: List[str]` field on `Config`
- Parses `NOVITA_API_KEY` / `NOVITA_API_KEYS` (multi-key, comma-separated)
- Adds Novita to `_legacy_keys_to_model_list` with `api_base=https://api.novita.ai/openai`
- Adds Novita to the auto-inference fallback chain (Gemini → Anthropic → DeepSeek → **Novita** → OpenAI)

**`.env.example`**
- Documents `NOVITA_API_KEY` with a link to novita.ai

**`litellm_config.example.yaml`**
- Adds Novita YAML examples for `kimi-k2.5`, `glm-5`, and `minimax-m2.5`

**`tests/test_llm_channel_config.py`**
- 3 new tests: single-key parsing + auto-model inference, multi-key deployments, and channel-based config

## Usage

**Quickstart (single key):**
```env
NOVITA_API_KEY=your-key
# Auto-selects openai/moonshotai/kimi-k2.5
```

**Multi-key load balancing:**
```env
NOVITA_API_KEYS=key1,key2,key3
```

**Named channel:**
```env
LLM_CHANNELS=novita
LLM_NOVITA_BASE_URL=https://api.novita.ai/openai
LLM_NOVITA_API_KEY=your-key
LLM_NOVITA_MODELS=moonshotai/kimi-k2.5,zai-org/glm-5
```

**YAML config:**
```yaml
model_list:
  - model_name: openai/moonshotai/kimi-k2.5
    litellm_params:
      model: openai/moonshotai/kimi-k2.5
      api_key: "os.environ/NOVITA_API_KEY"
      api_base: https://api.novita.ai/openai
```