### PR TITLE
feat: 支持 P1 Web 通知渠道一键测试 (#1200)

### DIFF
--- a/api/v1/endpoints/system_config.py
+++ b/api/v1/endpoints/system_config.py
@@ -22,6 +22,8 @@ from api.v1.schemas.system_config import (
     SystemConfigValidationErrorResponse,
     TestLLMChannelRequest,
     TestLLMChannelResponse,
+    TestNotificationChannelRequest,
+    TestNotificationChannelResponse,
     UpdateSystemConfigRequest,
     UpdateSystemConfigResponse,
     ValidateSystemConfigRequest,
@@ -342,6 +344,50 @@ def test_llm_channel(
             detail={
                 "error": "internal_error",
                 "message": "Failed to test LLM channel",
+            },
+        )
+
+
+@router.post(
+    "/config/notification/test-channel",
+    response_model=TestNotificationChannelResponse,
+    responses={
+        200: {"description": "Notification channel test completed"},
+        500: {"description": "Internal server error", "model": ErrorResponse},
+    },
+    summary="Test one notification channel",
+    description="Send a short test notification using unsaved or saved notification configuration.",
+)
+def test_notification_channel(
+    request: TestNotificationChannelRequest,
+    service: SystemConfigService = Depends(get_system_config_service),
+) -> TestNotificationChannelResponse:
+    """Validate and test one notification channel without writing `.env`."""
+    try:
+        payload = service.test_notification_channel(
+            channel=request.channel,
+            items=[item.model_dump() for item in request.items],
+            mask_token=request.mask_token,
+            title=request.title,
+            content=request.content,
+            timeout_seconds=request.timeout_seconds,
+        )
+        return TestNotificationChannelResponse.model_validate(payload)
+    except (ValueError, TypeError) as exc:
+        raise HTTPException(
+            status_code=422,
+            detail={
+                "error": "validation_error",
+                "message": str(exc),
+            },
+        )
+    except Exception as exc:
+        logger.error("Failed to test notification channel: %s", exc, exc_info=True)
+        raise HTTPException(
+            status_code=500,
+            detail={
+                "error": "internal_error",
+                "message": "Failed to test notification channel",
             },
         )
 

--- a/api/v1/schemas/system_config.py
+++ b/api/v1/schemas/system_config.py
@@ -8,6 +8,19 @@ from typing import Any, Dict, List, Literal, Optional
 from pydantic import BaseModel, ConfigDict, Field
 
 LLMCapabilityCheck = Literal["json", "tools", "vision", "stream"]
+NotificationTestChannel = Literal[
+    "wechat",
+    "feishu",
+    "telegram",
+    "email",
+    "pushover",
+    "pushplus",
+    "serverchan3",
+    "custom",
+    "discord",
+    "slack",
+    "astrbot",
+]
 
 
 class SystemConfigOption(BaseModel):
@@ -202,6 +215,43 @@ class TestLLMChannelResponse(BaseModel):
     resolved_model: Optional[str] = None
     latency_ms: Optional[int] = None
     capability_results: Dict[str, LLMCapabilityCheckResult] = Field(default_factory=dict)
+
+
+class NotificationTestAttempt(BaseModel):
+    """One notification delivery attempt result."""
+
+    channel: NotificationTestChannel
+    success: bool
+    message: str
+    target: Optional[str] = None
+    error_code: Optional[str] = None
+    stage: str = "notification_send"
+    retryable: bool = False
+    latency_ms: Optional[int] = None
+    http_status: Optional[int] = None
+
+
+class TestNotificationChannelRequest(BaseModel):
+    """Request payload for testing one notification channel."""
+
+    channel: NotificationTestChannel
+    items: List[SystemConfigUpdateItem] = Field(default_factory=list)
+    mask_token: str = "******"
+    title: str = Field(default="DSA 通知测试", min_length=1, max_length=80)
+    content: str = Field(default="这是一条来自 DSA Web 设置页的通知测试消息。", min_length=1, max_length=1000)
+    timeout_seconds: float = Field(default=20.0, ge=1.0, le=120.0)
+
+
+class TestNotificationChannelResponse(BaseModel):
+    """Response payload for one notification channel connectivity test."""
+
+    success: bool
+    message: str
+    error_code: Optional[str] = None
+    stage: Optional[str] = None
+    retryable: bool = False
+    latency_ms: Optional[int] = None
+    attempts: List[NotificationTestAttempt] = Field(default_factory=list)
 
 
 class DiscoverLLMChannelModelsRequest(BaseModel):

--- a/apps/dsa-web/src/api/__tests__/systemConfig.test.ts
+++ b/apps/dsa-web/src/api/__tests__/systemConfig.test.ts
@@ -61,4 +61,54 @@ describe('systemConfigApi', () => {
       expect.objectContaining({ capability_checks: ['json', 'stream'] }),
     );
   });
+
+  it('sends notification channel test payloads with snake_case fields', async () => {
+    post.mockResolvedValueOnce({
+      data: {
+        success: true,
+        message: 'ok',
+        error_code: null,
+        stage: 'notification_send',
+        retryable: false,
+        latency_ms: 15,
+        attempts: [
+          {
+            channel: 'custom',
+            success: true,
+            message: 'sent',
+            target: 'https://example.com/hook?token=***',
+            error_code: null,
+            stage: 'notification_send',
+            retryable: false,
+            latency_ms: 15,
+            http_status: 200,
+          },
+        ],
+      },
+    });
+
+    const result = await systemConfigApi.testNotificationChannel({
+      channel: 'custom',
+      items: [{ key: 'CUSTOM_WEBHOOK_URLS', value: 'https://example.com/hook?token=secret' }],
+      maskToken: '******',
+      title: 'hello',
+      content: 'world',
+      timeoutSeconds: 7,
+    });
+
+    expect(post).toHaveBeenCalledWith(
+      '/api/v1/system/config/notification/test-channel',
+      {
+        channel: 'custom',
+        items: [{ key: 'CUSTOM_WEBHOOK_URLS', value: 'https://example.com/hook?token=secret' }],
+        mask_token: '******',
+        title: 'hello',
+        content: 'world',
+        timeout_seconds: 7,
+      },
+    );
+    expect(result.latencyMs).toBe(15);
+    expect(result.attempts[0].errorCode).toBeNull();
+    expect(result.attempts[0].httpStatus).toBe(200);
+  });
 });

--- a/apps/dsa-web/src/api/systemConfig.ts
+++ b/apps/dsa-web/src/api/systemConfig.ts
@@ -12,6 +12,8 @@ import type {
   SystemConfigValidationErrorResponse,
   TestLLMChannelRequest,
   TestLLMChannelResponse,
+  TestNotificationChannelRequest,
+  TestNotificationChannelResponse,
   UpdateSystemConfigRequest,
   UpdateSystemConfigResponse,
   ValidateSystemConfigRequest,
@@ -99,6 +101,20 @@ function toSnakeTestChannelPayload(payload: TestLLMChannelRequest): Record<strin
   return request;
 }
 
+function toSnakeNotificationTestPayload(payload: TestNotificationChannelRequest): Record<string, unknown> {
+  return {
+    channel: payload.channel,
+    items: (payload.items || []).map((item) => ({
+      key: item.key,
+      value: item.value,
+    })),
+    mask_token: payload.maskToken ?? '******',
+    title: payload.title ?? 'DSA 通知测试',
+    content: payload.content ?? '这是一条来自 DSA Web 设置页的通知测试消息。',
+    timeout_seconds: payload.timeoutSeconds ?? 20,
+  };
+}
+
 function toSnakeDiscoverModelsPayload(payload: DiscoverLLMChannelModelsRequest): Record<string, unknown> {
   return {
     name: payload.name,
@@ -150,6 +166,14 @@ export const systemConfigApi = {
       toSnakeTestChannelPayload(payload),
     );
     return toCamelCase<TestLLMChannelResponse>(response.data);
+  },
+
+  async testNotificationChannel(payload: TestNotificationChannelRequest): Promise<TestNotificationChannelResponse> {
+    const response = await apiClient.post<Record<string, unknown>>(
+      '/api/v1/system/config/notification/test-channel',
+      toSnakeNotificationTestPayload(payload),
+    );
+    return toCamelCase<TestNotificationChannelResponse>(response.data);
   },
 
   async discoverLLMChannelModels(

--- a/apps/dsa-web/src/components/settings/NotificationTestPanel.tsx
+++ b/apps/dsa-web/src/components/settings/NotificationTestPanel.tsx
@@ -1,0 +1,195 @@
+import { useMemo, useState } from 'react';
+import type React from 'react';
+import { Send } from 'lucide-react';
+import { getParsedApiError, type ParsedApiError } from '../../api/error';
+import { systemConfigApi } from '../../api/systemConfig';
+import type {
+  NotificationTestChannel,
+  TestNotificationChannelResponse,
+  SystemConfigUpdateItem,
+} from '../../types/systemConfig';
+import { ApiErrorAlert, Badge, Button, InlineAlert, Input, Select } from '../common';
+import { SettingsSectionCard } from './SettingsSectionCard';
+
+const CHANNEL_OPTIONS: Array<{ value: NotificationTestChannel; label: string }> = [
+  { value: 'wechat', label: '企业微信' },
+  { value: 'feishu', label: '飞书 Webhook' },
+  { value: 'telegram', label: 'Telegram' },
+  { value: 'email', label: '邮件' },
+  { value: 'pushover', label: 'Pushover' },
+  { value: 'pushplus', label: 'PushPlus' },
+  { value: 'serverchan3', label: 'Server酱3' },
+  { value: 'custom', label: '自定义 Webhook' },
+  { value: 'discord', label: 'Discord' },
+  { value: 'slack', label: 'Slack' },
+  { value: 'astrbot', label: 'AstrBot' },
+];
+
+interface NotificationTestPanelProps {
+  items: SystemConfigUpdateItem[];
+  maskToken: string;
+  disabled?: boolean;
+}
+
+function clampTimeout(value: string): number {
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed)) return 20;
+  return Math.min(120, Math.max(1, parsed));
+}
+
+export const NotificationTestPanel: React.FC<NotificationTestPanelProps> = ({
+  items,
+  maskToken,
+  disabled = false,
+}) => {
+  const [channel, setChannel] = useState<NotificationTestChannel>('wechat');
+  const [title, setTitle] = useState('DSA 通知测试');
+  const [content, setContent] = useState('这是一条来自 DSA Web 设置页的通知测试消息。');
+  const [timeoutSeconds, setTimeoutSeconds] = useState('20');
+  const [result, setResult] = useState<TestNotificationChannelResponse | null>(null);
+  const [error, setError] = useState<ParsedApiError | null>(null);
+  const [isTesting, setIsTesting] = useState(false);
+
+  const normalizedItems = useMemo(
+    () => items.map((item) => ({ key: item.key, value: String(item.value ?? '') })),
+    [items],
+  );
+
+  const runTest = async () => {
+    setError(null);
+    setResult(null);
+    setIsTesting(true);
+    try {
+      const payload = await systemConfigApi.testNotificationChannel({
+        channel,
+        items: normalizedItems,
+        maskToken,
+        title: title.trim() || 'DSA 通知测试',
+        content: content.trim() || '这是一条来自 DSA Web 设置页的通知测试消息。',
+        timeoutSeconds: clampTimeout(timeoutSeconds),
+      });
+      setResult(payload);
+    } catch (requestError: unknown) {
+      setError(getParsedApiError(requestError));
+    } finally {
+      setIsTesting(false);
+    }
+  };
+
+  return (
+    <SettingsSectionCard
+      title="通知测试"
+      description="使用当前页面草稿发送一条真实测试通知；测试不会保存配置。"
+      actions={(
+        <Button
+          type="button"
+          variant="settings-primary"
+          size="sm"
+          onClick={() => void runTest()}
+          disabled={disabled || isTesting}
+          isLoading={isTesting}
+          loadingText="测试中..."
+        >
+          <Send className="h-4 w-4" />
+          发送测试
+        </Button>
+      )}
+    >
+      <div className="grid grid-cols-1 gap-3 md:grid-cols-[1fr_1fr_120px]">
+        <Select
+          label="渠道"
+          value={channel}
+          options={CHANNEL_OPTIONS}
+          disabled={disabled || isTesting}
+          onChange={(value) => setChannel(value as NotificationTestChannel)}
+        />
+        <Input
+          label="标题"
+          value={title}
+          maxLength={80}
+          disabled={disabled || isTesting}
+          onChange={(event) => setTitle(event.target.value)}
+        />
+        <Input
+          label="超时秒数"
+          type="number"
+          min={1}
+          max={120}
+          value={timeoutSeconds}
+          disabled={disabled || isTesting}
+          onChange={(event) => setTimeoutSeconds(event.target.value)}
+          onBlur={() => setTimeoutSeconds(String(clampTimeout(timeoutSeconds)))}
+        />
+      </div>
+
+      <label className="block">
+        <span className="mb-2 block text-sm font-medium text-foreground">正文</span>
+        <textarea
+          value={content}
+          maxLength={1000}
+          rows={4}
+          disabled={disabled || isTesting}
+          onChange={(event) => setContent(event.target.value)}
+          className="input-surface input-focus-glow min-h-[112px] w-full resize-y rounded-xl border bg-transparent px-4 py-3 text-sm leading-6 text-foreground outline-none disabled:cursor-not-allowed disabled:opacity-50"
+        />
+      </label>
+
+      {error ? <ApiErrorAlert error={error} /> : null}
+
+      {result ? (
+        <div className="space-y-3">
+          <InlineAlert
+            variant={result.success ? 'success' : 'danger'}
+            title={result.success ? '测试成功' : '测试失败'}
+            message={(
+              <span>
+                {result.message}
+                {typeof result.latencyMs === 'number' ? ` · ${result.latencyMs} ms` : ''}
+                {result.errorCode ? ` · ${result.errorCode}` : ''}
+              </span>
+            )}
+          />
+
+          {result.attempts.length ? (
+            <div className="space-y-2">
+              {result.attempts.map((attempt, index) => (
+                <div
+                  key={`${attempt.channel}-${index}-${attempt.target || 'target'}`}
+                  className="rounded-xl border settings-border bg-background/35 px-4 py-3"
+                >
+                  <div className="flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
+                    <div className="min-w-0">
+                      <div className="flex flex-wrap items-center gap-2">
+                        <Badge variant={attempt.success ? 'success' : 'danger'}>
+                          {attempt.success ? '成功' : '失败'}
+                        </Badge>
+                        <span className="text-sm font-medium text-foreground">
+                          Attempt {index + 1}
+                        </span>
+                        {typeof attempt.httpStatus === 'number' ? (
+                          <span className="text-xs text-muted-text">HTTP {attempt.httpStatus}</span>
+                        ) : null}
+                        {typeof attempt.latencyMs === 'number' ? (
+                          <span className="text-xs text-muted-text">{attempt.latencyMs} ms</span>
+                        ) : null}
+                      </div>
+                      <p className="mt-2 break-all text-xs leading-5 text-muted-text">
+                        {attempt.target || attempt.channel}
+                      </p>
+                    </div>
+                    {attempt.errorCode ? (
+                      <Badge variant={attempt.retryable ? 'warning' : 'default'}>
+                        {attempt.errorCode}
+                      </Badge>
+                    ) : null}
+                  </div>
+                  <p className="mt-2 text-xs leading-5 text-secondary-text">{attempt.message}</p>
+                </div>
+              ))}
+            </div>
+          ) : null}
+        </div>
+      ) : null}
+    </SettingsSectionCard>
+  );
+};

--- a/apps/dsa-web/src/components/settings/__tests__/NotificationTestPanel.test.tsx
+++ b/apps/dsa-web/src/components/settings/__tests__/NotificationTestPanel.test.tsx
@@ -1,0 +1,60 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { NotificationTestPanel } from '../NotificationTestPanel';
+
+const testNotificationChannel = vi.hoisted(() => vi.fn());
+
+vi.mock('../../../api/systemConfig', () => ({
+  systemConfigApi: {
+    testNotificationChannel,
+  },
+}));
+
+describe('NotificationTestPanel', () => {
+  beforeEach(() => {
+    testNotificationChannel.mockReset();
+    testNotificationChannel.mockResolvedValue({
+      success: true,
+      message: 'ok',
+      errorCode: null,
+      stage: 'notification_send',
+      retryable: false,
+      latencyMs: 12,
+      attempts: [
+        {
+          channel: 'custom',
+          success: true,
+          message: 'sent',
+          target: 'https://example.com/hook?token=***',
+          errorCode: null,
+          stage: 'notification_send',
+          retryable: false,
+          latencyMs: 12,
+          httpStatus: 200,
+        },
+      ],
+    });
+  });
+
+  it('submits draft notification items and renders attempt details', async () => {
+    render(
+      <NotificationTestPanel
+        items={[{ key: 'CUSTOM_WEBHOOK_URLS', value: 'https://example.com/hook?token=secret' }]}
+        maskToken="******"
+      />,
+    );
+
+    fireEvent.change(screen.getByLabelText('渠道'), { target: { value: 'custom' } });
+    fireEvent.click(screen.getByRole('button', { name: /发送测试/ }));
+
+    await waitFor(() => expect(testNotificationChannel).toHaveBeenCalledWith(expect.objectContaining({
+      channel: 'custom',
+      items: [{ key: 'CUSTOM_WEBHOOK_URLS', value: 'https://example.com/hook?token=secret' }],
+      maskToken: '******',
+      timeoutSeconds: 20,
+    })));
+    expect(await screen.findByText('测试成功')).toBeInTheDocument();
+    expect(screen.getByText('HTTP 200')).toBeInTheDocument();
+    expect(screen.getByText('https://example.com/hook?token=***')).toBeInTheDocument();
+  });
+});

--- a/apps/dsa-web/src/components/settings/index.ts
+++ b/apps/dsa-web/src/components/settings/index.ts
@@ -2,6 +2,7 @@ export * from './LLMChannelEditor';
 export * from './SettingsAlert';
 export * from './ChangePasswordCard';
 export * from './IntelligentImport';
+export * from './NotificationTestPanel';
 export * from './SettingsField';
 export * from './SettingsLoading';
 export * from './SettingsSectionCard';

--- a/apps/dsa-web/src/pages/SettingsPage.tsx
+++ b/apps/dsa-web/src/pages/SettingsPage.tsx
@@ -9,6 +9,7 @@ import {
   ChangePasswordCard,
   IntelligentImport,
   LLMChannelEditor,
+  NotificationTestPanel,
   SettingsCategoryNav,
   SettingsAlert,
   SettingsField,
@@ -655,6 +656,13 @@ const SettingsPage: React.FC = () => {
             ) : null}
             {activeCategory === 'system' && passwordChangeable ? (
               <ChangePasswordCard />
+            ) : null}
+            {activeCategory === 'notification' ? (
+              <NotificationTestPanel
+                items={rawActiveItems.map((item) => ({ key: item.key, value: String(item.value ?? '') }))}
+                maskToken={maskToken}
+                disabled={isSaving || isLoading}
+              />
             ) : null}
             {activeItems.length ? (
               <SettingsSectionCard

--- a/apps/dsa-web/src/pages/__tests__/SettingsPage.test.tsx
+++ b/apps/dsa-web/src/pages/__tests__/SettingsPage.test.tsx
@@ -92,6 +92,9 @@ vi.mock('../../components/settings', () => ({
       save llm channels
     </button>
   ),
+  NotificationTestPanel: ({ items }: { items: Array<{ key: string; value: string }> }) => (
+    <div>通知测试面板:{items.map((item) => item.key).join(',')}</div>
+  ),
   SettingsAlert: ({
     title,
     message,
@@ -168,7 +171,8 @@ const baseCategories = [
   { category: 'system', title: 'System', description: '系统设置', displayOrder: 1, fields: [] },
   { category: 'base', title: 'Base', description: '基础配置', displayOrder: 2, fields: [] },
   { category: 'ai_model', title: 'AI', description: '模型配置', displayOrder: 3, fields: [] },
-  { category: 'agent', title: 'Agent', description: 'Agent 配置', displayOrder: 4, fields: [] },
+  { category: 'notification', title: 'Notification', description: '通知配置', displayOrder: 4, fields: [] },
+  { category: 'agent', title: 'Agent', description: 'Agent 配置', displayOrder: 5, fields: [] },
 ];
 
 type ConfigState = {
@@ -275,6 +279,26 @@ function buildSystemConfigState(overrides: ConfigOverride = {}) {
             dataType: 'integer',
             uiControl: 'number',
             isSensitive: false,
+            isRequired: false,
+            isEditable: true,
+            options: [],
+            validation: {},
+            displayOrder: 1,
+          },
+        },
+      ],
+      notification: [
+        {
+          key: 'WECHAT_WEBHOOK_URL',
+          value: 'https://qyapi.example.com/hook',
+          rawValueExists: true,
+          isMasked: false,
+          schema: {
+            key: 'WECHAT_WEBHOOK_URL',
+            category: 'notification',
+            dataType: 'string',
+            uiControl: 'password',
+            isSensitive: true,
             isRequired: false,
             isEditable: true,
             options: [],
@@ -596,6 +620,15 @@ describe('SettingsPage', () => {
 
     expect(refreshAfterExternalSave).toHaveBeenCalledWith(['LLM_CHANNELS']);
     expect(load).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders notification test panel before notification fields', () => {
+    useSystemConfigMock.mockReturnValue(buildSystemConfigState({ activeCategory: 'notification' }));
+
+    render(<SettingsPage />);
+
+    expect(screen.getByText('通知测试面板:WECHAT_WEBHOOK_URL')).toBeInTheDocument();
+    expect(screen.getByText('WECHAT_WEBHOOK_URL')).toBeInTheDocument();
   });
 
   it('does not render desktop env backup card outside desktop runtime', () => {

--- a/apps/dsa-web/src/types/systemConfig.ts
+++ b/apps/dsa-web/src/types/systemConfig.ts
@@ -164,6 +164,50 @@ export interface TestLLMChannelResponse {
   capabilityResults?: Partial<Record<LLMCapabilityCheck, LLMCapabilityCheckResult>>;
 }
 
+export type NotificationTestChannel =
+  | 'wechat'
+  | 'feishu'
+  | 'telegram'
+  | 'email'
+  | 'pushover'
+  | 'pushplus'
+  | 'serverchan3'
+  | 'custom'
+  | 'discord'
+  | 'slack'
+  | 'astrbot';
+
+export interface NotificationTestAttempt {
+  channel: NotificationTestChannel;
+  success: boolean;
+  message: string;
+  target?: string | null;
+  errorCode?: string | null;
+  stage: string;
+  retryable: boolean;
+  latencyMs?: number | null;
+  httpStatus?: number | null;
+}
+
+export interface TestNotificationChannelRequest {
+  channel: NotificationTestChannel;
+  items?: SystemConfigUpdateItem[];
+  maskToken?: string;
+  title?: string;
+  content?: string;
+  timeoutSeconds?: number;
+}
+
+export interface TestNotificationChannelResponse {
+  success: boolean;
+  message: string;
+  errorCode?: string | null;
+  stage?: string | null;
+  retryable: boolean;
+  latencyMs?: number | null;
+  attempts: NotificationTestAttempt[];
+}
+
 export interface DiscoverLLMChannelModelsRequest {
   name: string;
   protocol: string;

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - [改进] 放宽 LiteLLM 依赖约束，保留 `>=1.80.10` 最低版本并显式排除 PyPI 事故版本 `1.82.7` / `1.82.8`，允许安装后续 1.x 修复版本。
 - [改进] 补齐通知渠道 P0 基线、Actions 映射与 `--check-notify` 只读诊断，完善 AstrBot 配置入口和通知回归快照。
 - [chore] 清理仓库根目录：移除误入库的 `.codex`、`review.md` 跟踪记录，将 smoke 测试入口迁移到 `scripts/`、环境检查脚本迁移为 `scripts/check_env.py`，并将 LiteLLM YAML 示例迁移到 `docs/examples/`。
+- [新功能] Web 设置页新增通知渠道一键测试，支持临时配置、耗时与脱敏 attempts 展示。
 
 ## [3.15.0] - 2026-05-05
 

--- a/docs/full-guide.md
+++ b/docs/full-guide.md
@@ -71,7 +71,7 @@ daily_stock_analysis/
 
 #### 通知渠道配置（可同时配置多个，全部推送）
 
-> 通知渠道、minimal/advanced key 分层、Actions 映射与 `--check-notify` 诊断口径详见 [通知能力基线](notifications.md)。
+> 通知渠道、minimal/advanced key 分层、Actions 映射、`--check-notify` 诊断和 Web 一键测试说明详见 [通知能力基线](notifications.md)。
 
 | Secret 名称 | 说明 | 必填 |
 |------------|------|:----:|

--- a/docs/full-guide_EN.md
+++ b/docs/full-guide_EN.md
@@ -71,7 +71,7 @@ Go to your forked repo → `Settings` → `Secrets and variables` → `Actions` 
 
 #### Notification Channels (Multiple can be configured, all will receive notifications)
 
-> The P0 notification baseline, minimal/advanced key split, Actions mapping, and `--check-notify` CLI behavior are tracked in [Notification Baseline](notifications.md). A complete English notification topic remains a later follow-up.
+> The notification baseline, minimal/advanced key split, Actions mapping, `--check-notify` CLI behavior, and Web one-click notification test are tracked in [Notification Baseline](notifications.md). A complete English notification topic remains a later follow-up.
 
 | Secret Name | Description | Required |
 |------------|------|:----:|

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -1,6 +1,6 @@
 # 通知能力基线
 
-本文档记录通知能力 P0 基线：渠道、配置 key、GitHub Actions 映射、Web 设置元数据和 CLI 诊断口径。P0 只做基线与只读诊断，不包含 Web 一键测试、渠道路由、降噪、模板产品化等后续 Phase 能力。
+本文档记录通知能力 P0/P1 基线：渠道、配置 key、GitHub Actions 映射、Web 设置元数据、CLI 诊断口径和 Web 一键测试。P0 只做基线与只读诊断；P1 增加 Web 单渠道真实测试，不包含渠道路由、降噪、模板产品化等后续 Phase 能力。
 
 ## 渠道基线
 
@@ -50,9 +50,19 @@ python main.py --check-notify
 - 返回码 `0`：没有 error 级诊断。
 - 返回码 `1`：存在 error，例如 0 个静态通知渠道已配置，或成对 key 只配置了一半。
 
+## Web 一键测试
+
+Web 设置页的“通知渠道”分类提供单渠道测试入口。测试会使用当前页面草稿值合成临时配置，发送一条真实测试通知，但不会保存 `.env`，也不会修改运行时全局配置。
+
+- 测试范围：11 个静态通知渠道，不包含 `UNKNOWN` 和运行时上下文渠道。
+- 普通渠道：返回单次发送结果、耗时和通用错误码。
+- 自定义 Webhook：按 URL 顺序返回 attempts，展示每个 URL 的成功/失败、HTTP 状态、耗时和错误码。
+- 返回结果会脱敏 token、secret、password、Bearer、完整 webhook query 和疑似 path token。
+- 配置缺失或发送失败返回 `success=false`，不会影响已保存配置和默认分析流程。
+
 ## 场景占位
 
 - Local：优先使用 `.env`，可用 `python main.py --check-notify` 做本地诊断。
 - Docker：配置来源与本地一致，需确保容器环境变量已注入。
 - GitHub Actions：只会读取 workflow `env:` 中显式映射的 Secret/Variable。
-- Desktop：当前 P0 仅补 Web 设置元数据和诊断口径，不新增桌面端通知测试入口。
+- Desktop：桌面端内嵌 Web 设置页可复用同一通知测试入口；测试仍只使用临时配置，不写入 `.env`。

--- a/src/notification_sender/astrbot_sender.py
+++ b/src/notification_sender/astrbot_sender.py
@@ -9,6 +9,8 @@ import logging
 import json
 import hmac
 import hashlib
+from typing import Optional
+
 import requests
 
 from src.config import Config
@@ -39,7 +41,7 @@ class AstrbotSender:
         url_ok = bool(self._astrbot_config['astrbot_url'])
         return url_ok
 
-    def send_to_astrbot(self, content: str) -> bool:
+    def send_to_astrbot(self, content: str, *, timeout_seconds: Optional[float] = None) -> bool:
         """
         推送消息到 AstrBot（通过适配器支持）
 
@@ -50,13 +52,13 @@ class AstrbotSender:
             是否发送成功
         """
         if self._astrbot_config['astrbot_url']:
-            return self._send_astrbot(content)
+            return self._send_astrbot(content, timeout_seconds=timeout_seconds)
 
         logger.warning("AstrBot 配置不完整，跳过推送")
         return False
 
 
-    def _send_astrbot(self, content: str) -> bool:
+    def _send_astrbot(self, content: str, *, timeout_seconds: Optional[float] = None) -> bool:
         import time
         """
         使用 Bot API 发送消息到 AstrBot
@@ -88,7 +90,7 @@ class AstrbotSender:
                 ).hexdigest()
             url = self._astrbot_config['astrbot_url']
             response = requests.post(
-                url, json=payload, timeout=10,
+                url, json=payload, timeout=timeout_seconds or 10,
                 headers={
                     "Content-Type": "application/json",
                     "X-Signature": signature,

--- a/src/notification_sender/custom_webhook_sender.py
+++ b/src/notification_sender/custom_webhook_sender.py
@@ -7,8 +7,9 @@
 """
 import logging
 import json
+import time
 from string import Template
-from typing import Any, Optional
+from typing import Any, Dict, List, Optional, Tuple
 
 import requests
 
@@ -160,6 +161,110 @@ class CustomWebhookSender:
         logger.error(f"自定义 Webhook 推送失败: HTTP {response.status_code}")
         logger.debug(f"响应内容: {response.text[:200]}")
         return False
+
+    def test_custom_webhooks(self, content: str, *, timeout_seconds: float = 20.0) -> List[Dict[str, Any]]:
+        """Send a test message to each custom webhook and return raw per-URL attempts."""
+        attempts: List[Dict[str, Any]] = []
+        for index, url in enumerate(self._custom_webhook_urls):
+            try:
+                payload = self._build_custom_webhook_payload(url, content)
+                attempts.append(
+                    self._post_custom_webhook_attempt(
+                        url=url,
+                        payload=payload,
+                        timeout_seconds=timeout_seconds,
+                        index=index,
+                    )
+                )
+            except Exception as exc:
+                attempts.append({
+                    "channel": "custom",
+                    "success": False,
+                    "message": f"自定义 Webhook {index + 1} 测试异常: {exc}",
+                    "target": url,
+                    "error_code": self._classify_custom_webhook_exception(exc)[0],
+                    "stage": "notification_send",
+                    "retryable": self._classify_custom_webhook_exception(exc)[1],
+                    "latency_ms": None,
+                    "http_status": None,
+                })
+        return attempts
+
+    def _post_custom_webhook_attempt(
+        self,
+        *,
+        url: str,
+        payload: dict,
+        timeout_seconds: float,
+        index: int,
+    ) -> Dict[str, Any]:
+        headers = {
+            'Content-Type': 'application/json; charset=utf-8',
+            'User-Agent': 'StockAnalysis/1.0',
+        }
+        if self._custom_webhook_bearer_token:
+            headers['Authorization'] = f'Bearer {self._custom_webhook_bearer_token}'
+
+        body = json.dumps(payload, ensure_ascii=False).encode('utf-8')
+        started_at = time.perf_counter()
+        try:
+            response = requests.post(
+                url,
+                data=body,
+                headers=headers,
+                timeout=timeout_seconds,
+                verify=self._webhook_verify_ssl,
+            )
+        except Exception as exc:
+            error_code, retryable = self._classify_custom_webhook_exception(exc)
+            return {
+                "channel": "custom",
+                "success": False,
+                "message": f"自定义 Webhook {index + 1} 测试失败: {exc}",
+                "target": url,
+                "error_code": error_code,
+                "stage": "notification_send",
+                "retryable": retryable,
+                "latency_ms": int((time.perf_counter() - started_at) * 1000),
+                "http_status": None,
+            }
+
+        latency_ms = int((time.perf_counter() - started_at) * 1000)
+        if response.status_code == 200:
+            return {
+                "channel": "custom",
+                "success": True,
+                "message": f"自定义 Webhook {index + 1} 测试发送成功",
+                "target": url,
+                "error_code": None,
+                "stage": "notification_send",
+                "retryable": False,
+                "latency_ms": latency_ms,
+                "http_status": response.status_code,
+            }
+
+        retryable = response.status_code == 429 or response.status_code >= 500
+        return {
+            "channel": "custom",
+            "success": False,
+            "message": f"自定义 Webhook {index + 1} 测试失败: HTTP {response.status_code}",
+            "target": url,
+            "error_code": "http_error",
+            "stage": "notification_send",
+            "retryable": retryable,
+            "latency_ms": latency_ms,
+            "http_status": response.status_code,
+        }
+
+    @staticmethod
+    def _classify_custom_webhook_exception(exc: Exception) -> Tuple[str, bool]:
+        if isinstance(exc, requests.exceptions.Timeout):
+            return "timeout", True
+        if isinstance(exc, requests.exceptions.ConnectionError):
+            return "network_error", True
+        if isinstance(exc, requests.exceptions.RequestException):
+            return "network_error", True
+        return "unexpected_error", False
     
     def _build_custom_webhook_payload(self, url: str, content: str) -> dict:
         """

--- a/src/notification_sender/discord_sender.py
+++ b/src/notification_sender/discord_sender.py
@@ -6,6 +6,8 @@ Discord 发送提醒服务
 1. 通过 webhook 或 Discord bot API 发送 Discord 消息
 """
 import logging
+from typing import Optional
+
 import requests
 
 from src.config import Config
@@ -39,7 +41,7 @@ class DiscordSender:
         webhook_ok = bool(self._discord_config['webhook_url'])
         return bot_ok or webhook_ok
     
-    def send_to_discord(self, content: str) -> bool:
+    def send_to_discord(self, content: str, *, timeout_seconds: Optional[float] = None) -> bool:
         """
         推送消息到 Discord（支持 Webhook 和 Bot API）
         
@@ -58,17 +60,17 @@ class DiscordSender:
 
         # 优先使用 Webhook（配置简单，权限低）
         if self._discord_config['webhook_url']:
-            return all(self._send_discord_webhook(chunk) for chunk in chunks)
+            return all(self._send_discord_webhook(chunk, timeout_seconds=timeout_seconds) for chunk in chunks)
 
         # 其次使用 Bot API（权限高，需要 channel_id）
         if self._discord_config['bot_token'] and self._discord_config['channel_id']:
-            return all(self._send_discord_bot(chunk) for chunk in chunks)
+            return all(self._send_discord_bot(chunk, timeout_seconds=timeout_seconds) for chunk in chunks)
 
         logger.warning("Discord 配置不完整，跳过推送")
         return False
 
   
-    def _send_discord_webhook(self, content: str) -> bool:
+    def _send_discord_webhook(self, content: str, *, timeout_seconds: Optional[float] = None) -> bool:
         """
         使用 Webhook 发送消息到 Discord
         
@@ -90,7 +92,7 @@ class DiscordSender:
             response = requests.post(
                 self._discord_config['webhook_url'],
                 json=payload,
-                timeout=10,
+                timeout=timeout_seconds or 10,
                 verify=self._webhook_verify_ssl
             )
             
@@ -104,7 +106,7 @@ class DiscordSender:
             logger.error(f"Discord Webhook 发送异常: {e}")
             return False
     
-    def _send_discord_bot(self, content: str) -> bool:
+    def _send_discord_bot(self, content: str, *, timeout_seconds: Optional[float] = None) -> bool:
         """
         使用 Bot API 发送消息到 Discord
         
@@ -125,7 +127,7 @@ class DiscordSender:
             }
             
             url = f'https://discord.com/api/v10/channels/{self._discord_config["channel_id"]}/messages'
-            response = requests.post(url, json=payload, headers=headers, timeout=10)
+            response = requests.post(url, json=payload, headers=headers, timeout=timeout_seconds or 10)
             
             if response.status_code == 200:
                 logger.info("Discord Bot 消息发送成功")

--- a/src/notification_sender/email_sender.py
+++ b/src/notification_sender/email_sender.py
@@ -132,7 +132,12 @@ class EmailSender:
                 pass
     
     def send_to_email(
-        self, content: str, subject: Optional[str] = None, receivers: Optional[List[str]] = None
+        self,
+        content: str,
+        subject: Optional[str] = None,
+        receivers: Optional[List[str]] = None,
+        *,
+        timeout_seconds: Optional[float] = None,
     ) -> bool:
         """
         通过 SMTP 发送邮件（自动识别 SMTP 服务器）
@@ -194,10 +199,10 @@ class EmailSender:
             # 根据配置选择连接方式
             if use_ssl:
                 # SSL 连接（端口 465）
-                server = smtplib.SMTP_SSL(smtp_server, smtp_port, timeout=30)
+                server = smtplib.SMTP_SSL(smtp_server, smtp_port, timeout=timeout_seconds or 30)
             else:
                 # TLS 连接（端口 587）
-                server = smtplib.SMTP(smtp_server, smtp_port, timeout=30)
+                server = smtplib.SMTP(smtp_server, smtp_port, timeout=timeout_seconds or 30)
                 server.starttls()
             
             server.login(sender, password)

--- a/src/notification_sender/feishu_sender.py
+++ b/src/notification_sender/feishu_sender.py
@@ -10,7 +10,7 @@ import hashlib
 import hmac
 import logging
 import time
-from typing import Any, Dict
+from typing import Any, Dict, Optional
 
 import requests
 
@@ -73,7 +73,7 @@ class FeishuSender:
         }
     
           
-    def send_to_feishu(self, content: str) -> bool:
+    def send_to_feishu(self, content: str, *, timeout_seconds: Optional[float] = None) -> bool:
         """
         推送消息到飞书机器人
         
@@ -141,7 +141,7 @@ class FeishuSender:
             return self._send_feishu_chunked(formatted_content, effective_max_bytes)
         
         try:
-            return self._send_feishu_message(formatted_content)
+            return self._send_feishu_message(formatted_content, timeout_seconds=timeout_seconds)
         except Exception as e:
             logger.error(f"发送飞书消息失败: {e}")
             return False
@@ -187,7 +187,7 @@ class FeishuSender:
         
         return success_count == total_chunks
     
-    def _send_feishu_message(self, content: str) -> bool:
+    def _send_feishu_message(self, content: str, *, timeout_seconds: Optional[float] = None) -> bool:
         """发送单条飞书消息（优先使用 Markdown 卡片）"""
         prepared_content = self._apply_keyword_prefix(content)
         security_fields = self._build_security_fields()
@@ -201,7 +201,7 @@ class FeishuSender:
             response = requests.post(
                 self._feishu_url,
                 json=request_payload,
-                timeout=30,
+                timeout=timeout_seconds or 30,
                 verify=self._webhook_verify_ssl
             )
 

--- a/src/notification_sender/pushover_sender.py
+++ b/src/notification_sender/pushover_sender.py
@@ -35,7 +35,13 @@ class PushoverSender:
         """检查 Pushover 配置是否完整"""
         return bool(self._pushover_config['user_key'] and self._pushover_config['api_token'])
 
-    def send_to_pushover(self, content: str, title: Optional[str] = None) -> bool:
+    def send_to_pushover(
+        self,
+        content: str,
+        title: Optional[str] = None,
+        *,
+        timeout_seconds: Optional[float] = None,
+    ) -> bool:
         """
         推送消息到 Pushover
         
@@ -57,7 +63,7 @@ class PushoverSender:
         Args:
             content: 消息内容（Markdown 格式，会转为纯文本）
             title: 消息标题（可选，默认为"股票分析报告"）
-            
+
         Returns:
             是否发送成功
         """
@@ -84,10 +90,18 @@ class PushoverSender:
         
         if len(plain_content) <= max_length:
             # 单条消息发送
-            return self._send_pushover_message(api_url, user_key, api_token, plain_content, title)
+            return self._send_pushover_message(api_url, user_key, api_token, plain_content, title, timeout_seconds=timeout_seconds)
         else:
             # 分段发送长消息
-            return self._send_pushover_chunked(api_url, user_key, api_token, plain_content, title, max_length)
+            return self._send_pushover_chunked(
+                api_url,
+                user_key,
+                api_token,
+                plain_content,
+                title,
+                max_length,
+                timeout_seconds=timeout_seconds,
+            )
       
     def _send_pushover_message(
         self, 
@@ -96,7 +110,9 @@ class PushoverSender:
         api_token: str, 
         message: str, 
         title: str,
-        priority: int = 0
+        priority: int = 0,
+        *,
+        timeout_seconds: Optional[float] = None,
     ) -> bool:
         """
         发送单条 Pushover 消息
@@ -118,7 +134,7 @@ class PushoverSender:
                 "priority": priority,
             }
             
-            response = requests.post(api_url, data=payload, timeout=30)
+            response = requests.post(api_url, data=payload, timeout=timeout_seconds or 30)
             
             if response.status_code == 200:
                 result = response.json()
@@ -145,7 +161,9 @@ class PushoverSender:
         api_token: str, 
         content: str, 
         title: str,
-        max_length: int
+        max_length: int,
+        *,
+        timeout_seconds: Optional[float] = None,
     ) -> bool:
         """
         分段发送长 Pushover 消息
@@ -198,7 +216,14 @@ class PushoverSender:
             # 添加分页标记到标题
             chunk_title = f"{title} ({i+1}/{total_chunks})" if total_chunks > 1 else title
             
-            if self._send_pushover_message(api_url, user_key, api_token, chunk, chunk_title):
+            if self._send_pushover_message(
+                api_url,
+                user_key,
+                api_token,
+                chunk,
+                chunk_title,
+                timeout_seconds=timeout_seconds,
+            ):
                 success_count += 1
                 logger.info(f"Pushover 第 {i+1}/{total_chunks} 批发送成功")
             else:
@@ -207,6 +232,5 @@ class PushoverSender:
             # 批次间隔，避免触发频率限制
             if i < total_chunks - 1:
                 time.sleep(1)
-        
+
         return success_count == total_chunks
-    

--- a/src/notification_sender/pushplus_sender.py
+++ b/src/notification_sender/pushplus_sender.py
@@ -31,7 +31,13 @@ class PushplusSender:
         self._pushplus_topic = getattr(config, 'pushplus_topic', None)
         self._pushplus_max_bytes = getattr(config, 'pushplus_max_bytes', 20000)
         
-    def send_to_pushplus(self, content: str, title: Optional[str] = None) -> bool:
+    def send_to_pushplus(
+        self,
+        content: str,
+        title: Optional[str] = None,
+        *,
+        timeout_seconds: Optional[float] = None,
+    ) -> bool:
         """
         推送消息到 PushPlus
 
@@ -81,12 +87,19 @@ class PushplusSender:
                     self._pushplus_max_bytes,
                 )
 
-            return self._send_pushplus_message(api_url, content, title)
+            return self._send_pushplus_message(api_url, content, title, timeout_seconds=timeout_seconds)
         except Exception as e:
             logger.error(f"发送 PushPlus 消息失败: {e}")
             return False
 
-    def _send_pushplus_message(self, api_url: str, content: str, title: str) -> bool:
+    def _send_pushplus_message(
+        self,
+        api_url: str,
+        content: str,
+        title: str,
+        *,
+        timeout_seconds: Optional[float] = None,
+    ) -> bool:
         payload = {
             "token": self._pushplus_token,
             "title": title,
@@ -97,7 +110,7 @@ class PushplusSender:
         if self._pushplus_topic:
             payload["topic"] = self._pushplus_topic
 
-        response = requests.post(api_url, json=payload, timeout=10)
+        response = requests.post(api_url, json=payload, timeout=timeout_seconds or 10)
 
         if response.status_code == 200:
             result = response.json()

--- a/src/notification_sender/serverchan3_sender.py
+++ b/src/notification_sender/serverchan3_sender.py
@@ -28,7 +28,13 @@ class Serverchan3Sender:
         """
         self._serverchan3_sendkey = getattr(config, 'serverchan3_sendkey', None)
         
-    def send_to_serverchan3(self, content: str, title: Optional[str] = None) -> bool:
+    def send_to_serverchan3(
+        self,
+        content: str,
+        title: Optional[str] = None,
+        *,
+        timeout_seconds: Optional[float] = None,
+    ) -> bool:
         """
         推送消息到 Server酱3
 
@@ -87,7 +93,7 @@ class Serverchan3Sender:
             headers = {
                 'Content-Type': 'application/json;charset=utf-8'
             }
-            response = requests.post(url, json=params, headers=headers, timeout=10)
+            response = requests.post(url, json=params, headers=headers, timeout=timeout_seconds or 10)
 
             if response.status_code == 200:
                 result = response.json()
@@ -103,4 +109,3 @@ class Serverchan3Sender:
             import traceback
             logger.debug(traceback.format_exc())
             return False
-

--- a/src/notification_sender/slack_sender.py
+++ b/src/notification_sender/slack_sender.py
@@ -8,6 +8,8 @@ Slack 发送提醒服务
 """
 import logging
 import json
+from typing import Optional
+
 import requests
 
 from src.config import Config
@@ -44,7 +46,7 @@ class SlackSender:
         """检查 Slack 配置是否完整（支持 Webhook 或 Bot API）"""
         return self._use_bot or bool(self._slack_webhook_url)
 
-    def send_to_slack(self, content: str) -> bool:
+    def send_to_slack(self, content: str, *, timeout_seconds: Optional[float] = None) -> bool:
         """
         推送消息到 Slack（支持 Webhook 和 Bot API）
 
@@ -66,11 +68,11 @@ class SlackSender:
 
         # 优先使用 Bot API（与 _send_slack_image 保持一致）
         if self._use_bot:
-            return all(self._send_slack_bot(chunk) for chunk in chunks)
+            return all(self._send_slack_bot(chunk, timeout_seconds=timeout_seconds) for chunk in chunks)
 
         # 其次使用 Webhook
         if self._slack_webhook_url:
-            return all(self._send_slack_webhook(chunk) for chunk in chunks)
+            return all(self._send_slack_webhook(chunk, timeout_seconds=timeout_seconds) for chunk in chunks)
 
         logger.warning("Slack 配置不完整，跳过推送")
         return False
@@ -96,7 +98,7 @@ class SlackSender:
             pos += _BLOCK_TEXT_LIMIT
         return blocks
 
-    def _send_slack_webhook(self, content: str) -> bool:
+    def _send_slack_webhook(self, content: str, *, timeout_seconds: Optional[float] = None) -> bool:
         """
         使用 Incoming Webhook 发送消息到 Slack
 
@@ -115,7 +117,7 @@ class SlackSender:
                 self._slack_webhook_url,
                 data=json.dumps(payload, ensure_ascii=False).encode('utf-8'),
                 headers={'Content-Type': 'application/json; charset=utf-8'},
-                timeout=15,
+                timeout=timeout_seconds or 15,
                 verify=self._webhook_verify_ssl,
             )
             if response.status_code == 200 and response.text == "ok":
@@ -127,7 +129,7 @@ class SlackSender:
             logger.error(f"Slack Webhook 发送异常: {e}")
             return False
 
-    def _send_slack_bot(self, content: str) -> bool:
+    def _send_slack_bot(self, content: str, *, timeout_seconds: Optional[float] = None) -> bool:
         """
         使用 Bot API (chat.postMessage) 发送消息到 Slack
 
@@ -151,7 +153,7 @@ class SlackSender:
                 'https://slack.com/api/chat.postMessage',
                 data=json.dumps(payload, ensure_ascii=False).encode('utf-8'),
                 headers=headers,
-                timeout=15,
+                timeout=timeout_seconds or 15,
             )
             result = response.json()
             if result.get("ok"):

--- a/src/notification_sender/telegram_sender.py
+++ b/src/notification_sender/telegram_sender.py
@@ -37,7 +37,7 @@ class TelegramSender:
         """检查 Telegram 配置是否完整"""
         return bool(self._telegram_config['bot_token'] and self._telegram_config['chat_id'])
    
-    def send_to_telegram(self, content: str) -> bool:
+    def send_to_telegram(self, content: str, *, timeout_seconds: Optional[float] = None) -> bool:
         """
         推送消息到 Telegram 机器人
         
@@ -72,10 +72,10 @@ class TelegramSender:
             
             if len(content) <= max_length:
                 # 单条消息发送
-                return self._send_telegram_message(api_url, chat_id, content, message_thread_id)
+                return self._send_telegram_message(api_url, chat_id, content, message_thread_id, timeout_seconds=timeout_seconds)
             else:
                 # 分段发送长消息
-                return self._send_telegram_chunked(api_url, chat_id, content, max_length, message_thread_id)
+                return self._send_telegram_chunked(api_url, chat_id, content, max_length, message_thread_id, timeout_seconds=timeout_seconds)
                 
         except Exception as e:
             logger.error(f"发送 Telegram 消息失败: {e}")
@@ -83,7 +83,15 @@ class TelegramSender:
             logger.debug(traceback.format_exc())
             return False
     
-    def _send_telegram_message(self, api_url: str, chat_id: str, text: str, message_thread_id: Optional[str] = None) -> bool:
+    def _send_telegram_message(
+        self,
+        api_url: str,
+        chat_id: str,
+        text: str,
+        message_thread_id: Optional[str] = None,
+        *,
+        timeout_seconds: Optional[float] = None,
+    ) -> bool:
         """Send a single Telegram message with exponential backoff retry (Fixes #287)"""
         # Convert Markdown to Telegram-compatible format
         telegram_text = self._convert_to_telegram_markdown(text)
@@ -101,7 +109,7 @@ class TelegramSender:
         max_retries = 3
         for attempt in range(1, max_retries + 1):
             try:
-                response = requests.post(api_url, json=payload, timeout=10)
+                response = requests.post(api_url, json=payload, timeout=timeout_seconds or 10)
             except (requests.exceptions.ConnectionError, requests.exceptions.Timeout) as e:
                 if attempt < max_retries:
                     delay = 2 ** attempt  # 2s, 4s
@@ -124,7 +132,7 @@ class TelegramSender:
                     
                     # If Markdown parsing failed, fall back to plain text
                     if self._should_fallback_to_plain_text(error_desc=error_desc):
-                        if self._send_plain_text_fallback(api_url, payload, text):
+                        if self._send_plain_text_fallback(api_url, payload, text, timeout_seconds=timeout_seconds):
                             return True
                     
                     return False
@@ -147,7 +155,7 @@ class TelegramSender:
                     time.sleep(delay)
                     continue
                 if self._should_fallback_to_plain_text(response_text=response.text):
-                    if self._send_plain_text_fallback(api_url, payload, text):
+                    if self._send_plain_text_fallback(api_url, payload, text, timeout_seconds=timeout_seconds):
                         return True
                 logger.error(f"Telegram 请求失败: HTTP {response.status_code}")
                 logger.error(f"响应内容: {response.text}")
@@ -169,7 +177,14 @@ class TelegramSender:
         )
         return any(marker in haystack for marker in markers)
 
-    def _send_plain_text_fallback(self, api_url: str, payload: dict, text: str) -> bool:
+    def _send_plain_text_fallback(
+        self,
+        api_url: str,
+        payload: dict,
+        text: str,
+        *,
+        timeout_seconds: Optional[float] = None,
+    ) -> bool:
         """Retry Telegram send without parse_mode when Markdown parsing fails."""
         logger.info("Telegram Markdown 解析失败，尝试使用纯文本格式重新发送...")
         plain_payload = dict(payload)
@@ -177,7 +192,7 @@ class TelegramSender:
         plain_payload['text'] = text
 
         try:
-            response = requests.post(api_url, json=plain_payload, timeout=10)
+            response = requests.post(api_url, json=plain_payload, timeout=timeout_seconds or 10)
         except (requests.exceptions.ConnectionError, requests.exceptions.Timeout) as e:
             logger.error(f"Telegram plain-text fallback failed: {e}")
             return False
@@ -202,7 +217,16 @@ class TelegramSender:
         logger.error(f"响应内容: {response.text}")
         return False
     
-    def _send_telegram_chunked(self, api_url: str, chat_id: str, content: str, max_length: int, message_thread_id: Optional[str] = None) -> bool:
+    def _send_telegram_chunked(
+        self,
+        api_url: str,
+        chat_id: str,
+        content: str,
+        max_length: int,
+        message_thread_id: Optional[str] = None,
+        *,
+        timeout_seconds: Optional[float] = None,
+    ) -> bool:
         """分段发送长 Telegram 消息"""
         # 按段落分割
         sections = content.split("\n---\n")
@@ -220,7 +244,7 @@ class TelegramSender:
                 if current_chunk:
                     chunk_content = "\n---\n".join(current_chunk)
                     logger.info(f"发送 Telegram 消息块 {chunk_index}...")
-                    if not self._send_telegram_message(api_url, chat_id, chunk_content, message_thread_id):
+                    if not self._send_telegram_message(api_url, chat_id, chunk_content, message_thread_id, timeout_seconds=timeout_seconds):
                         all_success = False
                     chunk_index += 1
                 
@@ -235,7 +259,7 @@ class TelegramSender:
         if current_chunk:
             chunk_content = "\n---\n".join(current_chunk)
             logger.info(f"发送 Telegram 消息块 {chunk_index}...")
-            if not self._send_telegram_message(api_url, chat_id, chunk_content, message_thread_id):
+            if not self._send_telegram_message(api_url, chat_id, chunk_content, message_thread_id, timeout_seconds=timeout_seconds):
                 all_success = False
                 
         return all_success

--- a/src/notification_sender/wechat_sender.py
+++ b/src/notification_sender/wechat_sender.py
@@ -11,6 +11,7 @@ import base64
 import hashlib
 import requests
 import time
+from typing import Optional
 
 from src.config import Config
 from src.formatters import chunk_content_by_max_bytes
@@ -36,7 +37,7 @@ class WechatSender:
         self._wechat_msg_type = getattr(config, 'wechat_msg_type', 'markdown')
         self._webhook_verify_ssl = getattr(config, 'webhook_verify_ssl', True)
         
-    def send_to_wechat(self, content: str) -> bool:
+    def send_to_wechat(self, content: str, *, timeout_seconds: Optional[float] = None) -> bool:
         """
         推送消息到企业微信机器人
         
@@ -86,7 +87,7 @@ class WechatSender:
             return self._send_wechat_chunked(content, max_bytes)
         
         try:
-            return self._send_wechat_message(content)
+            return self._send_wechat_message(content, timeout_seconds=timeout_seconds)
         except Exception as e:
             logger.error(f"发送企业微信消息失败: {e}")
             return False
@@ -124,14 +125,14 @@ class WechatSender:
             logger.error("企业微信图片发送异常: %s", e)
             return False
     
-    def _send_wechat_message(self, content: str) -> bool:
+    def _send_wechat_message(self, content: str, *, timeout_seconds: Optional[float] = None) -> bool:
         """发送企业微信消息"""
         payload = self._gen_wechat_payload(content)
         
         response = requests.post(
             self._wechat_url,
             json=payload,
-            timeout=10,
+            timeout=timeout_seconds or 10,
             verify=self._webhook_verify_ssl
         )
         

--- a/src/services/system_config_service.py
+++ b/src/services/system_config_service.py
@@ -31,6 +31,7 @@ from src.config import (
     normalize_news_strategy_profile,
     normalize_llm_channel_model,
     parse_env_bool,
+    parse_env_int,
     resolve_news_window_days,
     resolve_llm_channel_protocol,
     setup_env,
@@ -101,6 +102,80 @@ class SystemConfigService:
             "strategy": "specialist",
             "skill": "specialist",
         }
+    }
+    _NOTIFICATION_TEST_CHANNELS: Tuple[str, ...] = (
+        "wechat",
+        "feishu",
+        "telegram",
+        "email",
+        "pushover",
+        "pushplus",
+        "serverchan3",
+        "custom",
+        "discord",
+        "slack",
+        "astrbot",
+    )
+    _NOTIFICATION_TEST_KEY_MAP: Dict[str, Tuple[str, str]] = {
+        "WECHAT_WEBHOOK_URL": ("wechat_webhook_url", "string"),
+        "WECHAT_MSG_TYPE": ("wechat_msg_type", "string"),
+        "WECHAT_MAX_BYTES": ("wechat_max_bytes", "int"),
+        "FEISHU_WEBHOOK_URL": ("feishu_webhook_url", "string"),
+        "FEISHU_WEBHOOK_SECRET": ("feishu_webhook_secret", "string"),
+        "FEISHU_WEBHOOK_KEYWORD": ("feishu_webhook_keyword", "string"),
+        "FEISHU_MAX_BYTES": ("feishu_max_bytes", "int"),
+        "TELEGRAM_BOT_TOKEN": ("telegram_bot_token", "string"),
+        "TELEGRAM_CHAT_ID": ("telegram_chat_id", "string"),
+        "TELEGRAM_MESSAGE_THREAD_ID": ("telegram_message_thread_id", "string"),
+        "EMAIL_SENDER": ("email_sender", "string"),
+        "EMAIL_SENDER_NAME": ("email_sender_name", "string"),
+        "EMAIL_PASSWORD": ("email_password", "string"),
+        "EMAIL_RECEIVERS": ("email_receivers", "csv"),
+        "PUSHOVER_USER_KEY": ("pushover_user_key", "string"),
+        "PUSHOVER_API_TOKEN": ("pushover_api_token", "string"),
+        "PUSHPLUS_TOKEN": ("pushplus_token", "string"),
+        "PUSHPLUS_TOPIC": ("pushplus_topic", "string"),
+        "SERVERCHAN3_SENDKEY": ("serverchan3_sendkey", "string"),
+        "CUSTOM_WEBHOOK_URLS": ("custom_webhook_urls", "csv"),
+        "CUSTOM_WEBHOOK_BEARER_TOKEN": ("custom_webhook_bearer_token", "string"),
+        "CUSTOM_WEBHOOK_BODY_TEMPLATE": ("custom_webhook_body_template", "string"),
+        "WEBHOOK_VERIFY_SSL": ("webhook_verify_ssl", "bool"),
+        "DISCORD_WEBHOOK_URL": ("discord_webhook_url", "string"),
+        "DISCORD_BOT_TOKEN": ("discord_bot_token", "string"),
+        "DISCORD_MAIN_CHANNEL_ID": ("discord_main_channel_id", "string"),
+        "DISCORD_CHANNEL_ID": ("discord_main_channel_id", "string"),
+        "DISCORD_MAX_WORDS": ("discord_max_words", "int"),
+        "SLACK_WEBHOOK_URL": ("slack_webhook_url", "string"),
+        "SLACK_BOT_TOKEN": ("slack_bot_token", "string"),
+        "SLACK_CHANNEL_ID": ("slack_channel_id", "string"),
+        "ASTRBOT_URL": ("astrbot_url", "string"),
+        "ASTRBOT_TOKEN": ("astrbot_token", "string"),
+    }
+    _NOTIFICATION_REQUIRED_KEY_GROUPS: Dict[str, Tuple[Tuple[str, ...], ...]] = {
+        "wechat": (("WECHAT_WEBHOOK_URL",),),
+        "feishu": (("FEISHU_WEBHOOK_URL",),),
+        "telegram": (("TELEGRAM_BOT_TOKEN", "TELEGRAM_CHAT_ID"),),
+        "email": (("EMAIL_SENDER", "EMAIL_PASSWORD"),),
+        "pushover": (("PUSHOVER_USER_KEY", "PUSHOVER_API_TOKEN"),),
+        "pushplus": (("PUSHPLUS_TOKEN",),),
+        "serverchan3": (("SERVERCHAN3_SENDKEY",),),
+        "custom": (("CUSTOM_WEBHOOK_URLS",),),
+        "discord": (("DISCORD_WEBHOOK_URL",), ("DISCORD_BOT_TOKEN", "DISCORD_MAIN_CHANNEL_ID"), ("DISCORD_BOT_TOKEN", "DISCORD_CHANNEL_ID")),
+        "slack": (("SLACK_WEBHOOK_URL",), ("SLACK_BOT_TOKEN", "SLACK_CHANNEL_ID")),
+        "astrbot": (("ASTRBOT_URL",),),
+    }
+    _NOTIFICATION_TEST_TARGET_KEYS: Dict[str, Tuple[str, ...]] = {
+        "wechat": ("WECHAT_WEBHOOK_URL",),
+        "feishu": ("FEISHU_WEBHOOK_URL",),
+        "telegram": ("TELEGRAM_BOT_TOKEN",),
+        "email": ("EMAIL_RECEIVERS", "EMAIL_SENDER"),
+        "pushover": ("PUSHOVER_USER_KEY",),
+        "pushplus": ("PUSHPLUS_TOPIC",),
+        "serverchan3": ("SERVERCHAN3_SENDKEY",),
+        "custom": ("CUSTOM_WEBHOOK_URLS",),
+        "discord": ("DISCORD_WEBHOOK_URL", "DISCORD_MAIN_CHANNEL_ID", "DISCORD_CHANNEL_ID"),
+        "slack": ("SLACK_WEBHOOK_URL", "SLACK_CHANNEL_ID"),
+        "astrbot": ("ASTRBOT_URL",),
     }
 
     def __init__(self, manager: Optional[ConfigManager] = None):
@@ -228,6 +303,71 @@ class SystemConfigService:
             "valid": valid,
             "issues": issues,
         }
+
+    def test_notification_channel(
+        self,
+        *,
+        channel: str,
+        items: Sequence[Dict[str, str]],
+        mask_token: str = "******",
+        title: str = "DSA 通知测试",
+        content: str = "这是一条来自 DSA Web 设置页的通知测试消息。",
+        timeout_seconds: float = 20.0,
+    ) -> Dict[str, Any]:
+        """Send one real notification test without persisting submitted values."""
+        normalized_channel = (channel or "").strip().lower()
+        if normalized_channel not in self._NOTIFICATION_TEST_CHANNELS:
+            raise ValueError(f"Unsupported notification channel: {channel}")
+
+        effective_map = self._build_notification_test_effective_map(
+            items=items,
+            mask_token=mask_token,
+        )
+        missing = self._get_missing_notification_test_keys(normalized_channel, effective_map)
+        if missing:
+            return self._build_notification_test_result(
+                success=False,
+                message=f"通知渠道配置不完整，缺少: {', '.join(missing)}",
+                error_code="config_missing",
+                stage="config_validation",
+                retryable=False,
+                latency_ms=None,
+                attempts=[],
+            )
+
+        config = self._build_notification_test_config(effective_map)
+        try:
+            return self._dispatch_notification_test(
+                channel=normalized_channel,
+                config=config,
+                effective_map=effective_map,
+                title=title.strip(),
+                content=content.strip(),
+                timeout_seconds=float(timeout_seconds),
+            )
+        except Exception as exc:
+            logger.warning("Notification channel test failed for %s: %s", normalized_channel, exc)
+            error_code, retryable = self._classify_notification_exception(exc)
+            return self._build_notification_test_result(
+                success=False,
+                message=f"通知测试异常: {exc}",
+                error_code=error_code,
+                stage="notification_send",
+                retryable=retryable,
+                latency_ms=None,
+                attempts=[
+                    {
+                        "channel": normalized_channel,
+                        "success": False,
+                        "message": str(exc),
+                        "target": self._resolve_notification_test_target(normalized_channel, effective_map),
+                        "error_code": error_code,
+                        "stage": "notification_send",
+                        "retryable": retryable,
+                        "latency_ms": None,
+                    }
+                ],
+            )
 
     def get_setup_status(self) -> Dict[str, Any]:
         """Return read-only first-run setup status without mutating runtime state."""
@@ -1544,6 +1684,282 @@ class SystemConfigService:
     @staticmethod
     def _split_csv(value: str) -> List[str]:
         return [item.strip() for item in (value or "").split(",") if item.strip()]
+
+    def _build_notification_test_effective_map(
+        self,
+        *,
+        items: Sequence[Dict[str, str]],
+        mask_token: str,
+    ) -> Dict[str, str]:
+        """Merge saved/runtime config with unsaved notification test items."""
+        allowed_keys = set(self._NOTIFICATION_TEST_KEY_MAP)
+        effective = {
+            key: value
+            for key, value in self._build_display_config_map(self._manager.read_config_map()).items()
+            if key in allowed_keys
+        }
+
+        for raw_key, raw_value in os.environ.items():
+            key = str(raw_key).upper()
+            if key in allowed_keys:
+                effective[key] = "" if raw_value is None else str(raw_value)
+
+        for item in items:
+            key = str(item.get("key", "")).strip().upper()
+            if key not in allowed_keys:
+                continue
+            value = "" if item.get("value") is None else str(item.get("value"))
+            if value == mask_token:
+                continue
+            effective[key] = value
+
+        return effective
+
+    def _get_missing_notification_test_keys(
+        self,
+        channel: str,
+        effective_map: Dict[str, str],
+    ) -> List[str]:
+        """Return missing keys for a channel, honoring alternative key groups."""
+        groups = self._NOTIFICATION_REQUIRED_KEY_GROUPS.get(channel, ())
+        if not groups:
+            return []
+
+        missing_by_group: List[List[str]] = []
+        for group in groups:
+            missing = [key for key in group if not (effective_map.get(key) or "").strip()]
+            if not missing:
+                return []
+            missing_by_group.append(missing)
+
+        return missing_by_group[0] if missing_by_group else []
+
+    def _build_notification_test_config(self, effective_map: Dict[str, str]) -> Config:
+        """Build an isolated Config instance for notification testing."""
+        kwargs: Dict[str, Any] = {"stock_list": []}
+        for key, (attr, value_type) in self._NOTIFICATION_TEST_KEY_MAP.items():
+            if key not in effective_map:
+                continue
+            if key == "DISCORD_CHANNEL_ID" and (effective_map.get("DISCORD_MAIN_CHANNEL_ID") or "").strip():
+                continue
+            raw_value = effective_map.get(key, "")
+            kwargs[attr] = self._parse_notification_test_value(key, raw_value, value_type)
+        return Config(**kwargs)
+
+    def _parse_notification_test_value(self, key: str, value: str, value_type: str) -> Any:
+        if value_type == "csv":
+            return self._split_csv(value)
+        if value_type == "bool":
+            return parse_env_bool(value, default=True)
+        if value_type == "int":
+            defaults = {
+                "WECHAT_MAX_BYTES": 4000,
+                "FEISHU_MAX_BYTES": 20000,
+                "DISCORD_MAX_WORDS": 2000,
+            }
+            return parse_env_int(value, defaults.get(key, 0), field_name=key, minimum=1)
+        stripped = (value or "").strip()
+        return stripped or None
+
+    def _dispatch_notification_test(
+        self,
+        *,
+        channel: str,
+        config: Config,
+        effective_map: Dict[str, str],
+        title: str,
+        content: str,
+        timeout_seconds: float,
+    ) -> Dict[str, Any]:
+        from src.notification_sender import (
+            AstrbotSender,
+            CustomWebhookSender,
+            DiscordSender,
+            EmailSender,
+            FeishuSender,
+            PushoverSender,
+            PushplusSender,
+            Serverchan3Sender,
+            SlackSender,
+            TelegramSender,
+            WechatSender,
+        )
+
+        started_at = time.perf_counter()
+        target = self._resolve_notification_test_target(channel, effective_map)
+        titled_content = self._build_notification_test_content(title, content)
+
+        if channel == "custom":
+            attempts = CustomWebhookSender(config).test_custom_webhooks(
+                titled_content,
+                timeout_seconds=timeout_seconds,
+            )
+            latency_ms = int((time.perf_counter() - started_at) * 1000)
+            success = any(bool(attempt.get("success")) for attempt in attempts)
+            return self._build_notification_test_result(
+                success=success,
+                message="自定义 Webhook 通知测试成功" if success else "自定义 Webhook 通知测试失败",
+                error_code=None if success else "send_failed",
+                stage="notification_send",
+                retryable=any(bool(attempt.get("retryable")) for attempt in attempts),
+                latency_ms=latency_ms,
+                attempts=attempts,
+            )
+
+        dispatch = {
+            "wechat": lambda: WechatSender(config).send_to_wechat(titled_content, timeout_seconds=timeout_seconds),
+            "feishu": lambda: FeishuSender(config).send_to_feishu(titled_content, timeout_seconds=timeout_seconds),
+            "telegram": lambda: TelegramSender(config).send_to_telegram(titled_content, timeout_seconds=timeout_seconds),
+            "email": lambda: EmailSender(config).send_to_email(content, subject=title, timeout_seconds=timeout_seconds),
+            "pushover": lambda: PushoverSender(config).send_to_pushover(content, title=title, timeout_seconds=timeout_seconds),
+            "pushplus": lambda: PushplusSender(config).send_to_pushplus(content, title=title, timeout_seconds=timeout_seconds),
+            "serverchan3": lambda: Serverchan3Sender(config).send_to_serverchan3(content, title=title, timeout_seconds=timeout_seconds),
+            "discord": lambda: DiscordSender(config).send_to_discord(titled_content, timeout_seconds=timeout_seconds),
+            "slack": lambda: SlackSender(config).send_to_slack(titled_content, timeout_seconds=timeout_seconds),
+            "astrbot": lambda: AstrbotSender(config).send_to_astrbot(titled_content, timeout_seconds=timeout_seconds),
+        }
+
+        ok = bool(dispatch[channel]())
+        latency_ms = int((time.perf_counter() - started_at) * 1000)
+        attempt = {
+            "channel": channel,
+            "success": ok,
+            "message": "通知测试发送成功" if ok else "通知测试发送失败",
+            "target": target,
+            "error_code": None if ok else "send_failed",
+            "stage": "notification_send",
+            "retryable": False,
+            "latency_ms": latency_ms,
+        }
+        return self._build_notification_test_result(
+            success=ok,
+            message=f"{channel} 通知测试成功" if ok else f"{channel} 通知测试失败",
+            error_code=None if ok else "send_failed",
+            stage="notification_send",
+            retryable=False,
+            latency_ms=latency_ms,
+            attempts=[attempt],
+        )
+
+    @staticmethod
+    def _build_notification_test_content(title: str, content: str) -> str:
+        title = title.strip()
+        content = content.strip()
+        return f"{title}\n\n{content}" if title else content
+
+    def _resolve_notification_test_target(self, channel: str, effective_map: Dict[str, str]) -> str:
+        for key in self._NOTIFICATION_TEST_TARGET_KEYS.get(channel, ()):
+            raw_value = (effective_map.get(key) or "").strip()
+            if not raw_value:
+                continue
+            if key == "CUSTOM_WEBHOOK_URLS":
+                first_url = self._split_csv(raw_value)[0] if self._split_csv(raw_value) else ""
+                return self._mask_notification_target(first_url, source_key=key)
+            return self._mask_notification_target(raw_value, source_key=key)
+        return channel
+
+    @classmethod
+    def _build_notification_test_result(
+        cls,
+        *,
+        success: bool,
+        message: str,
+        error_code: Optional[str],
+        stage: Optional[str],
+        retryable: bool,
+        latency_ms: Optional[int],
+        attempts: Sequence[Dict[str, Any]],
+    ) -> Dict[str, Any]:
+        sanitized_attempts = [cls._sanitize_notification_attempt(attempt) for attempt in attempts]
+        return {
+            "success": success,
+            "message": cls._sanitize_notification_text(message),
+            "error_code": error_code,
+            "stage": stage,
+            "retryable": retryable,
+            "latency_ms": latency_ms,
+            "attempts": sanitized_attempts,
+        }
+
+    @classmethod
+    def _sanitize_notification_attempt(cls, attempt: Dict[str, Any]) -> Dict[str, Any]:
+        sanitized = dict(attempt)
+        if "message" in sanitized:
+            sanitized["message"] = cls._sanitize_notification_text(sanitized["message"])
+        if "target" in sanitized:
+            sanitized["target"] = cls._mask_notification_target(str(sanitized.get("target") or ""))
+        return sanitized
+
+    @classmethod
+    def _sanitize_notification_text(cls, text: Any) -> str:
+        sanitized = cls._sanitize_llm_error_text(text)
+        if not sanitized:
+            return ""
+        sanitized = re.sub(r"(?i)(bearer\s+)[a-z0-9._\-:]+", r"\1[REDACTED]", sanitized)
+        sanitized = re.sub(r"(?i)(token|secret|password|sendkey)([=:]\s*)[^\s,;&]+", r"\1\2[REDACTED]", sanitized)
+        sanitized = re.sub(
+            r"https?://[^\s]+",
+            lambda match: cls._mask_notification_target(match.group(0)),
+            sanitized,
+        )
+        return sanitized[:300]
+
+    @staticmethod
+    def _mask_notification_target(target: str, *, source_key: Optional[str] = None) -> str:
+        value = (target or "").strip()
+        if not value:
+            return ""
+        source_key_upper = (source_key or "").upper()
+        sensitive_source = any(
+            marker in source_key_upper
+            for marker in ("TOKEN", "PASSWORD", "SECRET", "SENDKEY", "USER_KEY", "API_KEY")
+        )
+        parsed = urlparse(value)
+        if not parsed.scheme or not parsed.netloc:
+            if sensitive_source:
+                return "***"
+            if len(value) > 10:
+                return f"{value[:3]}***{value[-2:]}"
+            return value
+
+        safe_netloc = parsed.netloc.rsplit("@", 1)[-1]
+        safe_segments: List[str] = []
+        for segment in parsed.path.split("/"):
+            if not segment:
+                safe_segments.append(segment)
+                continue
+            lower = segment.lower()
+            looks_secret = (
+                len(segment) >= 16
+                or lower.startswith("bot")
+                or "token" in lower
+                or "sendkey" in lower
+                or "secret" in lower
+                or re.search(r"[a-zA-Z].*\d|\d.*[a-zA-Z]", segment) is not None and len(segment) >= 10
+            )
+            if looks_secret:
+                safe_segments.append("***")
+            else:
+                safe_segments.append(segment)
+
+        query = ""
+        if parsed.query:
+            query = "&".join(
+                f"{part.split('=', 1)[0]}=***" if "=" in part else "***"
+                for part in parsed.query.split("&")
+                if part
+            )
+        return urlunparse(parsed._replace(netloc=safe_netloc, path="/".join(safe_segments), query=query, fragment=""))
+
+    @staticmethod
+    def _classify_notification_exception(exc: Exception) -> Tuple[str, bool]:
+        if isinstance(exc, requests.exceptions.Timeout):
+            return "timeout", True
+        if isinstance(exc, requests.exceptions.ConnectionError):
+            return "network_error", True
+        if isinstance(exc, requests.exceptions.RequestException):
+            return "network_error", True
+        return "unexpected_error", False
 
     @staticmethod
     def _setup_check(

--- a/tests/test_notification_sender.py
+++ b/tests/test_notification_sender.py
@@ -396,6 +396,25 @@ class TestCustomWebhookSender(unittest.TestCase):
         self.assertTrue(result)
         self.assertEqual(mock_post.call_count, 2)
 
+    @mock.patch("src.notification_sender.custom_webhook_sender.requests.post")
+    def test_test_custom_webhooks_returns_ordered_attempts(self, mock_post):
+        mock_post.side_effect = [_response(500), _response(200)]
+        cfg = _config(
+            custom_webhook_urls=[
+                "https://example.com/fail?access_token=secret",
+                "https://example.com/ok",
+            ]
+        )
+        sender = CustomWebhookSender(cfg)
+
+        attempts = sender.test_custom_webhooks("hello", timeout_seconds=7)
+
+        self.assertEqual(len(attempts), 2)
+        self.assertFalse(attempts[0]["success"])
+        self.assertTrue(attempts[1]["success"])
+        self.assertEqual(attempts[0]["http_status"], 500)
+        self.assertEqual(mock_post.call_args_list[0].kwargs["timeout"], 7)
+
     def test_bark_payload_shape_is_stable(self):
         sender = CustomWebhookSender(_config())
 
@@ -528,6 +547,19 @@ class TestPushoverSender(unittest.TestCase):
         call_data = mock_post.call_args[1]["data"]
         self.assertEqual(call_data["user"], "U")
         self.assertEqual(call_data["token"], "T")
+
+    @mock.patch("time.sleep")
+    @mock.patch("src.notification_sender.pushover_sender.requests.post")
+    def test_send_chunked_uses_test_timeout(self, mock_post, _mock_sleep):
+        mock_post.return_value = _response(200, {"status": 1})
+        cfg = _config(pushover_user_key="U", pushover_api_token="T")
+        sender = PushoverSender(cfg)
+
+        result = sender.send_to_pushover("\n\n".join(["A" * 800, "B" * 800, "C" * 800]), timeout_seconds=9)
+
+        self.assertTrue(result)
+        self.assertGreaterEqual(mock_post.call_count, 2)
+        self.assertTrue(all(call.kwargs["timeout"] == 9 for call in mock_post.call_args_list))
 
 
 class TestPushplusSender(unittest.TestCase):

--- a/tests/test_system_config_api.py
+++ b/tests/test_system_config_api.py
@@ -18,6 +18,7 @@ from api.v1.schemas.system_config import (
     DiscoverLLMChannelModelsRequest,
     ImportSystemConfigRequest,
     TestLLMChannelRequest,
+    TestNotificationChannelRequest,
     UpdateSystemConfigRequest,
 )
 from src.config import Config
@@ -321,6 +322,50 @@ class SystemConfigApiTestCase(unittest.TestCase):
         self.assertEqual(payload["capability_results"], {})
         mock_test.assert_called_once()
         self.assertEqual(mock_test.call_args.kwargs["capability_checks"], ["json", "stream"])
+
+    def test_test_notification_channel_endpoint_returns_service_payload(self) -> None:
+        with patch.object(
+            self.service,
+            "test_notification_channel",
+            return_value={
+                "success": True,
+                "message": "notification ok",
+                "error_code": None,
+                "stage": "notification_send",
+                "retryable": False,
+                "latency_ms": 42,
+                "attempts": [
+                    {
+                        "channel": "wechat",
+                        "success": True,
+                        "message": "sent",
+                        "target": "https://qyapi.example.com/cgi-bin/webhook/send?key=***",
+                        "error_code": None,
+                        "stage": "notification_send",
+                        "retryable": False,
+                        "latency_ms": 42,
+                        "http_status": 200,
+                    }
+                ],
+            },
+        ) as mock_test:
+            payload = system_config.test_notification_channel(
+                request=TestNotificationChannelRequest(
+                    channel="wechat",
+                    items=[{"key": "WECHAT_WEBHOOK_URL", "value": "https://example.com/hook"}],
+                    title="DSA 通知测试",
+                    content="hello",
+                    timeout_seconds=5,
+                ),
+                service=self.service,
+            ).model_dump()
+
+        self.assertTrue(payload["success"])
+        self.assertEqual(payload["attempts"][0]["channel"], "wechat")
+        self.assertEqual(payload["attempts"][0]["latency_ms"], 42)
+        mock_test.assert_called_once()
+        self.assertEqual(mock_test.call_args.kwargs["channel"], "wechat")
+        self.assertEqual(mock_test.call_args.kwargs["timeout_seconds"], 5)
 
     def test_validate_returns_user_facing_model_message_without_internal_env_key_name(self) -> None:
         validation = self.service.validate(

--- a/tests/test_system_config_service.py
+++ b/tests/test_system_config_service.py
@@ -6,6 +6,7 @@ import tempfile
 import unittest
 from pathlib import Path
 from types import SimpleNamespace
+from typing import Any, Dict, Optional
 from unittest.mock import Mock, patch
 
 from tests.litellm_stub import ensure_litellm_stub
@@ -846,6 +847,166 @@ class SystemConfigServiceTestCase(unittest.TestCase):
 
         self.assertFalse(validation["valid"])
         self.assertTrue(any(issue["key"] == "LITELLM_MODEL" and issue["code"] == "missing_runtime_source" for issue in validation["issues"]))
+
+    @staticmethod
+    def _mock_http_response(status_code: int, json_body: Optional[Dict[str, Any]] = None):
+        response = Mock()
+        response.status_code = status_code
+        response.text = "ok" if status_code == 200 else "error"
+        response.json.return_value = json_body or {"errcode": 0}
+        return response
+
+    def _notification_test_env(self):
+        return patch.dict(os.environ, {"ENV_FILE": str(self.env_path)}, clear=True)
+
+    @patch("src.notification_sender.wechat_sender.requests.post")
+    def test_test_notification_channel_uses_temporary_items_without_persisting(self, mock_post) -> None:
+        mock_post.return_value = self._mock_http_response(200, {"errcode": 0})
+
+        with self._notification_test_env():
+            before_instance = Config.get_instance()
+            payload = self.service.test_notification_channel(
+                channel="wechat",
+                items=[{"key": "WECHAT_WEBHOOK_URL", "value": "https://qyapi.example.com/cgi-bin/webhook/send?key=secret"}],
+                title="Test title",
+                content="hello",
+                timeout_seconds=3,
+            )
+            self.assertIs(Config.get_instance(), before_instance)
+
+        self.assertTrue(payload["success"])
+        self.assertEqual(payload["attempts"][0]["latency_ms"] >= 0, True)
+        self.assertIn("key=***", payload["attempts"][0]["target"])
+        self.assertNotIn("WECHAT_WEBHOOK_URL", self.env_path.read_text(encoding="utf-8"))
+        self.assertEqual(mock_post.call_args.kwargs["timeout"], 3)
+
+    def test_test_notification_channel_reports_missing_config(self) -> None:
+        with self._notification_test_env():
+            payload = self.service.test_notification_channel(
+                channel="telegram",
+                items=[{"key": "TELEGRAM_BOT_TOKEN", "value": "token"}],
+                title="Test title",
+                content="hello",
+                timeout_seconds=3,
+            )
+
+        self.assertFalse(payload["success"])
+        self.assertEqual(payload["error_code"], "config_missing")
+        self.assertIn("TELEGRAM_CHAT_ID", payload["message"])
+
+    @patch("src.notification_sender.wechat_sender.requests.post")
+    def test_test_notification_channel_skips_masked_secret_overwrite(self, mock_post) -> None:
+        self._rewrite_env("WECHAT_WEBHOOK_URL=https://saved.example.com/hook?key=savedsecret")
+        mock_post.return_value = self._mock_http_response(200, {"errcode": 0})
+
+        with self._notification_test_env():
+            payload = self.service.test_notification_channel(
+                channel="wechat",
+                items=[{"key": "WECHAT_WEBHOOK_URL", "value": "******"}],
+                mask_token="******",
+                title="Test title",
+                content="hello",
+                timeout_seconds=3,
+            )
+
+        self.assertTrue(payload["success"])
+        self.assertEqual(mock_post.call_args[0][0], "https://saved.example.com/hook?key=savedsecret")
+
+    @patch("src.notification_sender.custom_webhook_sender.requests.post")
+    def test_test_notification_channel_returns_custom_webhook_attempts(self, mock_post) -> None:
+        mock_post.side_effect = [
+            self._mock_http_response(500),
+            self._mock_http_response(200),
+        ]
+
+        with self._notification_test_env():
+            payload = self.service.test_notification_channel(
+                channel="custom",
+                items=[
+                    {
+                        "key": "CUSTOM_WEBHOOK_URLS",
+                        "value": (
+                            "https://example.com/robot/send?access_token=first,"
+                            "https://example.com/verylongsecrettoken1234567890"
+                        ),
+                    }
+                ],
+                title="Test title",
+                content="hello",
+                timeout_seconds=4,
+            )
+
+        self.assertTrue(payload["success"])
+        self.assertEqual(len(payload["attempts"]), 2)
+        self.assertFalse(payload["attempts"][0]["success"])
+        self.assertTrue(payload["attempts"][1]["success"])
+        self.assertIn("access_token=***", payload["attempts"][0]["target"])
+        self.assertNotIn("verylongsecrettoken1234567890", payload["attempts"][1]["target"])
+        self.assertEqual(mock_post.call_args_list[0].kwargs["timeout"], 4)
+
+    @patch("src.notification_sender.telegram_sender.requests.post")
+    def test_test_notification_channel_masks_short_sensitive_target(self, mock_post) -> None:
+        mock_post.return_value = self._mock_http_response(200, {"ok": True})
+
+        with self._notification_test_env():
+            payload = self.service.test_notification_channel(
+                channel="telegram",
+                items=[
+                    {"key": "TELEGRAM_BOT_TOKEN", "value": "tok123"},
+                    {"key": "TELEGRAM_CHAT_ID", "value": "chat-id"},
+                ],
+                title="Test title",
+                content="hello",
+                timeout_seconds=3,
+            )
+
+        self.assertTrue(payload["success"])
+        self.assertEqual(payload["attempts"][0]["target"], "***")
+        self.assertNotIn("tok123", str(payload))
+
+    @patch("src.notification_sender.wechat_sender.requests.post")
+    def test_test_notification_channel_strips_url_userinfo_from_target(self, mock_post) -> None:
+        mock_post.return_value = self._mock_http_response(200, {"errcode": 0})
+
+        with self._notification_test_env():
+            payload = self.service.test_notification_channel(
+                channel="wechat",
+                items=[
+                    {
+                        "key": "WECHAT_WEBHOOK_URL",
+                        "value": "https://user:password@example.com/cgi-bin/webhook/send?key=secret",
+                    }
+                ],
+                title="Test title",
+                content="hello",
+                timeout_seconds=3,
+            )
+
+        self.assertTrue(payload["success"])
+        target = payload["attempts"][0]["target"]
+        self.assertIn("https://example.com/cgi-bin/webhook/send?key=***", target)
+        self.assertNotIn("user", target)
+        self.assertNotIn("password", target)
+
+    @patch("src.notification_sender.discord_sender.requests.post")
+    def test_test_notification_channel_prefers_discord_main_channel_alias(self, mock_post) -> None:
+        mock_post.return_value = self._mock_http_response(200)
+
+        with self._notification_test_env():
+            payload = self.service.test_notification_channel(
+                channel="discord",
+                items=[
+                    {"key": "DISCORD_BOT_TOKEN", "value": "bot-token"},
+                    {"key": "DISCORD_MAIN_CHANNEL_ID", "value": "main-channel"},
+                    {"key": "DISCORD_CHANNEL_ID", "value": "legacy-channel"},
+                ],
+                title="Test title",
+                content="hello",
+                timeout_seconds=3,
+            )
+
+        self.assertTrue(payload["success"])
+        self.assertIn("/channels/main-channel/messages", mock_post.call_args[0][0])
 
     @patch("litellm.completion")
     def test_test_llm_channel_returns_success_payload(self, mock_completion) -> None:


### PR DESCRIPTION
## PR 类型

- [ ] fix
- [x] feat
- [ ] refactor
- [ ] docs
- [ ] chore
- [ ] test

## 背景与问题

Issue #1200 的 P0 配置基线已通过 #1205 合入。本 PR 继续实现 P1：Web 设置页需要支持对单个通知渠道执行一键真实测试，测试应使用当前页面草稿值，不保存 `.env`，并返回成功/失败、耗时、错误摘要；自定义 Webhook 需要展示逐 URL attempts。

## 具体改动

- 后端新增 `POST /api/v1/system/config/notification/test-channel` 与请求/响应 schema。
- 在 `SystemConfigService.test_notification_channel()` 中合成临时通知配置，并直接实例化目标 sender 发送测试消息。
- 各通知 sender 增加测试路径可选 `timeout_seconds` 参数，默认发送行为保持不变。
- 自定义 Webhook 增加 `test_custom_webhooks()`，按 URL 顺序返回 attempts。
- Web 设置页通知分类新增 `NotificationTestPanel`，接入渠道选择、标题、正文、timeout、结果和 attempts 展示。
- 补充后端/API/sender/Web 单元测试。
- 更新 `docs/notifications.md`、`docs/full-guide.md`、`docs/full-guide_EN.md` 和 `docs/CHANGELOG.md`。

## 关联 Issue

Refs #1200

## 验证命令与结果

```bash
git fetch upstream main --prune
git checkout -b feat/1200-p1-web-notification-test upstream/main
git cherry-pick 8323b36
./scripts/ci_gate.sh
cd apps/dsa-web && npm run lint
cd apps/dsa-web && npm run build
cd apps/dsa-web && npm run test -- src/api/__tests__/systemConfig.test.ts src/components/settings/__tests__/NotificationTestPanel.test.tsx src/pages/__tests__/SettingsPage.test.tsx
git diff --check upstream/main...HEAD
```

关键输出/结论：

- `./scripts/ci_gate.sh`：`1731 passed, 2 deselected, 47 warnings, 139 subtests passed`，backend gate 全部通过。
- `npm run lint`：通过。
- `npm run build`：通过；Vite 仍提示既有的大 chunk warning。
- `npm run test -- ...`：`3 passed (3)`，`26 passed (26)`。
- `git diff --check upstream/main...HEAD`：通过。

## 兼容性与风险

- 向后兼容：不会重写或迁移现有 `.env`。
- 默认通知发送行为保持不变；sender 新增的 timeout 参数均为 keyword-only 可选参数，未传入时沿用既有默认值。
- 新增 Web 测试只在用户显式点击测试按钮时发送真实外部通知。
- 测试响应返回给 Web 前已统一脱敏；token、secret、password、Bearer、query 参数、URL userinfo 和疑似 path token 均会被 mask。
- 剩余风险：第三方通知服务可能返回不同格式的 provider-specific 错误体，本期 P1 仅承诺通用错误摘要。

## 回滚方案

回滚本 PR 即可。该功能不持久化测试请求，也不重写现有 `.env`，因此无需配置 migration 或数据回滚。

## EXTRACT_PROMPT 变更（如适用）

不适用。

<details>
<summary>展开：完整 EXTRACT_PROMPT</summary>

```
未修改。
```

</details>

## 检查清单

- [x] 本 PR 有明确动机和业务价值 / This PR has a clear motivation and value
- [x] 已提供可复现的验证命令与结果 / Reproducible verification commands and results are included
- [x] 已评估兼容性与风险 / Compatibility and risk have been assessed
- [x] 已提供回滚方案 / A rollback plan is provided
- [x] 若涉及用户可见变更，已同步更新相关文档与 `docs/CHANGELOG.md`；`README.md` 仅在首页级信息变化时更新，细节优先写入 `docs/*.md` / If user-visible changes are included, relevant docs and `docs/CHANGELOG.md` are updated; `README.md` is updated only for homepage-level changes, with details kept in `docs/*.md`
