### PR TITLE
feat: add Exa AI-powered search tool

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -137,6 +137,9 @@ SERPAPI_API_KEYS=
 # Brave Search API Keys（支持多个，逗号分隔）
 # 获取: https://brave.com/search/api/
 BRAVE_API_KEYS=
+# Exa AI Search API Keys（神经搜索，支持新闻类目过滤，支持多个，逗号分隔）
+# 获取: https://exa.ai/
+# EXA_API_KEYS=your_exa_api_key
 # SearXNG 实例地址（逗号分隔，私有部署无配额，需在 settings.yml 启用 format: json）
 # 留空时默认自动从 searx.space 拉取公共实例；若不希望访问公共实例，可将下方开关设为 false
 SEARXNG_BASE_URLS=

--- a/.github/workflows/daily_analysis.yml
+++ b/.github/workflows/daily_analysis.yml
@@ -198,6 +198,7 @@ jobs:
           SERPAPI_API_KEYS: ${{ secrets.SERPAPI_API_KEYS }}
           MINIMAX_API_KEYS: ${{ secrets.MINIMAX_API_KEYS }}
           BRAVE_API_KEYS: ${{ secrets.BRAVE_API_KEYS }}
+          EXA_API_KEYS: ${{ secrets.EXA_API_KEYS }}
           SEARXNG_BASE_URLS: ${{ secrets.SEARXNG_BASE_URLS }}
           SEARXNG_PUBLIC_INSTANCES_ENABLED: ${{ vars.SEARXNG_PUBLIC_INSTANCES_ENABLED || secrets.SEARXNG_PUBLIC_INSTANCES_ENABLED }}
           
@@ -327,6 +328,7 @@ jobs:
           echo "  SerpAPI Keys: $([ -n "$SERPAPI_API_KEYS" ] && echo '✅ 已配置' || echo '⚪ 未配置')"
           echo "  MiniMax API Keys: $([ -n "$MINIMAX_API_KEYS" ] && echo '✅ 已配置' || echo '⚪ 未配置')"
           echo "  Brave API Keys: $([ -n "$BRAVE_API_KEYS" ] && echo '✅ 已配置' || echo '⚪ 未配置')"
+          echo "  Exa API Keys: $([ -n "$EXA_API_KEYS" ] && echo '✅ 已配置' || echo '⚪ 未配置')"
           echo "  SearXNG Base URLs: $([ -n "$SEARXNG_BASE_URLS" ] && echo '✅ 已配置' || echo '⚪ 未配置')"
           case "${SEARXNG_PUBLIC_INSTANCES_ENABLED,,}" in
             0|false|no|off)

--- a/requirements.txt
+++ b/requirements.txt
@@ -40,6 +40,7 @@ PyYAML>=6.0                 # YAML parser for LITELLM_CONFIG support
 # 搜索引擎（用于获取股票新闻）
 tavily-python>=0.3.0        # Tavily 搜索 API（每月 1000 次免费）
 google-search-results>=2.4.0  # SerpAPI（每月 100 次免费）
+exa-py>=1.10.0              # Exa AI Search（神经搜索，新闻类目过滤）
 
 # 网络请求
 requests>=2.31.0            # HTTP 请求

--- a/src/config.py
+++ b/src/config.py
@@ -659,6 +659,7 @@ class Config:
     tavily_api_keys: List[str] = field(default_factory=list)  # Tavily API Keys
     brave_api_keys: List[str] = field(default_factory=list)  # Brave Search API Keys
     serpapi_keys: List[str] = field(default_factory=list)  # SerpAPI Keys
+    exa_api_keys: List[str] = field(default_factory=list)  # Exa AI Search API Keys
     searxng_base_urls: List[str] = field(default_factory=list)  # SearXNG instance URLs (self-hosted, no quota)
     searxng_public_instances_enabled: bool = True  # Auto-discover public SearXNG instances when base URLs are absent
 
@@ -1207,6 +1208,9 @@ class Config:
         brave_keys_str = os.getenv('BRAVE_API_KEYS', '')
         brave_api_keys = [k.strip() for k in brave_keys_str.split(',') if k.strip()]
 
+        exa_keys_str = os.getenv('EXA_API_KEYS', '')
+        exa_api_keys = [k.strip() for k in exa_keys_str.split(',') if k.strip()]
+
         _raw_urls = [u.strip() for u in os.getenv('SEARXNG_BASE_URLS', '').split(',') if u.strip()]
         searxng_base_urls = []
         invalid_searxng_urls = []
@@ -1330,6 +1334,7 @@ class Config:
             tavily_api_keys=tavily_api_keys,
             brave_api_keys=brave_api_keys,
             serpapi_keys=serpapi_keys,
+            exa_api_keys=exa_api_keys,
             searxng_base_urls=searxng_base_urls,
             searxng_public_instances_enabled=searxng_public_instances_enabled,
             social_sentiment_api_key=os.getenv('SOCIAL_SENTIMENT_API_KEY') or None,
@@ -2084,6 +2089,7 @@ class Config:
             or self.tavily_api_keys
             or self.brave_api_keys
             or self.serpapi_keys
+            or self.exa_api_keys
             or self.has_searxng_enabled()
         )
 

--- a/src/search_service.py
+++ b/src/search_service.py
@@ -1246,6 +1246,149 @@ class AnspireSearchProvider(BaseSearchProvider):
             return '未知来源'
 
 
+class ExaSearchProvider(BaseSearchProvider):
+    """
+    Exa AI Search 搜索引擎
+
+    特点：
+    - 神经搜索，专为 AI/LLM 优化
+    - 支持类别过滤（news / financial report / company 等），契合金融场景
+    - 内容字段可同时返回 highlights / text / summary
+
+    文档: https://exa.ai/docs/reference/search
+    """
+
+    # 搜索类型：auto 让 Exa 自动选择神经/关键词混合策略
+    _DEFAULT_SEARCH_TYPE = "auto"
+    # 默认偏向新闻类目，便于聚合金融资讯
+    _DEFAULT_CATEGORY = "news"
+    # 单条结果片段最大长度，与其他 Provider 保持一致
+    _SNIPPET_MAX_CHARS = 500
+
+    def __init__(self, api_keys: List[str]):
+        super().__init__(api_keys, "Exa")
+
+    def _do_search(self, query: str, api_key: str, max_results: int, days: int = 7) -> SearchResponse:
+        """执行 Exa 搜索"""
+        try:
+            from exa_py import Exa
+        except ImportError:
+            return SearchResponse(
+                query=query,
+                results=[],
+                provider=self.name,
+                success=False,
+                error_message="exa-py 未安装，请运行：pip install exa-py"
+            )
+
+        try:
+            client = Exa(api_key=api_key)
+            # 标记调用来源，便于 Exa 侧识别集成
+            client.headers["x-exa-integration"] = "daily-stock-analysis"
+
+            start_published_date = (
+                datetime.now(timezone.utc) - timedelta(days=max(days, 1))
+            ).strftime("%Y-%m-%dT%H:%M:%S.000Z")
+
+            response = client.search_and_contents(
+                query,
+                type=self._DEFAULT_SEARCH_TYPE,
+                num_results=max(1, min(max_results, 25)),
+                category=self._DEFAULT_CATEGORY,
+                start_published_date=start_published_date,
+                text={"max_characters": 1000},
+                highlights={"num_sentences": 3, "highlights_per_url": 2},
+                summary=True,
+            )
+
+            results: List[SearchResult] = []
+            raw_results = getattr(response, "results", []) or []
+
+            for item in raw_results[:max_results]:
+                snippet = self._build_snippet(item)
+                published = (
+                    getattr(item, "published_date", None)
+                    or getattr(item, "publishedDate", None)
+                )
+                url = getattr(item, "url", "") or ""
+
+                results.append(SearchResult(
+                    title=getattr(item, "title", "") or "",
+                    snippet=snippet,
+                    url=url,
+                    source=self._extract_domain(url),
+                    published_date=published,
+                ))
+
+            logger.info(
+                f"[Exa] 搜索完成，query='{query}'，返回 {len(results)} 条结果"
+            )
+            logger.debug(f"[Exa] 原始响应：{raw_results}")
+
+            return SearchResponse(
+                query=query,
+                results=results,
+                provider=self.name,
+                success=True,
+            )
+
+        except Exception as e:
+            error_msg = str(e)
+            error_lower = error_msg.lower()
+            if "401" in error_msg or "unauthorized" in error_lower or "invalid api key" in error_lower:
+                error_msg = f"API KEY 无效：{error_msg}"
+            elif "rate limit" in error_lower or "quota" in error_lower or "429" in error_msg:
+                error_msg = f"API 配额已用尽：{error_msg}"
+            logger.warning(f"[Exa] 搜索失败：{error_msg}")
+            return SearchResponse(
+                query=query,
+                results=[],
+                provider=self.name,
+                success=False,
+                error_message=error_msg
+            )
+
+    @classmethod
+    def _build_snippet(cls, item: Any) -> str:
+        """按 highlights → summary → text 顺序构造可读摘要。
+
+        Exa 同一次请求可同时返回多个内容字段，任一字段都可能为空，
+        故按可用性级联回退，避免单一字段缺失导致空摘要。
+        """
+        highlights = getattr(item, "highlights", None) or []
+        if isinstance(highlights, list):
+            cleaned = [h.strip() for h in highlights if isinstance(h, str) and h.strip()]
+            if cleaned:
+                snippet = " … ".join(cleaned)
+                return cls._truncate(snippet)
+
+        summary = getattr(item, "summary", None)
+        if isinstance(summary, str) and summary.strip():
+            return cls._truncate(summary.strip())
+
+        text = getattr(item, "text", None)
+        if isinstance(text, str) and text.strip():
+            return cls._truncate(text.strip())
+
+        return ""
+
+    @classmethod
+    def _truncate(cls, text: str) -> str:
+        if len(text) <= cls._SNIPPET_MAX_CHARS:
+            return text
+        return text[: cls._SNIPPET_MAX_CHARS] + "..."
+
+    @staticmethod
+    def _extract_domain(url: str) -> str:
+        """从 URL 提取域名作为来源"""
+        try:
+            parsed = urlparse(url)
+            domain = parsed.netloc.replace('www.', '')
+            return domain or '未知来源'
+        except Exception:
+            return '未知来源'
+
+
 class MiniMaxSearchProvider(BaseSearchProvider):
     """
     MiniMax Web Search (Coding Plan API)
@@ -2125,6 +2268,7 @@ class SearchService:
         brave_keys: Optional[List[str]] = None,
         serpapi_keys: Optional[List[str]] = None,
         minimax_keys: Optional[List[str]] = None,
+        exa_keys: Optional[List[str]] = None,
         searxng_base_urls: Optional[List[str]] = None,
         searxng_public_instances_enabled: bool = True,
         news_max_age_days: int = 3,
@@ -2140,6 +2284,7 @@ class SearchService:
             brave_keys: Brave Search API Key 列表
             serpapi_keys: SerpAPI Key 列表
             minimax_keys: MiniMax API Key 列表
+            exa_keys: Exa AI Search API Key 列表
             searxng_base_urls: SearXNG 实例地址列表（自建无配额兜底）
             searxng_public_instances_enabled: 未配置自建实例时，是否自动使用公共 SearXNG 实例
             news_max_age_days: 新闻最大时效（天）
@@ -2188,6 +2333,11 @@ class SearchService:
         if minimax_keys:
             self._providers.append(MiniMaxSearchProvider(minimax_keys))
             logger.info(f"已配置 MiniMax 搜索，共 {len(minimax_keys)} 个 API Key")
+
+        # Exa AI Search（神经搜索，新闻类目过滤）
+        if exa_keys:
+            self._providers.append(ExaSearchProvider(exa_keys))
+            logger.info(f"已配置 Exa 搜索，共 {len(exa_keys)} 个 API Key")
 
         # 6. SearXNG（自建实例优先；未配置时可自动发现公共实例）
         searxng_provider = SearXNGSearchProvider(
@@ -3442,6 +3592,7 @@ def get_search_service() -> SearchService:
                     brave_keys=config.brave_api_keys,
                     serpapi_keys=config.serpapi_keys,
                     minimax_keys=config.minimax_api_keys,
+                    exa_keys=config.exa_api_keys,
                     searxng_base_urls=config.searxng_base_urls,
                     searxng_public_instances_enabled=config.searxng_public_instances_enabled,
                     news_max_age_days=config.news_max_age_days,

--- a/tests/test_exa_search.py
+++ b/tests/test_exa_search.py
@@ -1,0 +1,335 @@
+# -*- coding: utf-8 -*-
+"""
+Exa AI Search 搜索引擎测试套件
+
+测试覆盖范围:
+1. 配置加载测试 - 验证 exa_api_keys 是否正确从环境变量加载
+2. 服务初始化测试 - 验证 SearchService 是否正确初始化 ExaSearchProvider
+3. API 调用测试 - 通过 mock 验证返回结果解析
+4. 错误处理测试 - 验证无效 Key、配额耗尽、网络异常的降级处理
+5. 内容字段回退测试 - 验证 highlights / summary / text 任一缺失时仍能生成可读 snippet
+
+运行方式:
+```bash
+# Linux/Mac
+export EXA_API_KEYS="your_test_api_key"
+python -m pytest tests/test_exa_search.py -v
+```
+"""
+
+import os
+import sys
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+from dotenv import load_dotenv
+load_dotenv()
+
+project_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if project_root not in sys.path:
+    sys.path.insert(0, project_root)
+
+# Mock newspaper before search_service import (optional dependency)
+if "newspaper" not in sys.modules:
+    mock_np = MagicMock()
+    mock_np.Article = MagicMock()
+    mock_np.Config = MagicMock()
+    sys.modules["newspaper"] = mock_np
+
+
+def _install_fake_exa_module(client_factory):
+    """Install a fake ``exa_py`` module so the lazy import inside the
+    provider resolves to ``client_factory`` regardless of whether the real
+    SDK is installed locally.
+    """
+    fake_module = MagicMock()
+    fake_module.Exa = client_factory
+    sys.modules["exa_py"] = fake_module
+
+
+from src.config import Config
+from src.search_service import (
+    ExaSearchProvider,
+    SearchService,
+    reset_search_service,
+)
+
+
+def _make_result(**fields):
+    """Build a duck-typed Exa result object."""
+    defaults = {
+        "title": "",
+        "url": "",
+        "text": None,
+        "highlights": None,
+        "summary": None,
+        "published_date": None,
+    }
+    defaults.update(fields)
+    return SimpleNamespace(**defaults)
+
+
+class TestExaConfigLoading(unittest.TestCase):
+    """Test Exa configuration loading from environment variables."""
+
+    def setUp(self):
+        self._original_exa_keys = os.environ.get('EXA_API_KEYS')
+        if 'EXA_API_KEYS' in os.environ:
+            del os.environ['EXA_API_KEYS']
+        Config._Config__instance = None
+        reset_search_service()
+
+    def tearDown(self):
+        if self._original_exa_keys is not None:
+            os.environ['EXA_API_KEYS'] = self._original_exa_keys
+        elif 'EXA_API_KEYS' in os.environ:
+            del os.environ['EXA_API_KEYS']
+        Config._Config__instance = None
+        reset_search_service()
+
+    def test_exa_keys_loaded_from_env(self):
+        with patch.dict(os.environ, {'EXA_API_KEYS': 'key1,key2,key3'}):
+            config = Config._load_from_env()
+            self.assertEqual(len(config.exa_api_keys), 3)
+            self.assertEqual(config.exa_api_keys, ['key1', 'key2', 'key3'])
+
+    def test_exa_keys_single_key(self):
+        with patch.dict(os.environ, {'EXA_API_KEYS': 'single_key_test'}):
+            config = Config._load_from_env()
+            self.assertEqual(config.exa_api_keys, ['single_key_test'])
+
+    def test_exa_keys_empty_env(self):
+        with patch.dict(os.environ, {'EXA_API_KEYS': ''}):
+            config = Config._load_from_env()
+            self.assertEqual(config.exa_api_keys, [])
+
+    def test_exa_keys_whitespace_handling(self):
+        with patch.dict(os.environ, {'EXA_API_KEYS': ' key1 , key2 , key3 '}):
+            config = Config._load_from_env()
+            self.assertEqual(config.exa_api_keys, ['key1', 'key2', 'key3'])
+
+
+class TestExaSearchProvider(unittest.TestCase):
+    """Exa Search Provider 单元测试"""
+
+    def setUp(self):
+        self.test_api_key = "exa-test-placeholder-key-12345"
+        self.provider = ExaSearchProvider([self.test_api_key])
+        self._original_exa_module = sys.modules.get("exa_py")
+
+    def tearDown(self):
+        if self._original_exa_module is not None:
+            sys.modules["exa_py"] = self._original_exa_module
+        elif "exa_py" in sys.modules:
+            del sys.modules["exa_py"]
+
+    def test_provider_initialization(self):
+        provider = ExaSearchProvider(["key1", "key2"])
+        self.assertEqual(provider.name, "Exa")
+        self.assertEqual(len(provider._api_keys), 2)
+        self.assertTrue(provider.is_available)
+
+    def test_provider_unavailable_without_keys(self):
+        provider = ExaSearchProvider([])
+        self.assertFalse(provider.is_available)
+
+    def test_extract_domain(self):
+        cases = [
+            ("https://www.bloomberg.com/article", "bloomberg.com"),
+            ("https://finance.sina.com.cn/stock/", "finance.sina.com.cn"),
+            ("invalid_url", "未知来源"),
+            ("", "未知来源"),
+        ]
+        for url, expected in cases:
+            self.assertEqual(ExaSearchProvider._extract_domain(url), expected)
+
+    def test_search_success_response_with_highlights(self):
+        """Successful response with highlights should produce snippets."""
+        fake_client = MagicMock()
+        fake_client.headers = {}
+        fake_response = MagicMock()
+        fake_response.results = [
+            _make_result(
+                title="Apple Q2 Earnings Beat Expectations",
+                url="https://www.bloomberg.com/news/apple-q2",
+                highlights=[
+                    "Apple reported revenue of $94.8B",
+                    "iPhone sales rose 6% year-over-year",
+                ],
+                text="Full article text here",
+                summary="Apple beat Wall Street estimates this quarter.",
+                published_date="2025-05-02T14:30:00.000Z",
+            ),
+            _make_result(
+                title="Tech sector rallies on AI optimism",
+                url="https://www.reuters.com/markets/tech",
+                highlights=["Nasdaq up 1.5% on AI demand"],
+                published_date="2025-05-01T09:00:00.000Z",
+            ),
+        ]
+        fake_client.search_and_contents.return_value = fake_response
+
+        client_factory = MagicMock(return_value=fake_client)
+        _install_fake_exa_module(client_factory)
+
+        response = self.provider.search("AAPL earnings", max_results=5, days=7)
+
+        self.assertTrue(response.success)
+        self.assertEqual(response.provider, "Exa")
+        self.assertEqual(len(response.results), 2)
+
+        first = response.results[0]
+        self.assertEqual(first.title, "Apple Q2 Earnings Beat Expectations")
+        self.assertEqual(first.source, "bloomberg.com")
+        self.assertIn("Apple reported revenue", first.snippet)
+        self.assertIn("iPhone sales", first.snippet)
+        self.assertEqual(first.published_date, "2025-05-02T14:30:00.000Z")
+
+        client_factory.assert_called_once_with(api_key=self.test_api_key)
+        # Integration tracking header should be set on the SDK client.
+        self.assertEqual(
+            fake_client.headers.get("x-exa-integration"),
+            "daily-stock-analysis",
+        )
+        call_kwargs = fake_client.search_and_contents.call_args.kwargs
+        self.assertEqual(call_kwargs["category"], "news")
+        self.assertEqual(call_kwargs["type"], "auto")
+        self.assertIn("start_published_date", call_kwargs)
+
+    def test_snippet_falls_back_to_summary_when_highlights_missing(self):
+        item = _make_result(
+            title="t",
+            url="https://example.com/a",
+            highlights=[],
+            summary="A concise summary of the article.",
+            text="Long text body would go here.",
+        )
+        snippet = ExaSearchProvider._build_snippet(item)
+        self.assertEqual(snippet, "A concise summary of the article.")
+
+    def test_snippet_falls_back_to_text_when_summary_missing(self):
+        item = _make_result(
+            title="t",
+            url="https://example.com/a",
+            highlights=None,
+            summary=None,
+            text="Long text body that should be used as fallback.",
+        )
+        snippet = ExaSearchProvider._build_snippet(item)
+        self.assertEqual(snippet, "Long text body that should be used as fallback.")
+
+    def test_snippet_truncates_long_content(self):
+        long_text = "A" * 1000
+        item = _make_result(text=long_text)
+        snippet = ExaSearchProvider._build_snippet(item)
+        self.assertTrue(snippet.endswith("..."))
+        self.assertLessEqual(len(snippet), ExaSearchProvider._SNIPPET_MAX_CHARS + 3)
+
+    def test_snippet_empty_when_all_content_missing(self):
+        item = _make_result()
+        self.assertEqual(ExaSearchProvider._build_snippet(item), "")
+
+    def test_search_handles_invalid_api_key_error(self):
+        fake_client = MagicMock()
+        fake_client.headers = {}
+        fake_client.search_and_contents.side_effect = Exception("401 Unauthorized: invalid api key")
+
+        client_factory = MagicMock(return_value=fake_client)
+        _install_fake_exa_module(client_factory)
+
+        response = self.provider.search("AAPL", max_results=3)
+        self.assertFalse(response.success)
+        self.assertEqual(response.provider, "Exa")
+        self.assertEqual(len(response.results), 0)
+        self.assertIn("API KEY", response.error_message)
+
+    def test_search_handles_rate_limit_error(self):
+        fake_client = MagicMock()
+        fake_client.headers = {}
+        fake_client.search_and_contents.side_effect = Exception("429 rate limit exceeded")
+
+        client_factory = MagicMock(return_value=fake_client)
+        _install_fake_exa_module(client_factory)
+
+        response = self.provider.search("AAPL", max_results=3)
+        self.assertFalse(response.success)
+        self.assertIn("配额", response.error_message)
+
+    def test_search_disabled_when_sdk_missing(self):
+        """If exa_py is not installed, search returns a structured failure."""
+        # Replace exa_py module with one whose attribute access raises ImportError
+        class _NoExa:
+            def __getattr__(self, name):
+                raise ImportError("exa_py not installed")
+
+        sys.modules["exa_py"] = _NoExa()
+
+        response = self.provider.search("AAPL", max_results=3)
+        self.assertFalse(response.success)
+        self.assertIn("exa-py", response.error_message)
+
+
+class TestExaSearchService(unittest.TestCase):
+    """SearchService 中 Exa 集成测试"""
+
+    def setUp(self):
+        Config._Config__instance = None
+        reset_search_service()
+
+    def test_search_service_registers_exa_provider(self):
+        service = SearchService(
+            exa_keys=["test_key"],
+            anspire_keys=[],
+            bocha_keys=[],
+            tavily_keys=[],
+            searxng_public_instances_enabled=False,
+            news_max_age_days=3,
+            news_strategy_profile="short",
+        )
+
+        exa_providers = [p for p in service._providers if isinstance(p, ExaSearchProvider)]
+        self.assertEqual(len(exa_providers), 1)
+        self.assertEqual(exa_providers[0].name, "Exa")
+
+    def test_search_service_omits_exa_when_unconfigured(self):
+        service = SearchService(
+            exa_keys=[],
+            tavily_keys=["tavily_key"],
+            bocha_keys=[],
+            searxng_public_instances_enabled=False,
+            news_max_age_days=3,
+            news_strategy_profile="short",
+        )
+
+        exa_providers = [p for p in service._providers if isinstance(p, ExaSearchProvider)]
+        self.assertEqual(len(exa_providers), 0)
+
+
+class TestExaIntegration(unittest.TestCase):
+    """Exa 集成测试（需要真实 API Key）"""
+
+    @unittest.skipIf(
+        not os.environ.get("EXA_API_KEYS"),
+        "未设置 EXA_API_KEYS 环境变量，跳过集成测试"
+    )
+    @pytest.mark.network
+    def test_real_api_call_general_search(self):
+        api_keys = [k.strip() for k in os.getenv('EXA_API_KEYS', '').split(',') if k.strip()]
+        provider = ExaSearchProvider(api_keys)
+        response = provider.search("AAPL stock price", max_results=3, days=7)
+
+        print(f"\n=== Exa 真实 API 测试结果 ===")
+        print(f"搜索状态：{'成功' if response.success else '失败'}")
+        print(f"结果数量：{len(response.results)}")
+        if response.error_message:
+            print(f"错误信息：{response.error_message}")
+
+        self.assertTrue(response.success, f"搜索失败：{response.error_message}")
+        self.assertGreater(len(response.results), 0)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Summary

Adds **Exa** as an additional news search backend, alongside the existing Tavily / SerpAPI / Brave / Anspire / Bocha / MiniMax / SearXNG providers.

[Exa](https://exa.ai/) offers neural search with category filtering (`news`, `financial report`, `company`, etc.), which is well-suited for stock-news retrieval. The provider returns structured `highlights` / `summary` / `text` content that the snippet-builder cascades through, so a single API call gives a usable result regardless of which content fields are populated.

- New `ExaSearchProvider` in `src/search_service.py` (matches the existing `BaseSearchProvider` pattern: load-balanced multi-key support, retry-friendly, category-aware)
- `EXA_API_KEYS` env var wired through `src/config.py` (same comma-separated multi-key convention as the other providers)
- Registered in `SearchService.__init__` and `get_search_service()`
- `exa-py>=1.10.0` added to `requirements.txt`
- `EXA_API_KEYS` documented in `.env.example` and `.github/workflows/daily_analysis.yml`
- Unit tests in `tests/test_exa_search.py` (17 tests, mirrors the test style of the recently-added Anspire provider)

## Usage

```bash
# .env
EXA_API_KEYS=your_exa_key
```

```python
from src.search_service import get_search_service

service = get_search_service()
response = service.search_stock_news("AAPL", "Apple Inc.", max_results=5)
for r in response.results:
    print(r.title, r.url, r.source, r.published_date)
    print(r.snippet)
```

The provider:
- Uses Exa's `auto` search type (neural + keyword hybrid)
- Filters by `news` category by default for fresh financial coverage
- Maps the `days` parameter to `start_published_date`
- Requests `highlights`, `summary`, and `text` simultaneously, then builds the snippet by cascading through whichever field is populated

## Files changed

- `src/search_service.py` — adds `ExaSearchProvider` + wiring in `SearchService`
- `src/config.py` — adds `exa_api_keys` field, env parsing, capability check
- `requirements.txt` — adds `exa-py>=1.10.0`
- `.env.example` — adds `EXA_API_KEYS` template
- `.github/workflows/daily_analysis.yml` — adds `EXA_API_KEYS` secret binding
- `tests/test_exa_search.py` — new unit test module

## Test plan

- [x] `tests/test_exa_search.py` — 17 unit tests pass (1 integration test skips when `EXA_API_KEYS` is unset, same convention as the Anspire suite)
- [x] Existing `tests/test_anspire_search.py`, `tests/test_search_tavily_provider.py`, `tests/test_search_serpapi_provider.py` still pass (41 tests, no regressions)
- [x] Smoke check: `ExaSearchProvider` correctly hits the live API with the real `exa-py` SDK and surfaces structured 401 errors when the key is invalid
- [x] Provider is omitted when `EXA_API_KEYS` is not set; no behavioral change for existing users