### PR TITLE
feat: add optional Anspire API support for news search

### DIFF
--- a/.github/workflows/daily_analysis.yml
+++ b/.github/workflows/daily_analysis.yml
@@ -192,6 +192,7 @@ jobs:
           # ==========================================
           # 搜索服务
           # ==========================================
+          ANSPIRE_API_KEYS: ${{ secrets.ANSPIRE_API_KEYS }} 
           BOCHA_API_KEYS: ${{ secrets.BOCHA_API_KEYS }}
           TAVILY_API_KEYS: ${{ secrets.TAVILY_API_KEYS }}
           SERPAPI_API_KEYS: ${{ secrets.SERPAPI_API_KEYS }}


### PR DESCRIPTION
## PR Type

- [ ] fix
- [x] feat
- [ ] refactor
- [ ] docs
- [ ] chore
- [ ] test

---

## Background And Problem

当前项目虽然支持多种搜索引擎（如 Bocha、Tavily、SerpAPI 等），但未明确提供或验证 ANSPIRE_API_KEYS 的实际使用路径。

对于 A 股用户来说，中文搜索质量对新闻分析非常关键，而 Anspire 在中文内容上表现较好。

因此，希望补充并验证 ANSPIRE_API_KEYS 的配置能力，以增强新闻分析效果。

---

## Scope Of Change

本 PR 主要涉及：

- `.github/workflows/daily_analysis.yml`
  - 增加 ANSPIRE_API_KEYS 的环境变量注入：
    ```yaml
    ANSPIRE_API_KEYS: ${{ secrets.ANSPIRE_API_KEYS }}
    ```

- GitHub Actions Secrets 配置（非代码部分）
  - 在仓库中新增 `ANSPIRE_API_KEYS` secret

---

## Issue Link

无 Issue，本 PR 为配置增强与功能验证。

验收标准：
- 配置 ANSPIRE_API_KEYS 后，运行 workflow 不报错
- 新闻分析模块能够正常执行（即使 fallback 也不影响主流程）

---

## Verification Commands And Results

实际执行：

```bash
# GitHub Actions 手动触发
Actions → 每日股票分析 → Run workflow

mode = stocks-only
force_run = true