### PR TITLE
fix: pin get_market_now in realtime indicator tests to avoid CST/UTC date shift

### DIFF
--- a/tests/test_pipeline_realtime_indicators.py
+++ b/tests/test_pipeline_realtime_indicators.py
@@ -11,7 +11,7 @@ Covers:
 import os
 import sys
 import unittest
-from datetime import date, timedelta
+from datetime import date, datetime, timedelta, timezone
 from unittest.mock import MagicMock, patch
 
 import pandas as pd
@@ -114,26 +114,40 @@ class TestAugmentHistoricalWithRealtime(unittest.TestCase):
         self.assertEqual(len(result), 1)
         self.assertNotIn("close", result.columns)
 
+    @patch("src.core.pipeline.get_market_now")
     @patch("src.core.pipeline.is_market_open", return_value=True)
     @patch("src.core.pipeline.get_market_for_stock", return_value="cn")
     def test_appends_row_when_last_date_before_today(
-        self, _mock_market, _mock_open
+        self, _mock_market, _mock_open, mock_now
     ) -> None:
-        df = _make_historical_df(last_date=date.today() - timedelta(days=1))
+        today = date.today()
+        # Pin market clock to today (UTC) so the pipeline's market_today == date.today(),
+        # regardless of which timezone get_market_now would normally use (e.g. CST=UTC+8).
+        mock_now.return_value = datetime(
+            today.year, today.month, today.day, 10, 0, tzinfo=timezone.utc
+        )
+        df = _make_historical_df(last_date=today - timedelta(days=1))
         quote = _make_realtime_quote(price=15.72)
         result = self.pipeline._augment_historical_with_realtime(df, quote, "600519")
         self.assertEqual(len(result), len(df) + 1)
         last = result.iloc[-1]
         self.assertEqual(last["close"], 15.72)
-        self.assertEqual(last["date"], date.today())
+        self.assertEqual(last["date"], today)
 
+    @patch("src.core.pipeline.get_market_now")
     @patch("src.core.pipeline.is_market_open", return_value=True)
     @patch("src.core.pipeline.get_market_for_stock", return_value="cn")
     def test_updates_last_row_when_last_date_is_today(
-        self, _mock_market, _mock_open
+        self, _mock_market, _mock_open, mock_now
     ) -> None:
-        df = _make_historical_df(last_date=date.today(), days=25)
-        df.loc[df.index[-1], "date"] = date.today()
+        today = date.today()
+        # Pin market clock to today so last_date >= market_today and the row is updated
+        # rather than appended (avoids off-by-one when CI runs after market closes in CST).
+        mock_now.return_value = datetime(
+            today.year, today.month, today.day, 10, 0, tzinfo=timezone.utc
+        )
+        df = _make_historical_df(last_date=today, days=25)
+        df.loc[df.index[-1], "date"] = today
         quote = _make_realtime_quote(price=16.0)
         result = self.pipeline._augment_historical_with_realtime(df, quote, "600519")
         self.assertEqual(len(result), len(df))
@@ -170,10 +184,20 @@ class TestEnhanceContextRealtimeOverride(unittest.TestCase):
             self.config = Config._load_from_env()
         self.pipeline = StockAnalysisPipeline(config=self.config)
 
-    def test_today_overridden_when_realtime_and_trend_exist(self) -> None:
+    @patch("src.core.pipeline.get_market_now")
+    @patch("src.core.pipeline.get_market_for_stock", return_value="cn")
+    def test_today_overridden_when_realtime_and_trend_exist(
+        self, _mock_market, mock_now
+    ) -> None:
+        today = date.today()
+        # Pin market clock so _enhance_context sets enhanced['date'] == date.today().isoformat()
+        # regardless of which timezone get_market_now would normally use (e.g. CST=UTC+8).
+        mock_now.return_value = datetime(
+            today.year, today.month, today.day, 10, 0, tzinfo=timezone.utc
+        )
         context = {
             "code": "600519",
-            "date": (date.today() - timedelta(days=1)).isoformat(),
+            "date": (today - timedelta(days=1)).isoformat(),
             "today": {"close": 15.0, "ma5": 14.8, "ma10": 14.5},
             "yesterday": {"close": 14.5, "volume": 1000000},
         }
@@ -193,7 +217,7 @@ class TestEnhanceContextRealtimeOverride(unittest.TestCase):
         self.assertEqual(enhanced["today"]["ma10"], 15.2)
         self.assertEqual(enhanced["today"]["ma20"], 14.9)
         self.assertIn("多头", enhanced["ma_status"])
-        self.assertEqual(enhanced["date"], date.today().isoformat())
+        self.assertEqual(enhanced["date"], today.isoformat())
         self.assertIn("price_change_ratio", enhanced)
         self.assertIn("volume_change_ratio", enhanced)
 


### PR DESCRIPTION
## PR Type
- [x] fix

## Background And Problem

3 tests in `tests/test_pipeline_realtime_indicators.py` were flaking whenever CI runs after ~16:00 UTC:

```
FAILED test_appends_row_when_last_date_before_today   → datetime.date(2026-04-02) != datetime.date(2026-04-01)
FAILED test_updates_last_row_when_last_date_is_today  → 26 != 25  (row appended instead of updated)
FAILED test_today_overridden_when_realtime_and_trend_exist → '2026-04-02' != '2026-04-01'
```

**根因**：测试用 `date.today()`（CI 服务器 = UTC）做数据构造和断言，但 pipeline 调用 `get_market_now(market).date()`（市场本地时区；CN = CST = UTC+8）。UTC 16:00 之后 CST 时钟已是次日，导致 pipeline 的 "today" 与测试的 `date.today()` 相差一天。

**引入时间**：`c66fd3cf` — _[feature] 盘中实时分析 Issue #234 (#397)_（2026-02-25）

**影响**：这 3 个预存 flaky 测试导致本次无关的 PR #971 / #972 的 backend-gate 失败，这两个 PR 自身代码完全正确。

## Scope Of Change

- 仅 `tests/test_pipeline_realtime_indicators.py`，不涉及任何生产代码

## Fix

对 3 个受影响测试增加 `@patch('src.core.pipeline.get_market_now')`，将返回值固定为 `datetime(today.year, today.month, today.day, 10, 0, tzinfo=timezone.utc)`，使 pipeline 内部的 `market_today` 始终与测试的 `date.today()` 保持一致，不受 CI 运行时间影响。

## Verification Commands And Results

```bash
python -m pytest tests/test_pipeline_realtime_indicators.py -v
# 14 passed in 3.94s
```

## Compatibility And Risk
- **None** — 纯测试改动，不影响任何生产行为

## Rollback Plan
- `git revert` 本提交；flaky 失败恢复但属预存问题