### PR TITLE
[codex] add related projects to readmes

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,6 +245,13 @@ python main.py --webui-only
 
 > Agent 具体参数、`skill` 命名兼容、多 Agent 模式和预算护栏见 [完整指南](docs/full-guide.md#本地-webui-管理界面) 与 [LLM 配置指南](docs/LLM_CONFIG_GUIDE.md)。
 
+## 相关项目 (Related Projects)
+
+DSA 聚焦日常分析报告；下面两个同系列项目分别覆盖选股、策略验证与策略进化，适合按需延伸使用。它们当前独立维护，后续会优先探索与 DSA 的候选股导入、回测验证和报告联动。
+
+- [AlphaSift](https://github.com/ZhuLinsen/alphasift)：多因子选股与全市场扫描，用于从股票池中提取候选标的。
+- [AlphaEvo](https://github.com/ZhuLinsen/alphaevo)：策略回测与自我进化，用于验证策略规则，并通过迭代探索策略参数与组合。
+
 ## 🗺️ Roadmap
 
 查看已支持的功能和未来规划：[更新日志](docs/CHANGELOG.md)

--- a/docs/README_CHT.md
+++ b/docs/README_CHT.md
@@ -233,6 +233,13 @@ python main.py --webui-only
 
 > Agent 具體參數、`skill` 命名兼容、多 Agent 模式和預算護欄見 [完整指南](./full-guide.md#本地-webui-管理界面) 與 [LLM 配置指南](./LLM_CONFIG_GUIDE.md)。
 
+## 相關項目 (Related Projects)
+
+DSA 聚焦日常分析報告；以下兩個同系列項目分別覆蓋選股、策略驗證與策略進化，適合按需延伸使用。它們目前獨立維護，後續會優先探索與 DSA 的候選股導入、回測驗證和報告聯動。
+
+- [AlphaSift](https://github.com/ZhuLinsen/alphasift)：多因子選股與全市場掃描，用於從股票池中整理候選標的。
+- [AlphaEvo](https://github.com/ZhuLinsen/alphaevo)：策略回測與自我進化，用於驗證策略規則，並透過迭代探索策略參數與組合。
+
 ## 🗺️ Roadmap
 
 查看已支援的功能和未來規劃：[更新日誌](./CHANGELOG.md)

--- a/docs/README_EN.md
+++ b/docs/README_EN.md
@@ -233,6 +233,13 @@ After configuring any available AI API key, the Web `/chat` page can use strateg
 
 > Agent parameters, `skill` naming compatibility, multi-agent mode, and budget guards are covered in the [Full Guide](./full-guide_EN.md#local-webui-management-interface) and [LLM Config Guide](./LLM_CONFIG_GUIDE_EN.md).
 
+## Related Projects
+
+DSA focuses on daily analysis reports. These sibling projects cover stock screening, strategy validation, and strategy evolution for users who want to extend the workflow. They are maintained independently today, with candidate import, backtest validation, and report handoff planned as future integration directions.
+
+- [AlphaSift](https://github.com/ZhuLinsen/alphasift): multi-factor stock screening and full-market scanning for building candidate watchlists.
+- [AlphaEvo](https://github.com/ZhuLinsen/alphaevo): strategy backtesting and self-evolution experiments for validating rules and iteratively exploring strategy parameters and combinations.
+
 ## 🗺️ Roadmap
 
 See supported features and release notes in the [Changelog](./CHANGELOG.md). Suggestions are welcome through [GitHub Issues](https://github.com/ZhuLinsen/daily_stock_analysis/issues).


### PR DESCRIPTION
## Summary

- Add a Related Projects section before Roadmap in the simplified, Traditional Chinese, and English READMEs.
- Position AlphaSift and AlphaEvo as optional workflow extensions for stock screening, strategy validation, and strategy evolution.
- Keep the copy informational and avoid strong promotional or return-oriented wording.

## Why

The related projects are part of the broader workflow around DSA, but they read more naturally before Roadmap than near the footer. The wording also clarifies AlphaEvo's strategy self-evolution role without making aggressive promises.

## Validation

- `git diff --check HEAD~1..HEAD`

Docs only, tests not run.