### PR TITLE
fix: 让大盘复盘链路在 `REPORT_LANGUAGE=en` 时输出英文 Markdown… (#1029)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 <!-- 每条独立一行追加到本段末尾，无需分类标题，合并时冲突最小 -->
 
 - [修复] `AGENT_MAX_STEPS` 在 orchestrator 多 Agent 模式下改为作为各子 Agent 的步数上限而非硬覆盖；TechnicalAgent 等高默认值 Agent 会被封顶，低默认值 Agent 保持原值，减少不必要的 LLM 调用膨胀与配额消耗。
+- [修复] 大盘复盘链路接入 `REPORT_LANGUAGE`：`REPORT_LANGUAGE=en` 时，A 股/合并复盘的 Prompt、章节标题、模板兜底文案与通知包装标题统一改为英文，避免出现英文正文外包中文标题的问题。
 - [修复] **MiniMax-M2.7 模型连接测试支持** — 修复 LLM 通道连接测试在 MiniMax-M2.7 模型下返回 "Empty response" 的问题；增加了 `max_tokens` 上限（8→256）以容纳 MiniMax 思考过程，并添加 `content_blocks` 格式解析逻辑统一处理 MiniMax 响应格式差异。
 - [修复] 移除 `HistoryItem` 与 `ReportSummary` 响应 Schema 中 `sentiment_score` 的 `ge=0/le=100` 约束（fixes #942）——历史库中存储的超范围负值或大于 100 的情绪评分不再触发 Pydantic ValidationError，历史列表与详情接口恢复正常返回。
 - [改进] Agent IntelAgent 新增公司公告搜索维度（上交所/深交所/cninfo）与主力资金流工具（get_capital_flow），修复 Agent 模式下公告和资金流数据经常缺失的问题

--- a/src/core/market_review.py
+++ b/src/core/market_review.py
@@ -17,11 +17,31 @@ from typing import Optional
 from src.config import get_config
 from src.notification import NotificationService
 from src.market_analyzer import MarketAnalyzer
+from src.report_language import normalize_report_language
 from src.search_service import SearchService
 from src.analyzer import GeminiAnalyzer
 
 
 logger = logging.getLogger(__name__)
+
+
+def _get_market_review_text(language: str) -> dict[str, str]:
+    normalized = normalize_report_language(language)
+    if normalized == "en":
+        return {
+            "root_title": "# 🎯 Market Review",
+            "push_title": "🎯 Market Review",
+            "cn_title": "# A-share Market Recap",
+            "us_title": "# US Market Recap",
+            "separator": "> US market recap follows",
+        }
+    return {
+        "root_title": "# 🎯 大盘复盘",
+        "push_title": "🎯 大盘复盘",
+        "cn_title": "# A股大盘复盘",
+        "us_title": "# 美股大盘复盘",
+        "separator": "> 以下为美股大盘复盘",
+    }
 
 
 def run_market_review(
@@ -48,6 +68,7 @@ def run_market_review(
     """
     logger.info("开始执行大盘复盘分析...")
     config = get_config()
+    review_text = _get_market_review_text(getattr(config, "report_language", "zh"))
     region = (
         override_region
         if override_region is not None
@@ -71,11 +92,11 @@ def run_market_review(
             us_report = us_analyzer.run_daily_review()
             review_report = ''
             if cn_report:
-                review_report = f"# A股大盘复盘\n\n{cn_report}"
+                review_report = f"{review_text['cn_title']}\n\n{cn_report}"
             if us_report:
                 if review_report:
-                    review_report += "\n\n---\n\n> 以下为美股大盘复盘\n\n"
-                review_report += f"# 美股大盘复盘\n\n{us_report}"
+                    review_report += f"\n\n---\n\n{review_text['separator']}\n\n"
+                review_report += f"{review_text['us_title']}\n\n{us_report}"
             if not review_report:
                 review_report = None
         else:
@@ -91,7 +112,7 @@ def run_market_review(
             date_str = datetime.now().strftime('%Y%m%d')
             report_filename = f"market_review_{date_str}.md"
             filepath = notifier.save_report_to_file(
-                f"# 🎯 大盘复盘\n\n{review_report}", 
+                f"{review_text['root_title']}\n\n{review_report}",
                 report_filename
             )
             logger.info(f"大盘复盘报告已保存: {filepath}")
@@ -101,7 +122,7 @@ def run_market_review(
                 logger.info("合并推送模式：跳过大盘复盘单独推送，将在个股+大盘复盘后统一发送")
             elif send_notification and notifier.is_available():
                 # 添加标题
-                report_content = f"🎯 大盘复盘\n\n{review_report}"
+                report_content = f"{review_text['push_title']}\n\n{review_report}"
 
                 success = notifier.send(report_content, email_send_to_all=True)
                 if success:

--- a/src/market_analyzer.py
+++ b/src/market_analyzer.py
@@ -19,12 +19,26 @@ from typing import Optional, Dict, Any, List
 import pandas as pd
 
 from src.config import get_config
+from src.report_language import normalize_report_language
 from src.search_service import SearchService
 from src.core.market_profile import get_profile, MarketProfile
 from src.core.market_strategy import get_market_strategy_blueprint
 from data_provider.base import DataFetcherManager
 
 logger = logging.getLogger(__name__)
+
+
+_ENGLISH_SECTION_PATTERNS = {
+    "market_summary": r"###\s*(?:1\.\s*)?Market Summary",
+    "index_commentary": r"###\s*(?:2\.\s*)?(?:Index Commentary|Major Indices)",
+    "sector_highlights": r"###\s*(?:4\.\s*)?(?:Sector Highlights|Sector/Theme Highlights)",
+}
+
+_CHINESE_SECTION_PATTERNS = {
+    "market_summary": r"###\s*一、市场总结",
+    "index_commentary": r"###\s*二、(?:指数点评|主要指数)",
+    "sector_highlights": r"###\s*四、(?:热点解读|板块表现)",
+}
 
 
 @dataclass
@@ -110,6 +124,92 @@ class MarketAnalyzer:
         self.region = region if region in ("cn", "us") else "cn"
         self.profile: MarketProfile = get_profile(self.region)
         self.strategy = get_market_strategy_blueprint(self.region)
+
+    def _get_review_language(self) -> str:
+        configured = normalize_report_language(
+            getattr(getattr(self, "config", None), "report_language", "zh")
+        )
+        if self.region == "us":
+            return "en"
+        return configured
+
+    def _get_market_scope_name(self) -> str:
+        if self.region == "us":
+            return "US market"
+        if self._get_review_language() == "en":
+            return "A-share market"
+        return "A股市场"
+
+    def _get_review_title(self, date: str) -> str:
+        if self._get_review_language() == "en":
+            market_name = "US Market Recap" if self.region == "us" else "A-share Market Recap"
+            return f"## {date} {market_name}"
+        return f"## {date} 大盘复盘"
+
+    def _get_index_hint(self) -> str:
+        if self._get_review_language() == "en":
+            if self.region == "us":
+                return "Analyze the key moves in the S&P 500, Nasdaq, Dow, and other major indices."
+            return "Analyze the price action in the SSE, SZSE, ChiNext, and other major indices."
+        return self.profile.prompt_index_hint
+
+    def _get_strategy_prompt_block(self) -> str:
+        if not (self.region == "cn" and self._get_review_language() == "en"):
+            return self.strategy.to_prompt_block()
+        return """## Strategy Blueprint: A-share Three-Phase Recap Strategy
+Focus on index trend, liquidity, and sector rotation to shape the next-session trading plan.
+
+### Strategy Principles
+- Read index direction first, then confirm liquidity structure, and finally test sector persistence.
+- Every conclusion must map to position sizing, trading pace, and risk-control actions.
+- Base judgments on today's data and the latest 3-day news flow without inventing unverified information.
+
+### Analysis Dimensions
+- Trend Structure: Determine whether the market is in an uptrend, range, or defensive phase.
+  - Are the SSE, SZSE, and ChiNext moving in the same direction
+  - Is the market advancing on expanding volume or slipping on contracting volume
+  - Have key support or resistance levels been reclaimed or broken
+- Liquidity & Sentiment: Identify near-term risk appetite and market temperature.
+  - Advance/decline breadth and limit-up/limit-down structure
+  - Whether turnover is expanding or fading
+  - Whether high-beta leaders are showing divergence
+- Leading Themes: Distill tradable leadership and areas to avoid.
+  - Whether leading sectors have clear event catalysts
+  - Whether sector leaders are pulling the group higher
+  - Whether weakness is broadening across lagging sectors
+
+### Action Framework
+- Offensive: indices rise in sync, turnover expands, and core themes strengthen.
+- Balanced: index divergence or low-volume consolidation; keep sizing controlled and wait for confirmation.
+- Defensive: indices weaken and laggards broaden; prioritize risk control and de-risking."""
+
+    def _get_strategy_markdown_block(self) -> str:
+        if not (self.region == "cn" and self._get_review_language() == "en"):
+            return self.strategy.to_markdown_block()
+        return """### 6. Strategy Framework
+- **Trend Structure**: Determine whether the market is in an uptrend, range, or defensive phase.
+- **Liquidity & Sentiment**: Track breadth, turnover expansion, and whether leaders are diverging.
+- **Leading Themes**: Focus on sectors with catalysts and sustained leadership while avoiding broadening weakness.
+"""
+
+    def _get_market_mood_text(self, mood_key: str) -> str:
+        if self._get_review_language() == "en":
+            mapping = {
+                "strong_up": "strong gains",
+                "mild_up": "moderate gains",
+                "mild_down": "mild losses",
+                "strong_down": "clear weakness",
+                "range": "range-bound trading",
+            }
+        else:
+            mapping = {
+                "strong_up": "强势上涨",
+                "mild_up": "小幅上涨",
+                "mild_down": "小幅下跌",
+                "strong_down": "明显下跌",
+                "range": "震荡整理",
+            }
+        return mapping[mood_key]
 
     def get_market_overview(self) -> MarketOverview:
         """
@@ -307,24 +407,36 @@ class MarketAnalyzer:
     
     def _inject_data_into_review(self, review: str, overview: MarketOverview) -> str:
         """Inject structured data tables into the corresponding LLM prose sections."""
-        import re
-
         # Build data blocks
         stats_block = self._build_stats_block(overview)
         indices_block = self._build_indices_block(overview)
         sector_block = self._build_sector_block(overview)
+        patterns = (
+            _ENGLISH_SECTION_PATTERNS
+            if self._get_review_language() == "en"
+            else _CHINESE_SECTION_PATTERNS
+        )
 
-        # Inject market stats after "### 一、市场总结" section (before next ###)
         if stats_block:
-            review = self._insert_after_section(review, r'###\s*一、市场总结', stats_block)
+            review = self._insert_after_section(
+                review,
+                patterns["market_summary"],
+                stats_block,
+            )
 
-        # Inject indices table after "### 二、指数点评" section
         if indices_block:
-            review = self._insert_after_section(review, r'###\s*二、指数点评', indices_block)
+            review = self._insert_after_section(
+                review,
+                patterns["index_commentary"],
+                indices_block,
+            )
 
-        # Inject sector rankings after "### 四、热点解读" section
         if sector_block:
-            review = self._insert_after_section(review, r'###\s*四、热点解读', sector_block)
+            review = self._insert_after_section(
+                review,
+                patterns["sector_highlights"],
+                sector_block,
+            )
 
         return review
 
@@ -352,6 +464,13 @@ class MarketAnalyzer:
         has_stats = overview.up_count or overview.down_count or overview.total_amount
         if not has_stats:
             return ""
+        if self._get_review_language() == "en":
+            return (
+                f"> 📈 Advancers **{overview.up_count}** / Decliners **{overview.down_count}** / "
+                f"Flat **{overview.flat_count}** | "
+                f"Limit-up **{overview.limit_up_count}** / Limit-down **{overview.limit_down_count}** | "
+                f"Turnover **{overview.total_amount:.0f}** CNY bn"
+            )
         lines = [
             f"> 📈 上涨 **{overview.up_count}** 家 / 下跌 **{overview.down_count}** 家 / "
             f"平盘 **{overview.flat_count}** 家 | "
@@ -364,9 +483,16 @@ class MarketAnalyzer:
         """构建指数行情表格（不含振幅）"""
         if not overview.indices:
             return ""
-        lines = [
-            "| 指数 | 最新 | 涨跌幅 | 成交额(亿) |",
-            "|------|------|--------|-----------|"]
+        if self._get_review_language() == "en":
+            lines = [
+                "| Index | Last | Change % | Turnover |",
+                "|-------|------|----------|----------|",
+            ]
+        else:
+            lines = [
+                "| 指数 | 最新 | 涨跌幅 | 成交额(亿) |",
+                "|------|------|--------|-----------|",
+            ]
         for idx in overview.indices:
             arrow = "🔴" if idx.change_pct < 0 else "🟢" if idx.change_pct > 0 else "⚪"
             amount_raw = idx.amount or 0.0
@@ -389,16 +515,24 @@ class MarketAnalyzer:
             top = " | ".join(
                 [f"**{s['name']}**({s['change_pct']:+.2f}%)" for s in overview.top_sectors[:5]]
             )
-            lines.append(f"> 🔥 领涨: {top}")
+            if self._get_review_language() == "en":
+                lines.append(f"> 🔥 Leaders: {top}")
+            else:
+                lines.append(f"> 🔥 领涨: {top}")
         if overview.bottom_sectors:
             bot = " | ".join(
                 [f"**{s['name']}**({s['change_pct']:+.2f}%)" for s in overview.bottom_sectors[:5]]
             )
-            lines.append(f"> 💧 领跌: {bot}")
+            if self._get_review_language() == "en":
+                lines.append(f"> 💧 Laggards: {bot}")
+            else:
+                lines.append(f"> 💧 领跌: {bot}")
         return "\n".join(lines)
 
     def _build_review_prompt(self, overview: MarketOverview, news: List) -> str:
         """构建复盘报告 Prompt"""
+        review_language = self._get_review_language()
+
         # 指数行情信息（简洁格式，不用emoji）
         indices_text = ""
         for idx in overview.indices:
@@ -424,14 +558,14 @@ class MarketAnalyzer:
         # 按 region 组装市场概况与板块区块（美股无涨跌家数、板块数据）
         stats_block = ""
         sector_block = ""
-        if self.region == "us":
+        if review_language == "en":
             if self.profile.has_market_stats:
-                stats_block = f"""## Market Overview
-- Up: {overview.up_count} | Down: {overview.down_count} | Flat: {overview.flat_count}
-- Limit up: {overview.limit_up_count} | Limit down: {overview.limit_down_count}
-- Total volume (CNY bn): {overview.total_amount:.0f}"""
+                stats_block = f"""## Market Breadth
+- Advancers: {overview.up_count} | Decliners: {overview.down_count} | Flat: {overview.flat_count}
+- Limit-up: {overview.limit_up_count} | Limit-down: {overview.limit_down_count}
+- Turnover: {overview.total_amount:.0f} CNY bn"""
             else:
-                stats_block = "## Market Overview\n(US market has no equivalent advance/decline stats.)"
+                stats_block = "## Market Breadth\n(No equivalent advance/decline statistics are available for this market.)"
 
             if self.profile.has_sector_rankings:
                 sector_block = f"""## Sector Performance
@@ -460,23 +594,28 @@ Lagging: {bottom_sectors_text if bottom_sectors_text else "N/A"}"""
             if not indices_text
             else ""
         )
-        indices_placeholder = indices_text if indices_text else ("No index data (API error)" if self.region == "us" else "暂无指数数据（接口异常）")
-        news_placeholder = news_text if news_text else ("No relevant news" if self.region == "us" else "暂无相关新闻")
-
-        # 美股场景使用英文提示语，便于生成更符合美股语境的报告
-        if self.region == "us":
-            data_no_indices_hint_en = (
+        if review_language == "en":
+            data_no_indices_hint = (
                 "Note: Market data fetch failed. Rely mainly on [Market News] for qualitative analysis. Do not invent index levels."
                 if not indices_text
                 else ""
             )
-            return f"""You are a professional US/A/H market analyst. Please produce a concise US market recap report based on the data below.
+            indices_placeholder = indices_text if indices_text else "No index data (API error)"
+            news_placeholder = news_text if news_text else "No relevant news"
+        else:
+            indices_placeholder = indices_text if indices_text else "暂无指数数据（接口异常）"
+            news_placeholder = news_text if news_text else "暂无相关新闻"
+
+        if review_language == "en":
+            report_title = self._get_review_title(overview.date).removeprefix("## ").strip()
+            return f"""You are a professional US/A/H market analyst. Please produce a concise market recap report based on the data below.
 
 [Requirements]
 - Output pure Markdown only
 - No JSON
 - No code blocks
 - Use emoji sparingly in headings (at most one per heading)
+- The entire fixed shell, headings, guidance, and conclusion must be in English
 
 ---
 
@@ -495,36 +634,36 @@ Lagging: {bottom_sectors_text if bottom_sectors_text else "N/A"}"""
 ## Market News
 {news_placeholder}
 
-{data_no_indices_hint_en}
+{data_no_indices_hint}
 
-{self.strategy.to_prompt_block()}
+{self._get_strategy_prompt_block()}
 
 ---
 
 # Output Template (follow this structure)
 
-## {overview.date} US Market Recap
+## {report_title}
 
 ### 1. Market Summary
-(2-3 sentences on overall market performance, index moves, volume)
+(2-3 sentences summarizing overall market tone, index moves, and liquidity.)
 
 ### 2. Index Commentary
-(Analyse S&P 500, Nasdaq, Dow and other major index moves.)
+({self._get_index_hint()})
 
 ### 3. Fund Flows
-(Interpret volume and flow implications)
+(Interpret what turnover, participation, and flow signals imply.)
 
-### 4. Sector/Theme Highlights
-(Analyze drivers behind leading/lagging sectors)
+### 4. Sector Highlights
+(Analyze the drivers behind the leading and lagging sectors or themes.)
 
 ### 5. Outlook
-(Short-term view based on price action and news)
+(Provide the near-term outlook based on price action and news.)
 
 ### 6. Risk Alerts
-(Key risks to watch)
+(List the main risks to monitor.)
 
 ### 7. Strategy Plan
-(Provide risk-on/neutral/risk-off stance, position sizing guideline, and one invalidation trigger.)
+(Provide an offensive/balanced/defensive stance, a position-sizing guideline, one invalidation trigger, and end with “For reference only, not investment advice.”)
 
 ---
 
@@ -559,7 +698,7 @@ Output the report content directly, no extra commentary.
 
 {data_no_indices_hint}
 
-{self.strategy.to_prompt_block()}
+{self._get_strategy_prompt_block()}
 
 ---
 
@@ -571,7 +710,7 @@ Output the report content directly, no extra commentary.
 （2-3句话概括今日市场整体表现，包括指数涨跌、成交量变化）
 
 ### 二、指数点评
-（{self.profile.prompt_index_hint}）
+（{self._get_index_hint()}）
 
 ### 三、资金动向
 （解读成交额流向的含义）
@@ -609,15 +748,15 @@ Output the report content directly, no extra commentary.
         )
         if mood_index:
             if mood_index.change_pct > 1:
-                market_mood = "强势上涨"
+                market_mood = self._get_market_mood_text("strong_up")
             elif mood_index.change_pct > 0:
-                market_mood = "小幅上涨"
+                market_mood = self._get_market_mood_text("mild_up")
             elif mood_index.change_pct > -1:
-                market_mood = "小幅下跌"
+                market_mood = self._get_market_mood_text("mild_down")
             else:
-                market_mood = "明显下跌"
+                market_mood = self._get_market_mood_text("strong_down")
         else:
-            market_mood = "震荡整理"
+            market_mood = self._get_market_mood_text("range")
         
         # 指数行情（简洁格式）
         indices_text = ""
@@ -626,10 +765,49 @@ Output the report content directly, no extra commentary.
             indices_text += f"- **{idx.name}**: {idx.current:.2f} ({direction}{abs(idx.change_pct):.2f}%)\n"
         
         # 板块信息
-        top_text = "、".join([s['name'] for s in overview.top_sectors[:3]])
-        bottom_text = "、".join([s['name'] for s in overview.bottom_sectors[:3]])
-        
-        # 按 region 决定是否包含涨跌统计和板块（美股无）
+        separator = ", " if self._get_review_language() == "en" else "、"
+        top_text = separator.join([s['name'] for s in overview.top_sectors[:3]])
+        bottom_text = separator.join([s['name'] for s in overview.bottom_sectors[:3]])
+
+        if self._get_review_language() == "en":
+            stats_section = ""
+            if self.profile.has_market_stats:
+                stats_section = f"""
+### 3. Breadth & Liquidity
+| Metric | Value |
+|--------|-------|
+| Advancers | {overview.up_count} |
+| Decliners | {overview.down_count} |
+| Limit-up | {overview.limit_up_count} |
+| Limit-down | {overview.limit_down_count} |
+| Turnover | {overview.total_amount:.0f} CNY bn |
+"""
+            sector_section = ""
+            if self.profile.has_sector_rankings and (top_text or bottom_text):
+                sector_section = f"""
+### 4. Sector Highlights
+- **Leaders**: {top_text or "N/A"}
+- **Laggards**: {bottom_text or "N/A"}
+"""
+            report = f"""{self._get_review_title(overview.date)}
+
+### 1. Market Summary
+Today's {self._get_market_scope_name()} showed **{market_mood}**.
+
+### 2. Major Indices
+{indices_text or "- No index data available"}
+{stats_section}
+{sector_section}
+### 5. Risk Alerts
+Market conditions can change quickly. The data above is for reference only and does not constitute investment advice.
+
+{self._get_strategy_markdown_block()}
+
+---
+*Review Time: {datetime.now().strftime('%H:%M')}*
+"""
+            return report
+
         stats_section = ""
         if self.profile.has_market_stats:
             stats_section = f"""
@@ -650,8 +828,8 @@ Output the report content directly, no extra commentary.
 - **领跌**: {bottom_text}
 """
         market_label = "A股" if self.region == "cn" else "美股"
-        strategy_summary = self.strategy.to_markdown_block()
-        report = f"""## {overview.date} 大盘复盘
+        strategy_summary = self._get_strategy_markdown_block()
+        return f"""{self._get_review_title(overview.date)}
 
 ### 一、市场总结
 今日{market_label}市场整体呈现**{market_mood}**态势。
@@ -668,7 +846,6 @@ Output the report content directly, no extra commentary.
 ---
 *复盘时间: {datetime.now().strftime('%H:%M')}*
 """
-        return report
     
     def run_daily_review(self) -> str:
         """

--- a/src/market_analyzer.py
+++ b/src/market_analyzer.py
@@ -146,6 +146,22 @@ class MarketAnalyzer:
             return "A-share market"
         return "A股市场"
 
+    def _get_turnover_unit_label(self) -> str:
+        """Return the turnover unit label for the current market/language."""
+        if self.region == "us":
+            return "USD bn" if self._get_review_language() == "en" else "十亿美元"
+        return "CNY 100m" if self._get_review_language() == "en" else "亿"
+
+    def _format_turnover_value(self, amount_raw: float) -> str:
+        """Format raw turnover according to market-specific units."""
+        if amount_raw == 0.0:
+            return "N/A"
+        if self.region == "us":
+            return f"{amount_raw / 1e9:.2f}"
+        if amount_raw > 1e6:
+            return f"{amount_raw / 1e8:.0f}"
+        return f"{amount_raw:.0f}"
+
     def _get_review_title(self, date: str) -> str:
         if self._get_review_language() == "en":
             market_name = "US Market Recap" if self.region == "us" else "A-share Market Recap"
@@ -477,7 +493,7 @@ Focus on index trend, liquidity, and sector rotation to shape the next-session t
                 f"> 📈 Advancers **{overview.up_count}** / Decliners **{overview.down_count}** / "
                 f"Flat **{overview.flat_count}** | "
                 f"Limit-up **{overview.limit_up_count}** / Limit-down **{overview.limit_down_count}** | "
-                f"Turnover **{overview.total_amount:.0f}** (CNY 100m)"
+                f"Turnover **{overview.total_amount:.0f}** ({self._get_turnover_unit_label()})"
             )
         lines = [
             f"> 📈 上涨 **{overview.up_count}** 家 / 下跌 **{overview.down_count}** 家 / "
@@ -493,8 +509,8 @@ Focus on index trend, liquidity, and sector rotation to shape the next-session t
             return ""
         if self._get_review_language() == "en":
             lines = [
-                "| Index | Last | Change % | Turnover (CNY 100m) |",
-                "|-------|------|----------|--------------------|",
+                f"| Index | Last | Change % | Turnover ({self._get_turnover_unit_label()}) |",
+                "|-------|------|----------|-----------------|",
             ]
         else:
             lines = [
@@ -504,13 +520,7 @@ Focus on index trend, liquidity, and sector rotation to shape the next-session t
         for idx in overview.indices:
             arrow = "🔴" if idx.change_pct < 0 else "🟢" if idx.change_pct > 0 else "⚪"
             amount_raw = idx.amount or 0.0
-            if amount_raw == 0.0:
-                # Yahoo Finance 不提供成交额，显示 N/A 避免误解
-                amount_str = "N/A"
-            elif amount_raw > 1e6:
-                amount_str = f"{amount_raw / 1e8:.0f}"
-            else:
-                amount_str = f"{amount_raw:.0f}"
+            amount_str = self._format_turnover_value(amount_raw)
             lines.append(f"| {idx.name} | {idx.current:.2f} | {arrow} {idx.change_pct:+.2f}% | {amount_str} |")
         return "\n".join(lines)
 
@@ -571,7 +581,7 @@ Focus on index trend, liquidity, and sector rotation to shape the next-session t
                 stats_block = f"""## Market Breadth
 - Advancers: {overview.up_count} | Decliners: {overview.down_count} | Flat: {overview.flat_count}
 - Limit-up: {overview.limit_up_count} | Limit-down: {overview.limit_down_count}
-- Turnover: {overview.total_amount:.0f} (CNY 100m)"""
+- Turnover: {overview.total_amount:.0f} ({self._get_turnover_unit_label()})"""
             else:
                 stats_block = "## Market Breadth\n(No equivalent advance/decline statistics are available for this market.)"
 
@@ -789,7 +799,7 @@ Output the report content directly, no extra commentary.
 | Decliners | {overview.down_count} |
 | Limit-up | {overview.limit_up_count} |
 | Limit-down | {overview.limit_down_count} |
-| Turnover (CNY 100m) | {overview.total_amount:.0f} |
+| Turnover ({self._get_turnover_unit_label()}) | {overview.total_amount:.0f} |
 """
             sector_section = ""
             if self.profile.has_sector_rankings and (top_text or bottom_text):

--- a/src/market_analyzer.py
+++ b/src/market_analyzer.py
@@ -133,10 +133,16 @@ class MarketAnalyzer:
             return "en"
         return configured
 
-    def _get_market_scope_name(self) -> str:
+    def _get_template_review_language(self) -> str:
+        return normalize_report_language(
+            getattr(getattr(self, "config", None), "report_language", "zh")
+        )
+
+    def _get_market_scope_name(self, review_language: str | None = None) -> str:
+        review_language = review_language or self._get_review_language()
         if self.region == "us":
             return "US market"
-        if self._get_review_language() == "en":
+        if review_language == "en":
             return "A-share market"
         return "A股市场"
 
@@ -183,8 +189,9 @@ Focus on index trend, liquidity, and sector rotation to shape the next-session t
 - Balanced: index divergence or low-volume consolidation; keep sizing controlled and wait for confirmation.
 - Defensive: indices weaken and laggards broaden; prioritize risk control and de-risking."""
 
-    def _get_strategy_markdown_block(self) -> str:
-        if not (self.region == "cn" and self._get_review_language() == "en"):
+    def _get_strategy_markdown_block(self, review_language: str | None = None) -> str:
+        review_language = review_language or self._get_review_language()
+        if not (self.region == "cn" and review_language == "en"):
             return self.strategy.to_markdown_block()
         return """### 6. Strategy Framework
 - **Trend Structure**: Determine whether the market is in an uptrend, range, or defensive phase.
@@ -192,8 +199,9 @@ Focus on index trend, liquidity, and sector rotation to shape the next-session t
 - **Leading Themes**: Focus on sectors with catalysts and sustained leadership while avoiding broadening weakness.
 """
 
-    def _get_market_mood_text(self, mood_key: str) -> str:
-        if self._get_review_language() == "en":
+    def _get_market_mood_text(self, mood_key: str, review_language: str | None = None) -> str:
+        review_language = review_language or self._get_review_language()
+        if review_language == "en":
             mapping = {
                 "strong_up": "strong gains",
                 "mild_up": "moderate gains",
@@ -734,6 +742,7 @@ Output the report content directly, no extra commentary.
     
     def _generate_template_review(self, overview: MarketOverview, news: List) -> str:
         """使用模板生成复盘报告（无大模型时的备选方案）"""
+        template_language = self._get_template_review_language()
         mood_code = self.profile.mood_index_code
         # 根据 mood_index_code 查找对应指数
         # cn: mood_code="000001"，idx.code 可能为 "sh000001"（以 mood_code 结尾）
@@ -748,15 +757,15 @@ Output the report content directly, no extra commentary.
         )
         if mood_index:
             if mood_index.change_pct > 1:
-                market_mood = self._get_market_mood_text("strong_up")
+                market_mood = self._get_market_mood_text("strong_up", template_language)
             elif mood_index.change_pct > 0:
-                market_mood = self._get_market_mood_text("mild_up")
+                market_mood = self._get_market_mood_text("mild_up", template_language)
             elif mood_index.change_pct > -1:
-                market_mood = self._get_market_mood_text("mild_down")
+                market_mood = self._get_market_mood_text("mild_down", template_language)
             else:
-                market_mood = self._get_market_mood_text("strong_down")
+                market_mood = self._get_market_mood_text("strong_down", template_language)
         else:
-            market_mood = self._get_market_mood_text("range")
+            market_mood = self._get_market_mood_text("range", template_language)
         
         # 指数行情（简洁格式）
         indices_text = ""
@@ -765,11 +774,11 @@ Output the report content directly, no extra commentary.
             indices_text += f"- **{idx.name}**: {idx.current:.2f} ({direction}{abs(idx.change_pct):.2f}%)\n"
         
         # 板块信息
-        separator = ", " if self._get_review_language() == "en" else "、"
+        separator = ", " if template_language == "en" else "、"
         top_text = separator.join([s['name'] for s in overview.top_sectors[:3]])
         bottom_text = separator.join([s['name'] for s in overview.bottom_sectors[:3]])
 
-        if self._get_review_language() == "en":
+        if template_language == "en":
             stats_section = ""
             if self.profile.has_market_stats:
                 stats_section = f"""
@@ -789,10 +798,11 @@ Output the report content directly, no extra commentary.
 - **Leaders**: {top_text or "N/A"}
 - **Laggards**: {bottom_text or "N/A"}
 """
-            report = f"""{self._get_review_title(overview.date)}
+            market_name = "US Market Recap" if self.region == "us" else "A-share Market Recap"
+            report = f"""## {overview.date} {market_name}
 
 ### 1. Market Summary
-Today's {self._get_market_scope_name()} showed **{market_mood}**.
+Today's {self._get_market_scope_name(template_language)} showed **{market_mood}**.
 
 ### 2. Major Indices
 {indices_text or "- No index data available"}
@@ -801,7 +811,7 @@ Today's {self._get_market_scope_name()} showed **{market_mood}**.
 ### 5. Risk Alerts
 Market conditions can change quickly. The data above is for reference only and does not constitute investment advice.
 
-{self._get_strategy_markdown_block()}
+{self._get_strategy_markdown_block(template_language)}
 
 ---
 *Review Time: {datetime.now().strftime('%H:%M')}*
@@ -828,8 +838,8 @@ Market conditions can change quickly. The data above is for reference only and d
 - **领跌**: {bottom_text}
 """
         market_label = "A股" if self.region == "cn" else "美股"
-        strategy_summary = self._get_strategy_markdown_block()
-        return f"""{self._get_review_title(overview.date)}
+        strategy_summary = self._get_strategy_markdown_block(template_language)
+        return f"""## {overview.date} 大盘复盘
 
 ### 一、市场总结
 今日{market_label}市场整体呈现**{market_mood}**态势。

--- a/src/market_analyzer.py
+++ b/src/market_analyzer.py
@@ -469,7 +469,7 @@ Focus on index trend, liquidity, and sector rotation to shape the next-session t
                 f"> 📈 Advancers **{overview.up_count}** / Decliners **{overview.down_count}** / "
                 f"Flat **{overview.flat_count}** | "
                 f"Limit-up **{overview.limit_up_count}** / Limit-down **{overview.limit_down_count}** | "
-                f"Turnover **{overview.total_amount:.0f}** CNY bn"
+                f"Turnover **{overview.total_amount:.0f}** (CNY 100m)"
             )
         lines = [
             f"> 📈 上涨 **{overview.up_count}** 家 / 下跌 **{overview.down_count}** 家 / "
@@ -485,8 +485,8 @@ Focus on index trend, liquidity, and sector rotation to shape the next-session t
             return ""
         if self._get_review_language() == "en":
             lines = [
-                "| Index | Last | Change % | Turnover |",
-                "|-------|------|----------|----------|",
+                "| Index | Last | Change % | Turnover (CNY 100m) |",
+                "|-------|------|----------|--------------------|",
             ]
         else:
             lines = [
@@ -563,7 +563,7 @@ Focus on index trend, liquidity, and sector rotation to shape the next-session t
                 stats_block = f"""## Market Breadth
 - Advancers: {overview.up_count} | Decliners: {overview.down_count} | Flat: {overview.flat_count}
 - Limit-up: {overview.limit_up_count} | Limit-down: {overview.limit_down_count}
-- Turnover: {overview.total_amount:.0f} CNY bn"""
+- Turnover: {overview.total_amount:.0f} (CNY 100m)"""
             else:
                 stats_block = "## Market Breadth\n(No equivalent advance/decline statistics are available for this market.)"
 
@@ -780,7 +780,7 @@ Output the report content directly, no extra commentary.
 | Decliners | {overview.down_count} |
 | Limit-up | {overview.limit_up_count} |
 | Limit-down | {overview.limit_down_count} |
-| Turnover | {overview.total_amount:.0f} CNY bn |
+| Turnover (CNY 100m) | {overview.total_amount:.0f} |
 """
             sector_section = ""
             if self.profile.has_sector_rankings and (top_text or bottom_text):

--- a/tests/test_market_analyzer_generate_text.py
+++ b/tests/test_market_analyzer_generate_text.py
@@ -511,6 +511,36 @@ Sector text.
         assert "Leaders: **AI算力**(+3.25%)" in result
         assert "Laggards: **煤炭**(-1.12%)" in result
 
+    def test_us_english_indices_do_not_label_turnover_as_cny(self):
+        from src.core.market_profile import US_PROFILE
+        from src.core.market_strategy import get_market_strategy_blueprint
+        from src.market_analyzer import MarketOverview, MarketIndex
+
+        ma = self._make_market_analyzer_with_mock_generate_text(return_value=None)
+        ma.config.report_language = "en"
+        ma.region = "us"
+        ma.profile = US_PROFILE
+        ma.strategy = get_market_strategy_blueprint("us")
+        overview = MarketOverview(
+            date="2026-03-05",
+            indices=[
+                MarketIndex(
+                    code="SPX",
+                    name="S&P 500",
+                    current=5200.0,
+                    change=35.0,
+                    change_pct=0.68,
+                    amount=9876543210.0,
+                )
+            ],
+        )
+
+        result = ma._build_indices_block(overview)
+
+        assert "CNY 100m" not in result
+        assert "Turnover (USD bn)" in result
+        assert "| S&P 500 | 5200.00 |" in result
+
     def test_no_private_attribute_access_in_market_analyzer_source(self):
         """Static guard: market_analyzer.py must not access private analyzer attrs."""
         import ast

--- a/tests/test_market_analyzer_generate_text.py
+++ b/tests/test_market_analyzer_generate_text.py
@@ -321,6 +321,7 @@ class TestMarketAnalyzerBypassFix:
             cfg.llm_model_list = []
             cfg.openai_base_url = None
             cfg.market_review_region = "cn"
+            cfg.report_language = "zh"
             mock_cfg.return_value = cfg
             mock_cfg2.return_value = cfg
 
@@ -334,6 +335,7 @@ class TestMarketAnalyzerBypassFix:
 
             ma = MarketAnalyzer.__new__(MarketAnalyzer)
             ma.analyzer = analyzer
+            ma.config = cfg
             ma.profile = CN_PROFILE
             ma.strategy = get_market_strategy_blueprint("cn")
             ma.region = "cn"
@@ -397,6 +399,85 @@ class TestMarketAnalyzerBypassFix:
         _, kwargs = ma.analyzer.generate_text.call_args
         assert kwargs["max_tokens"] == 8192
         assert kwargs["temperature"] == 0.7
+
+    def test_generate_template_review_uses_english_shell_for_cn_when_report_language_is_en(self):
+        from src.market_analyzer import MarketOverview, MarketIndex
+
+        ma = self._make_market_analyzer_with_mock_generate_text(return_value=None)
+        ma.config.report_language = "en"
+        overview = MarketOverview(
+            date="2026-03-05",
+            indices=[
+                MarketIndex(
+                    code="000001",
+                    name="上证指数",
+                    current=3300.0,
+                    change=12.0,
+                    change_pct=0.36,
+                )
+            ],
+            up_count=3200,
+            down_count=1800,
+            limit_up_count=88,
+            limit_down_count=5,
+            total_amount=14567.0,
+            top_sectors=[{"name": "AI算力", "change_pct": 3.25}],
+            bottom_sectors=[{"name": "煤炭", "change_pct": -1.12}],
+        )
+
+        result = ma.generate_market_review(overview, [])
+
+        assert "A-share Market Recap" in result
+        assert "### 1. Market Summary" in result
+        assert "### 3. Breadth & Liquidity" in result
+        assert "### 4. Sector Highlights" in result
+        assert "### 6. Strategy Framework" in result
+        assert "### 一、市场总结" not in result
+
+    def test_inject_data_into_review_matches_english_headings(self):
+        from src.market_analyzer import MarketOverview, MarketIndex
+
+        ma = self._make_market_analyzer_with_mock_generate_text(return_value="review")
+        ma.config.report_language = "en"
+        overview = MarketOverview(
+            date="2026-03-05",
+            indices=[
+                MarketIndex(
+                    code="000001",
+                    name="上证指数",
+                    current=3300.0,
+                    change=12.0,
+                    change_pct=0.36,
+                    amount=145000000000.0,
+                )
+            ],
+            up_count=3200,
+            down_count=1800,
+            flat_count=100,
+            limit_up_count=88,
+            limit_down_count=5,
+            total_amount=14567.0,
+            top_sectors=[{"name": "AI算力", "change_pct": 3.25}],
+            bottom_sectors=[{"name": "煤炭", "change_pct": -1.12}],
+        )
+        review = """## 2026-03-05 A-share Market Recap
+
+### 1. Market Summary
+Summary text.
+
+### 2. Index Commentary
+Index text.
+
+### 4. Sector Highlights
+Sector text.
+"""
+
+        result = ma._inject_data_into_review(review, overview)
+
+        assert "Advancers **3200**" in result
+        assert "| Index | Last | Change % | Turnover |" in result
+        assert "Leaders: **AI算力**(+3.25%)" in result
+        assert "Laggards: **煤炭**(-1.12%)" in result
 
     def test_no_private_attribute_access_in_market_analyzer_source(self):
         """Static guard: market_analyzer.py must not access private analyzer attrs."""

--- a/tests/test_market_analyzer_generate_text.py
+++ b/tests/test_market_analyzer_generate_text.py
@@ -435,6 +435,36 @@ class TestMarketAnalyzerBypassFix:
         assert "### 6. Strategy Framework" in result
         assert "### 一、市场总结" not in result
 
+    def test_generate_template_review_keeps_chinese_shell_for_us_when_report_language_is_default(self):
+        from src.core.market_profile import US_PROFILE
+        from src.core.market_strategy import get_market_strategy_blueprint
+        from src.market_analyzer import MarketOverview, MarketIndex
+
+        ma = self._make_market_analyzer_with_mock_generate_text(return_value=None)
+        ma.region = "us"
+        ma.profile = US_PROFILE
+        ma.strategy = get_market_strategy_blueprint("us")
+        overview = MarketOverview(
+            date="2026-03-05",
+            indices=[
+                MarketIndex(
+                    code="SPX",
+                    name="标普500",
+                    current=5200.0,
+                    change=-18.0,
+                    change_pct=-0.35,
+                )
+            ],
+        )
+
+        result = ma.generate_market_review(overview, [])
+
+        assert "## 2026-03-05 大盘复盘" in result
+        assert "### 一、市场总结" in result
+        assert "今日美股市场整体呈现**小幅下跌**态势。" in result
+        assert "### 1. Market Summary" not in result
+        assert "US Market Recap" not in result
+
     def test_inject_data_into_review_matches_english_headings(self):
         from src.market_analyzer import MarketOverview, MarketIndex
 

--- a/tests/test_market_analyzer_generate_text.py
+++ b/tests/test_market_analyzer_generate_text.py
@@ -430,6 +430,7 @@ class TestMarketAnalyzerBypassFix:
         assert "A-share Market Recap" in result
         assert "### 1. Market Summary" in result
         assert "### 3. Breadth & Liquidity" in result
+        assert "Turnover (CNY 100m)" in result
         assert "### 4. Sector Highlights" in result
         assert "### 6. Strategy Framework" in result
         assert "### 一、市场总结" not in result
@@ -475,7 +476,8 @@ Sector text.
         result = ma._inject_data_into_review(review, overview)
 
         assert "Advancers **3200**" in result
-        assert "| Index | Last | Change % | Turnover |" in result
+        assert "Turnover **14567** (CNY 100m)" in result
+        assert "| Index | Last | Change % | Turnover (CNY 100m) |" in result
         assert "Leaders: **AI算力**(+3.25%)" in result
         assert "Laggards: **煤炭**(-1.12%)" in result
 

--- a/tests/test_market_review.py
+++ b/tests/test_market_review.py
@@ -1,0 +1,69 @@
+# -*- coding: utf-8 -*-
+"""Tests for localized market review wrappers."""
+
+import sys
+import unittest
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+
+for _mod in ("litellm", "google.generativeai", "google.genai", "anthropic"):
+    if _mod not in sys.modules:
+        sys.modules[_mod] = MagicMock()
+
+
+from src.core.market_review import run_market_review
+
+
+class MarketReviewLocalizationTestCase(unittest.TestCase):
+    def _make_notifier(self) -> MagicMock:
+        notifier = MagicMock()
+        notifier.save_report_to_file.return_value = "/tmp/market_review.md"
+        notifier.is_available.return_value = True
+        notifier.send.return_value = True
+        return notifier
+
+    def test_run_market_review_uses_english_notification_title(self) -> None:
+        notifier = self._make_notifier()
+        market_analyzer = MagicMock()
+        market_analyzer.run_daily_review.return_value = "## 2026-04-10 A-share Market Recap\n\nBody"
+
+        with patch(
+            "src.core.market_review.get_config",
+            return_value=SimpleNamespace(report_language="en", market_review_region="cn"),
+        ), patch("src.core.market_review.MarketAnalyzer", return_value=market_analyzer):
+            result = run_market_review(notifier, send_notification=True)
+
+        self.assertEqual(result, "## 2026-04-10 A-share Market Recap\n\nBody")
+        saved_content = notifier.save_report_to_file.call_args.args[0]
+        self.assertTrue(saved_content.startswith("# 🎯 Market Review\n\n"))
+        sent_content = notifier.send.call_args.args[0]
+        self.assertTrue(sent_content.startswith("🎯 Market Review\n\n"))
+        self.assertTrue(notifier.send.call_args.kwargs["email_send_to_all"])
+
+    def test_run_market_review_merges_both_regions_with_english_wrappers(self) -> None:
+        notifier = self._make_notifier()
+        cn_analyzer = MagicMock()
+        cn_analyzer.run_daily_review.return_value = "CN body"
+        us_analyzer = MagicMock()
+        us_analyzer.run_daily_review.return_value = "US body"
+
+        with patch(
+            "src.core.market_review.get_config",
+            return_value=SimpleNamespace(report_language="en", market_review_region="both"),
+        ), patch(
+            "src.core.market_review.MarketAnalyzer",
+            side_effect=[cn_analyzer, us_analyzer],
+        ):
+            result = run_market_review(notifier, send_notification=False)
+
+        self.assertIn("# A-share Market Recap\n\nCN body", result)
+        self.assertIn("> US market recap follows", result)
+        self.assertIn("# US Market Recap\n\nUS body", result)
+        saved_content = notifier.save_report_to_file.call_args.args[0]
+        self.assertTrue(saved_content.startswith("# 🎯 Market Review\n\n"))
+        notifier.send.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_market_review.py
+++ b/tests/test_market_review.py
@@ -1,18 +1,44 @@
 # -*- coding: utf-8 -*-
 """Tests for localized market review wrappers."""
 
+import importlib
 import sys
 import unittest
-from types import SimpleNamespace
+from types import ModuleType, SimpleNamespace
 from unittest.mock import MagicMock, patch
 
+from tests.litellm_stub import ensure_litellm_stub
 
-for _mod in ("litellm", "google.generativeai", "google.genai", "anthropic"):
-    if _mod not in sys.modules:
-        sys.modules[_mod] = MagicMock()
+ensure_litellm_stub()
+
+def _build_optional_module_stubs() -> dict[str, ModuleType]:
+    stubs: dict[str, ModuleType] = {}
+    google_module: ModuleType | None = None
+
+    for module_name in ("google.generativeai", "google.genai", "anthropic"):
+        try:
+            importlib.import_module(module_name)
+            continue
+        except ImportError:
+            stub = ModuleType(module_name)
+            stubs[module_name] = stub
+            if not module_name.startswith("google."):
+                continue
+            if google_module is None:
+                try:
+                    google_module = importlib.import_module("google")
+                except ImportError:
+                    google_module = ModuleType("google")
+                    stubs["google"] = google_module
+            setattr(google_module, module_name.split(".", 1)[1], stub)
+
+    return stubs
 
 
-from src.core.market_review import run_market_review
+with patch.dict(sys.modules, _build_optional_module_stubs()):
+    import src.core.market_review as market_review_module
+
+run_market_review = market_review_module.run_market_review
 
 
 class MarketReviewLocalizationTestCase(unittest.TestCase):
@@ -28,10 +54,11 @@ class MarketReviewLocalizationTestCase(unittest.TestCase):
         market_analyzer = MagicMock()
         market_analyzer.run_daily_review.return_value = "## 2026-04-10 A-share Market Recap\n\nBody"
 
-        with patch(
-            "src.core.market_review.get_config",
+        with patch.object(
+            market_review_module,
+            "get_config",
             return_value=SimpleNamespace(report_language="en", market_review_region="cn"),
-        ), patch("src.core.market_review.MarketAnalyzer", return_value=market_analyzer):
+        ), patch.object(market_review_module, "MarketAnalyzer", return_value=market_analyzer):
             result = run_market_review(notifier, send_notification=True)
 
         self.assertEqual(result, "## 2026-04-10 A-share Market Recap\n\nBody")
@@ -48,11 +75,13 @@ class MarketReviewLocalizationTestCase(unittest.TestCase):
         us_analyzer = MagicMock()
         us_analyzer.run_daily_review.return_value = "US body"
 
-        with patch(
-            "src.core.market_review.get_config",
+        with patch.object(
+            market_review_module,
+            "get_config",
             return_value=SimpleNamespace(report_language="en", market_review_region="both"),
-        ), patch(
-            "src.core.market_review.MarketAnalyzer",
+        ), patch.object(
+            market_review_module,
+            "MarketAnalyzer",
             side_effect=[cn_analyzer, us_analyzer],
         ):
             result = run_market_review(notifier, send_notification=False)

--- a/tests/test_market_strategy.py
+++ b/tests/test_market_strategy.py
@@ -2,6 +2,8 @@
 """Tests for market strategy blueprints."""
 
 import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
 
 from src.core.market_strategy import get_market_strategy_blueprint
 from src.market_analyzer import MarketAnalyzer, MarketOverview
@@ -43,6 +45,18 @@ class TestMarketAnalyzerStrategyPrompt(unittest.TestCase):
 
         self.assertIn("Strategy Plan", prompt)
         self.assertIn("US Market Regime Strategy", prompt)
+
+    def test_cn_prompt_uses_english_shell_when_report_language_is_en(self):
+        with patch("src.market_analyzer.get_config", return_value=SimpleNamespace(report_language="en")):
+            analyzer = MarketAnalyzer(region="cn")
+
+        prompt = analyzer._build_review_prompt(MarketOverview(date="2026-02-24"), [])
+
+        self.assertIn("# Today's Market Data", prompt)
+        self.assertIn("### 1. Market Summary", prompt)
+        self.assertIn("A-share Three-Phase Recap Strategy", prompt)
+        self.assertNotIn("### 一、市场总结", prompt)
+        self.assertNotIn("A股市场三段式复盘策略", prompt)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## PR Type
- [x] fix
- [ ] feat
- [ ] refactor
- [ ] docs
- [ ] chore
- [ ] test

## Background And Problem
- 大盘复盘链路在 `REPORT_LANGUAGE=en` 时仍会混入中文标题、中文 fallback 包装和中文通知外壳，导致英文内容与中文壳子混排。
- 同时英文美股路径里，部分成交额/金额文案仍沿用 A 股的 `CNY 100m` 表述，和美股英文上下文不一致。

## Scope Of Change
- `docs/CHANGELOG.md`
- `src/core/market_review.py`
- `src/market_analyzer.py`
- `tests/test_market_analyzer_generate_text.py`
- `tests/test_market_review.py`
- `tests/test_market_strategy.py`

## Documentation And Changelog
- 已同步更新 `docs/CHANGELOG.md`。
- 本次没有改 `README.md`，因为变更收敛在既有 `REPORT_LANGUAGE` 语义下的大盘复盘实现修复，没有新增配置项或新的使用入口。

## Issue Link
- Closes #1029

## Verification Commands And Results
```bash
python -m py_compile src/market_analyzer.py tests/test_market_analyzer_generate_text.py tests/test_market_review.py tests/test_market_strategy.py
python -m pytest tests/test_market_analyzer_generate_text.py -q
python -m pytest tests/test_market_review.py -q
python -m pytest tests/test_market_strategy.py -q
```

关键结果：`18 passed`、`2 passed`、`5 passed`

## Compatibility And Risk
- `REPORT_LANGUAGE=zh` 或未设置时仍保持中文默认行为。
- 英文路径现在统一跟随报告语言输出英文标题、英文 fallback 和英文通知包装；A 股金额单位仍保持原有中文/A 股表示方式。
- 额外补了一处美股英文金额单位修复，避免在英文美股 review 里继续出现 `CNY 100m` 这类错误标签。
- 我单独执行了相关 market 测试文件；将三组测试合并到同一进程里跑时，本地测试环境会触发一次既有的 `numpy/pandas` 重复加载问题，因此这里采用拆分验证。

## Rollback Plan
- `git revert <merge-commit>` 回滚本 PR。
- 回滚后重点检查英文 market review 标题/通知包装，以及美股英文文案中的成交额单位是否恢复到修改前状态。

## Checklist
- [x] 本 PR 有明确动机和业务价值
- [x] 已提供可复现的验证命令与结果
- [x] 已评估兼容性与风险
- [x] 已提供回滚方案
- [x] 已同步更新相关文档与 `docs/CHANGELOG.md`
