### PR TITLE
fix: Pipeline Agent K 线工具 DB-first 加载 + 冻结 target_date 消除重复请求 (Fixes #1066)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,9 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 <!-- 新条目格式：- [类型] 描述（类型取值：新功能/改进/修复/文档/测试/chore）-->
 <!-- 每条独立一行追加到本段末尾，无需分类标题，合并时冲突最小 -->
-- [修复] Pipeline Agent 工具主路径改为 DB-first 加载 K 线，消除同一只股票 9x5=45 次重复 HTTP 请求 (Fixes #1066)
-- [修复] Pipeline Agent 执行前按需预热 240 天历史到 DB，正常情况下工具调用无需重复网络请求
-- [修复] 冻结 target_date 通过 ContextVar 透传到 Pipeline Agent 工具线程，消除跨收盘边界时间漂移
+- [修复] Pipeline Agent 5 个 K 线工具（get_daily_history / analyze_trend / calculate_ma / get_volume_analysis / analyze_pattern）改为 DB-first 加载，消除同一只股票 9x5=45 次重复 HTTP 请求 (Fixes #1066)
+- [修复] Pipeline Agent 执行前按需预热 240 天 K 线历史到 DB，正常情况下 K 线工具调用无需重复网络请求
+- [修复] 冻结 target_date 通过 ContextVar 透传到 Pipeline Agent K 线工具线程，消除跨收盘边界时间漂移
 
 ## [3.13.0] - 2026-04-21
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 <!-- 新条目格式：- [类型] 描述（类型取值：新功能/改进/修复/文档/测试/chore）-->
 <!-- 每条独立一行追加到本段末尾，无需分类标题，合并时冲突最小 -->
+- [修复] Pipeline Agent 工具主路径改为 DB-first 加载 K 线，消除同一只股票 9x5=45 次重复 HTTP 请求 (Fixes #1066)
+- [修复] Pipeline Agent 执行前按需预热 240 天历史到 DB，正常情况下工具调用无需重复网络请求
+- [修复] 冻结 target_date 通过 ContextVar 透传到 Pipeline Agent 工具线程，消除跨收盘边界时间漂移
 
 ## [3.13.0] - 2026-04-21
 

--- a/src/agent/runner.py
+++ b/src/agent/runner.py
@@ -19,6 +19,7 @@ import json
 import logging
 import re
 import time
+import contextvars
 from concurrent.futures import ThreadPoolExecutor, TimeoutError as FuturesTimeoutError, as_completed
 from dataclasses import dataclass, field
 from typing import Any, Callable, Dict, List, Optional
@@ -653,8 +654,9 @@ def _execute_tools(
         timeout_triggered = False
         if tool_wait_timeout_seconds and tool_wait_timeout_seconds > 0:
             pool = ThreadPoolExecutor(max_workers=1)
+            ctx = contextvars.copy_context()
             try:
-                future = pool.submit(_exec_single, tc)
+                future = pool.submit(ctx.run, _exec_single, tc)
                 try:
                     _, result_str, success, dur, cached = future.result(timeout=tool_wait_timeout_seconds)
                 except FuturesTimeoutError:
@@ -696,7 +698,7 @@ def _execute_tools(
         pool = ThreadPoolExecutor(max_workers=min(len(tool_calls), 5))
         timeout_triggered = False
         try:
-            futures = {pool.submit(_exec_single, tc): tc for tc in tool_calls}
+            futures = {pool.submit(contextvars.copy_context().run, _exec_single, tc): tc for tc in tool_calls}
             pending = set(futures)
             for future in as_completed(
                 futures,

--- a/src/agent/tools/analysis_tools.py
+++ b/src/agent/tools/analysis_tools.py
@@ -16,48 +16,10 @@ logger = logging.getLogger(__name__)
 
 def _fetch_trend_data(stock_code: str):
     """Fetch historical OHLCV (DataFrame) for trend analysis. DB first, then DataFetcher fallback."""
-    from datetime import date, timedelta
-    import pandas as pd
-    from data_provider.base import canonical_stock_code, DataFetchError
-    from data_provider import DataFetcherManager
-    from src.storage import get_db
+    from src.services.history_loader import load_history_df
 
-    code = canonical_stock_code(stock_code)
-    if not code:
-        return None
-    end_date = date.today()
-    start_date = end_date - timedelta(days=89)  # ~60 trading days, mirrors pipeline Step 3
-
-    # 1. Try DB
-    try:
-        db = get_db()
-        bars = db.get_data_range(code, start_date, end_date)
-        if bars:
-            df = pd.DataFrame([b.to_dict() for b in bars])
-            logger.debug("analyze_trend(%s): loaded %d rows from DB", stock_code, len(df))
-            return df
-    except Exception as e:
-        logger.debug(
-            "analyze_trend(%s): DB lookup failed (%s), falling back to DataFetcherManager",
-            stock_code, e
-        )
-
-    # 2. Fallback to DataFetcherManager
-    try:
-        manager = DataFetcherManager()
-        df, _ = manager.get_daily_data(code, days=90)
-        if df is not None and not df.empty:
-            logger.info(
-                "analyze_trend(%s): DB empty, loaded %d rows from DataFetcherManager",
-                stock_code, len(df)
-            )
-            return df
-    except DataFetchError as e:
-        logger.warning("analyze_trend(%s): DataFetcherManager failed: %s", stock_code, e)
-    except Exception as e:
-        logger.warning("analyze_trend(%s): DataFetcherManager unexpected error: %s", stock_code, e)
-
-    return None
+    df, _ = load_history_df(stock_code, days=60)
+    return df
 
 
 def _handle_analyze_trend(stock_code: str) -> dict:
@@ -143,11 +105,9 @@ analyze_trend_tool = ToolDefinition(
 
 def _handle_calculate_ma(stock_code: str, periods: Optional[str] = None, days: int = 120) -> dict:
     """Calculate moving averages for arbitrary periods from historical K-line data."""
-    from data_provider import DataFetcherManager
-    import pandas as pd
+    from src.services.history_loader import load_history_df
 
-    manager = DataFetcherManager()
-    df, source = manager.get_daily_data(stock_code, days=days)
+    df, source = load_history_df(stock_code, days=days)
 
     if df is None or df.empty:
         return {"error": f"No historical data for {stock_code}"}
@@ -236,11 +196,10 @@ calculate_ma_tool = ToolDefinition(
 
 def _handle_get_volume_analysis(stock_code: str, days: int = 30) -> dict:
     """Analyse volume-price patterns over recent trading days."""
-    from data_provider import DataFetcherManager
+    from src.services.history_loader import load_history_df
     import pandas as pd
 
-    manager = DataFetcherManager()
-    df, source = manager.get_daily_data(stock_code, days=max(days + 20, 60))
+    df, source = load_history_df(stock_code, days=max(days + 20, 60))
 
     if df is None or df.empty:
         return {"error": f"No historical data for {stock_code}"}
@@ -353,11 +312,9 @@ get_volume_analysis_tool = ToolDefinition(
 
 def _handle_analyze_pattern(stock_code: str, days: int = 60) -> dict:
     """Detect common candlestick and chart patterns in recent price history."""
-    from data_provider import DataFetcherManager
-    import pandas as pd
+    from src.services.history_loader import load_history_df
 
-    manager = DataFetcherManager()
-    df, source = manager.get_daily_data(stock_code, days=max(days, 120))
+    df, source = load_history_df(stock_code, days=max(days, 120))
 
     if df is None or df.empty:
         return {"error": f"No historical data for {stock_code}"}

--- a/src/agent/tools/data_tools.py
+++ b/src/agent/tools/data_tools.py
@@ -234,8 +234,8 @@ get_realtime_quote_tool = ToolDefinition(
 
 def _handle_get_daily_history(stock_code: str, days: int = 60) -> dict:
     """Get daily OHLCV history data."""
-    manager = _get_fetcher_manager()
-    df, source = manager.get_daily_data(stock_code, days=days)
+    from src.services.history_loader import load_history_df
+    df, source = load_history_df(stock_code, days=days)
 
     if df is None or df.empty:
         return {"error": f"No historical data available for {stock_code}"}

--- a/src/core/pipeline.py
+++ b/src/core/pipeline.py
@@ -344,8 +344,10 @@ class StockAnalysisPipeline:
             # Step 3: 趋势分析（基于交易理念）— 在 Agent 分支之前执行，供两条路径共用
             trend_result: Optional[TrendAnalysisResult] = None
             try:
+                from src.services.history_loader import get_frozen_target_date
                 _mkt = get_market_for_stock(normalize_stock_code(code))
-                end_date = get_market_now(_mkt).date()
+                frozen = get_frozen_target_date()
+                end_date = frozen if frozen else get_market_now(_mkt).date()
                 start_date = end_date - timedelta(days=89)  # ~60 trading days for MA60
                 historical_bars = self.db.get_data_range(code, start_date, end_date)
                 if historical_bars:
@@ -736,6 +738,26 @@ class StockAnalysisPipeline:
         enriched_context["belong_boards"] = boards
         return enriched_context
 
+    def _ensure_agent_history(self, code: str, min_days: int = 240) -> None:
+        """Ensure at least *min_days* of K-line history is in DB for agent tools."""
+        from src.services.history_loader import get_frozen_target_date
+
+        target = get_frozen_target_date()
+        if target is None:
+            target = self._resolve_resume_target_date(code)
+        start = target - timedelta(days=int(min_days * 1.8))
+        bars = self.db.get_data_range(code, start, target)
+        if bars and len(bars) >= min(min_days, 200):
+            logger.debug("[%s] Agent history: %d bars in DB, sufficient", code, len(bars))
+            return
+        try:
+            df, source = self.fetcher_manager.get_daily_data(code, days=min_days)
+            if df is not None and not df.empty:
+                self.db.save_daily_data(df, code, source)
+                logger.info("[%s] Prefetched %d rows of history for agent (source: %s)", code, len(df), source)
+        except Exception as e:
+            logger.warning("[%s] Agent history prefetch failed: %s", code, e)
+
     def _analyze_with_agent(
         self, 
         code: str, 
@@ -788,6 +810,9 @@ class StockAnalysisPipeline:
                         logger.info(f"[{code}] Agent mode: social sentiment data injected into news_context")
                 except Exception as e:
                     logger.warning(f"[{code}] Agent mode: social sentiment fetch failed: {e}")
+
+            # Issue #1066: ensure deep history is in DB before agent tools run
+            self._ensure_agent_history(code)
 
             # 运行 Agent
             if report_language == "en":
@@ -1206,7 +1231,10 @@ class StockAnalysisPipeline:
             AnalysisResult 或 None
         """
         logger.info(f"========== 开始处理 {code} ==========")
-        
+
+        from src.services.history_loader import set_frozen_target_date, reset_frozen_target_date
+        frozen_td = self._resolve_resume_target_date(code, current_time=current_time)
+        token = set_frozen_target_date(frozen_td)
         try:
             self._emit_progress(12, f"{code}：正在准备分析任务")
             # Step 1: 获取并保存数据
@@ -1252,6 +1280,8 @@ class StockAnalysisPipeline:
             # 捕获所有异常，确保单股失败不影响整体
             logger.exception(f"[{code}] 处理过程发生未知异常: {e}")
             return None
+        finally:
+            reset_frozen_target_date(token)
     
     def run(
         self,

--- a/src/services/history_loader.py
+++ b/src/services/history_loader.py
@@ -1,0 +1,114 @@
+"""DB-first K-line history loader for Agent tools.
+
+Provides:
+- ContextVar-based frozen target_date propagation across threads
+- ``load_history_df``: read from DB first, DataFetcherManager fallback
+
+Fixes #1066 – eliminates 45+ redundant HTTP requests per stock in Agent mode.
+"""
+from __future__ import annotations
+
+import contextvars
+import logging
+from datetime import date, timedelta
+from threading import Lock
+from typing import Optional, Tuple
+
+import pandas as pd
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Frozen target date (ContextVar) – set once per stock in pipeline, read by
+# all agent tool threads via copy_context().run().
+# ---------------------------------------------------------------------------
+_frozen_target_date: contextvars.ContextVar[Optional[date]] = contextvars.ContextVar(
+    "_frozen_target_date", default=None,
+)
+
+
+def set_frozen_target_date(d: date) -> contextvars.Token:
+    return _frozen_target_date.set(d)
+
+
+def get_frozen_target_date() -> Optional[date]:
+    return _frozen_target_date.get()
+
+
+def reset_frozen_target_date(token: contextvars.Token) -> None:
+    _frozen_target_date.reset(token)
+
+
+# ---------------------------------------------------------------------------
+# Internal DataFetcherManager singleton (fallback only)
+# ---------------------------------------------------------------------------
+_fetcher_singleton = None
+_fetcher_lock = Lock()
+
+
+def _get_fetcher_manager():
+    global _fetcher_singleton
+    if _fetcher_singleton is None:
+        with _fetcher_lock:
+            if _fetcher_singleton is None:
+                from data_provider import DataFetcherManager
+                _fetcher_singleton = DataFetcherManager()
+    return _fetcher_singleton
+
+
+# ---------------------------------------------------------------------------
+# DB-first history loader
+# ---------------------------------------------------------------------------
+def load_history_df(
+    stock_code: str,
+    days: int = 60,
+    target_date: Optional[date] = None,
+) -> Tuple[Optional[pd.DataFrame], str]:
+    """Load K-line history, DB first with DataFetcherManager fallback.
+
+    Returns ``(df, source)`` where *source* is ``"db_cache"`` on DB hit or the
+    actual provider name on network fallback.  Returns ``(None, "none")`` when
+    both paths fail.
+    """
+    from data_provider.base import canonical_stock_code, normalize_stock_code
+    from src.storage import get_db
+
+    # Resolve effective end date
+    if target_date is not None:
+        end = target_date
+    else:
+        frozen = get_frozen_target_date()
+        end = frozen if frozen else date.today()
+
+    # Calendar-day buffer: ~1.8x trading days + margin for long holidays
+    start = end - timedelta(days=int(days * 1.8) + 10)
+
+    # --- 1. DB lookup (canonical code, then prefix-stripped fallback) ------
+    code = canonical_stock_code(stock_code)
+    try:
+        db = get_db()
+        bars = db.get_data_range(code, start, end)
+        if not bars:
+            alt = normalize_stock_code(stock_code)
+            if alt != code:
+                bars = db.get_data_range(alt, start, end)
+        if bars and len(bars) >= max(int(days * 0.3), 5):
+            df = pd.DataFrame([b.to_dict() for b in bars])
+            logger.debug(
+                "load_history_df(%s): %d bars from DB (requested %d)",
+                stock_code, len(df), days,
+            )
+            return df, "db_cache"
+    except Exception as e:
+        logger.debug("load_history_df(%s): DB read failed: %s", stock_code, e)
+
+    # --- 2. Network fallback via singleton DataFetcherManager -------------
+    try:
+        manager = _get_fetcher_manager()
+        df, source = manager.get_daily_data(stock_code, days=days)
+        if df is not None and not df.empty:
+            return df, source
+    except Exception as e:
+        logger.warning("load_history_df(%s): DataFetcherManager failed: %s", stock_code, e)
+
+    return None, "none"

--- a/tests/test_agent_frozen_context.py
+++ b/tests/test_agent_frozen_context.py
@@ -1,0 +1,113 @@
+# -*- coding: utf-8 -*-
+"""Verify that runner._execute_tools propagates ContextVar state (Issue #1066)."""
+from __future__ import annotations
+
+import json
+import threading
+import unittest
+from datetime import date
+
+from src.agent.tools.registry import ToolDefinition, ToolRegistry
+from src.services.history_loader import (
+    get_frozen_target_date,
+    reset_frozen_target_date,
+    set_frozen_target_date,
+)
+
+
+class _FakeToolCall:
+    """Minimal stand-in for the ToolCall dataclass used by runner."""
+
+    def __init__(self, name: str, arguments: dict | None = None):
+        self.name = name
+        self.arguments = arguments or {}
+        self.id = f"fake_{name}"
+
+
+def _make_spy_registry(tool_names: list[str], observed: list):
+    """Build a ToolRegistry with spy tools that record frozen_target_date."""
+
+    def _spy_handler(**kwargs):
+        observed.append(get_frozen_target_date())
+        return json.dumps({"ok": True})
+
+    registry = ToolRegistry()
+    for name in tool_names:
+        td = ToolDefinition(name=name, description="spy", parameters=[], handler=_spy_handler)
+        registry.register(td)
+    return registry
+
+
+class ExecuteToolsFrozenContextTestCase(unittest.TestCase):
+    """Test ContextVar propagation through _execute_tools ThreadPoolExecutor."""
+
+    def test_contextvar_propagates_to_single_tool_thread(self):
+        """Single-tool path with timeout uses copy_context().run()."""
+        from src.agent.runner import _execute_tools
+
+        frozen_date = date(2026, 4, 15)
+        observed: list[date | None] = []
+        registry = _make_spy_registry(["spy_tool"], observed)
+
+        tc = _FakeToolCall("spy_tool")
+        token = set_frozen_target_date(frozen_date)
+        try:
+            _execute_tools(
+                tool_calls=[tc],
+                tool_registry=registry,
+                step=1,
+                progress_callback=None,
+                tool_calls_log=[],
+                tool_wait_timeout_seconds=5.0,
+            )
+        finally:
+            reset_frozen_target_date(token)
+
+        self.assertEqual(len(observed), 1)
+        self.assertEqual(observed[0], frozen_date)
+
+    def test_contextvar_propagates_to_parallel_tool_threads(self):
+        """Multi-tool path propagates ContextVar to all concurrent worker threads.
+
+        Uses a Barrier to force genuine overlap: every spy handler blocks
+        until all workers have entered ctx.run(), so if a shared Context
+        were reused the second enter would raise RuntimeError.
+        """
+        from src.agent.runner import _execute_tools
+
+        frozen_date = date(2026, 4, 16)
+        num_tools = 3
+        barrier = threading.Barrier(num_tools, timeout=5)
+        observed: list[date | None] = []
+
+        def _slow_spy(**kwargs):
+            barrier.wait()
+            observed.append(get_frozen_target_date())
+            return json.dumps({"ok": True})
+
+        registry = ToolRegistry()
+        names = [f"spy_{i}" for i in range(num_tools)]
+        for name in names:
+            td = ToolDefinition(name=name, description="spy", parameters=[], handler=_slow_spy)
+            registry.register(td)
+
+        tool_calls = [_FakeToolCall(n) for n in names]
+        token = set_frozen_target_date(frozen_date)
+        try:
+            _execute_tools(
+                tool_calls=tool_calls,
+                tool_registry=registry,
+                step=1,
+                progress_callback=None,
+                tool_calls_log=[],
+                tool_wait_timeout_seconds=10.0,
+            )
+        finally:
+            reset_frozen_target_date(token)
+
+        self.assertEqual(len(observed), num_tools)
+        self.assertTrue(all(d == frozen_date for d in observed))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_history_loader.py
+++ b/tests/test_history_loader.py
@@ -1,0 +1,159 @@
+# -*- coding: utf-8 -*-
+"""Unit tests for src.services.history_loader (Issue #1066)."""
+from __future__ import annotations
+
+import unittest
+from datetime import date
+from unittest.mock import MagicMock, patch
+
+import pandas as pd
+
+
+class HistoryLoaderTestCase(unittest.TestCase):
+    """Tests for load_history_df and frozen target date ContextVar."""
+
+    # ------------------------------------------------------------------
+    # ContextVar lifecycle
+    # ------------------------------------------------------------------
+    def test_frozen_target_date_lifecycle(self):
+        from src.services.history_loader import (
+            get_frozen_target_date,
+            reset_frozen_target_date,
+            set_frozen_target_date,
+        )
+
+        self.assertIsNone(get_frozen_target_date())
+        d = date(2026, 4, 18)
+        token = set_frozen_target_date(d)
+        self.assertEqual(get_frozen_target_date(), d)
+        reset_frozen_target_date(token)
+        self.assertIsNone(get_frozen_target_date())
+
+    # ------------------------------------------------------------------
+    # DB hit path
+    # ------------------------------------------------------------------
+    @patch("src.storage.get_db")
+    def test_returns_db_data_when_sufficient(self, mock_get_db):
+        from src.services.history_loader import load_history_df
+
+        fake_bar = MagicMock()
+        fake_bar.to_dict.return_value = {
+            "date": "2026-04-18",
+            "open": 10,
+            "high": 11,
+            "low": 9,
+            "close": 10.5,
+            "volume": 100,
+        }
+        mock_db = MagicMock()
+        mock_db.get_data_range.return_value = [fake_bar] * 40
+        mock_get_db.return_value = mock_db
+
+        df, source = load_history_df("600519", days=60, target_date=date(2026, 4, 18))
+
+        self.assertIsNotNone(df)
+        self.assertEqual(source, "db_cache")
+        self.assertEqual(len(df), 40)
+        mock_db.get_data_range.assert_called_once()
+
+    # ------------------------------------------------------------------
+    # DB miss → DFM fallback
+    # ------------------------------------------------------------------
+    @patch("src.services.history_loader._get_fetcher_manager")
+    @patch("src.storage.get_db")
+    def test_falls_back_to_dfm_when_db_empty(self, mock_get_db, mock_get_fm):
+        from src.services.history_loader import load_history_df
+
+        mock_db = MagicMock()
+        mock_db.get_data_range.return_value = []
+        mock_get_db.return_value = mock_db
+
+        fake_df = pd.DataFrame({"close": [1, 2, 3]})
+        mock_fm = MagicMock()
+        mock_fm.get_daily_data.return_value = (fake_df, "eastmoney")
+        mock_get_fm.return_value = mock_fm
+
+        df, source = load_history_df("600519", days=60, target_date=date(2026, 4, 18))
+
+        self.assertIsNotNone(df)
+        self.assertEqual(source, "eastmoney")
+        mock_fm.get_daily_data.assert_called_once_with("600519", days=60)
+
+    # ------------------------------------------------------------------
+    # ContextVar integration
+    # ------------------------------------------------------------------
+    @patch("src.storage.get_db")
+    def test_uses_frozen_target_date_from_contextvar(self, mock_get_db):
+        from src.services.history_loader import (
+            load_history_df,
+            reset_frozen_target_date,
+            set_frozen_target_date,
+        )
+
+        frozen_date = date(2026, 4, 15)
+        token = set_frozen_target_date(frozen_date)
+        try:
+            mock_db = MagicMock()
+            fake_bar = MagicMock()
+            fake_bar.to_dict.return_value = {"date": "2026-04-15", "close": 10}
+            mock_db.get_data_range.return_value = [fake_bar] * 30
+            mock_get_db.return_value = mock_db
+
+            df, source = load_history_df("600519", days=30)
+
+            self.assertEqual(source, "db_cache")
+            call_args = mock_db.get_data_range.call_args
+            _code, _start, end = call_args[0]
+            self.assertEqual(end, frozen_date)
+        finally:
+            reset_frozen_target_date(token)
+
+    # ------------------------------------------------------------------
+    # normalize_stock_code fallback for prefixed codes
+    # ------------------------------------------------------------------
+    @patch("src.storage.get_db")
+    def test_uses_normalize_fallback_for_prefixed_code(self, mock_get_db):
+        from src.services.history_loader import load_history_df
+
+        fake_bar = MagicMock()
+        fake_bar.to_dict.return_value = {"date": "2026-04-18", "close": 10}
+
+        mock_db = MagicMock()
+
+        def side_effect(code, start, end):
+            if code == "SH600519":
+                return []
+            return [fake_bar] * 30
+
+        mock_db.get_data_range.side_effect = side_effect
+        mock_get_db.return_value = mock_db
+
+        df, source = load_history_df("SH600519", days=30, target_date=date(2026, 4, 18))
+
+        self.assertEqual(source, "db_cache")
+        self.assertEqual(mock_db.get_data_range.call_count, 2)
+
+    # ------------------------------------------------------------------
+    # Both paths fail gracefully
+    # ------------------------------------------------------------------
+    @patch("src.services.history_loader._get_fetcher_manager")
+    @patch("src.storage.get_db")
+    def test_graceful_when_both_fail(self, mock_get_db, mock_get_fm):
+        from src.services.history_loader import load_history_df
+
+        mock_db = MagicMock()
+        mock_db.get_data_range.side_effect = Exception("DB down")
+        mock_get_db.return_value = mock_db
+
+        mock_fm = MagicMock()
+        mock_fm.get_daily_data.side_effect = Exception("API down")
+        mock_get_fm.return_value = mock_fm
+
+        df, source = load_history_df("600519", days=60, target_date=date(2026, 4, 18))
+
+        self.assertIsNone(df)
+        self.assertEqual(source, "none")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## PR Type

- [x] fix

## Background And Problem

Issue #1066 指出：Agent 工具在同一轮分析中对每只股票重复发起多达 45 次 K 线 HTTP 请求，原因包括：

1. **无 DB-first 策略**：Agent tool handler（`get_daily_history`、`analyze_trend`、`calculate_ma`、`get_volume_analysis`、`analyze_pattern`）每次都直接实例化新的 `DataFetcherManager` 发起网络请求，未利用 pipeline Step 1 已写入 DB 的历史数据。
2. **target_date 时间漂移**：pipeline 使用冻结交易日完成 Step 1 预热和 Step 3 分析，但 Agent K 线工具执行时未继承该冻结日期。跨收盘边界时，工具按墙钟重新计算目标日，导致已预热数据被判 stale，触发重复补抓或返回空数据。
3. **ContextVar 未传播到工具线程**：`runner.py` 的 `ThreadPoolExecutor` 未使用 `copy_context()` 传播 ContextVar，导致工具线程读不到冻结日期。

## Scope Of Change

| 文件 | 变更类型 | 说明 |
|------|----------|------|
| `src/services/history_loader.py` | **新增** | ContextVar 管理 + DB-first `load_history_df` + 共享 DFM 单例兜底 |
| `src/agent/runner.py` | 修改 | 每个 `pool.submit` 独立 `copy_context()` 传播 ContextVar |
| `src/core/pipeline.py` | 修改 | `process_single_stock` 设置冻结日期；Step 3 使用冻结日期；新增 `_ensure_agent_history` 预热 240 天 K 线历史 |
| `src/agent/tools/data_tools.py` | 修改 | `_handle_get_daily_history` 改用 `load_history_df` |
| `src/agent/tools/analysis_tools.py` | 修改 | 4 个 K 线 handler 统一改用 `load_history_df`，移除冗余 `pandas` import |
| `tests/test_history_loader.py` | **新增** | 6 个单元测试覆盖 ContextVar 生命周期、DB-first、DFM fallback、code 规范化、双路径失败 |
| `tests/test_agent_frozen_context.py` | **新增** | 2 个单元测试覆盖单工具和并发多工具的 ContextVar 传播（Barrier 驱动真正并发） |
| `docs/CHANGELOG.md` | 修改 | 新增 3 条 `[Unreleased]` 修复记录 |

**本次修复范围明确限定为 5 个 K 线历史相关工具**：`get_daily_history`、`analyze_trend`、`calculate_ma`、`get_volume_analysis`、`analyze_pattern`。这些是 #1066 中 45x HTTP 请求的来源。

**不在范围内的工具**：`get_analysis_context` 是纯 DB 读取（零网络请求），其 `DatabaseManager.get_analysis_context()` 在 `upstream/main` 上本就未实现 `target_date` 过滤（见 `storage.py:1590-1593` 注释），属于独立的增强项，不在 #1066 修复范围内。`get_realtime_quote` 和 `get_chip_distribution` 均为实时数据工具，与 K 线历史无关。

## Issue Link

Fixes #1066

## Verification Commands And Results

**`ci_gate.sh` 语法检查 + flake8 关键检查**（本地使用 venv Python 3.12.13 执行，因系统 Python 3.9 缺少项目依赖）：

```bash
# ci_gate.sh syntax phase
python -m py_compile main.py src/config.py src/auth.py src/analyzer.py src/notification.py \
  src/storage.py src/scheduler.py src/search_service.py src/market_analyzer.py src/stock_analyzer.py
# → PASSED

# ci_gate.sh flake8 phase
flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
# → 0 errors

# 本 PR 新增/修改文件 py_compile
python -m py_compile src/services/history_loader.py src/agent/runner.py src/core/pipeline.py \
  src/agent/tools/data_tools.py src/agent/tools/analysis_tools.py
# → PASSED
```

**定向 pytest**：

```bash
python -m pytest tests/test_history_loader.py tests/test_agent_frozen_context.py -v
```

```
tests/test_history_loader.py::HistoryLoaderTestCase::test_falls_back_to_dfm_when_db_empty PASSED
tests/test_history_loader.py::HistoryLoaderTestCase::test_frozen_target_date_lifecycle PASSED
tests/test_history_loader.py::HistoryLoaderTestCase::test_graceful_when_both_fail PASSED
tests/test_history_loader.py::HistoryLoaderTestCase::test_returns_db_data_when_sufficient PASSED
tests/test_history_loader.py::HistoryLoaderTestCase::test_uses_frozen_target_date_from_contextvar PASSED
tests/test_history_loader.py::HistoryLoaderTestCase::test_uses_normalize_fallback_for_prefixed_code PASSED
tests/test_agent_frozen_context.py::ExecuteToolsFrozenContextTestCase::test_contextvar_propagates_to_parallel_tool_threads PASSED
tests/test_agent_frozen_context.py::ExecuteToolsFrozenContextTestCase::test_contextvar_propagates_to_single_tool_thread PASSED
8 passed in 3.12s
```

**pyflakes**：

```bash
python -m pyflakes src/services/history_loader.py src/agent/runner.py src/agent/tools/data_tools.py \
  src/agent/tools/analysis_tools.py tests/test_history_loader.py tests/test_agent_frozen_context.py
# → 0 warnings (runner.py:340 elapsed 和 analysis_tools.py:227 numpy 是 upstream/main 已有旧债)
```

**`ci_gate.sh` 的 `deterministic` 和 `offline-tests` 阶段**未在本地执行，原因：`test.sh` 脚本依赖 `akshare` / `yfinance` 等网络数据源包，本地 venv 未安装（非必要依赖）；这两个阶段与本 PR 的改动面（pipeline 内部预热和工具层 DB-first 路径）无交集。CI 中的 `backend-gate` 会覆盖完整 `ci_gate.sh`。

## Compatibility And Risk

**兼容性**：
- 不改变任何外部 API / Schema / 配置语义 / CLI 参数
- `load_history_df` 的 DB-first 行为对调用方透明，返回签名 `(Optional[DataFrame], str)` 与原 `DataFetcherManager.get_daily_data` 一致
- 冻结日期（ContextVar）仅在 pipeline 路径设置；API 直连 Agent 路径不设置 ContextVar，`load_history_df` 会 fallback 到 `date.today()`，日期行为与改动前一致

**API 直连 Agent 路径的行为变化**：

本 PR 修改的 5 个 tool handler 是全局注册的，API 直连 Agent 路径也会走 `load_history_df` 的 DB-first 逻辑。与改动前的差异：

- **改动前**：`get_daily_history` 总是走 `DataFetcherManager` 网络请求；`analyze_trend` 在 `upstream/main` 上已有 DB-first 逻辑（GPT 此前提交）
- **改动后**：5 个工具统一 DB-first，DB 不足时 fallback 到 DFM

在 API 直连路径下没有 `_ensure_agent_history` 预热，如果 DB 中只有旧数据且满足 30% 阈值，可能返回不够新的 K 线而跳过 DFM fallback。实际风险较低：(1) DB 中通常有每日 pipeline 写入的新数据；(2) DFM fallback 仍然存在；(3) `analyze_trend` 在 `upstream/main` 上本来就是 DB-first，行为未变。但此风险已知，如需更严格控制可在后续 PR 中对 DB 命中增加最新 bar 日期新鲜度检查。

**已知不在范围内的旧债**：
- API 直连 Agent 路径未接入冻结日期和预热（产品边界不同，#1066 仅针对 pipeline 路径）
- `get_analysis_context` 的 `DatabaseManager.get_analysis_context()` 在 `upstream/main` 上忽略 `target_date`，只取最新两天（`storage.py:1590-1593` 注释已标注），属于独立增强项
- `_history_fetch_attempts` 负缓存无过期（已另开 Issue #1098 跟踪）

## Rollback Plan

单 commit 修复 + 1 个 docs commit + 1 个 merge commit，可直接 `git revert <commit-sha>` 逐个回滚。回滚后恢复到改动前状态：Agent 工具直接走 `DataFetcherManager` 网络请求，pipeline ContextVar 不设置。

## Checklist

- [x] 本 PR 有明确动机和业务价值
- [x] 已提供可复现的验证命令与结果
- [x] 已评估兼容性与风险
- [x] 已提供回滚方案
- [x] 若涉及用户可见变更，已同步更新相关文档与 `docs/CHANGELOG.md`；未更新 `README.md`，因为本修复不改变用户可见能力、CLI/API 行为或部署方式，属于内部优化，信息已落在 `docs/CHANGELOG.md`