### PR TITLE
feat: Web 端分析支持推送通知开关 (Fixes #808)

### DIFF
--- a/api/v1/endpoints/analysis.py
+++ b/api/v1/endpoints/analysis.py
@@ -260,6 +260,7 @@ def _handle_async_analysis_batch(
         selection_source=selection_source,
         report_type=request.report_type,
         force_refresh=request.force_refresh,
+        notify=request.notify,
     )
 
     accepted = [
@@ -338,7 +339,8 @@ def _handle_sync_analysis(
             stock_code=stock_code,
             report_type=request.report_type,
             force_refresh=request.force_refresh,
-            query_id=query_id
+            query_id=query_id,
+            send_notification=request.notify,
         )
 
         if result is None:

--- a/api/v1/schemas/analysis.py
+++ b/api/v1/schemas/analysis.py
@@ -67,7 +67,11 @@ class AnalyzeRequest(BaseModel):
         pattern=SELECTION_SOURCE_PATTERN,
         example="autocomplete"
     )
-    
+    notify: bool = Field(
+        True,
+        description="是否发送推送通知（Telegram/企业微信等）"
+    )
+
     class Config:
         json_schema_extra = {
             "example": {
@@ -77,7 +81,8 @@ class AnalyzeRequest(BaseModel):
                 "async_mode": False,
                 "stock_name": "贵州茅台",
                 "original_query": "茅台",
-                "selection_source": "autocomplete"
+                "selection_source": "autocomplete",
+                "notify": True
             }
         }
 

--- a/apps/dsa-web/src/api/analysis.ts
+++ b/apps/dsa-web/src/api/analysis.ts
@@ -28,6 +28,7 @@ export const analysisApi = {
       stock_name: data.stockName,
       original_query: data.originalQuery,
       selection_source: data.selectionSource,
+      ...(data.notify !== undefined && { notify: data.notify }),
     };
 
     const response = await apiClient.post<Record<string, unknown>>(
@@ -60,6 +61,7 @@ export const analysisApi = {
       stock_name: data.stockName,
       original_query: data.originalQuery,
       selection_source: data.selectionSource,
+      ...(data.notify !== undefined && { notify: data.notify }),
     };
 
     const response = await apiClient.post<Record<string, unknown>>(

--- a/apps/dsa-web/src/pages/HomePage.tsx
+++ b/apps/dsa-web/src/pages/HomePage.tsx
@@ -41,6 +41,8 @@ const HomePage: React.FC = () => {
     toggleSelectAllVisible,
     deleteSelectedHistory,
     submitAnalysis,
+    notify,
+    setNotify,
     syncTaskCreated,
     syncTaskUpdated,
     syncTaskFailed,
@@ -174,6 +176,15 @@ const HomePage: React.FC = () => {
                 <p className="absolute -bottom-4 left-0 text-xs text-warning">{duplicateError}</p>
               ) : null}
             </div>
+            <label className="flex flex-shrink-0 cursor-pointer items-center gap-1 text-xs text-secondary-text select-none">
+              <input
+                type="checkbox"
+                checked={notify}
+                onChange={(e) => setNotify(e.target.checked)}
+                className="h-3.5 w-3.5 rounded border-border accent-primary"
+              />
+              推送通知
+            </label>
             <button
               type="button"
               onClick={() => handleSubmitAnalysis()}

--- a/apps/dsa-web/src/stores/stockPoolStore.ts
+++ b/apps/dsa-web/src/stores/stockPoolStore.ts
@@ -22,6 +22,7 @@ type SubmitAnalysisOptions = {
   stockName?: string;
   originalQuery?: string;
   selectionSource?: SelectionSource;
+  notify?: boolean;
 };
 
 let reportRequestSeq = 0;
@@ -32,6 +33,7 @@ const dismissedTaskIds = new Set<string>();
 export interface StockPoolState {
   query: string;
   selectionSource: SelectionSource;
+  notify: boolean;
   inputError?: string;
   duplicateError: string | null;
   error: ParsedApiError | null;
@@ -60,6 +62,7 @@ export interface StockPoolState {
   toggleSelectAllVisible: () => void;
   deleteSelectedHistory: () => Promise<void>;
   submitAnalysis: (options?: SubmitAnalysisOptions) => Promise<void>;
+  setNotify: (notify: boolean) => void;
   syncTaskCreated: (task: TaskInfo) => void;
   syncTaskUpdated: (task: TaskInfo) => void;
   syncTaskFailed: (task: TaskInfo) => void;
@@ -70,6 +73,7 @@ export interface StockPoolState {
 const initialState = {
   query: '',
   selectionSource: 'manual' as SelectionSource,
+  notify: true,
   inputError: undefined,
   duplicateError: null,
   error: null,
@@ -184,6 +188,8 @@ export const useStockPoolStore = create<StockPoolState>((set, get) => ({
   clearError: () => set({ error: null }),
 
   clearInlineMessages: () => set({ inputError: undefined, duplicateError: null }),
+
+  setNotify: (notify) => set({ notify }),
 
   openMarkdownDrawer: () => set({ markdownDrawerOpen: true }),
 
@@ -301,6 +307,7 @@ export const useStockPoolStore = create<StockPoolState>((set, get) => ({
     const stockName = options?.stockName;
     const selectionSource = options?.selectionSource ?? state.selectionSource;
     const originalQuery = (options?.originalQuery ?? state.query).trim();
+    const notify = options?.notify ?? state.notify;
 
     if (!stockCodeInput) {
       set({ inputError: '请输入股票代码', duplicateError: null });
@@ -337,6 +344,7 @@ export const useStockPoolStore = create<StockPoolState>((set, get) => ({
         stockName,
         originalQuery: originalQuery || stockCodeInput,
         selectionSource,
+        notify,
       });
 
       if (requestId !== analyzeRequestSeq) {

--- a/apps/dsa-web/src/types/analysis.ts
+++ b/apps/dsa-web/src/types/analysis.ts
@@ -14,6 +14,7 @@ export interface AnalysisRequest {
   stockName?: string;
   originalQuery?: string;
   selectionSource?: 'manual' | 'autocomplete' | 'import' | 'image';
+  notify?: boolean;
 }
 
 // ============ Report Types ============

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### 新功能
+
+- 🔔 **Web 端分析推送通知开关**（#808）— 首页分析按钮旁新增「推送通知」复选框，默认勾选；取消勾选时本次分析不发送 Telegram/企业微信等推送。API `POST /api/v1/analysis/analyze` 新增 `notify` 字段（`bool`，默认 `true`），不传时行为与修改前一致，Bot 和定时任务不受影响。
+
 ### 改进
 
 - 🖥️ **Dashboard 面板统一化（PR7-2）** — 新增 `DashboardPanelHeader` 和 `DashboardStateBlock` 作为历史、报告、资讯、任务和透明度等面板的通用组件；统一了各面板标题层级、加载/空态/错误态和 CSS 变量 token。

--- a/src/services/task_queue.py
+++ b/src/services/task_queue.py
@@ -342,6 +342,7 @@ class AnalysisTaskQueue:
         selection_source: Optional[str] = None,
         report_type: str = "detailed",
         force_refresh: bool = False,
+        notify: bool = True,
     ) -> Tuple[List[TaskInfo], List[DuplicateTaskError]]:
         """
         Submit analysis tasks in batch.
@@ -389,6 +390,7 @@ class AnalysisTaskQueue:
                         stock_code,
                         report_type,
                         force_refresh,
+                        notify,
                     )
                 except Exception:
                     # Roll back the current batch to avoid partial submission.
@@ -493,6 +495,7 @@ class AnalysisTaskQueue:
         stock_code: str,
         report_type: str,
         force_refresh: bool,
+        notify: bool = True,
     ) -> Optional[Dict[str, Any]]:
         """
         执行分析任务（在线程池中运行）
@@ -529,6 +532,7 @@ class AnalysisTaskQueue:
                 report_type=report_type,
                 force_refresh=force_refresh,
                 query_id=task_id,
+                send_notification=notify,
             )
             
             if result:


### PR DESCRIPTION
## PR Type

- [x] feat

## Background And Problem

Web 端触发分析时，推送通知（Telegram/企业微信等）始终发送，无法按需关闭。频繁调试或临时查看时会产生大量无用通知。

## Scope Of Change

- **后端**: `api/v1/schemas/analysis.py`、`api/v1/endpoints/analysis.py`、`src/services/task_queue.py`
- **前端**: `apps/dsa-web/src/types/analysis.ts`、`apps/dsa-web/src/api/analysis.ts`、`apps/dsa-web/src/stores/stockPoolStore.ts`、`apps/dsa-web/src/pages/HomePage.tsx`
- **文档**: `docs/CHANGELOG.md`

## Issue Link

Fixes #808

## Verification Commands And Results

### 后端验证

```bash
# ci_gate.sh 等效验证（Docker 容器内执行）
==> backend-gate: Python syntax check
python -m py_compile main.py src/config.py src/auth.py src/analyzer.py src/notification.py
python -m py_compile src/storage.py src/scheduler.py src/search_service.py
python -m py_compile src/market_analyzer.py src/stock_analyzer.py
python -m py_compile data_provider/*.py
# 全部通过，无输出

==> backend-gate: flake8 critical checks
flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
# 0（无错误）

==> backend-gate: offline test suite
python -m pytest -m "not network"
# collected 0 items, no tests ran (容器内无 tests/ 目录)
```

> 注：`./scripts/ci_gate.sh` 需要 Linux + Python 环境，已在部署服务器的 Docker 容器内逐步执行等效命令。`test.sh code` 和 `test.sh yfinance` 未执行（容器内无 `test.sh` 脚本），CI 流水线已通过 `backend-gate` 检查。

### 前端验证

```bash
cd apps/dsa-web && npm ci && npx eslint .
# 无错误/警告

npx tsc --noEmit
# 无错误

npm run build
# ✓ built in 10.41s
```

### OpenAPI Schema

`AnalyzeRequest` 的 `json_schema_extra` example 已同步添加 `"notify": true`，与字段定义一致。

### 功能测试（已部署验证）

- 勾选复选框分析 → 收到推送通知
- 取消勾选分析 → 不收到推送，Web 端正常显示结果
- 不传 `notify` 字段调用 API → 行为与修改前一致

## Compatibility And Risk

- API `notify` 字段默认 `true`，完全向后兼容，不传时行为不变
- Bot 和定时任务不调用此 API 参数，不受影响
- `notify` 作为执行参数传递（与 `force_refresh` 一致），不存入 `TaskInfo`，不影响任务状态数据结构
- 风险低：纯新增字段，无既有逻辑变更

## Rollback Plan

Revert 此 PR 即可，无数据迁移或配置依赖。

## Checklist

- [x] 本 PR 有明确动机和业务价值
- [x] 已提供可复现的验证命令与结果
- [x] 已评估兼容性与风险
- [x] 已提供回滚方案
- [x] 若涉及用户可见变更，已同步更新相关文档与 `docs/CHANGELOG.md`；未更新 `README.md`，因为本次改动不涉及入门/运行/部署/核心能力总览变化，信息已落入 `docs/CHANGELOG.md`