### PR TITLE
feat: support custom webhook body templates

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -278,6 +278,7 @@ AGENT_SKILLS=
 #
 # CUSTOM_WEBHOOK_URLS=https://oapi.dingtalk.com/robot/send?access_token=xxx,https://hooks.slack.com/services/xxx
 # CUSTOM_WEBHOOK_BEARER_TOKEN=  # 可选，用于需要认证的 Webhook (Header Authorization: Bearer <token>)
+# CUSTOM_WEBHOOK_BODY_TEMPLATE=  # 可选，JSON body 模板；支持 $content_json/$content/$title_json/$title
 # WEBHOOK_VERIFY_SSL=true   # 默认校验。设为 false 可支持自签名证书。警告：禁用后存在 MITM 劫持风险，仅限可信内网
 #
 # 【方式六】Pushover 配置

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 <!-- 新条目格式：- [类型] 描述（类型取值：新功能/改进/修复/文档/测试/chore）-->
 <!-- 每条独立一行追加到本段末尾，无需分类标题，合并时冲突最小 -->
+- [新功能] 自定义 Webhook 支持 `CUSTOM_WEBHOOK_BODY_TEMPLATE` JSON body 模板，便于适配 AstrBot、NapCat 和自建推送服务。
 - [修复] 统一持仓快照输出现价/市值/浮盈亏/收益率与价格元信息，并为 LLM 渠道测试补充结构化诊断与设置页排障提示。
 - [文档] 补充 LLM 渠道编辑器的官方来源、依赖兼容窗口、保存时的运行时模型清理规则，以及旧配置回退路径说明。
 - [测试] 补齐 task_queue 运行时配置同步回归证据，明确 `tests/test_task_queue_config_sync.py` 作为本轮验收项。

--- a/docs/full-guide.md
+++ b/docs/full-guide.md
@@ -90,6 +90,7 @@ daily_stock_analysis/
 | `SERVERCHAN3_SENDKEY` | Server酱³ Sendkey（[获取地址](https://sc3.ft07.com/)，手机APP推送服务） | 可选 |
 | `CUSTOM_WEBHOOK_URLS` | 自定义 Webhook（支持钉钉等，多个用逗号分隔） | 可选 |
 | `CUSTOM_WEBHOOK_BEARER_TOKEN` | 自定义 Webhook 的 Bearer Token（用于需要认证的 Webhook） | 可选 |
+| `CUSTOM_WEBHOOK_BODY_TEMPLATE` | 自定义 Webhook JSON body 模板，适配 AstrBot、NapCat、自建服务等特殊 payload | 可选 |
 | `WEBHOOK_VERIFY_SSL` | Webhook HTTPS 证书校验（默认 true）。设为 false 可支持自签名证书。警告：关闭有严重安全风险（MITM），仅限可信内网 | 可选 |
 
 > *注：至少配置一个渠道，配置多个则同时推送
@@ -725,6 +726,14 @@ EMAIL_GROUP_2=user2@example.com
 - 自建服务
 
 设置 `CUSTOM_WEBHOOK_URLS`，多个用逗号分隔。
+
+如需适配 AstrBot、NapCat 或自建服务的特殊 body，可设置 `CUSTOM_WEBHOOK_BODY_TEMPLATE`。该值必须渲染为 JSON object，推荐使用 `$content_json` 避免换行和引号破坏 JSON：
+
+```env
+CUSTOM_WEBHOOK_BODY_TEMPLATE={"msg_type":"text","content":$content_json}
+```
+
+可用占位符：`$content_json`、`$content`、`$title_json`、`$title`。
 
 ### Discord
 

--- a/docs/full-guide_EN.md
+++ b/docs/full-guide_EN.md
@@ -91,6 +91,7 @@ Go to your forked repo → `Settings` → `Secrets and variables` → `Actions` 
 | `SERVERCHAN3_SENDKEY` | ServerChan v3 Sendkey ([Get here](https://sc3.ft07.com/), mobile app push service) | Optional |
 | `CUSTOM_WEBHOOK_URLS` | Custom Webhook (supports DingTalk, etc., comma-separated) | Optional |
 | `CUSTOM_WEBHOOK_BEARER_TOKEN` | Bearer Token for custom webhooks (for authenticated webhooks) | Optional |
+| `CUSTOM_WEBHOOK_BODY_TEMPLATE` | Custom Webhook JSON body template for AstrBot, NapCat, or self-hosted services with special payloads | Optional |
 | `WEBHOOK_VERIFY_SSL` | Verify Webhook HTTPS certificates (default true). Set to false for self-signed certs. WARNING: Disabling has serious security risk (MITM), use only on trusted internal networks | Optional |
 
 > *Note: Configure at least one channel; multiple channels will all receive notifications
@@ -621,6 +622,16 @@ Supports any POST JSON Webhook, including:
 - Self-hosted services
 
 Set `CUSTOM_WEBHOOK_URLS`, separate multiple with commas.
+
+If AstrBot, NapCat, or a self-hosted service requires a custom request body, set
+`CUSTOM_WEBHOOK_BODY_TEMPLATE`. The rendered value must be a JSON object. Prefer
+`$content_json` so newlines and quotes stay valid JSON:
+
+```env
+CUSTOM_WEBHOOK_BODY_TEMPLATE={"msg_type":"text","content":$content_json}
+```
+
+Available placeholders: `$content_json`, `$content`, `$title_json`, `$title`.
 
 ### Discord
 

--- a/src/config.py
+++ b/src/config.py
@@ -725,6 +725,7 @@ class Config:
     # 适用于：钉钉、Discord、Slack、自建服务等任意支持 POST JSON 的 Webhook
     custom_webhook_urls: List[str] = field(default_factory=list)
     custom_webhook_bearer_token: Optional[str] = None  # Bearer Token（用于需要认证的 Webhook）
+    custom_webhook_body_template: Optional[str] = None  # 自定义 Webhook JSON body 模板
     webhook_verify_ssl: bool = True  # Webhook HTTPS 证书校验，false 可支持自签名（有 MITM 风险）
 
     # Discord 通知配置
@@ -1408,6 +1409,7 @@ class Config:
             serverchan3_sendkey=os.getenv('SERVERCHAN3_SENDKEY'),
             custom_webhook_urls=[u.strip() for u in os.getenv('CUSTOM_WEBHOOK_URLS', '').split(',') if u.strip()],
             custom_webhook_bearer_token=os.getenv('CUSTOM_WEBHOOK_BEARER_TOKEN'),
+            custom_webhook_body_template=os.getenv('CUSTOM_WEBHOOK_BODY_TEMPLATE'),
             webhook_verify_ssl=os.getenv('WEBHOOK_VERIFY_SSL', 'true').lower() == 'true',
             discord_bot_token=os.getenv('DISCORD_BOT_TOKEN'),
             discord_main_channel_id=(

--- a/src/core/config_registry.py
+++ b/src/core/config_registry.py
@@ -808,6 +808,23 @@ _FIELD_DEFINITIONS: Dict[str, Dict[str, Any]] = {
         "validation": {},
         "display_order": 51,
     },
+    "CUSTOM_WEBHOOK_BODY_TEMPLATE": {
+        "title": "Custom Webhook Body Template",
+        "description": (
+            "Optional JSON body template for custom webhooks. Supports $content_json, "
+            "$content, $title_json, and $title placeholders."
+        ),
+        "category": "notification",
+        "data_type": "string",
+        "ui_control": "textarea",
+        "is_sensitive": False,
+        "is_required": False,
+        "is_editable": True,
+        "default_value": None,
+        "options": [],
+        "validation": {},
+        "display_order": 52,
+    },
     "WEBHOOK_VERIFY_SSL": {
         "title": "Webhook SSL Verify",
         "description": "Verify HTTPS certificates for webhook requests. Set to false ONLY for self-signed certs in trusted internal networks. WARNING: Disabling allows MITM attacks—do NOT use on public networks.",
@@ -820,7 +837,7 @@ _FIELD_DEFINITIONS: Dict[str, Dict[str, Any]] = {
         "default_value": "true",
         "options": [],
         "validation": {},
-        "display_order": 52,
+        "display_order": 53,
     },
     "REPORT_SUMMARY_ONLY": {
         "title": "Report Summary Only",

--- a/src/notification_sender/custom_webhook_sender.py
+++ b/src/notification_sender/custom_webhook_sender.py
@@ -73,6 +73,9 @@ class CustomWebhookSender:
                         if self._post_custom_webhook(url, templated_payload, timeout=30):
                             logger.info(f"自定义 Webhook {i+1}（钉钉模板）推送成功")
                             success_count += 1
+                        elif self._send_dingtalk_chunked(url, content, max_bytes=20000):
+                            logger.info(f"自定义 Webhook {i+1}（钉钉模板失败，回退分批）推送成功")
+                            success_count += 1
                         else:
                             logger.error(f"自定义 Webhook {i+1}（钉钉模板）推送失败")
                     elif self._send_dingtalk_chunked(url, content, max_bytes=20000):

--- a/src/notification_sender/custom_webhook_sender.py
+++ b/src/notification_sender/custom_webhook_sender.py
@@ -68,7 +68,14 @@ class CustomWebhookSender:
                 
                 # 钉钉机器人对 body 有字节上限（约 20000 bytes），超长需要分批发送
                 if self._is_dingtalk_webhook(url):
-                    if self._send_dingtalk_chunked(url, content, max_bytes=20000):
+                    templated_payload = self._build_custom_webhook_template_payload(content)
+                    if templated_payload is not None:
+                        if self._post_custom_webhook(url, templated_payload, timeout=30):
+                            logger.info(f"自定义 Webhook {i+1}（钉钉模板）推送成功")
+                            success_count += 1
+                        else:
+                            logger.error(f"自定义 Webhook {i+1}（钉钉模板）推送失败")
+                    elif self._send_dingtalk_chunked(url, content, max_bytes=20000):
                         logger.info(f"自定义 Webhook {i+1}（钉钉）推送成功")
                         success_count += 1
                     else:

--- a/src/notification_sender/custom_webhook_sender.py
+++ b/src/notification_sender/custom_webhook_sender.py
@@ -7,6 +7,9 @@
 """
 import logging
 import json
+from string import Template
+from typing import Any, Optional
+
 import requests
 
 from src.config import Config
@@ -27,6 +30,7 @@ class CustomWebhookSender:
         """
         self._custom_webhook_urls = getattr(config, 'custom_webhook_urls', []) or []
         self._custom_webhook_bearer_token = getattr(config, 'custom_webhook_bearer_token', None)
+        self._custom_webhook_body_template = getattr(config, 'custom_webhook_body_template', None)
         self._webhook_verify_ssl = getattr(config, 'webhook_verify_ssl', True)
  
     def send_to_custom(self, content: str) -> bool:
@@ -153,6 +157,10 @@ class CustomWebhookSender:
         
         自动识别常见服务并使用对应格式
         """
+        templated_payload = self._build_custom_webhook_template_payload(content)
+        if templated_payload is not None:
+            return templated_payload
+
         url_lower = url.lower()
         
         # 钉钉机器人
@@ -195,6 +203,35 @@ class CustomWebhookSender:
             "message": content,
             "body": content
         }
+
+    def _build_custom_webhook_template_payload(self, content: str) -> Optional[dict]:
+        """Build payload from CUSTOM_WEBHOOK_BODY_TEMPLATE when configured."""
+        template = (self._custom_webhook_body_template or "").strip()
+        if not template:
+            return None
+
+        title = "股票分析报告"
+        variables = {
+            "title": title,
+            "title_json": json.dumps(title, ensure_ascii=False),
+            "content": content,
+            "content_json": json.dumps(content, ensure_ascii=False),
+        }
+        rendered = Template(template).safe_substitute(variables)
+        try:
+            payload: Any = json.loads(rendered)
+        except json.JSONDecodeError as exc:
+            logger.error(
+                "CUSTOM_WEBHOOK_BODY_TEMPLATE 不是有效 JSON，已回退为默认 Webhook payload: %s",
+                exc,
+            )
+            return None
+        if not isinstance(payload, dict):
+            logger.error(
+                "CUSTOM_WEBHOOK_BODY_TEMPLATE 必须渲染为 JSON object，已回退为默认 Webhook payload"
+            )
+            return None
+        return payload
     
     def _send_dingtalk_chunked(self, url: str, content: str, max_bytes: int = 20000) -> bool:
         import time as _time

--- a/tests/test_notification_sender.py
+++ b/tests/test_notification_sender.py
@@ -8,6 +8,7 @@ Does not duplicate test_notification.py which tests NotificationService.send() f
 import base64
 import hashlib
 import hmac
+import json
 import os
 import sys
 import unittest
@@ -375,6 +376,39 @@ class TestCustomWebhookSender(unittest.TestCase):
         cfg = _config(custom_webhook_urls=["https://example.com/webhook"])
         sender = CustomWebhookSender(cfg)
         result = sender.send_to_custom("hello")
+        self.assertTrue(result)
+        body = mock_post.call_args[1]["data"].decode("utf-8")
+        self.assertIn("hello", body)
+
+    @mock.patch("src.notification_sender.custom_webhook_sender.requests.post")
+    def test_send_uses_custom_body_template(self, mock_post):
+        mock_post.return_value = _response(200)
+        cfg = _config(
+            custom_webhook_urls=["https://example.com/webhook"],
+            custom_webhook_body_template='{"msg_type":"text","content":$content_json}',
+        )
+        sender = CustomWebhookSender(cfg)
+
+        result = sender.send_to_custom('hello "world"')
+
+        self.assertTrue(result)
+        body = mock_post.call_args[1]["data"].decode("utf-8")
+        self.assertEqual(
+            json.loads(body),
+            {"msg_type": "text", "content": 'hello "world"'},
+        )
+
+    @mock.patch("src.notification_sender.custom_webhook_sender.requests.post")
+    def test_invalid_custom_body_template_falls_back(self, mock_post):
+        mock_post.return_value = _response(200)
+        cfg = _config(
+            custom_webhook_urls=["https://example.com/webhook"],
+            custom_webhook_body_template='{"content": $content',
+        )
+        sender = CustomWebhookSender(cfg)
+
+        result = sender.send_to_custom("hello")
+
         self.assertTrue(result)
         body = mock_post.call_args[1]["data"].decode("utf-8")
         self.assertIn("hello", body)

--- a/tests/test_notification_sender.py
+++ b/tests/test_notification_sender.py
@@ -399,6 +399,25 @@ class TestCustomWebhookSender(unittest.TestCase):
         )
 
     @mock.patch("src.notification_sender.custom_webhook_sender.requests.post")
+    def test_dingtalk_send_uses_custom_body_template(self, mock_post):
+        mock_post.return_value = _response(200)
+        cfg = _config(
+            custom_webhook_urls=["https://oapi.dingtalk.com/robot/send?access_token=token"],
+            custom_webhook_body_template='{"msgtype":"text","text":{"content":$content_json}}',
+        )
+        sender = CustomWebhookSender(cfg)
+
+        result = sender.send_to_custom("hello dingtalk")
+
+        self.assertTrue(result)
+        mock_post.assert_called_once()
+        body = mock_post.call_args[1]["data"].decode("utf-8")
+        self.assertEqual(
+            json.loads(body),
+            {"msgtype": "text", "text": {"content": "hello dingtalk"}},
+        )
+
+    @mock.patch("src.notification_sender.custom_webhook_sender.requests.post")
     def test_invalid_custom_body_template_falls_back(self, mock_post):
         mock_post.return_value = _response(200)
         cfg = _config(

--- a/tests/test_notification_sender.py
+++ b/tests/test_notification_sender.py
@@ -417,6 +417,28 @@ class TestCustomWebhookSender(unittest.TestCase):
             {"msgtype": "text", "text": {"content": "hello dingtalk"}},
         )
 
+    @mock.patch("time.sleep", return_value=None)
+    @mock.patch("src.notification_sender.custom_webhook_sender.requests.post")
+    def test_dingtalk_template_failure_falls_back_to_chunked_send(
+        self, mock_post, _mock_sleep
+    ):
+        mock_post.side_effect = [_response(400), _response(200), _response(200), _response(200)]
+        cfg = _config(
+            custom_webhook_urls=["https://oapi.dingtalk.com/robot/send?access_token=token"],
+            custom_webhook_body_template='{"msgtype":"text","text":{"content":$content_json}}',
+        )
+        sender = CustomWebhookSender(cfg)
+
+        result = sender.send_to_custom("A" * 40000)
+
+        self.assertTrue(result)
+        self.assertGreater(mock_post.call_count, 1)
+        first_body = json.loads(mock_post.call_args_list[0].kwargs["data"].decode("utf-8"))
+        fallback_body = json.loads(mock_post.call_args_list[1].kwargs["data"].decode("utf-8"))
+        self.assertEqual(first_body["msgtype"], "text")
+        self.assertEqual(fallback_body["msgtype"], "markdown")
+        self.assertIn("markdown", fallback_body)
+
     @mock.patch("src.notification_sender.custom_webhook_sender.requests.post")
     def test_invalid_custom_body_template_falls_back(self, mock_post):
         mock_post.return_value = _response(200)


### PR DESCRIPTION
## Summary

Adds configurable JSON body templates for custom webhook notifications so integrations that expect a specific payload shape can be used without changing code.

## What Changed

- Adds `CUSTOM_WEBHOOK_BODY_TEMPLATE` to runtime config and the config registry.
- Lets custom webhook payloads render `$content_json`, `$content`, `$title_json`, and `$title` placeholders.
- Requires the rendered template to be a JSON object; invalid templates fall back to the existing auto-detected payload format.
- Updates `.env.example`, Chinese/English full guides, and changelog.
- Adds tests for successful custom body rendering and invalid-template fallback.

## User Impact

Users can adapt the existing custom webhook channel to AstrBot, NapCat, self-hosted push bridges, or other webhook receivers that require a custom JSON body.

## Validation

- `python3 -m pytest tests/test_notification_sender.py::TestCustomWebhookSender -q` -> PASS
- `python3 -m py_compile src/config.py src/notification_sender/custom_webhook_sender.py` -> PASS
- `git diff --check` -> PASS

## Compatibility And Risk

- Existing custom webhook behavior remains the default when `CUSTOM_WEBHOOK_BODY_TEMPLATE` is unset.
- Invalid JSON templates do not block notification delivery; they log an error and use the previous auto payload behavior.

## Rollback

Unset `CUSTOM_WEBHOOK_BODY_TEMPLATE` to return to previous runtime behavior, or revert this PR to remove the config field, docs, and tests.