### PR TITLE
ci: ignore vendored node modules in lint config

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -10,6 +10,7 @@ exclude =
     build,
     dist,
     node_modules,
+    */node_modules/*,
     *.egg-info
 # E501: 行太长（有些地方确实需要长行）
 # W503: 运算符在换行前（与 black 冲突）
@@ -31,4 +32,5 @@ markers =
 profile = black
 line_length = 120
 skip = .git,__pycache__,.env,venv,.venv,node_modules
+skip_glob = */node_modules/*
 known_first_party = config,storage,analyzer,notification,scheduler,search_service,market_analyzer,stock_analyzer,data_provider

--- a/setup.cfg
+++ b/setup.cfg
@@ -9,6 +9,7 @@ exclude =
     .venv*,
     build,
     dist,
+    node_modules,
     *.egg-info
 # E501: 行太长（有些地方确实需要长行）
 # W503: 运算符在换行前（与 black 冲突）
@@ -29,5 +30,5 @@ markers =
 [isort]
 profile = black
 line_length = 120
-skip = .git,__pycache__,.env,venv,.venv
+skip = .git,__pycache__,.env,venv,.venv,node_modules
 known_first_party = config,storage,analyzer,notification,scheduler,search_service,market_analyzer,stock_analyzer,data_provider


### PR DESCRIPTION
## Summary

- Exclude `node_modules` from flake8 discovery via `setup.cfg`.
- Keep isort aligned by skipping `node_modules` as well.

## Why

AutoCode PR repair hit a backend-gate failure from vendored desktop packaging files under `apps/dsa-desktop/node_modules`. Those generated/vendor files are not project Python sources and should not cause backend lint failures or prompt unrelated code repairs.

## Validation

- `git diff --check`