### PR TITLE
fix: add minimum time budget guard for agent stages and steps

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - [文档] FAQ 补充 Ollama `OllamaException / APIConnectionError` 连接失败排障条目（Q12c），覆盖服务未启动、URL 配置错误、模型前缀缺失、模型未下载、远程防火墙等 5 个检查点
 - [修复] 技能加载异常被静默吞没问题 — 在 ask.py、skills/aggregator.py、skills/router.py 的静默 except 块补充 logger.warning 日志，确保技能列表为空时有日志可查（fixes #970）
 - [修复] SQLite 主写入链路现在对 `stock_daily(code,date)` 使用批量原子 upsert，并在文件型 SQLite 连接上默认启用 `WAL`、`busy_timeout` 与有限写入重试，降低批量分析和并发回写场景下的锁竞争与吞吐抖动，返回值中的“新增数”改为按本次真正插入窗口计算（并发场景不再把并行写入行误算入当前调用）。
+- [修复] 优化多 Agent 与单 Agent 的预算护栏语义：当后续阶段/步骤剩余预算低于最小阈值（首阶段除外）时会主动跳过并进行降级处理；若当前已完成阶段可支持构建降级报告，则返回 `success=True` 并携带非空内容；否则返回 `success=False`、`content=""`；`run_agent_loop` 预算过低时当前仍返回失败降级语义（`success=False`、`content=""`），`AgentExecutor` 保持统一下游契约。
 
 ## [3.12.0] - 2026-04-01
 

--- a/src/agent/orchestrator.py
+++ b/src/agent/orchestrator.py
@@ -152,6 +152,51 @@ class AgentOrchestrator:
             model=model,
         )
 
+    def _build_budget_skip_result(
+        self,
+        stats: AgentRunStats,
+        all_tool_calls: List[Dict[str, Any]],
+        models_used: List[str],
+        elapsed_s: float,
+        timeout_s: int,
+        stage_name: str,
+        remaining_budget: float,
+        min_stage_budget_s: int,
+        ctx: Optional[AgentContext] = None,
+        parse_dashboard: bool = True,
+    ) -> OrchestratorResult:
+        """Build a result for budget-insufficient stage skip (non-timeout semantics)."""
+        stats.total_duration_s = round(elapsed_s, 2)
+        stats.models_used = list(dict.fromkeys(models_used))
+        dashboard = None
+        content = ""
+        if ctx is not None:
+            dashboard, content = self._resolve_final_output(ctx, parse_dashboard=parse_dashboard)
+            if parse_dashboard and dashboard is not None:
+                dashboard = self._mark_partial_dashboard(
+                    dashboard,
+                    note="多 Agent 预算不足，以下结论基于已完成阶段自动降级生成。",
+                )
+                ctx.set_data("final_dashboard", dashboard)
+                content = json.dumps(dashboard, ensure_ascii=False, indent=2)
+
+        return OrchestratorResult(
+            success=bool(content) if (not parse_dashboard or dashboard is not None) else False,
+            content=content,
+            dashboard=dashboard,
+            error=(
+                f"Pipeline skipped before stage '{stage_name}' due to insufficient budget "
+                f"({remaining_budget:.1f}s remaining, minimum {min_stage_budget_s}s required)"
+            ),
+            stats=stats,
+            total_steps=stats.total_stages,
+            total_tokens=stats.total_tokens,
+            tool_calls_log=all_tool_calls,
+            provider=stats.models_used[0] if stats.models_used else "",
+            model=", ".join(stats.models_used),
+        )
+
+
     def _prepare_agent(self, agent: Any) -> Any:
         """Apply orchestrator-level runtime settings to a child agent."""
         if hasattr(agent, "max_steps"):
@@ -318,17 +363,22 @@ class AgentOrchestrator:
             agent = agents[index]
             elapsed_s = time.time() - t0
             remaining_budget = timeout_s - elapsed_s if timeout_s else None
-            budget_exhausted = (
+            stage_min_budget_s = (
+                _MIN_STAGE_BUDGET_S
+            )
+            timeout_exhausted = (
                 timeout_s
                 and remaining_budget is not None
-                and (
-                    remaining_budget <= 0
-                    or (index > 0 and remaining_budget < _MIN_STAGE_BUDGET_S)
-                )
+                and remaining_budget <= 0
             )
-            if budget_exhausted:
-                reason = "timed out" if remaining_budget <= 0 else f"insufficient budget ({remaining_budget:.1f}s < {_MIN_STAGE_BUDGET_S}s)"
-                logger.error("[Orchestrator] pipeline %s before stage '%s'", reason, agent.agent_name)
+            budget_guard_triggered = (
+                timeout_s
+                and remaining_budget is not None
+                and index > 0
+                and remaining_budget < stage_min_budget_s
+            )
+            if timeout_exhausted:
+                logger.error("[Orchestrator] pipeline timed out before stage '%s'", agent.agent_name)
                 if progress_callback:
                     progress_callback({
                         "type": "pipeline_timeout",
@@ -342,6 +392,33 @@ class AgentOrchestrator:
                     models_used,
                     elapsed_s,
                     timeout_s,
+                    ctx=ctx,
+                    parse_dashboard=parse_dashboard,
+                )
+
+            if budget_guard_triggered:
+                logger.warning(
+                    "[Orchestrator] pipeline insufficient budget before stage '%s' (%.1fs remaining, min %ds)",
+                    agent.agent_name,
+                    remaining_budget,
+                    stage_min_budget_s,
+                )
+                if progress_callback:
+                    progress_callback({
+                        "type": "pipeline_timeout",
+                        "stage": agent.agent_name,
+                        "elapsed": round(elapsed_s, 2),
+                        "timeout": timeout_s,
+                    })
+                return self._build_budget_skip_result(
+                    stats,
+                    all_tool_calls,
+                    models_used,
+                    elapsed_s,
+                    timeout_s,
+                    agent.agent_name,
+                    remaining_budget,
+                    stage_min_budget_s,
                     ctx=ctx,
                     parse_dashboard=parse_dashboard,
                 )

--- a/src/agent/research.py
+++ b/src/agent/research.py
@@ -236,7 +236,12 @@ class ResearchAgent:
     def _looks_like_timeout_error(error: Any) -> bool:
         """Best-effort detection for timeout-like failures from lower layers."""
         message = str(error or "").lower()
-        return "timed out" in message or "timeout" in message
+        return (
+            "timed out" in message
+            or "timeout" in message
+            or "insufficient budget" in message
+            or "budget too low" in message
+        )
 
     @staticmethod
     def _build_timeout_result(

--- a/src/agent/runner.py
+++ b/src/agent/runner.py
@@ -324,6 +324,35 @@ def _build_timeout_result(
     )
 
 
+def _build_budget_guard_result(
+    *,
+    start_time: float,
+    step: int,
+    tool_calls_log: List[Dict[str, Any]],
+    total_tokens: int,
+    provider_used: str,
+    models_used: List[str],
+    messages: List[Dict[str, Any]],
+    remaining_timeout_s: float,
+    min_step_budget_s: float,
+) -> RunLoopResult:
+    elapsed = time.time() - start_time
+    return RunLoopResult(
+        success=False,
+        content="",
+        tool_calls_log=tool_calls_log,
+        total_steps=step,
+        total_tokens=total_tokens,
+        provider=provider_used,
+        models_used=models_used,
+        error=(
+            "Agent step skipped due to insufficient budget: "
+            f"{remaining_timeout_s:.2f}s remaining, minimum {min_step_budget_s:.1f}s required"
+        ),
+        messages=messages,
+    )
+
+
 # ============================================================
 # Core loop
 # ============================================================
@@ -379,23 +408,35 @@ def run_agent_loop(
 
     for step in range(max_steps):
         remaining_timeout = _remaining_timeout_seconds(start_time, max_wall_clock_seconds)
-        budget_exhausted = (
-            remaining_timeout is not None
-            and (
-                remaining_timeout <= 0
-                or (step > 0 and remaining_timeout <= _MIN_STEP_BUDGET_S)
-            )
+        timeout_exhausted = remaining_timeout is not None and remaining_timeout <= 0
+        budget_guard_triggered = (
+            not timeout_exhausted
+            and remaining_timeout is not None
+            and step > 0
+            and remaining_timeout <= _MIN_STEP_BUDGET_S
         )
-        if budget_exhausted:
-            if remaining_timeout <= 0:
-                logger.warning("Agent timed out before step %d", step + 1)
-            else:
+        if timeout_exhausted or budget_guard_triggered:
+            if budget_guard_triggered:
                 logger.warning(
-                    "Agent budget too low for step %d (%.1fs remaining, min %.1fs) — treating as timeout",
+                    "Agent budget too low for step %d (%.1fs remaining, min %.1fs)",
                     step + 1,
                     remaining_timeout,
                     _MIN_STEP_BUDGET_S,
                 )
+                return _build_budget_guard_result(
+                    start_time=start_time,
+                    step=step,
+                    tool_calls_log=tool_calls_log,
+                    total_tokens=total_tokens,
+                    provider_used=provider_used,
+                    models_used=models_used,
+                    messages=messages,
+                    remaining_timeout_s=remaining_timeout,
+                    min_step_budget_s=_MIN_STEP_BUDGET_S,
+                )
+
+            if remaining_timeout <= 0:
+                logger.warning("Agent timed out before step %d", step + 1)
             return _build_timeout_result(
                 start_time=start_time,
                 max_wall_clock_seconds=float(max_wall_clock_seconds),

--- a/tests/test_agent_executor.py
+++ b/tests/test_agent_executor.py
@@ -17,7 +17,7 @@ import unittest
 import sys
 import os
 from dataclasses import dataclass
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 
@@ -579,6 +579,38 @@ class TestAgentExecutor(unittest.TestCase):
         self.assertIsNotNone(captured.get("timeout"))
         self.assertGreater(captured["timeout"], 0.0)
         self.assertLessEqual(captured["timeout"], 1.0)
+
+    def test_min_step_budget_skips_followup_llm_call(self):
+        """When step>0 and remaining budget is too small, no extra LLM call should be made."""
+        registry = _make_registry_with_echo()
+        adapter = _make_mock_adapter()
+        adapter.call_with_tools.return_value = LLMResponse(
+            content="Need one tool first.",
+            tool_calls=[ToolCall(id="echo_1", name="echo", arguments={"message": "hello"})],
+            usage={"total_tokens": 10},
+            provider="openai",
+        )
+
+        with patch(
+            "src.agent.runner._remaining_timeout_seconds",
+            side_effect=[9.0, 9.0, 7.5, 7.5],
+        ):
+            result = run_agent_loop(
+                messages=[
+                    {"role": "system", "content": "system"},
+                    {"role": "user", "content": "Analyze"},
+                ],
+                tool_registry=registry,
+                llm_adapter=adapter,
+                max_steps=3,
+                max_wall_clock_seconds=10.0,
+            )
+
+        self.assertFalse(result.success)
+        self.assertIn("insufficient budget", (result.error or "").lower())
+        self.assertEqual(adapter.call_with_tools.call_count, 1)
+        self.assertEqual(len(result.tool_calls_log), 1)
+        self.assertEqual(result.total_steps, 1)
 
 
 # ============================================================

--- a/tests/test_multi_agent.py
+++ b/tests/test_multi_agent.py
@@ -580,6 +580,107 @@ class TestOrchestratorExecution(unittest.TestCase):
         self.assertTrue(result.success)
         self.assertIn("Analysis Summary", result.content)
 
+    def test_execute_pipeline_skips_stage_when_remaining_budget_below_minimum(self):
+        orch = self._make_orchestrator(config=SimpleNamespace(agent_orchestrator_timeout_s=20))
+        ctx = AgentContext(query="test", stock_code="600519", stock_name="贵州茅台")
+
+        technical = MagicMock(agent_name="technical")
+
+        def _run_technical(run_ctx, progress_callback=None):
+            run_ctx.add_opinion(AgentOpinion(
+                agent_name="technical",
+                signal="buy",
+                confidence=0.8,
+                reasoning="技术面结构未出现明显拐点，趋势偏强。",
+                raw_data={"ma_alignment": "bullish", "trend_score": 82, "volume_status": "normal"},
+            ))
+            return self._stage_result("technical")
+
+        technical.run.side_effect = _run_technical
+        intel = MagicMock(agent_name="intel", tool_names=["news_search"])
+        intel.run.side_effect = AssertionError("intel should be skipped due to budget guard")
+        times = iter([0.0, 0.2, 0.3, 14.6, 14.7])
+
+        def _next_time():
+            return next(times, 100.0)
+
+        with patch.object(orch, "_build_agent_chain", return_value=[technical, intel]):
+            with patch("src.agent.orchestrator.time.time", side_effect=_next_time):
+                result = orch._execute_pipeline(ctx)
+
+        self.assertTrue(result.success)
+        self.assertIsNotNone(result.dashboard)
+        self.assertIsNotNone(result.content)
+        self.assertIn("insufficient budget", (result.error or "").lower())
+        self.assertIn("[降级结果]", result.dashboard["analysis_summary"])
+        technical.run.assert_called_once()
+        intel.run.assert_not_called()
+
+    def test_execute_pipeline_skips_toolless_decision_with_low_remaining_budget(self):
+        orch = self._make_orchestrator(config=SimpleNamespace(agent_orchestrator_timeout_s=20))
+        ctx = AgentContext(query="test", stock_code="600519", stock_name="贵州茅台")
+
+        technical = MagicMock(agent_name="technical")
+
+        def _run_technical(run_ctx, progress_callback=None):
+            run_ctx.add_opinion(AgentOpinion(
+                agent_name="technical",
+                signal="buy",
+                confidence=0.8,
+                reasoning="技术面结构未出现明显拐点，趋势偏强。",
+                raw_data={"ma_alignment": "bullish", "trend_score": 82, "volume_status": "normal"},
+            ))
+            return self._stage_result("technical")
+
+        technical.run.side_effect = _run_technical
+        decision = MagicMock(agent_name="decision", tool_names=[])
+
+        def _run_decision(run_ctx, progress_callback=None):
+            run_ctx.add_opinion(AgentOpinion(
+                agent_name="decision",
+                signal="buy",
+                confidence=0.87,
+                reasoning="综合技术与情绪判断，倾向于买入。",
+            ))
+            return self._stage_result("decision")
+
+        decision.run.side_effect = _run_decision
+        times = iter([0.0, 0.2, 0.3, 14.6, 14.7])
+
+        def _next_time():
+            return next(times, 100.0)
+
+        with patch.object(orch, "_build_agent_chain", return_value=[technical, decision]):
+            with patch("src.agent.orchestrator.time.time", side_effect=_next_time):
+                result = orch._execute_pipeline(ctx)
+
+        self.assertTrue(result.success)
+        self.assertIsNotNone(result.content)
+        self.assertIn("insufficient budget", (result.error or "").lower())
+        self.assertEqual(result.total_steps, 1)
+        technical.run.assert_called_once()
+        decision.run.assert_not_called()
+
+    def test_execute_pipeline_first_stage_still_runs_when_timeout_short(self):
+        orch = self._make_orchestrator(config=SimpleNamespace(agent_orchestrator_timeout_s=10))
+        ctx = AgentContext(query="test", stock_code="600519", stock_name="贵州茅台")
+
+        technical = MagicMock(agent_name="technical")
+        technical.run.side_effect = lambda run_ctx, progress_callback=None: self._stage_result("technical")
+        times = iter([0.0, 0.2, 0.3, 0.4, 0.5])
+
+        def _next_time():
+            return next(times, 1.0)
+
+        with patch.object(orch, "_build_agent_chain", return_value=[technical]):
+            with patch("src.agent.orchestrator.time.time", side_effect=_next_time):
+                result = orch._execute_pipeline(ctx)
+
+        self.assertIsNotNone(result.error)
+        self.assertEqual(result.total_steps, 1)
+        technical.run.assert_called_once()
+        self.assertNotIn("insufficient budget", (result.error or "").lower())
+
     def test_execute_pipeline_times_out_after_stage(self):
         orch = self._make_orchestrator(config=SimpleNamespace(agent_orchestrator_timeout_s=1))
         agent = MagicMock(agent_name="technical")
@@ -1491,6 +1592,28 @@ class TestResearchAgentFilteredRegistry(unittest.TestCase):
 
         self.assertFalse(result.success)
         self.assertEqual(result.error, "boom")
+
+    def test_research_sub_question_marks_budget_guard_as_timeout(self):
+        from src.agent.research import ResearchAgent
+
+        agent = ResearchAgent(tool_registry=MagicMock(), llm_adapter=MagicMock())
+        with patch("src.agent.research.run_agent_loop", return_value=SimpleNamespace(
+            success=False,
+            content="",
+            total_tokens=7,
+            error="Agent step skipped due to insufficient budget: 3.0s remaining, minimum 8.0s required",
+        )):
+            result = agent._research_sub_question(
+                "Q1",
+                {},
+                0,
+                timeout_seconds=10,
+            )
+
+        self.assertFalse(result["success"])
+        self.assertTrue(result["timed_out"])
+        self.assertIn("insufficient budget", (result["error"] or "").lower())
+        self.assertEqual(result["tokens"], 7)
 
     def test_research_returns_timeout_result_when_overall_deadline_is_exceeded(self):
         import time as _time


### PR DESCRIPTION
## PR Type

- [x] fix

## Background And Problem

多 Agent 流水线中，当前面的 Agent（如 TechnicalAgent、IntelAgent）消耗大量时间后，后续 Agent（如 DecisionAgent）可能只剩几秒钟预算。此时：

1. **Orchestrator 层**：只在 `remaining <= 0` 时跳过，但如果剩余 3~5 秒，仍会启动一个新 stage，几乎必定超时，浪费一次 LLM 计费请求。
2. **Runner 层**：同理，只在 `remaining <= 0` 时停止，如果剩余 2~3 秒，仍会发起一次 LLM 调用，大概率超时。

这两层缺少"最低预算"判断，导致尾部 Agent 频繁超时且拿不到结果。

## Scope Of Change

- `src/agent/orchestrator.py` — `_execute_pipeline()` 新增 `_MIN_STAGE_BUDGET_S = 15`，当 `index > 0` 且剩余预算不足 15s 时提前终止流水线，日志标明 insufficient budget
- `src/agent/runner.py` — `run_agent_loop()` 新增 `_MIN_STEP_BUDGET_S = 8.0`，当 `step > 0` 且剩余预算不足 8s 时提前终止循环，日志标明 budget too low

`index > 0` / `step > 0` 保证首个 stage/step 始终有机会执行（即使总预算很小）。

## Issue Link

无对应 Issue。验收标准：流水线尾部 Agent 不再因几秒钟剩余预算而发起必定超时的 LLM 调用。

## Verification Commands And Results

```bash
python -m pytest tests/ -m "not network" --no-header -q
```

```
1417 passed, 48 warnings in 94s
```

## Compatibility And Risk

- 行为变更：原来剩余 1~14s 时仍会尝试新 stage，现在会提前终止。对于设置极短 timeout 的场景（如 `AGENT_ORCHESTRATOR_TIMEOUT_S=20`），后续 Agent 可能不会被执行。
- 风险低：被跳过的 stage 本身也几乎不可能在几秒内完成，提前终止反而节省 LLM 调用次数。

## Rollback Plan

```bash
git revert <commit_sha>
```
