### PR TITLE
feat: 支持 GitHub Actions 安全读取多渠道 LLM 密钥 (#872)

### DIFF
--- a/api/v1/endpoints/system_config.py
+++ b/api/v1/endpoints/system_config.py
@@ -294,6 +294,7 @@ def test_llm_channel(
             models=request.models,
             enabled=request.enabled,
             timeout_seconds=request.timeout_seconds,
+            effective_map=request.effective_map,
         )
         return TestLLMChannelResponse.model_validate(payload)
     except (ValueError, TypeError) as exc:
@@ -338,6 +339,7 @@ def discover_llm_channel_models(
             api_key=request.api_key,
             models=request.models,
             timeout_seconds=request.timeout_seconds,
+            effective_map=request.effective_map,
         )
         return DiscoverLLMChannelModelsResponse.model_validate(payload)
     except (ValueError, TypeError) as exc:

--- a/api/v1/schemas/system_config.py
+++ b/api/v1/schemas/system_config.py
@@ -149,6 +149,7 @@ class TestLLMChannelRequest(BaseModel):
     models: List[str] = Field(default_factory=list)
     enabled: bool = True
     timeout_seconds: float = 20.0
+    effective_map: Dict[str, str] = Field(default_factory=dict)
 
 
 class TestLLMChannelResponse(BaseModel):
@@ -171,6 +172,7 @@ class DiscoverLLMChannelModelsRequest(BaseModel):
     api_key: str = ""
     models: List[str] = Field(default_factory=list)
     timeout_seconds: float = 20.0
+    effective_map: Dict[str, str] = Field(default_factory=dict)
 
 
 class DiscoverLLMChannelModelsResponse(BaseModel):

--- a/apps/dsa-web/src/api/systemConfig.ts
+++ b/apps/dsa-web/src/api/systemConfig.ts
@@ -92,6 +92,7 @@ function toSnakeTestChannelPayload(payload: TestLLMChannelRequest): Record<strin
     models: payload.models,
     enabled: payload.enabled ?? true,
     timeout_seconds: payload.timeoutSeconds ?? 20,
+    effective_map: payload.effectiveMap ?? {},
   };
 }
 
@@ -103,6 +104,7 @@ function toSnakeDiscoverModelsPayload(payload: DiscoverLLMChannelModelsRequest):
     api_key: payload.apiKey ?? '',
     models: payload.models,
     timeout_seconds: payload.timeoutSeconds ?? 20,
+    effective_map: payload.effectiveMap ?? {},
   };
 }
 

--- a/apps/dsa-web/src/components/settings/LLMChannelEditor.tsx
+++ b/apps/dsa-web/src/components/settings/LLMChannelEditor.tsx
@@ -154,6 +154,8 @@ interface ChannelDiscoveryState {
   models: string[];
 }
 
+type ItemMapPayload = Record<string, string>;
+
 interface RuntimeConfig {
   primaryModel: string;
   agentPrimaryModel: string;
@@ -506,6 +508,17 @@ function splitModels(models: string): string[] {
     .split(',')
     .map((entry) => entry.trim())
     .filter(Boolean);
+}
+
+function buildEffectiveMapFromItems(items: Array<{ key: string; value: string }>): ItemMapPayload {
+  const effectiveMap: ItemMapPayload = {};
+  for (const item of items) {
+    if (!item.key) {
+      continue;
+    }
+    effectiveMap[item.key] = item.value;
+  }
+  return effectiveMap;
 }
 
 interface ParsedModelRef {
@@ -1004,6 +1017,7 @@ export const LLMChannelEditor: React.FC<LLMChannelEditorProps> = ({
   };
 
   const handleTest = async (channel: ChannelConfig, index: number) => {
+    const effectiveMap = buildEffectiveMapFromItems(items);
     setTestStates((previous) => ({
       ...previous,
       [index]: { status: 'loading', text: '测试中...' },
@@ -1017,6 +1031,7 @@ export const LLMChannelEditor: React.FC<LLMChannelEditorProps> = ({
         apiKey: channel.apiKey,
         models: splitModels(channel.models),
         enabled: channel.enabled,
+        effectiveMap,
       });
 
       const text = result.success
@@ -1040,6 +1055,7 @@ export const LLMChannelEditor: React.FC<LLMChannelEditorProps> = ({
   };
 
   const handleDiscoverModels = async (channel: ChannelConfig) => {
+    const effectiveMap = buildEffectiveMapFromItems(items);
     const requestId = discoveryRequestIdRef.current + 1;
     discoveryRequestIdRef.current = requestId;
     discoveryNonceRef.current[channel.id] = requestId;
@@ -1061,6 +1077,7 @@ export const LLMChannelEditor: React.FC<LLMChannelEditorProps> = ({
         baseUrl: channel.baseUrl,
         apiKey: channel.apiKey,
         models: splitModels(channel.models),
+        effectiveMap,
       });
 
       if (discoveryNonceRef.current[channel.id] !== nonce) return;

--- a/apps/dsa-web/src/types/systemConfig.ts
+++ b/apps/dsa-web/src/types/systemConfig.ts
@@ -135,6 +135,7 @@ export interface TestLLMChannelRequest {
   models: string[];
   enabled?: boolean;
   timeoutSeconds?: number;
+  effectiveMap?: Record<string, string>;
 }
 
 export interface TestLLMChannelResponse {
@@ -153,6 +154,7 @@ export interface DiscoverLLMChannelModelsRequest {
   apiKey?: string;
   models?: string[];
   timeoutSeconds?: number;
+  effectiveMap?: Record<string, string>;
 }
 
 export interface DiscoverLLMChannelModelsResponse {

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -79,6 +79,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - [改进] 🤖 **普通分析链路支持 LiteLLM 流式生成与更细任务进度** — 常规股票分析在 LLM 阶段会优先尝试 `stream=True` 并在服务端累积 chunk，首页任务 SSE 新增 `task_progress` 事件与更细的 `message/progress` 更新；仅在最终 JSON 解析成功后才持久化历史报告，不支持流式的 provider 会在首个 chunk 前自动回退到原非流式调用。
 - [新功能] Web AI 模型配置支持按渠道调用 `/models` 获取可用模型，并在渠道编辑器中以多选方式写回 `LLM_{CHANNEL}_MODELS`，获取失败时仍保留手动输入作为降级路径。
 - [修复] `LLM_CHANNELS` 现在会在常见 provider 渠道缺少 `LLM_{NAME}_API_KEY(S)` 时，安全回退读取匹配的 legacy Secrets（如 `DEEPSEEK_API_KEY`、`AIHUBMIX_KEY`、`OPENAI_API_KEY`、`GEMINI_API_KEY`、`ANTHROPIC_API_KEY`），让 GitHub Actions 可继续使用默认 `.env` 的非敏感渠道结构。
+- [修复] `LLM_CHANNELS` 现在会在常见 provider 渠道缺少 `LLM_{NAME}_API_KEY(S)` 时，安全回退读取匹配的 legacy Secrets（如 `DEEPSEEK_API_KEY`、`AIHUBMIX_KEY`、`OPENAI_API_KEY`、`GEMINI_API_KEY`、`ANTHROPIC_API_KEY`），让 GitHub Actions 可继续使用默认 `.env` 的非敏感渠道结构。当渠道配置了自定义 `base_url` 时，仅通过严格域名校验匹配 legacy 密钥，防止凭据泄露到非官方端点。
 - [文档] 更新中英文 LLM 配置指南与 FAQ，补充 GitHub Actions 下渠道模式复用 legacy Secrets 的用法，并明确自定义渠道仍建议使用 `LITELLM_CONFIG` + `LITELLM_CONFIG_YAML`。
 
 ## [3.11.0] - 2026-03-27

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -78,6 +78,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - [修复] 飞书群机器人通知现在支持 `FEISHU_WEBHOOK_SECRET` / `FEISHU_WEBHOOK_KEYWORD`，并在 Web 设置与文档中明确区分 Webhook 推送和 `FEISHU_APP_ID` / `FEISHU_APP_SECRET` 应用模式，降低误配导致的推送失败。
 - [改进] 🤖 **普通分析链路支持 LiteLLM 流式生成与更细任务进度** — 常规股票分析在 LLM 阶段会优先尝试 `stream=True` 并在服务端累积 chunk，首页任务 SSE 新增 `task_progress` 事件与更细的 `message/progress` 更新；仅在最终 JSON 解析成功后才持久化历史报告，不支持流式的 provider 会在首个 chunk 前自动回退到原非流式调用。
 - [新功能] Web AI 模型配置支持按渠道调用 `/models` 获取可用模型，并在渠道编辑器中以多选方式写回 `LLM_{CHANNEL}_MODELS`，获取失败时仍保留手动输入作为降级路径。
+- [修复] `LLM_CHANNELS` 现在会在常见 provider 渠道缺少 `LLM_{NAME}_API_KEY(S)` 时，安全回退读取匹配的 legacy Secrets（如 `DEEPSEEK_API_KEY`、`AIHUBMIX_KEY`、`OPENAI_API_KEY`、`GEMINI_API_KEY`、`ANTHROPIC_API_KEY`），让 GitHub Actions 可继续使用默认 `.env` 的非敏感渠道结构。
+- [文档] 更新中英文 LLM 配置指南与 FAQ，补充 GitHub Actions 下渠道模式复用 legacy Secrets 的用法，并明确自定义渠道仍建议使用 `LITELLM_CONFIG` + `LITELLM_CONFIG_YAML`。
 
 ## [3.11.0] - 2026-03-27
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -29,6 +29,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - [修复] 技能加载异常被静默吞没问题 — 在 ask.py、skills/aggregator.py、skills/router.py 的静默 except 块补充 logger.warning 日志，确保技能列表为空时有日志可查（fixes #970）
 - [修复] SQLite 主写入链路现在对 `stock_daily(code,date)` 使用批量原子 upsert，并在文件型 SQLite 连接上默认启用 `WAL`、`busy_timeout` 与有限写入重试，降低批量分析和并发回写场景下的锁竞争与吞吐抖动，返回值中的“新增数”改为按本次真正插入窗口计算（并发场景不再把并行写入行误算入当前调用）。
 - [修复] 优化多 Agent 与单 Agent 的预算护栏语义：当后续阶段/步骤剩余预算低于最小阈值（首阶段除外）时会主动跳过并进行降级处理；若当前已完成阶段可支持构建降级报告，则返回 `success=True` 并携带非空内容；否则返回 `success=False`、`content=""`；`run_agent_loop` 预算过低时当前仍返回失败降级语义（`success=False`、`content=""`），`AgentExecutor` 保持统一下游契约。
+- [修复] `LLM_CHANNELS` 在未配置 `LLM_{NAME}_API_KEY(S)` 时，只对内置 provider 渠道（`openai`、`deepseek`、`gemini`、`vertex_ai`、`anthropic`）及其已知别名回退匹配 legacy secrets；自定义渠道即便配置了 `LLM_{NAME}_PROTOCOL` 也不会误用其他 provider 的 `OPENAI_API_KEY`、`DEEPSEEK_API_KEY` 等。
+- [文档] 明确自定义渠道边界：当 `LLM_{NAME}_BASE_URL` 命中官方 provider HTTPS host（如 `api.openai.com`、`api.deepseek.com`、`api.aihubmix.com`、`api.anthropic.com`、`generativelanguage.googleapis.com`、`aiplatform.googleapis.com`）时，可按 host 与 legacy secret 回退；仅当自定义渠道指向非官方 host 时，才必须走 YAML 路径（未提交 `litellm_config.yaml` 时需同时配置 `LITELLM_CONFIG` 与 `LITELLM_CONFIG_YAML`，提交后只保留 `LITELLM_CONFIG`），并同步到 FAQ / LLM 配置文档。
 
 ## [3.12.0] - 2026-04-01
 
@@ -78,10 +80,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - [修复] 飞书群机器人通知现在支持 `FEISHU_WEBHOOK_SECRET` / `FEISHU_WEBHOOK_KEYWORD`，并在 Web 设置与文档中明确区分 Webhook 推送和 `FEISHU_APP_ID` / `FEISHU_APP_SECRET` 应用模式，降低误配导致的推送失败。
 - [改进] 🤖 **普通分析链路支持 LiteLLM 流式生成与更细任务进度** — 常规股票分析在 LLM 阶段会优先尝试 `stream=True` 并在服务端累积 chunk，首页任务 SSE 新增 `task_progress` 事件与更细的 `message/progress` 更新；仅在最终 JSON 解析成功后才持久化历史报告，不支持流式的 provider 会在首个 chunk 前自动回退到原非流式调用。
 - [新功能] Web AI 模型配置支持按渠道调用 `/models` 获取可用模型，并在渠道编辑器中以多选方式写回 `LLM_{CHANNEL}_MODELS`，获取失败时仍保留手动输入作为降级路径。
-- [修复] `LLM_CHANNELS` 现在会在常见 provider 渠道缺少 `LLM_{NAME}_API_KEY(S)` 时，安全回退读取匹配的 legacy Secrets（如 `DEEPSEEK_API_KEY`、`AIHUBMIX_KEY`、`OPENAI_API_KEY`、`GEMINI_API_KEY`、`ANTHROPIC_API_KEY`），让 GitHub Actions 可继续使用默认 `.env` 的非敏感渠道结构。
-- [修复] `LLM_CHANNELS` 现在会在常见 provider 渠道缺少 `LLM_{NAME}_API_KEY(S)` 时，安全回退读取匹配的 legacy Secrets（如 `DEEPSEEK_API_KEY`、`AIHUBMIX_KEY`、`OPENAI_API_KEY`、`GEMINI_API_KEY`、`ANTHROPIC_API_KEY`），让 GitHub Actions 可继续使用默认 `.env` 的非敏感渠道结构。当渠道配置了自定义 `base_url` 时，仅通过严格域名校验匹配 legacy 密钥，防止凭据泄露到非官方端点。
-- [修复] `LLM_CHANNELS` 现在会在常见 provider 渠道缺少 `LLM_{NAME}_API_KEY(S)` 时，安全回退读取匹配的 legacy Secrets（如 `DEEPSEEK_API_KEY`、`AIHUBMIX_KEY`、`OPENAI_API_KEY`、`GEMINI_API_KEY`、`ANTHROPIC_API_KEY`），让 GitHub Actions 可继续使用默认 `.env` 的非敏感渠道结构。当渠道配置了自定义 `base_url` 时，仅当 URL 使用 HTTPS 协议且通过严格域名校验时才匹配 legacy 密钥，防止凭据通过明文 HTTP 或非官方端点泄露。
-- [文档] 更新中英文 LLM 配置指南与 FAQ，补充 GitHub Actions 下渠道模式复用 legacy Secrets 的用法，并明确自定义渠道仍建议使用 `LITELLM_CONFIG` + `LITELLM_CONFIG_YAML`。
 
 ## [3.11.0] - 2026-03-27
 
@@ -423,7 +421,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - 🤖 **Agent background execution** (#495) — analysis continues when switching pages; badge notification on completion; auto-cancel in-progress stream on session switch
 - 📝 **Report Engine P0** — Pydantic schema validation for LLM JSON; Jinja2 templates (markdown/wechat/brief) with legacy fallback; content integrity checks with retry; brief mode (`REPORT_TYPE=brief`); history signal comparison
 - 📦 **Smart import** — multi-source import from image/CSV/Excel/clipboard; Vision LLM extracts code+name+confidence; name→code resolver (local map + pinyin + AkShare); confidence-tiered confirmation
-- ⚙️ **GitHub Actions LiteLLM config** — workflow supports `LITELLM_CONFIG`/`LITELLM_CONFIG_YAML` for flexible AI provider configuration
+- ⚙️ **GitHub Actions LiteLLM config** — workflow supports `LITELLM_CONFIG` as the custom routing configuration file path for AI provider setup
 - ⚙️ **Config engine refactor & system API** (#602) — unified config registry, validation and API exposure
 - 📖 **LLM configuration guide** — new `docs/LLM_CONFIG_GUIDE.md` covering 3-tier config, quick start, Vision/Agent/troubleshooting
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -80,6 +80,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - [新功能] Web AI 模型配置支持按渠道调用 `/models` 获取可用模型，并在渠道编辑器中以多选方式写回 `LLM_{CHANNEL}_MODELS`，获取失败时仍保留手动输入作为降级路径。
 - [修复] `LLM_CHANNELS` 现在会在常见 provider 渠道缺少 `LLM_{NAME}_API_KEY(S)` 时，安全回退读取匹配的 legacy Secrets（如 `DEEPSEEK_API_KEY`、`AIHUBMIX_KEY`、`OPENAI_API_KEY`、`GEMINI_API_KEY`、`ANTHROPIC_API_KEY`），让 GitHub Actions 可继续使用默认 `.env` 的非敏感渠道结构。
 - [修复] `LLM_CHANNELS` 现在会在常见 provider 渠道缺少 `LLM_{NAME}_API_KEY(S)` 时，安全回退读取匹配的 legacy Secrets（如 `DEEPSEEK_API_KEY`、`AIHUBMIX_KEY`、`OPENAI_API_KEY`、`GEMINI_API_KEY`、`ANTHROPIC_API_KEY`），让 GitHub Actions 可继续使用默认 `.env` 的非敏感渠道结构。当渠道配置了自定义 `base_url` 时，仅通过严格域名校验匹配 legacy 密钥，防止凭据泄露到非官方端点。
+- [修复] `LLM_CHANNELS` 现在会在常见 provider 渠道缺少 `LLM_{NAME}_API_KEY(S)` 时，安全回退读取匹配的 legacy Secrets（如 `DEEPSEEK_API_KEY`、`AIHUBMIX_KEY`、`OPENAI_API_KEY`、`GEMINI_API_KEY`、`ANTHROPIC_API_KEY`），让 GitHub Actions 可继续使用默认 `.env` 的非敏感渠道结构。当渠道配置了自定义 `base_url` 时，仅当 URL 使用 HTTPS 协议且通过严格域名校验时才匹配 legacy 密钥，防止凭据通过明文 HTTP 或非官方端点泄露。
 - [文档] 更新中英文 LLM 配置指南与 FAQ，补充 GitHub Actions 下渠道模式复用 legacy Secrets 的用法，并明确自定义渠道仍建议使用 `LITELLM_CONFIG` + `LITELLM_CONFIG_YAML`。
 
 ## [3.11.0] - 2026-03-27

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -91,7 +91,10 @@
    - `REPORT_TYPE`
    - `LLM_CHANNELS`、`LLM_{NAME}_BASE_URL`、`LLM_{NAME}_MODELS`
 
-如果你在 GitHub Actions 使用 `LLM_CHANNELS=deepseek,aihubmix` 这类常见 provider 渠道，不必把真实 `LLM_DEEPSEEK_API_KEY` / `LLM_AIHUBMIX_API_KEY` 写进默认 `.env`；把真实 Key 放在 `DEEPSEEK_API_KEY`、`AIHUBMIX_KEY`（或 `OPENAI_API_KEY`）即可。自定义渠道名仍建议改用 `LITELLM_CONFIG` + `LITELLM_CONFIG_YAML`。
+如果你在 GitHub Actions 使用 `LLM_CHANNELS=deepseek,aihubmix` 这类常见 provider 渠道，不必把真实 `LLM_DEEPSEEK_API_KEY` / `LLM_AIHUBMIX_API_KEY` 写进默认 `.env`；把真实 Key 放在 `DEEPSEEK_API_KEY`、`AIHUBMIX_KEY`（或 `OPENAI_API_KEY`）即可。  
+自定义渠道名可走高级 YAML 配置：  
+- 已提交 `litellm_config.yaml` 到仓库：只需在 `Actions` 中配置 `LITELLM_CONFIG` 指向文件路径（例如 `./litellm_config.yaml`）。  
+- 未提交文件：同时配置 `LITELLM_CONFIG=./litellm_config.yaml`（或其他可写路径）与 `LITELLM_CONFIG_YAML`（Secrets/Variables 中放 YAML 内容），workflow 会在运行时写入文件。
 
 ---
 
@@ -135,7 +138,7 @@ PROXY_PORT=10809
 
 **Q: 配置了 GEMINI_API_KEY 和 LLM_CHANNELS，为什么只用渠道？**
 
-系统按优先级只取一种：高级模型路由 YAML（`LITELLM_CONFIG`）> `LLM_CHANNELS` > legacy keys。YAML 仅在文件可正常解析且产出了有效 `model_list` 时才生效；路径无效或内容为空时自动回退。当你使用 `deepseek`、`aihubmix`、`openai`、`gemini`、`anthropic` 这类内置渠道名且未配置 `LLM_{NAME}_API_KEY(S)` 时，渠道模式会自动读取对应 legacy Secrets（如 `DEEPSEEK_API_KEY`），方便 GitHub Actions 沿用既有 Secrets。自定义渠道名不会自动回退。
+系统按优先级只取一种：高级模型路由 YAML（`LITELLM_CONFIG`）> `LLM_CHANNELS` > legacy keys。YAML 仅在文件可正常解析且产出了有效 `model_list` 时才生效；路径无效或内容为空时自动回退。当你使用 `deepseek`、`aihubmix`、`openai`、`gemini`、`anthropic` 这类内置渠道名且未配置 `LLM_{NAME}_API_KEY(S)` 时，渠道模式会自动读取对应 legacy Secrets（如 `DEEPSEEK_API_KEY`）。自定义渠道若 `LLM_<NAME>_BASE_URL` 指向官方 provider HTTPS host（如 `api.openai.com`、`api.deepseek.com`、`api.aihubmix.com`），也会按 host 回退到对应 legacy Secret；只有在自定义渠道指向其他 host 时，才需要改走高级 YAML。
 
 **Q: test_env 输出“未配置可用 AI 模型”怎么办？**
 

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -80,6 +80,8 @@
 1. 进入仓库 `Settings` → `Secrets and variables` → `Actions`
 2. **Secrets**（点击 `New repository secret`）：存放敏感信息
    - `GEMINI_API_KEY`
+   - `DEEPSEEK_API_KEY`
+   - `AIHUBMIX_KEY`
    - `OPENAI_API_KEY`
    - `TELEGRAM_BOT_TOKEN`
    - 各类 Webhook URL
@@ -87,6 +89,9 @@
    - `STOCK_LIST`
    - `GEMINI_MODEL`
    - `REPORT_TYPE`
+   - `LLM_CHANNELS`、`LLM_{NAME}_BASE_URL`、`LLM_{NAME}_MODELS`
+
+如果你在 GitHub Actions 使用 `LLM_CHANNELS=deepseek,aihubmix` 这类常见 provider 渠道，不必把真实 `LLM_DEEPSEEK_API_KEY` / `LLM_AIHUBMIX_API_KEY` 写进默认 `.env`；把真实 Key 放在 `DEEPSEEK_API_KEY`、`AIHUBMIX_KEY`（或 `OPENAI_API_KEY`）即可。自定义渠道名仍建议改用 `LITELLM_CONFIG` + `LITELLM_CONFIG_YAML`。
 
 ---
 
@@ -130,7 +135,7 @@ PROXY_PORT=10809
 
 **Q: 配置了 GEMINI_API_KEY 和 LLM_CHANNELS，为什么只用渠道？**
 
-系统按优先级只取一种：高级模型路由 YAML（`LITELLM_CONFIG`）> `LLM_CHANNELS` > legacy keys。但 YAML 仅在文件可正常解析且产出了有效 `model_list` 时才生效；如果 YAML 路径无效或内容为空，系统会自动回退到 `LLM_CHANNELS` 或 legacy keys。一旦某一层级实际生效，更低优先级的配置不参与解析。
+系统按优先级只取一种：高级模型路由 YAML（`LITELLM_CONFIG`）> `LLM_CHANNELS` > legacy keys。YAML 仅在文件可正常解析且产出了有效 `model_list` 时才生效；路径无效或内容为空时自动回退。当你使用 `deepseek`、`aihubmix`、`openai`、`gemini`、`anthropic` 这类内置渠道名且未配置 `LLM_{NAME}_API_KEY(S)` 时，渠道模式会自动读取对应 legacy Secrets（如 `DEEPSEEK_API_KEY`），方便 GitHub Actions 沿用既有 Secrets。自定义渠道名不会自动回退。
 
 **Q: test_env 输出“未配置可用 AI 模型”怎么办？**
 
@@ -138,7 +143,7 @@ PROXY_PORT=10809
 
 **Q: 如何同时使用多个模型（如 AIHubmix + DeepSeek + Gemini）？**
 
-使用渠道模式：设置 `LLM_CHANNELS=aihubmix,deepseek,gemini`，并配置各渠道的 `LLM_{NAME}_BASE_URL`、`LLM_{NAME}_API_KEY`、`LLM_{NAME}_MODELS`。也可在 Web 设置页 → AI 模型 → AI 模型接入 中可视化配置。
+使用渠道模式：设置 `LLM_CHANNELS=aihubmix,deepseek,gemini`，并配置各渠道的 `LLM_{NAME}_BASE_URL`、`LLM_{NAME}_MODELS`，本地 / Docker 再补 `LLM_{NAME}_API_KEY(S)`；若在 GitHub Actions 用默认 env 模板，真实 Key 可继续放 `AIHUBMIX_KEY`、`DEEPSEEK_API_KEY`、`GEMINI_API_KEY`。也可在 Web 设置页 → AI 模型 → 渠道编辑器中可视化配置。
 
 ---
 

--- a/docs/FAQ_EN.md
+++ b/docs/FAQ_EN.md
@@ -89,7 +89,10 @@ This document compiles common issues encountered by users and their solutions.
    - `REPORT_TYPE`
    - `LLM_CHANNELS`, `LLM_{NAME}_BASE_URL`, `LLM_{NAME}_MODELS`
 
-If you run `LLM_CHANNELS=deepseek,aihubmix` in GitHub Actions, you do not need to put real `LLM_DEEPSEEK_API_KEY` / `LLM_AIHUBMIX_API_KEY` values into the default `.env`. Put the real keys in `DEEPSEEK_API_KEY` and `AIHUBMIX_KEY` (or `OPENAI_API_KEY`) instead. Custom channel names should still use `LITELLM_CONFIG` + `LITELLM_CONFIG_YAML`.
+If you run `LLM_CHANNELS=deepseek,aihubmix` in GitHub Actions, you do not need to put real `LLM_DEEPSEEK_API_KEY` / `LLM_AIHUBMIX_API_KEY` values into the default `.env`. Put the real keys in `DEEPSEEK_API_KEY` and `AIHUBMIX_KEY` (or `OPENAI_API_KEY`) instead.  
+For custom channel names, use advanced YAML routing:
+- If you commit `litellm_config.yaml` in the repo: only set `LITELLM_CONFIG` to the file path (for example, `./litellm_config.yaml`).
+- If you do not commit the file: set both `LITELLM_CONFIG=./litellm_config.yaml` (or another writable path) and `LITELLM_CONFIG_YAML` (YAML content in Secrets/Variables), and the workflow will write the file at runtime.
 
 ---
 
@@ -134,6 +137,7 @@ PROXY_PORT=10809
 **Q: Configured both GEMINI_API_KEY and LLM_CHANNELS, why does it only use channels?**
 
 The system uses exactly one mode by priority: advanced YAML routing (`LITELLM_CONFIG`) > `LLM_CHANNELS` > legacy keys. YAML routing only takes effect when the file parses successfully and yields a non-empty `model_list`; otherwise it falls back automatically. Well-known channel names such as `deepseek`, `aihubmix`, `openai`, `gemini`, and `anthropic` can safely fall back to matching legacy Secrets (e.g. `DEEPSEEK_API_KEY`) when `LLM_{NAME}_API_KEY(S)` is absent, which is useful for GitHub Actions. Custom channel names do not auto-fallback.
+Custom channel names also can auto-fallback when `LLM_<NAME>_BASE_URL` points to an official provider HTTPS host (for example `api.openai.com`, `api.deepseek.com`, `api.aihubmix.com`); otherwise they must use advanced YAML routing.
 
 **Q: test_env says no usable AI model is configured, what should I do?**
 

--- a/docs/FAQ_EN.md
+++ b/docs/FAQ_EN.md
@@ -78,6 +78,8 @@ This document compiles common issues encountered by users and their solutions.
 1. Go to repo `Settings` → `Secrets and variables` → `Actions`
 2. **Secrets** (click `New repository secret`): Store sensitive information
    - `GEMINI_API_KEY`
+   - `DEEPSEEK_API_KEY`
+   - `AIHUBMIX_KEY`
    - `OPENAI_API_KEY`
    - `TELEGRAM_BOT_TOKEN`
    - Various Webhook URLs
@@ -85,6 +87,9 @@ This document compiles common issues encountered by users and their solutions.
    - `STOCK_LIST`
    - `GEMINI_MODEL`
    - `REPORT_TYPE`
+   - `LLM_CHANNELS`, `LLM_{NAME}_BASE_URL`, `LLM_{NAME}_MODELS`
+
+If you run `LLM_CHANNELS=deepseek,aihubmix` in GitHub Actions, you do not need to put real `LLM_DEEPSEEK_API_KEY` / `LLM_AIHUBMIX_API_KEY` values into the default `.env`. Put the real keys in `DEEPSEEK_API_KEY` and `AIHUBMIX_KEY` (or `OPENAI_API_KEY`) instead. Custom channel names should still use `LITELLM_CONFIG` + `LITELLM_CONFIG_YAML`.
 
 ---
 
@@ -128,7 +133,7 @@ PROXY_PORT=10809
 
 **Q: Configured both GEMINI_API_KEY and LLM_CHANNELS, why does it only use channels?**
 
-The system uses exactly one mode by priority: advanced YAML routing (`LITELLM_CONFIG`) > `LLM_CHANNELS` > legacy keys. However, YAML routing only takes effect when the file can be parsed successfully and yields a non-empty `model_list`; if the YAML path is invalid or the content is empty, the system automatically falls back to `LLM_CHANNELS` or legacy keys. Once a tier is active, lower-priority tiers are not used.
+The system uses exactly one mode by priority: advanced YAML routing (`LITELLM_CONFIG`) > `LLM_CHANNELS` > legacy keys. YAML routing only takes effect when the file parses successfully and yields a non-empty `model_list`; otherwise it falls back automatically. Well-known channel names such as `deepseek`, `aihubmix`, `openai`, `gemini`, and `anthropic` can safely fall back to matching legacy Secrets (e.g. `DEEPSEEK_API_KEY`) when `LLM_{NAME}_API_KEY(S)` is absent, which is useful for GitHub Actions. Custom channel names do not auto-fallback.
 
 **Q: test_env says no usable AI model is configured, what should I do?**
 
@@ -136,7 +141,7 @@ Start with one provider and its API key. If you want to pin a primary model, add
 
 **Q: How to use multiple models at once (e.g. AIHubmix + DeepSeek + Gemini)?**
 
-Use channel mode: set `LLM_CHANNELS=aihubmix,deepseek,gemini` and configure each channel's `LLM_{NAME}_BASE_URL`, `LLM_{NAME}_API_KEY`, `LLM_{NAME}_MODELS`. You can also configure this visually in Web Settings → AI Model → AI Model Access.
+Use channel mode: set `LLM_CHANNELS=aihubmix,deepseek,gemini` and configure each channel's `LLM_{NAME}_BASE_URL` and `LLM_{NAME}_MODELS`; for local / Docker add `LLM_{NAME}_API_KEY(S)` directly, while in GitHub Actions you can keep using `AIHUBMIX_KEY`, `DEEPSEEK_API_KEY`, and `GEMINI_API_KEY` for the real secrets. You can also configure visually in Web Settings → AI Model → Channel Editor.
 
 ---
 

--- a/docs/LLM_CONFIG_GUIDE.md
+++ b/docs/LLM_CONFIG_GUIDE.md
@@ -81,11 +81,13 @@ LITELLM_MODEL=ollama/qwen3:8b
 LLM_CHANNELS=deepseek,aihubmix
 
 # 2. 渠道一：配置 DeepSeek 官方
+# 本地 / Docker 推荐直接写渠道专属 Key：
 LLM_DEEPSEEK_BASE_URL=https://api.deepseek.com/v1
 LLM_DEEPSEEK_API_KEY=sk-1111111111111
 LLM_DEEPSEEK_MODELS=deepseek-chat,deepseek-reasoner
 
 # 3. 渠道二：配置一个常用的聚合中转 API
+# 本地 / Docker 推荐直接写渠道专属 Key：
 LLM_AIHUBMIX_BASE_URL=https://api.aihubmix.com/v1
 LLM_AIHUBMIX_API_KEY=sk-2222222222222
 LLM_AIHUBMIX_MODELS=gpt-4o-mini,claude-3-5-sonnet
@@ -118,6 +120,10 @@ LITELLM_MODEL=ollama/qwen3:8b
 - Web 设置页里的主模型、Agent 主模型、Fallback、Vision 下拉会保留这个值原样展示，不会再错误改写成 `openai/minimax/<模型名>`。
 
 > **致命避坑说明**：如果你启用了 `LLM_CHANNELS`，那么你直接写在外面的 `DEEPSEEK_API_KEY` 或 `OPENAI_API_KEY` 将**全部失效（系统一律无视）**！二者**选其一即可**，千万不要既写了新手模式又写了渠道模式结果产生冲突。
+
+> **GitHub Actions 兼容说明**：渠道模式仍优先于 legacy 模式，但常见 provider 渠道在缺少 `LLM_{NAME}_API_KEY(S)` 时，会按渠道名/官方域名安全回退读取已有 Secrets：`deepseek -> DEEPSEEK_API_KEY(S)`、`aihubmix -> AIHUBMIX_KEY / OPENAI_API_KEY(S)`、`openai -> OPENAI_API_KEY(S)`、`gemini/vertex -> GEMINI_API_KEY(S)`、`anthropic/claude -> ANTHROPIC_API_KEY(S)`。这意味着你可以继续使用默认 `.env` 中的非敏感渠道结构，把真实 Key 放在 GitHub Secrets 里，而不用把真实 `LLM_DEEPSEEK_API_KEY`、`LLM_AIHUBMIX_API_KEY` 写进仓库配置。
+>
+> **边界说明**：这个回退只覆盖常见 provider 渠道名；像 `my_proxy`、`corp_gateway` 这类自定义渠道名在 GitHub Actions 中仍建议改用 `LITELLM_CONFIG` + `LITELLM_CONFIG_YAML`，避免 secret 名与渠道名无法自动对齐。
 
 ---
 
@@ -152,6 +158,30 @@ model_list:
 ```
 
 ### GitHub Actions配置说明
+
+#### 渠道模式（推荐给不想暴露真实 Key 的用户）
+
+默认 `.env` / Variables 里只保留非敏感结构，例如：
+
+```env
+LLM_CHANNELS=deepseek,aihubmix
+LLM_DEEPSEEK_BASE_URL=https://api.deepseek.com/v1
+LLM_DEEPSEEK_MODELS=deepseek-chat,deepseek-reasoner
+LLM_AIHUBMIX_BASE_URL=https://api.aihubmix.com/v1
+LLM_AIHUBMIX_MODELS=gpt-4o-mini,claude-3-5-sonnet
+LITELLM_MODEL=deepseek/deepseek-chat
+AGENT_LITELLM_MODEL=deepseek/deepseek-reasoner
+LITELLM_FALLBACK_MODELS=openai/gpt-4o-mini,anthropic/claude-3-5-sonnet
+```
+
+真实 Key 放到 GitHub Secrets：
+
+- `DEEPSEEK_API_KEY`
+- `AIHUBMIX_KEY`（或 `OPENAI_API_KEY`，按你的渠道实际用途）
+- `GEMINI_API_KEY`
+- `ANTHROPIC_API_KEY`
+
+这样无需改 workflow，也无需把真实 `LLM_DEEPSEEK_API_KEY` / `LLM_AIHUBMIX_API_KEY` 写进默认 `.env`。若你使用的是自定义渠道名，则请改用下面的 YAML 高级配置。
 
 1. `Settings` → `Secrets and variables` → `Actions` → `Secret`标签页下的`New repository secret` 或者 `Variables`标签页下的`New repository variable`
 
@@ -202,7 +232,7 @@ VISION_PROVIDER_PRIORITY=gemini,anthropic,openai
 | 遇到了什么诡异报错？ | 罪魁祸首可能是啥？ | 该怎么收拾它？ |
 |----------------------|----------------------|------------------|
 | **界面提示主模型未配置** | 系统不知道你到底想用哪家的哪个模型 | 在 `.env` 中写上一句明白话：`LITELLM_MODEL=provider/你的模型名`。比如 `openai/gpt-4o-mini` |
-| **我写了好几家的Key，为什么死活只有一个生效？修改还没用？** | 你把 **极简模式** 和 **渠道模式** 混着写了！ | 想好一条路走到黑——只要简单就删掉 `LLM_CHANNELS` 开头的；想要丰富备用切换就要全部转投到 `LLM_CHANNELS` 下的编制里。 |
+| **我写了好几家的Key，为什么死活只有一个生效？修改还没用？** | 大概率是模式混用，或渠道名和 Secret 名没对齐。 | 本地 / Docker 请优先直接写 `LLM_{NAME}_API_KEY(S)`；GitHub Actions 下，`deepseek` / `aihubmix` / `openai` / `gemini` / `anthropic` 等常见渠道可复用对应 legacy Secrets；自定义渠道请改用 `LITELLM_CONFIG` + `LITELLM_CONFIG_YAML`。 |
 | **错误码报 400 或 401 或 Invalid API Key** | API Key 填错、少复制了一截、账号充值没到账、或者模型名字敲错（极度常见）。 | 1. 检查复制的 Key 前后是否有误填空格。<br> 2. 检查 Base URL 最后是不是少了一个 `/v1`。<br> 3. 检查模型名是否少写了 `openai/` 之类的前缀！ |
 | **转圈转不停，最后报 Timeout / ConnectionRefused 等** | 1. 在国内使用国外原版（像 Google、OpenAI），没开代理被墙了。<br>2. 你买的云服务器压根不能出境。 | 非常推荐使用**国内官方**（如DeepSeek、阿里）或者各种**兼容 OpenAI 的聚合中转接口**。因为中转站把网络问题帮你解决好了。 |
 | **Ollama 报 404、`Could not get model info` 或 `api/generate/api/show`** | 误用 `OPENAI_BASE_URL` 配置 Ollama，系统会错误拼接 URL | 改用 `OLLAMA_API_BASE=http://localhost:11434` 或渠道模式（`LLM_CHANNELS=ollama` + `LLM_OLLAMA_BASE_URL`） |

--- a/docs/LLM_CONFIG_GUIDE.md
+++ b/docs/LLM_CONFIG_GUIDE.md
@@ -119,11 +119,14 @@ LITELLM_MODEL=ollama/qwen3:8b
 - 如果你通过 OpenAI Compatible 渠道接 MiniMax，请在渠道模型里直接填写 `minimax/<模型名>`，例如 `minimax/MiniMax-M1`。
 - Web 设置页里的主模型、Agent 主模型、Fallback、Vision 下拉会保留这个值原样展示，不会再错误改写成 `openai/minimax/<模型名>`。
 
-> **致命避坑说明**：如果你启用了 `LLM_CHANNELS`，那么你直接写在外面的 `DEEPSEEK_API_KEY` 或 `OPENAI_API_KEY` 将**全部失效（系统一律无视）**！二者**选其一即可**，千万不要既写了新手模式又写了渠道模式结果产生冲突。
+> **关键说明**：当你启用 `LLM_CHANNELS` 后，系统会优先按**渠道模式**运行；对常见 provider 渠道（如 `deepseek`、`aihubmix`、`openai`、`gemini`、`anthropic`）在未配置 `LLM_{NAME}_API_KEY(S)` 时，会按渠道名/官方域名安全回退到对应 legacy Secret（如 `DEEPSEEK_API_KEY(S)`、`AIHUBMIX_KEY / OPENAI_API_KEY(S)`、`GEMINI_API_KEY(S)`、`ANTHROPIC_API_KEY(S)`）。  
+如自定义渠道名的 `LLM_{NAME}_BASE_URL` 指向官方 provider HTTPS host（如 `api.openai.com`、`api.deepseek.com`、`api.aihubmix.com`、`api.anthropic.com`、`generativelanguage.googleapis.com`、`aiplatform.googleapis.com`），同样会按 host 做 legacy Secret 回退；否则建议走高级 YAML 配置：提交实体 YAML 文件时可仅设置 `LITELLM_CONFIG`；未提交文件时需同时加 `LITELLM_CONFIG_YAML`。
 
 > **GitHub Actions 兼容说明**：渠道模式仍优先于 legacy 模式，但常见 provider 渠道在缺少 `LLM_{NAME}_API_KEY(S)` 时，会按渠道名/官方域名安全回退读取已有 Secrets：`deepseek -> DEEPSEEK_API_KEY(S)`、`aihubmix -> AIHUBMIX_KEY / OPENAI_API_KEY(S)`、`openai -> OPENAI_API_KEY(S)`、`gemini/vertex -> GEMINI_API_KEY(S)`、`anthropic/claude -> ANTHROPIC_API_KEY(S)`。这意味着你可以继续使用默认 `.env` 中的非敏感渠道结构，把真实 Key 放在 GitHub Secrets 里，而不用把真实 `LLM_DEEPSEEK_API_KEY`、`LLM_AIHUBMIX_API_KEY` 写进仓库配置。
 >
-> **边界说明**：这个回退只覆盖常见 provider 渠道名；像 `my_proxy`、`corp_gateway` 这类自定义渠道名在 GitHub Actions 中仍建议改用 `LITELLM_CONFIG` + `LITELLM_CONFIG_YAML`，避免 secret 名与渠道名无法自动对齐。
+> **边界说明**：这个回退覆盖两类场景：一是内置 provider 渠道名，二是任意通道名只要 `LLM_<通道名>_BASE_URL` 命中官方 provider host（并且是 HTTPS）也会触发 host-based 回退。像 `proxy.example.com`、`my_proxy` 这类非官方主机名（例如企业自建转发、中转聚合、未公开域名）不会按渠道名映射 legacy Secret，建议走高级 YAML 模式：
+> - 若你已提交实体 `litellm_config.yaml` 文件：`LITELLM_CONFIG` 只需指向该文件路径（例如 `./litellm_config.yaml`）。
+> - 若你不提交实体文件：`LITELLM_CONFIG` 需提供写入路径，且同时补 `LITELLM_CONFIG_YAML`（可放在 Secrets/Variables），由 workflow 在运行时写入 YAML 内容。
 
 ---
 
@@ -181,7 +184,9 @@ LITELLM_FALLBACK_MODELS=openai/gpt-4o-mini,anthropic/claude-3-5-sonnet
 - `GEMINI_API_KEY`
 - `ANTHROPIC_API_KEY`
 
-这样无需改 workflow，也无需把真实 `LLM_DEEPSEEK_API_KEY` / `LLM_AIHUBMIX_API_KEY` 写进默认 `.env`。若你使用的是自定义渠道名，则请改用下面的 YAML 高级配置。
+这样无需改 workflow，也无需把真实 `LLM_DEEPSEEK_API_KEY` / `LLM_AIHUBMIX_API_KEY` 写进默认 `.env`。若你的自定义渠道名使用官方 provider 的 HTTPS host，可按 host 回退到对应 legacy Secret；若使用自定义中转 host（如 `myproxy.example.com`）请改用下面的 YAML 高级配置，按实际场景选一：
+- 已提交 `litellm_config.yaml` 到仓库：仅配置 `LITELLM_CONFIG=./litellm_config.yaml`。
+- 未提交文件：配置 `LITELLM_CONFIG=./litellm_config.yaml`（路径）与 `LITELLM_CONFIG_YAML`（YAML 内容，来自 Secrets/Variables）。
 
 1. `Settings` → `Secrets and variables` → `Actions` → `Secret`标签页下的`New repository secret` 或者 `Variables`标签页下的`New repository variable`
 
@@ -189,9 +194,9 @@ LITELLM_FALLBACK_MODELS=openai/gpt-4o-mini,anthropic/claude-3-5-sonnet
 
 | Secret 名称 | 说明 | 必填 |
 |------------|------|:----:|
-| `LITELLM_CONFIG` | 高级模型路由配置文件路径，通常配置 `./litellm_config.yaml` | 必填 |
+| `LITELLM_CONFIG` | 高级模型路由配置文件路径（如 `./litellm_config.yaml`） | 必填 |
+| `LITELLM_CONFIG_YAML` | 可选：如未提交实体配置文件，可在 `Actions` Secret/Variable 中放 YAML 内容；workflow 会写入 `LITELLM_CONFIG` 路径 | 可选 |
 | `LITELLM_MODEL` | 默认主模型名称或路由别名 | 必填 |
-| `LITELLM_CONFIG_YAML` | 存放 YAML 配置文件内容，可不在仓库中提交实体文件 | 可选 |
 | `LITELLM_API_KEY` | 用于存储API Key，可在配置文件中引用（环境变量引用方式）。由于GitHub Actions必须要指定导入的环境变量，因此你不能像本地运行模式那样自由命名环境变量 | 可选，必须配置到repository secret中 |
 | `ANTHROPIC_API_KEY` | 如果要多个API Key，这个变量名称也能拿来用 | 可选，必须配置到repository secret中 |
 | `OPENAI_API_KEY` | 同上，可以用来存储API Key | 可选，必须配置到repository secret中 |
@@ -232,7 +237,7 @@ VISION_PROVIDER_PRIORITY=gemini,anthropic,openai
 | 遇到了什么诡异报错？ | 罪魁祸首可能是啥？ | 该怎么收拾它？ |
 |----------------------|----------------------|------------------|
 | **界面提示主模型未配置** | 系统不知道你到底想用哪家的哪个模型 | 在 `.env` 中写上一句明白话：`LITELLM_MODEL=provider/你的模型名`。比如 `openai/gpt-4o-mini` |
-| **我写了好几家的Key，为什么死活只有一个生效？修改还没用？** | 大概率是模式混用，或渠道名和 Secret 名没对齐。 | 本地 / Docker 请优先直接写 `LLM_{NAME}_API_KEY(S)`；GitHub Actions 下，`deepseek` / `aihubmix` / `openai` / `gemini` / `anthropic` 等常见渠道可复用对应 legacy Secrets；自定义渠道请改用 `LITELLM_CONFIG` + `LITELLM_CONFIG_YAML`。 |
+| **我写了好几家的Key，为什么死活只有一个生效？修改还没用？** | 大概率是模式混用，或渠道名和 Secret 名没对齐。 | 本地 / Docker 请优先直接写 `LLM_{NAME}_API_KEY(S)`；GitHub Actions 下，`deepseek` / `aihubmix` / `openai` / `gemini` / `anthropic` 等常见渠道可复用对应 legacy Secrets，另外自定义渠道若 `LLM_<NAME>_BASE_URL` 命中官方 provider HTTPS host 也可按 host 回退。若自定义渠道使用非官方 host，请走高级 YAML 配置：提交 `litellm_config.yaml` 时只配 `LITELLM_CONFIG`，不提交时再补 `LITELLM_CONFIG_YAML`。 |
 | **错误码报 400 或 401 或 Invalid API Key** | API Key 填错、少复制了一截、账号充值没到账、或者模型名字敲错（极度常见）。 | 1. 检查复制的 Key 前后是否有误填空格。<br> 2. 检查 Base URL 最后是不是少了一个 `/v1`。<br> 3. 检查模型名是否少写了 `openai/` 之类的前缀！ |
 | **转圈转不停，最后报 Timeout / ConnectionRefused 等** | 1. 在国内使用国外原版（像 Google、OpenAI），没开代理被墙了。<br>2. 你买的云服务器压根不能出境。 | 非常推荐使用**国内官方**（如DeepSeek、阿里）或者各种**兼容 OpenAI 的聚合中转接口**。因为中转站把网络问题帮你解决好了。 |
 | **Ollama 报 404、`Could not get model info` 或 `api/generate/api/show`** | 误用 `OPENAI_BASE_URL` 配置 Ollama，系统会错误拼接 URL | 改用 `OLLAMA_API_BASE=http://localhost:11434` 或渠道模式（`LLM_CHANNELS=ollama` + `LLM_OLLAMA_BASE_URL`） |

--- a/docs/LLM_CONFIG_GUIDE_EN.md
+++ b/docs/LLM_CONFIG_GUIDE_EN.md
@@ -81,11 +81,13 @@ If you prefer modifying files, configuring this in the `.env` file is also very 
 LLM_CHANNELS=deepseek,aihubmix
 
 # 2. Channel 1: Configure Official DeepSeek
+# For local / Docker runs, the channel-specific key is still the clearest option:
 LLM_DEEPSEEK_BASE_URL=https://api.deepseek.com/v1
 LLM_DEEPSEEK_API_KEY=sk-1111111111111
 LLM_DEEPSEEK_MODELS=deepseek-chat,deepseek-reasoner
 
 # 3. Channel 2: Configure a common relay/proxy API
+# For local / Docker runs, the channel-specific key is still the clearest option:
 LLM_AIHUBMIX_BASE_URL=https://api.aihubmix.com/v1
 LLM_AIHUBMIX_API_KEY=sk-2222222222222
 LLM_AIHUBMIX_MODELS=gpt-4o-mini,claude-3-5-sonnet
@@ -118,6 +120,10 @@ LITELLM_MODEL=ollama/qwen3:8b
 - The Web settings page now keeps that value unchanged in Primary, Agent Primary, Fallback, and Vision selectors instead of rewriting it to `openai/minimax/<model-name>`.
 
 > **Critical Warning**: If you enable `LLM_CHANNELS`, any standard `DEEPSEEK_API_KEY` or `OPENAI_API_KEY` declared independently will be **completely ignored**. **Use only one mode** to prevent configuration conflicts.
+
+> **GitHub Actions Compatibility**: Channels mode still wins over legacy mode, but well-known provider channels can now safely reuse existing Secrets when `LLM_{NAME}_API_KEY(S)` is absent: `deepseek -> DEEPSEEK_API_KEY(S)`, `aihubmix -> AIHUBMIX_KEY / OPENAI_API_KEY(S)`, `openai -> OPENAI_API_KEY(S)`, `gemini/vertex -> GEMINI_API_KEY(S)`, `anthropic/claude -> ANTHROPIC_API_KEY(S)`. This lets you keep only the non-sensitive channel structure in the default `.env` and store real keys in GitHub Secrets instead of writing real `LLM_DEEPSEEK_API_KEY` / `LLM_AIHUBMIX_API_KEY` values into repo config.
+>
+> **Boundary**: This fallback only applies to common provider channel names / official hosts. Custom channel names such as `my_proxy` or `corp_gateway` should still use `LITELLM_CONFIG` + `LITELLM_CONFIG_YAML` in GitHub Actions.
 
 ---
 
@@ -153,6 +159,34 @@ model_list:
 
 ---
 
+## GitHub Actions Notes
+
+### Channels Mode Without Exposing Real Keys
+
+Keep only the non-sensitive channel structure in the default `.env` / GitHub Variables:
+
+```env
+LLM_CHANNELS=deepseek,aihubmix
+LLM_DEEPSEEK_BASE_URL=https://api.deepseek.com/v1
+LLM_DEEPSEEK_MODELS=deepseek-chat,deepseek-reasoner
+LLM_AIHUBMIX_BASE_URL=https://api.aihubmix.com/v1
+LLM_AIHUBMIX_MODELS=gpt-4o-mini,claude-3-5-sonnet
+LITELLM_MODEL=deepseek/deepseek-chat
+AGENT_LITELLM_MODEL=deepseek/deepseek-reasoner
+LITELLM_FALLBACK_MODELS=openai/gpt-4o-mini,anthropic/claude-3-5-sonnet
+```
+
+Store the real keys in GitHub Secrets:
+
+- `DEEPSEEK_API_KEY`
+- `AIHUBMIX_KEY` (or `OPENAI_API_KEY`, depending on the actual endpoint you use)
+- `GEMINI_API_KEY`
+- `ANTHROPIC_API_KEY`
+
+This works without changing the workflow and avoids writing real `LLM_DEEPSEEK_API_KEY` / `LLM_AIHUBMIX_API_KEY` values into the default `.env`. For custom channel names, prefer `LITELLM_CONFIG` + `LITELLM_CONFIG_YAML`.
+
+---
+
 ## Advanced Feature: Vision Model Config
 
 Certain specific features in our system (like uploading a stock chart screenshot to extract the stock code) require models capable of computer vision. You need to assign a dedicated vision model in your `.env`.
@@ -184,7 +218,7 @@ Afraid you got the config wrong? Type the following commands in your terminal to
 | Weird Error You Got? | Likely Culprit | How to Fix It? |
 |----------------------|----------------|----------------|
 | **The UI says the primary model is not configured** | The system doesn't know which provider/model you want to use. | Add a clear instruction in `.env`: `LITELLM_MODEL=provider/your_model_name`. Example: `openai/gpt-4o-mini`. |
-| **I added multiple provider Keys, why is only one working?** | You mixed the **Simple Mode** and **Channels Mode**! | Choose one path. For simple setups, delete anything starting with `LLM_CHANNELS`. To use multi-model fallbacks, migrate all your Keys into the `LLM_CHANNELS` setup. |
+| **I added multiple provider Keys, why is only one working?** | Usually you mixed config modes, or your channel name does not match a supported fallback mapping. | For local / Docker, prefer explicit `LLM_{NAME}_API_KEY(S)`. In GitHub Actions, common provider channel names such as `deepseek` / `aihubmix` / `openai` / `gemini` / `anthropic` can reuse matching legacy Secrets. Custom channel names should switch to `LITELLM_CONFIG` + `LITELLM_CONFIG_YAML`. |
 | **Returns 400, 401, or Invalid API Key** | The API Key is wrong, copied incompletely, account lacks credits, or you mistyped the model name (extremely common). | 1. Ensure there are no spaces at the start/end of your Key.<br> 2. Ensure your Base URL ends with `/v1`.<br> 3. Check if you forgot the `openai/` prefix on the model name! |
 | **Spins endlessly, eventually hits Timeout/ConnectionRefused** | You are using restricted APIs (like Google/OpenAI) in a blocked region without a proxy, or your cloud server lacks external internet access. | Highly recommend using **official regional APIs** (like DeepSeek) or **OpenAI-compatible relay platforms**. Third-party platforms bypass these network constraints. |
 | **Ollama returns 404, `Could not get model info`, or `api/generate/api/show`** | Using `OPENAI_BASE_URL` for Ollama makes the system concatenate URLs incorrectly | Use `OLLAMA_API_BASE=http://localhost:11434` or channel mode (`LLM_CHANNELS=ollama` + `LLM_OLLAMA_BASE_URL`) instead |

--- a/docs/LLM_CONFIG_GUIDE_EN.md
+++ b/docs/LLM_CONFIG_GUIDE_EN.md
@@ -119,11 +119,14 @@ LITELLM_MODEL=ollama/qwen3:8b
 - If you access MiniMax through an OpenAI-compatible channel, enter the model as `minimax/<model-name>` in the channel model list, for example `minimax/MiniMax-M1`.
 - The Web settings page now keeps that value unchanged in Primary, Agent Primary, Fallback, and Vision selectors instead of rewriting it to `openai/minimax/<model-name>`.
 
-> **Critical Warning**: If you enable `LLM_CHANNELS`, any standard `DEEPSEEK_API_KEY` or `OPENAI_API_KEY` declared independently will be **completely ignored**. **Use only one mode** to prevent configuration conflicts.
+> **Key Note**: Enabling `LLM_CHANNELS` makes channel mode the primary mode. For common providers (such as `deepseek`, `aihubmix`, `openai`, `gemini`, `anthropic`), if `LLM_{NAME}_API_KEY(S)` is not provided, the system safely falls back to the corresponding legacy secret by channel name/official host (for example, `DEEPSEEK_API_KEY(S)`, `AIHUBMIX_KEY / OPENAI_API_KEY(S)`, `GEMINI_API_KEY(S)`, `ANTHROPIC_API_KEY(S)`).  
+If a custom channel `LLM_{NAME}_BASE_URL` points to an official provider HTTPS host (for example `api.openai.com`, `api.deepseek.com`, `api.aihubmix.com`, `api.anthropic.com`, `generativelanguage.googleapis.com`, `aiplatform.googleapis.com`), it also follows the same host-based legacy secret fallback. If you use a non-official host, use the advanced YAML path: with committed YAML set only `LITELLM_CONFIG` (file path); without file submission, also provide `LITELLM_CONFIG_YAML`.
 
 > **GitHub Actions Compatibility**: Channels mode still wins over legacy mode, but well-known provider channels can now safely reuse existing Secrets when `LLM_{NAME}_API_KEY(S)` is absent: `deepseek -> DEEPSEEK_API_KEY(S)`, `aihubmix -> AIHUBMIX_KEY / OPENAI_API_KEY(S)`, `openai -> OPENAI_API_KEY(S)`, `gemini/vertex -> GEMINI_API_KEY(S)`, `anthropic/claude -> ANTHROPIC_API_KEY(S)`. This lets you keep only the non-sensitive channel structure in the default `.env` and store real keys in GitHub Secrets instead of writing real `LLM_DEEPSEEK_API_KEY` / `LLM_AIHUBMIX_API_KEY` values into repo config.
 >
-> **Boundary**: This fallback only applies to common provider channel names / official hosts. Custom channel names such as `my_proxy` or `corp_gateway` should still use `LITELLM_CONFIG` + `LITELLM_CONFIG_YAML` in GitHub Actions.
+> **Boundary**: This fallback applies to built-in provider channel names, and also to any channel whose `LLM_<NAME>_BASE_URL` resolves to an official provider host over HTTPS. Custom channels pointing to private/proxy hosts (for example `proxy.example.com`, `my_proxy`) do not auto-map legacy secrets; use advanced YAML routing:
+> - If you commit an actual `litellm_config.yaml` file: set `LITELLM_CONFIG` to its path (for example, `./litellm_config.yaml`).
+> - If you do not commit a file: set `LITELLM_CONFIG` to the target path and also set `LITELLM_CONFIG_YAML` in Secrets/Variables; the workflow will write the YAML content at runtime.
 
 ---
 
@@ -183,7 +186,9 @@ Store the real keys in GitHub Secrets:
 - `GEMINI_API_KEY`
 - `ANTHROPIC_API_KEY`
 
-This works without changing the workflow and avoids writing real `LLM_DEEPSEEK_API_KEY` / `LLM_AIHUBMIX_API_KEY` values into the default `.env`. For custom channel names, prefer `LITELLM_CONFIG` + `LITELLM_CONFIG_YAML`.
+This works without changing the workflow and avoids writing real `LLM_DEEPSEEK_API_KEY` / `LLM_AIHUBMIX_API_KEY` values into the default `.env`. If a custom channel name uses an official provider HTTPS host, it can still inherit legacy secrets via host-based fallback; if it uses a custom proxy host, use advanced YAML routing and choose one of:
+- If you commit `litellm_config.yaml` in the repo: only set `LITELLM_CONFIG=./litellm_config.yaml`.
+- If you do not commit the file: set both `LITELLM_CONFIG=./litellm_config.yaml` and `LITELLM_CONFIG_YAML` (content via Secrets/Variables).
 
 ---
 
@@ -218,7 +223,7 @@ Afraid you got the config wrong? Type the following commands in your terminal to
 | Weird Error You Got? | Likely Culprit | How to Fix It? |
 |----------------------|----------------|----------------|
 | **The UI says the primary model is not configured** | The system doesn't know which provider/model you want to use. | Add a clear instruction in `.env`: `LITELLM_MODEL=provider/your_model_name`. Example: `openai/gpt-4o-mini`. |
-| **I added multiple provider Keys, why is only one working?** | Usually you mixed config modes, or your channel name does not match a supported fallback mapping. | For local / Docker, prefer explicit `LLM_{NAME}_API_KEY(S)`. In GitHub Actions, common provider channel names such as `deepseek` / `aihubmix` / `openai` / `gemini` / `anthropic` can reuse matching legacy Secrets. Custom channel names should switch to `LITELLM_CONFIG` + `LITELLM_CONFIG_YAML`. |
+| **I added multiple provider Keys, why is only one working?** | Usually you mixed config modes, or your channel name does not match a supported fallback mapping. | For local / Docker, prefer explicit `LLM_{NAME}_API_KEY(S)`. In GitHub Actions, built-in provider channels (`deepseek` / `aihubmix` / `openai` / `gemini` / `anthropic`) and custom channels with official HTTPS `LLM_<NAME>_BASE_URL` can reuse matching legacy Secrets. If your custom channel uses a proxy/private host, use advanced YAML routing: commit `litellm_config.yaml` and set only `LITELLM_CONFIG`, or set both `LITELLM_CONFIG` + `LITELLM_CONFIG_YAML`. |
 | **Returns 400, 401, or Invalid API Key** | The API Key is wrong, copied incompletely, account lacks credits, or you mistyped the model name (extremely common). | 1. Ensure there are no spaces at the start/end of your Key.<br> 2. Ensure your Base URL ends with `/v1`.<br> 3. Check if you forgot the `openai/` prefix on the model name! |
 | **Spins endlessly, eventually hits Timeout/ConnectionRefused** | You are using restricted APIs (like Google/OpenAI) in a blocked region without a proxy, or your cloud server lacks external internet access. | Highly recommend using **official regional APIs** (like DeepSeek) or **OpenAI-compatible relay platforms**. Third-party platforms bypass these network constraints. |
 | **Ollama returns 404, `Could not get model info`, or `api/generate/api/show`** | Using `OPENAI_BASE_URL` for Ollama makes the system concatenate URLs incorrectly | Use `OLLAMA_API_BASE=http://localhost:11434` or channel mode (`LLM_CHANNELS=ollama` + `LLM_OLLAMA_BASE_URL`) instead |

--- a/src/config.py
+++ b/src/config.py
@@ -100,27 +100,32 @@ def resolve_channel_legacy_api_keys(channel_name: str, base_url: Optional[str]) 
     normalized_name = canonicalize_llm_channel_protocol(channel_name)
     raw_name = (channel_name or "").strip().lower()
     host = (urlparse(base_url or "").hostname or "").lower()
+    # Name-based fallback is only safe when no custom base_url is configured,
+    # because requests will go to the provider's default endpoint.  When a
+    # base_url IS present, only trust the strict host check to prevent legacy
+    # secrets from leaking to attacker-controlled endpoints.
+    has_custom_url = bool(base_url and base_url.strip())
 
-    if _is_provider_host(host, "aihubmix.com") or raw_name == "aihubmix":
+    if _is_provider_host(host, "aihubmix.com") or (not has_custom_url and raw_name == "aihubmix"):
         aihubmix_key = os.getenv('AIHUBMIX_KEY', '').strip()
         if aihubmix_key:
             return [aihubmix_key], 'AIHUBMIX_KEY'
         return read_env_key_list('OPENAI_API_KEYS', 'OPENAI_API_KEY')
 
-    if _is_provider_host(host, "deepseek.com") or normalized_name == "deepseek":
+    if _is_provider_host(host, "deepseek.com") or (not has_custom_url and normalized_name == "deepseek"):
         return read_env_key_list('DEEPSEEK_API_KEYS', 'DEEPSEEK_API_KEY')
 
     if (
-        normalized_name in {"gemini", "vertex_ai"}
-        or _is_provider_host(host, "generativelanguage.googleapis.com")
+        _is_provider_host(host, "generativelanguage.googleapis.com")
         or _is_provider_host(host, "aiplatform.googleapis.com")
+        or (not has_custom_url and normalized_name in {"gemini", "vertex_ai"})
     ):
         return read_env_key_list('GEMINI_API_KEYS', 'GEMINI_API_KEY')
 
-    if _is_provider_host(host, "anthropic.com") or normalized_name == "anthropic":
+    if _is_provider_host(host, "anthropic.com") or (not has_custom_url and normalized_name == "anthropic"):
         return read_env_key_list('ANTHROPIC_API_KEYS', 'ANTHROPIC_API_KEY')
 
-    if _is_provider_host(host, "openai.com") or normalized_name == "openai":
+    if _is_provider_host(host, "openai.com") or (not has_custom_url and normalized_name == "openai"):
         return read_env_key_list('OPENAI_API_KEYS', 'OPENAI_API_KEY')
 
     return [], None

--- a/src/config.py
+++ b/src/config.py
@@ -68,6 +68,62 @@ def parse_env_bool(value: Optional[str], default: bool = False) -> bool:
     return normalized not in _FALSEY_ENV_VALUES
 
 
+def parse_env_csv_list(value: Optional[str]) -> List[str]:
+    """Parse a comma-separated env value into a trimmed list."""
+    return [item.strip() for item in (value or "").split(',') if item.strip()]
+
+
+def read_env_key_list(multi_var: str, single_var: Optional[str] = None) -> Tuple[List[str], Optional[str]]:
+    """Read multi/single API key env vars with source tracking."""
+    keys = parse_env_csv_list(os.getenv(multi_var, ''))
+    if keys:
+        return keys, multi_var
+    if single_var:
+        single_key = os.getenv(single_var, '').strip()
+        if single_key:
+            return [single_key], single_var
+    return [], None
+
+
+def resolve_channel_legacy_api_keys(channel_name: str, base_url: Optional[str]) -> Tuple[List[str], Optional[str]]:
+    """Map well-known channel names/hosts to legacy provider secrets.
+
+    This keeps local/Docker channel-specific env vars as the primary source, but
+    allows common provider channels in GitHub Actions to reuse existing legacy
+    secret names without writing real keys into the default `.env`.
+    """
+    normalized_name = canonicalize_llm_channel_protocol(channel_name)
+    raw_name = (channel_name or "").strip().lower()
+    host = (urlparse(base_url or "").hostname or "").lower()
+
+    if "aihubmix.com" in host or raw_name == "aihubmix":
+        openai_keys, openai_source = read_env_key_list('OPENAI_API_KEYS')
+        if openai_keys:
+            return openai_keys, openai_source
+        aihubmix_key = os.getenv('AIHUBMIX_KEY', '').strip()
+        if aihubmix_key:
+            return [aihubmix_key], 'AIHUBMIX_KEY'
+        return read_env_key_list('OPENAI_API_KEYS', 'OPENAI_API_KEY')
+
+    if "deepseek.com" in host or normalized_name == "deepseek":
+        return read_env_key_list('DEEPSEEK_API_KEYS', 'DEEPSEEK_API_KEY')
+
+    if (
+        normalized_name in {"gemini", "vertex_ai"}
+        or "generativelanguage.googleapis.com" in host
+        or "aiplatform.googleapis.com" in host
+    ):
+        return read_env_key_list('GEMINI_API_KEYS', 'GEMINI_API_KEY')
+
+    if "anthropic.com" in host or normalized_name == "anthropic":
+        return read_env_key_list('ANTHROPIC_API_KEYS', 'ANTHROPIC_API_KEY')
+
+    if "openai.com" in host or normalized_name == "openai":
+        return read_env_key_list('OPENAI_API_KEYS', 'OPENAI_API_KEY')
+
+    return [], None
+
+
 def parse_env_int(
     value: Optional[str],
     default: int,
@@ -899,22 +955,13 @@ class Config:
         
         # === LiteLLM multi-key parsing ===
         # GEMINI_API_KEYS (comma-separated) > GEMINI_API_KEY (single)
-        _gemini_keys_raw = os.getenv('GEMINI_API_KEYS', '')
-        gemini_api_keys = [k.strip() for k in _gemini_keys_raw.split(',') if k.strip()]
-        _single_gemini = os.getenv('GEMINI_API_KEY', '').strip()
-        if not gemini_api_keys and _single_gemini:
-            gemini_api_keys = [_single_gemini]
+        gemini_api_keys, _ = read_env_key_list('GEMINI_API_KEYS', 'GEMINI_API_KEY')
 
         # ANTHROPIC_API_KEYS > ANTHROPIC_API_KEY
-        _anthropic_keys_raw = os.getenv('ANTHROPIC_API_KEYS', '')
-        anthropic_api_keys = [k.strip() for k in _anthropic_keys_raw.split(',') if k.strip()]
-        _single_anthropic = os.getenv('ANTHROPIC_API_KEY', '').strip()
-        if not anthropic_api_keys and _single_anthropic:
-            anthropic_api_keys = [_single_anthropic]
+        anthropic_api_keys, _ = read_env_key_list('ANTHROPIC_API_KEYS', 'ANTHROPIC_API_KEY')
 
         # OPENAI_API_KEYS > AIHUBMIX_KEY > OPENAI_API_KEY
-        _openai_keys_raw = os.getenv('OPENAI_API_KEYS', '')
-        openai_api_keys = [k.strip() for k in _openai_keys_raw.split(',') if k.strip()]
+        openai_api_keys, _ = read_env_key_list('OPENAI_API_KEYS')
         if not openai_api_keys:
             _aihubmix = os.getenv('AIHUBMIX_KEY', '').strip()
             _single_openai = os.getenv('OPENAI_API_KEY', '').strip()
@@ -923,12 +970,7 @@ class Config:
                 openai_api_keys = [_fallback_key]
 
         # DEEPSEEK_API_KEYS > DEEPSEEK_API_KEY (independent from OpenAI-compatible layer)
-        _deepseek_keys_raw = os.getenv('DEEPSEEK_API_KEYS', '')
-        deepseek_api_keys = [k.strip() for k in _deepseek_keys_raw.split(',') if k.strip()]
-        if not deepseek_api_keys:
-            _single_deepseek = os.getenv('DEEPSEEK_API_KEY', '').strip()
-            if _single_deepseek:
-                deepseek_api_keys = [_single_deepseek]
+        deepseek_api_keys, _ = read_env_key_list('DEEPSEEK_API_KEYS', 'DEEPSEEK_API_KEY')
 
         # LITELLM_MODEL: explicit config takes precedence; else infer from available keys
         litellm_model = os.getenv('LITELLM_MODEL', '').strip()
@@ -1495,8 +1537,7 @@ class Config:
             enabled = parse_env_bool(os.getenv(f'LLM_{ch_upper}_ENABLED'), default=True)
 
             # API keys: LLM_{NAME}_API_KEYS (multi) > LLM_{NAME}_API_KEY (single)
-            api_keys_raw = os.getenv(f'LLM_{ch_upper}_API_KEYS', '')
-            api_keys = [k.strip() for k in api_keys_raw.split(',') if k.strip()]
+            api_keys = parse_env_csv_list(os.getenv(f'LLM_{ch_upper}_API_KEYS', ''))
             if not api_keys:
                 single_key = os.getenv(f'LLM_{ch_upper}_API_KEY', '').strip()
                 if single_key:
@@ -1531,6 +1572,14 @@ class Config:
 
             if not api_keys and channel_allows_empty_api_key(protocol, base_url):
                 api_keys = [""]
+            if not api_keys:
+                api_keys, legacy_source = resolve_channel_legacy_api_keys(ch_name, base_url)
+                if api_keys and legacy_source:
+                    _logger.info(
+                        "LLM channel '%s': using legacy API key fallback from %s",
+                        ch_name,
+                        legacy_source,
+                    )
 
             if not api_keys:
                 _logger.warning(f"LLM channel '{ch_name}': no API key configured, skipped")

--- a/src/config.py
+++ b/src/config.py
@@ -99,33 +99,38 @@ def resolve_channel_legacy_api_keys(channel_name: str, base_url: Optional[str]) 
     """
     normalized_name = canonicalize_llm_channel_protocol(channel_name)
     raw_name = (channel_name or "").strip().lower()
-    host = (urlparse(base_url or "").hostname or "").lower()
+    parsed_url = urlparse(base_url or "")
+    host = (parsed_url.hostname or "").lower()
+    scheme = (parsed_url.scheme or "").lower()
     # Name-based fallback is only safe when no custom base_url is configured,
     # because requests will go to the provider's default endpoint.  When a
     # base_url IS present, only trust the strict host check to prevent legacy
     # secrets from leaking to attacker-controlled endpoints.
     has_custom_url = bool(base_url and base_url.strip())
+    # Reject non-HTTPS custom URLs for host-based fallback to prevent
+    # credential exposure over plaintext HTTP connections.
+    host_fallback_ok = has_custom_url and scheme == "https"
 
-    if _is_provider_host(host, "aihubmix.com") or (not has_custom_url and raw_name == "aihubmix"):
+    if (host_fallback_ok and _is_provider_host(host, "aihubmix.com")) or (not has_custom_url and raw_name == "aihubmix"):
         aihubmix_key = os.getenv('AIHUBMIX_KEY', '').strip()
         if aihubmix_key:
             return [aihubmix_key], 'AIHUBMIX_KEY'
         return read_env_key_list('OPENAI_API_KEYS', 'OPENAI_API_KEY')
 
-    if _is_provider_host(host, "deepseek.com") or (not has_custom_url and normalized_name == "deepseek"):
+    if (host_fallback_ok and _is_provider_host(host, "deepseek.com")) or (not has_custom_url and normalized_name == "deepseek"):
         return read_env_key_list('DEEPSEEK_API_KEYS', 'DEEPSEEK_API_KEY')
 
     if (
-        _is_provider_host(host, "generativelanguage.googleapis.com")
-        or _is_provider_host(host, "aiplatform.googleapis.com")
+        (host_fallback_ok and _is_provider_host(host, "generativelanguage.googleapis.com"))
+        or (host_fallback_ok and _is_provider_host(host, "aiplatform.googleapis.com"))
         or (not has_custom_url and normalized_name in {"gemini", "vertex_ai"})
     ):
         return read_env_key_list('GEMINI_API_KEYS', 'GEMINI_API_KEY')
 
-    if _is_provider_host(host, "anthropic.com") or (not has_custom_url and normalized_name == "anthropic"):
+    if (host_fallback_ok and _is_provider_host(host, "anthropic.com")) or (not has_custom_url and normalized_name == "anthropic"):
         return read_env_key_list('ANTHROPIC_API_KEYS', 'ANTHROPIC_API_KEY')
 
-    if _is_provider_host(host, "openai.com") or (not has_custom_url and normalized_name == "openai"):
+    if (host_fallback_ok and _is_provider_host(host, "openai.com")) or (not has_custom_url and normalized_name == "openai"):
         return read_env_key_list('OPENAI_API_KEYS', 'OPENAI_API_KEY')
 
     return [], None

--- a/src/config.py
+++ b/src/config.py
@@ -90,14 +90,31 @@ def _is_provider_host(host: str, domain: str) -> bool:
     return host == domain or host.endswith('.' + domain)
 
 
-def resolve_channel_legacy_api_keys(channel_name: str, base_url: Optional[str]) -> Tuple[List[str], Optional[str]]:
+def resolve_channel_legacy_api_keys(
+    channel_name: str,
+    base_url: Optional[str],
+    resolved_protocol: Optional[str] = None,
+) -> Tuple[List[str], Optional[str]]:
     """Map well-known channel names/hosts to legacy provider secrets.
 
     This keeps local/Docker channel-specific env vars as the primary source, but
     allows common provider channels in GitHub Actions to reuse existing legacy
     secret names without writing real keys into the default `.env`.
+
+    Protocol override is only honored for known provider channels (e.g.
+    ``openai``, ``deepseek``, etc.); custom channel aliases should not accidentally
+    inherit those legacy secrets.
     """
-    normalized_name = canonicalize_llm_channel_protocol(channel_name)
+    # For known provider channel names, allow protocol override to shift legacy
+    # fallback behavior; keep custom aliases isolated.
+    normalized_channel = canonicalize_llm_channel_protocol(channel_name)
+    normalized_protocol = canonicalize_llm_channel_protocol(resolved_protocol) if resolved_protocol else None
+    effective_name = (
+        normalized_protocol
+        if resolved_protocol and normalized_channel in _MANAGED_LITELLM_KEY_PROVIDERS
+        else normalized_channel
+    )
+    normalized_name = effective_name
     raw_name = (channel_name or "").strip().lower()
     parsed_url = urlparse(base_url or "")
     host = (parsed_url.hostname or "").lower()
@@ -239,6 +256,34 @@ def resolve_news_window_days(news_max_age_days: int, news_strategy_profile: Opti
     return max(1, min(max(1, int(news_max_age_days)), profile_days))
 
 
+def infer_llm_protocol_from_base_url(base_url: Optional[str]) -> str:
+    """Infer known provider protocol from official base URL host."""
+    parsed = urlparse(base_url or "")
+    host = (parsed.hostname or "").lower()
+    if not host:
+        return ""
+
+    if host in {"127.0.0.1", "localhost", "0.0.0.0"}:
+        # Keep local server default behavior unchanged.
+        return "openai"
+
+    if _is_provider_host(host, "aihubmix.com"):
+        return "openai"
+    if _is_provider_host(host, "deepseek.com"):
+        return "deepseek"
+    if (
+        _is_provider_host(host, "generativelanguage.googleapis.com")
+        or _is_provider_host(host, "aiplatform.googleapis.com")
+    ):
+        return "gemini"
+    if _is_provider_host(host, "anthropic.com"):
+        return "anthropic"
+    if _is_provider_host(host, "openai.com"):
+        return "openai"
+
+    return "openai"
+
+
 def canonicalize_llm_channel_protocol(value: Optional[str]) -> str:
     """Normalize a protocol label into a LiteLLM provider identifier."""
     candidate = (value or "").strip().lower().replace("-", "_")
@@ -279,11 +324,10 @@ def resolve_llm_channel_protocol(
             return name_protocol
 
     if base_url:
-        parsed = urlparse(base_url)
-        if parsed.hostname in {"127.0.0.1", "localhost", "0.0.0.0"}:
-            # Default to openai for local servers (vLLM, LM Studio, LocalAI, etc.).
-            # Ollama users should set PROTOCOL=ollama explicitly or name the channel "ollama".
-            return "openai"
+        inferred_protocol = infer_llm_protocol_from_base_url(base_url)
+        if inferred_protocol:
+            return inferred_protocol
+        # Fallback for unusual hostnames that still rely on OpenAI-compatible paths.
         return "openai"
 
     return ""
@@ -1585,7 +1629,7 @@ class Config:
             if not api_keys and channel_allows_empty_api_key(protocol, base_url):
                 api_keys = [""]
             if not api_keys:
-                api_keys, legacy_source = resolve_channel_legacy_api_keys(ch_name, base_url)
+                api_keys, legacy_source = resolve_channel_legacy_api_keys(ch_name, base_url, resolved_protocol=protocol)
                 if api_keys and legacy_source:
                     _logger.info(
                         "LLM channel '%s': using legacy API key fallback from %s",

--- a/src/config.py
+++ b/src/config.py
@@ -85,6 +85,11 @@ def read_env_key_list(multi_var: str, single_var: Optional[str] = None) -> Tuple
     return [], None
 
 
+def _is_provider_host(host: str, domain: str) -> bool:
+    """Strict host check: exact match or subdomain of *domain*."""
+    return host == domain or host.endswith('.' + domain)
+
+
 def resolve_channel_legacy_api_keys(channel_name: str, base_url: Optional[str]) -> Tuple[List[str], Optional[str]]:
     """Map well-known channel names/hosts to legacy provider secrets.
 
@@ -96,29 +101,26 @@ def resolve_channel_legacy_api_keys(channel_name: str, base_url: Optional[str]) 
     raw_name = (channel_name or "").strip().lower()
     host = (urlparse(base_url or "").hostname or "").lower()
 
-    if "aihubmix.com" in host or raw_name == "aihubmix":
-        openai_keys, openai_source = read_env_key_list('OPENAI_API_KEYS')
-        if openai_keys:
-            return openai_keys, openai_source
+    if _is_provider_host(host, "aihubmix.com") or raw_name == "aihubmix":
         aihubmix_key = os.getenv('AIHUBMIX_KEY', '').strip()
         if aihubmix_key:
             return [aihubmix_key], 'AIHUBMIX_KEY'
         return read_env_key_list('OPENAI_API_KEYS', 'OPENAI_API_KEY')
 
-    if "deepseek.com" in host or normalized_name == "deepseek":
+    if _is_provider_host(host, "deepseek.com") or normalized_name == "deepseek":
         return read_env_key_list('DEEPSEEK_API_KEYS', 'DEEPSEEK_API_KEY')
 
     if (
         normalized_name in {"gemini", "vertex_ai"}
-        or "generativelanguage.googleapis.com" in host
-        or "aiplatform.googleapis.com" in host
+        or _is_provider_host(host, "generativelanguage.googleapis.com")
+        or _is_provider_host(host, "aiplatform.googleapis.com")
     ):
         return read_env_key_list('GEMINI_API_KEYS', 'GEMINI_API_KEY')
 
-    if "anthropic.com" in host or normalized_name == "anthropic":
+    if _is_provider_host(host, "anthropic.com") or normalized_name == "anthropic":
         return read_env_key_list('ANTHROPIC_API_KEYS', 'ANTHROPIC_API_KEY')
 
-    if "openai.com" in host or normalized_name == "openai":
+    if _is_provider_host(host, "openai.com") or normalized_name == "openai":
         return read_env_key_list('OPENAI_API_KEYS', 'OPENAI_API_KEY')
 
     return [], None

--- a/src/services/system_config_service.py
+++ b/src/services/system_config_service.py
@@ -14,8 +14,11 @@ from urllib.parse import urljoin, urlparse, urlunparse
 import requests
 
 from src.config import (
+    _is_provider_host,
+    _MANAGED_LITELLM_KEY_PROVIDERS,
     SUPPORTED_LLM_CHANNEL_PROTOCOLS,
     Config,
+    resolve_channel_legacy_api_keys,
     _get_litellm_provider,
     _uses_direct_env_provider,
     canonicalize_llm_channel_protocol,
@@ -247,6 +250,7 @@ class SystemConfigService:
         api_key: str,
         models: Sequence[str] = (),
         timeout_seconds: float = 20.0,
+        effective_map: Optional[Dict[str, str]] = None,
         ) -> Dict[str, Any]:
         """Discover available models from an OpenAI-compatible `/models` endpoint."""
         channel_name = name.strip() or "channel"
@@ -259,6 +263,7 @@ class SystemConfigService:
             model_values=existing_models,
             field_prefix="discover_channel",
             require_base_url=True,
+            effective_map=effective_map,
         )
         if not resolved_protocol and existing_models:
             resolved_protocol = resolve_llm_channel_protocol(
@@ -292,6 +297,22 @@ class SystemConfigService:
             }
 
         api_keys = [segment.strip() for segment in api_key.split(",") if segment.strip()]
+        if not api_keys and not channel_allows_empty_api_key(resolved_protocol, base_url):
+            if effective_map is not None:
+                fallback_api_keys = self._read_legacy_api_keys_from_map(
+                    channel_name=name,
+                    base_url=base_url,
+                    resolved_protocol=resolved_protocol,
+                    effective_map=effective_map,
+                )
+            else:
+                fallback_api_keys, _ = resolve_channel_legacy_api_keys(
+                    channel_name=name,
+                    base_url=base_url,
+                    resolved_protocol=resolved_protocol,
+                )
+            if fallback_api_keys:
+                api_keys = fallback_api_keys
         selected_api_key = api_keys[0] if api_keys else ""
         request_headers = {"Accept": "application/json"}
         if selected_api_key:
@@ -381,6 +402,7 @@ class SystemConfigService:
         models: Sequence[str],
         enabled: bool = True,
         timeout_seconds: float = 20.0,
+        effective_map: Optional[Dict[str, str]] = None,
     ) -> Dict[str, Any]:
         """Run a minimal completion call against one channel definition."""
         raw_models = [str(model).strip() for model in models if str(model).strip()]
@@ -394,6 +416,7 @@ class SystemConfigService:
             enabled=enabled,
             field_prefix="test_channel",
             require_complete=True,
+            effective_map=effective_map,
         )
         errors = [issue for issue in validation_issues if issue["severity"] == "error"]
         if errors:
@@ -410,6 +433,22 @@ class SystemConfigService:
         resolved_models = [normalize_llm_channel_model(model, resolved_protocol, base_url) for model in raw_models]
         resolved_model = resolved_models[0]
         api_keys = [segment.strip() for segment in api_key.split(",") if segment.strip()]
+        if not api_keys and not channel_allows_empty_api_key(resolved_protocol, base_url):
+            if effective_map is not None:
+                fallback_api_keys = self._read_legacy_api_keys_from_map(
+                    channel_name=name,
+                    base_url=base_url,
+                    resolved_protocol=resolved_protocol,
+                    effective_map=effective_map,
+                )
+            else:
+                fallback_api_keys, _ = resolve_channel_legacy_api_keys(
+                    channel_name=name,
+                    base_url=base_url,
+                    resolved_protocol=resolved_protocol,
+                )
+            if fallback_api_keys:
+                api_keys = fallback_api_keys
         selected_api_key = api_keys[0] if api_keys else ""
 
         call_kwargs: Dict[str, Any] = {
@@ -1165,6 +1204,7 @@ class SystemConfigService:
                     enabled=enabled,
                     field_prefix=prefix,
                     require_complete=enabled,
+                    effective_map=effective_map,
                 )
             )
 
@@ -1455,6 +1495,7 @@ class SystemConfigService:
         enabled: bool,
         field_prefix: str,
         require_complete: bool,
+        effective_map: Optional[Dict[str, str]] = None,
     ) -> List[Dict[str, Any]]:
         """Validate one normalized LLM channel definition."""
         if not require_complete:
@@ -1468,6 +1509,7 @@ class SystemConfigService:
             model_values=model_values,
             field_prefix=field_prefix,
             require_base_url=False,
+            effective_map=effective_map,
         )
         models_key = f"{field_prefix}_MODELS" if field_prefix != "test_channel" else "models"
 
@@ -1482,6 +1524,7 @@ class SystemConfigService:
                     "actual": "",
                 }
             )
+
         elif not resolved_protocol:
             unresolved = [model for model in model_values if "/" not in model]
             if unresolved:
@@ -1511,6 +1554,7 @@ class SystemConfigService:
         model_values: Sequence[str] = (),
         field_prefix: str,
         require_base_url: bool,
+        effective_map: Optional[Dict[str, str]] = None,
     ) -> Tuple[List[Dict[str, Any]], str]:
         """Validate connection-level fields shared by test and discovery flows."""
         issues: List[Dict[str, Any]] = []
@@ -1581,14 +1625,87 @@ class SystemConfigService:
         # treated as empty (they produce zero usable keys after split+strip).
         _parsed_api_keys = [seg.strip() for seg in api_key_value.split(",") if seg.strip()]
         if not _parsed_api_keys and not channel_allows_empty_api_key(resolved_protocol, base_url_value):
-            issues.append(
-                {
-                    "key": api_key_key,
-                    "code": "missing_api_key",
-                    "message": f"LLM channel '{channel_name}' requires an API key",
-                    "severity": "error",
-                    "expected": "non-empty API key",
-                    "actual": api_key_value,
-                }
-            )
+            if effective_map is not None:
+                _fallback_api_keys = SystemConfigService._read_legacy_api_keys_from_map(
+                    channel_name=channel_name,
+                    base_url=base_url_value,
+                    resolved_protocol=resolved_protocol,
+                    effective_map=effective_map,
+                )
+            else:
+                _fallback_api_keys, _ = resolve_channel_legacy_api_keys(
+                    channel_name=channel_name,
+                    base_url=base_url_value,
+                    resolved_protocol=resolved_protocol,
+                )
+            if not _fallback_api_keys:
+                issues.append(
+                    {
+                        "key": api_key_key,
+                        "code": "missing_api_key",
+                        "message": f"LLM channel '{channel_name}' requires an API key",
+                        "severity": "error",
+                        "expected": "non-empty API key",
+                        "actual": api_key_value,
+                    }
+                )
         return issues, resolved_protocol
+
+    @staticmethod
+    def _read_legacy_api_keys_from_map(
+        *,
+        channel_name: str,
+        base_url: Optional[str],
+        resolved_protocol: Optional[str],
+        effective_map: Dict[str, str],
+    ) -> List[str]:
+        """Resolve legacy API keys from the effective form values (without reading process env)."""
+        normalized_channel = canonicalize_llm_channel_protocol(channel_name)
+        normalized_protocol = canonicalize_llm_channel_protocol(resolved_protocol) if resolved_protocol else None
+        effective_name = (
+            normalized_protocol
+            if resolved_protocol and normalized_channel in _MANAGED_LITELLM_KEY_PROVIDERS
+            else normalized_channel
+        )
+        raw_name = (channel_name or "").strip().lower()
+        normalized_name = effective_name
+        parsed_url = urlparse(base_url or "")
+        host = (parsed_url.hostname or "").lower()
+        scheme = (parsed_url.scheme or "").lower()
+        has_custom_url = bool(base_url and base_url.strip())
+        host_fallback_ok = has_custom_url and scheme == "https"
+
+        def _read_from_map(csv_key: str, single_key: str) -> List[str]:
+            csv_value = (effective_map.get(csv_key) or "").strip()
+            keys = [k.strip() for k in csv_value.split(",") if k.strip()]
+            if keys:
+                return keys
+            single_value = (effective_map.get(single_key) or "").strip()
+            return [single_value] if single_value else []
+
+        if (
+            (host_fallback_ok and _is_provider_host(host, "aihubmix.com"))
+            or (not has_custom_url and normalized_name == "aihubmix")
+        ):
+            aihubmix_key = (effective_map.get("AIHUBMIX_KEY") or "").strip()
+            if aihubmix_key:
+                return [aihubmix_key]
+            return _read_from_map("OPENAI_API_KEYS", "OPENAI_API_KEY")
+
+        if (host_fallback_ok and _is_provider_host(host, "deepseek.com")) or (not has_custom_url and normalized_name == "deepseek"):
+            return _read_from_map("DEEPSEEK_API_KEYS", "DEEPSEEK_API_KEY")
+
+        if (
+            (host_fallback_ok and _is_provider_host(host, "generativelanguage.googleapis.com"))
+            or (host_fallback_ok and _is_provider_host(host, "aiplatform.googleapis.com"))
+            or (not has_custom_url and normalized_name in {"gemini", "vertex_ai"})
+        ):
+            return _read_from_map("GEMINI_API_KEYS", "GEMINI_API_KEY")
+
+        if (host_fallback_ok and _is_provider_host(host, "anthropic.com")) or (not has_custom_url and normalized_name == "anthropic"):
+            return _read_from_map("ANTHROPIC_API_KEYS", "ANTHROPIC_API_KEY")
+
+        if (host_fallback_ok and _is_provider_host(host, "openai.com")) or (not has_custom_url and normalized_name == "openai"):
+            return _read_from_map("OPENAI_API_KEYS", "OPENAI_API_KEY")
+
+        return []

--- a/tests/test_llm_channel_config.py
+++ b/tests/test_llm_channel_config.py
@@ -267,6 +267,23 @@ class LLMChannelConfigTestCase(unittest.TestCase):
 
     @patch("src.config.setup_env")
     @patch.object(Config, "_parse_litellm_yaml", return_value=[])
+    def test_provider_named_channel_with_spoofed_base_url_blocks_legacy_key(self, _mock_parse_yaml, _mock_setup_env) -> None:
+        """LLM_CHANNELS=openai with a non-openai base_url must NOT receive OPENAI_API_KEY."""
+        env = {
+            "LLM_CHANNELS": "openai",
+            "LLM_OPENAI_BASE_URL": "https://api.openai.com.evil.tld/v1",
+            "LLM_OPENAI_MODELS": "gpt-4o-mini",
+            "OPENAI_API_KEY": "sk-openai-secret",
+        }
+
+        with patch.dict(os.environ, env, clear=True):
+            config = Config._load_from_env()
+
+        self.assertEqual(config.llm_channels, [])
+        self.assertEqual(config.llm_models_source, "legacy_env")
+
+    @patch("src.config.setup_env")
+    @patch.object(Config, "_parse_litellm_yaml", return_value=[])
     def test_custom_openai_compatible_channel_does_not_fall_back_to_legacy_keys(self, _mock_parse_yaml, _mock_setup_env) -> None:
         env = {
             "LLM_CHANNELS": "my_proxy",

--- a/tests/test_llm_channel_config.py
+++ b/tests/test_llm_channel_config.py
@@ -122,6 +122,131 @@ class LLMChannelConfigTestCase(unittest.TestCase):
 
     @patch("src.config.setup_env")
     @patch.object(Config, "_parse_litellm_yaml", return_value=[])
+    def test_channel_specific_api_key_takes_precedence_over_legacy_key(self, _mock_parse_yaml, _mock_setup_env) -> None:
+        env = {
+            "LLM_CHANNELS": "deepseek",
+            "LLM_DEEPSEEK_BASE_URL": "https://api.deepseek.com/v1",
+            "LLM_DEEPSEEK_API_KEY": "sk-channel-key",
+            "LLM_DEEPSEEK_MODELS": "deepseek-chat",
+            "DEEPSEEK_API_KEY": "sk-legacy-key",
+        }
+
+        with patch.dict(os.environ, env, clear=True):
+            config = Config._load_from_env()
+
+        self.assertEqual(config.llm_models_source, "llm_channels")
+        self.assertEqual(config.llm_channels[0]["api_keys"], ["sk-channel-key"])
+        self.assertEqual(config.llm_model_list[0]["litellm_params"]["api_key"], "sk-channel-key")
+
+    @patch("src.config.setup_env")
+    @patch.object(Config, "_parse_litellm_yaml", return_value=[])
+    def test_deepseek_channel_falls_back_to_legacy_deepseek_key(self, _mock_parse_yaml, _mock_setup_env) -> None:
+        env = {
+            "LLM_CHANNELS": "deepseek",
+            "LLM_DEEPSEEK_BASE_URL": "https://api.deepseek.com/v1",
+            "LLM_DEEPSEEK_MODELS": "deepseek-chat,deepseek-reasoner",
+            "DEEPSEEK_API_KEY": "sk-deepseek-legacy",
+        }
+
+        with patch.dict(os.environ, env, clear=True):
+            config = Config._load_from_env()
+
+        self.assertEqual(config.llm_models_source, "llm_channels")
+        self.assertEqual(config.llm_channels[0]["api_keys"], ["sk-deepseek-legacy"])
+        self.assertEqual(
+            config.llm_channels[0]["models"],
+            ["deepseek/deepseek-chat", "deepseek/deepseek-reasoner"],
+        )
+
+    @patch("src.config.setup_env")
+    @patch.object(Config, "_parse_litellm_yaml", return_value=[])
+    def test_aihubmix_channel_falls_back_to_legacy_aihubmix_key(self, _mock_parse_yaml, _mock_setup_env) -> None:
+        env = {
+            "LLM_CHANNELS": "aihubmix",
+            "LLM_AIHUBMIX_BASE_URL": "https://api.aihubmix.com/v1",
+            "LLM_AIHUBMIX_MODELS": "gpt-4o-mini",
+            "AIHUBMIX_KEY": "sk-aihubmix-legacy",
+        }
+
+        with patch.dict(os.environ, env, clear=True):
+            config = Config._load_from_env()
+
+        self.assertEqual(config.llm_models_source, "llm_channels")
+        self.assertEqual(config.llm_channels[0]["api_keys"], ["sk-aihubmix-legacy"])
+        params = config.llm_model_list[0]["litellm_params"]
+        self.assertEqual(params["api_key"], "sk-aihubmix-legacy")
+        self.assertEqual(params["extra_headers"]["APP-Code"], "GPIJ3886")
+
+    @patch("src.config.setup_env")
+    @patch.object(Config, "_parse_litellm_yaml", return_value=[])
+    def test_openai_channel_falls_back_to_legacy_openai_key(self, _mock_parse_yaml, _mock_setup_env) -> None:
+        env = {
+            "LLM_CHANNELS": "openai",
+            "LLM_OPENAI_BASE_URL": "https://api.openai.com/v1",
+            "LLM_OPENAI_MODELS": "gpt-4o-mini",
+            "OPENAI_API_KEY": "sk-openai-legacy",
+        }
+
+        with patch.dict(os.environ, env, clear=True):
+            config = Config._load_from_env()
+
+        self.assertEqual(config.llm_models_source, "llm_channels")
+        self.assertEqual(config.llm_channels[0]["api_keys"], ["sk-openai-legacy"])
+        self.assertEqual(config.llm_channels[0]["models"], ["openai/gpt-4o-mini"])
+
+    @patch("src.config.setup_env")
+    @patch.object(Config, "_parse_litellm_yaml", return_value=[])
+    def test_gemini_channel_falls_back_to_legacy_gemini_key(self, _mock_parse_yaml, _mock_setup_env) -> None:
+        env = {
+            "LLM_CHANNELS": "gemini",
+            "LLM_GEMINI_MODELS": "gemini-2.5-flash",
+            "GEMINI_API_KEY": "sk-gemini-legacy",
+        }
+
+        with patch.dict(os.environ, env, clear=True):
+            config = Config._load_from_env()
+
+        self.assertEqual(config.llm_models_source, "llm_channels")
+        self.assertEqual(config.llm_channels[0]["api_keys"], ["sk-gemini-legacy"])
+        self.assertEqual(config.llm_channels[0]["models"], ["gemini/gemini-2.5-flash"])
+
+    @patch("src.config.setup_env")
+    @patch.object(Config, "_parse_litellm_yaml", return_value=[])
+    def test_anthropic_channel_falls_back_to_legacy_anthropic_key(self, _mock_parse_yaml, _mock_setup_env) -> None:
+        env = {
+            "LLM_CHANNELS": "claude",
+            "LLM_CLAUDE_MODELS": "claude-3-5-sonnet",
+            "ANTHROPIC_API_KEY": "sk-anthropic-legacy",
+        }
+
+        with patch.dict(os.environ, env, clear=True):
+            config = Config._load_from_env()
+
+        self.assertEqual(config.llm_models_source, "llm_channels")
+        self.assertEqual(config.llm_channels[0]["protocol"], "anthropic")
+        self.assertEqual(config.llm_channels[0]["api_keys"], ["sk-anthropic-legacy"])
+        self.assertEqual(config.llm_channels[0]["models"], ["anthropic/claude-3-5-sonnet"])
+
+    @patch("src.config.setup_env")
+    @patch.object(Config, "_parse_litellm_yaml", return_value=[])
+    def test_custom_openai_compatible_channel_does_not_fall_back_to_legacy_keys(self, _mock_parse_yaml, _mock_setup_env) -> None:
+        env = {
+            "LLM_CHANNELS": "my_proxy",
+            "LLM_MY_PROXY_PROTOCOL": "openai",
+            "LLM_MY_PROXY_BASE_URL": "https://proxy.example.com/v1",
+            "LLM_MY_PROXY_MODELS": "gpt-4o-mini",
+            "OPENAI_API_KEY": "sk-openai-legacy",
+        }
+
+        with patch.dict(os.environ, env, clear=True):
+            config = Config._load_from_env()
+
+        self.assertEqual(config.llm_channels, [])
+        self.assertEqual(config.llm_models_source, "legacy_env")
+        self.assertEqual(config.llm_model_list[0]["model_name"], "__legacy_openai__")
+
+    @patch("src.config.setup_env")
+    @patch.object(Config, "_parse_litellm_yaml", return_value=[])
     def test_llm_temperature_falls_back_to_legacy_provider_temperature(self, _mock_parse_yaml, _mock_setup_env) -> None:
         env = {
             "GEMINI_API_KEY": "secret-key-value",

--- a/tests/test_llm_channel_config.py
+++ b/tests/test_llm_channel_config.py
@@ -284,6 +284,23 @@ class LLMChannelConfigTestCase(unittest.TestCase):
 
     @patch("src.config.setup_env")
     @patch.object(Config, "_parse_litellm_yaml", return_value=[])
+    def test_http_base_url_blocks_legacy_key_fallback(self, _mock_parse_yaml, _mock_setup_env) -> None:
+        """Plaintext HTTP base URLs must not trigger host-based legacy key fallback."""
+        env = {
+            "LLM_CHANNELS": "openai",
+            "LLM_OPENAI_BASE_URL": "http://api.openai.com/v1",
+            "LLM_OPENAI_MODELS": "gpt-4o-mini",
+            "OPENAI_API_KEY": "sk-openai-secret",
+        }
+
+        with patch.dict(os.environ, env, clear=True):
+            config = Config._load_from_env()
+
+        self.assertEqual(config.llm_channels, [])
+        self.assertEqual(config.llm_models_source, "legacy_env")
+
+    @patch("src.config.setup_env")
+    @patch.object(Config, "_parse_litellm_yaml", return_value=[])
     def test_custom_openai_compatible_channel_does_not_fall_back_to_legacy_keys(self, _mock_parse_yaml, _mock_setup_env) -> None:
         env = {
             "LLM_CHANNELS": "my_proxy",

--- a/tests/test_llm_channel_config.py
+++ b/tests/test_llm_channel_config.py
@@ -319,6 +319,58 @@ class LLMChannelConfigTestCase(unittest.TestCase):
 
     @patch("src.config.setup_env")
     @patch.object(Config, "_parse_litellm_yaml", return_value=[])
+    def test_custom_channel_with_official_anthropic_host_infers_anthropic_protocol(self, _mock_parse_yaml, _mock_setup_env) -> None:
+        env = {
+            "LLM_CHANNELS": "my_claude",
+            "LLM_MY_CLAUDE_BASE_URL": "https://api.anthropic.com/v1",
+            "LLM_MY_CLAUDE_MODELS": "claude-3-5-sonnet",
+            "ANTHROPIC_API_KEY": "sk-anthropic-legacy",
+        }
+
+        with patch.dict(os.environ, env, clear=True):
+            config = Config._load_from_env()
+
+        self.assertEqual(config.llm_channels[0]["protocol"], "anthropic")
+        self.assertEqual(config.llm_channels[0]["models"], ["anthropic/claude-3-5-sonnet"])
+        self.assertEqual(config.llm_channels[0]["api_keys"], ["sk-anthropic-legacy"])
+
+    @patch("src.config.setup_env")
+    @patch.object(Config, "_parse_litellm_yaml", return_value=[])
+    def test_custom_channel_without_base_url_does_not_match_protocol_override_legacy_fallback(self, _mock_parse_yaml, _mock_setup_env) -> None:
+        env = {
+            "LLM_CHANNELS": "my_proxy",
+            "LLM_MY_PROXY_PROTOCOL": "openai",
+            "LLM_MY_PROXY_MODELS": "gpt-4o-mini",
+            "OPENAI_API_KEY": "sk-openai-legacy",
+        }
+
+        with patch.dict(os.environ, env, clear=True):
+            config = Config._load_from_env()
+
+        self.assertEqual(config.llm_channels, [])
+        self.assertEqual(config.llm_models_source, "legacy_env")
+
+    @patch("src.config.setup_env")
+    @patch.object(Config, "_parse_litellm_yaml", return_value=[])
+    def test_explicit_protocol_override_selects_legacy_key_by_protocol(self, _mock_parse_yaml, _mock_setup_env) -> None:
+        """When LLM_{NAME}_PROTOCOL differs from channel name, legacy key
+        fallback should match the resolved protocol, not the channel name."""
+        env = {
+            "LLM_CHANNELS": "gemini",
+            "LLM_GEMINI_PROTOCOL": "openai",
+            "LLM_GEMINI_MODELS": "gpt-4o-mini",
+            "GEMINI_API_KEY": "sk-gemini-wrong",
+            "OPENAI_API_KEY": "sk-openai-correct",
+        }
+
+        with patch.dict(os.environ, env, clear=True):
+            config = Config._load_from_env()
+
+        self.assertEqual(config.llm_channels[0]["protocol"], "openai")
+        self.assertEqual(config.llm_channels[0]["api_keys"], ["sk-openai-correct"])
+
+    @patch("src.config.setup_env")
+    @patch.object(Config, "_parse_litellm_yaml", return_value=[])
     def test_llm_temperature_falls_back_to_legacy_provider_temperature(self, _mock_parse_yaml, _mock_setup_env) -> None:
         env = {
             "GEMINI_API_KEY": "secret-key-value",

--- a/tests/test_llm_channel_config.py
+++ b/tests/test_llm_channel_config.py
@@ -229,6 +229,44 @@ class LLMChannelConfigTestCase(unittest.TestCase):
 
     @patch("src.config.setup_env")
     @patch.object(Config, "_parse_litellm_yaml", return_value=[])
+    def test_aihubmix_prefers_aihubmix_key_over_openai_keys(self, _mock_parse_yaml, _mock_setup_env) -> None:
+        """When both AIHUBMIX_KEY and OPENAI_API_KEYS exist, AIHUBMIX_KEY wins."""
+        env = {
+            "LLM_CHANNELS": "aihubmix",
+            "LLM_AIHUBMIX_BASE_URL": "https://api.aihubmix.com/v1",
+            "LLM_AIHUBMIX_MODELS": "gpt-4o-mini",
+            "AIHUBMIX_KEY": "sk-aihubmix-correct",
+            "OPENAI_API_KEYS": "sk-openai-wrong-1,sk-openai-wrong-2",
+            "OPENAI_API_KEY": "sk-openai-wrong-single",
+        }
+
+        with patch.dict(os.environ, env, clear=True):
+            config = Config._load_from_env()
+
+        self.assertEqual(config.llm_channels[0]["api_keys"], ["sk-aihubmix-correct"])
+        self.assertEqual(config.llm_model_list[0]["litellm_params"]["api_key"], "sk-aihubmix-correct")
+
+    @patch("src.config.setup_env")
+    @patch.object(Config, "_parse_litellm_yaml", return_value=[])
+    def test_spoofed_host_does_not_trigger_legacy_key_fallback(self, _mock_parse_yaml, _mock_setup_env) -> None:
+        """Attacker-controlled domains like api.openai.com.evil.tld must not receive legacy keys."""
+        env = {
+            "LLM_CHANNELS": "evil",
+            "LLM_EVIL_PROTOCOL": "openai",
+            "LLM_EVIL_BASE_URL": "https://api.openai.com.evil.tld/v1",
+            "LLM_EVIL_MODELS": "gpt-4o-mini",
+            "OPENAI_API_KEY": "sk-openai-secret",
+        }
+
+        with patch.dict(os.environ, env, clear=True):
+            config = Config._load_from_env()
+
+        # Channel should be skipped (no key resolved), falling back to legacy_env
+        self.assertEqual(config.llm_channels, [])
+        self.assertEqual(config.llm_models_source, "legacy_env")
+
+    @patch("src.config.setup_env")
+    @patch.object(Config, "_parse_litellm_yaml", return_value=[])
     def test_custom_openai_compatible_channel_does_not_fall_back_to_legacy_keys(self, _mock_parse_yaml, _mock_setup_env) -> None:
         env = {
             "LLM_CHANNELS": "my_proxy",

--- a/tests/test_system_config_api.py
+++ b/tests/test_system_config_api.py
@@ -282,13 +282,23 @@ class SystemConfigApiTestCase(unittest.TestCase):
                     base_url="https://api.example.com/v1",
                     api_key="sk-test",
                     models=["gpt-4o-mini"],
+                    effective_map={"DEEPSEEK_API_KEY": "sk-draft"},
                 ),
                 service=self.service,
             ).model_dump()
 
         self.assertTrue(payload["success"])
         self.assertEqual(payload["resolved_model"], "openai/gpt-4o-mini")
-        mock_test.assert_called_once()
+        mock_test.assert_called_once_with(
+            name="primary",
+            protocol="openai",
+            base_url="https://api.example.com/v1",
+            api_key="sk-test",
+            models=["gpt-4o-mini"],
+            enabled=True,
+            timeout_seconds=20.0,
+            effective_map={"DEEPSEEK_API_KEY": "sk-draft"},
+        )
 
     def test_validate_returns_user_facing_model_message_without_internal_env_key_name(self) -> None:
         validation = self.service.validate(
@@ -326,13 +336,22 @@ class SystemConfigApiTestCase(unittest.TestCase):
                     protocol="openai",
                     base_url="https://dashscope.aliyuncs.com/compatible-mode/v1",
                     api_key="sk-test",
+                    effective_map={"DEEPSEEK_API_KEY": "sk-draft"},
                 ),
                 service=self.service,
             ).model_dump()
 
         self.assertTrue(payload["success"])
         self.assertEqual(payload["models"], ["qwen-plus", "qwen-turbo"])
-        mock_discover.assert_called_once()
+        mock_discover.assert_called_once_with(
+            name="dashscope",
+            protocol="openai",
+            base_url="https://dashscope.aliyuncs.com/compatible-mode/v1",
+            api_key="sk-test",
+            models=[],
+            timeout_seconds=20.0,
+            effective_map={"DEEPSEEK_API_KEY": "sk-draft"},
+        )
 
 
 if __name__ == "__main__":

--- a/tests/test_system_config_service.py
+++ b/tests/test_system_config_service.py
@@ -278,6 +278,45 @@ class SystemConfigServiceTestCase(unittest.TestCase):
         self.assertTrue(validation["valid"], validation["issues"])
         self.assertEqual(validation["issues"], [])
 
+    def test_validate_accepts_channel_with_legacy_deepseek_key_fallback(self) -> None:
+        validation = self.service.validate(
+            items=[
+                {"key": "LLM_CHANNELS", "value": "deepseek"},
+                {"key": "LLM_DEEPSEEK_BASE_URL", "value": "https://api.deepseek.com/v1"},
+                {"key": "LLM_DEEPSEEK_MODELS", "value": "deepseek-chat"},
+                {"key": "DEEPSEEK_API_KEY", "value": "sk-deepseek-legacy"},
+            ]
+        )
+
+        self.assertTrue(validation["valid"])
+        self.assertFalse(any(issue["code"] == "missing_api_key" for issue in validation["issues"]))
+
+    def test_validate_accepts_custom_channel_with_official_anthropic_host_legacy_fallback(self) -> None:
+        validation = self.service.validate(
+            items=[
+                {"key": "LLM_CHANNELS", "value": "my_claude"},
+                {"key": "LLM_MY_CLAUDE_BASE_URL", "value": "https://api.anthropic.com/v1"},
+                {"key": "LLM_MY_CLAUDE_MODELS", "value": "claude-3-5-sonnet"},
+                {"key": "ANTHROPIC_API_KEY", "value": "sk-anthropic-legacy"},
+            ]
+        )
+
+        self.assertTrue(validation["valid"])
+        self.assertFalse(any(issue["code"] == "missing_api_key" for issue in validation["issues"]))
+
+    def test_validate_rejects_custom_channel_without_base_url_protocol_override_no_legacy_fallback(self) -> None:
+        validation = self.service.validate(
+            items=[
+                {"key": "LLM_CHANNELS", "value": "my_proxy"},
+                {"key": "LLM_MY_PROXY_PROTOCOL", "value": "openai"},
+                {"key": "LLM_MY_PROXY_MODELS", "value": "gpt-4o-mini"},
+                {"key": "OPENAI_API_KEY", "value": "sk-openai-legacy"},
+            ]
+        )
+
+        self.assertFalse(validation["valid"])
+        self.assertTrue(any(issue["code"] == "missing_api_key" for issue in validation["issues"]))
+
     def test_validate_reports_unknown_primary_model_for_channels(self) -> None:
         validation = self.service.validate(
             items=[
@@ -653,6 +692,50 @@ class SystemConfigServiceTestCase(unittest.TestCase):
         self.assertFalse(mock_get.call_args.kwargs["allow_redirects"])
 
     @patch("src.services.system_config_service.requests.get")
+    def test_discover_llm_channel_models_uses_legacy_env_key_when_request_key_empty(self, mock_get) -> None:
+        with patch.dict(os.environ, {"DEEPSEEK_API_KEY": "sk-deepseek-legacy"}, clear=False):
+            mock_response = Mock()
+            mock_response.ok = True
+            mock_response.status_code = 200
+            mock_response.json.return_value = {"data": [{"id": "deepseek-chat"}]}
+            mock_get.return_value = mock_response
+
+            payload = self.service.discover_llm_channel_models(
+                name="deepseek",
+                protocol="deepseek",
+                base_url="https://api.deepseek.com/v1",
+                api_key="",
+            )
+
+            self.assertTrue(payload["success"])
+            self.assertEqual(
+                mock_get.call_args.kwargs["headers"]["Authorization"],
+                "Bearer sk-deepseek-legacy",
+            )
+
+    @patch("src.services.system_config_service.requests.get")
+    def test_discover_llm_channel_models_uses_effective_map_legacy_key_when_request_key_empty(self, mock_get) -> None:
+        mock_response = Mock()
+        mock_response.ok = True
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"data": [{"id": "deepseek-chat"}]}
+        mock_get.return_value = mock_response
+
+        payload = self.service.discover_llm_channel_models(
+            name="deepseek",
+            protocol="deepseek",
+            base_url="https://api.deepseek.com/v1",
+            api_key="",
+            effective_map={"DEEPSEEK_API_KEY": "sk-deepseek-draft"},
+        )
+
+        self.assertTrue(payload["success"])
+        self.assertEqual(
+            mock_get.call_args.kwargs["headers"]["Authorization"],
+            "Bearer sk-deepseek-draft",
+        )
+
+    @patch("src.services.system_config_service.requests.get")
     def test_discover_llm_channel_models_rejects_redirect_responses(self, mock_get) -> None:
         mock_response = Mock()
         mock_response.ok = True
@@ -695,12 +778,79 @@ class SystemConfigServiceTestCase(unittest.TestCase):
         self.assertEqual(payload["resolved_protocol"], "gemini")
         self.assertIn("does not support /models discovery yet", payload["error"])
 
+    def test_discover_llm_channel_models_rejects_official_anthropic_host_as_unsupported(self) -> None:
+        with patch.dict(os.environ, {"ANTHROPIC_API_KEY": "sk-anthropic-legacy"}, clear=False):
+            payload = self.service.discover_llm_channel_models(
+                name="my_claude",
+                protocol="",
+                base_url="https://api.anthropic.com/v1",
+                api_key="",
+                models=["claude-3-5-sonnet"],
+            )
+
+        self.assertFalse(payload["success"])
+        self.assertEqual(payload["resolved_protocol"], "anthropic")
+        self.assertIn("does not support /models discovery yet", payload["error"])
+
     def test_build_llm_models_url_strips_query_and_fragment(self) -> None:
         models_url = SystemConfigService._build_llm_models_url(
             "https://example.com/v1/chat/completions?api-version=1#frag"
         )
 
         self.assertEqual(models_url, "https://example.com/v1/models")
+
+    def test_test_llm_channel_uses_legacy_env_key_when_request_key_empty(self) -> None:
+        with patch("litellm.completion") as mock_completion, patch.dict(
+            os.environ,
+            {"AIHUBMIX_KEY": "sk-aihubmix-legacy"},
+            clear=False,
+        ):
+            mock_completion.return_value = type(
+                "MockResponse",
+                (),
+                {
+                    "choices": [type("Choice", (), {"message": type("Message", (), {"content": "OK"})()})()],
+                },
+            )()
+
+            payload = self.service.test_llm_channel(
+                name="aihubmix",
+                protocol="openai",
+                base_url="https://api.aihubmix.com/v1",
+                api_key="",
+                models=["gpt-4o-mini"],
+            )
+
+            self.assertTrue(payload["success"])
+            self.assertEqual(
+                mock_completion.call_args.kwargs.get("api_key"),
+                "sk-aihubmix-legacy",
+            )
+
+    @patch("litellm.completion")
+    def test_test_llm_channel_uses_effective_map_legacy_key_when_request_key_empty(self, mock_completion) -> None:
+        mock_completion.return_value = type(
+            "MockResponse",
+            (),
+            {
+                "choices": [type("Choice", (), {"message": type("Message", (), {"content": "OK"})()})()],
+            },
+        )()
+
+        payload = self.service.test_llm_channel(
+            name="deepseek",
+            protocol="deepseek",
+            base_url="https://api.deepseek.com/v1",
+            api_key="",
+            models=["deepseek-chat"],
+            effective_map={"DEEPSEEK_API_KEY": "sk-deepseek-draft"},
+        )
+
+        self.assertTrue(payload["success"])
+        self.assertEqual(
+            mock_completion.call_args.kwargs.get("api_key"),
+            "sk-deepseek-draft",
+        )
 
     def test_validate_reports_invalid_event_rule_semantics(self) -> None:
         validation = self.service.validate(items=[{


### PR DESCRIPTION
## PR Type
- [ ] fix
- [x] feat
- [ ] refactor
- [ ] docs
- [ ] chore
- [ ] test

## Background And Problem
- 当前问题：在不修改 GitHub Actions workflow 的前提下，让仓库可用现有 Secrets 安全驱动多渠道 LLM 配置，避免把真实 API Key 写进 `.env`。
- 影响范围：本次改动涉及 16 个文件，Diff 为 `+806 / -48`。
- 触发来源：Issue 自动执行（Issue #872）。

## Scope Of Change
- `.codex`
- `api/v1/endpoints/system_config.py`
- `api/v1/schemas/system_config.py`
- `apps/dsa-web/src/api/systemConfig.ts`
- `apps/dsa-web/src/components/settings/LLMChannelEditor.tsx`
- `apps/dsa-web/src/types/systemConfig.ts`
- `docs/CHANGELOG.md`
- `docs/FAQ.md`
- `docs/FAQ_EN.md`
- `docs/LLM_CONFIG_GUIDE.md`
- `docs/LLM_CONFIG_GUIDE_EN.md`
- `src/config.py`
- ... and 4 more files

## Documentation And Changelog
- 已同步更新文档/变更记录：`docs/CHANGELOG.md`, `docs/FAQ.md`, `docs/FAQ_EN.md`, `docs/LLM_CONFIG_GUIDE.md`, `docs/LLM_CONFIG_GUIDE_EN.md`。

## Issue Link
Closes #872

## Verification Commands And Results
```bash
./scripts/ci_gate.sh flake8
```

关键输出/结论 / Key output & conclusion:
- lint:PASS

## Compatibility And Risk
- **High**：涉及 `.codex`, `api/v1/endpoints/system_config.py`, `api/v1/schemas/system_config.py`, `apps/dsa-web/src/api/systemConfig.ts`, `apps/dsa-web/src/components/settings/LLMChannelEditor.tsx`, `apps/dsa-web/src/types/systemConfig.ts`，请重点审查变更范围、验证覆盖与发布影响。
- 前提假设：
  - 运行时会加载一个不含真实密钥的默认 `.env`，其中已包含 `LLM_CHANNELS`、各渠道 `BASE_URL/MODELS` 以及 `LITELLM_MODEL`、`AGENT_LITELLM_MODEL`、`LITELLM_FALLBACK_MODELS` 等非敏感项。
  - 当前 GitHub Actions 已注入 `DEEPSEEK_API_KEY`、`AIHUBMIX_KEY`、`OPENAI_API_KEY`、`GEMINI_API_KEY`、`ANTHROPIC_API_KEY` 等 legacy 名称，但不会自动注入任意 `LLM_<NAME>_API_KEY`。
  - 本次保守范围只补齐常见 provider channel 对 legacy secrets 的回退读取；任意自定义 channel 名在 GitHub Actions 中仍建议走 `LITELLM_CONFIG_YAML`。

## Rollback Plan
- `git revert <merge-commit>` 回滚本 PR 提交，重点确认 `.codex`, `api/v1/endpoints/system_config.py`, `api/v1/schemas/system_config.py`, `apps/dsa-web/src/api/systemConfig.ts` 恢复正常。

## Acceptance Criteria
- 当 `.env` 中声明 `LLM_CHANNELS=deepseek,aihubmix`，且进程环境只提供 `DEEPSEEK_API_KEY` 与 `AIHUBMIX_KEY`/`OPENAI_API_KEY` 时，`Config._load_from_env()` 仍能生成有效的 `llm_channels` 和 `llm_model_list`，并将 `llm_models_source` 识别为 `llm_channels`。
- 显式配置的 `LLM_<NAME>_API_KEYS`/`LLM_<NAME>_API_KEY` 仍保持最高优先级；只有在渠道级 key 缺失时才回退到对应 legacy provider keys，避免破坏现有本地配置语义。
- DeepSeek、AIHubMix/OpenAI-compatible、Gemini、Anthropic 的渠道回退行为有单元测试覆盖，且缺少 key 的自定义 channel 仍会被安全跳过。
- GitHub Actions 用户无需再把真实 `LLM_DEEPSEEK_API_KEY` 或 `LLM_AIHUBMIX_API_KEY` 写入 `.env`；文档明确说明应把真实密钥放在已有 legacy secret 名下，并说明自定义渠道在 Actions 中应改用 `LITELLM_CONFIG_YAML`。
- 相关中文文档、英文镜像文档和 `docs/CHANGELOG.md` 的 `[Unreleased]` 均同步更新，且 changelog 使用扁平条目格式。

## Implementation
已修复评审提到的核心不一致问题：`test_llm_channel` / `discover_llm_channel_models` 现在在缺少请求内 `api_key` 时，会优先从同一次请求的 `effective_map` 读取 legacy key 回退，而非只读进程环境变量。
已把该 `effective_map` 从前端到后端链路贯通（`system_config` schema → endpoint → service），并补充 Web 侧在 `LLMChannelEditor` 的测试/模型发现请求中携带当前表单 `items`。
新增/调整了 `test_system_config_service.py` 与 `test_system_config_api.py` 的回归用例，覆盖 `effective_map` 的透传与 fallback 行为一致性。
验证结果：`pytest -q tests/test_system_config_service.py tests/test_system_config_api.py` 全部通过（81 passed）；`cd apps/dsa-web && npm run test -- src/components/settings/__tests__/LLMChannelEditor.test.tsx` 全部通过（1 file, 9 passed）。

## Notes
- Risk is marked as high. Please review scope, validation coverage, and release impact carefully.

## Checklist
- [x] 本 PR 有明确动机和业务价值 / This PR has a clear motivation and value
- [x] 已提供可复现的验证命令与结果 / Reproducible verification commands and results are included
- [x] 已评估兼容性与风险 / Compatibility and risk have been assessed
- [x] 已提供回滚方案 / A rollback plan is provided
- [x] 已同步更新相关文档与 `docs/CHANGELOG.md`，并在 PR 描述中说明文档落点 / Relevant docs and `docs/CHANGELOG.md` are updated, and the documentation location is stated in this PR