### PR TITLE
fix: 在 ask.py 的 _load_skills() 和… (#968)

### DIFF
--- a/bot/commands/ask.py
+++ b/bot/commands/ask.py
@@ -128,7 +128,8 @@ class AskCommand(BotCommand):
 
             sm = get_skill_manager()
             return list(sm.list_skills())
-        except Exception:
+        except Exception as e:
+            logger.warning("_load_skills failed: %s", e, exc_info=True)
             return []
 
     @classmethod
@@ -137,7 +138,8 @@ class AskCommand(BotCommand):
             from src.agent.skills.defaults import get_primary_default_skill_id
 
             return get_primary_default_skill_id(cls._load_skills())
-        except Exception:
+        except Exception as e:
+            logger.warning("_get_default_skill_id failed: %s", e, exc_info=True)
             return ""
 
     @classmethod

--- a/tests/test_ask_command.py
+++ b/tests/test_ask_command.py
@@ -344,5 +344,26 @@ class TestAskCommandMultiStock(unittest.TestCase):
         self.assertEqual(captured["context"]["strategies"], ["chan_theory"])
 
 
+class TestAskCommandSilentExceptionFix(unittest.TestCase):
+    """Verify that _load_skills and _get_default_skill_id log warnings on failure."""
+
+    def test_load_skills_logs_warning_and_returns_empty_list(self):
+        boom = RuntimeError("skill manager unavailable")
+        with patch("src.agent.factory.get_skill_manager", side_effect=boom):
+            with self.assertLogs("bot.commands.ask", level="WARNING") as cm:
+                result = AskCommand._load_skills()
+        self.assertEqual(result, [])
+        self.assertTrue(any("_load_skills failed" in line for line in cm.output))
+
+    def test_get_default_skill_id_logs_warning_and_returns_empty_string(self):
+        boom = RuntimeError("defaults unavailable")
+        with patch.object(AskCommand, "_load_skills", return_value=[]):
+            with patch("src.agent.skills.defaults.get_primary_default_skill_id", side_effect=boom):
+                with self.assertLogs("bot.commands.ask", level="WARNING") as cm:
+                    result = AskCommand._get_default_skill_id()
+        self.assertEqual(result, "")
+        self.assertTrue(any("_get_default_skill_id failed" in line for line in cm.output))
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## PR Type
- [x] fix
- [ ] feat
- [ ] refactor
- [ ] docs
- [ ] chore
- [ ] test

## Background And Problem
- 当前问题：在 ask.py 的 _load_skills() 和 _get_default_skill_id() 两处 except Exception 块中补加 logger.warning 日志，保留降级行为的同时使异常可观测。
- 影响范围：本次改动涉及 2 个文件，Diff 为 `+25 / -2`。
- 触发来源：Issue 自动执行（Issue #968）。

## Scope Of Change
- `bot/commands/ask.py`
- `tests/test_ask_command.py`

## Documentation And Changelog
- 当前补丁未包含 `README.md`、`docs/` 或 `docs/CHANGELOG.md` 更新；如果本次变更涉及 CLI、API、配置、日志语义或其他用户可见行为，请在合并前补充原因与文档落点。

## Issue Link
Closes #968

## Verification Commands And Results
```bash
./scripts/ci_gate.sh flake8
./scripts/ci_gate.sh offline-tests
```

关键输出/结论 / Key output & conclusion:
- lint:PASS, test:PASS

## Compatibility And Risk
- **Low**：涉及 `bot/commands/ask.py`, `tests/test_ask_command.py`，未识别额外兼容性风险。
- 前提假设：
  - 文件顶部已有 logger = logging.getLogger(__name__)，无需新增 import。
  - 不需要将返回值从空列表/空字符串改为 None，只补日志即可满足 issue 要求；若维护者后续希望改返回类型，可另开 PR。
  - issue 未要求修改其他 except Exception 块（第252、313、328、343、656、669行），本次只修复明确提到的两处静默块。

## Rollback Plan
- `git revert <merge-commit>` 回滚本 PR 提交，重点确认 `bot/commands/ask.py`, `tests/test_ask_command.py` 恢复正常。

## Acceptance Criteria
- _load_skills() 捕获异常时输出 logger.warning，包含 exc_info=True，并仍返回空列表。
- _get_default_skill_id() 捕获异常时输出 logger.warning，包含 exc_info=True，并仍返回空字符串。
- python -m py_compile bot/commands/ask.py 通过，无语法错误。
- 现有测试套件（pytest -m 'not network'）不回归。

## Implementation
● Search (grep)
  │ "def _load_skills|def _get_default_skill_id|except Exception" (bot/commands/ask.py)
  └ 10 lines found

● Read ask.py
  │ bot/commands/ask.py
  └ L120:150 (31 lines read)

● Search (glob)
  │ "tests/test_*ask*.py"
  └ 2 files found

● Read test_ask_command.py
  │ tests/test_ask_command.py
  └ 348 lines read

● Read ask.py
  │ bot/commands/ask.py
  └ L1:30 (30 lines read)

Now I have everything I need. Let me make the two targeted fixes and add test coverage:

● Edit ask.py +4 -2
  └ bot/commands/ask.py

Now add regression tests for the two warning paths:

● Read test_ask_command.py
  │ tests/test_ask_command.py
  └ L343:349 (6 lines read)

● Edit test_ask_command.py +21
  └ tests/test_ask_command.py

● Check syntax of changed files (shell)
  │ cd /tmp/autocode-runs/autocode-issue-968-bug-bot-ask-1775080236 && python -m py_compile
  │ bot/commands/ask.py && python -m py_compile tests/test_ask_command.py && echo "syntax OK"
  └ 2 lines...

● Run ask command tests (shell)
  │ cd /tmp/autocode-runs/autocode-issue-968-bug-bot-ask-1775080236 && python -m pytest
  │ tests/test_ask_command.py -q 2>&1 | tail -20
  └ 12 lines...

所有 14 个测试通过。

---

**实现摘要：**

1. **`bot/commands/ask.py`** — 在 `_load_skills()` 和 `_get_default_skill_id()` 的 `except Exception` 块中分别绑定异常变量 `as e`，并补加 `logger.warning("... failed: %s", e, exc_info=True)`；降级返回值（`[]`/`""`）保持不变。

2. **`tests/test_ask_command.py`** — 新增 `TestAskCommandSilentExceptionFix` 测试类，覆盖两处修复点：mock 触发异常后断言 `WARNING` 日志包含预期关键字，且返回值仍为空列表/空字符串。

3. `python -m py_compile` 语法检查通过，`pytest tests/test_ask_command.py` 全部 14 条用例通过。

## Checklist
- [x] 本 PR 有明确动机和业务价值 / This PR has a clear motivation and value
- [x] 已提供可复现的验证命令与结果 / Reproducible verification commands and results are included
- [x] 已评估兼容性与风险 / Compatibility and risk have been assessed
- [x] 已提供回滚方案 / A rollback plan is provided
- [ ] 文档与 `docs/CHANGELOG.md` 同步仍需确认；如涉及用户可见变更，请在合并前补充原因与文档落点 / Documentation and `docs/CHANGELOG.md` sync still needs confirmation before merge when user-visible behavior changes