### PR TITLE
fix: docker方式部署不能打开web页面 (#796)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### 修复
+
+- 🐳 **Docker WebUI 运行时优先复用预构建静态资源** — `prepare_webui_frontend_assets()` 现在会先检查镜像内已有的 `static/index.html` 是否可直接复用；当容器运行时不包含 `apps/dsa-web` 源码目录且未安装 `npm` 时，也不会误报“未找到前端项目，无法自动构建”，从而恢复 Docker 部署后的 WebUI 打开能力。
+
 ## [3.11.0] - 2026-03-27
 
 ### 发布亮点

--- a/docs/full-guide.md
+++ b/docs/full-guide.md
@@ -306,6 +306,7 @@ daily_stock_analysis/
 
 Dockerfile 使用多阶段构建，前端会在构建镜像时自动打包并内置到 `static/`。
 如需覆盖静态资源，可挂载本地 `static/` 到容器内 `/app/static`。
+运行中的 `server` 容器默认直接复用 `/app/static` 里的预构建产物，不要求容器内保留 `apps/dsa-web` 源码目录或运行时安装 `npm`；若 WebUI 无法打开，请优先确认 `/app/static/index.html` 是否存在。
 
 ### 快速启动
 

--- a/docs/full-guide_EN.md
+++ b/docs/full-guide_EN.md
@@ -284,6 +284,8 @@ Default schedule: Every weekday at **18:00 (Beijing Time)** automatic execution.
 
 ## Docker Deployment
 
+The image uses prebuilt frontend assets under `/app/static` at runtime, so the running `server` container does not require the `apps/dsa-web` source tree or runtime `npm`. If WebUI cannot be opened after Docker deployment, first verify that `/app/static/index.html` exists inside the container.
+
 ### Quick Start
 
 ```bash

--- a/src/webui_frontend.py
+++ b/src/webui_frontend.py
@@ -150,6 +150,13 @@ def prepare_webui_frontend_assets() -> bool:
         logger.warning("如需启动时自动构建，可设置 WEBUI_AUTO_BUILD=true")
         return False
 
+    force_build = _is_truthy_env("WEBUI_FORCE_BUILD", "false")
+    needs_build, artifact_index = _needs_frontend_build(frontend_dir=frontend_dir, force_build=force_build)
+
+    if not needs_build:
+        logger.info("检测到可直接复用的前端静态产物，跳过运行时自动构建: %s", artifact_index)
+        return True
+
     package_json = frontend_dir / "package.json"
     if not package_json.exists():
         logger.warning("未找到前端项目，无法自动构建: %s", package_json)
@@ -162,8 +169,6 @@ def prepare_webui_frontend_assets() -> bool:
         logger.warning("请先手动构建前端静态资源: %s", _manual_build_command(frontend_dir))
         return False
 
-    force_build = _is_truthy_env("WEBUI_FORCE_BUILD", "false")
-
     lock_file = frontend_dir / "package-lock.json"
     needs_install = _needs_dependency_install(
         frontend_dir=frontend_dir,
@@ -171,12 +176,6 @@ def prepare_webui_frontend_assets() -> bool:
         lock_file=lock_file,
         force_build=force_build,
     )
-
-    needs_build, artifact_index = _needs_frontend_build(frontend_dir=frontend_dir, force_build=force_build)
-
-    if not needs_install and not needs_build:
-        logger.info("前端静态资源已是最新，跳过 npm install/build")
-        return True
 
     commands = []
     if needs_install:

--- a/tests/test_webui_frontend.py
+++ b/tests/test_webui_frontend.py
@@ -1,0 +1,42 @@
+import logging
+
+import src.webui_frontend as webui_frontend
+
+
+def _prepare_fake_repo(tmp_path, monkeypatch):
+    repo_root = tmp_path / "repo"
+    module_path = repo_root / "src" / "webui_frontend.py"
+    module_path.parent.mkdir(parents=True)
+    module_path.touch()
+    monkeypatch.setattr(webui_frontend, "__file__", str(module_path))
+    return repo_root
+
+
+def test_prepare_webui_frontend_assets_reuses_prebuilt_static_without_source(tmp_path, monkeypatch, caplog):
+    repo_root = _prepare_fake_repo(tmp_path, monkeypatch)
+    static_index = repo_root / "static" / "index.html"
+    static_index.parent.mkdir(parents=True)
+    static_index.write_text("<!doctype html>", encoding="utf-8")
+
+    monkeypatch.delenv("WEBUI_AUTO_BUILD", raising=False)
+    monkeypatch.delenv("WEBUI_FORCE_BUILD", raising=False)
+    monkeypatch.setattr(webui_frontend.shutil, "which", lambda _: None)
+
+    with caplog.at_level(logging.INFO):
+        assert webui_frontend.prepare_webui_frontend_assets() is True
+
+    assert "检测到可直接复用的前端静态产物" in caplog.text
+    assert "未找到前端项目，无法自动构建" not in caplog.text
+    assert "未检测到 npm，无法自动构建前端" not in caplog.text
+
+
+def test_prepare_webui_frontend_assets_fails_without_static_or_source(tmp_path, monkeypatch, caplog):
+    _prepare_fake_repo(tmp_path, monkeypatch)
+
+    monkeypatch.delenv("WEBUI_AUTO_BUILD", raising=False)
+    monkeypatch.delenv("WEBUI_FORCE_BUILD", raising=False)
+
+    with caplog.at_level(logging.WARNING):
+        assert webui_frontend.prepare_webui_frontend_assets() is False
+
+    assert "未找到前端项目，无法自动构建" in caplog.text


### PR DESCRIPTION
## PR Type
- [x] fix
- [ ] feat
- [ ] refactor
- [ ] docs
- [ ] chore
- [ ] test

## Background And Problem
- 当前问题：修复 Docker 部署时后端对前端资源的就绪判断，使镜像内已有的 `static/` 产物可直接被识别并正常打开 WebUI，而不要求运行时存在 `apps/dsa-web` 源码目录。
- 影响范围：本次改动涉及 5 个文件，Diff 为 `+56 / -8`。
- 触发来源：Issue 自动执行（Issue #796）。

## Scope Of Change
- `docs/CHANGELOG.md`
- `docs/full-guide.md`
- `docs/full-guide_EN.md`
- `src/webui_frontend.py`
- `tests/test_webui_frontend.py`

## Issue Link
- `Fixes #796`

## Verification Commands And Results
```bash
./scripts/ci_gate.sh flake8
./scripts/ci_gate.sh offline-tests
```

关键输出/结论 / Key output & conclusion:
- lint:PASS, test:PASS

## Compatibility And Risk
- Medium：变更集中在 docs/CHANGELOG.md, docs/full-guide.md, docs/full-guide_EN.md, src/webui_frontend.py, tests/test_webui_frontend.py，已完成本地验证，仍建议按文件范围复核。

## Rollback Plan
- 若合入后发现问题，回滚本 PR 对 `docs/CHANGELOG.md`, `docs/full-guide.md`, `docs/full-guide_EN.md`, `src/webui_frontend.py`, `tests/test_webui_frontend.py` 的改动，并重新执行 `./scripts/ci_gate.sh` 确认恢复。

## Acceptance Criteria
- 在类似 Docker 运行环境中，若 `/app/static/index.html` 已存在，即使 `/app/apps/dsa-web` 不存在且运行时没有 `npm`，`prepare_webui_frontend_assets()` 也应返回成功，不再输出“未找到前端项目，无法自动构建”这类误导性告警。
- 当静态产物不存在时，现有失败与引导行为保持有效：仍会提示前端未就绪，而不是误报成功。
- 本地源码运行场景保持兼容：`WEBUI_AUTO_BUILD=true` 时，只有在确实需要安装依赖或重新构建时才要求 `package.json`/`npm`；`WEBUI_AUTO_BUILD=false` 的现有语义不变。
- 新增回归测试覆盖“有预构建 `static/`、无前端源码目录”的 Docker-like 场景，以及“无静态产物时仍失败”的场景。
- 补充 `docs/CHANGELOG.md`，必要时补充一处 Docker/WebUI 说明文档，明确 Docker 镜像依赖预构建静态资源而非运行时自动构建。

## Implementation
修复了 `src/webui_frontend.py` 的判断顺序：`WEBUI_AUTO_BUILD=true` 时先复用现有 `static/index.html`，Docker 运行时即使没有 `apps/dsa-web` 源码目录和 `npm` 也不会误报自动构建失败。
保留了无静态产物时的失败语义：当 `static/` 不存在且无法构建时，仍会返回失败并给出原有告警。
新增 `tests/test_webui_frontend.py`，覆盖“有预构建 static、无前端源码目录”和“无 static 仍失败”两条回归场景。
更新了 `docs/CHANGELOG.md`、`docs/full-guide.md`、`docs/full-guide_EN.md`，补充 Docker 镜像依赖 `/app/static` 预构建资源的说明。
README 未改：本次是部署细节修正，说明已落在 `docs/full-guide.md` / `docs/full-guide_EN.md`，避免重复维护。
已执行 `python -m py_compile src/webui_frontend.py tests/test_webui_frontend.py` 和 `python -m pytest tests/test_webui_frontend.py`，均通过。

## Checklist
- [x] 本 PR 有明确动机和业务价值 / This PR has a clear motivation and value
- [x] 已提供可复现的验证命令与结果 / Reproducible verification commands and results are included
- [x] 已评估兼容性与风险 / Compatibility and risk have been assessed
- [x] 已提供回滚方案 / A rollback plan is provided
- [x] 若涉及用户可见变更，已同步更新相关文档与 `docs/CHANGELOG.md`；若未更新 `README.md`，已说明原因与文档落点 / If user-visible changes are included, the relevant docs and `docs/CHANGELOG.md` are updated; if `README.md` was not updated, the reason and documentation location are explained