### PR TITLE
fix: MiniMax tool calling support — text-mode fallback + max_tokens default

### DIFF
--- a/src/agent/llm_adapter.py
+++ b/src/agent/llm_adapter.py
@@ -386,6 +386,11 @@ class LLMToolAdapter:
         }
         if max_tokens is not None:
             call_kwargs["max_tokens"] = max_tokens
+        elif "minimax" in model.lower():
+            # MiniMax models default to thinking mode (CoT), which consumes significant
+            # output tokens before the actual response. Set a safe default to avoid
+            # finish_reason=length being mistaken for insufficient balance (issue 1008).
+            call_kwargs["max_tokens"] = 16000
         if timeout is not None:
             call_kwargs["timeout"] = timeout
 
@@ -495,7 +500,11 @@ class LLMToolAdapter:
         # DeepSeek/Qwen thinking mode; not in standard OpenAI type, accessed via getattr
         reasoning_content = getattr(choice.message, "reasoning_content", None)
 
+        # MiniMax does not support structured tool_calls via LiteLLM (supports_function_calling=False).
+        # The model outputs tool calls as plain text: [TOOL_CALL]{tool => "name", args => {...}}[/TOOL_CALL]
+        # Parse these text blocks when no structured tool_calls are present.
         if choice.message.tool_calls:
+            # Structured tool_calls (OpenAI-compatible providers)
             for tc in choice.message.tool_calls:
                 args: Dict[str, Any] = {}
                 if tc.function.arguments:
@@ -521,6 +530,27 @@ class LLMToolAdapter:
                     arguments=args,
                     thought_signature=sig,
                 ))
+        elif text_content:
+            # MiniMax text-mode tool_call fallback: parse [TOOL_CALL]{...}[/TOOL_CALL] blocks
+            import re
+            tc_blocks = re.findall(r'\[TOOL_CALL\]\s*\{[^}]+\}(?:\s*\[/TOOL_CALL\])?', text_content, re.DOTALL)
+            for i, block in enumerate(tc_blocks):
+                # Extract {name, args {...}}
+                m = re.search(r'tool\s*=>\s*"([^"]+)"', block)
+                args_m = re.search(r'args\s*=>\s*\{([^}]+)\}', block)
+                if m:
+                    name = m.group(1)
+                    args_str = args_m.group(1) if args_m else ""
+                    # Parse key => value pairs
+                    args = {}
+                    for kv in re.findall(r'--(\w+)\s+"([^"]*)"', args_str):
+                        args[kv[0]] = kv[1]
+                    tool_calls.append(ToolCall(
+                        id=f"minimax_tc_{i}",
+                        name=name,
+                        arguments=args,
+                        thought_signature=None,
+                    ))
 
         usage: Dict[str, Any] = {}
         if response.usage:


### PR DESCRIPTION
## 问题

### 1. finish_reason=length 被误判为余额不足

MiniMax 默认开启思考模式（CoT），思考 token 先消耗 max_tokens，导致回复被截断为 finish_reason=length，LiteLLM 误判为 insufficient balance (1008)。

修复：对 minimax 模型默认设置 max_tokens=16000。

### 2. 结构化 tool_calls 不生效

litellm.supports_function_calling(model="Minimax-M2.7-highspeed", custom_llm_provider="minimax") 返回 False。MiniMax 把工具调用输出为纯文本 [TOOL_CALL]{...}[/TOOL_CALL] 而非结构化 tool_calls 字段，LiteLLM 解析为空数组，工具永远不会被执行。

修复：在 _parse_litellm_response 里添加文本层 fallback，正则解析 [TOOL_CALL] 块还原为结构化 ToolCall。

## 测试
- 多次问股调用验证工具正常执行，行情数据正常返回
- max_tokens=16000 避免回复被截断