### PR TITLE
feat: add market light summary to reviews

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 <!-- 新条目格式：- [类型] 描述（类型取值：新功能/改进/修复/文档/测试/chore）-->
 <!-- 每条独立一行追加到本段末尾，无需分类标题，合并时冲突最小 -->
 - [新功能] 自定义 Webhook 支持 `CUSTOM_WEBHOOK_BODY_TEMPLATE` JSON body 模板，便于适配 AstrBot、NapCat 和自建推送服务。
+- [新功能] 大盘复盘结构化区块新增大盘红绿灯结论，基于盘面温度输出 green/yellow/red、核心原因和操作建议。
 - [修复] 统一持仓快照输出现价/市值/浮盈亏/收益率与价格元信息，并为 LLM 渠道测试补充结构化诊断与设置页排障提示。
 - [文档] 补充 LLM 渠道编辑器的官方来源、依赖兼容窗口、保存时的运行时模型清理规则，以及旧配置回退路径说明。
 - [测试] 补齐 task_queue 运行时配置同步回归证据，明确 `tests/test_task_queue_config_sync.py` 作为本轮验收项。

--- a/docs/full-guide.md
+++ b/docs/full-guide.md
@@ -309,7 +309,7 @@ daily_stock_analysis/
 > - TickFlow 能力按套餐权限分层：有限权限套餐仍可使用主指数查询；支持 `CN_Equity_A` 标的池查询的套餐才会启用 TickFlow 市场统计。
 > - 官方 quickstart 已文档化 `quotes.get(universes=["CN_Equity_A"])`，但线上 smoke test 进一步确认：`TICKFLOW_API_KEY` 不等于一定具备该权限，且 `quotes.get(symbols=[...])` 单次存在标的数量限制。
 > - TickFlow 实际返回的 `change_pct` / `amplitude` 为比例值；系统已在接入层统一转换为百分比值，确保与现有数据源字段语义一致。
-> - A 股大盘复盘报告采用盘后工作台式结构：固定包含盘面温度、指数明细、板块 Top 表、新闻催化、明日交易计划和风险提示；若部分数据源缺失，则保留可用区块并在对应位置降级展示。
+> - A 股大盘复盘报告采用盘后工作台式结构：固定包含大盘红绿灯、盘面温度、指数明细、板块 Top 表、新闻催化、明日交易计划和风险提示；若部分数据源缺失，则保留可用区块并在对应位置降级展示。
 > - 字段契约：
 >   - `fundamental_context.belong_boards` = 个股关联板块列表（当前仅 A 股写入；无数据时为 `[]`）；
 >   - `fundamental_context.boards.data` = `sector_rankings`（板块涨跌榜，结构 `{top, bottom}`）；

--- a/docs/full-guide_EN.md
+++ b/docs/full-guide_EN.md
@@ -301,7 +301,7 @@ Default schedule: Every weekday at **18:00 (Beijing Time)** automatic execution.
 > - TickFlow behavior is capability-based rather than just key-based: limited plans can still enhance main CN indices, while plans with `CN_Equity_A` universe query support also enhance market breadth.
 > - The official quickstart documents `quotes.get(universes=["CN_Equity_A"])`, but online smoke tests confirmed two additional real-world constraints: universe access depends on plan permissions, and `quotes.get(symbols=[...])` has a per-request symbol limit.
 > - TickFlow currently returns `change_pct` / `amplitude` as ratio values; this integration normalizes them to the project's percent convention so they match AkShare / Tushare / efinance semantics.
-> - CN market review reports now use a post-market workstation layout with fixed market-temperature, index detail, sector Top tables, news catalysts, next-session plan, and risk sections. Missing data sources degrade by omitting or simplifying only the affected block.
+> - CN market review reports now use a post-market workstation layout with fixed market light, market temperature, index detail, sector Top tables, news catalysts, next-session plan, and risk sections. Missing data sources degrade by omitting or simplifying only the affected block.
 > - Per-stock analysis, realtime quote priority, and sector rankings fallback remain unchanged.
 
 ---

--- a/src/market_analyzer.py
+++ b/src/market_analyzer.py
@@ -561,7 +561,7 @@ Focus on index trend, liquidity, and sector rotation to shape the next-session t
             )
         light = self.build_market_light_snapshot(overview)
         score, label = light["score"], light["temperature_label"]
-        participation = overview.up_count + overview.down_count + overview.flat_count
+        participation = overview.up_count + overview.down_count
         up_ratio = overview.up_count / participation if participation else 0.0
         limit_spread = overview.limit_up_count - overview.limit_down_count
         lines = [
@@ -573,7 +573,7 @@ Focus on index trend, liquidity, and sector rotation to shape the next-session t
             "",
             "| 指标 | 数值 | 观察 |",
             "|------|------|------|",
-            f"| 上涨/下跌/平盘 | {overview.up_count} / {overview.down_count} / {overview.flat_count} | 上涨占比 {up_ratio:.1%} |",
+            f"| 上涨/下跌/平盘 | {overview.up_count} / {overview.down_count} / {overview.flat_count} | 上涨占比(不含平盘) {up_ratio:.1%} |",
             f"| 涨停/跌停 | {overview.limit_up_count} / {overview.limit_down_count} | 涨跌停差 {limit_spread:+d} |",
             f"| 两市成交额 | {overview.total_amount:.0f} 亿 | {self._describe_turnover(overview.total_amount)} |",
         ]

--- a/src/market_analyzer.py
+++ b/src/market_analyzer.py
@@ -545,17 +545,30 @@ Focus on index trend, liquidity, and sector rotation to shape the next-session t
         if not has_stats:
             return ""
         if self._get_review_language() == "en":
-            return (
-                f"> 📈 Advancers **{overview.up_count}** / Decliners **{overview.down_count}** / "
-                f"Flat **{overview.flat_count}** | "
-                f"Limit-up **{overview.limit_up_count}** / Limit-down **{overview.limit_down_count}** | "
-                f"Turnover **{overview.total_amount:.0f}** ({self._get_turnover_unit_label()})"
+            light = self.build_market_light_snapshot(overview)
+            return "\n".join(
+                [
+                    f"> **Market Light**: {light['status']} ({light['label']}) | "
+                    f"**{light['score']}/100** {self._build_temperature_bar(light['score'])}",
+                    f"> **Reasons**: {'; '.join(light['reasons'])}",
+                    f"> **Guidance**: {light['guidance']}",
+                    "",
+                    f"> 📈 Advancers **{overview.up_count}** / Decliners **{overview.down_count}** / "
+                    f"Flat **{overview.flat_count}** | "
+                    f"Limit-up **{overview.limit_up_count}** / Limit-down **{overview.limit_down_count}** | "
+                    f"Turnover **{overview.total_amount:.0f}** ({self._get_turnover_unit_label()})",
+                ]
             )
-        score, label = self._build_market_temperature(overview)
+        light = self.build_market_light_snapshot(overview)
+        score, label = light["score"], light["temperature_label"]
         participation = overview.up_count + overview.down_count + overview.flat_count
         up_ratio = overview.up_count / participation if participation else 0.0
         limit_spread = overview.limit_up_count - overview.limit_down_count
         lines = [
+            f"> **大盘红绿灯**：{light['status']}（{light['label']}） | **{score}/100** {self._build_temperature_bar(score)}",
+            f"> **核心原因**：{'；'.join(light['reasons'])}",
+            f"> **操作建议**：{light['guidance']}",
+            "",
             f"> **盘面温度**：{label} **{score}/100** {self._build_temperature_bar(score)}",
             "",
             "| 指标 | 数值 | 观察 |",
@@ -565,6 +578,86 @@ Focus on index trend, liquidity, and sector rotation to shape the next-session t
             f"| 两市成交额 | {overview.total_amount:.0f} 亿 | {self._describe_turnover(overview.total_amount)} |",
         ]
         return "\n".join(lines)
+
+    def build_market_light_snapshot(self, overview: MarketOverview) -> Dict[str, Any]:
+        """Build a deterministic market-light snapshot from structured breadth data."""
+        score, temperature_label = self._build_market_temperature(overview)
+        if score >= 60:
+            status = "green"
+        elif score >= 40:
+            status = "yellow"
+        else:
+            status = "red"
+
+        if self._get_review_language() == "en":
+            label_map = {
+                "green": "constructive",
+                "yellow": "watch",
+                "red": "defensive",
+            }
+            guidance_map = {
+                "green": "Risk appetite is acceptable; focus on leading themes and position discipline.",
+                "yellow": "Signals are mixed; keep position sizing moderate and wait for confirmation.",
+                "red": "Risk is elevated; prioritize drawdown control and avoid chasing weak rebounds.",
+            }
+            reasons = self._build_market_light_reasons_en(overview, score)
+        else:
+            label_map = {
+                "green": "可进攻",
+                "yellow": "需观察",
+                "red": "偏防守",
+            }
+            guidance_map = {
+                "green": "风险偏好尚可，关注主线延续与仓位纪律。",
+                "yellow": "信号分化，控制仓位并等待量价确认。",
+                "red": "风险偏高，优先控制回撤，避免追高弱反弹。",
+            }
+            reasons = self._build_market_light_reasons_zh(overview, score)
+
+        return {
+            "status": status,
+            "label": label_map[status],
+            "score": score,
+            "temperature_label": temperature_label,
+            "reasons": reasons,
+            "guidance": guidance_map[status],
+        }
+
+    def _build_market_light_reasons_zh(self, overview: MarketOverview, score: int) -> List[str]:
+        participation = overview.up_count + overview.down_count
+        up_ratio = overview.up_count / participation if participation else None
+        reasons: List[str] = [f"盘面温度 {score}/100"]
+        if up_ratio is not None:
+            if up_ratio >= 0.6:
+                reasons.append(f"上涨家数占比 {up_ratio:.0%}，赚钱效应扩散")
+            elif up_ratio <= 0.4:
+                reasons.append(f"上涨家数占比 {up_ratio:.0%}，亏钱效应较强")
+            else:
+                reasons.append(f"上涨家数占比 {up_ratio:.0%}，市场分化")
+        if overview.indices:
+            avg_change = sum(idx.change_pct for idx in overview.indices) / len(overview.indices)
+            reasons.append(f"主要指数平均涨跌幅 {avg_change:+.2f}%")
+        if overview.limit_up_count or overview.limit_down_count:
+            reasons.append(f"涨跌停差 {overview.limit_up_count - overview.limit_down_count:+d}")
+        return reasons[:4]
+
+    def _build_market_light_reasons_en(self, overview: MarketOverview, score: int) -> List[str]:
+        participation = overview.up_count + overview.down_count
+        up_ratio = overview.up_count / participation if participation else None
+        reasons: List[str] = [f"market temperature {score}/100"]
+        if up_ratio is not None:
+            if up_ratio >= 0.6:
+                reasons.append(f"advancers ratio {up_ratio:.0%}, breadth is expanding")
+            elif up_ratio <= 0.4:
+                reasons.append(f"advancers ratio {up_ratio:.0%}, downside pressure dominates")
+            else:
+                reasons.append(f"advancers ratio {up_ratio:.0%}, breadth is mixed")
+        if overview.indices:
+            avg_change = sum(idx.change_pct for idx in overview.indices) / len(overview.indices)
+            reasons.append(f"average major-index change {avg_change:+.2f}%")
+        if overview.limit_up_count or overview.limit_down_count:
+            reasons.append(f"limit-up/down spread {overview.limit_up_count - overview.limit_down_count:+d}")
+        return reasons[:4]
 
     def _build_indices_block(self, overview: MarketOverview) -> str:
         """构建指数行情表格"""

--- a/tests/test_market_analyzer_generate_text.py
+++ b/tests/test_market_analyzer_generate_text.py
@@ -827,6 +827,10 @@ Sector text.
 
         result = ma._inject_data_into_review(review, overview, news)
 
+        assert "大盘红绿灯" in result
+        assert "green（可进攻）" in result
+        assert "核心原因" in result
+        assert "操作建议" in result
         assert "盘面温度" in result
         assert "| 上涨/下跌/平盘 | 3200 / 1800 / 100 |" in result
         assert "| 指数 | 最新 | 涨跌幅 | 开盘 | 最高 | 最低 | 振幅 | 成交额(亿) |" in result
@@ -835,6 +839,30 @@ Sector text.
         assert "| 1 | AI算力 | +3.25% |" in result
         assert "#### 近三日催化线索" in result
         assert "AI算力板块走强" in result
+
+    def test_market_light_snapshot_marks_defensive_market_red(self):
+        from src.market_analyzer import MarketIndex, MarketOverview
+
+        ma = self._make_market_analyzer_with_mock_generate_text(return_value="review")
+        overview = MarketOverview(
+            date="2026-03-06",
+            indices=[
+                MarketIndex(code="000001", name="上证指数", current=3200, change_pct=-1.8),
+                MarketIndex(code="399001", name="深证成指", current=9800, change_pct=-2.4),
+            ],
+            up_count=900,
+            down_count=4100,
+            limit_up_count=10,
+            limit_down_count=80,
+            total_amount=9800.0,
+        )
+
+        snapshot = ma.build_market_light_snapshot(overview)
+
+        assert snapshot["status"] == "red"
+        assert snapshot["label"] == "偏防守"
+        assert snapshot["score"] < 40
+        assert any("亏钱效应" in reason for reason in snapshot["reasons"])
 
     def test_us_english_indices_do_not_label_turnover_as_cny(self):
         from src.core.market_profile import US_PROFILE

--- a/tests/test_market_analyzer_generate_text.py
+++ b/tests/test_market_analyzer_generate_text.py
@@ -864,6 +864,37 @@ Sector text.
         assert snapshot["score"] < 40
         assert any("亏钱效应" in reason for reason in snapshot["reasons"])
 
+    def test_market_light_snapshot_uses_english_labels_and_reasons(self):
+        from src.market_analyzer import MarketIndex, MarketOverview
+
+        ma = self._make_market_analyzer_with_mock_generate_text(return_value="review")
+        ma.config.report_language = "en"
+        overview = MarketOverview(
+            date="2026-03-06",
+            indices=[
+                MarketIndex(code="000001", name="SSE Composite", current=3200, change_pct=-1.8),
+                MarketIndex(code="399001", name="SZSE Component", current=9800, change_pct=-2.4),
+            ],
+            up_count=900,
+            down_count=4100,
+            limit_up_count=10,
+            limit_down_count=80,
+            total_amount=9800.0,
+        )
+
+        snapshot = ma.build_market_light_snapshot(overview)
+
+        assert snapshot["status"] == "red"
+        assert snapshot["label"] == "defensive"
+        assert snapshot["guidance"] == (
+            "Risk is elevated; prioritize drawdown control and avoid chasing weak rebounds."
+        )
+        assert snapshot["reasons"][0].startswith("market temperature ")
+        assert any(
+            reason.startswith("advancers ratio ") and "downside pressure dominates" in reason
+            for reason in snapshot["reasons"]
+        )
+
     def test_us_english_indices_do_not_label_turnover_as_cny(self):
         from src.core.market_profile import US_PROFILE
         from src.core.market_strategy import get_market_strategy_blueprint


### PR DESCRIPTION
## Summary

Adds a deterministic market-light block to market review output, keeping the traffic-light conclusion inside the existing market review report.

## What Changed

- Builds a `green` / `yellow` / `red` market-light snapshot from the existing market temperature score.
- Adds core reasons and action guidance alongside the market-light result.
- Injects the block into Chinese market review reports and adds an English `Market Light` equivalent for English output.
- Keeps market light as part of the same market review report instead of creating a separate report type.
- Updates user docs, changelog, and focused market-review tests.

## User Impact

Users get a clear top-level market state conclusion in the same report they already receive, while later Web cards, Bot summaries, notifications, and alert rules can reuse the same structured result.

## Validation

- `python3 -m pytest tests/test_market_analyzer_generate_text.py::TestMarketAnalyzerBypassFix::test_inject_data_into_review_matches_reference_style_chinese_headings tests/test_market_analyzer_generate_text.py::TestMarketAnalyzerBypassFix::test_market_light_snapshot_marks_defensive_market_red -q` -> PASS, 2 tests passed
- `python3 -m py_compile src/market_analyzer.py` -> PASS
- `git diff --check` -> PASS

## Compatibility And Risk

- This changes market-review text content by adding a new block, but does not remove existing market temperature content.
- Scoring is deterministic and based on already available market overview data.

## Rollback

Revert this PR to remove the market-light block and return to the previous market temperature-only report block.