### PR TITLE
fix: add .HK suffix support to stock code validation / 后端股票代码验证增加 .HK 后缀支持

### DIFF
--- a/src/services/stock_code_utils.py
+++ b/src/services/stock_code_utils.py
@@ -18,12 +18,21 @@ _PREFIX_DIGIT_LENS: dict = {
     "HK": (5,),
 }
 
+# Known exchange suffixes and the digit lengths they accept.
+# e.g. 600519.SH -> 600519, 00700.HK -> 00700
+_SUFFIX_DIGIT_LENS: dict = {
+    ".SH": (6,),
+    ".SZ": (6,),
+    ".SS": (6,),
+    ".HK": (5,),
+}
+
 
 def _strip_exchange_prefix(text: str) -> Optional[str]:
     """Strip leading exchange prefix (SH/SZ/HK etc.) and return the bare digits, or None."""
     for prefix, digit_lens in _PREFIX_DIGIT_LENS.items():
         if text.startswith(prefix):
-            base = text[len(prefix):]
+            base = text[len(prefix) :]
             if base.isdigit() and len(base) in digit_lens:
                 return base
     return None
@@ -36,10 +45,10 @@ def is_code_like(value: str) -> bool:
         return False
     if text.isdigit() and len(text) in (5, 6):
         return True
-    for suffix in (".SH", ".SZ", ".SS"):
+    for suffix, digit_lens in _SUFFIX_DIGIT_LENS.items():
         if text.endswith(suffix):
             base = text[: -len(suffix)].strip()
-            if base.isdigit() and len(base) in (5, 6):
+            if base.isdigit() and len(base) in digit_lens:
                 return True
     if re.match(r"^[A-Z]{1,5}(?:\.(?:US|[A-Z]))?$", text):
         return True
@@ -54,7 +63,7 @@ def normalize_code(raw: str) -> Optional[str]:
 
     Supports:
     - Plain digit codes: 600519, 00700
-    - Suffix format: 600519.SH, 600519.SZ
+    - Suffix format: 600519.SH, 600519.SZ, 00700.HK
     - Prefix format: SH600519, SZ000001, HK00700 (case-insensitive)
     - US ticker symbols: AAPL, TSLA
     """
@@ -65,10 +74,10 @@ def normalize_code(raw: str) -> Optional[str]:
         return text
     if re.match(r"^[A-Z]{1,5}(?:\.(?:US|[A-Z]))?$", text):
         return text
-    for suffix in (".SH", ".SZ", ".SS"):
+    for suffix, digit_lens in _SUFFIX_DIGIT_LENS.items():
         if text.endswith(suffix):
             base = text[: -len(suffix)].strip()
-            if base.isdigit() and len(base) in (5, 6):
+            if base.isdigit() and len(base) in digit_lens:
                 return base
     # Support exchange-prefixed codes: SH600519 -> 600519, HK00700 -> 00700
     stripped = _strip_exchange_prefix(text)


### PR DESCRIPTION
## 问题 / Problem

后端 `is_code_like()` 和 `normalize_code()` 函数只识别 `.SH`、`.SZ`、`.SS` 后缀，不识别 `.HK`。

当用户从自动补全下拉框选择港股时（如点击"友邦保险"发送 `01299.HK`），后端拒绝该代码，导致：

```
请求失败 — 请输入有效的股票代码或股票名称
```

The backend `is_code_like()` and `normalize_code()` functions only recognized `.SH`, `.SZ`, `.SS` suffixes but not `.HK`. When users selected HK stocks from the autocomplete dropdown (e.g. clicking "友邦保险" which sends `01299.HK`), the backend rejected the canonical code.

## 修改内容 / Changes

- 新增 `_SUFFIX_DIGIT_LENS` 字典，将后缀映射到允许的数字长度（`.HK` → 5位，`.SH/.SZ/.SS` → 6位）
- `is_code_like()` 改用 `_SUFFIX_DIGIT_LENS` 替代硬编码的后缀元组
- `normalize_code()` 同上
- 更新 docstring 补充 `.HK` 后缀说明
---
- Added `_SUFFIX_DIGIT_LENS` dict mapping suffixes to allowed digit lengths (`.HK` → 5 digits, `.SH/.SZ/.SS` → 6 digits)
- Updated `is_code_like()` to use `_SUFFIX_DIGIT_LENS` instead of hardcoded suffix tuple
- Updated `normalize_code()` to use `_SUFFIX_DIGIT_LENS`
- Updated docstring to document `.HK` suffix support

## 验证结果 / Verification

| 输入 / Input | 修复前 / Before | 修复后 / After |
|-------------|----------------|---------------|
| `01299.HK` | ❌ 拒绝 | ✅ 接受 → `01299` |
| `00700.HK` | ❌ 拒绝 | ✅ 接受 → `00700` |
| `600519.SH` | ✅ 接受 | ✅ 接受 |
| `hk00700` | ✅ 接受 | ✅ 接受 |

## 改动文件 / Files Changed

`src/services/stock_code_utils.py` — 新增常量 + 修改 2 处逻辑