### PR TITLE
fix: return latest trade date on non-trade days for chip distribution…

### DIFF
--- a/data_provider/tushare_fetcher.py
+++ b/data_provider/tushare_fetcher.py
@@ -1035,7 +1035,8 @@ class TushareFetcher(BaseFetcher):
             else:
                 use_today = True
         else:
-            use_today = False
+            # 非交易日： today不在trade_dates中，trade_dates[0]就是最近交易日
+            use_today = True
 
         start_date = self._pick_trade_date(trade_dates, use_today=use_today)
         if start_date is None:

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -44,6 +44,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - [新功能] 集成 Anspire Search 作为可选语义搜索后端; 配置 `ANSPIRE_*` 可使用Anspire Search获取实时行情及新闻资讯，未配置时行为与此前一致。Anspire Search请使用 `tests/test_anspire_search.py`（手动脚本）。
 - [修复] GitHub Actions `daily_analysis.yml` 未注入 `REPORT_LANGUAGE` 环境变量，导致用户在 Secrets/Variables 中配置后不生效（fixes #1013）
 - [修复] `GET /api/v1/analysis/status/{task_id}` 从数据库回填已完成任务时缺少 `current_price` / `change_pct`，导致首页报告股票名旁不显示实时价格（fixes #983）
+- [修复] 修复非交易日（周末/节假日）筹码分布与板块排行返回倒数第二个交易日数据的问题现在正常返回最近交易日数据（fix #1009）
 
 ## [3.12.0] - 2026-04-01
 

--- a/tests/test_tushare_fetcher_followups.py
+++ b/tests/test_tushare_fetcher_followups.py
@@ -57,7 +57,54 @@ class TestTushareFetcherFollowUps(unittest.TestCase):
 
         self.assertEqual(fetcher._api.trade_cal.call_count, 2)
         self.assertEqual(rate_limit_mock.call_count, 2)
+    def test_get_trade_time_returns_latest_trade_date_on_non_trade_day(self) -> None:
+        """Non-trade day (e.g. Saturday) should return the most recent trade
+        date (Friday), not the one before it (Thursday).  Fixes #1009."""
+        fetcher = self._make_fetcher()
+        # 2026-03-21 is Saturday; Friday 20 and Thursday 19 are trade dates
+        fetcher._api.trade_cal.return_value = pd.DataFrame(
+            {
+                "cal_date": ["20260314", "20260315", "20260316",
+                             "20260317", "20260318", "20260319",
+                             "20260320", "20260321"],
+                "is_open": [0, 0, 1, 1, 1, 1, 1, 0],
+            }
+        )
 
+        with patch.object(
+            fetcher,
+            "_get_china_now",
+            # called twice: once by get_trade_time, once by _get_trade_dates
+            side_effect=[datetime(2026, 3, 21, 10, 0)] * 2,
+        ), patch.object(fetcher, "_check_rate_limit"):
+            result = fetcher.get_trade_time(early_time="00:00", late_time="19:00")
+
+        # Should be Friday (20th), NOT Thursday (19th)
+        self.assertEqual(result, "20260320")
+
+    def test_get_trade_time_trade_day_before_data_ready_returns_previous(self) -> None:
+        """On a trade day within the early-late window, should return the
+        previous trade date (data not ready yet for today)."""
+        fetcher = self._make_fetcher()
+        fetcher._api.trade_cal.return_value = pd.DataFrame(
+            {
+                "cal_date": ["20260319", "20260320"],
+                "is_open": [1, 1],
+            }
+        )
+
+        with patch.object(
+            fetcher,
+            "_get_china_now",
+            # Friday 10:00 AM - within 00:00~19:00 window, data not ready
+            side_effect=[datetime(2026, 3, 20, 10, 0)] * 2,
+        ), patch.object(fetcher, "_check_rate_limit"):
+            result = fetcher.get_trade_time(early_time="00:00", late_time="19:00")
+
+        # Data not ready, should fall back to Thursday (19th)
+        self.assertEqual(result, "20260319")
+        
+          
     def test_get_sector_rankings_rate_limits_calendar_and_rankings_api(self) -> None:
         fetcher = self._make_fetcher()
         fetcher._api.trade_cal.return_value = pd.DataFrame(


### PR DESCRIPTION
## PR Type

- [x] fix
- [ ] feat
- [ ] refactor
- [ ] docs
- [ ] chore
- [ ] test

## Background And Problem

**Problem Statement:**
On non-trade dats, get_trade_time() returned the second-to-last trade instead of the latest one.

**Root Cause:**
_pick_trade_date(trade_dates,use_today=False) skips trade_dates[0], but on non-trade days trade_dates[0] is already the most recent trade date

**Solution:**
for non-trade days, put use_today=Ture

## Scope Of Change

- data_provider/tushare_fetcher.py
- docs/CHANGELOG.md
- tests/test_tushare_fetcher_followups.py

## Issue Link

必须填写以下之一 / Fill in one of:
- `Fixes #1009 ‘

## Verification Commands And Results

请填写你实际执行过的命令和关键结果（不要只写"已测试"）。  
*(EN) Paste the commands you actually ran and their key output (don't just write "tested"):*

```bash
# example
python -m py_compile data_provider/tushare_fetcher.py
python -m pytest tests/test_tushare_fetcher_followups.py
./scripts/ci_gate.sh
python -m pytest tests/test_main_schedule_mode.py::MainScheduleModeTestCase::test_schedule_time_provider_propagates_config_read_failures -vv
```

关键输出/结论 / Key output & conclusion:
- python -m py_compile data_provider/tushare_fetcher.py 通过
- python -m pytest tests/test_tushare_fetcher_followups.py 通过（7 passed）
- ./scripts/ci_gate.sh 跑完后结果为：1 failed, 1501 passed, 2 deselected，唯一失败项是 
tests/test_main_schedule_mode.py::MainScheduleModeTestCase::test_schedule_time_provider_propagates_config_read_failures - AssertionError: RuntimeError not raised
针对上述失败项单独复跑后通过（1 passed），未见与本次修复存在直接耦合
<img width="997" height="160" alt="image" src="https://github.com/user-attachments/assets/2cb7aee7-3eb4-46bb-a29f-288fa8829d75" />


## Compatibility And Risk

请说明兼容性影响、潜在风险（如无请写 `None`）。  
本次修复仅涉及tushare查询时使用的trade_date时间，仅影响tushare查询结果时效性。无兼容性影响，无潜在风险。

## Rollback Plan
回滚 data_provider/tushare_fetcher.py， docs/CHANGELOG.md 和tests/test_tushare_fetcher_followups.py 的本次提交即可恢复旧行为。


## EXTRACT_PROMPT Change (if applicable)

若本 PR 修改了 `src/services/image_stock_extractor.py` 中的 `EXTRACT_PROMPT`，请在此处粘贴完整变更后的 prompt。  
*If this PR changes `EXTRACT_PROMPT` in `src/services/image_stock_extractor.py`, paste the full updated prompt here:*

<details>
<summary>展开 / Expand: Full EXTRACT_PROMPT</summary>

```
(paste full prompt here)
```

</details>

## Checklist

- [x] 本 PR 有明确动机和业务价值 / This PR has a clear motivation and value
- [x] 已提供可复现的验证命令与结果 / Reproducible verification commands and results are included
- [x] 已评估兼容性与风险 / Compatibility and risk have been assessed
- [x] 已提供回滚方案 / A rollback plan is provided
- [x] 若涉及用户可见变更，已同步更新相关文档与 `docs/CHANGELOG.md`；若未更新 `README.md`，已说明原因与文档落点 / If user-visible changes are included, the relevant docs and `docs/CHANGELOG.md` are updated; if `README.md` was not updated, the reason and documentation location are explained
