### PR TITLE
chore: 抽出 Web LLM provider template P0 真源 (#1180)

### DIFF
--- a/apps/dsa-web/src/components/settings/LLMChannelEditor.tsx
+++ b/apps/dsa-web/src/components/settings/LLMChannelEditor.tsx
@@ -4,102 +4,12 @@ import type { ParsedApiError } from '../../api/error';
 import { getParsedApiError } from '../../api/error';
 import { systemConfigApi } from '../../api/systemConfig';
 import { ApiErrorAlert, Badge, Button, InlineAlert, Input, Select, StatusDot, Tooltip } from '../common';
-
-type ChannelProtocol = 'openai' | 'deepseek' | 'gemini' | 'anthropic' | 'vertex_ai' | 'ollama';
-
-interface ChannelPreset {
-  label: string;
-  protocol: ChannelProtocol;
-  baseUrl: string;
-  placeholder: string;
-}
-
-const CHANNEL_PRESETS: Record<string, ChannelPreset> = {
-  aihubmix: {
-    label: 'AIHubmix（聚合平台）',
-    protocol: 'openai',
-    baseUrl: 'https://aihubmix.com/v1',
-    placeholder: 'gpt-5.5,claude-sonnet-4-6,gemini-3.1-pro-preview',
-  },
-  deepseek: {
-    label: 'DeepSeek 官方',
-    protocol: 'deepseek',
-    baseUrl: 'https://api.deepseek.com',
-    placeholder: 'deepseek-v4-flash,deepseek-v4-pro',
-  },
-  dashscope: {
-    label: '通义千问（Dashscope）',
-    protocol: 'openai',
-    baseUrl: 'https://dashscope.aliyuncs.com/compatible-mode/v1',
-    placeholder: 'qwen3.6-plus,qwen3.6-flash',
-  },
-  zhipu: {
-    label: '智谱 GLM',
-    protocol: 'openai',
-    baseUrl: 'https://open.bigmodel.cn/api/paas/v4',
-    placeholder: 'glm-5.1,glm-4.7-flash',
-  },
-  moonshot: {
-    label: 'Moonshot（月之暗面）',
-    protocol: 'openai',
-    baseUrl: 'https://api.moonshot.cn/v1',
-    placeholder: 'kimi-k2.6,kimi-k2.5',
-  },
-  minimax: {
-    label: 'MiniMax 官方',
-    protocol: 'openai',
-    baseUrl: 'https://api.minimax.io/v1',
-    placeholder: 'MiniMax-M2.7,MiniMax-M2.7-highspeed',
-  },
-  volcengine: {
-    label: '火山方舟（豆包）',
-    protocol: 'openai',
-    baseUrl: 'https://ark.cn-beijing.volces.com/api/v3',
-    placeholder: 'doubao-seed-1-6-251015,doubao-seed-1-6-thinking-251015',
-  },
-  siliconflow: {
-    label: '硅基流动（SiliconFlow）',
-    protocol: 'openai',
-    baseUrl: 'https://api.siliconflow.cn/v1',
-    placeholder: 'deepseek-ai/DeepSeek-V3.2,Qwen/Qwen3-235B-A22B-Thinking-2507',
-  },
-  openrouter: {
-    label: 'OpenRouter',
-    protocol: 'openai',
-    baseUrl: 'https://openrouter.ai/api/v1',
-    placeholder: '~openai/gpt-latest,~anthropic/claude-sonnet-latest',
-  },
-  gemini: {
-    label: 'Gemini 官方',
-    protocol: 'gemini',
-    baseUrl: '',
-    placeholder: 'gemini-3.1-pro-preview,gemini-3-flash-preview',
-  },
-  anthropic: {
-    label: 'Anthropic 官方',
-    protocol: 'anthropic',
-    baseUrl: '',
-    placeholder: 'claude-sonnet-4-6,claude-opus-4-7',
-  },
-  openai: {
-    label: 'OpenAI 官方',
-    protocol: 'openai',
-    baseUrl: 'https://api.openai.com/v1',
-    placeholder: 'gpt-5.5,gpt-5.4-mini',
-  },
-  ollama: {
-    label: 'Ollama（本地）',
-    protocol: 'ollama',
-    baseUrl: 'http://127.0.0.1:11434',
-    placeholder: 'llama3.2,qwen2.5',
-  },
-  custom: {
-    label: '自定义渠道',
-    protocol: 'openai',
-    baseUrl: '',
-    placeholder: 'model-name-1,model-name-2',
-  },
-};
+import type { ChannelProtocol } from './llmProviderTemplates';
+import {
+  LLM_PROVIDER_TEMPLATE_BY_ID,
+  LLM_PROVIDER_TEMPLATES,
+  MODEL_PLACEHOLDERS_BY_PROTOCOL,
+} from './llmProviderTemplates';
 
 const PROTOCOL_OPTIONS: Array<{ value: ChannelProtocol; label: string }> = [
   { value: 'openai', label: 'OpenAI Compatible' },
@@ -109,15 +19,6 @@ const PROTOCOL_OPTIONS: Array<{ value: ChannelProtocol; label: string }> = [
   { value: 'vertex_ai', label: 'Vertex AI' },
   { value: 'ollama', label: 'Ollama' },
 ];
-
-const MODEL_PLACEHOLDERS: Record<ChannelProtocol, string> = {
-  openai: 'gpt-5.5,qwen3.6-plus',
-  deepseek: 'deepseek-v4-flash,deepseek-v4-pro',
-  gemini: 'gemini-3.1-pro-preview,gemini-3-flash-preview',
-  anthropic: 'claude-sonnet-4-6,claude-opus-4-7',
-  vertex_ai: 'gemini-3.1-pro-preview',
-  ollama: 'llama3.2,qwen2.5',
-};
 
 const KNOWN_MODEL_PREFIXES = new Set([
   'openai',
@@ -215,7 +116,7 @@ const ChannelRow: React.FC<ChannelRowProps> = ({
   onTest,
   onDiscoverModels,
 }) => {
-  const preset = CHANNEL_PRESETS[channel.name];
+  const preset = LLM_PROVIDER_TEMPLATE_BY_ID[channel.name];
   const displayName = preset?.label || channel.name;
   const selectedModels = splitModels(channel.models);
   const discoveredModels = discoveryState?.models || [];
@@ -421,7 +322,7 @@ const ChannelRow: React.FC<ChannelRowProps> = ({
               value={channel.models}
               disabled={busy}
               onChange={(e) => onUpdate(index, 'models', e.target.value)}
-              placeholder={preset?.placeholder || MODEL_PLACEHOLDERS[channel.protocol]}
+              placeholder={preset?.placeholderModels || MODEL_PLACEHOLDERS_BY_PROTOCOL[channel.protocol]}
               hint={
                 discoveredModels.length > 0
                   ? '如有自定义模型名未出现在列表中，可继续手动补充，保存格式仍为逗号分隔。'
@@ -991,15 +892,15 @@ export const LLMChannelEditor: React.FC<LLMChannelEditorProps> = ({
       const updated = { ...channel, [field]: value };
 
       if (field === 'name' && typeof value === 'string') {
-        const newPreset = CHANNEL_PRESETS[value];
+        const newPreset = LLM_PROVIDER_TEMPLATE_BY_ID[value];
         if (newPreset) {
-          const oldPreset = CHANNEL_PRESETS[channel.name];
+          const oldPreset = LLM_PROVIDER_TEMPLATE_BY_ID[channel.name];
           if (!updated.baseUrl || updated.baseUrl === (oldPreset?.baseUrl ?? '')) {
             updated.baseUrl = newPreset.baseUrl;
           }
           updated.protocol = newPreset.protocol;
-          if (!updated.models || updated.models === (oldPreset?.placeholder ?? '')) {
-            updated.models = newPreset.placeholder;
+          if (!updated.models || updated.models === (oldPreset?.placeholderModels ?? '')) {
+            updated.models = newPreset.placeholderModels;
           }
         }
       }
@@ -1050,7 +951,7 @@ export const LLMChannelEditor: React.FC<LLMChannelEditorProps> = ({
   };
 
   const addChannel = () => {
-    const preset = CHANNEL_PRESETS[addPreset] || CHANNEL_PRESETS.custom;
+    const preset = LLM_PROVIDER_TEMPLATE_BY_ID[addPreset] || LLM_PROVIDER_TEMPLATE_BY_ID.custom;
     setChannels((previous) => {
       const existingNames = new Set(previous.map((channel) => channel.name));
       const baseName = addPreset === 'custom' ? 'custom' : addPreset;
@@ -1069,7 +970,7 @@ export const LLMChannelEditor: React.FC<LLMChannelEditorProps> = ({
           protocol: preset.protocol,
           baseUrl: preset.baseUrl,
           apiKey: '',
-          models: preset.placeholder || '',
+          models: preset.placeholderModels || '',
           enabled: true,
         },
       ];
@@ -1313,8 +1214,8 @@ export const LLMChannelEditor: React.FC<LLMChannelEditorProps> = ({
               <Select
                 value={addPreset}
                 onChange={setAddPreset}
-                options={Object.entries(CHANNEL_PRESETS).map(([value, preset]) => ({
-                  value,
+                options={LLM_PROVIDER_TEMPLATES.map((preset) => ({
+                  value: preset.channelId,
                   label: preset.label,
                 }))}
                 disabled={busy}

--- a/apps/dsa-web/src/components/settings/__tests__/LLMChannelEditor.test.tsx
+++ b/apps/dsa-web/src/components/settings/__tests__/LLMChannelEditor.test.tsx
@@ -146,6 +146,65 @@ describe('LLMChannelEditor', () => {
     expect(screen.getByLabelText('模型（逗号分隔）')).toHaveValue(models);
   });
 
+  it('preserves manually edited base URL and models when switching preset names', async () => {
+    render(
+      <LLMChannelEditor
+        items={[]}
+        configVersion="v1"
+        maskToken="******"
+        onSaved={() => {}}
+      />
+    );
+
+    fireEvent.change(screen.getByRole('combobox'), { target: { value: 'deepseek' } });
+    fireEvent.click(screen.getByRole('button', { name: '+ 添加渠道' }));
+
+    await screen.findByRole('button', { name: /DeepSeek 官方/i });
+    fireEvent.change(screen.getByLabelText('Base URL'), {
+      target: { value: 'https://proxy.example.com/v1' },
+    });
+    fireEvent.change(screen.getByLabelText('模型（逗号分隔）'), {
+      target: { value: 'custom-model-a,custom-model-b' },
+    });
+    fireEvent.change(screen.getByLabelText('渠道名称'), {
+      target: { value: 'minimax' },
+    });
+
+    await screen.findByRole('button', { name: /MiniMax 官方/i });
+    expect(screen.getByLabelText('Base URL')).toHaveValue('https://proxy.example.com/v1');
+    expect(screen.getByLabelText('模型（逗号分隔）')).toHaveValue('custom-model-a,custom-model-b');
+  });
+
+  it('uses the selected preset defaults when adding a duplicate provider channel', async () => {
+    render(
+      <LLMChannelEditor
+        items={[]}
+        configVersion="v1"
+        maskToken="******"
+        onSaved={() => {}}
+      />
+    );
+
+    fireEvent.change(screen.getByRole('combobox'), { target: { value: 'minimax' } });
+    fireEvent.click(screen.getByRole('button', { name: '+ 添加渠道' }));
+    await screen.findByRole('button', { name: /MiniMax 官方/i });
+    fireEvent.click(screen.getByRole('button', { name: '+ 添加渠道' }));
+
+    await screen.findByRole('button', { name: /minimax2/i });
+    expect(screen.getAllByLabelText('渠道名称').map((input) => (input as HTMLInputElement).value)).toEqual([
+      'minimax',
+      'minimax2',
+    ]);
+    expect(screen.getAllByLabelText('Base URL').map((input) => (input as HTMLInputElement).value)).toEqual([
+      'https://api.minimax.io/v1',
+      'https://api.minimax.io/v1',
+    ]);
+    expect(screen.getAllByLabelText('模型（逗号分隔）').map((input) => (input as HTMLInputElement).value)).toEqual([
+      'MiniMax-M2.7,MiniMax-M2.7-highspeed',
+      'MiniMax-M2.7,MiniMax-M2.7-highspeed',
+    ]);
+  });
+
   it('saves the MiniMax preset into LLM channel env keys', async () => {
     update.mockResolvedValue({
       success: true,

--- a/apps/dsa-web/src/components/settings/__tests__/llmProviderTemplates.test.ts
+++ b/apps/dsa-web/src/components/settings/__tests__/llmProviderTemplates.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest';
+import {
+  LLM_PROVIDER_TEMPLATE_BY_ID,
+  LLM_PROVIDER_TEMPLATES,
+  MODEL_PLACEHOLDERS_BY_PROTOCOL,
+} from '../llmProviderTemplates';
+
+describe('llmProviderTemplates', () => {
+  it('keeps provider template order aligned with the existing preset dropdown order', () => {
+    expect(LLM_PROVIDER_TEMPLATES.map((template) => template.channelId)).toEqual([
+      'aihubmix',
+      'deepseek',
+      'dashscope',
+      'zhipu',
+      'moonshot',
+      'minimax',
+      'volcengine',
+      'siliconflow',
+      'openrouter',
+      'gemini',
+      'anthropic',
+      'openai',
+      'ollama',
+      'custom',
+    ]);
+  });
+
+  it('derives lookup keys from unique channel ids', () => {
+    const channelIds = LLM_PROVIDER_TEMPLATES.map((template) => template.channelId);
+
+    expect(new Set(channelIds).size).toBe(channelIds.length);
+    for (const template of LLM_PROVIDER_TEMPLATES) {
+      expect(LLM_PROVIDER_TEMPLATE_BY_ID[template.channelId]).toBe(template);
+    }
+  });
+
+  it('uses volcengine as the default Volcengine Ark provider id', () => {
+    expect(LLM_PROVIDER_TEMPLATE_BY_ID.volcengine).toMatchObject({
+      label: '火山方舟（豆包）',
+      protocol: 'openai',
+      baseUrl: 'https://ark.cn-beijing.volces.com/api/v3',
+      placeholderModels: 'doubao-seed-1-6-251015,doubao-seed-1-6-thinking-251015',
+    });
+    expect(LLM_PROVIDER_TEMPLATE_BY_ID.ark).toBeUndefined();
+  });
+
+  it('keeps basic metadata on non-custom provider templates', () => {
+    for (const template of LLM_PROVIDER_TEMPLATES.filter((item) => item.channelId !== 'custom')) {
+      expect(template.capabilities.length).toBeGreaterThan(0);
+      expect(template.officialSources.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('keeps protocol-level fallback placeholders centralized', () => {
+    expect(MODEL_PLACEHOLDERS_BY_PROTOCOL).toMatchObject({
+      openai: 'gpt-5.5,qwen3.6-plus',
+      deepseek: 'deepseek-v4-flash,deepseek-v4-pro',
+      gemini: 'gemini-3.1-pro-preview,gemini-3-flash-preview',
+      anthropic: 'claude-sonnet-4-6,claude-opus-4-7',
+      vertex_ai: 'gemini-3.1-pro-preview',
+      ollama: 'llama3.2,qwen2.5',
+    });
+  });
+});

--- a/apps/dsa-web/src/components/settings/llmProviderTemplates.ts
+++ b/apps/dsa-web/src/components/settings/llmProviderTemplates.ts
@@ -1,0 +1,168 @@
+export type ChannelProtocol = 'openai' | 'deepseek' | 'gemini' | 'anthropic' | 'vertex_ai' | 'ollama';
+
+export interface LLMProviderTemplate {
+  channelId: string;
+  label: string;
+  protocol: ChannelProtocol;
+  baseUrl: string;
+  placeholderModels: string;
+  capabilities: string[];
+  officialSources: Array<{
+    label: string;
+    url: string;
+  }>;
+}
+
+export const LLM_PROVIDER_TEMPLATES: LLMProviderTemplate[] = [
+  {
+    channelId: 'aihubmix',
+    label: 'AIHubmix（聚合平台）',
+    protocol: 'openai',
+    baseUrl: 'https://aihubmix.com/v1',
+    placeholderModels: 'gpt-5.5,claude-sonnet-4-6,gemini-3.1-pro-preview',
+    capabilities: ['openai-compatible', 'aggregator'],
+    officialSources: [{ label: 'AIHubmix', url: 'https://aihubmix.com/' }],
+  },
+  {
+    channelId: 'deepseek',
+    label: 'DeepSeek 官方',
+    protocol: 'deepseek',
+    baseUrl: 'https://api.deepseek.com',
+    placeholderModels: 'deepseek-v4-flash,deepseek-v4-pro',
+    capabilities: ['official-api', 'openai-compatible'],
+    officialSources: [{ label: 'DeepSeek API Docs', url: 'https://api-docs.deepseek.com/' }],
+  },
+  {
+    channelId: 'dashscope',
+    label: '通义千问（Dashscope）',
+    protocol: 'openai',
+    baseUrl: 'https://dashscope.aliyuncs.com/compatible-mode/v1',
+    placeholderModels: 'qwen3.6-plus,qwen3.6-flash',
+    capabilities: ['openai-compatible', 'model-discovery'],
+    officialSources: [
+      { label: 'DashScope Text Generation', url: 'https://help.aliyun.com/zh/model-studio/text-generation-model/' },
+    ],
+  },
+  {
+    channelId: 'zhipu',
+    label: '智谱 GLM',
+    protocol: 'openai',
+    baseUrl: 'https://open.bigmodel.cn/api/paas/v4',
+    placeholderModels: 'glm-5.1,glm-4.7-flash',
+    capabilities: ['openai-compatible'],
+    officialSources: [{ label: 'Zhipu Model Overview', url: 'https://docs.bigmodel.cn/cn/guide/start/model-overview' }],
+  },
+  {
+    channelId: 'moonshot',
+    label: 'Moonshot（月之暗面）',
+    protocol: 'openai',
+    baseUrl: 'https://api.moonshot.cn/v1',
+    placeholderModels: 'kimi-k2.6,kimi-k2.5',
+    capabilities: ['openai-compatible'],
+    officialSources: [{ label: 'Kimi Platform Docs', url: 'https://platform.kimi.com/docs/models' }],
+  },
+  {
+    channelId: 'minimax',
+    label: 'MiniMax 官方',
+    protocol: 'openai',
+    baseUrl: 'https://api.minimax.io/v1',
+    placeholderModels: 'MiniMax-M2.7,MiniMax-M2.7-highspeed',
+    capabilities: ['openai-compatible'],
+    officialSources: [
+      { label: 'MiniMax OpenAI API', url: 'https://platform.minimax.io/docs/api-reference/text-chat' },
+      { label: 'MiniMax Models', url: 'https://platform.minimax.io/docs/api-reference/models/openai/list-models' },
+    ],
+  },
+  {
+    channelId: 'volcengine',
+    label: '火山方舟（豆包）',
+    protocol: 'openai',
+    baseUrl: 'https://ark.cn-beijing.volces.com/api/v3',
+    placeholderModels: 'doubao-seed-1-6-251015,doubao-seed-1-6-thinking-251015',
+    capabilities: ['openai-compatible'],
+    officialSources: [
+      { label: 'Volcengine Ark Inference', url: 'https://www.volcengine.com/docs/82379/2121998' },
+      { label: 'Volcengine Ark Models', url: 'https://www.volcengine.com/docs/82379/1949118' },
+    ],
+  },
+  {
+    channelId: 'siliconflow',
+    label: '硅基流动（SiliconFlow）',
+    protocol: 'openai',
+    baseUrl: 'https://api.siliconflow.cn/v1',
+    placeholderModels: 'deepseek-ai/DeepSeek-V3.2,Qwen/Qwen3-235B-A22B-Thinking-2507',
+    capabilities: ['openai-compatible', 'model-discovery'],
+    officialSources: [{ label: 'SiliconFlow Models', url: 'https://docs.siliconflow.cn/quickstart/models' }],
+  },
+  {
+    channelId: 'openrouter',
+    label: 'OpenRouter',
+    protocol: 'openai',
+    baseUrl: 'https://openrouter.ai/api/v1',
+    placeholderModels: '~openai/gpt-latest,~anthropic/claude-sonnet-latest',
+    capabilities: ['openai-compatible', 'aggregator', 'model-discovery'],
+    officialSources: [
+      { label: 'OpenRouter Models API', url: 'https://openrouter.ai/docs/api/api-reference/models/get-models' },
+    ],
+  },
+  {
+    channelId: 'gemini',
+    label: 'Gemini 官方',
+    protocol: 'gemini',
+    baseUrl: '',
+    placeholderModels: 'gemini-3.1-pro-preview,gemini-3-flash-preview',
+    capabilities: ['official-api', 'vision'],
+    officialSources: [{ label: 'Gemini Models', url: 'https://ai.google.dev/gemini-api/docs/models' }],
+  },
+  {
+    channelId: 'anthropic',
+    label: 'Anthropic 官方',
+    protocol: 'anthropic',
+    baseUrl: '',
+    placeholderModels: 'claude-sonnet-4-6,claude-opus-4-7',
+    capabilities: ['official-api'],
+    officialSources: [
+      { label: 'Anthropic Models', url: 'https://docs.anthropic.com/en/docs/about-claude/models/all-models' },
+    ],
+  },
+  {
+    channelId: 'openai',
+    label: 'OpenAI 官方',
+    protocol: 'openai',
+    baseUrl: 'https://api.openai.com/v1',
+    placeholderModels: 'gpt-5.5,gpt-5.4-mini',
+    capabilities: ['official-api', 'openai-compatible', 'model-discovery'],
+    officialSources: [{ label: 'OpenAI Models', url: 'https://platform.openai.com/docs/models' }],
+  },
+  {
+    channelId: 'ollama',
+    label: 'Ollama（本地）',
+    protocol: 'ollama',
+    baseUrl: 'http://127.0.0.1:11434',
+    placeholderModels: 'llama3.2,qwen2.5',
+    capabilities: ['local-runtime'],
+    officialSources: [{ label: 'Ollama API', url: 'https://github.com/ollama/ollama/blob/main/docs/api.md' }],
+  },
+  {
+    channelId: 'custom',
+    label: '自定义渠道',
+    protocol: 'openai',
+    baseUrl: '',
+    placeholderModels: 'model-name-1,model-name-2',
+    capabilities: [],
+    officialSources: [],
+  },
+];
+
+export const LLM_PROVIDER_TEMPLATE_BY_ID: Record<string, LLMProviderTemplate> = Object.fromEntries(
+  LLM_PROVIDER_TEMPLATES.map((template) => [template.channelId, template]),
+);
+
+export const MODEL_PLACEHOLDERS_BY_PROTOCOL: Record<ChannelProtocol, string> = {
+  openai: 'gpt-5.5,qwen3.6-plus',
+  deepseek: 'deepseek-v4-flash,deepseek-v4-pro',
+  gemini: 'gemini-3.1-pro-preview,gemini-3-flash-preview',
+  anthropic: 'claude-sonnet-4-6,claude-opus-4-7',
+  vertex_ai: 'gemini-3.1-pro-preview',
+  ollama: 'llama3.2,qwen2.5',
+};

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - [修复] 移除截图识别对 Gemini 3 Vision 模型的过时降级逻辑，默认推断改用当前 Gemini 模型配置。
 - [新功能] EventMonitor 支持 `price_change_percent` 涨跌幅阈值规则，可按上涨或下跌方向触发实时告警。
 - [文档] 明确 `price_change_percent` 事件告警仅为配置与运行时规则扩展，未变更模型/provider/base URL/LiteLLM 兼容语义；回退路径为关闭/移除 Event Monitor 配置；兼容验证与回归依据见 `tests/test_multi_agent.py`、`tests/test_system_config_service.py`。
+- [chore] 抽出 Web LLM provider preset 单一模板数据源，保持现有配置保存语义不变。
 
 ## [3.14.2] - 2026-04-30
 


### PR DESCRIPTION
## PR Type

- [ ] fix
- [ ] feat
- [ ] refactor
- [ ] docs
- [x] chore
- [ ] test

## Background And Problem

#1180 规划了 LLM 配置中心后续路线，其中 P0 要求先统一已存在 Web preset 的 provider template 真源，避免后续 P1/P2/P3/P4 在 Web、文档、Actions 和测试之间继续重复维护同一组 provider 默认值。

本 PR **仅解决 #1180 中的 P0 部分**：把 `LLMChannelEditor.tsx` 内联的 provider preset 抽成单一前端数据源。它不补 Actions 映射，不增强后端检测，也不深化 provider 文档，避免审查范围被误判为整个 #1180 路线图。

## Scope Of Change

- 新增 `apps/dsa-web/src/components/settings/llmProviderTemplates.ts`：
  - 集中维护 provider `channelId`、`label`、`protocol`、`baseUrl`、`placeholderModels`、基础能力元数据和官方来源。
  - 使用有序数组作为唯一真源，并派生 `LLM_PROVIDER_TEMPLATE_BY_ID`。
- 更新 `apps/dsa-web/src/components/settings/LLMChannelEditor.tsx`：
  - 组件改为消费 provider template 模块。
  - 保持快速添加下拉顺序、`custom` preset、重复添加 provider、手动 `baseUrl/models` 保护逻辑不变。
- 补充前端测试：
  - provider template 顺序、唯一 id、`volcengine` 默认 id、无 `ark` 默认 preset、基础元数据。
  - 手动 `baseUrl/models` 不被 preset 切换覆盖。
  - 重复添加 `minimax` 生成 `minimax2` 时仍使用 MiniMax 默认值。
- 更新 `docs/CHANGELOG.md` 的 `[Unreleased]` 扁平条目。

## Issue Link

Refs #1180

仅覆盖 #1180 的 **P0：统一已存在 preset 的 provider template 真源**。不使用 `Fixes`，因为 #1180 还包含 P1-P4 后续任务。

## Verification Commands And Results

```bash
cd apps/dsa-web && npm ci
cd apps/dsa-web && npm run test -- LLMChannelEditor.test.tsx llmProviderTemplates.test.ts
cd apps/dsa-web && npm run lint
cd apps/dsa-web && npm run build
git diff --check
```

关键输出/结论：

- `npm ci`：PASS；npm audit 报告既有 `10 vulnerabilities (4 moderate, 6 high)`，本 PR 未修改依赖。
- `npm run test -- LLMChannelEditor.test.tsx llmProviderTemplates.test.ts`：PASS，`2 passed (2)`，`28 passed (28)`。
- `npm run lint`：PASS。
- `npm run build`：PASS；Vite 保留既有 chunk size warning。
- `git diff --check`：PASS。

## Compatibility And Risk

- 兼容性：本 PR 不改变 API、`.env` schema、运行时配置优先级、模型路由、第三方 provider 语义或保存 payload。
- 旧配置：不会自动迁移、清空、回填或静默改写用户旧 `.env`。
- 用户行为：快速添加 preset 的默认值和顺序保持不变；切换 preset 时继续保护用户已手动输入的有效 `baseUrl/models`。
- 风险点：主要风险是 provider template 抽取时发生默认值或顺序漂移；已通过模板测试和组件回归测试约束。

本 PR 不修改第三方模型 / API 兼容语义、请求参数、路由前缀或 provider fallback；新增的 `capabilities` / `officialSources` 只是前端模板元数据，不参与运行时请求。

## Rollback Plan

Revert this PR 即可恢复 `LLMChannelEditor.tsx` 内联 preset 常量和原组件行为。由于不改 API、后端、`.env` schema 或用户配置，回滚不需要额外数据迁移或配置回滚。

## EXTRACT_PROMPT Change (if applicable)

不适用。本 PR 未修改 `src/services/image_stock_extractor.py` 或 `EXTRACT_PROMPT`。

<details>
<summary>展开 / Expand: Full EXTRACT_PROMPT</summary>

```
N/A
```

</details>

## Checklist

- [x] 本 PR 有明确动机和业务价值 / This PR has a clear motivation and value
- [x] 已提供可复现的验证命令与结果 / Reproducible verification commands and results are included
- [x] 已评估兼容性与风险 / Compatibility and risk have been assessed
- [x] 已提供回滚方案 / A rollback plan is provided
- [x] 若涉及用户可见变更，已同步更新相关文档与 `docs/CHANGELOG.md`；`README.md` 仅在首页级信息变化时更新，细节优先写入 `docs/*.md` / If user-visible changes are included, relevant docs and `docs/CHANGELOG.md` are updated; `README.md` is updated only for homepage-level changes, with details kept in `docs/*.md`
