### PR TITLE
fix: inject REPORT_LANGUAGE into workflow and add current_price to status API (#1013, #983)

### DIFF
--- a/.github/workflows/daily_analysis.yml
+++ b/.github/workflows/daily_analysis.yml
@@ -181,6 +181,7 @@ jobs:
           # 运行配置 ⬅️ 新增！
           # ==========================================
           REPORT_TYPE: ${{ vars.REPORT_TYPE || secrets.REPORT_TYPE || 'simple' }}
+          REPORT_LANGUAGE: ${{ vars.REPORT_LANGUAGE || secrets.REPORT_LANGUAGE || '' }}
           SINGLE_STOCK_NOTIFY: ${{ vars.SINGLE_STOCK_NOTIFY || secrets.SINGLE_STOCK_NOTIFY || 'false' }}
           MARKET_REVIEW_ENABLED: ${{ vars.MARKET_REVIEW_ENABLED || secrets.MARKET_REVIEW_ENABLED || 'true' }}
           ANALYSIS_DELAY: ${{ vars.ANALYSIS_DELAY || secrets.ANALYSIS_DELAY || '0' }}

--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@
 | `RUN_IMMEDIATELY` | 非定时模式启动时是否立即执行一次分析 | 可选 |
 | `SINGLE_STOCK_NOTIFY` | 单股推送模式：设为 `true` 则每分析完一只股票立即推送 | 可选 |
 | `REPORT_TYPE` | 报告类型：`simple`(精简)、`full`(完整)、`brief`(3-5句概括)，Docker环境推荐设为 `full` | 可选 |
-| `REPORT_LANGUAGE` | 报告输出语言：`zh`(默认中文) / `en`(英文)；会同步影响 Prompt、Markdown 模板、通知 fallback 与 Web 报告页固定文案 | 可选 |
+| `REPORT_LANGUAGE` | 报告输出语言：`zh`(默认中文) / `en`(英文)；会同步影响 Prompt、Markdown 模板、通知 fallback 与 Web 报告页固定文案。仓库自带 `daily_analysis.yml` 已显式映射该变量，直接在 Actions Secrets/Variables 中配置即可生效 | 可选 |
 | `REPORT_SUMMARY_ONLY` | 仅分析结果摘要：设为 `true` 时只推送汇总，不含个股详情 | 可选 |
 | `REPORT_TEMPLATES_DIR` | Jinja2 模板目录（相对项目根，默认 `templates`） | 可选 |
 | `REPORT_RENDERER_ENABLED` | 启用 Jinja2 模板渲染（默认 `false`，保证零回归） | 可选 |

--- a/api/v1/endpoints/analysis.py
+++ b/api/v1/endpoints/analysis.py
@@ -619,8 +619,6 @@ def get_analysis_status(task_id: str) -> TaskStatus:
                 realtime = enhanced_context.get('realtime') or {}
                 current_price = realtime.get('price')
                 change_pct = realtime.get('change_pct')
-                if change_pct is None:
-                    change_pct = realtime.get('change_60d')
                 realtime_quote_raw = context_snapshot.get('realtime_quote_raw') or {}
                 if current_price is None:
                     current_price = realtime_quote_raw.get('price')

--- a/api/v1/endpoints/analysis.py
+++ b/api/v1/endpoints/analysis.py
@@ -609,6 +609,21 @@ def get_analysis_status(task_id: str) -> TaskStatus:
                 (raw_result or {}).get("report_language") if isinstance(raw_result, dict) else None
             )
             stock_name = get_localized_stock_name(record.name, record.code, report_language)
+
+            # Extract current_price / change_pct from context_snapshot
+            current_price = None
+            change_pct = None
+            context_snapshot = parse_json_field(getattr(record, 'context_snapshot', None))
+            if context_snapshot and isinstance(context_snapshot, dict):
+                enhanced_context = context_snapshot.get('enhanced_context') or {}
+                realtime = enhanced_context.get('realtime') or {}
+                current_price = realtime.get('price')
+                change_pct = realtime.get('change_pct') or realtime.get('change_60d')
+                if current_price is None:
+                    realtime_quote_raw = context_snapshot.get('realtime_quote_raw') or {}
+                    current_price = realtime_quote_raw.get('price')
+                    change_pct = change_pct or realtime_quote_raw.get('change_pct') or realtime_quote_raw.get('pct_chg')
+
             # Build report from DB record so completed tasks return real data
             report_dict = AnalysisReport(
                 meta=ReportMeta(
@@ -620,6 +635,8 @@ def get_analysis_status(task_id: str) -> TaskStatus:
                     report_language=report_language,
                     created_at=record.created_at.isoformat() if record.created_at else None,
                     model_used=model_used,
+                    current_price=current_price,
+                    change_pct=change_pct,
                 ),
                 summary=ReportSummary(
                     sentiment_score=record.sentiment_score,

--- a/api/v1/endpoints/analysis.py
+++ b/api/v1/endpoints/analysis.py
@@ -618,11 +618,16 @@ def get_analysis_status(task_id: str) -> TaskStatus:
                 enhanced_context = context_snapshot.get('enhanced_context') or {}
                 realtime = enhanced_context.get('realtime') or {}
                 current_price = realtime.get('price')
-                change_pct = realtime.get('change_pct') or realtime.get('change_60d')
+                change_pct = realtime.get('change_pct')
+                if change_pct is None:
+                    change_pct = realtime.get('change_60d')
                 if current_price is None:
                     realtime_quote_raw = context_snapshot.get('realtime_quote_raw') or {}
                     current_price = realtime_quote_raw.get('price')
-                    change_pct = change_pct or realtime_quote_raw.get('change_pct') or realtime_quote_raw.get('pct_chg')
+                    if change_pct is None:
+                        change_pct = realtime_quote_raw.get('change_pct')
+                    if change_pct is None:
+                        change_pct = realtime_quote_raw.get('pct_chg')
 
             # Build report from DB record so completed tasks return real data
             report_dict = AnalysisReport(

--- a/api/v1/endpoints/analysis.py
+++ b/api/v1/endpoints/analysis.py
@@ -621,13 +621,13 @@ def get_analysis_status(task_id: str) -> TaskStatus:
                 change_pct = realtime.get('change_pct')
                 if change_pct is None:
                     change_pct = realtime.get('change_60d')
+                realtime_quote_raw = context_snapshot.get('realtime_quote_raw') or {}
                 if current_price is None:
-                    realtime_quote_raw = context_snapshot.get('realtime_quote_raw') or {}
                     current_price = realtime_quote_raw.get('price')
-                    if change_pct is None:
-                        change_pct = realtime_quote_raw.get('change_pct')
-                    if change_pct is None:
-                        change_pct = realtime_quote_raw.get('pct_chg')
+                if change_pct is None:
+                    change_pct = realtime_quote_raw.get('change_pct')
+                if change_pct is None:
+                    change_pct = realtime_quote_raw.get('pct_chg')
 
             # Build report from DB record so completed tasks return real data
             report_dict = AnalysisReport(

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -39,6 +39,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - [改进] TushareFetcher `_normalize_data` 对港股（`hk_daily`）不再对 `vol`/`amount` 做 A 股手→股、千元→元 的缩放，与 Tushare 港股字段语义一致。
 - [测试] 补充 `TushareFetcher._normalize_data` 港股与 A 股/ETF 单位处理的单元测试。
 - [新功能] 集成 Anspire Search 作为可选语义搜索后端; 配置 `ANSPIRE_*` 可使用Anspire Search获取实时行情及新闻资讯，未配置时行为与此前一致。Anspire Search请使用 `tests/test_anspire_search.py`（手动脚本）。
+- [修复] GitHub Actions `daily_analysis.yml` 未注入 `REPORT_LANGUAGE` 环境变量，导致用户在 Secrets/Variables 中配置后不生效（fixes #1013）
+- [修复] `GET /api/v1/analysis/status/{task_id}` 从数据库回填已完成任务时缺少 `current_price` / `change_pct`，导致首页报告股票名旁不显示实时价格（fixes #983）
 
 ## [3.12.0] - 2026-04-01
 

--- a/docs/README_EN.md
+++ b/docs/README_EN.md
@@ -125,7 +125,7 @@ Go to your forked repo → `Settings` → `Secrets and variables` → `Actions` 
 | `CUSTOM_WEBHOOK_BEARER_TOKEN` | Bearer token for custom webhooks (if required) | Optional |
 | `SINGLE_STOCK_NOTIFY` | Send notification immediately after each stock | Optional |
 | `REPORT_TYPE` | `simple`, `full`, or `brief` (Docker recommended: `full`) | Optional |
-| `REPORT_LANGUAGE` | Report output language: `zh` (default Chinese) / `en` (English); affects prompt instructions, Markdown templates, notification fallbacks, and fixed labels in the Web report view | Optional |
+| `REPORT_LANGUAGE` | Report output language: `zh` (default Chinese) / `en` (English); affects prompt instructions, Markdown templates, notification fallbacks, and fixed labels in the Web report view. The bundled `daily_analysis.yml` already maps this variable, so setting it in Actions Secrets/Variables works out of the box | Optional |
 | `ANALYSIS_DELAY` | Delay between stocks and market review (seconds) | Optional |
 
 > Note: Configure at least one channel; multiple channels will all receive notifications.

--- a/docs/full-guide.md
+++ b/docs/full-guide.md
@@ -102,7 +102,7 @@ daily_stock_analysis/
 |------------|------|:----:|
 | `SINGLE_STOCK_NOTIFY` | 单股推送模式：设为 `true` 则每分析完一只股票立即推送 | 可选 |
 | `REPORT_TYPE` | 报告类型：`simple`(精简)、`full`(完整)、`brief`(3-5句概括)，Docker环境推荐设为 `full` | 可选 |
-| `REPORT_LANGUAGE` | 报告输出语言：`zh`(默认中文) / `en`(英文)；会同步影响 Prompt、模板、通知 fallback 与 Web 报告页固定文案 | 可选 |
+| `REPORT_LANGUAGE` | 报告输出语言：`zh`(默认中文) / `en`(英文)；会同步影响 Prompt、模板、通知 fallback 与 Web 报告页固定文案。仓库自带 `daily_analysis.yml` 已显式映射该变量，直接在 Actions Secrets/Variables 中配置即可生效 | 可选 |
 | `REPORT_SUMMARY_ONLY` | 仅分析结果摘要：设为 `true` 时只推送汇总，不含个股详情；多股时适合快速浏览（默认 false，Issue #262） | 可选 |
 | `REPORT_TEMPLATES_DIR` | Jinja2 模板目录（相对项目根，默认 `templates`） | 可选 |
 | `REPORT_RENDERER_ENABLED` | 启用 Jinja2 模板渲染（默认 `false`，保证零回归） | 可选 |

--- a/docs/full-guide_EN.md
+++ b/docs/full-guide_EN.md
@@ -103,7 +103,7 @@ Go to your forked repo → `Settings` → `Secrets and variables` → `Actions` 
 |------------|------|:----:|
 | `SINGLE_STOCK_NOTIFY` | Single stock push mode: set to `true` to push immediately after each stock analysis | Optional |
 | `REPORT_TYPE` | Report type: `simple` (concise), `full` (complete), `brief` (3-5 sentences), Docker recommended: `full` | Optional |
-| `REPORT_LANGUAGE` | Report output language: `zh` (default Chinese) / `en` (English); also updates prompt instructions, templates, notification fallbacks, and fixed copy in the Web report view | Optional |
+| `REPORT_LANGUAGE` | Report output language: `zh` (default Chinese) / `en` (English); also updates prompt instructions, templates, notification fallbacks, and fixed copy in the Web report view. The bundled `daily_analysis.yml` already maps this variable, so setting it in Actions Secrets/Variables works out of the box | Optional |
 | `REPORT_TEMPLATES_DIR` | Jinja2 template directory (relative to project root, default `templates`) | Optional |
 | `REPORT_RENDERER_ENABLED` | Enable Jinja2 template rendering (default `false`, zero regression) | Optional |
 | `REPORT_INTEGRITY_ENABLED` | Enable report integrity checks, retry or placeholder on missing fields (default `true`) | Optional |

--- a/tests/test_analysis_api_contract.py
+++ b/tests/test_analysis_api_contract.py
@@ -127,6 +127,50 @@ class AnalysisApiContractTestCase(unittest.TestCase):
         self.assertEqual(result.result.report["meta"]["current_price"], 180.35)
         self.assertEqual(result.result.report["meta"]["change_pct"], -1.25)
 
+    def test_get_analysis_status_completed_db_snapshot_does_not_use_change_60d_as_intraday_change(self) -> None:
+        if get_analysis_status is None:
+            self.skipTest("analysis endpoint helpers unavailable in this environment")
+
+        mock_queue = MagicMock()
+        mock_queue.get_task.return_value = None
+        mock_db = MagicMock()
+        mock_db.get_analysis_history.return_value = [
+            SimpleNamespace(
+                id=3,
+                code="MSFT",
+                name="Microsoft",
+                report_type="detailed",
+                raw_result={"report_language": "en", "model_used": "test-model"},
+                context_snapshot={
+                    "enhanced_context": {
+                        "realtime": {
+                            "price": 412.6,
+                            "change_pct": None,
+                            "change_60d": 14.8,
+                        }
+                    },
+                    "realtime_quote_raw": {"price": 412.6},
+                },
+                sentiment_score=70,
+                operation_advice="Hold",
+                trend_prediction="Neutral",
+                analysis_summary="summary",
+                ideal_buy=None,
+                secondary_buy=None,
+                stop_loss=None,
+                take_profit=None,
+                created_at=None,
+            )
+        ]
+
+        with patch("api.v1.endpoints.analysis.get_task_queue", return_value=mock_queue), \
+             patch("src.storage.DatabaseManager.get_instance", return_value=mock_db):
+            result = get_analysis_status("task-3")
+
+        self.assertEqual(result.status, "completed")
+        self.assertEqual(result.result.report["meta"]["current_price"], 412.6)
+        self.assertIsNone(result.result.report["meta"]["change_pct"])
+
     def test_report_type_full_maps_to_full_pipeline_mode(self) -> None:
         service = object.__new__(AnalysisService)
         pipeline_instance = MagicMock()

--- a/tests/test_analysis_api_contract.py
+++ b/tests/test_analysis_api_contract.py
@@ -3,6 +3,7 @@
 
 import asyncio
 from concurrent.futures import Future
+from datetime import datetime
 import json
 import tempfile
 import unittest
@@ -21,6 +22,7 @@ try:
         _handle_sync_analysis,
         _build_analysis_report,
         _load_sync_fundamental_sources,
+        get_analysis_status,
     )
 except Exception:  # pragma: no cover - optional dependency environments
     create_app = None
@@ -28,6 +30,7 @@ except Exception:  # pragma: no cover - optional dependency environments
     _handle_sync_analysis = None
     _build_analysis_report = None
     _load_sync_fundamental_sources = None
+    get_analysis_status = None
 
 from src.enums import ReportType
 from src.services.analysis_service import AnalysisService
@@ -349,6 +352,55 @@ class AnalysisApiContractTestCase(unittest.TestCase):
             query_id="q_sync_001",
             code="600519",
         )
+
+    def test_get_analysis_status_reads_price_fields_from_context_snapshot_preserving_zero_change_pct(self) -> None:
+        if get_analysis_status is None:
+            self.skipTest("analysis endpoint helpers unavailable in this environment")
+
+        record = SimpleNamespace(
+            id=1,
+            code="600519",
+            name="贵州茅台",
+            report_type="detailed",
+            created_at=datetime(2026, 4, 10, 12, 0, 0),
+            raw_result=json.dumps({"model_used": "test-model", "report_language": "zh"}),
+            context_snapshot=json.dumps(
+                {
+                    "enhanced_context": {
+                        "realtime": {
+                            "price": 1234.5,
+                            "change_pct": 0.0,
+                            "change_60d": 9.99,
+                        }
+                    },
+                    "realtime_quote_raw": {
+                        "price": 999.9,
+                        "change_pct": 8.88,
+                        "pct_chg": 7.77,
+                    },
+                }
+            ),
+            sentiment_score=80,
+            operation_advice="持有",
+            trend_prediction="震荡上行",
+            analysis_summary="summary",
+            ideal_buy=None,
+            secondary_buy=None,
+            stop_loss=None,
+            take_profit=None,
+        )
+        mock_db = MagicMock()
+        mock_db.get_analysis_history.return_value = [record]
+
+        with patch("api.v1.endpoints.analysis.get_task_queue") as queue_mock, \
+             patch("src.storage.DatabaseManager.get_instance", return_value=mock_db):
+            queue_mock.return_value.get_task.return_value = None
+            status = get_analysis_status("task_123")
+
+        self.assertEqual(status.status, "completed")
+        self.assertEqual(status.result.report["meta"]["current_price"], 1234.5)
+        self.assertEqual(status.result.report["meta"]["change_pct"], 0.0)
+        self.assertEqual(status.result.report["meta"]["model_used"], "test-model")
 
     def test_openapi_declares_single_and_batch_async_202_payloads(self) -> None:
         if create_app is None:

--- a/tests/test_analysis_api_contract.py
+++ b/tests/test_analysis_api_contract.py
@@ -39,6 +39,94 @@ from src.services.task_queue import AnalysisTaskQueue
 
 
 class AnalysisApiContractTestCase(unittest.TestCase):
+    def test_get_analysis_status_completed_db_snapshot_preserves_zero_change_pct(self) -> None:
+        if get_analysis_status is None:
+            self.skipTest("analysis endpoint helpers unavailable in this environment")
+
+        mock_queue = MagicMock()
+        mock_queue.get_task.return_value = None
+        mock_db = MagicMock()
+        mock_db.get_analysis_history.return_value = [
+            SimpleNamespace(
+                id=1,
+                code="600519",
+                name="贵州茅台",
+                report_type="detailed",
+                raw_result={"report_language": "zh", "model_used": "test-model"},
+                context_snapshot={
+                    "enhanced_context": {
+                        "realtime": {
+                            "price": 1234.5,
+                            "change_pct": 0.0,
+                            "change_60d": 12.3,
+                        }
+                    },
+                    "realtime_quote_raw": {"price": 1234.5, "change_pct": 9.9},
+                },
+                sentiment_score=80,
+                operation_advice="持有",
+                trend_prediction="看多",
+                analysis_summary="summary",
+                ideal_buy=None,
+                secondary_buy=None,
+                stop_loss=None,
+                take_profit=None,
+                created_at=None,
+            )
+        ]
+
+        with patch("api.v1.endpoints.analysis.get_task_queue", return_value=mock_queue), \
+             patch("src.storage.DatabaseManager.get_instance", return_value=mock_db):
+            result = get_analysis_status("task-1")
+
+        self.assertEqual(result.status, "completed")
+        self.assertEqual(result.result.report["meta"]["current_price"], 1234.5)
+        self.assertEqual(result.result.report["meta"]["change_pct"], 0.0)
+
+    def test_get_analysis_status_completed_db_snapshot_reads_change_pct_from_raw_when_price_present(self) -> None:
+        if get_analysis_status is None:
+            self.skipTest("analysis endpoint helpers unavailable in this environment")
+
+        mock_queue = MagicMock()
+        mock_queue.get_task.return_value = None
+        mock_db = MagicMock()
+        mock_db.get_analysis_history.return_value = [
+            SimpleNamespace(
+                id=2,
+                code="AAPL",
+                name="Apple",
+                report_type="detailed",
+                raw_result={"report_language": "en", "model_used": "test-model"},
+                context_snapshot={
+                    "enhanced_context": {
+                        "realtime": {
+                            "price": 180.35,
+                            "change_pct": None,
+                            "change_60d": None,
+                        }
+                    },
+                    "realtime_quote_raw": {"price": 180.35, "pct_chg": -1.25},
+                },
+                sentiment_score=72,
+                operation_advice="Hold",
+                trend_prediction="Neutral",
+                analysis_summary="summary",
+                ideal_buy=None,
+                secondary_buy=None,
+                stop_loss=None,
+                take_profit=None,
+                created_at=None,
+            )
+        ]
+
+        with patch("api.v1.endpoints.analysis.get_task_queue", return_value=mock_queue), \
+             patch("src.storage.DatabaseManager.get_instance", return_value=mock_db):
+            result = get_analysis_status("task-2")
+
+        self.assertEqual(result.status, "completed")
+        self.assertEqual(result.result.report["meta"]["current_price"], 180.35)
+        self.assertEqual(result.result.report["meta"]["change_pct"], -1.25)
+
     def test_report_type_full_maps_to_full_pipeline_mode(self) -> None:
         service = object.__new__(AnalysisService)
         pipeline_instance = MagicMock()


### PR DESCRIPTION
## PR Type
- [x] fix
- [ ] feat
- [ ] refactor
- [ ] docs
- [ ] chore
- [ ] test

## Background And Problem
- `REPORT_LANGUAGE` 之前只在部分报告链路生效，GitHub Actions 的 `daily_analysis.yml` 也没有把该变量注入进程，导致用户即使在 Actions Variables 里配置了英文，实际运行仍可能回落到中文。
- `/api/v1/analysis/status/{task_id}` 在从数据库快照回填状态时，`change_pct` 依赖 `current_price is None` 才会继续读取 `realtime_quote_raw`，会漏掉“价格已存在但涨跌幅只在 raw quote 里”的场景，也会错误处理 `0.0`。

## Scope Of Change
- `.github/workflows/daily_analysis.yml`
- `README.md`
- `api/v1/endpoints/analysis.py`
- `docs/CHANGELOG.md`
- `docs/README_EN.md`
- `docs/full-guide.md`
- `docs/full-guide_EN.md`
- `tests/test_analysis_api_contract.py`

## Documentation And Changelog
- 已同步更新 `README.md`、`docs/README_EN.md`、`docs/full-guide.md`、`docs/full-guide_EN.md`、`docs/CHANGELOG.md`。
- 文档现在明确说明仓库自带的 `daily_analysis.yml` 已显式映射 `REPORT_LANGUAGE`，在 GitHub Actions Variables / Secrets 中配置后即可生效。

## Issue Link
- Closes #1013
- Fixes #983

## Verification Commands And Results
```bash
python -m py_compile api/v1/endpoints/analysis.py tests/test_analysis_api_contract.py
python -m pytest tests/test_analysis_api_contract.py -q
```

关键结果：`35 passed`

## Compatibility And Risk
- workflow 变更仅新增 `REPORT_LANGUAGE` 注入，不改变未配置场景的默认中文行为。
- status API 修复只补强 DB snapshot 的回填逻辑，优先级仍保持 `enhanced_context.realtime` 在前、`realtime_quote_raw` 在后。
- 这次特意补了 `change_pct=0.0` 保留和“price 在 enhanced_context、change_pct 仅在 raw quote”两个回归场景，避免再被 truthy/falsy 或耦合条件误伤。

## Rollback Plan
- `git revert <merge-commit>` 回滚本 PR。
- 回滚后重点检查 `.github/workflows/daily_analysis.yml` 的环境变量映射，以及 `/api/v1/analysis/status/{task_id}` 的 `current_price` / `change_pct` 返回值。

## Checklist
- [x] 本 PR 有明确动机和业务价值
- [x] 已提供可复现的验证命令与结果
- [x] 已评估兼容性与风险
- [x] 已提供回滚方案
- [x] 已同步更新相关文档与 `docs/CHANGELOG.md`
