### PR TITLE
fix(security): block path traversal in SPA fallback route

### DIFF
--- a/api/app.py
+++ b/api/app.py
@@ -304,14 +304,19 @@ def create_app(static_dir: Optional[Path] = None) -> FastAPI:
                     status_code=404,
                     content={"error": "not_found", "message": f"API endpoint /{full_path} not found"}
                 )
-            
-            file_path = static_dir / full_path
-            if file_path.exists() and file_path.is_file():
+
+            # Reuse the same containment check as /assets/* so that requests
+            # like `/%2e%2e/%2e%2e/etc/passwd` cannot escape static_dir via
+            # the SPA fallback. Starlette's :path converter does not collapse
+            # `..` segments, so static_dir / full_path can resolve outside
+            # the bundle root if served unchecked.
+            file_path = _resolve_asset_path(static_dir, full_path) if full_path else None
+            if file_path is not None and file_path.is_file():
                 # Issue #520: Explicitly resolve MIME type to avoid
                 # browsers rejecting JS modules served as text/plain.
                 content_type, _ = mimetypes.guess_type(str(file_path))
                 return FileResponse(file_path, media_type=content_type)
-            
+
             return FileResponse(static_dir / "index.html")
     
     return app

--- a/tests/test_analysis_api_contract.py
+++ b/tests/test_analysis_api_contract.py
@@ -940,6 +940,38 @@ class AnalysisApiContractTestCase(unittest.TestCase):
             {"error": "not_found", "message": "API endpoint /api not found"},
         )
 
+    def test_spa_fallback_blocks_path_traversal(self) -> None:
+        """SPA fallback must not serve files outside static_dir.
+
+        Starlette's :path converter does not normalize `..` segments, so
+        without an explicit containment check `static_dir / full_path` can
+        resolve to arbitrary files on disk (CVE-class path traversal).
+        """
+        if create_app is None:
+            self.skipTest("fastapi is not installed in this test environment")
+
+        from fastapi.responses import FileResponse
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            static_dir = root / "static"
+            static_dir.mkdir()
+            (static_dir / "index.html").write_text("<html>spa</html>", encoding="utf-8")
+            secret = root / "secret.txt"
+            secret.write_text("TOPSECRET", encoding="utf-8")
+
+            app = create_app(static_dir=static_dir)
+            serve_spa = next(
+                route.endpoint for route in app.routes
+                if getattr(route, "path", None) == "/{full_path:path}"
+            )
+
+            for traversal in ("../secret.txt", "../../secret.txt", "foo/../../secret.txt"):
+                with self.subTest(traversal=traversal):
+                    response = asyncio.run(serve_spa(None, traversal))
+                    self.assertIsInstance(response, FileResponse)
+                    self.assertEqual(Path(response.path).resolve(), (static_dir / "index.html").resolve())
+
     def test_sse_generator_reraises_cancelled_error(self) -> None:
         """CancelledError must propagate (not be swallowed) from the SSE event generator."""
         try:


### PR DESCRIPTION
## Security Vulnerability Report

**Type:** Path traversal / arbitrary file read
**Severity:** High (unauthenticated)
**Location:** `api/app.py:299-315` (pre-fix line numbers — `serve_spa` handler under `if has_frontend:`)

### Description

The SPA fallback handler at `/{full_path:path}` joined the user-supplied `full_path` straight into a `pathlib.Path` and then served the result via `FileResponse`:

```python
file_path = static_dir / full_path
if file_path.exists() and file_path.is_file():
    content_type, _ = mimetypes.guess_type(str(file_path))
    return FileResponse(file_path, media_type=content_type)
```

Two things make this exploitable end-to-end:

1. **Starlette's `:path` converter** (`PathConvertor`, regex `.*`) does not collapse `..` segments — the raw value is handed to the endpoint.
2. **Uvicorn / httptools** percent-decode the path but do not normalize it either, so `..` segments and percent-encoded `%2e%2e` survive routing.

`pathlib`'s `.is_file()` is implemented via `os.stat`, which resolves `..` at the OS level. So `static_dir / "../../../../etc/passwd"` (or `/%2e%2e/%2e%2e/%2e%2e/%2e%2e/etc/passwd` against a vanilla `uvicorn`/Docker deployment) produces a path that escapes `static_dir`, passes the `is_file()` check, and is served by `FileResponse`.

The auth middleware (`api/middlewares/auth.py`) only guards `/api/v1/*`, so the SPA fallback is reachable unauthenticated even when `ADMIN_AUTH_ENABLED=true`. An attacker who can reach the HTTP port can read arbitrary files readable by the server process — `.env` and admin password hash under `data/`, `.session_secret`, source code, SSH keys, etc.

The repo already had `_resolve_asset_path` in the same file for exactly this concern on the parallel `/assets/{asset_path:path}` route (rejects null bytes, leading `/` or `\`, backslashes, drive letters, and any candidate that is not `is_relative_to` the base after `.resolve()`). That helper is generic on its base-dir argument; the SPA fallback simply wasn't wired through it.

### Fix

`serve_spa` now calls the same `_resolve_asset_path(static_dir, full_path)` helper and falls back to `index.html` whenever the resolved candidate is `None` or not a regular file. Two-line behavioral diff plus a comment.

### Reproduction

Against a stock deployment (`uvicorn server:app`, frontend bundle present):

```bash
# literal traversal
curl --path-as-is http://target:8000/../../../../etc/hostname

# percent-encoded traversal (survives most browser-side normalizers)
curl http://target:8000/%2e%2e/%2e%2e/%2e%2e/%2e%2e/etc/hostname
```

Both return the file contents. After the patch they return `index.html` (200) with no file leakage.

### Regression test

Added `test_spa_fallback_blocks_path_traversal` in `tests/test_analysis_api_contract.py`. Creates a temp `static_dir`, writes a sibling `secret.txt`, asserts that `../secret.txt`, `../../secret.txt`, and `foo/../../secret.txt` all return the SPA index FileResponse pointing at `static_dir/index.html` — not the secret file.

### Notes

- Minimal change, no refactor — the existing `_resolve_asset_path` was already general on its base-dir argument, so the SPA path now just uses it.
- The empty-string guard (`if full_path else None`) preserves the original behavior at `/` (returns `index.html`); the helper would itself return `None` for an empty string but skipping the call is slightly clearer about intent.
- Per `AGENTS.md`: backend change scoped to `api/`, no schema/auth/data-source impact, no docs touched (security fix, no user-visible API change). `python -m py_compile api/app.py tests/test_analysis_api_contract.py` clean.

---
Found by [Aeon](https://github.com/aaronjmars/aeon-aaron) — automated security scanner. Happy to coordinate disclosure timing if you'd prefer to release the patch first.