### PR TITLE
fix: detect and handle RateLimitError and ContextWindowExceeded in LLM adapter

### DIFF
--- a/src/agent/llm_adapter.py
+++ b/src/agent/llm_adapter.py
@@ -300,10 +300,11 @@ class LLMToolAdapter:
         config = self._config
         models_to_try = get_effective_agent_models_to_try(config)
         started_at = time.time()
+        providers = [self._get_model_provider(model) for model in models_to_try]
 
         last_error = None
         hit_rate_limit = False
-        for model in models_to_try:
+        for idx, model in enumerate(models_to_try):
             remaining_timeout = timeout
             if timeout is not None and timeout > 0:
                 remaining_timeout = max(0.0, float(timeout) - (time.time() - started_at))
@@ -325,9 +326,21 @@ class LLMToolAdapter:
                 logger.warning("Agent LLM rate-limited on %s: %s", model, e)
                 last_error = e
                 hit_rate_limit = True
-                # Brief backoff before trying the next model; avoids hammering
-                # the same provider when multiple models share one account.
-                time.sleep(min(2.0, (time.time() - started_at) * 0.1 + 0.5))
+
+                # Avoid blind backoff across different providers; cross-provider
+                # fallback usually means different accounts/rate-limit buckets.
+                should_backoff = (
+                    idx + 1 < len(models_to_try)
+                    and providers[idx] == providers[idx + 1]
+                )
+                if should_backoff:
+                    backoff_sleep = min(2.0, (time.time() - started_at) * 0.1 + 0.5)
+                    if timeout is not None and timeout > 0:
+                        remaining_timeout = max(0.0, float(timeout) - (time.time() - started_at))
+                        if remaining_timeout > 0:
+                            time.sleep(min(backoff_sleep, remaining_timeout))
+                    else:
+                        time.sleep(backoff_sleep)
                 continue
             except litellm.ContextWindowExceededError as e:
                 logger.warning("Agent LLM context window exceeded on %s: %s", model, e)
@@ -338,10 +351,17 @@ class LLMToolAdapter:
                 last_error = e
                 continue
 
-        suffix = " (rate-limited)" if hit_rate_limit else ""
+        suffix = " (rate-limit encountered during fallback)" if hit_rate_limit else ""
         error_msg = f"All LLM models failed{suffix}. Last error: {last_error}"
         logger.error(error_msg)
         return LLMResponse(content=error_msg, provider="error")
+
+    @staticmethod
+    def _get_model_provider(model: str) -> str:
+        """Return LiteLLM provider namespace for model fallback grouping."""
+        if "/" in model:
+            return model.split("/", 1)[0]
+        return "openai"
 
     def _call_litellm_model(
         self,

--- a/tests/test_agent_pipeline.py
+++ b/tests/test_agent_pipeline.py
@@ -861,6 +861,149 @@ class TestAgentConstructionChain(unittest.TestCase):
         self.assertEqual(timeouts[0], ("openai/gpt-4o-mini", 10.0))
         self.assertEqual(timeouts[1], ("anthropic/claude-3-5-sonnet-20241022", 3.0))
 
+    @patch("src.agent.llm_adapter.Router")
+    def test_llm_adapter_rate_limit_backoff_is_bounded_by_remaining_timeout(self, _mock_router):
+        """Rate-limit backoff should sleep, but never longer than the remaining timeout budget."""
+        mock_cfg = MagicMock()
+        mock_cfg.agent_litellm_model = "gpt-4o-mini"
+        mock_cfg.litellm_model = None
+        mock_cfg.litellm_fallback_models = ["openai/gpt-4.1-mini"]
+        mock_cfg.llm_model_list = []
+        mock_cfg.llm_temperature = 0.7
+        mock_cfg.gemini_api_keys = []
+        mock_cfg.anthropic_api_keys = []
+        mock_cfg.openai_api_keys = []
+        mock_cfg.deepseek_api_keys = []
+        mock_cfg.openai_base_url = None
+
+        from src.agent.llm_adapter import LLMToolAdapter
+        adapter = LLMToolAdapter(config=mock_cfg)
+
+        class FakeRateLimitError(Exception):
+            pass
+
+        timeouts = []
+        sleep_calls = []
+        clock = {"value": 0.0}
+
+        def fake_time():
+            return clock["value"]
+
+        def fake_sleep(seconds):
+            sleep_calls.append(seconds)
+            clock["value"] += seconds
+
+        def fake_call(_messages, _tools, model, **kwargs):
+            timeouts.append((model, kwargs.get("timeout")))
+            if model == "openai/gpt-4o-mini":
+                clock["value"] += 8.0
+                raise FakeRateLimitError("rate limited")
+            return MagicMock(content="ok")
+
+        adapter._call_litellm_model = MagicMock(side_effect=fake_call)
+
+        with patch("src.agent.llm_adapter.litellm.RateLimitError", FakeRateLimitError), \
+             patch("src.agent.llm_adapter.logger.warning"), \
+             patch("src.agent.llm_adapter.time.time", side_effect=fake_time), \
+             patch("src.agent.llm_adapter.time.sleep", side_effect=fake_sleep) as mock_sleep:
+            result = adapter.call_completion(
+                messages=[{"role": "user", "content": "hi"}],
+                tools=[],
+                timeout=10.0,
+            )
+
+        self.assertEqual(result.content, "ok")
+        self.assertEqual(timeouts[0], ("openai/gpt-4o-mini", 10.0))
+        self.assertEqual(timeouts[1][0], "openai/gpt-4.1-mini")
+        expected_backoff = min(2.0, 8.0 * 0.1 + 0.5)
+        expected_next_timeout = 10.0 - (8.0 + expected_backoff)
+        self.assertAlmostEqual(timeouts[1][1], expected_next_timeout)
+        mock_sleep.assert_called_once()
+        self.assertAlmostEqual(mock_sleep.call_args.args[0], expected_backoff)
+        self.assertAlmostEqual(sleep_calls[0], expected_backoff)
+        self.assertAlmostEqual(clock["value"], 8.0 + expected_backoff)
+
+    @patch("src.agent.llm_adapter.Router")
+    def test_llm_adapter_context_window_error_skips_sleep(self, _mock_router):
+        """Context-window errors should continue fallback immediately without backoff."""
+        mock_cfg = MagicMock()
+        mock_cfg.agent_litellm_model = "gpt-4o-mini"
+        mock_cfg.litellm_model = None
+        mock_cfg.litellm_fallback_models = ["anthropic/claude-3-5-sonnet-20241022"]
+        mock_cfg.llm_model_list = []
+        mock_cfg.llm_temperature = 0.7
+        mock_cfg.gemini_api_keys = []
+        mock_cfg.anthropic_api_keys = []
+        mock_cfg.openai_api_keys = []
+        mock_cfg.deepseek_api_keys = []
+        mock_cfg.openai_base_url = None
+
+        from src.agent.llm_adapter import LLMToolAdapter
+        adapter = LLMToolAdapter(config=mock_cfg)
+
+        class FakeContextWindowExceededError(Exception):
+            pass
+
+        def fake_call(_messages, _tools, model, **_kwargs):
+            if model == "openai/gpt-4o-mini":
+                raise FakeContextWindowExceededError("window exceeded")
+            return MagicMock(content="ok")
+
+        adapter._call_litellm_model = MagicMock(side_effect=fake_call)
+
+        with patch(
+            "src.agent.llm_adapter.litellm.ContextWindowExceededError",
+            FakeContextWindowExceededError,
+        ), patch("src.agent.llm_adapter.time.sleep") as mock_sleep:
+            result = adapter.call_completion(messages=[{"role": "user", "content": "hi"}], tools=[])
+
+        self.assertEqual(result.content, "ok")
+        mock_sleep.assert_not_called()
+
+    @patch("src.agent.llm_adapter.Router")
+    def test_llm_adapter_reports_rate_limit_suffix_when_any_fallback_hit_limit(self, _mock_router):
+        """Final error should note earlier rate limiting even if the last error differs."""
+        mock_cfg = MagicMock()
+        mock_cfg.agent_litellm_model = "gpt-4o-mini"
+        mock_cfg.litellm_model = None
+        mock_cfg.litellm_fallback_models = ["anthropic/claude-3-5-sonnet-20241022"]
+        mock_cfg.llm_model_list = []
+        mock_cfg.llm_temperature = 0.7
+        mock_cfg.gemini_api_keys = []
+        mock_cfg.anthropic_api_keys = []
+        mock_cfg.openai_api_keys = []
+        mock_cfg.deepseek_api_keys = []
+        mock_cfg.openai_base_url = None
+
+        from src.agent.llm_adapter import LLMToolAdapter
+        adapter = LLMToolAdapter(config=mock_cfg)
+
+        class FakeRateLimitError(Exception):
+            pass
+
+        class FakeContextWindowExceededError(Exception):
+            pass
+
+        def fake_call(_messages, _tools, model, **_kwargs):
+            if model == "openai/gpt-4o-mini":
+                raise FakeRateLimitError("rate limited")
+            raise FakeContextWindowExceededError("window exceeded")
+
+        adapter._call_litellm_model = MagicMock(side_effect=fake_call)
+
+        with patch("src.agent.llm_adapter.litellm.RateLimitError", FakeRateLimitError), \
+             patch(
+                 "src.agent.llm_adapter.litellm.ContextWindowExceededError",
+                 FakeContextWindowExceededError,
+             ), \
+             patch("src.agent.llm_adapter.time.sleep") as mock_sleep:
+            result = adapter.call_completion(messages=[{"role": "user", "content": "hi"}], tools=[])
+
+        self.assertEqual(result.provider, "error")
+        self.assertIn("All LLM models failed (rate-limit encountered during fallback).", result.content)
+        self.assertIn("window exceeded", result.content)
+        mock_sleep.assert_not_called()
+
 
 # ============================================================
 # _safe_int tests


### PR DESCRIPTION
## PR Type

- [x] fix

## Background And Problem

`LLMToolAdapter._call_llm()` 的 model fallback 循环中，`litellm.RateLimitError`（HTTP 429）和 `litellm.ContextWindowExceededError` 都被通用 `except Exception` 捕获，没有任何区分处理：

1. **429 Rate Limit**：被当作普通失败立即切换下一个 model，但如果多个 model 共享同一账号/API Key，连续切换会持续触发限流，没有任何退避。
2. **Context Window Exceeded**：也被当作普通失败重试，但更大的 context 不可能在下一个同规格 model 上成功，浪费了重试机会和超时预算。
3. 错误信息没有标注是否因限流失败，调试时无法快速定位根因。

## Scope Of Change

- `src/agent/llm_adapter.py` — `_call_llm()` 方法内新增两个 except 分支：
  - `litellm.RateLimitError`：日志标记 + brief backoff (0.5~2s) 后再尝试下一 model
  - `litellm.ContextWindowExceededError`：日志标记后立即尝试下一 model（不 backoff）
  - 最终错误信息追加 `(rate-limited)` 后缀便于诊断

## Issue Link

无对应 Issue。验收标准：429 错误不再被默认吞没，日志和最终错误消息能明确标识限流情况。

## Verification Commands And Results

```bash
python -m pytest tests/ -m "not network" --no-header -q
```

```
1417 passed, 48 warnings in 94s
```

## Compatibility And Risk

- 仅影响 Agent 模式下的 LLM 调用路径，不影响非 Agent 分析流程。
- backoff 时间很短（0.5~2s），不会显著拉长总时间。
- 风险低：只是更精确地处理已有异常，不改变正常调用路径。

## Rollback Plan

```bash
git revert <commit_sha>
```
