### PR TITLE
feat: add bot error notification for failed analysis tasks

### DIFF
--- a/bot/commands/analyze.py
+++ b/bot/commands/analyze.py
@@ -79,16 +79,24 @@ class AnalyzeCommand(BotCommand):
             # 调用分析服务
             from src.services.task_service import get_task_service
             from src.enums import ReportType
-            
+
             service = get_task_service()
-            
+
+            # 检查线程池容量
+            if service.available_workers <= 0:
+                return BotResponse.markdown_response(
+                    f"⏳ **分析队列繁忙**\n\n"
+                    f"当前所有分析线程正在使用中，请等待当前任务完成后再试。\n\n"
+                    f"提示：若长时间无响应，可能是某个任务卡住了，请联系管理员检查。"
+                )
+
             # 提交异步分析任务
             result = service.submit_analysis(
                 code=code,
                 report_type=ReportType.from_str(report_type),
                 source_message=message
             )
-            
+
             if result.get("success"):
                 task_id = result.get("task_id", "")
                 return BotResponse.markdown_response(
@@ -96,12 +104,13 @@ class AnalyzeCommand(BotCommand):
                     f"• 股票代码: `{code}`\n"
                     f"• 报告类型: {ReportType.from_str(report_type).display_name}\n"
                     f"• 任务 ID: `{task_id[:20]}...`\n\n"
-                    f"分析完成后将自动推送结果。"
+                    f"分析完成后将自动推送结果。\n"
+                    f"如遇异常，错误信息将自动推送至此会话。"
                 )
             else:
                 error = result.get("error", "未知错误")
                 return BotResponse.error_response(f"提交分析任务失败: {error}")
-                
+
         except Exception as e:
             logger.error(f"[AnalyzeCommand] 执行失败: {e}")
             return BotResponse.error_response(f"分析失败: {str(e)[:100]}")

--- a/src/services/task_service.py
+++ b/src/services/task_service.py
@@ -45,6 +45,12 @@ class TaskService:
         self._max_workers = max_workers
         self._tasks: Dict[str, Dict[str, Any]] = {}
         self._tasks_lock = threading.Lock()
+        self._running_count = 0
+
+    @property
+    def available_workers(self) -> int:
+        """可用的 worker 线程数"""
+        return max(0, self._max_workers - self._running_count)
 
     @classmethod
     def get_instance(cls) -> 'TaskService':
@@ -92,7 +98,22 @@ class TaskService:
 
         task_id = f"{code}_{datetime.now().strftime('%Y%m%d_%H%M%S_%f')}"
 
+        # 检查是否有可用 worker
+        if self.available_workers <= 0:
+            queue_depth = sum(1 for t in self._tasks.values() if t.get('status') == 'pending')
+            logger.warning(f"[TaskService] 线程池已满，拒绝提交 {code}（队列深度={queue_depth}）")
+            # 尝试发送错误通知
+            if source_message:
+                self._send_error_notification(source_message, code, "当前分析队列繁忙，请稍后再试。若有任务长时间未完成，可能是卡住了。")
+            return {
+                "success": False,
+                "error": "分析队列繁忙，请稍后再试",
+                "code": code,
+                "task_id": task_id
+            }
+
         # 提交到线程池
+        self._running_count += 1
         self.executor.submit(
             self._run_analysis,
             code,
@@ -103,7 +124,7 @@ class TaskService:
             query_source
         )
 
-        logger.info(f"[TaskService] 已提交股票 {code} 的分析任务, task_id={task_id}, report_type={report_type.value}")
+        logger.info(f"[TaskService] 已提交股票 {code} 的分析任务, task_id={task_id}, report_type={report_type.value}, running={self._running_count}/{self._max_workers}")
 
         return {
             "success": True,
@@ -137,6 +158,21 @@ class TaskService:
         db = get_db()
         records = db.get_analysis_history(code=code, query_id=query_id, days=days, limit=limit)
         return [r.to_dict() for r in records]
+
+    def _send_error_notification(self, source_message: BotMessage, code: str, error_msg: str) -> None:
+        """发送错误通知到触发分析的会话"""
+        try:
+            from src.notification import NotificationService
+            notifier = NotificationService(source_message=source_message)
+            content = (
+                f"❌ **分析失败**\n\n"
+                f"• 股票代码: `{code}`\n"
+                f"• 错误信息: {error_msg}\n\n"
+                f"请稍后重试或检查股票代码是否正确。"
+            )
+            notifier.send_to_context(content)
+        except Exception as e:
+            logger.error(f"[TaskService] 发送错误通知失败: {e}")
 
     def _run_analysis(
         self,
@@ -221,6 +257,8 @@ class TaskService:
                     })
 
                 logger.warning(f"[TaskService] 股票 {code} 分析失败: {fail_message}")
+                if source_message:
+                    self._send_error_notification(source_message, code, fail_message)
                 return {"success": False, "task_id": task_id, "error": fail_message}
 
         except Exception as e:
@@ -234,7 +272,11 @@ class TaskService:
                     "error": error_msg
                 })
 
+            if source_message:
+                self._send_error_notification(source_message, code, f"分析过程异常: {error_msg[:200]}")
             return {"success": False, "task_id": task_id, "error": error_msg}
+        finally:
+            self._running_count = max(0, self._running_count - 1)
 
 
 # ============================================================


### PR DESCRIPTION
- Track running worker count and expose available_workers property
- Check thread pool capacity before submitting analysis tasks
- Send error notification to DingTalk session on analysis failure
- Decrement running count in finally block to prevent counter drift

This ensures users get immediate feedback when their analysis task fails or the queue is full, rather than silently waiting.

## PR Type

- [x] feat


## Background And Problem

请描述当前问题、影响范围与触发场景。  
当机器人分析任务失败或线程池满时，用户无法收到任何反馈，任务静默失败。具体场景：                                                                                
  1. 所有 3 个 worker 都在忙，新提交的任务被拒绝但用户不知情                                                                                                          
  2. 分析过程中发生错误（LLM 调用失败、数据源异常），无通知触达用户                                                                                                   
  3. 异常退出时 worker 计数器未递减，导致可用 worker 持续为 0           

## Scope Of Change

请列出本 PR 修改的模块和文件范围。  
 - `bot/commands/analyze.py`: 提交分析前检查线程池容量，队列满时提示用户                                                                                             
  - `src/services/task_service.py`: 追踪运行中 worker 数量，暴露 `available_workers` 属性，失败时通过 `_send_error_notification()` 发送错误通知，finally块中递减计数器防止漂移        
    
## Issue Link
无

## Verification Commands And Results

请填写你实际执行过的命令和关键结果（不要只写"已测试"）。  
 ```bash
  python -m py_compile bot/commands/analyze.py src/services/task_service.py
  ./scripts/ci_gate.sh 
```                                                                                                                                               
  
  通过编译检查。手动验证：                                                                                                                                            
  - 3 个 worker 全满时提交分析 → 收到 "分析队列繁忙" 提示 ✓ 
  - 分析失败（无效股票代码）→ 钉钉收到错误通知 ✓           
  - 异常退出后计数器正确递减，新任务可正常提交 ✓
关键输出/结论 / Key output & conclusion:

## Compatibility And Risk

请说明兼容性影响、潜在风险（如无请写 `None`）。  
*(EN) Describe compatibility impact and potential risks (write `None` if not applicable).*

  - 向后兼容，已有 API 不变                                                                                                                                           
  - available_workers 为新增属性                                                                                                                                      
  - 错误通知包裹在 try/except 中，不影响主流程    

## Rollback Plan

请至少写一句可执行的回滚方案（必填）。  
  Revert this PR。无配置或数据迁移需要。 


<details>
<summary>展开 / Expand: Full EXTRACT_PROMPT</summary>

```
(paste full prompt here)
```

</details>

## Checklist

- [ ] 本 PR 有明确动机和业务价值 / This PR has a clear motivation and value
- [x] 已提供可复现的验证命令与结果 / Reproducible verification commands and results are included
- [x] 已评估兼容性与风险 / Compatibility and risk have been assessed
- [ ] 已提供回滚方案 / A rollback plan is provided
- [ ] 若涉及用户可见变更，已同步更新相关文档与 `docs/CHANGELOG.md`；`README.md` 仅在首页级信息变化时更新，细节优先写入 `docs/*.md` / If user-visible changes are included, relevant docs and `docs/CHANGELOG.md` are updated; `README.md` is updated only for homepage-level changes, with details kept in `docs/*.md`
