### PR TITLE
fix: decouple tushare init from sdk runtime dependency

### DIFF
--- a/data_provider/tushare_fetcher.py
+++ b/data_provider/tushare_fetcher.py
@@ -72,6 +72,44 @@ def _is_us_code(stock_code: str) -> bool:
     return bool(re.match(r'^[A-Z]{1,5}(\.[A-Z])?$', code))
 
 
+class _TushareHttpClient:
+    """Lightweight Tushare Pro client that does not require the tushare SDK."""
+
+    def __init__(self, token: str, timeout: int = 30, api_url: str = "http://api.tushare.pro") -> None:
+        self._token = token
+        self._timeout = timeout
+        self._api_url = api_url
+
+    def query(self, api_name: str, fields: str = "", **kwargs) -> pd.DataFrame:
+        req_params = {
+            "api_name": api_name,
+            "token": self._token,
+            "params": kwargs,
+            "fields": fields,
+        }
+        res = requests.post(self._api_url, json=req_params, timeout=self._timeout)
+        if res.status_code != 200:
+            raise Exception(f"Tushare API HTTP {res.status_code}")
+
+        result = _json.loads(res.text)
+        if result.get("code") != 0:
+            raise Exception(result.get("msg") or f"Tushare API error code {result.get('code')}")
+
+        data = result.get("data") or {}
+        columns = data.get("fields") or []
+        items = data.get("items") or []
+        return pd.DataFrame(items, columns=columns)
+
+    def __getattr__(self, api_name: str):
+        if api_name.startswith("_"):
+            raise AttributeError(api_name)
+
+        def caller(**kwargs) -> pd.DataFrame:
+            return self.query(api_name, **kwargs)
+
+        return caller
+
+
 class TushareFetcher(BaseFetcher):
     """
     Tushare Pro 数据源实现
@@ -115,70 +153,34 @@ class TushareFetcher(BaseFetcher):
     def _init_api(self) -> None:
         """
         初始化 Tushare API
-        
-        如果 Token 未配置，此数据源将不可用
+
+        如果 Token 未配置，此数据源将不可用。
+        这里直接使用内置 HTTP client，避免运行时强依赖 tushare SDK，
+        从而减少 Docker / PyInstaller / 多虚拟环境场景下因缺包导致的初始化失败。
         """
         config = get_config()
-        
+
         if not config.tushare_token:
             logger.warning("Tushare Token 未配置，此数据源不可用")
             return
-        
-        try:
-            import tushare as ts
-            
-            # Set Token
-            ts.set_token(config.tushare_token)
-            
-            # Get API instance
-            self._api = ts.pro_api()
-            
-            # Fix: tushare SDK 1.4.x hardcodes api.waditu.com/dataapi which may
-            # be unavailable (503). Monkey-patch the query method to use the
-            # official api.tushare.pro endpoint which posts to root URL.
-            self._patch_api_endpoint(config.tushare_token)
 
+        try:
+            self._api = self._build_api_client(config.tushare_token)
             logger.info("Tushare API 初始化成功")
-            
         except Exception as e:
             logger.error(f"Tushare API 初始化失败: {e}")
             self._api = None
 
-    def _patch_api_endpoint(self, token: str) -> None:
+    def _build_api_client(self, token: str) -> _TushareHttpClient:
         """
-        Patch tushare SDK to use the official api.tushare.pro endpoint.
+        Build a lightweight Tushare Pro client over direct HTTP requests.
 
-        The SDK (v1.4.x) hardcodes http://api.waditu.com/dataapi and appends
-        /{api_name} to the URL. That endpoint may return 503, causing silent
-        empty-DataFrame failures. This method replaces the query method to
-        POST directly to http://api.tushare.pro (root URL, no path suffix).
+        The project already normalizes all Pro calls through the same request
+        contract, so we do not need the official tushare SDK during runtime.
         """
-        import types
-
-        TUSHARE_API_URL = "http://api.tushare.pro"
-        _token = token
-        _timeout = getattr(self._api, '_DataApi__timeout', 30)
-
-        def patched_query(self_api, api_name, fields='', **kwargs):
-            req_params = {
-                'api_name': api_name,
-                'token': _token,
-                'params': kwargs,
-                'fields': fields,
-            }
-            res = requests.post(TUSHARE_API_URL, json=req_params, timeout=_timeout)
-            if res.status_code != 200:
-                raise Exception(f"Tushare API HTTP {res.status_code}")
-            result = _json.loads(res.text)
-            if result['code'] != 0:
-                raise Exception(result['msg'])
-            data = result['data']
-            columns = data['fields']
-            items = data['items']
-            return pd.DataFrame(items, columns=columns)
-
-        self._api.query = types.MethodType(patched_query, self._api)
-        logger.debug(f"Tushare API endpoint patched to {TUSHARE_API_URL}")
+        client = _TushareHttpClient(token=token)
+        logger.debug("Tushare API client configured for direct HTTP calls")
+        return client
 
     def _determine_priority(self) -> int:
         """

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### 修复
+
+- 🧩 **Tushare 初始化不再强依赖本地 SDK 包** — `TushareFetcher` 现在直接使用内置 HTTP client 访问 Tushare Pro，不再在启动阶段先 `import tushare` 才能初始化；修复了 Docker、桌面打包或环境重建后因缺少 `tushare` 包而提前报 `No module named 'tushare'` 的问题，并补充对应回归测试。
+
 ## [3.10.1] - 2026-03-24
 
 ### 新功能

--- a/tests/test_tushare_fetcher_http_client.py
+++ b/tests/test_tushare_fetcher_http_client.py
@@ -1,0 +1,79 @@
+# -*- coding: utf-8 -*-
+"""Regression tests for TushareFetcher HTTP client initialization."""
+
+import importlib.util
+import json
+import sys
+import unittest
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from tests.litellm_stub import ensure_litellm_stub
+
+ensure_litellm_stub()
+
+try:
+    json_repair_available = importlib.util.find_spec("json_repair") is not None
+except ValueError:
+    json_repair_available = "json_repair" in sys.modules
+
+if not json_repair_available and "json_repair" not in sys.modules:
+    sys.modules["json_repair"] = MagicMock()
+
+from data_provider.tushare_fetcher import TushareFetcher, _TushareHttpClient
+
+
+class TestTushareHttpClient(unittest.TestCase):
+    """Ensure the lightweight HTTP client preserves Tushare Pro request semantics."""
+
+    def test_query_posts_to_official_pro_endpoint(self) -> None:
+        client = _TushareHttpClient(token="demo-token", timeout=15)
+        response = MagicMock(
+            status_code=200,
+            text=json.dumps(
+                {
+                    "code": 0,
+                    "data": {
+                        "fields": ["ts_code", "close"],
+                        "items": [["600519.SH", 1688.0]],
+                    },
+                }
+            ),
+        )
+
+        with patch("data_provider.tushare_fetcher.requests.post", return_value=response) as post_mock:
+            df = client.daily(ts_code="600519.SH", start_date="20260320", end_date="20260325")
+
+        post_mock.assert_called_once_with(
+            "http://api.tushare.pro",
+            json={
+                "api_name": "daily",
+                "token": "demo-token",
+                "params": {
+                    "ts_code": "600519.SH",
+                    "start_date": "20260320",
+                    "end_date": "20260325",
+                },
+                "fields": "",
+            },
+            timeout=15,
+        )
+        self.assertEqual(df.to_dict(orient="records"), [{"ts_code": "600519.SH", "close": 1688.0}])
+
+
+class TestTushareFetcherInit(unittest.TestCase):
+    """Ensure fetcher initialization no longer depends on the tushare SDK package."""
+
+    def test_init_builds_http_client_when_token_present(self) -> None:
+        config = SimpleNamespace(tushare_token="demo-token")
+
+        with patch("data_provider.tushare_fetcher.get_config", return_value=config):
+            fetcher = TushareFetcher()
+
+        self.assertIsInstance(fetcher._api, _TushareHttpClient)
+        self.assertTrue(fetcher.is_available())
+        self.assertEqual(fetcher.priority, -1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## PR Type

- [x] fix
- [ ] feat
- [ ] refactor
- [ ] docs
- [ ] chore
- [ ] test

## Background And Problem

Issue #845 中的报错不是 Tushare 官方接口或中转参数本身异常，而是 `TushareFetcher` 在初始化阶段先 `import tushare`，导致运行环境、Docker 镜像或桌面打包产物里一旦缺少 `tushare` 包，就会在真正发出 HTTP 请求前直接报 `No module named 'tushare'`。

问题影响范围：

- 配置了 `TUSHARE_TOKEN` 的源码运行环境
- Docker / docker compose 部署路径
- PyInstaller 桌面打包产物

根因：

- `data_provider/tushare_fetcher.py` 主链路虽然已经走 Tushare Pro HTTP 请求，但初始化仍然把 SDK 作为前置依赖
- 当前 smoke/回归没有覆盖“无 SDK 但有 Token”的初始化路径

## Scope Of Change

- `data_provider/tushare_fetcher.py`
  - 新增内置 `_TushareHttpClient`
  - `TushareFetcher._init_api()` 改为直接构建 HTTP client，不再强依赖 `tushare` SDK
- `tests/test_tushare_fetcher_http_client.py`
  - 新增回归测试，覆盖 HTTP 请求协议和无 SDK 初始化路径
- `docs/CHANGELOG.md`
  - 记录本次修复

## Issue Link

Fixes #845

## Verification Commands And Results

```bash
python -m py_compile data_provider/tushare_fetcher.py
python -m pytest tests/test_stock_code_bse.py tests/test_tushare_fetcher_http_client.py tests/test_tushare_fetcher_followups.py -q
```

关键输出/结论 / Key output & conclusion:

- `python -m py_compile ...` 通过
- `pytest` 结果：`21 passed in 0.53s`

## Compatibility And Risk

- 兼容性：
  - `TushareFetcher` 主链路仍然使用同一套 Pro 请求协议，调用方接口不变
  - `get_realtime_quote()` 中保留的旧版 tushare SDK 降级分支未移除，只是不再阻断初始化主链路
- 风险：
  - 这次没有跑在线 Tushare 实网验证，主要依赖现有请求契约和离线回归
  - 没有在当前环境实际跑 Docker rebuild 或 Windows PyInstaller 打包验证
- README 未更新原因：
  - 本次没有新增配置项、CLI/API 参数或使用方式变化；文档落点已更新到 `docs/CHANGELOG.md`

## Rollback Plan

若发现兼容性问题，回滚 `data_provider/tushare_fetcher.py` 中 `_TushareHttpClient` 与 `_init_api()` 的改动，并删除新增测试 `tests/test_tushare_fetcher_http_client.py`，即可恢复到原先依赖 SDK 初始化的实现。

## EXTRACT_PROMPT Change (if applicable)

N/A

## Checklist

- [x] 本 PR 有明确动机和业务价值 / This PR has a clear motivation and value
- [x] 已提供可复现的验证命令与结果 / Reproducible verification commands and results are included
- [x] 已评估兼容性与风险 / Compatibility and risk have been assessed
- [x] 已提供回滚方案 / A rollback plan is provided
- [x] 若涉及用户可见变更，已同步更新相关文档与 `docs/CHANGELOG.md`；若未更新 `README.md`，已说明原因与文档落点 / If user-visible changes are included, the relevant docs and `docs/CHANGELOG.md` are updated; if `README.md` was not updated, the reason and documentation location are explained
