### PR TITLE
data_provider: use Tencent single-stock endpoint for HK realtime quotes

### DIFF
--- a/data_provider/akshare_fetcher.py
+++ b/data_provider/akshare_fetcher.py
@@ -1427,7 +1427,10 @@ class AkshareFetcher(BaseFetcher):
             circ_mv_yi = safe_float(fields[45])
             total_mv_yi = safe_float(fields[44])
             quote = UnifiedRealtimeQuote(
-                code=stock_code,
+                # Use the 5-digit normalized form so downstream supplement /
+                # cache / comparison logic sees a single canonical shape
+                # regardless of the input shape (HK00700 / 0700.HK / 0700).
+                code=normalized_code,
                 name=fields[1] if len(fields) > 1 else "",
                 source=RealtimeSource.TENCENT,
                 price=safe_float(fields[3]),

--- a/data_provider/akshare_fetcher.py
+++ b/data_provider/akshare_fetcher.py
@@ -188,6 +188,26 @@ def _to_sina_tx_symbol(stock_code: str) -> str:
     return f"sz{base}"
 
 
+def _to_hk_tx_symbol(stock_code: str) -> str:
+    """Convert HK code to hk-prefixed symbol for Tencent/Sina single-stock API.
+
+    Accepts the same input shapes that ``_get_hk_realtime_quote`` already
+    normalizes: ``00700``, ``0700``, ``HK00700``, ``0700.HK``.
+
+    Examples:
+        >>> _to_hk_tx_symbol('00700')
+        'hk00700'
+        >>> _to_hk_tx_symbol('0700.HK')
+        'hk00700'
+    """
+    code = stock_code.strip().lower()
+    if code.endswith('.hk'):
+        code = code[:-3]
+    if code.startswith('hk'):
+        code = code[2:]
+    return f"hk{code.zfill(5)}"
+
+
 def _classify_realtime_http_error(exc: Exception) -> Tuple[str, str]:
     """
     Classify Sina/Tencent realtime quote failures into stable categories.
@@ -1324,12 +1344,132 @@ class AkshareFetcher(BaseFetcher):
             circuit_breaker.record_failure(source_key, str(e))
             return None
     
+    def _get_hk_realtime_quote_from_tencent(
+        self, stock_code: str, normalized_code: str
+    ) -> Optional[UnifiedRealtimeQuote]:
+        """获取港股实时行情（腾讯单股接口）。
+
+        数据来源：腾讯财经 ``http://qt.gtimg.cn/q=hkXXXXX``，单股查询毫秒级返回。
+        相对 ``stock_hk_spot_em`` 的优点：
+            - 单股请求，负载小，无需拉全市场 4621+ 行 DataFrame；
+            - 路径上不依赖 ``push2.eastmoney.com`` —— 后者对部分海外网络
+              会在握手后主动 ``RST`` 连接，触发熔断。
+
+        字段映射来自实测：腾讯 HK 数据从 ``fields[44]`` 起的字段含义与 A 股
+        不一致（例如 A 股 ``fields[46]`` 是市净率，HK 接口在该位置为
+        数据源标签 ``"TENCENT"``），因此换手率/振幅/PB 等字段在 HK 接口上
+        不可靠，在此实现里不解析。
+
+        Args:
+            stock_code: 用户传入的港股代码（任意支持格式）。
+            normalized_code: 已 zfill 5 位的纯数字代码，用于排查日志。
+
+        Returns:
+            ``UnifiedRealtimeQuote`` 对象；解析失败或无数据返回 ``None``。
+        """
+        symbol = _to_hk_tx_symbol(stock_code)
+        url = f"http://{TENCENT_REALTIME_ENDPOINT}={symbol}"
+
+        headers = {
+            'Referer': 'http://finance.qq.com',
+            'User-Agent': random.choice(USER_AGENTS),
+        }
+
+        api_start = time.time()
+        try:
+            self._enforce_rate_limit()
+            response = requests.get(url, headers=headers, timeout=10)
+            response.encoding = 'gbk'
+        except Exception as exc:
+            api_elapsed = time.time() - api_start
+            logger.info(
+                f"[API错误] 腾讯港股接口请求 {stock_code} ({symbol}) 异常: "
+                f"{type(exc).__name__}: {exc}, elapsed={api_elapsed:.2f}s"
+            )
+            return None
+
+        api_elapsed = time.time() - api_start
+
+        if response.status_code != 200:
+            logger.info(
+                f"[API错误] 腾讯港股接口 {symbol} HTTP {response.status_code}, "
+                f"elapsed={api_elapsed:.2f}s"
+            )
+            return None
+
+        content = response.text.strip()
+        if '=""' in content or not content:
+            logger.info(f"[API返回] 腾讯港股接口返回空数据 ({symbol})")
+            return None
+
+        data_start = content.find('"')
+        data_end = content.rfind('"')
+        if data_start == -1 or data_end <= data_start:
+            logger.info(f"[API返回] 腾讯港股接口数据格式异常 ({symbol})")
+            return None
+
+        fields = content[data_start + 1:data_end].split('~')
+
+        # HK 接口在 fields[6] 位置已经是"股"为单位（A 股位置 6 是"手"），
+        # fields[44]/[45] 是"亿"为单位的总市值/流通市值，
+        # fields[48]/[49] 是 52 周最高/最低（A 股该位置是涨跌停价/量比）。
+        if len(fields) < 50:
+            logger.info(
+                f"[API返回] 腾讯港股接口字段数不足 (got={len(fields)}, "
+                f"need=50, symbol={symbol})"
+            )
+            return None
+
+        try:
+            circ_mv_yi = safe_float(fields[45])
+            total_mv_yi = safe_float(fields[44])
+            quote = UnifiedRealtimeQuote(
+                code=stock_code,
+                name=fields[1] if len(fields) > 1 else "",
+                source=RealtimeSource.TENCENT,
+                price=safe_float(fields[3]),
+                change_pct=safe_float(fields[32]),
+                change_amount=safe_float(fields[31]),
+                volume=safe_int(fields[6]),
+                amount=safe_float(fields[37]),
+                open_price=safe_float(fields[5]),
+                high=safe_float(fields[33]),
+                low=safe_float(fields[34]),
+                pre_close=safe_float(fields[4]),
+                pe_ratio=safe_float(fields[39]),
+                circ_mv=circ_mv_yi * 100000000 if circ_mv_yi is not None else None,
+                total_mv=total_mv_yi * 100000000 if total_mv_yi is not None else None,
+                high_52w=safe_float(fields[48]),
+                low_52w=safe_float(fields[49]),
+            )
+        except (IndexError, ValueError) as exc:
+            logger.info(
+                f"[API返回] 腾讯港股接口字段解析失败 ({symbol}): "
+                f"{type(exc).__name__}: {exc}"
+            )
+            return None
+
+        if quote.price is None or quote.price <= 0:
+            logger.info(
+                f"[API返回] 腾讯港股接口 {symbol} 价格无效 (price={quote.price}), "
+                f"忽略此次响应"
+            )
+            return None
+
+        logger.info(
+            f"[港股实时行情-腾讯] {stock_code} {quote.name}: "
+            f"价格={quote.price}, 涨跌={quote.change_pct}%, "
+            f"elapsed={api_elapsed:.2f}s"
+        )
+        return quote
+
     def _get_hk_realtime_quote(self, stock_code: str) -> Optional[UnifiedRealtimeQuote]:
         """
         获取港股实时行情数据
 
-        主数据源：ak.stock_hk_spot_em()（东方财富）
-        备用数据源：ak.stock_hk_spot()（新浪）
+        主数据源：腾讯单股接口（``http://qt.gtimg.cn/q=hkXXXXX``，毫秒级）
+        备用数据源 1：``ak.stock_hk_spot_em()``（东方财富，全市场快照）
+        备用数据源 2：``ak.stock_hk_spot()``（新浪，全市场快照）
         包含：最新价、涨跌幅、成交量、成交额等
 
         Args:
@@ -1340,6 +1480,7 @@ class AkshareFetcher(BaseFetcher):
         """
         import akshare as ak
         circuit_breaker = get_realtime_circuit_breaker()
+        tencent_key = "akshare_hk_tencent"
         em_key = "akshare_hk_em"
         sina_key = "akshare_hk_sina"
 
@@ -1355,7 +1496,26 @@ class AkshareFetcher(BaseFetcher):
             raw_code = raw_code[2:]
         code = raw_code.zfill(5)
 
-        # --- 主数据源：东方财富 ---
+        # --- 主数据源：腾讯单股接口（毫秒级，不依赖东财港股端点） ---
+        if circuit_breaker.is_available(tencent_key):
+            try:
+                quote = self._get_hk_realtime_quote_from_tencent(stock_code, code)
+                if quote is not None:
+                    circuit_breaker.record_success(tencent_key)
+                    return quote
+                circuit_breaker.record_failure(tencent_key, "tencent_returned_none")
+            except Exception as exc:
+                logger.warning(
+                    f"[API错误] 腾讯港股接口获取 {stock_code} 异常: "
+                    f"{type(exc).__name__}: {exc}，回退至东方财富"
+                )
+                circuit_breaker.record_failure(tencent_key, str(exc))
+        else:
+            logger.info(
+                f"[熔断] 数据源 {tencent_key} 处于熔断状态，跳过腾讯单股接口"
+            )
+
+        # --- 备用数据源 1：东方财富全市场快照 ---
         if circuit_breaker.is_available(em_key):
             try:
                 logger.info(f"[API调用] ak.stock_hk_spot_em() 获取港股实时行情...")
@@ -1403,7 +1563,7 @@ class AkshareFetcher(BaseFetcher):
         else:
             logger.info(f"[熔断] 数据源 {em_key} 处于熔断状态，尝试使用备用链路")
 
-        # --- 备用数据源：新浪 ---
+        # --- 备用数据源 2：新浪全市场快照 ---
         if not circuit_breaker.is_available(sina_key):
             logger.info(f"[熔断] 数据源 {sina_key} 处于熔断状态，跳过备用链路")
             return None

--- a/data_provider/akshare_fetcher.py
+++ b/data_provider/akshare_fetcher.py
@@ -1375,9 +1375,12 @@ class AkshareFetcher(BaseFetcher):
             'User-Agent': random.choice(USER_AGENTS),
         }
 
+        # Note: rate limiting is handled by the caller (`_get_hk_realtime_quote`)
+        # before any HK source is queried — calling `_enforce_rate_limit` again
+        # here would add a redundant 2–5s jitter sleep per request.
+
         api_start = time.time()
         try:
-            self._enforce_rate_limit()
             response = requests.get(url, headers=headers, timeout=10)
             response.encoding = 'gbk'
         except Exception as exc:

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 <!-- 新条目格式：- [类型] 描述（类型取值：新功能/改进/修复/文档/测试/chore）-->
 <!-- 每条独立一行追加到本段末尾，无需分类标题，合并时冲突最小 -->
+- [改进] 港股实时行情主源切换为腾讯单股接口（`http://qt.gtimg.cn/q=hkXXXXX`），单股响应从 35s+（拉全市场）降到亚秒级，并绕开 `push2.eastmoney.com` 港股端点对部分海外网络主动 RST 触发 `RemoteDisconnected` 的连接问题；原 `stock_hk_spot_em` / `stock_hk_spot` 保留为备用链路 1/2，腾讯独立熔断器 key `akshare_hk_tencent`。
+- [测试] 新增 `tests/test_hk_tencent_realtime.py`，覆盖 HK 腾讯单股 payload 字段映射（含 volume 单位、市值亿→元、52 周高低位置与 A 股不一致）以及 HTTP 500 / 空响应 / 字段不足 / price=0 / 连接异常等失败路径。
 - [新功能] 大盘复盘支持港股市场：`MARKET_REVIEW_REGION` 新增 `hk` 选项；`both` 扩展为 A股+港股+美股，并新增港股指数（HSI/HSTECH/HSCEI）复盘链路。
 - [修复] Bot `/market` 命令复用 `get_open_markets_today()` / `compute_effective_region()` 做交易日过滤：结果作为 `override_region` 透传给 `run_market_review`；若结果为空字符串则跳过复盘并推送“今日相关市场休市”，与 CLI/调度入口行为一致。
 - [测试] 新增 `tests/test_bot_market_command.py`，覆盖 `MARKET_REVIEW_REGION=both` + open markets `{"cn","us"}` / `{"cn","hk"}` 的 `override_region` 透传断言，并覆盖全市场休市跳过与关闭交易日检查路径；新增 `tests/test_yfinance_hk_indices.py` 覆盖港股指数符号映射与部分/全部失败降级路径。

--- a/tests/test_hk_stock_name_fallback.py
+++ b/tests/test_hk_stock_name_fallback.py
@@ -87,6 +87,13 @@ class TestHKRealtimeFallback(unittest.TestCase):
         # Bypass rate limiting
         self.fetcher._enforce_rate_limit = lambda: None
         self.fetcher._set_random_user_agent = lambda: None
+        # Force the new Tencent single-stock path to return None so that these
+        # tests continue to exercise the stock_hk_spot_em / stock_hk_spot
+        # fallback chain. The Tencent path is covered by
+        # tests/test_hk_tencent_realtime.py.
+        self.fetcher._get_hk_realtime_quote_from_tencent = (
+            lambda stock_code, normalized_code: None
+        )
 
     @patch("data_provider.akshare_fetcher.get_realtime_circuit_breaker")
     def test_em_success_returns_quote_with_name(self, mock_cb):

--- a/tests/test_hk_tencent_realtime.py
+++ b/tests/test_hk_tencent_realtime.py
@@ -136,6 +136,22 @@ class TestHkTencentRealtimeParsing(unittest.TestCase):
             self.fetcher._get_hk_realtime_quote_from_tencent("00700", "00700")
         )
 
+    @patch("data_provider.akshare_fetcher.requests.get")
+    def test_quote_code_uses_normalized_form(self, mock_get):
+        """quote.code must be the 5-digit normalized form regardless of input shape.
+
+        Downstream supplement / cache / comparison logic should see a single
+        canonical code, not the user's original input (HK00700, 0700.HK, etc.).
+        """
+        mock_get.return_value = _mock_response(TENCENT_HK_PAYLOAD_00700)
+        for raw_input in ("00700", "HK00700", "hk00700", "0700.HK", "0700"):
+            with self.subTest(raw_input=raw_input):
+                quote = self.fetcher._get_hk_realtime_quote_from_tencent(
+                    raw_input, "00700"
+                )
+                self.assertIsNotNone(quote)
+                self.assertEqual(quote.code, "00700")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_hk_tencent_realtime.py
+++ b/tests/test_hk_tencent_realtime.py
@@ -1,0 +1,141 @@
+# -*- coding: utf-8 -*-
+"""
+Regression tests for the HK realtime quote path that fetches from the
+Tencent single-stock endpoint (`http://qt.gtimg.cn/q=hkXXXXX`).
+
+The Tencent payload uses a tilde-separated layout that mostly matches the
+A-share format up to ``fields[37]``, but starting at ``fields[44]`` the
+field semantics diverge (HK has no turnover_rate/PB/limit-up/limit-down at
+those positions). These tests pin down the HK-specific field mapping and
+guard against accidental reuse of the A-share parser.
+"""
+
+import sys
+import unittest
+from unittest.mock import MagicMock, patch
+
+if "litellm" not in sys.modules:
+    sys.modules["litellm"] = MagicMock()
+if "json_repair" not in sys.modules:
+    sys.modules["json_repair"] = MagicMock()
+
+from data_provider.akshare_fetcher import AkshareFetcher, _to_hk_tx_symbol
+
+
+# Real captured payload from `curl http://qt.gtimg.cn/q=hk00700`. Trimmed
+# to keep the fixture readable but preserves all 78 fields.
+TENCENT_HK_PAYLOAD_00700 = (
+    'v_hk00700="100~腾讯控股~00700~479.200~473.800~474.600~19321018.0~0~0~'
+    '479.200~0~0~0~0~0~0~0~0~0~479.200~0~0~0~0~0~0~0~0~0~19321018.0~'
+    '2026/04/29 16:08:43~5.400~1.14~480.600~474.600~479.200~19321018.0~'
+    '9231869057.790~0~17.57~~0~0~1.27~43729.8639~43729.8639~TENCENT~0.95~'
+    '683.000~464.900~0.71~-43.20~0~0~0~0~0~17.57~3.45~0.21~100~-20.00~'
+    '-4.92~GP~19.48~11.27~-3.97~-2.88~-21.05~9125597636.00~9125597636.00~'
+    '17.57~4.531~477.815~-12.87~HKD~1~50";'
+)
+
+
+def _mock_response(text: str, status_code: int = 200) -> MagicMock:
+    resp = MagicMock()
+    resp.status_code = status_code
+    resp.text = text
+    resp.encoding = "gbk"
+    return resp
+
+
+class TestToHkTxSymbol(unittest.TestCase):
+    """Pure-function input normalization for the Tencent/Sina HK symbol."""
+
+    def test_plain_5_digit(self):
+        self.assertEqual(_to_hk_tx_symbol("00700"), "hk00700")
+
+    def test_4_digit_pads_to_5(self):
+        self.assertEqual(_to_hk_tx_symbol("0700"), "hk00700")
+
+    def test_uppercase_hk_prefix(self):
+        self.assertEqual(_to_hk_tx_symbol("HK00700"), "hk00700")
+
+    def test_dot_hk_suffix(self):
+        self.assertEqual(_to_hk_tx_symbol("0700.HK"), "hk00700")
+
+    def test_mixed_case_and_whitespace(self):
+        self.assertEqual(_to_hk_tx_symbol(" Hk00700 "), "hk00700")
+
+
+class TestHkTencentRealtimeParsing(unittest.TestCase):
+    """End-to-end parsing of the Tencent HK payload."""
+
+    def setUp(self):
+        self.fetcher = AkshareFetcher()
+        # Stub out side effects unrelated to the parsing under test.
+        self.fetcher._set_random_user_agent = MagicMock()
+        self.fetcher._enforce_rate_limit = MagicMock()
+
+    @patch("data_provider.akshare_fetcher.requests.get")
+    def test_parses_full_hk_quote(self, mock_get):
+        mock_get.return_value = _mock_response(TENCENT_HK_PAYLOAD_00700)
+
+        quote = self.fetcher._get_hk_realtime_quote_from_tencent("00700", "00700")
+
+        self.assertIsNotNone(quote)
+        self.assertEqual(quote.code, "00700")
+        self.assertEqual(quote.name, "腾讯控股")
+        self.assertAlmostEqual(quote.price, 479.200)
+        self.assertAlmostEqual(quote.pre_close, 473.800)
+        self.assertAlmostEqual(quote.open_price, 474.600)
+        self.assertAlmostEqual(quote.high, 480.600)
+        self.assertAlmostEqual(quote.low, 474.600)
+        self.assertAlmostEqual(quote.change_amount, 5.400)
+        self.assertAlmostEqual(quote.change_pct, 1.14)
+        # HK volume is reported in shares, not lots — must NOT be multiplied by 100.
+        self.assertEqual(quote.volume, 19321018)
+        self.assertAlmostEqual(quote.amount, 9231869057.790)
+        self.assertAlmostEqual(quote.pe_ratio, 17.57)
+        # 总市值 / 流通市值 are reported in 亿 (1e8); converted to 元.
+        self.assertAlmostEqual(quote.total_mv, 43729.8639 * 1e8)
+        self.assertAlmostEqual(quote.circ_mv, 43729.8639 * 1e8)
+        self.assertAlmostEqual(quote.high_52w, 683.000)
+        self.assertAlmostEqual(quote.low_52w, 464.900)
+
+    @patch("data_provider.akshare_fetcher.requests.get")
+    def test_returns_none_on_http_500(self, mock_get):
+        mock_get.return_value = _mock_response("", status_code=500)
+        self.assertIsNone(
+            self.fetcher._get_hk_realtime_quote_from_tencent("00700", "00700")
+        )
+
+    @patch("data_provider.akshare_fetcher.requests.get")
+    def test_returns_none_on_empty_payload(self, mock_get):
+        mock_get.return_value = _mock_response('v_hk00700="";')
+        self.assertIsNone(
+            self.fetcher._get_hk_realtime_quote_from_tencent("00700", "00700")
+        )
+
+    @patch("data_provider.akshare_fetcher.requests.get")
+    def test_returns_none_on_short_field_count(self, mock_get):
+        mock_get.return_value = _mock_response('v_hk00700="100~腾讯~00700~479.2";')
+        self.assertIsNone(
+            self.fetcher._get_hk_realtime_quote_from_tencent("00700", "00700")
+        )
+
+    @patch("data_provider.akshare_fetcher.requests.get")
+    def test_returns_none_when_price_is_zero(self, mock_get):
+        # Replace the price field (index 3) with 0 — should be treated as no data.
+        zero_price_payload = TENCENT_HK_PAYLOAD_00700.replace(
+            "00700~479.200~", "00700~0~"
+        )
+        mock_get.return_value = _mock_response(zero_price_payload)
+        self.assertIsNone(
+            self.fetcher._get_hk_realtime_quote_from_tencent("00700", "00700")
+        )
+
+    @patch("data_provider.akshare_fetcher.requests.get")
+    def test_request_exception_returns_none(self, mock_get):
+        mock_get.side_effect = ConnectionError("Connection aborted.")
+        self.assertIsNone(
+            self.fetcher._get_hk_realtime_quote_from_tencent("00700", "00700")
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
  ## Why

  `_get_hk_realtime_quote` currently calls `ak.stock_hk_spot_em()` as the primary source. Two recurring issues:

  1. **Whole-market snapshot for single-stock query** — Each call pulls the full ~4600-row HK universe and filters by code in pandas. Observed response time: 35-45s per query.

  2. **Connection RST on some networks** — `push2.eastmoney.com` (upstream behind `stock_hk_spot_em`) closes the TLS connection without a response on certain non-mainland networks, raising
   `RemoteDisconnected('Remote end closed connection without response')` after ~7-9s. Verified across `akshare 1.18.56 → 1.18.59`, so it is not a client-side issue. Mainland networks
  return `HTTP 200` with full payload in ~0.4s on the same `curl` URL; affected networks see `HTTP=000` with TCP RST after ~0.8s. The breaker trips on 3 consecutive failures and falls back
   to the even slower `stock_hk_spot()` path.

  ## What

  - Add `_to_hk_tx_symbol(stock_code)` — normalize `00700` / `0700` / `HK00700` / `0700.HK` to `hk00700`.
  - Add `_get_hk_realtime_quote_from_tencent(stock_code, normalized_code)` — fetch from `http://qt.gtimg.cn/q=hkXXXXX` (single-stock, sub-second).
  - Reorder `_get_hk_realtime_quote`: try Tencent first; `stock_hk_spot_em` and `stock_hk_spot` retained as fallback links 1 and 2.
  - New independent circuit breaker key `akshare_hk_tencent` so Tencent-path failures do not poison the existing `akshare_hk_em` / `akshare_hk_sina` breakers.

  The Tencent HK payload mostly matches the A-share field layout up to `fields[37]` but diverges from `fields[44]` onwards: HK has no `turnover_rate` / PB / limit-up / limit-down at the
  A-share positions, and `fields[48]/[49]` hold the 52-week high/low instead. The new HK parser uses a dedicated field map and treats unreliable A-share-only fields as `None`. This avoids
  accidentally surfacing the data-source label `"TENCENT"` (which sits at HK `fields[46]`) as PB.

  ## Tests

  - **`tests/test_hk_tencent_realtime.py` (new, 11 cases)** — pin the HK field mapping with a captured Tencent payload (`hk00700`); plus failure paths: HTTP 500, empty body, short field
  count, `price=0`, `ConnectionError`. Also covers `_to_hk_tx_symbol` input shape normalization.
  - **`tests/test_hk_stock_name_fallback.py`** — `setUp` stubs the new Tencent path to `None` so existing `stock_hk_spot_em` / `stock_hk_spot` fallback assertions continue unchanged. All 5
   existing cases still pass.
  - **`tests/test_hk_realtime_routing.py`** — unchanged, still passes.

  `flake8 --select=E9,F63,F7,F82` clean; `py_compile data_provider/*.py` clean.

  ## Risks

  - Tencent endpoint format (tilde-separated, no JSON schema) is not officially documented. HK field positions are based on a captured live payload (78 fields total). If Tencent silently
  re-orders fields, the new path returns `None` and the existing `stock_hk_spot_em` / `stock_hk_spot` links take over. **The change is strictly additive** — a complete Tencent-side break
  degrades to current behaviour, not worse.
  - Tencent HK does not expose `turnover_rate` / PB / `amplitude`. Downstream `_quote_needs_supplement` will still trigger secondary supplement for these fields when LongbridgeFetcher is
  not configured.

  ## Rollback

  `git revert <merge-commit>` — no schema, config, or migration changes. The new circuit breaker key is held in the in-memory breaker registry; no persistent state to clean up.
