### PR TITLE
feat #1180: 补齐主流 LLM 渠道模板与 Actions 映射 P1

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -114,6 +114,50 @@ GEMINI_API_KEY=
 # LLM_CHANNELS=ollama
 # LLM_OLLAMA_BASE_URL=http://localhost:11434
 # LLM_OLLAMA_MODELS=qwen3:8b,llama3.2
+#
+# 更多主流渠道最小模板：
+# 多渠道组合时只保留一个 LLM_CHANNELS，并把渠道名合并，例如：
+# LLM_CHANNELS=dashscope,zhipu,minimax,ark
+# API_KEY 与 API_KEYS 二选一；多 Key 用 API_KEYS，若同时设置则 API_KEYS 优先。
+#
+# 阿里百炼 / DashScope（OpenAI 兼容模式）
+# LLM_CHANNELS=dashscope
+# LLM_DASHSCOPE_PROTOCOL=openai
+# LLM_DASHSCOPE_BASE_URL=https://dashscope.aliyuncs.com/compatible-mode/v1
+# LLM_DASHSCOPE_API_KEY=sk-xxx
+# LLM_DASHSCOPE_API_KEYS=key1,key2
+# LLM_DASHSCOPE_MODELS=qwen-plus,qwen-turbo
+#
+# 智谱 / Zhipu GLM（OpenAI 兼容模式）
+# LLM_CHANNELS=zhipu
+# LLM_ZHIPU_PROTOCOL=openai
+# LLM_ZHIPU_BASE_URL=https://open.bigmodel.cn/api/paas/v4/
+# LLM_ZHIPU_API_KEY=sk-xxx
+# LLM_ZHIPU_API_KEYS=key1,key2
+# LLM_ZHIPU_MODELS=glm-5.1,glm-4.7
+#
+# MiniMax LLM 渠道（不同于搜索服务 MINIMAX_API_KEYS）
+# LLM_CHANNELS=minimax
+# LLM_MINIMAX_PROTOCOL=openai
+# LLM_MINIMAX_BASE_URL=https://api.minimax.io/v1
+# LLM_MINIMAX_API_KEY=sk-xxx
+# LLM_MINIMAX_API_KEYS=key1,key2
+# LLM_MINIMAX_MODELS=minimax/MiniMax-M2.7
+#
+# 火山方舟 / Volcengine Ark（https://www.volcengine.com/docs/82379）
+# channel name 默认为 ark，GitHub Actions 默认 workflow 只映射 LLM_ARK_*
+# 如果你自定义 channel name（如 volcengine），需自行在 workflow env: 中扩展
+# LLM_CHANNELS=ark
+# LLM_ARK_PROTOCOL=openai
+# LLM_ARK_BASE_URL=https://ark.cn-beijing.volces.com/api/v3
+# LLM_ARK_API_KEY=sk-xxx
+# LLM_ARK_API_KEYS=key1,key2
+# LLM_ARK_MODELS=<your-endpoint-or-model-id>
+# 火山方舟的模型 / endpoint id、套餐类型和地域以控制台为准。
+#
+# 可选：按最终模型名指定主模型与 fallback。
+# LITELLM_MODEL=openai/qwen-plus
+# LITELLM_FALLBACK_MODELS=openai/glm-5.1,minimax/MiniMax-M2.7
 
 # 高级：模型路由 YAML 配置（可选，参考 litellm_config.example.yaml）
 # LITELLM_CONFIG=./litellm_config.yaml

--- a/.github/workflows/daily_analysis.yml
+++ b/.github/workflows/daily_analysis.yml
@@ -172,6 +172,38 @@ jobs:
           LLM_OLLAMA_ENABLED: ${{ vars.LLM_OLLAMA_ENABLED || secrets.LLM_OLLAMA_ENABLED }}
           LLM_OLLAMA_EXTRA_HEADERS: ${{ vars.LLM_OLLAMA_EXTRA_HEADERS || secrets.LLM_OLLAMA_EXTRA_HEADERS }}
 
+          LLM_DASHSCOPE_PROTOCOL: ${{ vars.LLM_DASHSCOPE_PROTOCOL || secrets.LLM_DASHSCOPE_PROTOCOL }}
+          LLM_DASHSCOPE_BASE_URL: ${{ vars.LLM_DASHSCOPE_BASE_URL || secrets.LLM_DASHSCOPE_BASE_URL }}
+          LLM_DASHSCOPE_API_KEY: ${{ secrets.LLM_DASHSCOPE_API_KEY }}
+          LLM_DASHSCOPE_API_KEYS: ${{ secrets.LLM_DASHSCOPE_API_KEYS }}
+          LLM_DASHSCOPE_MODELS: ${{ vars.LLM_DASHSCOPE_MODELS || secrets.LLM_DASHSCOPE_MODELS }}
+          LLM_DASHSCOPE_ENABLED: ${{ vars.LLM_DASHSCOPE_ENABLED || secrets.LLM_DASHSCOPE_ENABLED }}
+          LLM_DASHSCOPE_EXTRA_HEADERS: ${{ vars.LLM_DASHSCOPE_EXTRA_HEADERS || secrets.LLM_DASHSCOPE_EXTRA_HEADERS }}
+
+          LLM_ZHIPU_PROTOCOL: ${{ vars.LLM_ZHIPU_PROTOCOL || secrets.LLM_ZHIPU_PROTOCOL }}
+          LLM_ZHIPU_BASE_URL: ${{ vars.LLM_ZHIPU_BASE_URL || secrets.LLM_ZHIPU_BASE_URL }}
+          LLM_ZHIPU_API_KEY: ${{ secrets.LLM_ZHIPU_API_KEY }}
+          LLM_ZHIPU_API_KEYS: ${{ secrets.LLM_ZHIPU_API_KEYS }}
+          LLM_ZHIPU_MODELS: ${{ vars.LLM_ZHIPU_MODELS || secrets.LLM_ZHIPU_MODELS }}
+          LLM_ZHIPU_ENABLED: ${{ vars.LLM_ZHIPU_ENABLED || secrets.LLM_ZHIPU_ENABLED }}
+          LLM_ZHIPU_EXTRA_HEADERS: ${{ vars.LLM_ZHIPU_EXTRA_HEADERS || secrets.LLM_ZHIPU_EXTRA_HEADERS }}
+
+          LLM_MINIMAX_PROTOCOL: ${{ vars.LLM_MINIMAX_PROTOCOL || secrets.LLM_MINIMAX_PROTOCOL }}
+          LLM_MINIMAX_BASE_URL: ${{ vars.LLM_MINIMAX_BASE_URL || secrets.LLM_MINIMAX_BASE_URL }}
+          LLM_MINIMAX_API_KEY: ${{ secrets.LLM_MINIMAX_API_KEY }}
+          LLM_MINIMAX_API_KEYS: ${{ secrets.LLM_MINIMAX_API_KEYS }}
+          LLM_MINIMAX_MODELS: ${{ vars.LLM_MINIMAX_MODELS || secrets.LLM_MINIMAX_MODELS }}
+          LLM_MINIMAX_ENABLED: ${{ vars.LLM_MINIMAX_ENABLED || secrets.LLM_MINIMAX_ENABLED }}
+          LLM_MINIMAX_EXTRA_HEADERS: ${{ vars.LLM_MINIMAX_EXTRA_HEADERS || secrets.LLM_MINIMAX_EXTRA_HEADERS }}
+
+          LLM_ARK_PROTOCOL: ${{ vars.LLM_ARK_PROTOCOL || secrets.LLM_ARK_PROTOCOL }}
+          LLM_ARK_BASE_URL: ${{ vars.LLM_ARK_BASE_URL || secrets.LLM_ARK_BASE_URL }}
+          LLM_ARK_API_KEY: ${{ secrets.LLM_ARK_API_KEY }}
+          LLM_ARK_API_KEYS: ${{ secrets.LLM_ARK_API_KEYS }}
+          LLM_ARK_MODELS: ${{ vars.LLM_ARK_MODELS || secrets.LLM_ARK_MODELS }}
+          LLM_ARK_ENABLED: ${{ vars.LLM_ARK_ENABLED || secrets.LLM_ARK_ENABLED }}
+          LLM_ARK_EXTRA_HEADERS: ${{ vars.LLM_ARK_EXTRA_HEADERS || secrets.LLM_ARK_EXTRA_HEADERS }}
+
           # ==========================================
           # 数据源
           # ==========================================

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - [修复] 统一持仓快照输出现价/市值/浮盈亏/收益率与价格元信息，并为 LLM 渠道测试补充结构化诊断与设置页排障提示。
 - [文档] 补充 LLM 渠道编辑器的官方来源、依赖兼容窗口、保存时的运行时模型清理规则，以及旧配置回退路径说明。
 - [测试] 补齐 task_queue 运行时配置同步回归证据，明确 `tests/test_task_queue_config_sync.py` 作为本轮验收项。
+- [改进] 补齐主流 LLM 渠道的 .env 模板与 GitHub Actions 变量映射，覆盖 DashScope、智谱、MiniMax 和火山方舟等渠道。
 
 ## [3.14.2] - 2026-04-30
 

--- a/docs/LLM_CONFIG_GUIDE.md
+++ b/docs/LLM_CONFIG_GUIDE.md
@@ -99,7 +99,27 @@ LITELLM_MODEL=ollama/qwen3:8b
 - Moonshot / Kimi 官方：<https://platform.moonshot.ai/docs/guide/compatibility>
 - Anthropic 官方：<https://docs.anthropic.com/en/api/messages>
 - Gemini 官方：<https://ai.google.dev/gemini-api/docs/openai>
+- 智谱 OpenAI API 兼容：<https://docs.bigmodel.cn/cn/guide/develop/openai/introduction>
+- MiniMax OpenAI Compatible API：<https://platform.minimax.io/docs/api-reference/text-openai-api>
+- 火山方舟 Base URL / 鉴权：<https://www.volcengine.com/docs/82379/1298459?lang=zh>；OpenAI SDK 兼容：<https://www.volcengine.com/docs/82379/1330626?lang=zh>
 - Ollama 官方：<https://github.com/ollama/ollama/blob/main/docs/api.md>
+
+### 常用 Provider 模板速查
+
+下表只给出通用模板和官方来源可验证的边界。JSON 输出、tool calling、vision、stream 的支持经常与具体模型、套餐、region 或兼容模式有关；不确定时请以厂商官方最新文档和你实际启用的模型说明为准。
+
+| 渠道 | 推荐 channel id | protocol | Base URL 示例 | 模型示例 | 能力说明 |
+| --- | --- | --- | --- | --- | --- |
+| OpenAI 官方 | `openai` | `openai` | `https://api.openai.com/v1` | `gpt-4o-mini` | JSON / tools / vision / stream 取决于具体 OpenAI 模型能力。 |
+| DeepSeek 官方 | `deepseek` | `deepseek` | `https://api.deepseek.com` | `deepseek-v4-flash` | 文本与 stream 走 DeepSeek 官方协议；JSON / tools 按官方模型说明验证。 |
+| Gemini 官方 | `gemini` | `gemini` | 通常不需要 Base URL | `gemini-2.5-flash` | Gemini key 直连支持 vision / stream；OpenAI compatible 用法请单独核对 Google 官方兼容文档。 |
+| Claude / Anthropic | `anthropic` | `anthropic` | 通常不需要 Base URL | `claude-3-5-sonnet-20241022` | Messages API 支持 stream 和部分 vision 模型；tools / JSON 按 Anthropic 模型能力确认。 |
+| Kimi / Moonshot | `moonshot` | `openai` | `https://api.moonshot.ai/v1` | `kimi-k2.6` | OpenAI 兼容；`kimi-k2.6` 有 thinking / non-thinking temperature 约束，见上文说明。 |
+| Qwen / DashScope | `dashscope` | `openai` | `https://dashscope.aliyuncs.com/compatible-mode/v1` | `qwen-plus` | 官方兼容文档提供非流式、stream 和 function call 示例；tools 与 stream 组合限制按官方文档确认。 |
+| 智谱 GLM | `zhipu` | `openai` | `https://open.bigmodel.cn/api/paas/v4/` | `glm-5.1` | 官方 OpenAI 兼容文档给出 stream、tools、图像理解示例；能力随 GLM 模型变化。 |
+| MiniMax | `minimax` | `openai` | `https://api.minimax.io/v1` | `minimax/MiniMax-M2.7` | 官方 OpenAI compatible 文档提供 stream 与 tool use 示例；图像 / 音频输入并非所有 OpenAI compatible 文本模型都支持。 |
+| 火山方舟 / Ark | `ark` | `openai` | `https://ark.cn-beijing.volces.com/api/v3` | `<your-endpoint-or-model-id>` | Base URL、region、套餐类型和模型 / endpoint id 以控制台与官方文档为准；结构化输出、vision、tools、stream 均需按启用模型验证。 |
+| Ollama | `ollama` | `ollama` | `http://localhost:11434` | `qwen3:8b` | 本地模型无需 API Key；避免误用 `OPENAI_BASE_URL`，能力由本地模型决定。 |
 
 如果不方便用网页版，在 `.env` 文件中配置也非常丝滑，它能让你同时管理多个第三方平台。规则如下：
 
@@ -147,6 +167,7 @@ LITELLM_MODEL=ollama/qwen3:8b
 
 - 如果你通过 OpenAI Compatible 渠道接 MiniMax，请在渠道模型里直接填写 `minimax/<模型名>`，例如 `minimax/MiniMax-M1`。
 - Web 设置页里的主模型、Agent 主模型、Fallback、Vision 下拉会保留这个值原样展示，不会再错误改写成 `openai/minimax/<模型名>`。
+- `LLM_MINIMAX_API_KEY` / `LLM_MINIMAX_API_KEYS` 用于 LLM 渠道；搜索服务使用的是 `MINIMAX_API_KEYS`，两者不要混用。
 
 ### 问股 Agent / LiteLLM 配置兼容说明
 
@@ -233,10 +254,46 @@ model_list:
 
 - 运行时选择：`LLM_CHANNELS`、`LITELLM_MODEL`、`LITELLM_FALLBACK_MODELS`、`AGENT_LITELLM_MODEL`、`VISION_MODEL`、`VISION_PROVIDER_PRIORITY`、`LLM_TEMPERATURE`
 - 多 Key：`GEMINI_API_KEYS`、`ANTHROPIC_API_KEYS`、`OPENAI_API_KEYS`、`DEEPSEEK_API_KEYS`（当前 workflow 仅从 repository secrets 导入，不会读取同名 Variables）
-- 常用渠道名：`primary`、`secondary`、`gemini`、`deepseek`、`aihubmix`、`openai`、`anthropic`、`moonshot`、`ollama`
+- 常用渠道名：`primary`、`secondary`、`gemini`、`deepseek`、`aihubmix`、`openai`、`anthropic`、`moonshot`、`ollama`、`dashscope`、`zhipu`、`minimax`、`ark`
 
 例如在 GitHub Actions 中配置 `LLM_CHANNELS=primary,deepseek` 时，需同步配置 `LLM_PRIMARY_*` / `LLM_DEEPSEEK_*`。其中 `LLM_<NAME>_API_KEY` / `LLM_<NAME>_API_KEYS` 当前也仅从 repository secrets 导入；如果你把这些值放在 Variables，运行时不会生效。若使用自定义渠道名（如 `my_proxy`），GitHub Actions 还必须在 workflow `env:` 中显式新增对应的 `LLM_MY_PROXY_*` 映射；本地 `.env` 和 Docker 不受这个限制。
 
+常用 Actions 配置示例：
+
+```text
+# DashScope / 智谱：非敏感字段可以放 Variables，API Key 必须放 Secrets
+Variables:
+  LLM_CHANNELS=dashscope,zhipu
+  LLM_DASHSCOPE_PROTOCOL=openai
+  LLM_DASHSCOPE_BASE_URL=https://dashscope.aliyuncs.com/compatible-mode/v1
+  LLM_DASHSCOPE_MODELS=qwen-plus
+  LLM_ZHIPU_PROTOCOL=openai
+  LLM_ZHIPU_BASE_URL=https://open.bigmodel.cn/api/paas/v4/
+  LLM_ZHIPU_MODELS=glm-5.1
+Secrets:
+  LLM_DASHSCOPE_API_KEY=sk-xxx
+  LLM_ZHIPU_API_KEY=sk-xxx
+
+# MiniMax LLM 渠道：不要和搜索服务 MINIMAX_API_KEYS 混用
+Variables:
+  LLM_CHANNELS=minimax
+  LLM_MINIMAX_PROTOCOL=openai
+  LLM_MINIMAX_BASE_URL=https://api.minimax.io/v1
+  LLM_MINIMAX_MODELS=minimax/MiniMax-M2.7
+Secrets:
+  LLM_MINIMAX_API_KEY=sk-xxx
+
+# 火山方舟 / Volcengine Ark：默认 workflow 只映射 LLM_ARK_*
+Variables:
+  LLM_CHANNELS=ark
+  LLM_ARK_PROTOCOL=openai
+  LLM_ARK_BASE_URL=https://ark.cn-beijing.volces.com/api/v3
+  LLM_ARK_MODELS=<your-endpoint-or-model-id>
+Secrets:
+  LLM_ARK_API_KEY=sk-xxx
+```
+
+火山方舟的 `ark` 是本仓库推荐的默认 channel id，用于匹配 `daily_analysis.yml` 已显式透传的 `LLM_ARK_*`。如果你把 channel 改成 `volcengine` 或其他名字，本地 `.env` 仍可工作，但 GitHub Actions 需要自己在 workflow `env:` 中新增 `LLM_VOLCENGINE_*` 或对应前缀映射。
 
 > **三层配置互斥准则**：YAML 优先级最高！只要配置了 YAML，**渠道模式** 和 **新手极简模式** 统统被忽略。系统优先级为：`YAML配置 > 渠道模式 > 极简单模型`。
 

--- a/docs/LLM_CONFIG_GUIDE_EN.md
+++ b/docs/LLM_CONFIG_GUIDE_EN.md
@@ -99,7 +99,27 @@ The backend exposes a read-only status endpoint at `GET /api/v1/system/config/se
 - Moonshot / Kimi official compatibility docs: <https://platform.moonshot.ai/docs/guide/compatibility>
 - Anthropic official Messages API: <https://docs.anthropic.com/en/api/messages>
 - Gemini official OpenAI compatibility docs: <https://ai.google.dev/gemini-api/docs/openai>
+- Zhipu OpenAI API compatibility: <https://docs.bigmodel.cn/cn/guide/develop/openai/introduction>
+- MiniMax OpenAI Compatible API: <https://platform.minimax.io/docs/api-reference/text-openai-api>
+- Volcengine Ark Base URL / authentication: <https://www.volcengine.com/docs/82379/1298459?lang=zh>; OpenAI SDK compatibility: <https://www.volcengine.com/docs/82379/1330626?lang=zh>
 - Ollama API docs: <https://github.com/ollama/ollama/blob/main/docs/api.md>
+
+### Common Provider Template Reference
+
+This table only provides generic templates and boundaries that can be checked against official documentation. JSON output, tool calling, vision, and streaming support often depend on the exact model, plan, region, or compatibility mode. When in doubt, follow the provider's latest official docs and the model you enabled.
+
+| Provider | Recommended channel id | protocol | Base URL example | Sample model | Capability notes |
+| --- | --- | --- | --- | --- | --- |
+| OpenAI official | `openai` | `openai` | `https://api.openai.com/v1` | `gpt-4o-mini` | JSON / tools / vision / stream depend on the specific OpenAI model. |
+| DeepSeek official | `deepseek` | `deepseek` | `https://api.deepseek.com` | `deepseek-v4-flash` | Text and streaming use DeepSeek's official protocol; verify JSON / tools against the specific model docs. |
+| Gemini official | `gemini` | `gemini` | Usually not required | `gemini-2.5-flash` | Direct Gemini keys support vision / stream; check Google's compatibility docs before using OpenAI-compatible mode. |
+| Claude / Anthropic | `anthropic` | `anthropic` | Usually not required | `claude-3-5-sonnet-20241022` | Messages API supports streaming and some vision models; tools / JSON depend on Anthropic model capabilities. |
+| Kimi / Moonshot | `moonshot` | `openai` | `https://api.moonshot.ai/v1` | `kimi-k2.6` | OpenAI compatible; `kimi-k2.6` has thinking / non-thinking temperature constraints documented above. |
+| Qwen / DashScope | `dashscope` | `openai` | `https://dashscope.aliyuncs.com/compatible-mode/v1` | `qwen-plus` | Official compatibility docs include non-streaming, streaming, and function calling examples; verify tool + stream combinations in provider docs. |
+| Zhipu GLM | `zhipu` | `openai` | `https://open.bigmodel.cn/api/paas/v4/` | `glm-5.1` | Official OpenAI-compatible docs include streaming, tools, and image-understanding examples; capabilities vary by GLM model. |
+| MiniMax | `minimax` | `openai` | `https://api.minimax.io/v1` | `minimax/MiniMax-M2.7` | Official OpenAI-compatible docs include streaming and tool-use examples; image / audio input is not supported by every text model in that mode. |
+| Volcengine Ark | `ark` | `openai` | `https://ark.cn-beijing.volces.com/api/v3` | `<your-endpoint-or-model-id>` | Base URL, region, plan type, and model / endpoint id must match the Ark console and official docs; validate structured output, vision, tools, and stream per enabled model. |
+| Ollama | `ollama` | `ollama` | `http://localhost:11434` | `qwen3:8b` | Local models require no API key; avoid using `OPENAI_BASE_URL`; capabilities depend on the local model. |
 
 If you prefer modifying files, configuring this in the `.env` file is also very smooth. It allows you to manage multiple platforms simultaneously. The rules are:
 
@@ -147,6 +167,7 @@ LITELLM_MODEL=ollama/qwen3:8b
 
 - If you access MiniMax through an OpenAI-compatible channel, enter the model as `minimax/<model-name>` in the channel model list, for example `minimax/MiniMax-M1`.
 - The Web settings page now keeps that value unchanged in Primary, Agent Primary, Fallback, and Vision selectors instead of rewriting it to `openai/minimax/<model-name>`.
+- `LLM_MINIMAX_API_KEY` / `LLM_MINIMAX_API_KEYS` are for the LLM channel. The search provider uses `MINIMAX_API_KEYS`; do not mix the two.
 
 ### Ask-Stock Agent / LiteLLM compatibility notes
 
@@ -210,9 +231,46 @@ The bundled `daily_analysis.yml` explicitly passes the common LLM runtime fields
 
 - Runtime selection: `LLM_CHANNELS`, `LITELLM_MODEL`, `LITELLM_FALLBACK_MODELS`, `AGENT_LITELLM_MODEL`, `VISION_MODEL`, `VISION_PROVIDER_PRIORITY`, `LLM_TEMPERATURE`
 - Multiple keys: `GEMINI_API_KEYS`, `ANTHROPIC_API_KEYS`, `OPENAI_API_KEYS`, `DEEPSEEK_API_KEYS` (the current workflow imports these from repository Secrets only, not from same-named Variables)
-- Common channel names: `primary`, `secondary`, `gemini`, `deepseek`, `aihubmix`, `openai`, `anthropic`, `moonshot`, `ollama`
+- Common channel names: `primary`, `secondary`, `gemini`, `deepseek`, `aihubmix`, `openai`, `anthropic`, `moonshot`, `ollama`, `dashscope`, `zhipu`, `minimax`, `ark`
 
 For example, if you set `LLM_CHANNELS=primary,deepseek` in GitHub Actions, also configure the corresponding `LLM_PRIMARY_*` and `LLM_DEEPSEEK_*` entries. The `LLM_<NAME>_API_KEY` / `LLM_<NAME>_API_KEYS` fields are also imported from repository Secrets only right now, so storing them in Variables will not work at runtime. If you use a custom channel name such as `my_proxy`, GitHub Actions must explicitly add matching `LLM_MY_PROXY_*` mappings in the workflow `env:` block. Local `.env` and Docker runs do not have this limitation.
+
+Common Actions examples:
+
+```text
+# DashScope / Zhipu: non-sensitive fields can use Variables; API keys must use Secrets
+Variables:
+  LLM_CHANNELS=dashscope,zhipu
+  LLM_DASHSCOPE_PROTOCOL=openai
+  LLM_DASHSCOPE_BASE_URL=https://dashscope.aliyuncs.com/compatible-mode/v1
+  LLM_DASHSCOPE_MODELS=qwen-plus
+  LLM_ZHIPU_PROTOCOL=openai
+  LLM_ZHIPU_BASE_URL=https://open.bigmodel.cn/api/paas/v4/
+  LLM_ZHIPU_MODELS=glm-5.1
+Secrets:
+  LLM_DASHSCOPE_API_KEY=sk-xxx
+  LLM_ZHIPU_API_KEY=sk-xxx
+
+# MiniMax LLM channel: do not mix it with the search-service MINIMAX_API_KEYS
+Variables:
+  LLM_CHANNELS=minimax
+  LLM_MINIMAX_PROTOCOL=openai
+  LLM_MINIMAX_BASE_URL=https://api.minimax.io/v1
+  LLM_MINIMAX_MODELS=minimax/MiniMax-M2.7
+Secrets:
+  LLM_MINIMAX_API_KEY=sk-xxx
+
+# Volcengine Ark: the bundled workflow only maps LLM_ARK_* by default
+Variables:
+  LLM_CHANNELS=ark
+  LLM_ARK_PROTOCOL=openai
+  LLM_ARK_BASE_URL=https://ark.cn-beijing.volces.com/api/v3
+  LLM_ARK_MODELS=<your-endpoint-or-model-id>
+Secrets:
+  LLM_ARK_API_KEY=sk-xxx
+```
+
+`ark` is this repository's recommended default channel id for Volcengine Ark because it matches the `LLM_ARK_*` variables explicitly passed by `daily_analysis.yml`. If you rename the channel to `volcengine` or anything else, local `.env` still works, but GitHub Actions must add matching `LLM_VOLCENGINE_*` or equivalent mappings in the workflow `env:` block.
 
 ---
 


### PR DESCRIPTION
## PR Type

- [ ] fix
- [x] feat
- [ ] refactor
- [x] docs
- [ ] chore
- [ ] test

## Background And Problem

Issue #1180 的 P1 目标是补齐 LLM 配置中心的可复制模板、GitHub Actions 变量映射和文档说明。当前本地 `.env` 可以配置任意 `LLM_CHANNELS`，但 GitHub Actions 不会自动导入任意 Secrets / Variables；DashScope、智谱、MiniMax、火山方舟等常见渠道缺少默认 workflow 映射和清晰示例，容易出现本地可用、云端不生效。

## Scope Of Change

- 更新 `.env.example`：新增 `dashscope`、`zhipu`、`minimax`、`ark` 的最小渠道模板，补充 `API_KEY` / `API_KEYS` 优先级、Ark channel id 说明和主模型 / fallback 示例。
- 更新 `.github/workflows/daily_analysis.yml`：显式透传四组 `LLM_<CHANNEL>_*` 字段，API Key 仅从 Secrets 读取，非敏感字段沿用 `vars || secrets`。
- 更新 `docs/LLM_CONFIG_GUIDE.md` / `docs/LLM_CONFIG_GUIDE_EN.md`：补充官方来源、provider 速查表、Actions 示例、MiniMax LLM Key 与搜索 Key 区分，以及 Ark 自定义 channel 的 workflow 限制。
- 更新 `docs/CHANGELOG.md`：追加 `[Unreleased]` 扁平改进条目。

本 PR 不修改 Web preset、后端检测接口、LiteLLM 路由、配置优先级、运行时 fallback、API schema 或配置检查 echo 区块。

## Issue Link

Refs #1180

## Verification Commands And Results

```bash
git diff --check
python -c "import yaml; from pathlib import Path; yaml.safe_load(Path('.github/workflows/daily_analysis.yml').read_text()); print('daily_analysis.yml parsed')"
python -m pytest tests/test_llm_channel_config.py tests/test_config_env_compat.py -q
PATH=/opt/homebrew/Caskroom/miniconda/base/bin:$PATH ./scripts/ci_gate.sh
```

关键输出/结论 / Key output & conclusion:

- `git diff --check` 通过。
- `daily_analysis.yml parsed`。
- `tests/test_llm_channel_config.py tests/test_config_env_compat.py`：`42 passed`。
- `./scripts/ci_gate.sh` 完整通过：
  - Python syntax check passed
  - flake8 critical checks passed (`0`)
  - deterministic checks passed
  - offline test suite: `1631 passed, 2 deselected, 52 warnings, 127 subtests passed in 56.66s`
  - `==> backend-gate: all checks passed`

## Compatibility And Risk

- 兼容性影响：纯追加 `.env` 模板、文档和 workflow env 映射，不改变运行时配置解析、请求参数、路由前缀、provider fallback 或配置优先级。
- 旧配置影响：未配置新增 Secrets / Variables 时新增 env 值为空，不影响现有 Actions 用户；不需要 migration，不会自动改写、清空或迁移用户 `.env`。
- Secrets / Variables：`LLM_<CHANNEL>_API_KEY(S)` 仅从 repository Secrets 读取；非敏感字段沿用 `vars || secrets`。
- 官方来源：
  - DashScope OpenAI 兼容模式：https://help.aliyun.com/zh/model-studio/compatibility-of-openai-with-dashscope
  - 智谱 OpenAI API 兼容：https://docs.bigmodel.cn/cn/guide/develop/openai/introduction
  - MiniMax OpenAI Compatible API：https://platform.minimax.io/docs/api-reference/text-openai-api
  - 火山方舟 Base URL / 鉴权：https://www.volcengine.com/docs/82379/1298459?lang=zh
  - 火山方舟 OpenAI SDK 兼容：https://www.volcengine.com/docs/82379/1330626?lang=zh
- 风险：厂商模型名、套餐、region、endpoint id 和能力矩阵可能随官方文档变化；文档中已说明能力需按官方最新文档和具体启用模型验证。GitHub Actions 真实运行仍以 PR CI / 用户 Secrets 配置为准。

## Rollback Plan

最小回滚方式是 revert this PR。若只需临时规避 workflow 影响，可删除 `.github/workflows/daily_analysis.yml` 中新增的四组 `LLM_DASHSCOPE_*`、`LLM_ZHIPU_*`、`LLM_MINIMAX_*`、`LLM_ARK_*` env 映射；`.env.example` 和文档改动不影响运行时，无需数据或配置迁移。

## EXTRACT_PROMPT Change (if applicable)

未修改 `src/services/image_stock_extractor.py` 中的 `EXTRACT_PROMPT`。

<details>
<summary>展开 / Expand: Full EXTRACT_PROMPT</summary>

```text
N/A
```

</details>

## Checklist

- [x] 本 PR 有明确动机和业务价值 / This PR has a clear motivation and value
- [x] 已提供可复现的验证命令与结果 / Reproducible verification commands and results are included
- [x] 已评估兼容性与风险 / Compatibility and risk have been assessed
- [x] 已提供回滚方案 / A rollback plan is provided
- [x] 若涉及用户可见变更，已同步更新相关文档与 `docs/CHANGELOG.md`；`README.md` 仅在首页级信息变化时更新，细节优先写入 `docs/*.md` / If user-visible changes are included, relevant docs and `docs/CHANGELOG.md` are updated; `README.md` is updated only for homepage-level changes, with details kept in `docs/*.md`
