### PR TITLE
refactor: 在不修改源码、依赖、构建和运行行为的前提下，先由维护者确认是否接受… (#1141)

### DIFF
--- a/.understand-anything/README.md
+++ b/.understand-anything/README.md
@@ -1,0 +1,60 @@
+# Repository Knowledge Graph Snapshot
+
+This directory is reserved for **static, contributor-facing knowledge graph assets**.
+Files here must stay reviewable in Git, must not change runtime behavior, and must not require
+additional build, CI, or deployment steps.
+
+## What this snapshot helps with
+
+- Finding the main entrypoints and run modes quickly
+- Understanding how `api/`, `apps/`, `bot/`, `data_provider/`, `src/`, and `strategies/` fit together
+- Estimating which surfaces are affected when one module changes
+- Mapping common automation paths such as local runs, GitHub Actions, and Docker
+
+## Entrypoints and run modes
+
+| Surface | Primary entry | What it does |
+|--------|---------------|--------------|
+| Daily analysis / CLI | `main.py` | Runs stock analysis, market review, scheduling, and service startup modes |
+| FastAPI service | `server.py`, `api/` | Exposes HTTP APIs, auth, history, task, and asset routes |
+| Core orchestration | `src/core/`, `src/services/` | Coordinates analysis flow, report assembly, notifications, and business services |
+| Data adapters | `data_provider/` | Normalizes market/news/fundamental inputs from multiple providers with fallback behavior |
+| Strategy layer | `strategies/`, `src/agent/` | Encapsulates strategy prompts, agent skills, and decision helpers |
+| Bot integrations | `bot/` | Connects command handling and notifications to chat platforms |
+| Web workspace | `apps/dsa-web/` | React/Vite frontend for analysis, history, settings, backtest, and portfolio |
+| Desktop app | `apps/dsa-desktop/` | Electron shell around the web workspace plus desktop-specific bridge APIs |
+| Automation / cloud runs | `.github/workflows/`, `scripts/`, `docker/` | CI, scheduled analysis, packaging, and deployment paths |
+
+## Directory collaboration
+
+```text
+data_provider/ -> src/services/ + src/core/
+src/core/ -> src/reports/ -> notification senders / persistence
+api/ -> src/services/ + src/repositories/ -> frontend clients
+apps/dsa-web/ -> api/ HTTP endpoints
+apps/dsa-desktop/ -> apps/dsa-web/ build output + desktop bridge
+bot/ -> src/services/ + strategy/agent helpers
+.github/workflows/ / docker/ / scripts/ -> main.py / server.py / static assets
+```
+
+## Impact hints for contributors
+
+| If you change... | Usually re-check... |
+|------------------|---------------------|
+| `data_provider/` | Provider fallback order, normalized fields, timeouts, downstream analysis assumptions |
+| `src/core/` or `src/services/` | Report generation, notification flow, API responses, scheduling behavior |
+| `src/schemas/` or API payloads | FastAPI endpoints, Web/Desktop compatibility, history/report rendering |
+| `apps/dsa-web/` | API contracts, auth/task polling, static build output, desktop embedding |
+| `apps/dsa-desktop/` | Web build artifacts, preload bridge, release packaging |
+| `bot/` | Command routing, notification formatting, service contracts |
+| `.github/workflows/`, `scripts/`, `docker/` | CI expectations, local scripts, release and deployment paths |
+
+## Accepted scope for future `.understand-anything/` updates
+
+Pull requests that touch this directory are acceptable when they:
+
+1. Add or refresh static knowledge graph artifacts for contributor understanding only
+2. Stay confined to `.understand-anything/` plus at most minimal documentation links
+3. Avoid source-code, dependency, workflow, Docker, and runtime behavior changes
+4. Keep content textual, reviewable, and free of secrets, binaries, or environment-specific paths
+5. Document the generator or source of truth when regeneration details are relevant

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 <!-- 新条目格式：- [类型] 描述（类型取值：新功能/改进/修复/文档/测试/chore）-->
 <!-- 每条独立一行追加到本段末尾，无需分类标题，合并时冲突最小 -->
+- [文档] 新增 `.understand-anything/README.md` 贡献者知识图谱快照，并在中英文贡献指南中明确该目录的受控接收边界。
 
 ## [3.14.1] - 2026-04-26
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -98,6 +98,15 @@ npm run lint
 npm run build
 ```
 
+### 贡献者知识图谱资产（`.understand-anything/`）
+
+仓库可以接收放在 `.understand-anything/` 下的**静态、可审查、可再生成**的贡献者辅助资产，用于帮助新贡献者理解项目入口、目录协作关系和改动影响面。
+
+- 这类 PR 应只影响 `.understand-anything/`，如确有必要，最多附带最小范围的 `docs/` 说明链接。
+- 不应修改 `src/`、`api/`、`apps/`、`bot/`、`data_provider/`、依赖、构建配置、CI/workflow、Docker 或运行时行为。
+- 产物应保持文本化、可 diff，并说明生成来源；不要提交密钥、二进制、大体积截图或环境专属路径。
+- 当前目录用途与边界见 [`../.understand-anything/README.md`](../.understand-anything/README.md)。
+
 ## 📋 优先贡献方向
 
 查看 [Roadmap](README.md#-roadmap) 了解当前需要的功能：

--- a/docs/CONTRIBUTING_EN.md
+++ b/docs/CONTRIBUTING_EN.md
@@ -101,6 +101,15 @@ npm run lint
 npm run build
 ```
 
+### Contributor Knowledge Graph Assets (`.understand-anything/`)
+
+This repository accepts **static, reviewable, regenerable** contributor-support assets under `.understand-anything/` when they help newcomers understand entrypoints, directory relationships, and likely impact surfaces.
+
+- These PRs should stay inside `.understand-anything/`, with at most a minimal supporting link in `docs/` when needed.
+- They must not change `src/`, `api/`, `apps/`, `bot/`, `data_provider/`, dependencies, build config, CI/workflows, Docker, or runtime behavior.
+- Keep the output textual and diff-friendly, and note the generator/source when relevant; do not commit secrets, binaries, large screenshots, or environment-specific paths.
+- See [`../.understand-anything/README.md`](../.understand-anything/README.md) for the current scope and snapshot.
+
 ### Documentation Sync Rule
 
 When modifying a Chinese-language core document (e.g., `docs/full-guide.md`), your PR description **must state** whether the corresponding English document has been updated. If not updated, explain why.

--- a/tests/test_understand_anything_docs.py
+++ b/tests/test_understand_anything_docs.py
@@ -1,0 +1,37 @@
+# -*- coding: utf-8 -*-
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+def test_understand_anything_snapshot_exists_with_required_sections() -> None:
+    snapshot = REPO_ROOT / ".understand-anything" / "README.md"
+
+    assert snapshot.exists()
+    content = snapshot.read_text(encoding="utf-8")
+
+    assert "# Repository Knowledge Graph Snapshot" in content
+    assert "## Entrypoints and run modes" in content
+    assert "## Directory collaboration" in content
+    assert "## Accepted scope for future `.understand-anything/` updates" in content
+    assert "main.py" in content
+    assert "server.py" in content
+    assert "data_provider/" in content
+    assert "apps/dsa-web/" in content
+
+
+def test_contributing_guides_document_understand_anything_boundary() -> None:
+    zh = (REPO_ROOT / "docs" / "CONTRIBUTING.md").read_text(encoding="utf-8")
+    en = (REPO_ROOT / "docs" / "CONTRIBUTING_EN.md").read_text(encoding="utf-8")
+
+    assert ".understand-anything/" in zh
+    assert "静态、可审查、可再生成" in zh
+    assert ".understand-anything/" in en
+    assert "static, reviewable, regenerable" in en
+
+
+def test_changelog_mentions_knowledge_graph_docs_entry() -> None:
+    changelog = (REPO_ROOT / "docs" / "CHANGELOG.md").read_text(encoding="utf-8")
+
+    assert ".understand-anything/README.md" in changelog


### PR DESCRIPTION
## PR Type
- [ ] fix
- [ ] feat
- [x] refactor
- [ ] docs
- [ ] chore
- [ ] test

## Background And Problem
- 当前问题：在不修改源码、依赖、构建和运行行为的前提下，先由维护者确认是否接受 `.understand-anything/` 这类生成型知识图谱产物，再按最小范围提交仅包含该目录的 PR。
- 影响范围：本次改动涉及 5 个文件，Diff 为 `+116 / -0`。
- 触发来源：Issue 自动执行（Issue #1141）。

## Scope Of Change
- `.understand-anything/README.md`
- `docs/CHANGELOG.md`
- `docs/CONTRIBUTING.md`
- `docs/CONTRIBUTING_EN.md`
- `tests/test_understand_anything_docs.py`

## Documentation And Changelog
- 已同步更新文档/变更记录：`.understand-anything/README.md`, `docs/CHANGELOG.md`, `docs/CONTRIBUTING.md`, `docs/CONTRIBUTING_EN.md`。

## Issue Link
Closes #1141

## Verification Commands And Results
```bash
./scripts/ci_gate.sh flake8
./scripts/ci_gate.sh offline-tests
```

关键输出/结论 / Key output & conclusion:
- lint:PASS, test:PASS

## Compatibility And Risk
- **Low**：涉及 `.understand-anything/README.md`, `docs/CHANGELOG.md`, `docs/CONTRIBUTING.md`, `docs/CONTRIBUTING_EN.md`, `tests/test_understand_anything_docs.py`，未识别额外兼容性风险。
- 前提假设：
  - 更小且更稳妥的路径是先做仓库治理层面的接受性判断，而不是扩展成应用代码改造。
  - 若维护者接受，该 PR 应仅新增 `.understand-anything/` 目录及其静态生成结果，不改动 `src/`、`api/`、`apps/`、`bot/`、`data_provider/`、workflow、Docker 或运行配置。
  - 该知识图谱属于贡献者辅助资料，定位更接近文档/索引资产，而不是产品功能。
  - 如仓库需要说明来源与更新方式，可附带一处最小文档说明；否则优先只提交目录本身，避免扩大改动面。

## Rollback Plan
- `git revert <merge-commit>` 回滚本 PR 提交，重点确认 `.understand-anything/README.md`, `docs/CHANGELOG.md`, `docs/CONTRIBUTING.md`, `docs/CONTRIBUTING_EN.md` 恢复正常。

## Acceptance Criteria
- 维护者明确确认仓库可以接收 `.understand-anything/` 这类生成型辅助资产。
- 最终 PR 不修改任何源码、运行时依赖、构建配置、CI/workflow、部署脚本或用户行为。
- 新增内容范围受控在 `.understand-anything/`，并且其内容能帮助新贡献者理解入口、目录协作关系和模块依赖。
- 若补充说明文档，说明内容仅覆盖该目录的用途、来源和是否可再生成，不引入新的流程要求或工具依赖。

## Checklist
- [x] 本 PR 有明确动机和业务价值 / This PR has a clear motivation and value
- [x] 已提供可复现的验证命令与结果 / Reproducible verification commands and results are included
- [x] 已评估兼容性与风险 / Compatibility and risk have been assessed
- [x] 已提供回滚方案 / A rollback plan is provided
- [x] 已同步更新相关文档与 `docs/CHANGELOG.md`，并在 PR 描述中说明文档落点 / Relevant docs and `docs/CHANGELOG.md` are updated, and the documentation location is stated in this PR