### PR TITLE
fix: 缺失值判断逻辑不应静默吞掉非预期异常 (#996)

### DIFF
--- a/data_provider/base.py
+++ b/data_provider/base.py
@@ -680,6 +680,14 @@ class DataFetcherManager:
         try:
             isna_result = pd.isna(value)
         except (TypeError, ValueError) as exc:
+            if hasattr(value, "__array__"):
+                logger.debug(
+                    "[%s] pd.isna failed for array-like object; re-raise: value_type=%s error_type=%s",
+                    context,
+                    type(value).__name__,
+                    type(exc).__name__,
+                )
+                raise
             logger.debug(
                 "[%s] pd.isna fallback: value_type=%s error_type=%s",
                 context,
@@ -1813,7 +1821,7 @@ class DataFetcherManager:
                 return False
             return any(
                 DataFetcherManager._has_meaningful_payload(v)
-                for v in payload.to_numpy().reshape(-1).tolist()
+                for v in payload.to_numpy().flat
             )
         if isinstance(payload, (pd.Series, pd.Index)):
             return any(DataFetcherManager._has_meaningful_payload(v) for v in payload.tolist())
@@ -1823,7 +1831,7 @@ class DataFetcherManager:
             else:
                 return any(
                     DataFetcherManager._has_meaningful_payload(v)
-                    for v in payload.reshape(-1).tolist()
+                    for v in payload.flat
                 )
         if isinstance(payload, (list, tuple, set)):
             return any(DataFetcherManager._has_meaningful_payload(v) for v in payload)

--- a/tests/test_fundamental_context.py
+++ b/tests/test_fundamental_context.py
@@ -491,6 +491,17 @@ class TestFundamentalContext(unittest.TestCase):
         self.assertIn("[board_value] pd.isna fallback", joined_logs)
         self.assertIn("[fundamental_payload] pd.isna fallback", joined_logs)
 
+    def test_missing_value_helpers_propagate_array_protocol_pd_isna_errors(self) -> None:
+        class _ArrayProtocolErrorPayload:
+            def __array__(self):
+                raise ValueError("boom")
+
+        payload = _ArrayProtocolErrorPayload()
+        with self.assertRaises(ValueError):
+            DataFetcherManager._is_missing_board_value(payload)
+        with self.assertRaises(ValueError):
+            DataFetcherManager._has_meaningful_payload(payload)
+
     def test_missing_value_helpers_propagate_unexpected_pd_isna_errors(self) -> None:
         sentinel = object()
         with patch("data_provider.base.pd.isna", side_effect=RuntimeError("boom")):


### PR DESCRIPTION
## PR Type
- [x] fix
- [ ] feat
- [ ] refactor
- [ ] docs
- [ ] chore
- [ ] test

## Background And Problem
- 当前问题：收紧基础缺失值判断中的异常处理范围，避免静默吞掉非预期异常，并为现有 fallback 行为补齐可回归的单测。
- 影响范围：本次改动涉及 2 个文件，Diff 为 `+113 / -10`。
- 触发来源：Issue 自动执行（Issue #996）。

## Scope Of Change
- `data_provider/base.py`
- `tests/test_fundamental_context.py`

## Documentation And Changelog
- 当前补丁未包含 `README.md`、`docs/` 或 `docs/CHANGELOG.md` 更新；如果本次变更涉及 CLI、API、配置、日志语义或其他用户可见行为，请在合并前补充原因与文档落点。

## Issue Link
Closes #996

## Verification Commands And Results
```bash
./scripts/ci_gate.sh flake8
```

关键输出/结论 / Key output & conclusion:
- lint:PASS

## Compatibility And Risk
- **Medium**：涉及 `data_provider/base.py`, `tests/test_fundamental_context.py`，建议按文件范围复核。
- 前提假设：
  - 问题主入口在 data_provider/base.py 中使用 pd.isna 的缺失值辅助函数，尤其是 _is_missing_board_value，必要时同步收敛同文件中语义相近的 _has_meaningful_payload。
  - 允许继续兼容可预期的非标量/类型歧义场景，但应改为显式判断或仅捕获明确异常类型，而不是直接 except Exception 后 pass。
  - 若仍需保底处理，低噪音日志记录异常类型、对象类型和调用语境即可，不需要输出完整原始 payload。
  - 本次按最小改动处理当前 issue 描述的基础判空路径，不扩展清理仓库中其他无关的 broad exception。

## Rollback Plan
- `git revert <merge-commit>` 回滚本 PR 提交，重点确认 `data_provider/base.py`, `tests/test_fundamental_context.py` 恢复正常。

## Acceptance Criteria
- 缺失值判断 helper 不再通过 except Exception + pass 静默吞掉所有异常，只保留明确可预期的异常处理路径。
- 常见空值输入（None、NaN、空字符串、null/nan 等占位值）行为保持兼容，不引入板块归一化或 fundamental block 判定回归。
- 当 pd.isna 或相关对象行为出现非预期异常时，能够被上层感知或至少留下带上下文的低噪音日志，不再无痕忽略。
- 新增回归测试覆盖正常空值、可预期 fallback 场景以及非预期异常场景。

## Implementation
已将 `data_provider/base.py` 的 `_try_scalar_isna` 调整为：`pd.isna` 遇到 `TypeError/ValueError` 时，若值对象实现了 `__array__`，不再静默 fallback，直接上抛异常，修复了 `__array__` 内部抛 `ValueError` 被吞掉的问题。
保留无 `__array__` 值的既有降级行为与日志分支，避免影响既有“预期缺失值歧义”兜底路径。
在 `tests/test_fundamental_context.py` 新增 `test_missing_value_helpers_propagate_array_protocol_pd_isna_errors`，构造 `__array__` 抛 `ValueError("boom")` 的对象，覆盖该真实异常路径。
已运行相关回归：`python -m pytest tests/test_fundamental_context.py -q`，`20 passed`。

## Checklist
- [x] 本 PR 有明确动机和业务价值 / This PR has a clear motivation and value
- [x] 已提供可复现的验证命令与结果 / Reproducible verification commands and results are included
- [x] 已评估兼容性与风险 / Compatibility and risk have been assessed
- [x] 已提供回滚方案 / A rollback plan is provided
- [ ] 文档与 `docs/CHANGELOG.md` 同步仍需确认；如涉及用户可见变更，请在合并前补充原因与文档落点 / Documentation and `docs/CHANGELOG.md` sync still needs confirmation before merge when user-visible behavior changes