### PR TITLE
fix: fetch strategy list from config instead of invalid value

### DIFF
--- a/bot/commands/strategies.py
+++ b/bot/commands/strategies.py
@@ -49,11 +49,10 @@ class StrategiesCommand(BotCommand):
 
             config = get_config()
             sm = get_skill_manager(config)
-            from src.agent.factory import DEFAULT_AGENT_SKILLS
 
             # Derive activation status from config without mutating the skill
             # manager — this is a read-only listing command.
-            configured_active: set = set(config.agent_skills or DEFAULT_AGENT_SKILLS)
+            configured_active: set = set(config.agent_skills) if config.agent_skills else {s.name for s in sm.list_skills()}
 
             all_skills = sm.list_skills()
             if not all_skills:


### PR DESCRIPTION
<!--
For Chinese contributors: 请直接用中文填写。
For English contributors: please fill in English. All fields marked (EN) accept English.
-->

## PR Type

- [x] fix
- [ ] feat
- [ ] refactor
- [ ] docs
- [ ] chore
- [ ] test

## Background And Problem
在bot中使用command: /strategies会返回策略空：
<img width="450" alt="image" src="https://github.com/user-attachments/assets/5233dc4c-e31c-4a9a-bfb9-a82baa08d775" />
这是因为DEFAULT_AGENT_SKILLS不存在于factory.py，需要换一个方式获取默认值。

## Scope Of Change

bot\commands\strategies.py

## Verification Commands And Results

修改后，执行/strategies或/skills命令，会从config中取AGENT_SKILLS所定义的skill列表（如果没有配置，会取skill manager中默认配置的所有skill）

<img width="450" alt="image" src="https://github.com/user-attachments/assets/862f00c1-a58a-4581-bd5f-ce710cceb808" />


## Compatibility And Risk

None

## Rollback Plan

请至少写一句可执行的回滚方案（必填）。  
git revert b4cc70f444f65b21197c510268638d6f7e95bb42

## Checklist

- [x] 本 PR 有明确动机和业务价值 / This PR has a clear motivation and value
- [x] 已提供可复现的验证命令与结果 / Reproducible verification commands and results are included
- [x] 已评估兼容性与风险 / Compatibility and risk have been assessed
- [x] 已提供回滚方案 / A rollback plan is provided
- [x] 若涉及用户可见变更，已同步更新相关文档与 `docs/CHANGELOG.md`；`README.md` 仅在首页级信息变化时更新，细节优先写入 `docs/*.md` / If user-visible changes are included, relevant docs and `docs/CHANGELOG.md` are updated; `README.md` is updated only for homepage-level changes, with details kept in `docs/*.md`
