### PR TITLE
fix: preserve change_pct in history detail (#1084)

### DIFF
--- a/api/v1/endpoints/history.py
+++ b/api/v1/endpoints/history.py
@@ -234,7 +234,9 @@ def get_history_detail(
             change_pct = realtime.get("change_pct")
 
             # 缺失时再从 realtime_quote_raw 兜底
-            realtime_quote_raw = context_snapshot.get("realtime_quote_raw") or {}
+            realtime_quote_raw = context_snapshot.get("realtime_quote_raw")
+            if not isinstance(realtime_quote_raw, dict):
+                realtime_quote_raw = {}
             if current_price is None:
                 current_price = realtime_quote_raw.get("price")
             if change_pct is None:

--- a/api/v1/endpoints/history.py
+++ b/api/v1/endpoints/history.py
@@ -221,21 +221,26 @@ def get_history_detail(
             )
         
         # 从 context_snapshot 中提取价格信息
+        # 注意：使用 `is None` 而非 `or`，避免把 0.0（平盘）误判为缺失值；
+        # 同时不混用 `change_60d`（60 日累计涨跌幅）作为日内 change_pct 的兜底。
         current_price = None
         change_pct = None
         context_snapshot = result.get("context_snapshot")
         if context_snapshot and isinstance(context_snapshot, dict):
-            # 尝试从 enhanced_context.realtime 获取
+            # 优先从 enhanced_context.realtime 获取
             enhanced_context = context_snapshot.get("enhanced_context") or {}
             realtime = enhanced_context.get("realtime") or {}
             current_price = realtime.get("price")
-            change_pct = realtime.get("change_pct") or realtime.get("change_60d")
-            
-            # 也尝试从 realtime_quote_raw 获取
+            change_pct = realtime.get("change_pct")
+
+            # 缺失时再从 realtime_quote_raw 兜底
+            realtime_quote_raw = context_snapshot.get("realtime_quote_raw") or {}
             if current_price is None:
-                realtime_quote_raw = context_snapshot.get("realtime_quote_raw") or {}
                 current_price = realtime_quote_raw.get("price")
-                change_pct = change_pct or realtime_quote_raw.get("change_pct") or realtime_quote_raw.get("pct_chg")
+            if change_pct is None:
+                change_pct = realtime_quote_raw.get("change_pct")
+            if change_pct is None:
+                change_pct = realtime_quote_raw.get("pct_chg")
         
         raw_result = result.get("raw_result")
         if not isinstance(raw_result, dict):

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - [改进] Agent 日线工具优先复用本地缓存，并持久化新获取的日线与新闻情报
 - [修复] GitHub Actions 每日分析工作流补齐 `LLM_CHANNELS`、多 Key 与常用 `LLM_<NAME>_*` 渠道变量透传，避免本地可用的多模型配置在云端定时任务中失效（Fixes #1063, #872）
 - [文档] 修正 `feishu_sender.py` 中飞书自定义机器人 Webhook 消息格式示例为 interactive card JSON，并补充飞书自动化 Webhook 触发器配置教程（参数 JSON 与 `card.elements[0].text.content` 字段映射）。
+- [修复] 历史报告详情接口修正 `change_pct` 取值：使用 `is None` 判断避免把 0.0（平盘）当作缺失值丢弃，移除错误的 `change_60d` 兜底，并在 `enhanced_context.realtime` 缺涨跌幅时回退到 `realtime_quote_raw.change_pct` / `pct_chg`，避免历史详情页“不显示涨跌幅” (Fixes #1084)
 
 ## [3.13.0] - 2026-04-21
 

--- a/tests/test_analysis_history.py
+++ b/tests/test_analysis_history.py
@@ -268,9 +268,10 @@ class AnalysisHistoryTestCase(unittest.TestCase):
         self.assertEqual(report.meta.current_price, 200.0)
         self.assertEqual(report.meta.change_pct, 1.23)
 
-    def test_history_detail_ignores_non_dict_realtime_quote_raw(self) -> None:
-        """Malformed realtime_quote_raw should not break detail responses."""
-        if get_history_detail is None:
+    @patch("src.auth.is_auth_enabled", return_value=False)
+    def test_history_detail_ignores_non_dict_realtime_quote_raw(self, mock_auth) -> None:
+        """GET /api/v1/history/{id} should tolerate truthy non-dict realtime_quote_raw."""
+        if TestClient is None or create_app is None:
             self.skipTest("fastapi is not installed in this test environment")
 
         context_snapshot = {
@@ -296,9 +297,16 @@ class AnalysisHistoryTestCase(unittest.TestCase):
                 self.fail("未找到保存的历史记录")
             record_id = row.id
 
-        report = get_history_detail(str(record_id), db_manager=self.db)
-        self.assertEqual(report.meta.current_price, 300.0)
-        self.assertIsNone(report.meta.change_pct)
+        static_dir = Path(self._temp_dir.name) / "empty-static"
+        static_dir.mkdir(exist_ok=True)
+        client = TestClient(create_app(static_dir=static_dir))
+
+        response = client.get(f"/api/v1/history/{record_id}")
+
+        self.assertEqual(response.status_code, 200)
+        payload = response.json()
+        self.assertEqual(payload["meta"]["current_price"], 300.0)
+        self.assertIsNone(payload["meta"]["change_pct"])
 
     def test_history_detail_accepts_dict_raw_result(self) -> None:
         """_record_to_detail_dict should handle dict raw_result without json.loads errors."""

--- a/tests/test_analysis_history.py
+++ b/tests/test_analysis_history.py
@@ -196,6 +196,78 @@ class AnalysisHistoryTestCase(unittest.TestCase):
         self.assertIsNotNone(detail)
         self.assertIsNone(detail.get("model_used"))
 
+    def test_history_detail_preserves_zero_change_pct(self) -> None:
+        """change_pct=0.0（平盘）应原样返回，而不是被当成缺失值丢失。
+
+        Regression for issue #1084: history endpoint used `or` chains that
+        treated 0.0 as falsy and silently dropped the daily change.
+        """
+        if get_history_detail is None:
+            self.skipTest("fastapi is not installed in this test environment")
+
+        context_snapshot = {
+            "enhanced_context": {
+                "realtime": {"price": 100.0, "change_pct": 0.0},
+            }
+        }
+        query_id = "query_change_pct_zero"
+        saved = self.db.save_analysis_history(
+            result=self._build_result(),
+            query_id=query_id,
+            report_type="simple",
+            news_content="新闻摘要",
+            context_snapshot=context_snapshot,
+            save_snapshot=True,
+        )
+        self.assertEqual(saved, 1)
+
+        with self.db.get_session() as session:
+            row = session.query(AnalysisHistory).filter(AnalysisHistory.query_id == query_id).first()
+            if row is None:
+                self.fail("未找到保存的历史记录")
+            record_id = row.id
+
+        report = get_history_detail(str(record_id), db_manager=self.db)
+        self.assertEqual(report.meta.current_price, 100.0)
+        self.assertEqual(report.meta.change_pct, 0.0)
+
+    def test_history_detail_falls_back_to_realtime_quote_raw_change_pct(self) -> None:
+        """缺少 enhanced_context.realtime.change_pct 时，应回退到 realtime_quote_raw。
+
+        Regression for issue #1084: previously the realtime_quote_raw fallback
+        was only consulted when current_price was missing, so reports with
+        price-only enhanced_context lost their change_pct entirely.
+        """
+        if get_history_detail is None:
+            self.skipTest("fastapi is not installed in this test environment")
+
+        context_snapshot = {
+            "enhanced_context": {
+                "realtime": {"price": 200.0},
+            },
+            "realtime_quote_raw": {"change_pct": 1.23},
+        }
+        query_id = "query_change_pct_fallback"
+        saved = self.db.save_analysis_history(
+            result=self._build_result(),
+            query_id=query_id,
+            report_type="simple",
+            news_content="新闻摘要",
+            context_snapshot=context_snapshot,
+            save_snapshot=True,
+        )
+        self.assertEqual(saved, 1)
+
+        with self.db.get_session() as session:
+            row = session.query(AnalysisHistory).filter(AnalysisHistory.query_id == query_id).first()
+            if row is None:
+                self.fail("未找到保存的历史记录")
+            record_id = row.id
+
+        report = get_history_detail(str(record_id), db_manager=self.db)
+        self.assertEqual(report.meta.current_price, 200.0)
+        self.assertEqual(report.meta.change_pct, 1.23)
+
     def test_history_detail_accepts_dict_raw_result(self) -> None:
         """_record_to_detail_dict should handle dict raw_result without json.loads errors."""
         result = self._build_result()

--- a/tests/test_analysis_history.py
+++ b/tests/test_analysis_history.py
@@ -268,6 +268,38 @@ class AnalysisHistoryTestCase(unittest.TestCase):
         self.assertEqual(report.meta.current_price, 200.0)
         self.assertEqual(report.meta.change_pct, 1.23)
 
+    def test_history_detail_ignores_non_dict_realtime_quote_raw(self) -> None:
+        """Malformed realtime_quote_raw should not break detail responses."""
+        if get_history_detail is None:
+            self.skipTest("fastapi is not installed in this test environment")
+
+        context_snapshot = {
+            "enhanced_context": {
+                "realtime": {"price": 300.0},
+            },
+            "realtime_quote_raw": "not-a-dict",
+        }
+        query_id = "query_change_pct_non_dict_raw"
+        saved = self.db.save_analysis_history(
+            result=self._build_result(),
+            query_id=query_id,
+            report_type="simple",
+            news_content="新闻摘要",
+            context_snapshot=context_snapshot,
+            save_snapshot=True,
+        )
+        self.assertEqual(saved, 1)
+
+        with self.db.get_session() as session:
+            row = session.query(AnalysisHistory).filter(AnalysisHistory.query_id == query_id).first()
+            if row is None:
+                self.fail("未找到保存的历史记录")
+            record_id = row.id
+
+        report = get_history_detail(str(record_id), db_manager=self.db)
+        self.assertEqual(report.meta.current_price, 300.0)
+        self.assertIsNone(report.meta.change_pct)
+
     def test_history_detail_accepts_dict_raw_result(self) -> None:
         """_record_to_detail_dict should handle dict raw_result without json.loads errors."""
         result = self._build_result()


### PR DESCRIPTION
## 改了什么

修复历史报告详情接口 `GET /api/v1/history/{record_id}` 的 `change_pct` 取值缺口（issue #1084）。

- `api/v1/endpoints/history.py`
  - 用 `is None` 判定替换原本的 `or` 链，避免把 `change_pct=0.0`（平盘）当作缺失值丢弃。
  - 移除错误的 `change_60d`（60 日累计涨跌幅）兜底，避免把不同口径的累计值混入日内涨跌幅。
  - `realtime_quote_raw` 的 `change_pct` / `pct_chg` 兜底从原本「只有 `current_price` 缺失时才用」修正为独立判断，当 `enhanced_context.realtime` 只带 `price` 时也能补齐涨跌幅。这与 #1028 修过的 `api/v1/endpoints/analysis.py` 路径保持一致。
- `tests/test_analysis_history.py`：新增两个回归用例
  - `test_history_detail_preserves_zero_change_pct`：`change_pct=0.0` 必须保留为 0.0。
  - `test_history_detail_falls_back_to_realtime_quote_raw_change_pct`：当 `enhanced_context.realtime` 缺 `change_pct` 时回退到 `realtime_quote_raw`。
- `docs/CHANGELOG.md`：`[Unreleased]` 追加修复记录。

## 为什么这么改

issue #1084 反馈历史报告详情卡片不显示涨跌幅。当前 `api/v1/endpoints/analysis.py`（任务状态接口）已用相同写法修过类似问题（PR #1028），但 `api/v1/endpoints/history.py` 仍保留旧的 `or` 链 + `change_60d` 兜底，所以同样的报告通过历史详情查看时会丢字段；前端 `apps/dsa-web/src/components/report/ReportOverview.tsx` 直接读 `meta.changePct`，接口层缺失则页面就不显示。

## 验证情况

```
python -m py_compile api/v1/endpoints/history.py tests/test_analysis_history.py
python -m pytest tests/test_analysis_history.py -q
# 24 passed
```

## 未验证项

- 未跑完整 `./scripts/ci_gate.sh`，由 CI 覆盖。
- 未做端到端 Web 联调（前端展示链路未变）。

## 风险点

仅改后端历史详情接口的字段兜底逻辑，不改 schema、不改前端、不改写库行为。`change_60d` 原本被作为日内涨跌幅 fallback 是错误口径，移除后历史详情只展示日内 `change_pct`，与 `analysis.py` 行为一致；如果某些旧快照同时缺 `change_pct` 和 `pct_chg`，本次修复后字段为 `null`（原行为是错把 60 日累计值当涨跌幅显示）。

## 回滚方式

revert 本 PR 即可，无 schema / 数据迁移。

Fixes #1084