### PR TITLE
fix: detect stale static bundles in build pipeline and at runtime (#1064)

### DIFF
--- a/api/app.py
+++ b/api/app.py
@@ -87,6 +87,8 @@ def _resolve_asset_path(assets_dir: Path, asset_path: str) -> Optional[Path]:
     decoded_path = unquote(asset_path)
     if not decoded_path or decoded_path.startswith(("/", "\\")):
         return None
+    if "\x00" in decoded_path:
+        return None
     if "\\" in decoded_path:
         return None
     if ":" in decoded_path.split("/", 1)[0]:

--- a/api/app.py
+++ b/api/app.py
@@ -22,6 +22,7 @@ import re
 from contextlib import asynccontextmanager
 from datetime import datetime
 from pathlib import Path
+from urllib.parse import unquote
 from typing import List, Optional
 
 from fastapi import FastAPI, Request
@@ -37,6 +38,7 @@ _INDEX_ASSET_REF_PATTERN = re.compile(
     r"""(?:src|href)\s*=\s*["'](/assets/[^"']+)["']""",
     re.IGNORECASE,
 )
+_SAFE_MISSING_ASSET_MEDIA_TYPES = frozenset({"text/css", "text/javascript"})
 
 
 def _check_frontend_assets_consistency(static_dir: Path) -> List[str]:
@@ -77,6 +79,31 @@ def _check_frontend_assets_consistency(static_dir: Path) -> List[str]:
             ", ".join(missing),
         )
     return missing
+
+
+def _resolve_asset_path(assets_dir: Path, asset_path: str) -> Optional[Path]:
+    """Resolve a requested asset path while keeping it confined to assets_dir."""
+    decoded_path = unquote(asset_path)
+    if not decoded_path or decoded_path.startswith(("/", "\\")):
+        return None
+    if "\\" in decoded_path:
+        return None
+    if ":" in decoded_path.split("/", 1)[0]:
+        return None
+
+    assets_root = assets_dir.resolve()
+    candidate = (assets_root / decoded_path).resolve()
+    if not candidate.is_relative_to(assets_root):
+        return None
+    return candidate
+
+
+def _missing_asset_media_type(asset_path: str) -> str:
+    """Return a safe media type for a missing asset response."""
+    content_type, _ = mimetypes.guess_type(asset_path)
+    if content_type in _SAFE_MISSING_ASSET_MEDIA_TYPES:
+        return content_type
+    return "text/plain"
 
 from api.v1 import api_v1_router
 from api.middlewares.auth import add_auth_middleware
@@ -242,25 +269,20 @@ def create_app(static_dir: Optional[Path] = None) -> FastAPI:
 
         @app.get("/assets/{asset_path:path}", include_in_schema=False)
         async def serve_asset(asset_path: str):
-            # Disallow path traversal; assets are flat files emitted by vite.
-            if ".." in asset_path.split("/") or asset_path.startswith("/"):
+            file_path = _resolve_asset_path(assets_dir, asset_path)
+            if file_path is None:
                 return Response(
                     content="not found",
                     status_code=404,
                     media_type="text/plain",
                 )
-            file_path = assets_dir / asset_path
             if file_path.is_file():
                 content_type, _ = mimetypes.guess_type(str(file_path))
                 return FileResponse(file_path, media_type=content_type)
-            # Pick a content-type matching the requested extension so
-            # browsers don't reject the response with a strict-MIME error
-            # before the user sees the 404.
-            fallback_type, _ = mimetypes.guess_type(asset_path)
             return Response(
-                content=f"asset not found: /assets/{asset_path}",
+                content="asset not found",
                 status_code=404,
-                media_type=fallback_type or "text/plain",
+                media_type=_missing_asset_media_type(asset_path),
             )
 
         # SPA 路由回退

--- a/api/app.py
+++ b/api/app.py
@@ -28,6 +28,7 @@ from typing import List, Optional
 from fastapi import FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import FileResponse, HTMLResponse, JSONResponse, Response
+from fastapi.staticfiles import StaticFiles
 
 logger = logging.getLogger(__name__)
 
@@ -267,8 +268,15 @@ def create_app(static_dir: Optional[Path] = None) -> FastAPI:
         # static file simply does not exist on disk.
         assets_dir = static_dir / "assets"
 
-        @app.get("/assets/{asset_path:path}", include_in_schema=False)
-        async def serve_asset(asset_path: str):
+        assets_static_files = StaticFiles(directory=str(assets_dir), check_dir=False)
+        assets_root = assets_dir.resolve()
+
+        @app.api_route(
+            "/assets/{asset_path:path}",
+            methods=["GET", "HEAD"],
+            include_in_schema=False,
+        )
+        async def serve_asset(request: Request, asset_path: str):
             file_path = _resolve_asset_path(assets_dir, asset_path)
             if file_path is None:
                 return Response(
@@ -277,8 +285,8 @@ def create_app(static_dir: Optional[Path] = None) -> FastAPI:
                     media_type="text/plain",
                 )
             if file_path.is_file():
-                content_type, _ = mimetypes.guess_type(str(file_path))
-                return FileResponse(file_path, media_type=content_type)
+                relative_path = file_path.relative_to(assets_root).as_posix()
+                return await assets_static_files.get_response(relative_path, request.scope)
             return Response(
                 content="asset not found",
                 status_code=404,

--- a/api/app.py
+++ b/api/app.py
@@ -15,17 +15,68 @@ FastAPI 应用工厂模块
     app = create_app()
 """
 
+import logging
 import mimetypes
 import os
+import re
 from contextlib import asynccontextmanager
 from datetime import datetime
 from pathlib import Path
-from typing import Optional
+from typing import List, Optional
 
 from fastapi import FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
-from fastapi.staticfiles import StaticFiles
-from fastapi.responses import FileResponse, HTMLResponse, JSONResponse
+from fastapi.responses import FileResponse, HTMLResponse, JSONResponse, Response
+
+logger = logging.getLogger(__name__)
+
+# Match src="/assets/foo.js" / href="/assets/foo.css" produced by the
+# vite build. Used by the startup self-check to surface packaging
+# mismatches early (see GitHub #1064 / #1065 / #1050).
+_INDEX_ASSET_REF_PATTERN = re.compile(
+    r"""(?:src|href)\s*=\s*["'](/assets/[^"']+)["']""",
+    re.IGNORECASE,
+)
+
+
+def _check_frontend_assets_consistency(static_dir: Path) -> List[str]:
+    """
+    Verify that ``index.html`` only references assets that actually exist
+    under ``static_dir``. Returns the list of missing references; an empty
+    list means the bundle is consistent.
+
+    Logs an actionable error when a mismatch is detected so the root cause
+    is visible in ``logs/desktop.log`` instead of surfacing as a silent
+    blank page.
+    """
+    index_html = static_dir / "index.html"
+    if not index_html.is_file():
+        return []
+    try:
+        html = index_html.read_text(encoding="utf-8", errors="replace")
+    except OSError as exc:
+        logger.warning("Failed to read %s for asset check: %s", index_html, exc)
+        return []
+
+    missing: List[str] = []
+    for match in _INDEX_ASSET_REF_PATTERN.finditer(html):
+        ref = match.group(1)
+        candidate = static_dir / ref.lstrip("/")
+        if not candidate.is_file() and ref not in missing:
+            missing.append(ref)
+
+    if missing:
+        logger.error(
+            "Frontend bundle is inconsistent: index.html references %d asset(s) "
+            "that are not present on disk under %s. This will surface as a "
+            "blank page in the desktop app (see GitHub #1064 / #1065). "
+            "Missing: %s. Re-run the frontend build and make sure the packaging "
+            "step copies the freshly generated static/ directory.",
+            len(missing),
+            static_dir,
+            ", ".join(missing),
+        )
+    return missing
 
 from api.v1 import api_v1_router
 from api.middlewares.auth import add_auth_middleware
@@ -121,6 +172,11 @@ def create_app(static_dir: Optional[Path] = None) -> FastAPI:
     has_frontend = static_dir.exists() and (static_dir / "index.html").exists()
     
     if has_frontend:
+        # Surface bundle inconsistencies as soon as the app starts so that
+        # blank-page reports (#1064 / #1065 / #1050) can be diagnosed from
+        # logs/desktop.log instead of via browser devtools.
+        _check_frontend_assets_consistency(static_dir)
+
         @app.get("/", include_in_schema=False)
         async def root():
             """根路由 - 返回前端页面"""
@@ -177,11 +233,36 @@ def create_app(static_dir: Optional[Path] = None) -> FastAPI:
     # ============================================================
     
     if has_frontend:
-        # 挂载静态资源目录
+        # Serve `/assets/*` explicitly so that misses return a plain-text
+        # 404 with the correct Content-Type instead of the default JSON
+        # error response. JSON for a JS/CSS request is what masked the
+        # blank-page root cause in #1064; here we make it obvious that the
+        # static file simply does not exist on disk.
         assets_dir = static_dir / "assets"
-        if assets_dir.exists():
-            app.mount("/assets", StaticFiles(directory=assets_dir), name="assets")
-        
+
+        @app.get("/assets/{asset_path:path}", include_in_schema=False)
+        async def serve_asset(asset_path: str):
+            # Disallow path traversal; assets are flat files emitted by vite.
+            if ".." in asset_path.split("/") or asset_path.startswith("/"):
+                return Response(
+                    content="not found",
+                    status_code=404,
+                    media_type="text/plain",
+                )
+            file_path = assets_dir / asset_path
+            if file_path.is_file():
+                content_type, _ = mimetypes.guess_type(str(file_path))
+                return FileResponse(file_path, media_type=content_type)
+            # Pick a content-type matching the requested extension so
+            # browsers don't reject the response with a strict-MIME error
+            # before the user sees the 404.
+            fallback_type, _ = mimetypes.guess_type(asset_path)
+            return Response(
+                content=f"asset not found: /assets/{asset_path}",
+                status_code=404,
+                media_type=fallback_type or "text/plain",
+            )
+
         # SPA 路由回退
         @app.get("/{full_path:path}", include_in_schema=False)
         async def serve_spa(request: Request, full_path: str):

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -27,6 +27,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - [文档] 优化根 README 结构，保留功能特性、技术栈、快速开始、推送效果、Web、Agent、赞助商和新闻源链接入口，将细配置、交易纪律和基本面语义收口到完整指南，并将 Docker 徽章指向官方镜像页
 - [文档] 同步英文与繁中 README 的精简入口结构，并补齐完整指南中的 LLM 用量 API 与持仓管理说明
 - [文档] 调整 AI 协作与 PR 模板中的 README 维护规则，明确 README 非必要不更新，细节优先进入专题文档
+- [修复] 桌面端打包链路新增 `scripts/check_static_assets.py` 静态资源一致性检查，并在 `build-backend(.ps1|-macos.sh)` 的源 `static/` 与 PyInstaller 产物里各跑一次；同时在后端启动时校验 `index.html` 引用的 `/assets/*.js`/`*.css` 是否真实存在，发现错配时直接在 `logs/desktop.log` 打印明确错误，避免重现 Release 包打开后白屏（Refs #1064 / #1065 / #1050）
+- [改进] 后端 `/assets/*` 由显式路由托管，资源缺失时返回与请求扩展名匹配的 `text/javascript` / `text/css` 404，而不是被默认 JSON 错误响应误导排查（Refs #1064）
 
 ## [3.13.0] - 2026-04-21
 

--- a/scripts/build-backend-macos.sh
+++ b/scripts/build-backend-macos.sh
@@ -30,6 +30,9 @@ fi
 npm run build
 popd >/dev/null
 
+log "Verifying static asset references (source)..."
+"${PYTHON_BIN}" "${SCRIPT_DIR}/check_static_assets.py" "${ROOT_DIR}/static"
+
 log "Building backend executable..."
 if ! "${PYTHON_BIN}" -m PyInstaller --version >/dev/null 2>&1; then
   "${PYTHON_BIN}" -m pip install pyinstaller
@@ -108,5 +111,16 @@ echo "Running: ${cmd[*]}"
 popd >/dev/null
 
 cp -R "${ROOT_DIR}/dist/stock_analysis" "${ROOT_DIR}/dist/backend/stock_analysis"
+
+log "Verifying static asset references (packaged)..."
+packaged_static="${ROOT_DIR}/dist/backend/stock_analysis/_internal/static"
+if [[ ! -d "${packaged_static}" ]]; then
+  packaged_static="${ROOT_DIR}/dist/backend/stock_analysis/static"
+fi
+if [[ -d "${packaged_static}" ]]; then
+  "${PYTHON_BIN}" "${SCRIPT_DIR}/check_static_assets.py" "${packaged_static}"
+else
+  log "WARNING: could not locate packaged static directory under dist/backend/stock_analysis; skipping post-package check."
+fi
 
 log "Backend build completed."

--- a/scripts/build-backend.ps1
+++ b/scripts/build-backend.ps1
@@ -15,6 +15,12 @@ if ([string]::IsNullOrWhiteSpace($pythonBin)) {
 
 Write-Host "Using Python: $pythonBin"
 
+Write-Host 'Verifying static asset references (source)...'
+& $pythonBin "${PSScriptRoot}\check_static_assets.py" 'static'
+if ($LASTEXITCODE -ne 0) {
+  throw "Static asset sanity check failed for source static/. See GitHub #1064."
+}
+
 function Test-PythonCode {
   param(
     [string]$Python,
@@ -123,5 +129,19 @@ if (!(Test-Path 'dist\stock_analysis')) {
 }
 
 Copy-Item -Path 'dist\stock_analysis' -Destination 'dist\backend\stock_analysis' -Recurse -Force
+
+Write-Host 'Verifying static asset references (packaged)...'
+$packagedStatic = Join-Path 'dist\backend\stock_analysis' '_internal\static'
+if (-not (Test-Path $packagedStatic)) {
+  $packagedStatic = Join-Path 'dist\backend\stock_analysis' 'static'
+}
+if (Test-Path $packagedStatic) {
+  & $pythonBin "${PSScriptRoot}\check_static_assets.py" $packagedStatic
+  if ($LASTEXITCODE -ne 0) {
+    throw "Static asset sanity check failed for packaged $packagedStatic. See GitHub #1064."
+  }
+} else {
+  Write-Warning "Could not locate packaged static directory under dist\backend\stock_analysis; skipping post-package check."
+}
 
 Write-Host 'Backend build completed.'

--- a/scripts/check_static_assets.py
+++ b/scripts/check_static_assets.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+Static frontend sanity check for the desktop / server packaging pipeline.
+
+Validates that ``index.html`` only references ``/assets/*.js`` and
+``/assets/*.css`` files that actually exist on disk. A mismatch here is the
+most common cause of the "Preparing backend..." / blank-page bug reported in
+GitHub issues #1064, #1065, #1050: vite re-builds with a new content hash,
+but the packaging step picks up a stale ``static/`` directory or copies the
+files out of sync, so the browser receives a 404 (often as JSON) for the
+main bundle and refuses to execute it.
+
+Usage:
+    python scripts/check_static_assets.py [<static_dir>]
+
+Exits 0 when consistent, non-zero with a human-readable message otherwise.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+from typing import List, Tuple
+
+# Match src="/assets/foo.js" or href="/assets/foo.css", with single or double
+# quotes. Vite emits absolute paths by default (``base: '/'``).
+_ASSET_PATTERN = re.compile(
+    r"""(?:src|href)\s*=\s*["'](/assets/[^"']+)["']""",
+    re.IGNORECASE,
+)
+
+
+def _parse_referenced_assets(index_html: str) -> List[str]:
+    """Return the unique list of ``/assets/...`` paths referenced by ``index.html``."""
+    seen: List[str] = []
+    for match in _ASSET_PATTERN.finditer(index_html):
+        ref = match.group(1)
+        if ref not in seen:
+            seen.append(ref)
+    return seen
+
+
+def check_static_dir(static_dir: Path) -> Tuple[List[str], List[str]]:
+    """
+    Inspect ``static_dir`` and return ``(referenced, missing)``.
+
+    ``referenced`` is the list of ``/assets/...`` paths declared in
+    ``index.html``. ``missing`` is the subset that does not exist on disk.
+    Raises ``FileNotFoundError`` if ``index.html`` itself is missing.
+    """
+    index_html_path = static_dir / "index.html"
+    if not index_html_path.is_file():
+        raise FileNotFoundError(f"index.html not found under {static_dir}")
+
+    html = index_html_path.read_text(encoding="utf-8", errors="replace")
+    referenced = _parse_referenced_assets(html)
+
+    missing: List[str] = []
+    for ref in referenced:
+        # ref looks like "/assets/index-xxx.js"; strip the leading slash so
+        # it resolves relative to ``static_dir``.
+        candidate = static_dir / ref.lstrip("/")
+        if not candidate.is_file():
+            missing.append(ref)
+    return referenced, missing
+
+
+def main(argv: List[str]) -> int:
+    if len(argv) > 1:
+        static_dir = Path(argv[1]).resolve()
+    else:
+        static_dir = (Path(__file__).resolve().parent.parent / "static").resolve()
+
+    print(f"[check_static_assets] inspecting {static_dir}")
+
+    try:
+        referenced, missing = check_static_dir(static_dir)
+    except FileNotFoundError as exc:
+        print(f"[check_static_assets] ERROR: {exc}", file=sys.stderr)
+        print(
+            "[check_static_assets] Hint: build the frontend first via "
+            "`cd apps/dsa-web && npm install && npm run build`.",
+            file=sys.stderr,
+        )
+        return 2
+
+    if not referenced:
+        print(
+            "[check_static_assets] WARNING: index.html does not reference any "
+            "/assets/* files; this is unusual for a vite build.",
+            file=sys.stderr,
+        )
+        return 0
+
+    if missing:
+        print(
+            "[check_static_assets] ERROR: index.html references assets that "
+            "are not present on disk:",
+            file=sys.stderr,
+        )
+        for ref in missing:
+            print(f"  - {ref}", file=sys.stderr)
+        print(
+            "[check_static_assets] This produces a blank page on first load "
+            "(see GitHub #1064 / #1065). Re-run the frontend build and make "
+            "sure the packaging step copies the freshly generated static/ "
+            "directory.",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(
+        f"[check_static_assets] OK: {len(referenced)} asset reference(s) "
+        f"resolved successfully."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/tests/test_static_assets_consistency.py
+++ b/tests/test_static_assets_consistency.py
@@ -242,6 +242,7 @@ def test_existing_asset_supports_head_and_conditional_requests(tmp_path: Path) -
         "/assets/C:%5Csecret.txt",
         "/assets/%5Cwindows%5Csystem32%5Cconfig",
         "/assets/%2e%2e/%2e%2e/secret.txt",
+        "/assets/%2500.js",
     ],
 )
 def test_asset_traversal_attempts_are_rejected(

--- a/tests/test_static_assets_consistency.py
+++ b/tests/test_static_assets_consistency.py
@@ -202,6 +202,39 @@ def test_existing_asset_is_served_from_explicit_assets_route(tmp_path: Path) -> 
     assert css_response.headers["content-type"].startswith("text/css")
 
 
+def test_existing_asset_supports_head_and_conditional_requests(tmp_path: Path) -> None:
+    from api.app import create_app
+
+    static_dir = tmp_path / "static"
+    assets_dir = static_dir / "assets"
+    assets_dir.mkdir(parents=True)
+    js_file = assets_dir / "index-abc.js"
+    js_file.write_text("console.log('ok')", encoding="utf-8")
+    (assets_dir / "index-abc.css").write_text("body{color:#fff}", encoding="utf-8")
+    _write_index(static_dir, _vite_index("index-abc.js", "index-abc.css"))
+
+    client = TestClient(create_app(static_dir=static_dir))
+
+    get_response = client.get("/assets/index-abc.js")
+    etag = get_response.headers["etag"]
+
+    head_response = client.head("/assets/index-abc.js")
+    cached_response = client.get(
+        "/assets/index-abc.js",
+        headers={"if-none-match": etag},
+    )
+
+    assert get_response.status_code == 200
+    assert head_response.status_code == 200
+    assert head_response.content == b""
+    assert head_response.headers["etag"] == etag
+    assert head_response.headers["content-type"].startswith("text/javascript")
+
+    assert cached_response.status_code == 304
+    assert cached_response.content == b""
+    assert cached_response.headers["etag"] == etag
+
+
 @pytest.mark.parametrize(
     "request_path",
     [

--- a/tests/test_static_assets_consistency.py
+++ b/tests/test_static_assets_consistency.py
@@ -176,6 +176,32 @@ def test_missing_asset_returns_safe_404_content_types(tmp_path: Path) -> None:
     assert html_response.headers["content-type"].startswith("text/plain")
 
 
+def test_existing_asset_is_served_from_explicit_assets_route(tmp_path: Path) -> None:
+    from api.app import create_app
+
+    static_dir = tmp_path / "static"
+    assets_dir = static_dir / "assets"
+    assets_dir.mkdir(parents=True)
+    js_file = assets_dir / "index-abc.js"
+    css_file = assets_dir / "index-abc.css"
+    js_file.write_text("console.log('ok')", encoding="utf-8")
+    css_file.write_text("body{color:#fff}", encoding="utf-8")
+    _write_index(static_dir, _vite_index("index-abc.js", "index-abc.css"))
+
+    client = TestClient(create_app(static_dir=static_dir))
+
+    js_response = client.get("/assets/index-abc.js")
+    css_response = client.get("/assets/index-abc.css")
+
+    assert js_response.status_code == 200
+    assert js_response.text == "console.log('ok')"
+    assert js_response.headers["content-type"].startswith("text/javascript")
+
+    assert css_response.status_code == 200
+    assert css_response.text == "body{color:#fff}"
+    assert css_response.headers["content-type"].startswith("text/css")
+
+
 @pytest.mark.parametrize(
     "request_path",
     [

--- a/tests/test_static_assets_consistency.py
+++ b/tests/test_static_assets_consistency.py
@@ -17,6 +17,7 @@ import sys
 from pathlib import Path
 
 import pytest
+from fastapi.testclient import TestClient
 
 
 SCRIPT_DIR = Path(__file__).resolve().parent.parent / "scripts"
@@ -144,3 +145,64 @@ def test_backend_startup_check_silent_when_bundle_consistent(
         "Frontend bundle is inconsistent" in record.getMessage()
         for record in caplog.records
     )
+
+
+def test_missing_asset_returns_safe_404_content_types(tmp_path: Path) -> None:
+    from api.app import create_app
+
+    static_dir = tmp_path / "static"
+    assets_dir = static_dir / "assets"
+    assets_dir.mkdir(parents=True)
+    (assets_dir / "index-abc.js").write_text("// ok", encoding="utf-8")
+    (assets_dir / "index-abc.css").write_text("/* ok */", encoding="utf-8")
+    _write_index(static_dir, _vite_index("index-abc.js", "index-abc.css"))
+
+    client = TestClient(create_app(static_dir=static_dir))
+
+    js_response = client.get("/assets/index-missing.js")
+    css_response = client.get("/assets/index-missing.css")
+    html_response = client.get("/assets/%3Cscript%3Ealert(1)%3C/script%3E.html")
+
+    assert js_response.status_code == 404
+    assert js_response.text == "asset not found"
+    assert js_response.headers["content-type"].startswith("text/javascript")
+
+    assert css_response.status_code == 404
+    assert css_response.text == "asset not found"
+    assert css_response.headers["content-type"].startswith("text/css")
+
+    assert html_response.status_code == 404
+    assert html_response.text == "asset not found"
+    assert html_response.headers["content-type"].startswith("text/plain")
+
+
+@pytest.mark.parametrize(
+    "request_path",
+    [
+        "/assets/..%5C..%5Csecret.txt",
+        "/assets/C:%5Csecret.txt",
+        "/assets/%5Cwindows%5Csystem32%5Cconfig",
+        "/assets/%2e%2e/%2e%2e/secret.txt",
+    ],
+)
+def test_asset_traversal_attempts_are_rejected(
+    tmp_path: Path,
+    request_path: str,
+) -> None:
+    from api.app import create_app
+
+    static_dir = tmp_path / "static"
+    assets_dir = static_dir / "assets"
+    assets_dir.mkdir(parents=True)
+    (assets_dir / "index-abc.js").write_text("// ok", encoding="utf-8")
+    (assets_dir / "index-abc.css").write_text("/* ok */", encoding="utf-8")
+    _write_index(static_dir, _vite_index("index-abc.js", "index-abc.css"))
+    outside_secret = tmp_path / "secret.txt"
+    outside_secret.write_text("top secret", encoding="utf-8")
+
+    client = TestClient(create_app(static_dir=static_dir))
+    response = client.get(request_path)
+
+    assert response.status_code == 404
+    assert response.text == "not found"
+    assert "top secret" not in response.text

--- a/tests/test_static_assets_consistency.py
+++ b/tests/test_static_assets_consistency.py
@@ -1,0 +1,146 @@
+# -*- coding: utf-8 -*-
+"""Tests for ``scripts/check_static_assets.py`` and the equivalent
+backend startup self-check in ``api.app``.
+
+Both code paths target the blank-page / "Preparing backend..." regression
+captured in GitHub issues #1064, #1065 and #1050: vite produces a fresh
+``index.html`` that references ``/assets/index-<hash>.js``, but the
+packaging step copies a stale ``static/assets`` directory, so the bundle
+referenced by ``index.html`` does not exist on disk.
+"""
+
+from __future__ import annotations
+
+import importlib
+import logging
+import sys
+from pathlib import Path
+
+import pytest
+
+
+SCRIPT_DIR = Path(__file__).resolve().parent.parent / "scripts"
+if str(SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_DIR))
+
+check_static_assets = importlib.import_module("check_static_assets")
+
+
+def _write_index(static_dir: Path, body: str) -> None:
+    static_dir.mkdir(parents=True, exist_ok=True)
+    (static_dir / "index.html").write_text(body, encoding="utf-8")
+
+
+def _vite_index(js_name: str, css_name: str) -> str:
+    return (
+        "<!doctype html><html><head>"
+        f'<script type="module" crossorigin src="/assets/{js_name}"></script>'
+        f'<link rel="stylesheet" crossorigin href="/assets/{css_name}">'
+        "</head><body><div id=\"root\"></div></body></html>"
+    )
+
+
+def test_check_static_dir_passes_when_assets_match(tmp_path: Path) -> None:
+    static_dir = tmp_path / "static"
+    assets_dir = static_dir / "assets"
+    assets_dir.mkdir(parents=True)
+    (assets_dir / "index-abc.js").write_text("// js", encoding="utf-8")
+    (assets_dir / "index-abc.css").write_text("/* css */", encoding="utf-8")
+    _write_index(static_dir, _vite_index("index-abc.js", "index-abc.css"))
+
+    referenced, missing = check_static_assets.check_static_dir(static_dir)
+
+    assert sorted(referenced) == ["/assets/index-abc.css", "/assets/index-abc.js"]
+    assert missing == []
+
+
+def test_check_static_dir_detects_stale_bundle(tmp_path: Path) -> None:
+    """index.html references new hash but assets/ holds an old hash."""
+    static_dir = tmp_path / "static"
+    assets_dir = static_dir / "assets"
+    assets_dir.mkdir(parents=True)
+    # Stale on-disk bundle.
+    (assets_dir / "index-OLD.js").write_text("// old", encoding="utf-8")
+    (assets_dir / "index-OLD.css").write_text("/* old */", encoding="utf-8")
+    # Fresh index.html points to a different hash.
+    _write_index(static_dir, _vite_index("index-NEW.js", "index-NEW.css"))
+
+    referenced, missing = check_static_assets.check_static_dir(static_dir)
+
+    assert "/assets/index-NEW.js" in referenced
+    assert sorted(missing) == ["/assets/index-NEW.css", "/assets/index-NEW.js"]
+
+
+def test_check_static_dir_raises_when_index_missing(tmp_path: Path) -> None:
+    static_dir = tmp_path / "static"
+    static_dir.mkdir()
+    with pytest.raises(FileNotFoundError):
+        check_static_assets.check_static_dir(static_dir)
+
+
+def test_main_returns_nonzero_when_assets_missing(tmp_path: Path, capsys) -> None:
+    static_dir = tmp_path / "static"
+    (static_dir / "assets").mkdir(parents=True)
+    _write_index(static_dir, _vite_index("index-MISSING.js", "index-MISSING.css"))
+
+    rc = check_static_assets.main(["check_static_assets.py", str(static_dir)])
+
+    captured = capsys.readouterr()
+    assert rc == 1
+    assert "ERROR" in captured.err
+    assert "/assets/index-MISSING.js" in captured.err
+
+
+def test_main_returns_zero_when_consistent(tmp_path: Path) -> None:
+    static_dir = tmp_path / "static"
+    assets = static_dir / "assets"
+    assets.mkdir(parents=True)
+    (assets / "main.js").write_text("// ok", encoding="utf-8")
+    (assets / "main.css").write_text("/* ok */", encoding="utf-8")
+    _write_index(static_dir, _vite_index("main.js", "main.css"))
+
+    rc = check_static_assets.main(["check_static_assets.py", str(static_dir)])
+    assert rc == 0
+
+
+def test_backend_startup_check_logs_when_bundle_inconsistent(
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    from api import app as app_module
+
+    static_dir = tmp_path / "static"
+    (static_dir / "assets").mkdir(parents=True)
+    _write_index(static_dir, _vite_index("index-NEW.js", "index-NEW.css"))
+
+    with caplog.at_level(logging.ERROR, logger="api.app"):
+        missing = app_module._check_frontend_assets_consistency(static_dir)
+
+    assert sorted(missing) == ["/assets/index-NEW.css", "/assets/index-NEW.js"]
+    assert any(
+        "Frontend bundle is inconsistent" in record.getMessage()
+        for record in caplog.records
+    )
+
+
+def test_backend_startup_check_silent_when_bundle_consistent(
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    from api import app as app_module
+
+    static_dir = tmp_path / "static"
+    assets = static_dir / "assets"
+    assets.mkdir(parents=True)
+    (assets / "index-abc.js").write_text("// js", encoding="utf-8")
+    (assets / "index-abc.css").write_text("/* css */", encoding="utf-8")
+    _write_index(static_dir, _vite_index("index-abc.js", "index-abc.css"))
+
+    with caplog.at_level(logging.ERROR, logger="api.app"):
+        missing = app_module._check_frontend_assets_consistency(static_dir)
+
+    assert missing == []
+    assert not any(
+        "Frontend bundle is inconsistent" in record.getMessage()
+        for record in caplog.records
+    )


### PR DESCRIPTION
## PR Type

- [x] fix

## Background And Problem

Multiple users reported that the Windows免安装包打开后白屏 / 卡在 "Preparing backend..."（#1064、#1065、#1050）。我交叉对比代码后定位的根因不是历史 #520 的 MIME 问题（那条已在 v3.4.9 通过 `mimetypes.guess_type()` 修复），而是 **Release 产物前/后端版本错配**：

- `apps/dsa-web/vite.config.ts` 构建出的 `static/index.html` 引用带 hash 的 `/assets/index-<hash>.js`、`/assets/index-<hash>.css`。
- `scripts/build-backend.ps1` / `build-backend-macos.sh` 通过 PyInstaller `--add-data static;static` 把 `static/` 打入后端可执行文件。
- 一旦发布流水线只重建了前端而没同步重打后端，或本地解压目录里有旧 `static/` 残留，`index.html` 引用的 hash 文件名在 `assets/` 中根本不存在 → 浏览器请求 `/assets/index-<hash>.js` 命中 FastAPI 的 `StaticFiles` mount → 404 默认返回 `application/json` → 浏览器以 strict-MIME 拒绝执行模块脚本 → 白屏。

#1064 用户复现时给的 `content-type: application/json` 响应头正好对得上这个链路。

## Scope Of Change

- `scripts/check_static_assets.py`（新增）：跨平台 Python 脚本，解析 `index.html` 的 `/assets/*` 引用并核对真实文件是否存在；不一致时返回非 0 并打印明确的修复指引。
- `scripts/build-backend.ps1` / `scripts/build-backend-macos.sh`：在 `npm run build` 之后跑一次源 `static/` 检查；在 PyInstaller 产出 `dist/backend/stock_analysis/` 后再针对 `_internal/static`（或 `static`）跑一次 packaged 检查。任一失败直接 fail-fast 终止打包。
- `api/app.py`：
  - 启动时调用 `_check_frontend_assets_consistency()`，发现错配直接打印含 `#1064/#1065` 引用的 ERROR 日志（不抛异常，避免破坏无法解析 HTML 的非常规部署）。
  - 把原 `app.mount("/assets", StaticFiles(...))` 替换为显式的 `serve_asset()` 路由：命中真实文件时按扩展名带 `media_type` 返回；缺失时返回与请求扩展名匹配的 `text/javascript` / `text/css` 404，而不是被默认 JSON 错误响应误导。仍保留 path traversal 防护。
- `tests/test_static_assets_consistency.py`（新增）：7 条确定性单元测试覆盖正/反两条路径与启动期日志。
- `docs/CHANGELOG.md`：在 `[Unreleased]` 段追加 2 条扁平条目。

## Issue Link

Refs #1064
Refs #1065
Refs #1050

（#1064 仍是 canonical OPEN issue；#1065 已作为重复关闭；#1050 是 stale 关闭的同源现象。本 PR 合入后建议在 #1064 评论里同步修复说明。）

## Verification Commands And Results

```bash
python -m py_compile api/app.py scripts/check_static_assets.py tests/test_static_assets_consistency.py main.py
python -m pytest tests/test_static_assets_consistency.py -q
python -m pytest tests/test_api_app_cors.py -q
flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
python scripts/check_static_assets.py static
flake8 api/app.py scripts/check_static_assets.py tests/test_static_assets_consistency.py
```

关键结论：
- `pytest tests/test_static_assets_consistency.py` → **7 passed**。
- `pytest tests/test_api_app_cors.py` → **2 passed**（确认现有 CORS / 路由行为未回归）。
- 关键 flake8 (`E9,F63,F7,F82`) → **0**。
- 完整 flake8 在 `api/app.py` 上的告警数 = 修改前后均为 20，**未引入新告警**；新增脚本/测试 0 告警。
- `scripts/check_static_assets.py` 在仓库当前 `static/` 上正确报告 `OK: 2 asset reference(s) resolved successfully`。

未运行：`./scripts/ci_gate.sh` 完整离线测试套件（耗时较长且本环境 Windows 桌面打包链路无法执行）；后续依赖 CI 的 `backend-gate` 覆盖。Web 前端无改动，未跑 `npm run lint && npm run build`。

## Compatibility And Risk

- 后端：`/assets/*` 由显式路由代替 `StaticFiles` mount，命中已有静态文件的行为保持一致（带正确 `Content-Type` 的 `FileResponse`）；唯一行为差异是 **404 响应的 body 与 Content-Type**——之前是 JSON `{"detail": "Not Found"}`，现在是与扩展名匹配的纯文本 404。这对正常用户是改善，对依赖 JSON 404 的客户端为不兼容；目前仓库内未发现这种依赖。
- 启动期一致性自检不抛异常，只打日志，所以即使解析失败也不会影响后端可用性。
- 打包链路新增的检查在前端产物缺失或错配时会 **fail-fast**，这是预期行为（避免再次发出坏包）；常规分支构建有完整 `npm run build` 步骤，不会误报。
- 桌面端 Electron 渲染逻辑未触碰；macOS / Windows 打包脚本对称改动。

## Rollback Plan

`git revert 6477d07`（本 PR 单一提交）；或在 `scripts/build-backend.ps1`、`scripts/build-backend-macos.sh` 注释掉两处 `check_static_assets.py` 调用，并在 `api/app.py` 把 `serve_asset` 路由换回 `app.mount("/assets", StaticFiles(directory=assets_dir), name="assets")`。

## EXTRACT_PROMPT Change (if applicable)

None.
