### PR TITLE
feat(workflow): make analysis job timeout configurable via vars

### DIFF
--- a/.github/workflows/daily_analysis.yml
+++ b/.github/workflows/daily_analysis.yml
@@ -32,7 +32,7 @@ jobs:
   analyze:
     runs-on: ubuntu-latest
     # 添加超时限制，防止任务卡死
-    timeout-minutes: 30
+    timeout-minutes: ${{ fromJSON(vars.ANALYSIS_TIMEOUT_MINUTES || '30') }}
     
     steps:
       - name: 随机延迟（避免固定时间访问）


### PR DESCRIPTION
## Summary

- Replace hardcoded `timeout-minutes: 30` in `daily_analysis.yml` with a configurable `ANALYSIS_TIMEOUT_MINUTES` repository variable
- Defaults to `30` minutes (no behavior change for existing users)
- Forks and users with large watchlists can now increase the timeout via **Settings → Secrets and variables → Actions → Variables** without modifying the workflow file

## Usage

Set `ANALYSIS_TIMEOUT_MINUTES` as a repository variable:

```
Settings → Secrets and variables → Actions → Variables tab → New repository variable
Name: ANALYSIS_TIMEOUT_MINUTES
Value: 60  (or any value in minutes)
```

If not set, the default remains 30 minutes.

## Change

```diff
-    timeout-minutes: 30
+    timeout-minutes: ${{ fromJSON(vars.ANALYSIS_TIMEOUT_MINUTES || '30') }}
```

`fromJSON()` is used to ensure the value is parsed as a number, since `vars.*` returns strings.