### PR TITLE
feat: add MiniMax as a first-class LLM channel provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -105,6 +105,12 @@ GEMINI_API_KEY=
 # LLM_CHANNELS=ollama
 # LLM_OLLAMA_BASE_URL=http://localhost:11434
 # LLM_OLLAMA_MODELS=qwen3:8b,llama3.2
+#
+# 示例：MiniMax（自动使用 api.minimax.io 无需填写 base_url）
+# LLM_CHANNELS=minimax
+# LLM_MINIMAX_API_KEY=your_minimax_api_key_here
+# LLM_MINIMAX_MODELS=MiniMax-M2.7,MiniMax-M2.7-highspeed
+# LITELLM_MODEL=openai/MiniMax-M2.7
 
 # 高级：模型路由 YAML 配置（可选，参考 litellm_config.example.yaml）
 # LITELLM_CONFIG=./litellm_config.yaml

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 <!-- 新条目格式：- [类型] 描述（类型取值：新功能/改进/修复/文档/测试/chore）-->
 <!-- 每条独立一行追加到本段末尾，无需分类标题，合并时冲突最小 -->
 
+- [新功能] 新增 MiniMax 作为 LLM 渠道支持：`LLM_CHANNELS=minimax` 渠道可自动使用 `api.minimax.io` 海外端点（无需手动配置 base_url），支持 `MiniMax-M2.7` 与 `MiniMax-M2.7-highspeed` 模型，已同步更新 `.env.example`、`docs/LLM_CONFIG_GUIDE.md` 与 `litellm_config.example.yaml`。
 - [修复] 大盘复盘链路接入 `REPORT_LANGUAGE`：`REPORT_LANGUAGE=en` 时，A 股/合并复盘的 Prompt、章节标题、模板兜底文案与通知包装标题统一改为英文，避免出现英文正文外包中文标题的问题。
 - [修复] `AGENT_MAX_STEPS` 在 orchestrator 多 Agent 模式下统一明确为“默认作为各子 Agent 的步数上限而非硬覆盖；TechnicalAgent 等高默认值 Agent 会被封顶、低默认值 Agent 保持原值；当用户主动调高（>10）时，再统一覆盖所有子 Agent 采用全局值”，同时修复用户设置 12 但 TechnicalAgent 仍以默认 6 步运行并报 "Agent exceeded max steps" 的问题（fixes #1026）
 - [修复] Specialist（Skill）Agent 失败不再中断整个分析管线，改为与 intel/risk 相同的优雅降级策略

--- a/docs/LLM_CONFIG_GUIDE.md
+++ b/docs/LLM_CONFIG_GUIDE.md
@@ -112,6 +112,26 @@ LLM_OLLAMA_MODELS=qwen3:8b,llama3.2
 LITELLM_MODEL=ollama/qwen3:8b
 ```
 
+### 示例：MiniMax 渠道模式
+
+MiniMax 提供 OpenAI 兼容接口（`api.minimax.io`），只需声明 `minimax` 渠道并填写 API Key，无需手动配置 base_url：
+
+```env
+# 1. 开启渠道模式，声明 minimax 渠道
+LLM_CHANNELS=minimax
+
+# 2. 填入 MiniMax API Key（从 https://platform.minimax.io 获取）
+LLM_MINIMAX_API_KEY=your_minimax_api_key_here
+
+# 3. 声明可用模型（MiniMax-M2.7 性能最强，highspeed 更快）
+LLM_MINIMAX_MODELS=MiniMax-M2.7,MiniMax-M2.7-highspeed
+
+# 4. 指定主模型
+LITELLM_MODEL=openai/MiniMax-M2.7
+```
+
+> **注意**：`MINIMAX_API_KEYS`（复数，无 `LLM_` 前缀）是用于新闻搜索（Coding Plan 搜索 API）的 Key，与此处 LLM 渠道的 `LLM_MINIMAX_API_KEY` 相互独立，用途不同。
+
 ### MiniMax 渠道模型填写说明
 
 - 如果你通过 OpenAI Compatible 渠道接 MiniMax，请在渠道模型里直接填写 `minimax/<模型名>`，例如 `minimax/MiniMax-M1`。

--- a/litellm_config.example.yaml
+++ b/litellm_config.example.yaml
@@ -82,6 +82,19 @@ model_list:
   #     model: ollama/qwen3:8b
   #     api_base: http://localhost:11434
 
+  # --- MiniMax (OpenAI 兼容，海外 api.minimax.io) ---
+  # - model_name: openai/MiniMax-M2.7
+  #   litellm_params:
+  #     model: openai/MiniMax-M2.7
+  #     api_key: "os.environ/MINIMAX_API_KEY"
+  #     api_base: https://api.minimax.io/v1
+
+  # - model_name: openai/MiniMax-M2.7-highspeed
+  #   litellm_params:
+  #     model: openai/MiniMax-M2.7-highspeed
+  #     api_key: "os.environ/MINIMAX_API_KEY"
+  #     api_base: https://api.minimax.io/v1
+
 # ===================================
 # Router 设置（可选）
 # ===================================

--- a/src/config.py
+++ b/src/config.py
@@ -48,7 +48,9 @@ class ConfigIssue:
 
 
 _MANAGED_LITELLM_KEY_PROVIDERS = {"gemini", "vertex_ai", "anthropic", "openai", "deepseek"}
-SUPPORTED_LLM_CHANNEL_PROTOCOLS = ("openai", "anthropic", "gemini", "vertex_ai", "deepseek", "ollama")
+SUPPORTED_LLM_CHANNEL_PROTOCOLS = ("openai", "anthropic", "gemini", "vertex_ai", "deepseek", "ollama", "minimax")
+# Default base URL for the MiniMax OpenAI-compatible API (overseas endpoint)
+_MINIMAX_DEFAULT_BASE_URL = "https://api.minimax.io/v1"
 _FALSEY_ENV_VALUES = {"0", "false", "no", "off"}
 AGENT_MAX_STEPS_DEFAULT = 10
 NEWS_STRATEGY_WINDOWS: Dict[str, int] = {
@@ -182,6 +184,7 @@ def canonicalize_llm_channel_protocol(value: Optional[str]) -> str:
         "google": "gemini",
         "vertex": "vertex_ai",
         "vertexai": "vertex_ai",
+        "minimaxi": "minimax",
     }
     return aliases.get(candidate, candidate)
 
@@ -264,6 +267,9 @@ def normalize_llm_channel_model(model: str, protocol: Optional[str], base_url: O
 
     if not resolved_protocol:
         return normalized_model
+    # MiniMax uses the OpenAI-compatible API; route via openai/ prefix with explicit api_base.
+    if resolved_protocol == "minimax":
+        return f"openai/{normalized_model}"
     return f"{resolved_protocol}/{normalized_model}"
 
 
@@ -1578,6 +1584,9 @@ class Config:
                         litellm_params['api_key'] = api_key
                     if ch['base_url']:
                         litellm_params['api_base'] = ch['base_url']
+                    elif ch.get('protocol') == 'minimax':
+                        # MiniMax uses OpenAI-compatible API; inject default overseas base URL
+                        litellm_params['api_base'] = _MINIMAX_DEFAULT_BASE_URL
                     # Auto-inject aihubmix sponsored header
                     headers = dict(ch.get('extra_headers') or {})
                     if ch['base_url'] and 'aihubmix.com' in ch['base_url']:

--- a/tests/test_llm_channel_config.py
+++ b/tests/test_llm_channel_config.py
@@ -311,6 +311,73 @@ class LLMChannelConfigTestCase(unittest.TestCase):
             ["gpt4o", "openai/gpt-4o-mini"],
         )
 
+    @patch("src.config.setup_env")
+    @patch.object(Config, "_parse_litellm_yaml", return_value=[])
+    def test_minimax_channel_normalizes_model_to_openai_prefix(self, _mock_parse_yaml, _mock_setup_env) -> None:
+        """MiniMax uses the OpenAI-compatible API, so models should be prefixed with openai/."""
+        env = {
+            "LLM_CHANNELS": "minimax",
+            "LLM_MINIMAX_API_KEY": "sk-minimax-key",
+            "LLM_MINIMAX_MODELS": "MiniMax-M2.7,MiniMax-M2.7-highspeed",
+        }
+
+        with patch.dict(os.environ, env, clear=True):
+            config = Config._load_from_env()
+
+        self.assertEqual(config.llm_models_source, "llm_channels")
+        self.assertEqual(config.llm_channels[0]["protocol"], "minimax")
+        models = config.llm_channels[0]["models"]
+        self.assertIn("openai/MiniMax-M2.7", models)
+        self.assertIn("openai/MiniMax-M2.7-highspeed", models)
+
+    @patch("src.config.setup_env")
+    @patch.object(Config, "_parse_litellm_yaml", return_value=[])
+    def test_minimax_channel_auto_injects_default_base_url(self, _mock_parse_yaml, _mock_setup_env) -> None:
+        """When no base_url is set for a minimax channel, api.minimax.io/v1 should be injected."""
+        env = {
+            "LLM_CHANNELS": "minimax",
+            "LLM_MINIMAX_API_KEY": "sk-minimax-key",
+            "LLM_MINIMAX_MODELS": "MiniMax-M2.7",
+        }
+
+        with patch.dict(os.environ, env, clear=True):
+            config = Config._load_from_env()
+
+        params = config.llm_model_list[0]["litellm_params"]
+        self.assertEqual(params["api_base"], "https://api.minimax.io/v1")
+        self.assertEqual(params["model"], "openai/MiniMax-M2.7")
+
+    @patch("src.config.setup_env")
+    @patch.object(Config, "_parse_litellm_yaml", return_value=[])
+    def test_minimax_channel_respects_custom_base_url(self, _mock_parse_yaml, _mock_setup_env) -> None:
+        """An explicit base_url should override the default api.minimax.io endpoint."""
+        env = {
+            "LLM_CHANNELS": "minimax",
+            "LLM_MINIMAX_API_KEY": "sk-minimax-key",
+            "LLM_MINIMAX_MODELS": "MiniMax-M2.7",
+            "LLM_MINIMAX_BASE_URL": "https://api.minimaxi.com/v1",
+        }
+
+        with patch.dict(os.environ, env, clear=True):
+            config = Config._load_from_env()
+
+        params = config.llm_model_list[0]["litellm_params"]
+        self.assertEqual(params["api_base"], "https://api.minimaxi.com/v1")
+
+    @patch("src.config.setup_env")
+    @patch.object(Config, "_parse_litellm_yaml", return_value=[])
+    def test_minimax_protocol_resolved_from_channel_name(self, _mock_parse_yaml, _mock_setup_env) -> None:
+        """Channel named 'minimax' should auto-resolve to minimax protocol without explicit PROTOCOL setting."""
+        env = {
+            "LLM_CHANNELS": "minimax",
+            "LLM_MINIMAX_API_KEY": "sk-minimax-key",
+            "LLM_MINIMAX_MODELS": "MiniMax-M2.7",
+        }
+
+        with patch.dict(os.environ, env, clear=True):
+            config = Config._load_from_env()
+
+        self.assertEqual(config.llm_channels[0]["protocol"], "minimax")
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

- Add minimax as a supported LLM_CHANNELS protocol, auto-resolving the overseas endpoint https://api.minimax.io/v1 without requiring manual BASE_URL configuration
- Normalize minimax channel models to the openai/ prefix since MiniMax uses the OpenAI-compatible API, so MiniMax-M2.7 becomes openai/MiniMax-M2.7 in LiteLLM routing
- Add minimaxi as a protocol alias for users preferring the domestic endpoint
- Update .env.example, docs/LLM_CONFIG_GUIDE.md, and litellm_config.example.yaml with MiniMax LLM channel examples
- Add 4 unit tests covering: model normalization, default api_base injection, custom base_url override, and channel name to protocol resolution
- Add CHANGELOG entry under [Unreleased]

## Usage

Minimal setup - no BASE_URL needed:
LLM_CHANNELS=minimax
LLM_MINIMAX_API_KEY=your_key_here
LLM_MINIMAX_MODELS=MiniMax-M2.7,MiniMax-M2.7-highspeed
LITELLM_MODEL=openai/MiniMax-M2.7

Note: MINIMAX_API_KEYS (plural, no LLM_ prefix) is for the news search (Coding Plan) API and is independent from this LLM channel key.

## API Reference

Chat (OpenAI Compatible): https://platform.minimax.io/docs/api-reference/text-openai-api

## Test plan

- Unit tests: pytest tests/test_llm_channel_config.py -v — 21/21 passed
- Integration test: direct call to api.minimax.io/v1/chat/completions with MiniMax-M2.7 returns 200
- Config compile check: python -m py_compile src/config.py
- No regressions in config-related test suites (75/75 passed)