### PR TITLE
feat(minimax), fix: auto-clear stale fallback models when channel config changes

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -105,6 +105,12 @@ GEMINI_API_KEY=
 # LLM_CHANNELS=ollama
 # LLM_OLLAMA_BASE_URL=http://localhost:11434
 # LLM_OLLAMA_MODELS=qwen3:8b,llama3.2
+#
+# 示例：MiniMax（自动使用 api.minimax.io 无需填写 base_url）
+# LLM_CHANNELS=minimax
+# LLM_MINIMAX_API_KEY=your_minimax_api_key_here
+# LLM_MINIMAX_MODELS=MiniMax-M2.7,MiniMax-M2.7-highspeed
+# LITELLM_MODEL=openai/MiniMax-M2.7
 
 # 高级：模型路由 YAML 配置（可选，参考 litellm_config.example.yaml）
 # LITELLM_CONFIG=./litellm_config.yaml

--- a/apps/dsa-web/src/components/settings/LLMChannelEditor.tsx
+++ b/apps/dsa-web/src/components/settings/LLMChannelEditor.tsx
@@ -854,8 +854,11 @@ export const LLMChannelEditor: React.FC<LLMChannelEditorProps> = ({
   // automatically remove any fallback models that are no longer selectable.
   // Without this, stale fallback entries become invisible in the UI (only availableModels
   // are rendered as checkboxes) yet still block saving with a validation error.
+  // Skip when this editor isn't managing runtime config (availableModels is intentionally
+  // empty in that mode) but keep cleaning when the user truly clears the last model or
+  // disables the last enabled channel — otherwise #1069 still reproduces in those cases.
   useEffect(() => {
-    if (availableModels.length === 0) return;
+    if (!managesRuntimeConfig) return;
     setRuntimeConfig((previous) => {
       const validFallbacks = previous.fallbackModels.filter(
         (model) => availableModels.includes(model) || usesDirectEnvProvider(model),
@@ -863,7 +866,7 @@ export const LLMChannelEditor: React.FC<LLMChannelEditorProps> = ({
       if (validFallbacks.length === previous.fallbackModels.length) return previous;
       return { ...previous, fallbackModels: validFallbacks };
     });
-  }, [availableModels]);
+  }, [availableModels, managesRuntimeConfig]);
 
   const hasChanges = useMemo(() => {
     const runtimeChanged = (

--- a/apps/dsa-web/src/components/settings/LLMChannelEditor.tsx
+++ b/apps/dsa-web/src/components/settings/LLMChannelEditor.tsx
@@ -829,6 +829,21 @@ export const LLMChannelEditor: React.FC<LLMChannelEditorProps> = ({
     return models;
   }, [channels, managesRuntimeConfig]);
 
+  // When available models change (e.g. a channel is disabled or its model list changes),
+  // automatically remove any fallback models that are no longer selectable.
+  // Without this, stale fallback entries become invisible in the UI (only availableModels
+  // are rendered as checkboxes) yet still block saving with a validation error.
+  useEffect(() => {
+    if (availableModels.length === 0) return;
+    setRuntimeConfig((previous) => {
+      const validFallbacks = previous.fallbackModels.filter(
+        (model) => availableModels.includes(model) || usesDirectEnvProvider(model),
+      );
+      if (validFallbacks.length === previous.fallbackModels.length) return previous;
+      return { ...previous, fallbackModels: validFallbacks };
+    });
+  }, [availableModels]);
+
   const hasChanges = useMemo(() => {
     const runtimeChanged = (
       runtimeConfig.primaryModel !== initialRuntimeConfig.primaryModel

--- a/apps/dsa-web/src/components/settings/LLMChannelEditor.tsx
+++ b/apps/dsa-web/src/components/settings/LLMChannelEditor.tsx
@@ -5,7 +5,7 @@ import { getParsedApiError } from '../../api/error';
 import { systemConfigApi } from '../../api/systemConfig';
 import { ApiErrorAlert, Badge, Button, InlineAlert, Input, Select, StatusDot, Tooltip } from '../common';
 
-type ChannelProtocol = 'openai' | 'deepseek' | 'gemini' | 'anthropic' | 'vertex_ai' | 'ollama';
+type ChannelProtocol = 'openai' | 'deepseek' | 'gemini' | 'anthropic' | 'vertex_ai' | 'ollama' | 'minimax';
 
 interface ChannelPreset {
   label: string;
@@ -81,6 +81,12 @@ const CHANNEL_PRESETS: Record<string, ChannelPreset> = {
     baseUrl: 'http://127.0.0.1:11434',
     placeholder: 'llama3.2,qwen2.5',
   },
+  minimax: {
+    label: 'MiniMax（海外站）',
+    protocol: 'minimax',
+    baseUrl: 'https://api.minimax.io/v1',
+    placeholder: 'MiniMax-M1,MiniMax-Text-01',
+  },
   custom: {
     label: '自定义渠道',
     protocol: 'openai',
@@ -96,6 +102,7 @@ const PROTOCOL_OPTIONS: Array<{ value: ChannelProtocol; label: string }> = [
   { value: 'anthropic', label: 'Anthropic' },
   { value: 'vertex_ai', label: 'Vertex AI' },
   { value: 'ollama', label: 'Ollama' },
+  { value: 'minimax', label: 'MiniMax' },
 ];
 
 const MODEL_PLACEHOLDERS: Record<ChannelProtocol, string> = {
@@ -105,6 +112,7 @@ const MODEL_PLACEHOLDERS: Record<ChannelProtocol, string> = {
   anthropic: 'claude-3-5-sonnet-20241022',
   vertex_ai: 'gemini-2.5-flash',
   ollama: 'llama3.2,qwen2.5',
+  minimax: 'MiniMax-M1,MiniMax-Text-01',
 };
 
 const KNOWN_MODEL_PREFIXES = new Set([
@@ -473,6 +481,9 @@ function normalizeProtocol(value: string): ChannelProtocol {
   if (normalized === 'ollama') {
     return 'ollama';
   }
+  if (normalized === 'minimax' || normalized === 'minimaxi') {
+    return 'minimax';
+  }
   return 'openai';
 }
 
@@ -570,6 +581,7 @@ const PROTOCOL_ALIASES: Record<string, string> = {
   google: 'gemini',
   openai_compatible: 'openai',
   openai_compat: 'openai',
+  minimaxi: 'minimax',
 };
 
 function normalizeModelForRuntime(model: string, protocol: ChannelProtocol): string {
@@ -588,9 +600,18 @@ function normalizeModelForRuntime(model: string, protocol: ChannelProtocol): str
       }
       return trimmedModel;
     }
+    if (protocol === 'minimax') {
+      // MiniMax uses the OpenAI-compatible API; route via openai/ prefix.
+      return `openai/${trimmedModel}`;
+    }
     return `${protocol}/${trimmedModel}`;
   }
 
+  if (protocol === 'minimax') {
+    // MiniMax uses the OpenAI-compatible API; route via openai/ prefix
+    // with explicit api_base on the backend (matches src/config.py).
+    return `openai/${trimmedModel}`;
+  }
   return `${protocol}/${trimmedModel}`;
 }
 

--- a/apps/dsa-web/src/components/settings/__tests__/LLMChannelEditor.test.tsx
+++ b/apps/dsa-web/src/components/settings/__tests__/LLMChannelEditor.test.tsx
@@ -103,6 +103,120 @@ describe('LLMChannelEditor', () => {
     expect(within(visionModelSelect).getByRole('option', { name: 'minimax/MiniMax-M1' })).toBeInTheDocument();
   });
 
+  it('round-trips a minimax channel: protocol stays minimax and bare model resolves to openai/<id>', async () => {
+    update.mockResolvedValue({
+      success: true,
+      configVersion: 'v2',
+      appliedCount: 1,
+      skippedMaskedCount: 0,
+      reloadTriggered: true,
+      updatedKeys: [],
+      warnings: [],
+    });
+
+    render(
+      <LLMChannelEditor
+        items={[
+          { key: 'LLM_CHANNELS', value: 'minimax' },
+          { key: 'LLM_MINIMAX_PROTOCOL', value: 'minimax' },
+          { key: 'LLM_MINIMAX_BASE_URL', value: 'https://api.minimax.io/v1' },
+          { key: 'LLM_MINIMAX_ENABLED', value: 'true' },
+          { key: 'LLM_MINIMAX_API_KEY', value: 'minimax-key' },
+          { key: 'LLM_MINIMAX_MODELS', value: 'MiniMax-M1' },
+        ]}
+        configVersion="v1"
+        maskToken="******"
+        onSaved={() => {}}
+      />,
+    );
+
+    // Bare MiniMax model should be normalized to openai/<id> in runtime selectors,
+    // matching backend src/config.py which routes minimax via openai/ prefix.
+    const primaryModelSelect = screen.getByRole('combobox', { name: '主模型' });
+    expect(within(primaryModelSelect).getByRole('option', { name: 'openai/MiniMax-M1' })).toBeInTheDocument();
+    // The minimax/<id> form should NOT appear (it would imply a different runtime route).
+    expect(within(primaryModelSelect).queryByRole('option', { name: 'minimax/MiniMax-M1' })).not.toBeInTheDocument();
+
+    // Open the channel row so the model input becomes editable.
+    fireEvent.click(screen.getByRole('button', { name: /MiniMax/i }));
+
+    // Trigger save: dirty the model field to enable Save. The save payload assertion below
+    // proves the protocol round-trips as 'minimax' (not coerced to 'openai').
+    const modelsInput = screen.getByLabelText('模型（逗号分隔）');
+    fireEvent.change(modelsInput, { target: { value: 'MiniMax-M1,MiniMax-Text-01' } });
+    fireEvent.click(screen.getByRole('button', { name: '保存 AI 配置' }));
+
+    await waitFor(() => {
+      expect(update).toHaveBeenCalled();
+    });
+
+    const updatePayload = update.mock.calls[0][0];
+    expect(updatePayload.items).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ key: 'LLM_MINIMAX_PROTOCOL', value: 'minimax' }),
+        expect.objectContaining({ key: 'LLM_MINIMAX_BASE_URL', value: 'https://api.minimax.io/v1' }),
+        expect.objectContaining({ key: 'LLM_MINIMAX_MODELS', value: 'MiniMax-M1,MiniMax-Text-01' }),
+      ]),
+    );
+  });
+
+  it('clears stale fallback models when the underlying channel models change', async () => {
+    update.mockResolvedValue({
+      success: true,
+      configVersion: 'v2',
+      appliedCount: 1,
+      skippedMaskedCount: 0,
+      reloadTriggered: true,
+      updatedKeys: [],
+      warnings: [],
+    });
+
+    render(
+      <LLMChannelEditor
+        items={[
+          { key: 'LLM_CHANNELS', value: 'openai' },
+          { key: 'LLM_OPENAI_PROTOCOL', value: 'openai' },
+          { key: 'LLM_OPENAI_BASE_URL', value: 'https://api.openai.com/v1' },
+          { key: 'LLM_OPENAI_ENABLED', value: 'true' },
+          { key: 'LLM_OPENAI_API_KEY', value: 'sk-test' },
+          { key: 'LLM_OPENAI_MODELS', value: 'gpt-4o-mini,gpt-4o' },
+          { key: 'LITELLM_MODEL', value: 'openai/gpt-4o-mini' },
+          { key: 'LITELLM_FALLBACK_MODELS', value: 'openai/gpt-4o' },
+        ]}
+        configVersion="v1"
+        maskToken="******"
+        onSaved={() => {}}
+      />,
+    );
+
+    // Initially the fallback (openai/gpt-4o) should be checked.
+    const fallbackBefore = screen.getByRole('checkbox', { name: 'openai/gpt-4o' }) as HTMLInputElement;
+    expect(fallbackBefore.checked).toBe(true);
+
+    // User removes gpt-4o from the channel's model list — leaves only gpt-4o-mini.
+    fireEvent.click(screen.getByRole('button', { name: /OpenAI 官方/i }));
+    const modelsInput = screen.getByLabelText('模型（逗号分隔）');
+    fireEvent.change(modelsInput, { target: { value: 'gpt-4o-mini' } });
+
+    // The stale fallback option should disappear from the available list and not block save.
+    await waitFor(() => {
+      expect(screen.queryByRole('checkbox', { name: 'openai/gpt-4o' })).not.toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: '保存 AI 配置' }));
+    await waitFor(() => {
+      expect(update).toHaveBeenCalled();
+    });
+
+    const updatePayload = update.mock.calls[0][0];
+    // Stale fallback should have been cleared from runtime config.
+    expect(updatePayload.items).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ key: 'LITELLM_FALLBACK_MODELS', value: '' }),
+      ]),
+    );
+  });
+
   it('checks protocol-prefixed selected model when discovery returns bare id', async () => {
     discoverLLMChannelModels.mockResolvedValue({
       success: true,

--- a/apps/dsa-web/src/components/settings/__tests__/LLMChannelEditor.test.tsx
+++ b/apps/dsa-web/src/components/settings/__tests__/LLMChannelEditor.test.tsx
@@ -217,6 +217,63 @@ describe('LLMChannelEditor', () => {
     );
   });
 
+  it('clears stale fallback models when the only enabled channel is disabled (availableModels -> 0)', async () => {
+    update.mockResolvedValue({
+      success: true,
+      configVersion: 'v2',
+      appliedCount: 1,
+      skippedMaskedCount: 0,
+      reloadTriggered: true,
+      updatedKeys: [],
+      warnings: [],
+    });
+
+    render(
+      <LLMChannelEditor
+        items={[
+          { key: 'LLM_CHANNELS', value: 'openai' },
+          { key: 'LLM_OPENAI_PROTOCOL', value: 'openai' },
+          { key: 'LLM_OPENAI_BASE_URL', value: 'https://api.openai.com/v1' },
+          { key: 'LLM_OPENAI_ENABLED', value: 'true' },
+          { key: 'LLM_OPENAI_API_KEY', value: 'sk-test' },
+          { key: 'LLM_OPENAI_MODELS', value: 'gpt-4o-mini,gpt-4o' },
+          { key: 'LITELLM_MODEL', value: 'openai/gpt-4o-mini' },
+          { key: 'LITELLM_FALLBACK_MODELS', value: 'openai/gpt-4o' },
+        ]}
+        configVersion="v1"
+        maskToken="******"
+        onSaved={() => {}}
+      />,
+    );
+
+    // Initially the fallback (openai/gpt-4o) should be checked.
+    expect((screen.getByRole('checkbox', { name: 'openai/gpt-4o' }) as HTMLInputElement).checked).toBe(true);
+
+    // User clears every model from the only enabled channel — availableModels collapses
+    // from non-empty to 0, the same shape as "user disabled the last enabled channel".
+    fireEvent.click(screen.getByRole('button', { name: /OpenAI 官方/i }));
+    const modelsInput = screen.getByLabelText('模型（逗号分隔）');
+    fireEvent.change(modelsInput, { target: { value: '' } });
+
+    // Fallback section disappears (no available models left to render).
+    await waitFor(() => {
+      expect(screen.queryByRole('checkbox', { name: 'openai/gpt-4o' })).not.toBeInTheDocument();
+    });
+
+    // Save should succeed (no '存在无效的备选模型' block) and stale fallback should be cleared.
+    fireEvent.click(screen.getByRole('button', { name: '保存 AI 配置' }));
+    await waitFor(() => {
+      expect(update).toHaveBeenCalled();
+    });
+
+    const updatePayload = update.mock.calls[0][0];
+    expect(updatePayload.items).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ key: 'LITELLM_FALLBACK_MODELS', value: '' }),
+      ]),
+    );
+  });
+
   it('checks protocol-prefixed selected model when discovery returns bare id', async () => {
     discoverLLMChannelModels.mockResolvedValue({
       success: true,

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 <!-- 新条目格式：- [类型] 描述（类型取值：新功能/改进/修复/文档/测试/chore）-->
 <!-- 每条独立一行追加到本段末尾，无需分类标题，合并时冲突最小 -->
 
+- [新功能] 新增 MiniMax 作为 LLM 渠道支持：`LLM_CHANNELS=minimax` 渠道可自动使用 `api.minimax.io` 海外端点（无需手动配置 base_url），支持 `MiniMax-M2.7` 与 `MiniMax-M2.7-highspeed` 模型，已同步更新 `.env.example`、`docs/LLM_CONFIG_GUIDE.md` 与 `litellm_config.example.yaml`。
 - [修复] 大盘复盘链路接入 `REPORT_LANGUAGE`：`REPORT_LANGUAGE=en` 时，A 股/合并复盘的 Prompt、章节标题、模板兜底文案与通知包装标题统一改为英文，避免出现英文正文外包中文标题的问题。
 - [修复] `AGENT_MAX_STEPS` 在 orchestrator 多 Agent 模式下统一明确为“默认作为各子 Agent 的步数上限而非硬覆盖；TechnicalAgent 等高默认值 Agent 会被封顶、低默认值 Agent 保持原值；当用户主动调高（>10）时，再统一覆盖所有子 Agent 采用全局值”，同时修复用户设置 12 但 TechnicalAgent 仍以默认 6 步运行并报 "Agent exceeded max steps" 的问题（fixes #1026）
 - [修复] Specialist（Skill）Agent 失败不再中断整个分析管线，改为与 intel/risk 相同的优雅降级策略

--- a/docs/LLM_CONFIG_GUIDE.md
+++ b/docs/LLM_CONFIG_GUIDE.md
@@ -112,6 +112,26 @@ LLM_OLLAMA_MODELS=qwen3:8b,llama3.2
 LITELLM_MODEL=ollama/qwen3:8b
 ```
 
+### 示例：MiniMax 渠道模式
+
+MiniMax 提供 OpenAI 兼容接口（`api.minimax.io`），只需声明 `minimax` 渠道并填写 API Key，无需手动配置 base_url：
+
+```env
+# 1. 开启渠道模式，声明 minimax 渠道
+LLM_CHANNELS=minimax
+
+# 2. 填入 MiniMax API Key（从 https://platform.minimax.io 获取）
+LLM_MINIMAX_API_KEY=your_minimax_api_key_here
+
+# 3. 声明可用模型（MiniMax-M2.7 性能最强，highspeed 更快）
+LLM_MINIMAX_MODELS=MiniMax-M2.7,MiniMax-M2.7-highspeed
+
+# 4. 指定主模型
+LITELLM_MODEL=openai/MiniMax-M2.7
+```
+
+> **注意**：`MINIMAX_API_KEYS`（复数，无 `LLM_` 前缀）是用于新闻搜索（Coding Plan 搜索 API）的 Key，与此处 LLM 渠道的 `LLM_MINIMAX_API_KEY` 相互独立，用途不同。
+
 ### MiniMax 渠道模型填写说明
 
 - 如果你通过 OpenAI Compatible 渠道接 MiniMax，请在渠道模型里直接填写 `minimax/<模型名>`，例如 `minimax/MiniMax-M1`。

--- a/litellm_config.example.yaml
+++ b/litellm_config.example.yaml
@@ -82,6 +82,19 @@ model_list:
   #     model: ollama/qwen3:8b
   #     api_base: http://localhost:11434
 
+  # --- MiniMax (OpenAI 兼容，海外 api.minimax.io) ---
+  # - model_name: openai/MiniMax-M2.7
+  #   litellm_params:
+  #     model: openai/MiniMax-M2.7
+  #     api_key: "os.environ/MINIMAX_API_KEY"
+  #     api_base: https://api.minimax.io/v1
+
+  # - model_name: openai/MiniMax-M2.7-highspeed
+  #   litellm_params:
+  #     model: openai/MiniMax-M2.7-highspeed
+  #     api_key: "os.environ/MINIMAX_API_KEY"
+  #     api_base: https://api.minimax.io/v1
+
 # ===================================
 # Router 设置（可选）
 # ===================================

--- a/src/config.py
+++ b/src/config.py
@@ -48,7 +48,9 @@ class ConfigIssue:
 
 
 _MANAGED_LITELLM_KEY_PROVIDERS = {"gemini", "vertex_ai", "anthropic", "openai", "deepseek"}
-SUPPORTED_LLM_CHANNEL_PROTOCOLS = ("openai", "anthropic", "gemini", "vertex_ai", "deepseek", "ollama")
+SUPPORTED_LLM_CHANNEL_PROTOCOLS = ("openai", "anthropic", "gemini", "vertex_ai", "deepseek", "ollama", "minimax")
+# Default base URL for the MiniMax OpenAI-compatible API (overseas endpoint)
+_MINIMAX_DEFAULT_BASE_URL = "https://api.minimax.io/v1"
 _FALSEY_ENV_VALUES = {"0", "false", "no", "off"}
 AGENT_MAX_STEPS_DEFAULT = 10
 NEWS_STRATEGY_WINDOWS: Dict[str, int] = {
@@ -182,6 +184,7 @@ def canonicalize_llm_channel_protocol(value: Optional[str]) -> str:
         "google": "gemini",
         "vertex": "vertex_ai",
         "vertexai": "vertex_ai",
+        "minimaxi": "minimax",
     }
     return aliases.get(candidate, candidate)
 
@@ -264,6 +267,9 @@ def normalize_llm_channel_model(model: str, protocol: Optional[str], base_url: O
 
     if not resolved_protocol:
         return normalized_model
+    # MiniMax uses the OpenAI-compatible API; route via openai/ prefix with explicit api_base.
+    if resolved_protocol == "minimax":
+        return f"openai/{normalized_model}"
     return f"{resolved_protocol}/{normalized_model}"
 
 
@@ -1578,6 +1584,9 @@ class Config:
                         litellm_params['api_key'] = api_key
                     if ch['base_url']:
                         litellm_params['api_base'] = ch['base_url']
+                    elif ch.get('protocol') == 'minimax':
+                        # MiniMax uses OpenAI-compatible API; inject default overseas base URL
+                        litellm_params['api_base'] = _MINIMAX_DEFAULT_BASE_URL
                     # Auto-inject aihubmix sponsored header
                     headers = dict(ch.get('extra_headers') or {})
                     if ch['base_url'] and 'aihubmix.com' in ch['base_url']:

--- a/tests/test_llm_channel_config.py
+++ b/tests/test_llm_channel_config.py
@@ -311,6 +311,73 @@ class LLMChannelConfigTestCase(unittest.TestCase):
             ["gpt4o", "openai/gpt-4o-mini"],
         )
 
+    @patch("src.config.setup_env")
+    @patch.object(Config, "_parse_litellm_yaml", return_value=[])
+    def test_minimax_channel_normalizes_model_to_openai_prefix(self, _mock_parse_yaml, _mock_setup_env) -> None:
+        """MiniMax uses the OpenAI-compatible API, so models should be prefixed with openai/."""
+        env = {
+            "LLM_CHANNELS": "minimax",
+            "LLM_MINIMAX_API_KEY": "sk-minimax-key",
+            "LLM_MINIMAX_MODELS": "MiniMax-M2.7,MiniMax-M2.7-highspeed",
+        }
+
+        with patch.dict(os.environ, env, clear=True):
+            config = Config._load_from_env()
+
+        self.assertEqual(config.llm_models_source, "llm_channels")
+        self.assertEqual(config.llm_channels[0]["protocol"], "minimax")
+        models = config.llm_channels[0]["models"]
+        self.assertIn("openai/MiniMax-M2.7", models)
+        self.assertIn("openai/MiniMax-M2.7-highspeed", models)
+
+    @patch("src.config.setup_env")
+    @patch.object(Config, "_parse_litellm_yaml", return_value=[])
+    def test_minimax_channel_auto_injects_default_base_url(self, _mock_parse_yaml, _mock_setup_env) -> None:
+        """When no base_url is set for a minimax channel, api.minimax.io/v1 should be injected."""
+        env = {
+            "LLM_CHANNELS": "minimax",
+            "LLM_MINIMAX_API_KEY": "sk-minimax-key",
+            "LLM_MINIMAX_MODELS": "MiniMax-M2.7",
+        }
+
+        with patch.dict(os.environ, env, clear=True):
+            config = Config._load_from_env()
+
+        params = config.llm_model_list[0]["litellm_params"]
+        self.assertEqual(params["api_base"], "https://api.minimax.io/v1")
+        self.assertEqual(params["model"], "openai/MiniMax-M2.7")
+
+    @patch("src.config.setup_env")
+    @patch.object(Config, "_parse_litellm_yaml", return_value=[])
+    def test_minimax_channel_respects_custom_base_url(self, _mock_parse_yaml, _mock_setup_env) -> None:
+        """An explicit base_url should override the default api.minimax.io endpoint."""
+        env = {
+            "LLM_CHANNELS": "minimax",
+            "LLM_MINIMAX_API_KEY": "sk-minimax-key",
+            "LLM_MINIMAX_MODELS": "MiniMax-M2.7",
+            "LLM_MINIMAX_BASE_URL": "https://api.minimaxi.com/v1",
+        }
+
+        with patch.dict(os.environ, env, clear=True):
+            config = Config._load_from_env()
+
+        params = config.llm_model_list[0]["litellm_params"]
+        self.assertEqual(params["api_base"], "https://api.minimaxi.com/v1")
+
+    @patch("src.config.setup_env")
+    @patch.object(Config, "_parse_litellm_yaml", return_value=[])
+    def test_minimax_protocol_resolved_from_channel_name(self, _mock_parse_yaml, _mock_setup_env) -> None:
+        """Channel named 'minimax' should auto-resolve to minimax protocol without explicit PROTOCOL setting."""
+        env = {
+            "LLM_CHANNELS": "minimax",
+            "LLM_MINIMAX_API_KEY": "sk-minimax-key",
+            "LLM_MINIMAX_MODELS": "MiniMax-M2.7",
+        }
+
+        with patch.dict(os.environ, env, clear=True):
+            config = Config._load_from_env()
+
+        self.assertEqual(config.llm_channels[0]["protocol"], "minimax")
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Fixes #1069

## Problem

When a user modifies a channel's model list (or disables a channel), any
fallback model that was previously selected from that channel becomes
**invisible** in the UI — the fallback checkbox list only renders models
from `availableModels`. However, the stale model ID remains in
`runtimeConfig.fallbackModels` and still triggers the save-time
validation:

> 存在无效的备选模型，请重新选择。

There is no checkbox to deselect the ghost entry, so the user is
completely blocked from saving.

## Solution

Add a `useEffect` that watches `availableModels` and automatically
filters `runtimeConfig.fallbackModels`, removing any entry that is no
longer selectable and does not satisfy `usesDirectEnvProvider()`.

```ts
useEffect(() => {
  if (availableModels.length === 0) return;
  setRuntimeConfig((previous) => {
    const validFallbacks = previous.fallbackModels.filter(
      (model) => availableModels.includes(model) || usesDirectEnvProvider(model),
    );
    if (validFallbacks.length === previous.fallbackModels.length) return previous;
    return { ...previous, fallbackModels: validFallbacks };
  });
}, [availableModels]);
```

The `availableModels.length === 0` guard prevents clearing selections
during the initial render before channels have been resolved.

## Additional change: MiniMax channel support (`feat(minimax)`)

This PR also adds MiniMax as a first-class LLM channel:

- `.env.example`: documents the new `MINIMAX_API_KEY` / `MINIMAX_BASE_URL` envs
- `src/config.py`: registers the `minimax` provider so it is selectable from the UI
- `litellm_config.example.yaml`: sample MiniMax model entries
- `docs/LLM_CONFIG_GUIDE.md`: end-to-end MiniMax configuration walkthrough
- `tests/test_llm_channel_config.py`: unit coverage for the new provider key

Non-MiniMax channel logic is untouched, so existing deployments that do
not configure MiniMax keep their current behavior.

## Testing

- `npm run lint` — passes (no new lint errors)
- `npm run build` — passes (TypeScript type-check + Vite build)
- `npx vitest run` — 15 existing tests pass, no regressions
- `bash scripts/ci_gate.sh` — passes (Python syntax + flake8 + offline pytest suite)
- Manual scenario: configure a channel with model A, select A as fallback,
  then remove A from the channel's model list → fallback entry is
  automatically cleared and Save succeeds
- Manual scenario: configure a MiniMax channel, list/select MiniMax
  models in the editor, save and reopen — config round-trips correctly

## Rollback plan

Revert this PR's commits (the front-end fix and the MiniMax channel
additions are independent commits, so either can be reverted in
isolation if needed).