### PR TITLE
Fix agent fallback, portfolio pricing, and task queue tests

### DIFF
--- a/api/v1/schemas/portfolio.py
+++ b/api/v1/schemas/portfolio.py
@@ -160,6 +160,11 @@ class PortfolioPositionItem(BaseModel):
     market_value_base: float
     unrealized_pnl_base: float
     valuation_currency: str
+    price_source: str = "unknown"
+    price_provider: Optional[str] = None
+    price_date: Optional[str] = None
+    price_stale: bool = False
+    price_available: bool = True
 
 
 class PortfolioAccountSnapshot(BaseModel):

--- a/apps/dsa-web/src/pages/PortfolioPage.tsx
+++ b/apps/dsa-web/src/pages/PortfolioPage.tsx
@@ -1011,7 +1011,15 @@ const PortfolioPage: React.FC = () => {
                         </div>
                       </td>
                       <td className="py-2 pr-2 text-right">{formatPositionMoney(row.marketValueBase, row)}</td>
-                      <td className={`py-2 text-right ${row.unrealizedPnlBase >= 0 ? 'text-success' : 'text-danger'}`}>
+                      <td
+                        className={`py-2 text-right ${
+                          hasPositionPrice(row)
+                            ? row.unrealizedPnlBase >= 0
+                              ? 'text-success'
+                              : 'text-danger'
+                            : 'text-secondary'
+                        }`}
+                      >
                         {formatPositionMoney(row.unrealizedPnlBase, row)}
                       </td>
                     </tr>

--- a/apps/dsa-web/src/pages/PortfolioPage.tsx
+++ b/apps/dsa-web/src/pages/PortfolioPage.tsx
@@ -80,6 +80,31 @@ function formatPct(value: number | undefined | null): string {
   return `${value.toFixed(2)}%`;
 }
 
+function hasPositionPrice(row: PortfolioPositionItem): boolean {
+  return row.priceAvailable !== false && row.priceSource !== 'missing';
+}
+
+function formatPositionPrice(row: PortfolioPositionItem): string {
+  if (!hasPositionPrice(row)) return '--';
+  return row.lastPrice.toFixed(4);
+}
+
+function formatPositionMoney(value: number, row: PortfolioPositionItem): string {
+  if (!hasPositionPrice(row)) return '--';
+  return formatMoney(value, row.valuationCurrency);
+}
+
+function getPositionPriceLabel(row: PortfolioPositionItem): string {
+  if (!hasPositionPrice(row)) return '缺价';
+  if (row.priceSource === 'realtime_quote') {
+    return row.priceProvider ? `实时价 · ${row.priceProvider}` : '实时价';
+  }
+  if (row.priceSource === 'history_close') {
+    return row.priceStale && row.priceDate ? `收盘价 · ${row.priceDate}` : '收盘价';
+  }
+  return row.priceSource || '未知来源';
+}
+
 function formatSideLabel(value: PortfolioSide): string {
   return value === 'buy' ? '买入' : '卖出';
 }
@@ -979,10 +1004,15 @@ const PortfolioPage: React.FC = () => {
                       <td className="py-2 pr-2 font-mono text-foreground">{row.symbol}</td>
                       <td className="py-2 pr-2 text-right">{row.quantity.toFixed(2)}</td>
                       <td className="py-2 pr-2 text-right">{row.avgCost.toFixed(4)}</td>
-                      <td className="py-2 pr-2 text-right">{row.lastPrice.toFixed(4)}</td>
-                      <td className="py-2 pr-2 text-right">{formatMoney(row.marketValueBase, row.valuationCurrency)}</td>
+                      <td className="py-2 pr-2 text-right">
+                        <div>{formatPositionPrice(row)}</div>
+                        <div className={`text-[11px] ${hasPositionPrice(row) ? 'text-secondary' : 'text-warning'}`}>
+                          {getPositionPriceLabel(row)}
+                        </div>
+                      </td>
+                      <td className="py-2 pr-2 text-right">{formatPositionMoney(row.marketValueBase, row)}</td>
                       <td className={`py-2 text-right ${row.unrealizedPnlBase >= 0 ? 'text-success' : 'text-danger'}`}>
-                        {formatMoney(row.unrealizedPnlBase, row.valuationCurrency)}
+                        {formatPositionMoney(row.unrealizedPnlBase, row)}
                       </td>
                     </tr>
                   ))}

--- a/apps/dsa-web/src/types/portfolio.ts
+++ b/apps/dsa-web/src/types/portfolio.ts
@@ -38,6 +38,11 @@ export interface PortfolioPositionItem {
   marketValueBase: number;
   unrealizedPnlBase: number;
   valuationCurrency: string;
+  priceSource?: 'realtime_quote' | 'history_close' | 'missing' | string;
+  priceProvider?: string | null;
+  priceDate?: string | null;
+  priceStale?: boolean;
+  priceAvailable?: boolean;
 }
 
 export interface PortfolioAccountSnapshot {

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,8 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 <!-- 每条独立一行追加到本段末尾，无需分类标题，合并时冲突最小 -->
 - [修复] 问股 Agent 在未配置可用 LLM 时保留后端真实错误原因并维持 `done.success=false` 失败语义，避免前端把配置缺失误当成成功回答。
 - [文档] 补充 LLM 配置指南与 FAQ，明确问股 Agent 对 `LITELLM_CONFIG` / `LLM_CHANNELS` / legacy `GEMINI_*` `OPENAI_*` `ANTHROPIC_*` 的兼容优先级、回退路径与“不静默迁移旧配置”的结论。
-- [修复] Agent 模式未生成有效决策仪表盘时保留本地趋势分析的评分、趋势和操作建议，避免首页结果被 `50 / 观望 / 未知` 缺省值覆盖。
-- [修复] 持仓快照现价缺失时不再静默回退为持仓成本；当天快照可使用实时价 fallback，并为持仓明细返回价格来源、日期、stale 与缺价状态。
+- [修复] Agent 模式未生成有效决策仪表盘时保留本地趋势分析的评分、趋势和操作建议，并将强买/强卖 fallback 归一到兼容的 `buy`/`sell` 决策类型，避免首页结果被 `50 / 观望 / 未知` 缺省值覆盖。
+- [修复] 持仓快照现价缺失时不再静默回退为持仓成本；当天快照优先使用历史收盘价，仅在缺失时使用实时价 fallback，缺价持仓不再污染市值与未实现盈亏汇总，并为持仓明细返回价格来源、日期、stale 与缺价状态。
 - [测试] 补齐 `task_queue` 轻量导入 stub 的股票代码规范化函数，恢复 `tests/test_task_queue_config_sync.py` 收集与运行。
 
 ## [3.14.1] - 2026-04-26

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,6 +13,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 <!-- 每条独立一行追加到本段末尾，无需分类标题，合并时冲突最小 -->
 - [修复] 问股 Agent 在未配置可用 LLM 时保留后端真实错误原因并维持 `done.success=false` 失败语义，避免前端把配置缺失误当成成功回答。
 - [文档] 补充 LLM 配置指南与 FAQ，明确问股 Agent 对 `LITELLM_CONFIG` / `LLM_CHANNELS` / legacy `GEMINI_*` `OPENAI_*` `ANTHROPIC_*` 的兼容优先级、回退路径与“不静默迁移旧配置”的结论。
+- [修复] Agent 模式未生成有效决策仪表盘时保留本地趋势分析的评分、趋势和操作建议，避免首页结果被 `50 / 观望 / 未知` 缺省值覆盖。
+- [修复] 持仓快照现价缺失时不再静默回退为持仓成本；当天快照可使用实时价 fallback，并为持仓明细返回价格来源、日期、stale 与缺价状态。
+- [测试] 补齐 `task_queue` 轻量导入 stub 的股票代码规范化函数，恢复 `tests/test_task_queue_config_sync.py` 收集与运行。
 
 ## [3.14.1] - 2026-04-26
 

--- a/docs/full-guide.md
+++ b/docs/full-guide.md
@@ -1189,7 +1189,7 @@ A: 检查是否启用了 Actions，以及 cron 表达式是否正确（注意是
 - 导入流程会先把 CSV 解析成标准化记录，再逐条提交到持仓账本；遇到忙碌行会计入 `failed_count`，不会因为单行冲突让整批请求整体失败。
 - 交易去重优先使用账户内唯一的 `trade_uid`，缺失时回退到基于日期、代码、方向、数量、价格、费用、税费、币种的确定性哈希。
 - 卖出会先校验可用数量，超卖返回 `409 portfolio_oversell`；并发写入冲突时可能返回 `409 portfolio_busy`。
-- 持仓快照的 `positions[]` 会返回 `price_source`、`price_date`、`price_stale`、`price_available` 等价格元信息；当天快照在历史收盘价缺失时会尝试实时价，历史 `as_of` 快照不会拉取实时价，也不会再把成本价静默当作现价。
+- 持仓快照的 `positions[]` 会返回 `price_source`、`price_date`、`price_stale`、`price_available` 等价格元信息；当天快照优先使用历史收盘价，仅在收盘价缺失时尝试实时价 fallback，历史 `as_of` 快照不会拉取实时价，也不会再把成本价静默当作现价；缺价持仓会标记 `price_available=false` 并从市值与未实现盈亏汇总中排除。
 - 汇率刷新会先尝试在线源；若在线获取失败，则回退到最近一次缓存并标记 `is_stale=true`，避免快照和风险页整体不可用。
 - 当 `PORTFOLIO_FX_UPDATE_ENABLED=false` 时，手动刷新接口会明确返回“在线刷新已禁用”，页面不会误导为“当前没有可刷新的汇率对”。
 - 风险摘要包含集中度、回撤、止损接近度等信息；`sector_concentration` 会优先尝试按板块归类，失败时降级到 `UNCLASSIFIED`，不会阻断风险结果返回。

--- a/docs/full-guide.md
+++ b/docs/full-guide.md
@@ -1189,6 +1189,7 @@ A: 检查是否启用了 Actions，以及 cron 表达式是否正确（注意是
 - 导入流程会先把 CSV 解析成标准化记录，再逐条提交到持仓账本；遇到忙碌行会计入 `failed_count`，不会因为单行冲突让整批请求整体失败。
 - 交易去重优先使用账户内唯一的 `trade_uid`，缺失时回退到基于日期、代码、方向、数量、价格、费用、税费、币种的确定性哈希。
 - 卖出会先校验可用数量，超卖返回 `409 portfolio_oversell`；并发写入冲突时可能返回 `409 portfolio_busy`。
+- 持仓快照的 `positions[]` 会返回 `price_source`、`price_date`、`price_stale`、`price_available` 等价格元信息；当天快照在历史收盘价缺失时会尝试实时价，历史 `as_of` 快照不会拉取实时价，也不会再把成本价静默当作现价。
 - 汇率刷新会先尝试在线源；若在线获取失败，则回退到最近一次缓存并标记 `is_stale=true`，避免快照和风险页整体不可用。
 - 当 `PORTFOLIO_FX_UPDATE_ENABLED=false` 时，手动刷新接口会明确返回“在线刷新已禁用”，页面不会误导为“当前没有可刷新的汇率对”。
 - 风险摘要包含集中度、回撤、止损接近度等信息；`sector_concentration` 会优先尝试按板块归类，失败时降级到 `UNCLASSIFIED`，不会阻断风险结果返回。

--- a/docs/full-guide_EN.md
+++ b/docs/full-guide_EN.md
@@ -984,7 +984,7 @@ A: Check if Actions is enabled, and if cron expression is correct (note it's UTC
 - The button calls the existing `POST /api/v1/portfolio/fx/refresh` endpoint and reloads snapshot/risk data only.
 - If upstream FX fetch fails, the page may still remain stale after refresh and will explain the fallback result inline.
 - When `PORTFOLIO_FX_UPDATE_ENABLED=false`, the refresh API returns an explicit disabled status and the page shows that online FX refresh is disabled instead of implying that no refreshable pairs exist.
-- Portfolio snapshot `positions[]` now includes price metadata such as `price_source`, `price_date`, `price_stale`, and `price_available`. Today's snapshot may use realtime quotes when no daily close exists, while historical `as_of` snapshots stay on historical-close semantics and no longer silently treat cost basis as the current price.
+- Portfolio snapshot `positions[]` now includes price metadata such as `price_source`, `price_date`, `price_stale`, and `price_available`. Today's snapshot uses the historical close first and only falls back to realtime quotes when no close exists, while historical `as_of` snapshots stay on historical-close semantics and no longer silently treat cost basis as the current price. Missing-price positions are marked with `price_available=false` and excluded from market value / unrealized PnL totals.
 
 ## Agent Tool Data Cache And Persistence
 

--- a/docs/full-guide_EN.md
+++ b/docs/full-guide_EN.md
@@ -984,6 +984,7 @@ A: Check if Actions is enabled, and if cron expression is correct (note it's UTC
 - The button calls the existing `POST /api/v1/portfolio/fx/refresh` endpoint and reloads snapshot/risk data only.
 - If upstream FX fetch fails, the page may still remain stale after refresh and will explain the fallback result inline.
 - When `PORTFOLIO_FX_UPDATE_ENABLED=false`, the refresh API returns an explicit disabled status and the page shows that online FX refresh is disabled instead of implying that no refreshable pairs exist.
+- Portfolio snapshot `positions[]` now includes price metadata such as `price_source`, `price_date`, `price_stale`, and `price_available`. Today's snapshot may use realtime quotes when no daily close exists, while historical `as_of` snapshots stay on historical-close semantics and no longer silently treat cost basis as the current price.
 
 ## Agent Tool Data Cache And Persistence
 

--- a/src/core/pipeline.py
+++ b/src/core/pipeline.py
@@ -1001,16 +1001,19 @@ class StockAnalysisPipeline:
         else:
             result.operation_advice = "Watch" if report_language == "en" else "观望"
 
+        from src.agent.protocols import normalize_decision_signal
+
         signal_name = getattr(buy_signal, "name", "").lower()
         signal_to_decision = {
-            "strong_buy": "strong_buy",
+            "strong_buy": "buy",
             "buy": "buy",
             "hold": "hold",
             "wait": "hold",
             "sell": "sell",
-            "strong_sell": "strong_sell",
+            "strong_sell": "sell",
         }
         result.decision_type = signal_to_decision.get(signal_name, result.decision_type or "hold")
+        result.decision_type = normalize_decision_signal(result.decision_type)
         result.data_sources = f"{result.data_sources},trend:fallback" if result.data_sources else "trend:fallback"
 
     @staticmethod

--- a/src/core/pipeline.py
+++ b/src/core/pipeline.py
@@ -822,7 +822,14 @@ class StockAnalysisPipeline:
             agent_result = executor.run(message, context=initial_context)
 
             # 转换为 AnalysisResult
-            result = self._agent_result_to_analysis_result(agent_result, code, stock_name, report_type, query_id)
+            result = self._agent_result_to_analysis_result(
+                agent_result,
+                code,
+                stock_name,
+                report_type,
+                query_id,
+                trend_result=trend_result,
+            )
             if result:
                 result.query_id = query_id
             # Agent weak integrity: placeholder fill only, no LLM retry
@@ -892,7 +899,13 @@ class StockAnalysisPipeline:
             return None
 
     def _agent_result_to_analysis_result(
-        self, agent_result, code: str, stock_name: str, report_type: ReportType, query_id: str
+        self,
+        agent_result,
+        code: str,
+        stock_name: str,
+        report_type: ReportType,
+        query_id: str,
+        trend_result: Optional[TrendAnalysisResult] = None,
     ) -> AnalysisResult:
         """
         将 AgentResult 转换为 AnalysisResult。
@@ -952,12 +965,53 @@ class StockAnalysisPipeline:
             # structure, so we unwrap it here.
             result.dashboard = dash.get("dashboard") or dash
         else:
-            result.sentiment_score = 50
-            result.operation_advice = "Watch" if report_language == "en" else "观望"
+            self._apply_trend_fallback(result, trend_result, report_language)
             if not result.error_message:
                 result.error_message = "Agent failed to generate a valid decision dashboard" if report_language == "en" else "Agent 未能生成有效的决策仪表盘"
 
         return result
+
+    @staticmethod
+    def _apply_trend_fallback(
+        result: AnalysisResult,
+        trend_result: Optional[TrendAnalysisResult],
+        report_language: str,
+    ) -> None:
+        if trend_result is None:
+            result.sentiment_score = 50
+            result.operation_advice = "Watch" if report_language == "en" else "观望"
+            return
+
+        score = getattr(trend_result, "signal_score", None)
+        try:
+            numeric_score = int(score)
+        except (TypeError, ValueError):
+            numeric_score = 50
+        result.sentiment_score = numeric_score if numeric_score > 0 else 50
+
+        trend_status = getattr(trend_result, "trend_status", None)
+        trend_label = getattr(trend_status, "value", None) or str(trend_status or "").strip()
+        if trend_label:
+            result.trend_prediction = trend_label
+
+        buy_signal = getattr(trend_result, "buy_signal", None)
+        signal_label = getattr(buy_signal, "value", None) or str(buy_signal or "").strip()
+        if signal_label:
+            result.operation_advice = signal_label
+        else:
+            result.operation_advice = "Watch" if report_language == "en" else "观望"
+
+        signal_name = getattr(buy_signal, "name", "").lower()
+        signal_to_decision = {
+            "strong_buy": "strong_buy",
+            "buy": "buy",
+            "hold": "hold",
+            "wait": "hold",
+            "sell": "sell",
+            "strong_sell": "strong_sell",
+        }
+        result.decision_type = signal_to_decision.get(signal_name, result.decision_type or "hold")
+        result.data_sources = f"{result.data_sources},trend:fallback" if result.data_sources else "trend:fallback"
 
     @staticmethod
     def _is_placeholder_stock_name(name: str, code: str) -> bool:

--- a/src/repositories/portfolio_repo.py
+++ b/src/repositories/portfolio_repo.py
@@ -687,6 +687,10 @@ class PortfolioRepository:
     # Price / FX
     # ------------------------------------------------------------------
     def get_latest_close(self, symbol: str, as_of: date) -> Optional[float]:
+        close = self.get_latest_close_with_date(symbol=symbol, as_of=as_of)
+        return close[0] if close is not None else None
+
+    def get_latest_close_with_date(self, symbol: str, as_of: date) -> Optional[Tuple[float, date]]:
         with self.db.get_session() as session:
             row = session.execute(
                 select(StockDaily)
@@ -701,7 +705,7 @@ class PortfolioRepository:
             ).scalar_one_or_none()
             if row is None or row.close is None:
                 return None
-            return float(row.close)
+            return float(row.close), row.date
 
     def save_fx_rate(
         self,

--- a/src/services/portfolio_service.py
+++ b/src/services/portfolio_service.py
@@ -1000,21 +1000,26 @@ class PortfolioService:
             price_info = self._resolve_position_price(symbol=symbol, as_of_date=as_of_date)
             last_price = price_info.price
 
-            local_market_value = qty * float(last_price)
-            market_base, stale_market, _ = self._convert_amount(
-                amount=local_market_value,
-                from_currency=currency,
-                to_currency=account.base_currency,
-                as_of_date=as_of_date,
-            )
-            cost_base, stale_cost, _ = self._convert_amount(
-                amount=total_cost,
-                from_currency=currency,
-                to_currency=account.base_currency,
-                as_of_date=as_of_date,
-            )
-            unrealized_base = market_base - cost_base
-            fx_stale = fx_stale or stale_market or stale_cost
+            if price_info.is_available:
+                local_market_value = qty * float(last_price)
+                market_base, stale_market, _ = self._convert_amount(
+                    amount=local_market_value,
+                    from_currency=currency,
+                    to_currency=account.base_currency,
+                    as_of_date=as_of_date,
+                )
+                cost_base, stale_cost, _ = self._convert_amount(
+                    amount=total_cost,
+                    from_currency=currency,
+                    to_currency=account.base_currency,
+                    as_of_date=as_of_date,
+                )
+                unrealized_base = market_base - cost_base
+                fx_stale = fx_stale or stale_market or stale_cost
+            else:
+                market_base = 0.0
+                cost_base = 0.0
+                unrealized_base = 0.0
 
             position_rows.append(
                 {
@@ -1044,18 +1049,6 @@ class PortfolioService:
     def _resolve_position_price(self, *, symbol: str, as_of_date: date) -> _ResolvedPositionPrice:
         today = date.today()
 
-        if as_of_date == today:
-            realtime_price, provider = self._fetch_realtime_position_price(symbol)
-            if realtime_price is not None and realtime_price > 0:
-                return _ResolvedPositionPrice(
-                    price=float(realtime_price),
-                    source="realtime_quote",
-                    price_date=today,
-                    is_stale=False,
-                    is_available=True,
-                    provider=provider,
-                )
-
         close = self.repo.get_latest_close_with_date(symbol=symbol, as_of=as_of_date)
         if close is not None:
             close_price, close_date = close
@@ -1066,6 +1059,18 @@ class PortfolioService:
                     price_date=close_date,
                     is_stale=close_date < as_of_date,
                     is_available=True,
+                )
+
+        if as_of_date == today:
+            realtime_price, provider = self._fetch_realtime_position_price(symbol)
+            if realtime_price is not None and realtime_price > 0:
+                return _ResolvedPositionPrice(
+                    price=float(realtime_price),
+                    source="realtime_quote",
+                    price_date=today,
+                    is_stale=False,
+                    is_available=True,
+                    provider=provider,
                 )
 
         return _ResolvedPositionPrice(

--- a/src/services/portfolio_service.py
+++ b/src/services/portfolio_service.py
@@ -70,6 +70,16 @@ class _AvgState:
     total_cost: float = 0.0
 
 
+@dataclass(frozen=True)
+class _ResolvedPositionPrice:
+    price: float
+    source: str
+    price_date: Optional[date]
+    is_stale: bool
+    is_available: bool
+    provider: Optional[str] = None
+
+
 class PortfolioService:
     """Business logic for account CRUD, event writes, and snapshot replay."""
 
@@ -987,9 +997,8 @@ class PortfolioService:
                     }
                 )
 
-            last_price = self.repo.get_latest_close(symbol=symbol, as_of=as_of_date)
-            if last_price is None or last_price <= 0:
-                last_price = avg_cost
+            price_info = self._resolve_position_price(symbol=symbol, as_of_date=as_of_date)
+            last_price = price_info.price
 
             local_market_value = qty * float(last_price)
             market_base, stale_market, _ = self._convert_amount(
@@ -1019,6 +1028,11 @@ class PortfolioService:
                     "market_value_base": round(market_base, 8),
                     "unrealized_pnl_base": round(unrealized_base, 8),
                     "valuation_currency": account.base_currency,
+                    "price_source": price_info.source,
+                    "price_provider": price_info.provider,
+                    "price_date": price_info.price_date.isoformat() if price_info.price_date else None,
+                    "price_stale": price_info.is_stale,
+                    "price_available": price_info.is_available,
                 }
             )
 
@@ -1026,6 +1040,67 @@ class PortfolioService:
             total_cost_base += cost_base
 
         return position_rows, lot_rows, market_value_base, total_cost_base, fx_stale
+
+    def _resolve_position_price(self, *, symbol: str, as_of_date: date) -> _ResolvedPositionPrice:
+        today = date.today()
+
+        if as_of_date == today:
+            realtime_price, provider = self._fetch_realtime_position_price(symbol)
+            if realtime_price is not None and realtime_price > 0:
+                return _ResolvedPositionPrice(
+                    price=float(realtime_price),
+                    source="realtime_quote",
+                    price_date=today,
+                    is_stale=False,
+                    is_available=True,
+                    provider=provider,
+                )
+
+        close = self.repo.get_latest_close_with_date(symbol=symbol, as_of=as_of_date)
+        if close is not None:
+            close_price, close_date = close
+            if close_price > 0:
+                return _ResolvedPositionPrice(
+                    price=float(close_price),
+                    source="history_close",
+                    price_date=close_date,
+                    is_stale=close_date < as_of_date,
+                    is_available=True,
+                )
+
+        return _ResolvedPositionPrice(
+            price=0.0,
+            source="missing",
+            price_date=None,
+            is_stale=True,
+            is_available=False,
+        )
+
+    @staticmethod
+    def _fetch_realtime_position_price(symbol: str) -> Tuple[Optional[float], Optional[str]]:
+        try:
+            from data_provider.base import DataFetcherManager
+
+            quote = DataFetcherManager().get_realtime_quote(symbol, log_final_failure=False)
+        except Exception as exc:
+            logger.warning("Failed to fetch realtime portfolio price for %s: %s", symbol, exc)
+            return None, None
+
+        if quote is None:
+            return None, None
+
+        price = getattr(quote, "price", None)
+        try:
+            numeric_price = float(price)
+        except (TypeError, ValueError):
+            return None, None
+
+        if numeric_price <= 0:
+            return None, None
+
+        source = getattr(quote, "source", None)
+        provider = getattr(source, "value", None) or (str(source) if source is not None else None)
+        return numeric_price, provider
 
     @staticmethod
     def _consume_fifo_lots(

--- a/tests/test_agent_pipeline.py
+++ b/tests/test_agent_pipeline.py
@@ -517,6 +517,46 @@ class TestAgentResultConversion(unittest.TestCase):
         self.assertEqual(result.decision_type, "buy")
         self.assertIn("trend:fallback", result.data_sources)
 
+    def test_convert_invalid_dashboard_normalizes_strong_trend_decision_type(self):
+        """Fallback preserves strong advice text while keeping stable decision_type values."""
+        pipeline = self._make_pipeline()
+
+        from src.agent.executor import AgentResult
+        from src.enums import ReportType
+        from src.stock_analyzer import BuySignal, TrendAnalysisResult, TrendStatus
+
+        cases = [
+            (BuySignal.STRONG_BUY, "buy", "强烈买入"),
+            (BuySignal.STRONG_SELL, "sell", "强烈卖出"),
+        ]
+
+        for buy_signal, expected_decision, expected_advice in cases:
+            with self.subTest(buy_signal=buy_signal):
+                agent_result = AgentResult(
+                    success=True,
+                    content="LLM returned text but no dashboard JSON",
+                    dashboard=None,
+                    provider="ollama",
+                )
+                trend_result = TrendAnalysisResult(
+                    code="600519",
+                    trend_status=TrendStatus.BULL,
+                    buy_signal=buy_signal,
+                    signal_score=80,
+                )
+
+                result = pipeline._agent_result_to_analysis_result(
+                    agent_result,
+                    "600519",
+                    "贵州茅台",
+                    ReportType.SIMPLE,
+                    "q-trend-fallback",
+                    trend_result=trend_result,
+                )
+
+                self.assertEqual(result.operation_advice, expected_advice)
+                self.assertEqual(result.decision_type, expected_decision)
+
     def test_convert_uses_dashboard_stock_name_when_input_is_placeholder(self):
         """When input name is placeholder-like, prefer dashboard stock_name."""
         pipeline = self._make_pipeline()

--- a/tests/test_agent_pipeline.py
+++ b/tests/test_agent_pipeline.py
@@ -479,6 +479,44 @@ class TestAgentResultConversion(unittest.TestCase):
         self.assertEqual(result.operation_advice, "观望")
         self.assertIn("Max steps exceeded", result.error_message)
 
+    def test_convert_invalid_dashboard_preserves_local_trend_result(self):
+        """Invalid Agent dashboard should not erase already-computed trend data."""
+        pipeline = self._make_pipeline()
+
+        from src.agent.executor import AgentResult
+        from src.enums import ReportType
+        from src.stock_analyzer import BuySignal, TrendAnalysisResult, TrendStatus
+
+        agent_result = AgentResult(
+            success=True,
+            content="LLM returned text but no dashboard JSON",
+            dashboard=None,
+            provider="ollama",
+        )
+        trend_result = TrendAnalysisResult(
+            code="600519",
+            trend_status=TrendStatus.BULL,
+            buy_signal=BuySignal.BUY,
+            signal_score=64,
+        )
+
+        result = pipeline._agent_result_to_analysis_result(
+            agent_result,
+            "600519",
+            "贵州茅台",
+            ReportType.SIMPLE,
+            "q-trend-fallback",
+            trend_result=trend_result,
+        )
+
+        self.assertIsNotNone(result)
+        self.assertTrue(result.success)
+        self.assertEqual(result.sentiment_score, 64)
+        self.assertEqual(result.trend_prediction, "多头排列")
+        self.assertEqual(result.operation_advice, "买入")
+        self.assertEqual(result.decision_type, "buy")
+        self.assertIn("trend:fallback", result.data_sources)
+
     def test_convert_uses_dashboard_stock_name_when_input_is_placeholder(self):
         """When input name is placeholder-like, prefer dashboard stock_name."""
         pipeline = self._make_pipeline()

--- a/tests/test_portfolio_service.py
+++ b/tests/test_portfolio_service.py
@@ -100,6 +100,36 @@ class PortfolioServiceTestCase(unittest.TestCase):
         self.assertEqual(pos["price_provider"], "unit-test")
         self.assertTrue(pos["price_available"])
 
+    def test_current_snapshot_uses_close_before_realtime_fallback(self) -> None:
+        today = date.today()
+        account = self.service.create_account(name="Main", broker="Demo", market="cn", base_currency="CNY")
+        aid = account["id"]
+        self.service.record_trade(
+            account_id=aid,
+            symbol="600519",
+            trade_date=today,
+            side="buy",
+            quantity=10,
+            price=100,
+            market="cn",
+            currency="CNY",
+        )
+        self._save_close("600519", today, 118.0)
+
+        with patch.object(
+            PortfolioService,
+            "_fetch_realtime_position_price",
+            side_effect=AssertionError("close price should be used before realtime fallback"),
+        ):
+            snapshot = self.service.get_portfolio_snapshot(account_id=aid, as_of=today, cost_method="fifo")
+
+        pos = snapshot["accounts"][0]["positions"][0]
+        self.assertAlmostEqual(pos["last_price"], 118.0, places=6)
+        self.assertAlmostEqual(pos["market_value_base"], 1180.0, places=6)
+        self.assertAlmostEqual(pos["unrealized_pnl_base"], 180.0, places=6)
+        self.assertEqual(pos["price_source"], "history_close")
+        self.assertTrue(pos["price_available"])
+
     def test_historical_snapshot_marks_missing_price_without_cost_fallback(self) -> None:
         account = self.service.create_account(name="Main", broker="Demo", market="cn", base_currency="CNY")
         aid = account["id"]
@@ -127,9 +157,13 @@ class PortfolioServiceTestCase(unittest.TestCase):
 
         pos = snapshot["accounts"][0]["positions"][0]
         self.assertEqual(pos["last_price"], 0.0)
+        self.assertEqual(pos["market_value_base"], 0.0)
+        self.assertEqual(pos["unrealized_pnl_base"], 0.0)
         self.assertEqual(pos["price_source"], "missing")
         self.assertFalse(pos["price_available"])
         self.assertTrue(pos["price_stale"])
+        self.assertEqual(snapshot["accounts"][0]["total_market_value"], 0.0)
+        self.assertEqual(snapshot["accounts"][0]["unrealized_pnl"], 0.0)
 
     def test_snapshot_fifo_vs_avg_on_partial_sell(self) -> None:
         account = self.service.create_account(name="Main", broker="Demo", market="cn", base_currency="CNY")

--- a/tests/test_portfolio_service.py
+++ b/tests/test_portfolio_service.py
@@ -74,6 +74,63 @@ class PortfolioServiceTestCase(unittest.TestCase):
         )
         self.db.save_daily_data(df, code=symbol, data_source="unit-test")
 
+    def test_current_snapshot_uses_realtime_price_when_close_missing(self) -> None:
+        today = date.today()
+        account = self.service.create_account(name="Main", broker="Demo", market="cn", base_currency="CNY")
+        aid = account["id"]
+        self.service.record_trade(
+            account_id=aid,
+            symbol="600519",
+            trade_date=today,
+            side="buy",
+            quantity=10,
+            price=100,
+            market="cn",
+            currency="CNY",
+        )
+
+        with patch.object(PortfolioService, "_fetch_realtime_position_price", return_value=(125.0, "unit-test")):
+            snapshot = self.service.get_portfolio_snapshot(account_id=aid, as_of=today, cost_method="fifo")
+
+        pos = snapshot["accounts"][0]["positions"][0]
+        self.assertAlmostEqual(pos["last_price"], 125.0, places=6)
+        self.assertAlmostEqual(pos["market_value_base"], 1250.0, places=6)
+        self.assertAlmostEqual(pos["unrealized_pnl_base"], 250.0, places=6)
+        self.assertEqual(pos["price_source"], "realtime_quote")
+        self.assertEqual(pos["price_provider"], "unit-test")
+        self.assertTrue(pos["price_available"])
+
+    def test_historical_snapshot_marks_missing_price_without_cost_fallback(self) -> None:
+        account = self.service.create_account(name="Main", broker="Demo", market="cn", base_currency="CNY")
+        aid = account["id"]
+        self.service.record_trade(
+            account_id=aid,
+            symbol="600519",
+            trade_date=date(2026, 1, 1),
+            side="buy",
+            quantity=10,
+            price=100,
+            market="cn",
+            currency="CNY",
+        )
+
+        with patch.object(
+            PortfolioService,
+            "_fetch_realtime_position_price",
+            side_effect=AssertionError("historical snapshot should not fetch realtime quote"),
+        ):
+            snapshot = self.service.get_portfolio_snapshot(
+                account_id=aid,
+                as_of=date(2026, 1, 2),
+                cost_method="fifo",
+            )
+
+        pos = snapshot["accounts"][0]["positions"][0]
+        self.assertEqual(pos["last_price"], 0.0)
+        self.assertEqual(pos["price_source"], "missing")
+        self.assertFalse(pos["price_available"])
+        self.assertTrue(pos["price_stale"])
+
     def test_snapshot_fifo_vs_avg_on_partial_sell(self) -> None:
         account = self.service.create_account(name="Main", broker="Demo", market="cn", base_currency="CNY")
         aid = account["id"]

--- a/tests/test_task_queue_config_sync.py
+++ b/tests/test_task_queue_config_sync.py
@@ -17,6 +17,7 @@ _orig_data_provider = sys.modules.get("data_provider")
 if _orig_data_provider_base is None:
     base_mod = types.ModuleType("data_provider.base")
     base_mod.canonical_stock_code = lambda x: (x or "").strip().upper()
+    base_mod.normalize_stock_code = lambda x: (x or "").strip().upper().removesuffix(".SH").removesuffix(".SZ")
     sys.modules["data_provider.base"] = base_mod
 
 if _orig_data_provider is None:
@@ -24,7 +25,7 @@ if _orig_data_provider is None:
     pkg_mod.base = sys.modules["data_provider.base"]
     sys.modules["data_provider"] = pkg_mod
 
-from src.services.task_queue import AnalysisTaskQueue, get_task_queue
+from src.services.task_queue import AnalysisTaskQueue, get_task_queue, _dedupe_stock_code_key
 
 if _orig_data_provider_base is None:
     sys.modules.pop("data_provider.base", None)
@@ -88,6 +89,9 @@ class TaskQueueConfigSyncTestCase(unittest.TestCase):
 
         self.assertIs(first, second)
         self.assertEqual(second.max_workers, 1)
+
+    def test_dedupe_stock_code_key_normalizes_market_suffix(self) -> None:
+        self.assertEqual(_dedupe_stock_code_key(" 600519.sh "), "600519")
 
     def test_get_task_queue_defers_sync_when_busy(self) -> None:
         queue = AnalysisTaskQueue(max_workers=3)


### PR DESCRIPTION
## PR Type
- [x] fix
- [ ] feat
- [ ] refactor
- [x] docs
- [ ] chore
- [x] test

## Background And Problem
This PR addresses the priority issues from the recent triage after PR #1139 was merged:

- #1140: Agent mode could return no valid dashboard and overwrite already-computed local trend data with default `50 / 观望 / 未知` values.
- #1097: portfolio snapshots silently used average cost as `last_price` when no daily close was available, which made market value and unrealized PnL look valid but incorrect.
- #1124: `tests/test_task_queue_config_sync.py` still failed collection because its lightweight `data_provider.base` stub did not expose `normalize_stock_code`.

## Scope Of Change
- Preserve local trend score, trend prediction, and operation advice when Agent output has no valid dashboard.
- Normalize Agent fallback `decision_type` to the stable `buy|hold|sell` enum; strong buy/sell semantics stay in `operation_advice` and trend fields.
- Add portfolio position price metadata: `price_source`, `price_provider`, `price_date`, `price_stale`, and `price_available`.
- Use historical close first for today's portfolio snapshot; only when no daily close exists does the service try realtime quote fallback. Historical `as_of` snapshots remain historical-close only.
- Do not treat missing prices as losses: missing-price positions are marked unavailable and excluded from market value / unrealized PnL totals instead of using cost basis or zero as a real valuation.
- Update the Web portfolio table to show realtime/close/missing price source, hide derived money values when a position price is unavailable, and use neutral PnL styling for missing-price rows.
- Restore `task_queue` config sync test collection and cover market suffix normalization.
- Update `docs/CHANGELOG.md`, `docs/full-guide.md`, and `docs/full-guide_EN.md`.

## Review Feedback Addressed
- Fixed `src/core/pipeline.py` fallback so `strong_buy` / `strong_sell` map to compatible `buy` / `sell` `decision_type` values.
- Fixed `src/services/portfolio_service.py` price resolution to check historical close before realtime fallback for today's snapshots.
- Added regression coverage that today's close does not call realtime quote fallback.
- Fixed missing-price valuation math so account-level totals are not skewed by unavailable prices.
- Fixed Web missing-price PnL cells to use neutral text styling.

## Issue Link
Fixes #1140
Fixes #1097
Refs #1124

## Verification Commands And Results
```bash
python -m pytest tests/test_agent_pipeline.py::TestAgentResultConversion::test_convert_invalid_dashboard_normalizes_strong_trend_decision_type tests/test_agent_pipeline.py::TestAgentResultConversion::test_convert_invalid_dashboard_preserves_local_trend_result tests/test_portfolio_service.py::PortfolioServiceTestCase::test_current_snapshot_uses_close_before_realtime_fallback tests/test_portfolio_service.py::PortfolioServiceTestCase::test_current_snapshot_uses_realtime_price_when_close_missing tests/test_portfolio_service.py::PortfolioServiceTestCase::test_historical_snapshot_marks_missing_price_without_cost_fallback -q
python -m pytest tests/test_portfolio_service.py tests/test_agent_pipeline.py::TestAgentResultConversion -q
python -m pytest tests/test_task_queue_config_sync.py tests/test_portfolio_service.py tests/test_agent_pipeline.py::TestAgentResultConversion -q
python -m pytest tests/test_portfolio_api.py::PortfolioApiTestCase::test_account_event_snapshot_flow tests/test_data_tools_portfolio_snapshot.py -q
python -m py_compile src/core/pipeline.py src/services/portfolio_service.py tests/test_agent_pipeline.py tests/test_portfolio_service.py
cd apps/dsa-web && npm run lint
cd apps/dsa-web && npm run build
./scripts/ci_gate.sh syntax
./scripts/ci_gate.sh flake8
git diff --check
```

Results:
- Review-specific regression tests: 5 passed.
- Targeted backend tests: 26 passed.
- Portfolio API/tool tests: 3 passed, with existing Pydantic deprecation warnings.
- Python compile, Web lint/build, backend syntax, critical flake8, and diff whitespace checks: pass.
- Earlier full `./scripts/ci_gate.sh offline-tests`: 1567 passed, 1 failed on `test_schedule_time_provider_propagates_config_read_failures`; isolated rerun of that exact test passed, so this looks like an order-dependent/flaky failure not tied to this diff.

## Compatibility And Risk
- Portfolio API adds optional fields to `positions[]`; existing required fields remain unchanged.
- For positions with no usable price, API now marks `price_available=false` and `price_source=missing`; Web hides derived market value / unrealized PnL for that row to avoid presenting false precision.
- Today's snapshots only perform realtime quote lookups for open positions without a usable daily close. Historical snapshots do not call realtime quote fallback.
- Agent fallback only applies when no valid dashboard is available; valid Agent dashboards still take precedence.
- Agent fallback `decision_type` remains limited to `buy|hold|sell`, preserving downstream counters, filters, notifications, and persistence consumers.

## Rollback Plan
Revert commits `97038af` and `7b1f62a` to restore previous Agent conversion, portfolio snapshot price behavior, Web display, tests, and docs.

## Checklist
- [x] This PR has a clear motivation and value
- [x] Reproducible verification commands and results are included
- [x] Compatibility and risk have been assessed
- [x] Rollback plan is provided
- [x] Relevant docs and `docs/CHANGELOG.md` are updated