### PR TITLE
fix: 版本号不对

### DIFF
--- a/apps/dsa-desktop/main.js
+++ b/apps/dsa-desktop/main.js
@@ -408,6 +408,7 @@ async function createWindow() {
       preload: path.join(__dirname, 'preload.js'),
       nodeIntegration: false,
       contextIsolation: true,
+      additionalArguments: [`--dsa-desktop-version=${app.getVersion()}`],
     },
   });
   logStartup('BrowserWindow created');

--- a/apps/dsa-desktop/package.json
+++ b/apps/dsa-desktop/package.json
@@ -1,11 +1,12 @@
 {
   "name": "daily-stock-analysis-desktop",
-  "version": "0.1.0",
+  "version": "3.12.0",
   "private": true,
   "main": "main.js",
   "scripts": {
     "dev": "electron .",
-    "build": "electron-builder"
+    "build": "electron-builder",
+    "test": "node --test tests/preload.test.js"
   },
   "devDependencies": {
     "electron": "^31.4.0",

--- a/apps/dsa-desktop/preload.js
+++ b/apps/dsa-desktop/preload.js
@@ -1,6 +1,19 @@
 const { contextBridge } = require('electron');
-const { version } = require('./package.json');
+
+const DESKTOP_VERSION_ARG_PREFIX = '--dsa-desktop-version=';
+
+function readDesktopVersion(argv = process.argv) {
+  const versionArg = argv.find(
+    (value) => typeof value === 'string' && value.startsWith(DESKTOP_VERSION_ARG_PREFIX)
+  );
+  return versionArg ? versionArg.slice(DESKTOP_VERSION_ARG_PREFIX.length) : '';
+}
 
 contextBridge.exposeInMainWorld('dsaDesktop', {
-  version,
+  version: readDesktopVersion(),
 });
+
+module.exports = {
+  DESKTOP_VERSION_ARG_PREFIX,
+  readDesktopVersion,
+};

--- a/apps/dsa-desktop/preload.js
+++ b/apps/dsa-desktop/preload.js
@@ -1,5 +1,6 @@
 const { contextBridge } = require('electron');
+const { version } = require('./package.json');
 
 contextBridge.exposeInMainWorld('dsaDesktop', {
-  version: '0.1.0',
+  version,
 });

--- a/apps/dsa-desktop/tests/preload.test.js
+++ b/apps/dsa-desktop/tests/preload.test.js
@@ -2,8 +2,53 @@ const assert = require('node:assert/strict');
 const test = require('node:test');
 const Module = require('node:module');
 
-test('preload exposes desktop version from package.json', (t) => {
+test('preload exposes desktop version from BrowserWindow additionalArguments', (t) => {
   const originalLoad = Module._load;
+  const originalArgv = [...process.argv];
+  const exposeInMainWorldCalls = [];
+  const expectedVersion = '3.12.0';
+
+  Module._load = function patchedLoad(request, parent, isMain) {
+    if (request === 'electron') {
+      return {
+        contextBridge: {
+          exposeInMainWorld: (...args) => {
+            exposeInMainWorldCalls.push(args);
+          },
+        },
+      };
+    }
+    return originalLoad.call(this, request, parent, isMain);
+  };
+
+  const preloadPath = require.resolve('../preload.js');
+  delete require.cache[preloadPath];
+  process.argv = [...originalArgv, `--dsa-desktop-version=${expectedVersion}`];
+
+  t.after(() => {
+    Module._load = originalLoad;
+    process.argv = originalArgv;
+    delete require.cache[preloadPath];
+  });
+
+  const preloadModule = require('../preload.js');
+
+  assert.equal(exposeInMainWorldCalls.length, 1);
+  assert.deepEqual(exposeInMainWorldCalls[0], [
+    'dsaDesktop',
+    {
+      version: expectedVersion,
+    },
+  ]);
+  assert.equal(
+    preloadModule.readDesktopVersion([`--dsa-desktop-version=${expectedVersion}`]),
+    expectedVersion
+  );
+});
+
+test('preload falls back to empty version when BrowserWindow does not pass one', (t) => {
+  const originalLoad = Module._load;
+  const originalArgv = [...process.argv];
   const exposeInMainWorldCalls = [];
 
   Module._load = function patchedLoad(request, parent, isMain) {
@@ -21,19 +66,22 @@ test('preload exposes desktop version from package.json', (t) => {
 
   const preloadPath = require.resolve('../preload.js');
   delete require.cache[preloadPath];
+  process.argv = originalArgv.filter((value) => !value.startsWith('--dsa-desktop-version='));
 
   t.after(() => {
     Module._load = originalLoad;
+    process.argv = originalArgv;
     delete require.cache[preloadPath];
   });
 
-  require('../preload.js');
+  const preloadModule = require('../preload.js');
 
   assert.equal(exposeInMainWorldCalls.length, 1);
   assert.deepEqual(exposeInMainWorldCalls[0], [
     'dsaDesktop',
     {
-      version: require('../package.json').version,
+      version: '',
     },
   ]);
+  assert.equal(preloadModule.readDesktopVersion(['--unrelated=1']), '');
 });

--- a/apps/dsa-desktop/tests/preload.test.js
+++ b/apps/dsa-desktop/tests/preload.test.js
@@ -1,0 +1,39 @@
+const assert = require('node:assert/strict');
+const test = require('node:test');
+const Module = require('node:module');
+
+test('preload exposes desktop version from package.json', (t) => {
+  const originalLoad = Module._load;
+  const exposeInMainWorldCalls = [];
+
+  Module._load = function patchedLoad(request, parent, isMain) {
+    if (request === 'electron') {
+      return {
+        contextBridge: {
+          exposeInMainWorld: (...args) => {
+            exposeInMainWorldCalls.push(args);
+          },
+        },
+      };
+    }
+    return originalLoad.call(this, request, parent, isMain);
+  };
+
+  const preloadPath = require.resolve('../preload.js');
+  delete require.cache[preloadPath];
+
+  t.after(() => {
+    Module._load = originalLoad;
+    delete require.cache[preloadPath];
+  });
+
+  require('../preload.js');
+
+  assert.equal(exposeInMainWorldCalls.length, 1);
+  assert.deepEqual(exposeInMainWorldCalls[0], [
+    'dsaDesktop',
+    {
+      version: require('../package.json').version,
+    },
+  ]);
+});

--- a/apps/dsa-web/src/pages/SettingsPage.tsx
+++ b/apps/dsa-web/src/pages/SettingsPage.tsx
@@ -51,6 +51,7 @@ const SettingsPage: React.FC = () => {
   const desktopImportRef = useRef<HTMLInputElement | null>(null);
   const isDesktopRuntime = typeof window !== 'undefined' && Boolean((window as DesktopWindow).dsaDesktop);
   const desktopAppVersion = getDesktopAppVersion();
+  const shouldShowDesktopVersionCard = Boolean(desktopAppVersion);
 
   // Set page title
   useEffect(() => {
@@ -298,7 +299,9 @@ const SettingsPage: React.FC = () => {
                 title="版本信息"
                 description="用于确认当前 WebUI 静态资源是否已经切换到最新构建。"
               >
-                <div className={`grid grid-cols-1 gap-3 ${isDesktopRuntime ? 'md:grid-cols-4' : 'md:grid-cols-3'}`}>
+                <div
+                  className={`grid grid-cols-1 gap-3 ${shouldShowDesktopVersionCard ? 'md:grid-cols-4' : 'md:grid-cols-3'}`}
+                >
                   <div className="rounded-2xl border settings-border bg-background/40 px-4 py-3">
                     <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-muted-text">
                       WebUI 版本
@@ -323,7 +326,7 @@ const SettingsPage: React.FC = () => {
                       {WEB_BUILD_INFO.buildTime}
                     </p>
                   </div>
-                  {isDesktopRuntime && desktopAppVersion ? (
+                  {shouldShowDesktopVersionCard ? (
                     <div className="rounded-2xl border settings-border bg-background/40 px-4 py-3">
                       <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-muted-text">
                         桌面端版本

--- a/apps/dsa-web/src/pages/SettingsPage.tsx
+++ b/apps/dsa-web/src/pages/SettingsPage.tsx
@@ -25,6 +25,14 @@ type DesktopWindow = Window & {
   };
 };
 
+function getDesktopAppVersion() {
+  if (typeof window === 'undefined') {
+    return '';
+  }
+
+  return (window as DesktopWindow).dsaDesktop?.version?.trim() || '';
+}
+
 function formatDesktopEnvFilename() {
   const now = new Date();
   const pad = (value: number) => value.toString().padStart(2, '0');
@@ -42,6 +50,7 @@ const SettingsPage: React.FC = () => {
   const [showImportConfirm, setShowImportConfirm] = useState(false);
   const desktopImportRef = useRef<HTMLInputElement | null>(null);
   const isDesktopRuntime = typeof window !== 'undefined' && Boolean((window as DesktopWindow).dsaDesktop);
+  const desktopAppVersion = getDesktopAppVersion();
 
   // Set page title
   useEffect(() => {
@@ -289,7 +298,7 @@ const SettingsPage: React.FC = () => {
                 title="版本信息"
                 description="用于确认当前 WebUI 静态资源是否已经切换到最新构建。"
               >
-                <div className="grid grid-cols-1 gap-3 md:grid-cols-3">
+                <div className={`grid grid-cols-1 gap-3 ${isDesktopRuntime ? 'md:grid-cols-4' : 'md:grid-cols-3'}`}>
                   <div className="rounded-2xl border settings-border bg-background/40 px-4 py-3">
                     <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-muted-text">
                       WebUI 版本
@@ -314,6 +323,16 @@ const SettingsPage: React.FC = () => {
                       {WEB_BUILD_INFO.buildTime}
                     </p>
                   </div>
+                  {isDesktopRuntime && desktopAppVersion ? (
+                    <div className="rounded-2xl border settings-border bg-background/40 px-4 py-3">
+                      <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-muted-text">
+                        桌面端版本
+                      </p>
+                      <p className="mt-2 break-all font-mono text-sm text-foreground">
+                        {desktopAppVersion}
+                      </p>
+                    </div>
+                  ) : null}
                 </div>
                 <p className="text-xs leading-6 text-muted-text">
                   重新执行前端构建或 Docker 镜像构建后，此处的构建标识和构建时间会更新，可用来确认当前页面资源是否已切换。

--- a/apps/dsa-web/src/pages/__tests__/SettingsPage.test.tsx
+++ b/apps/dsa-web/src/pages/__tests__/SettingsPage.test.tsx
@@ -341,6 +341,19 @@ describe('SettingsPage', () => {
     expect(screen.getByText('3.12.0')).toBeInTheDocument();
   });
 
+  it('keeps version grid at three columns when desktop runtime has no usable version', async () => {
+    (window as { dsaDesktop?: unknown }).dsaDesktop = { version: '   ' };
+
+    render(<SettingsPage />);
+
+    const section = (await screen.findByRole('heading', { name: '版本信息' })).closest('section');
+    const versionGrid = section?.querySelector('div.grid.grid-cols-1.gap-3');
+
+    expect(screen.queryByText('桌面端版本')).not.toBeInTheDocument();
+    expect(versionGrid).toHaveClass('md:grid-cols-3');
+    expect(versionGrid).not.toHaveClass('md:grid-cols-4');
+  });
+
   it('falls back to build identifier when package version is still placeholder', () => {
     expect(resolveWebBuildInfo({
       packageVersion: '0.0.0',

--- a/apps/dsa-web/src/pages/__tests__/SettingsPage.test.tsx
+++ b/apps/dsa-web/src/pages/__tests__/SettingsPage.test.tsx
@@ -331,6 +331,16 @@ describe('SettingsPage', () => {
     expect(screen.getByText('2026-03-29T02:15:30.000Z')).toBeInTheDocument();
   });
 
+  it('renders desktop app version in system settings during desktop runtime', async () => {
+    (window as { dsaDesktop?: unknown }).dsaDesktop = { version: '3.12.0' };
+
+    render(<SettingsPage />);
+
+    expect(await screen.findByRole('heading', { name: '版本信息' })).toBeInTheDocument();
+    expect(screen.getByText('桌面端版本')).toBeInTheDocument();
+    expect(screen.getByText('3.12.0')).toBeInTheDocument();
+  });
+
   it('falls back to build identifier when package version is still placeholder', () => {
     expect(resolveWebBuildInfo({
       packageVersion: '0.0.0',
@@ -500,7 +510,7 @@ describe('SettingsPage', () => {
   });
 
   it('renders desktop env backup actions in desktop runtime and exports saved env', async () => {
-    (window as { dsaDesktop?: unknown }).dsaDesktop = { version: '0.1.0' };
+    (window as { dsaDesktop?: unknown }).dsaDesktop = { version: '3.12.0' };
 
     render(<SettingsPage />);
 
@@ -514,7 +524,7 @@ describe('SettingsPage', () => {
   });
 
   it('asks for confirmation before importing when local drafts exist', async () => {
-    (window as { dsaDesktop?: unknown }).dsaDesktop = { version: '0.1.0' };
+    (window as { dsaDesktop?: unknown }).dsaDesktop = { version: '3.12.0' };
     useSystemConfigMock.mockReturnValue(buildSystemConfigState({ hasDirty: true, dirtyCount: 2 }));
 
     render(<SettingsPage />);
@@ -528,7 +538,7 @@ describe('SettingsPage', () => {
   });
 
   it('reloads config after successful desktop env import', async () => {
-    (window as { dsaDesktop?: unknown }).dsaDesktop = { version: '0.1.0' };
+    (window as { dsaDesktop?: unknown }).dsaDesktop = { version: '3.12.0' };
 
     const { container } = render(<SettingsPage />);
 
@@ -548,7 +558,7 @@ describe('SettingsPage', () => {
   });
 
   it('shows an error when desktop env import succeeds but reload fails', async () => {
-    (window as { dsaDesktop?: unknown }).dsaDesktop = { version: '0.1.0' };
+    (window as { dsaDesktop?: unknown }).dsaDesktop = { version: '3.12.0' };
     load.mockResolvedValue(false);
 
     const { container } = render(<SettingsPage />);

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - [修复] `StockAnalysisPipeline` 搜索服务与社交舆情服务改为可选降级初始化：任一服务初始化异常时记录 warning 并以禁用状态继续运行，避免外部依赖抖动阻塞主分析链路与 SSE 进度回调。
 - [文档] DEPLOY.md 和 deploy-webui-cloud.md 新增"UI 元素异常变大/布局错乱"排查步骤（重建 Docker 镜像或手动执行 npm run build）
 - [文档] 补充飞书 Webhook 配置说明：强调 `FEISHU_WEBHOOK_URL` 是群通知必填项、`FEISHU_WEBHOOK_SECRET` 与飞书机器人「签名校验」必须两端同时启用或同时关闭、`FEISHU_APP_SECRET` 仅用于应用/Stream Bot 模式不可替代 Webhook；同步完善英文指南并在 `.env.example` 为相关配置项补充内联说明注释
+- [修复] 桌面端版本展示改为统一读取 `apps/dsa-desktop/package.json`：移除 preload 中硬编码的 `0.1.0`，并在设置页展示真实桌面端版本，避免开发态与打包态长期显示错误版本号。
 
 - [新功能] 集成 Longbridge OpenAPI 作为美股/港股可选数据源；配置 `LONGBRIDGE_*` 后优先使用长桥获取日线与实时行情，YFinance / AkShare 兜底；未配置时行为与此前一致。长桥联调请使用 `tests/longbridge_live_smoke.py`（手动脚本，不参与 pytest 收集）。
 - [文档] 澄清 README（中/英/繁）中长桥「首选 / 兜底 / 未配置不调用」的边界；`docs/README_EN.md` / `docs/README_CHT.md` 顶部导航与完整指南链接改为 `./` 相对路径，避免在文档子目录下解析错误；`LONGBRIDGE_PRINT_QUOTE_PACKAGES` 与代码及 `.env.example` 对齐为未设置时默认关闭。

--- a/docs/desktop-package.md
+++ b/docs/desktop-package.md
@@ -154,6 +154,12 @@ win-unpacked/
 
 > 建议：macOS 用户在升级 DMG 前先执行一次 `导出 .env`，这样即使旧 `.app` 被整体替换，也能在新版本里直接恢复配置
 
+### 设置页版本信息
+
+- `系统设置 -> 版本信息` 中的“桌面端版本”由 Electron 主进程的 `app.getVersion()` 提供，并通过 preload bridge 暴露给前端
+- 开发态 `npm run dev` 与打包态 `npm run build` / 安装包都会复用同一条版本注入链路，不再在 `preload.js` 里维护独立硬编码版本号
+- `README.md` 继续保留安装和运行入口说明；这类桌面端运行时细节统一落在本专题文档维护，避免入门文档膨胀
+
 ## 常见问题
 
 ### 启动后一直显示 "Preparing backend..."


### PR DESCRIPTION
## PR Type
- [x] fix
- [ ] feat
- [ ] refactor
- [ ] docs
- [ ] chore
- [ ] test

## Background And Problem
- 当前问题：桌面端长期通过 preload 硬编码暴露 `0.1.0`，导致设置页显示的桌面端版本和真实应用版本脱节。
- 这次修复除了保留 Web 设置页里的版本展示外，还把版本传递链路改成由 Electron 主进程统一提供，避免 preload 在 Electron 31 环境里直接读取本地 `package.json` 带来的沙箱兼容性风险。
- 触发来源：Issue #1038。

## Scope Of Change
- `apps/dsa-desktop/main.js`
- `apps/dsa-desktop/package.json`
- `apps/dsa-desktop/preload.js`
- `apps/dsa-desktop/tests/preload.test.js`
- `apps/dsa-web/src/pages/SettingsPage.tsx`
- `apps/dsa-web/src/pages/__tests__/SettingsPage.test.tsx`
- `docs/CHANGELOG.md`
- `docs/desktop-package.md`

## Documentation And Changelog
- 已同步更新 `docs/CHANGELOG.md`
- 已补充 `docs/desktop-package.md` 中“设置页版本信息”说明，作为本次桌面端运行时行为变更的专题文档落点
- 未更新 `README.md`，因为本次不涉及入门、运行、部署主路径变更，只是桌面端运行时版本展示与 bridge 细节修复；这类细节按仓库约定统一维护在 `docs/desktop-package.md`

## Issue Link
Closes #1038

## Verification Commands And Results
```bash
cd apps/dsa-desktop && npm run test
cd apps/dsa-web && npm ci
cd apps/dsa-web && npm run test -- --run src/pages/__tests__/SettingsPage.test.tsx
cd apps/dsa-web && npm run lint
cd apps/dsa-web && npm run build
node --check apps/dsa-desktop/main.js
node --check apps/dsa-desktop/preload.js
```

关键输出/结论 / Key output & conclusion:
- `apps/dsa-desktop` preload 单测通过（`2 passed`），覆盖“带 additionalArguments 传入版本”和“未传入时回退为空字符串”两条路径
- `apps/dsa-web` 设置页相关测试通过（`16 passed`）
- `apps/dsa-web` `npm run lint` 通过
- `apps/dsa-web` `npm run build` 通过
- `node --check apps/dsa-desktop/main.js` 与 `node --check apps/dsa-desktop/preload.js` 通过
- 本地未完成完整 Electron 打包验证：尝试安装桌面端完整依赖以执行 `npm run build` 时，Electron 二进制下载在当前环境长时间阻塞，因此本次先补齐了 preload 真实链路修复、单测和 Web 侧联动验证，并把桌面构建缺口显式记录在下方风险项中

## Compatibility And Risk
- **Medium**：本次仍会影响桌面端版本展示链路，但版本来源已从 preload 直接读取本地文件改为主进程 `app.getVersion()` + `BrowserWindow.additionalArguments`，与 Electron 31 默认沙箱 preload 更兼容
- Web 侧风险较低：设置页仅在 `desktopAppVersion` 非空时展示“桌面端版本”卡片，空版本场景已有回归测试覆盖三列布局
- 未完成的风险点：当前本地环境未拿到完整 Electron build 产物证据，因此仍建议以 PR CI / 后续桌面打包验证结果作为最终合入前确认

## Rollback Plan
- `git revert <merge-commit>` 回滚本 PR 提交
- 回滚时重点确认 `apps/dsa-desktop/main.js`、`apps/dsa-desktop/preload.js`、`apps/dsa-web/src/pages/SettingsPage.tsx` 恢复到原先版本展示链路

## Acceptance Criteria
- 桌面端设置页显示的版本号不再固定为 `0.1.0`
- 版本号由 Electron 主进程统一提供，preload 不再直接读取本地 `package.json`
- `window.dsaDesktop.version` 在有值时可被设置页展示，在空值时不会引入 4 列空布局
- `docs/CHANGELOG.md` 与 `docs/desktop-package.md` 已同步记录这次用户可见修复

## Checklist
- [x] 本 PR 有明确动机和业务价值 / This PR has a clear motivation and value
- [x] 已提供可复现的验证命令与结果 / Reproducible verification commands and results are included
- [x] 已评估兼容性与风险 / Compatibility and risk have been assessed
- [x] 已提供回滚方案 / A rollback plan is provided
- [x] 若涉及用户可见变更，已同步更新相关文档与 `docs/CHANGELOG.md`；若未更新 `README.md`，已说明原因与文档落点 / If user-visible changes are included, the relevant docs and `docs/CHANGELOG.md` are updated; if `README.md` was not updated, the reason and documentation location are explained