### PR TITLE
feat: [Issue #1200 P3] 支持通知路由策略

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -476,6 +476,13 @@ AGENT_SKILLS=
 # MD2IMG_ENGINE=wkhtmltoimage   # wkhtmltoimage(默认) | markdown-to-file(emoji 更好，需 npm i -g markdown-to-file)
 # 转图工具：wkhtmltopdf (apt install wkhtmltopdf / brew install wkhtmltopdf)，或 markdown-to-file
 #
+# 【通知路由策略】(Issue #1200 P3)
+# 默认留空：该类型通知发送到所有已配置渠道。填写后仅发送到列出的已配置渠道。
+# 允许值：wechat,feishu,telegram,email,pushover,pushplus,serverchan3,custom,discord,slack,astrbot
+# NOTIFICATION_REPORT_CHANNELS=
+# NOTIFICATION_ALERT_CHANNELS=
+# NOTIFICATION_SYSTEM_ERROR_CHANNELS=
+#
 # 【实时行情预取】(Issue #455)
 # PREFETCH_REALTIME_QUOTES=true   # 设为 false 可禁用，避免 efinance/akshare_em 全市场拉取；tushare 为单股接口，预取仅拉首股
 

--- a/.github/workflows/daily_analysis.yml
+++ b/.github/workflows/daily_analysis.yml
@@ -320,6 +320,11 @@ jobs:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
           SLACK_CHANNEL_ID: ${{ secrets.SLACK_CHANNEL_ID }}
 
+          # 通知路由策略（留空时保持全部已配置渠道）
+          NOTIFICATION_REPORT_CHANNELS: ${{ vars.NOTIFICATION_REPORT_CHANNELS || secrets.NOTIFICATION_REPORT_CHANNELS }}
+          NOTIFICATION_ALERT_CHANNELS: ${{ vars.NOTIFICATION_ALERT_CHANNELS || secrets.NOTIFICATION_ALERT_CHANNELS }}
+          NOTIFICATION_SYSTEM_ERROR_CHANNELS: ${{ vars.NOTIFICATION_SYSTEM_ERROR_CHANNELS || secrets.NOTIFICATION_SYSTEM_ERROR_CHANNELS }}
+
           # ==========================================
           # 自选股配置
           # ==========================================

--- a/bot/commands/market.py
+++ b/bot/commands/market.py
@@ -107,6 +107,7 @@ class MarketCommand(BotCommand):
                         notifier.send(
                             "🎯 大盘复盘\n\n今日相关市场休市，已跳过大盘复盘。",
                             email_send_to_all=True,
+                            route_type="report",
                         )
                     return
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - [测试] 补充设置项帮助元数据、API schema、前端弹窗交互测试，并修复 Bot 名称路由与调度时间 provider 测试的离线 CI 稳定性问题。
 - [修复] 港股日线跳过不支持港股的内置历史数据源，避免港股代码错配到非港股市场数据。
 - [修复] 修正分析 API 对北交所 `BJ` 前缀与 `.BJ` 后缀股票代码的校验，保持前端自动补全与 Tushare `ts_code` 调用格式一致。
+- [新功能] 新增通知路由策略，支持按 report、alert、system_error 将通知收窄到指定已配置渠道。
 
 ## [3.15.0] - 2026-05-05
 

--- a/docs/full-guide.md
+++ b/docs/full-guide.md
@@ -104,7 +104,7 @@ daily_stock_analysis/
 
 > *注：至少配置一个渠道，配置多个则同时推送
 >
-> 当前默认 `daily_analysis.yml` 只显式映射固定 Secret / Variable 名称，不会自动把 `STOCK_GROUP_1`、`EMAIL_GROUP_1` 这类任意编号变量导入运行环境。所以分组邮箱功能目前不适用于仓库自带默认 GitHub Actions workflow；它适用于本地 `.env`、Docker，或你自行显式扩展过 `env:` 映射的运行环境。P0 已显式映射 `CUSTOM_WEBHOOK_BODY_TEMPLATE`、`WEBHOOK_VERIFY_SSL`、`FEISHU_WEBHOOK_SECRET`、`FEISHU_WEBHOOK_KEYWORD`、`PUSHPLUS_TOPIC`；`MARKDOWN_TO_IMAGE_CHANNELS` 和 `MERGE_EMAIL_NOTIFICATION` 仍作为行为开关留给后续阶段处理。
+> 当前默认 `daily_analysis.yml` 只显式映射固定 Secret / Variable 名称，不会自动把 `STOCK_GROUP_1`、`EMAIL_GROUP_1` 这类任意编号变量导入运行环境。所以分组邮箱功能目前不适用于仓库自带默认 GitHub Actions workflow；它适用于本地 `.env`、Docker，或你自行显式扩展过 `env:` 映射的运行环境。Actions 已显式映射 `CUSTOM_WEBHOOK_BODY_TEMPLATE`、`WEBHOOK_VERIFY_SSL`、`FEISHU_WEBHOOK_SECRET`、`FEISHU_WEBHOOK_KEYWORD`、`PUSHPLUS_TOPIC` 以及 P3 通知路由键；`MARKDOWN_TO_IMAGE_CHANNELS` 和 `MERGE_EMAIL_NOTIFICATION` 仍作为行为开关不在默认 workflow 中自动映射。
 
 #### 推送行为配置
 
@@ -122,6 +122,9 @@ daily_stock_analysis/
 | `ANALYSIS_DELAY` | 个股分析和大盘分析之间的延迟（秒），避免API限流，如 `10` | 可选 |
 | `MERGE_EMAIL_NOTIFICATION` | 个股与大盘复盘合并推送（默认 false），减少邮件数量、降低垃圾邮件风险；与 `SINGLE_STOCK_NOTIFY` 互斥（单股模式下合并不生效） | 可选 |
 | `MARKDOWN_TO_IMAGE_CHANNELS` | 将 Markdown 转为图片发送的渠道（用逗号分隔）：telegram,wechat,custom,email,slack；单股推送需同时配置且安装转图工具 | 可选 |
+| `NOTIFICATION_REPORT_CHANNELS` | report 路由渠道（单股推送、聚合日报、大盘复盘、合并推送等）；留空表示所有已配置渠道 | 可选 |
+| `NOTIFICATION_ALERT_CHANNELS` | alert 路由渠道（EventMonitor 告警）；留空表示所有已配置渠道 | 可选 |
+| `NOTIFICATION_SYSTEM_ERROR_CHANNELS` | system_error 预留路由渠道；当前不新增自动系统错误生产者，留空表示所有已配置渠道 | 可选 |
 | `MARKDOWN_TO_IMAGE_MAX_CHARS` | 超过此长度不转图片，避免超大图片（默认 15000） | 可选 |
 | `MD2IMG_ENGINE` | 转图引擎：`wkhtmltoimage`（默认，需 wkhtmltopdf）或 `markdown-to-file`（emoji 更好，需 `npm i -g markdown-to-file`） | 可选 |
 | `PREFETCH_REALTIME_QUOTES` | 设为 `false` 可禁用实时行情预取，避免 efinance/akshare_em 全市场拉取（默认 true） | 可选 |
@@ -253,6 +256,9 @@ daily_stock_analysis/
 | `SERVERCHAN3_SENDKEY` | Server酱³ Sendkey | 可选 |
 | `ASTRBOT_URL` | AstrBot Webhook URL | 可选 |
 | `ASTRBOT_TOKEN` | AstrBot Bearer Token（可选） | 可选 |
+| `NOTIFICATION_REPORT_CHANNELS` | report 路由渠道，逗号分隔；允许值：wechat,feishu,telegram,email,pushover,pushplus,serverchan3,custom,discord,slack,astrbot | 可选 |
+| `NOTIFICATION_ALERT_CHANNELS` | alert 路由渠道，逗号分隔；留空保持全渠道 | 可选 |
+| `NOTIFICATION_SYSTEM_ERROR_CHANNELS` | system_error 预留路由渠道，逗号分隔；留空保持全渠道 | 可选 |
 
 > 说明：默认 `daily_analysis` GitHub Actions workflow 只映射固定变量名，不会自动导入任意编号的 `STOCK_GROUP_N` / `EMAIL_GROUP_N`。因此分组邮箱目前仅在本地 `.env`、Docker 或其他已显式注入这些环境变量的运行环境中生效；若你要在自己的 GitHub Actions 中使用，需在 workflow 的 job `env:` 中逐组显式映射。
 

--- a/docs/full-guide_EN.md
+++ b/docs/full-guide_EN.md
@@ -105,7 +105,7 @@ Go to your forked repo → `Settings` → `Secrets and variables` → `Actions` 
 
 > *Note: Configure at least one channel; multiple channels will all receive notifications
 >
-> The default `daily_analysis.yml` in this repository only exports fixed Secret / Variable names. Arbitrary numbered env vars such as `STOCK_GROUP_1` and `EMAIL_GROUP_1` are not auto-injected into the job, so grouped email routing is not available in the stock workflow unless you explicitly extend the workflow's `env:` mapping in your own fork. P0 maps `CUSTOM_WEBHOOK_BODY_TEMPLATE`, `WEBHOOK_VERIFY_SSL`, `FEISHU_WEBHOOK_SECRET`, `FEISHU_WEBHOOK_KEYWORD`, and `PUSHPLUS_TOPIC`; `MARKDOWN_TO_IMAGE_CHANNELS` and `MERGE_EMAIL_NOTIFICATION` remain behavior toggles for a later phase.
+> The default `daily_analysis.yml` in this repository only exports fixed Secret / Variable names. Arbitrary numbered env vars such as `STOCK_GROUP_1` and `EMAIL_GROUP_1` are not auto-injected into the job, so grouped email routing is not available in the stock workflow unless you explicitly extend the workflow's `env:` mapping in your own fork. Actions now maps `CUSTOM_WEBHOOK_BODY_TEMPLATE`, `WEBHOOK_VERIFY_SSL`, `FEISHU_WEBHOOK_SECRET`, `FEISHU_WEBHOOK_KEYWORD`, `PUSHPLUS_TOPIC`, and the P3 notification route keys; `MARKDOWN_TO_IMAGE_CHANNELS` and `MERGE_EMAIL_NOTIFICATION` remain behavior toggles outside the default workflow mapping.
 
 #### Push Behavior Configuration
 
@@ -120,6 +120,9 @@ Go to your forked repo → `Settings` → `Secrets and variables` → `Actions` 
 | `REPORT_INTEGRITY_RETRY` | Integrity retry count (default `1`, `0` = placeholder only) | Optional |
 | `REPORT_HISTORY_COMPARE_N` | History signal comparison count, `0` off (default), `>0` enable | Optional |
 | `ANALYSIS_DELAY` | Delay between stock analysis and market review (seconds) to avoid API rate limits, e.g., `10` | Optional |
+| `NOTIFICATION_REPORT_CHANNELS` | Report route channels for single-stock, aggregate daily, market review, merged push, and Feishu document success notifications. Empty means all configured channels | Optional |
+| `NOTIFICATION_ALERT_CHANNELS` | Alert route channels for EventMonitor notifications. Empty means all configured channels | Optional |
+| `NOTIFICATION_SYSTEM_ERROR_CHANNELS` | Reserved system_error route channels. No automatic system error producer is added in P3; empty means all configured channels | Optional |
 
 #### Other Configuration
 
@@ -229,6 +232,9 @@ For the P0 notification baseline and diagnostics, see [Notification Baseline](no
 | `SERVERCHAN3_SENDKEY` | ServerChan v3 Sendkey | Optional |
 | `ASTRBOT_URL` | AstrBot Webhook URL | Optional |
 | `ASTRBOT_TOKEN` | Optional AstrBot Bearer Token | Optional |
+| `NOTIFICATION_REPORT_CHANNELS` | Report route channels, comma-separated. Allowed values: wechat,feishu,telegram,email,pushover,pushplus,serverchan3,custom,discord,slack,astrbot | Optional |
+| `NOTIFICATION_ALERT_CHANNELS` | Alert route channels, comma-separated. Empty keeps all configured channels | Optional |
+| `NOTIFICATION_SYSTEM_ERROR_CHANNELS` | Reserved system_error route channels, comma-separated. Empty keeps all configured channels | Optional |
 
 > Note: the default `daily_analysis` GitHub Actions workflow only maps fixed variable names. It does not automatically import arbitrary numbered variables such as `STOCK_GROUP_N` / `EMAIL_GROUP_N`. This feature therefore works in local `.env`, Docker, or any runtime where you explicitly inject those variables.
 

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -1,6 +1,6 @@
 # 通知能力基线
 
-本文档记录通知能力 P0-P2 基线：渠道、配置 key、GitHub Actions 映射、Web 设置元数据、CLI 诊断口径、Web 一键测试和自定义 Webhook Body 模板语义。P0 只做基线与只读诊断；P1 增加 Web 单渠道真实测试；P2 只产品化现有 Body 模板，不包含渠道路由、降噪、per-URL 模板或新增一等渠道。
+本文档记录通知能力 P0-P3 基线：渠道、配置 key、GitHub Actions 映射、Web 设置元数据、CLI 诊断口径、Web 一键测试、自定义 Webhook Body 模板语义和通知路由策略。P0 只做基线与只读诊断；P1 增加 Web 单渠道真实测试；P2 产品化现有 Body 模板；P3 增加 report / alert / system_error 路由，不包含降噪、per-URL 模板或新增一等渠道。
 
 ## 渠道基线
 
@@ -25,7 +25,8 @@
 
 - Minimal key：足以启用一个通知渠道的最小配置。
 - Advanced key：只影响认证、安全、格式、线程、群组、证书校验或展示行为，不能单独启用渠道。
-- P0-P2 不新增路由、降噪或发送策略语义；相关配置如未来引入，应先更新本文档、`.env.example`、Web 元数据与回归测试。
+- P3 的 `NOTIFICATION_*_CHANNELS` 属于 Advanced key：只收窄已启用渠道，不会单独启用渠道。
+- 降噪、长尾渠道和更细粒度路由不在 P3 范围内；相关配置如未来引入，应先更新本文档、`.env.example`、Web 元数据与回归测试。
 
 ## GitHub Actions 映射
 
@@ -37,7 +38,13 @@
 - `FEISHU_WEBHOOK_KEYWORD`
 - `PUSHPLUS_TOPIC`
 
-P0 不映射 `MARKDOWN_TO_IMAGE_CHANNELS` 与 `MERGE_EMAIL_NOTIFICATION`。它们是发送形态或聚合行为开关，不是渠道凭证；在 Actions 中自动开始读取同名 Secret/Variable 会引入行为变化，留到后续专门阶段处理。
+P3 补齐以下通知路由映射：
+
+- `NOTIFICATION_REPORT_CHANNELS`
+- `NOTIFICATION_ALERT_CHANNELS`
+- `NOTIFICATION_SYSTEM_ERROR_CHANNELS`
+
+默认 workflow 仍不映射 `MARKDOWN_TO_IMAGE_CHANNELS` 与 `MERGE_EMAIL_NOTIFICATION`。它们是发送形态或聚合行为开关，不是渠道凭证；在 Actions 中自动开始读取同名 Secret/Variable 会引入额外行为变化。
 
 ## CLI 诊断
 
@@ -99,6 +106,25 @@ CUSTOM_WEBHOOK_BODY_TEMPLATE={"user_id":123456,"message":$content_json}
 # 群聊：CUSTOM_WEBHOOK_URLS=http://127.0.0.1:3000/send_group_msg
 CUSTOM_WEBHOOK_BODY_TEMPLATE={"group_id":123456789,"message":$content_json}
 ```
+
+## 通知路由策略
+
+P3 新增三类通知路由配置：
+
+| 路由类型 | 配置 key | 当前生产者 |
+| --- | --- | --- |
+| `report` | `NOTIFICATION_REPORT_CHANNELS` | 单股推送、聚合日报、大盘复盘、合并推送、飞书文档成功链接 |
+| `alert` | `NOTIFICATION_ALERT_CHANNELS` | EventMonitor 触发通知 |
+| `system_error` | `NOTIFICATION_SYSTEM_ERROR_CHANNELS` | 预留能力；当前不新增自动系统错误生产者 |
+
+配置值为逗号分隔渠道枚举：`wechat,feishu,telegram,email,pushover,pushplus,serverchan3,custom,discord,slack,astrbot`。
+
+- 留空或未配置：保持旧行为，发送到所有已配置静态渠道。
+- 非空：只发送到路由列表与已配置渠道的交集；交集为空时不会 fallback 到全渠道。
+- `send_to_context()` 不受路由限制，机器人会话上下文仍会收到触发任务的回复。
+- 路由过滤发生在 Markdown 转图片前，`MARKDOWN_TO_IMAGE_CHANNELS` 只对路由后的渠道子集生效。
+- `MERGE_EMAIL_NOTIFICATION` 不需要额外配置；只要 `email` 仍在 report 路由后的渠道中，现有合并邮件行为保持不变。
+- `--check-notify` 会把未知渠道值报为 error，把合法但未启用的路由目标报为 warning。
 
 ## 场景占位
 

--- a/main.py
+++ b/main.py
@@ -521,7 +521,7 @@ def run_full_analysis(
             if parts:
                 combined_content = "\n\n---\n\n".join(parts)
                 if pipeline.notifier.is_available():
-                    if pipeline.notifier.send(combined_content, email_send_to_all=True):
+                    if pipeline.notifier.send(combined_content, email_send_to_all=True, route_type="report"):
                         logger.info("已合并推送（个股+大盘复盘）")
                     else:
                         logger.warning("合并推送失败")
@@ -572,7 +572,10 @@ def run_full_analysis(
                     logger.info(f"飞书云文档创建成功: {doc_url}")
                     # 可选：将文档链接也推送到群里
                     if not args.no_notify:
-                        pipeline.notifier.send(f"[{now.strftime('%Y-%m-%d %H:%M')}] 复盘文档创建成功: {doc_url}")
+                        pipeline.notifier.send(
+                            f"[{now.strftime('%Y-%m-%d %H:%M')}] 复盘文档创建成功: {doc_url}",
+                            route_type="report",
+                        )
 
         except Exception as e:
             logger.error(f"飞书文档生成失败: {e}")

--- a/src/agent/events.py
+++ b/src/agent/events.py
@@ -552,7 +552,7 @@ def build_event_monitor_from_config(config=None, notifier=None) -> Optional[Even
         title = f"Event Alert | {triggered.rule.stock_code}"
         content = triggered.message or triggered.rule.description or "Alert triggered"
         alert_text = NotificationBuilder.build_simple_alert(title=title, content=content, alert_type="warning")
-        sent = notification_service.send(alert_text)
+        sent = notification_service.send(alert_text, route_type="alert")
         if not sent:
             logger.info("[EventMonitor] No notification channel available for alert: %s", title)
 

--- a/src/config.py
+++ b/src/config.py
@@ -24,6 +24,7 @@ from src.report_language import (
     is_supported_report_language_value,
     normalize_report_language,
 )
+from src.notification_routing import parse_notification_route_channels
 
 logger = logging.getLogger(__name__)
 
@@ -747,6 +748,11 @@ class Config:
     astrbot_token: Optional[str] = None
     astrbot_url: Optional[str] = None
 
+    # 通知路由策略（Issue #1200 P3）：留空表示该类型使用全部已配置渠道
+    notification_report_channels: List[str] = field(default_factory=list)
+    notification_alert_channels: List[str] = field(default_factory=list)
+    notification_system_error_channels: List[str] = field(default_factory=list)
+
     # 单股推送模式：每分析完一只股票立即推送，而不是汇总后推送
     single_stock_notify: bool = False
 
@@ -1457,6 +1463,15 @@ class Config:
             slack_channel_id=os.getenv('SLACK_CHANNEL_ID'),
             astrbot_url=os.getenv('ASTRBOT_URL'),
             astrbot_token=os.getenv('ASTRBOT_TOKEN'),
+            notification_report_channels=parse_notification_route_channels(
+                os.getenv('NOTIFICATION_REPORT_CHANNELS')
+            ),
+            notification_alert_channels=parse_notification_route_channels(
+                os.getenv('NOTIFICATION_ALERT_CHANNELS')
+            ),
+            notification_system_error_channels=parse_notification_route_channels(
+                os.getenv('NOTIFICATION_SYSTEM_ERROR_CHANNELS')
+            ),
             single_stock_notify=os.getenv('SINGLE_STOCK_NOTIFY', 'false').lower() == 'true',
             report_type=cls._parse_report_type(os.getenv('REPORT_TYPE', 'simple')),
             report_language=cls._parse_report_language(report_language_raw),

--- a/src/core/config_registry.py
+++ b/src/core/config_registry.py
@@ -11,8 +11,9 @@ from copy import deepcopy
 from typing import Any, Dict, List, Optional
 
 from src.config import AGENT_MAX_STEPS_DEFAULT
+from src.notification_routing import ROUTABLE_NOTIFICATION_CHANNELS
 
-SCHEMA_VERSION = "2026-05-05"
+SCHEMA_VERSION = "2026-05-10"
 
 _CATEGORY_DEFINITIONS: List[Dict[str, Any]] = [
     {
@@ -1456,6 +1457,48 @@ _FIELD_DEFINITIONS: Dict[str, Dict[str, Any]] = {
         "options": [],
         "validation": {},
         "display_order": 61,
+    },
+    "NOTIFICATION_REPORT_CHANNELS": {
+        "title": "Report Notification Channels",
+        "description": "Comma-separated route for report notifications. Empty keeps all configured channels.",
+        "category": "notification",
+        "data_type": "array",
+        "ui_control": "textarea",
+        "is_sensitive": False,
+        "is_required": False,
+        "is_editable": True,
+        "default_value": "",
+        "options": [{"label": channel, "value": channel} for channel in ROUTABLE_NOTIFICATION_CHANNELS],
+        "validation": {"allowed_values": list(ROUTABLE_NOTIFICATION_CHANNELS), "delimiter": ","},
+        "display_order": 62,
+    },
+    "NOTIFICATION_ALERT_CHANNELS": {
+        "title": "Alert Notification Channels",
+        "description": "Comma-separated route for event alert notifications. Empty keeps all configured channels.",
+        "category": "notification",
+        "data_type": "array",
+        "ui_control": "textarea",
+        "is_sensitive": False,
+        "is_required": False,
+        "is_editable": True,
+        "default_value": "",
+        "options": [{"label": channel, "value": channel} for channel in ROUTABLE_NOTIFICATION_CHANNELS],
+        "validation": {"allowed_values": list(ROUTABLE_NOTIFICATION_CHANNELS), "delimiter": ","},
+        "display_order": 63,
+    },
+    "NOTIFICATION_SYSTEM_ERROR_CHANNELS": {
+        "title": "System Error Notification Channels",
+        "description": "Comma-separated route reserved for system error notifications. Empty keeps all configured channels.",
+        "category": "notification",
+        "data_type": "array",
+        "ui_control": "textarea",
+        "is_sensitive": False,
+        "is_required": False,
+        "is_editable": True,
+        "default_value": "",
+        "options": [{"label": channel, "value": channel} for channel in ROUTABLE_NOTIFICATION_CHANNELS],
+        "validation": {"allowed_values": list(ROUTABLE_NOTIFICATION_CHANNELS), "delimiter": ","},
+        "display_order": 64,
     },
     "SCHEDULE_TIME": {
         "title": "Schedule Time",

--- a/src/core/market_review.py
+++ b/src/core/market_review.py
@@ -133,7 +133,7 @@ def run_market_review(
                 # 添加标题
                 report_content = f"{review_text['push_title']}\n\n{review_report}"
 
-                success = notifier.send(report_content, email_send_to_all=True)
+                success = notifier.send(report_content, email_send_to_all=True, route_type="report")
                 if success:
                     logger.info("大盘复盘推送成功")
                 else:

--- a/src/core/pipeline.py
+++ b/src/core/pipeline.py
@@ -1867,7 +1867,11 @@ class StockAnalysisPipeline:
                     report_content = self.notifier.generate_single_stock_report(result)
                     logger.info(f"[{stock_code}] 使用精简报告格式")
 
-                if self.notifier.send(report_content, email_stock_codes=[stock_code]):
+                if self.notifier.send(
+                    report_content,
+                    email_stock_codes=[stock_code],
+                    route_type="report",
+                ):
                     logger.info(f"[{stock_code}] 单股推送成功")
                 else:
                     logger.warning(f"[{stock_code}] 单股推送失败")
@@ -1913,6 +1917,7 @@ class StockAnalysisPipeline:
             # 推送通知
             if self.notifier.is_available():
                 channels = self.notifier.get_available_channels()
+                channels = self.notifier.get_channels_for_route("report", channels=channels)
                 context_success = self.notifier.send_to_context(report)
 
                 # Issue #455: Markdown 转图片（与 notification.send 逻辑一致）

--- a/src/notification.py
+++ b/src/notification.py
@@ -23,6 +23,10 @@ from enum import Enum
 
 from src.config import Config, get_config
 from src.enums import ReportType
+from src.notification_routing import (
+    get_notification_route_config,
+    split_notification_route_channels,
+)
 from src.report_language import (
     get_localized_stock_name,
     get_report_labels,
@@ -341,6 +345,42 @@ class NotificationService(
     def get_available_channels(self) -> List[NotificationChannel]:
         """获取所有已配置的渠道"""
         return self._available_channels
+
+    def get_channels_for_route(
+        self,
+        route_type: Optional[str],
+        channels: Optional[List[NotificationChannel]] = None,
+    ) -> List[NotificationChannel]:
+        """Return channels allowed for a route type.
+
+        ``route_type=None`` keeps the legacy behavior and returns all supplied
+        static channels. Empty route config also keeps all supplied channels.
+        Non-empty route config that matches no enabled channel returns an empty
+        list.
+        """
+        target_channels = list(channels if channels is not None else self._available_channels)
+        if route_type is None:
+            return target_channels
+
+        route_config = get_notification_route_config(route_type)
+        if route_config is None:
+            logger.warning("未知通知路由类型 %s，沿用全部已配置渠道", route_type)
+            return target_channels
+
+        configured_route_channels = getattr(self._config, route_config["config_attr"], []) or []
+        if not configured_route_channels:
+            return target_channels
+
+        valid_channels, invalid_channels = split_notification_route_channels(configured_route_channels)
+        if invalid_channels:
+            logger.warning(
+                "%s 包含未知通知渠道，将忽略: %s",
+                route_config["env_key"],
+                ", ".join(invalid_channels),
+            )
+
+        allowed = set(valid_channels)
+        return [channel for channel in target_channels if channel.value in allowed]
     
     def get_channel_names(self) -> str:
         """获取所有已配置渠道的名称"""
@@ -1585,7 +1625,8 @@ class NotificationService(
         self,
         content: str,
         email_stock_codes: Optional[List[str]] = None,
-        email_send_to_all: bool = False
+        email_send_to_all: bool = False,
+        route_type: Optional[str] = None,
     ) -> bool:
         """
         统一发送接口 - 向所有已配置的渠道发送
@@ -1602,6 +1643,7 @@ class NotificationService(
             content: 消息内容（Markdown 格式）
             email_stock_codes: 股票代码列表（可选，用于邮件渠道路由到对应分组邮箱，Issue #268）
             email_send_to_all: 邮件是否发往所有配置邮箱（用于大盘复盘等无股票归属的内容）
+            route_type: 通知路由类型；None 保持旧行为，report/alert/system_error 按配置过滤静态渠道
 
         Returns:
             是否至少有一个渠道发送成功
@@ -1615,11 +1657,19 @@ class NotificationService(
             logger.warning("通知服务不可用，跳过推送")
             return False
 
+        target_channels = self.get_channels_for_route(route_type)
+        if not target_channels:
+            if context_success:
+                logger.info("已通过消息上下文渠道完成推送（路由后无其他通知渠道）")
+                return True
+            logger.warning("通知路由 %s 未命中任何已配置渠道，跳过静态通知渠道", route_type)
+            return False
+
         # Markdown to image (Issue #289): convert once if any channel needs it.
         # Per-channel decision via _should_use_image_for_channel (see send() docstring for fallback rules).
         image_bytes = None
         channels_needing_image = {
-            ch for ch in self._available_channels
+            ch for ch in target_channels
             if ch.value in self._markdown_to_image_channels
         }
         if channels_needing_image:
@@ -1645,13 +1695,13 @@ class NotificationService(
                     hint,
                 )
 
-        channel_names = self.get_channel_names()
-        logger.info(f"正在向 {len(self._available_channels)} 个渠道发送通知：{channel_names}")
+        channel_names = ', '.join(ChannelDetector.get_channel_name(ch) for ch in target_channels)
+        logger.info(f"正在向 {len(target_channels)} 个渠道发送通知：{channel_names}")
 
         success_count = 0
         fail_count = 0
 
-        for channel in self._available_channels:
+        for channel in target_channels:
             channel_name = ChannelDetector.get_channel_name(channel)
             use_image = self._should_use_image_for_channel(channel, image_bytes)
             try:

--- a/src/notification_routing.py
+++ b/src/notification_routing.py
@@ -1,0 +1,88 @@
+# -*- coding: utf-8 -*-
+"""Notification route configuration helpers.
+
+This module intentionally works with plain strings only. Importing
+``NotificationChannel`` here would create a dependency cycle with the runtime
+notification service.
+"""
+
+from __future__ import annotations
+
+from typing import Dict, Iterable, List, Optional, Tuple
+
+ROUTABLE_NOTIFICATION_CHANNELS: Tuple[str, ...] = (
+    "wechat",
+    "feishu",
+    "telegram",
+    "email",
+    "pushover",
+    "pushplus",
+    "serverchan3",
+    "custom",
+    "discord",
+    "slack",
+    "astrbot",
+)
+ROUTABLE_NOTIFICATION_CHANNEL_SET = frozenset(ROUTABLE_NOTIFICATION_CHANNELS)
+
+NOTIFICATION_ROUTE_CONFIGS: Dict[str, Dict[str, str]] = {
+    "report": {
+        "env_key": "NOTIFICATION_REPORT_CHANNELS",
+        "config_attr": "notification_report_channels",
+        "description": "Routes stock, daily, and market-review report notifications.",
+    },
+    "alert": {
+        "env_key": "NOTIFICATION_ALERT_CHANNELS",
+        "config_attr": "notification_alert_channels",
+        "description": "Routes event-driven alert notifications.",
+    },
+    "system_error": {
+        "env_key": "NOTIFICATION_SYSTEM_ERROR_CHANNELS",
+        "config_attr": "notification_system_error_channels",
+        "description": "Routes future system error notifications.",
+    },
+}
+
+
+def parse_notification_route_channels(raw_value: object) -> List[str]:
+    """Parse comma-separated route channel strings without dropping invalid tokens."""
+    if raw_value is None:
+        return []
+    if isinstance(raw_value, str):
+        items: Iterable[object] = raw_value.split(",")
+    elif isinstance(raw_value, (list, tuple, set)):
+        items = raw_value
+    else:
+        items = [raw_value]
+
+    channels: List[str] = []
+    for item in items:
+        token = str(item).strip().lower()
+        if token:
+            channels.append(token)
+    return channels
+
+
+def split_notification_route_channels(channels: Iterable[object]) -> Tuple[List[str], List[str]]:
+    """Return unique valid and invalid route channels while preserving input order."""
+    valid: List[str] = []
+    invalid: List[str] = []
+    seen_valid = set()
+    seen_invalid = set()
+
+    for channel in parse_notification_route_channels(channels):
+        if channel in ROUTABLE_NOTIFICATION_CHANNEL_SET:
+            if channel not in seen_valid:
+                valid.append(channel)
+                seen_valid.add(channel)
+        elif channel not in seen_invalid:
+            invalid.append(channel)
+            seen_invalid.add(channel)
+    return valid, invalid
+
+
+def get_notification_route_config(route_type: Optional[str]) -> Optional[Dict[str, str]]:
+    """Return route metadata for a normalized route type, or None for unknown routes."""
+    if route_type is None:
+        return None
+    return NOTIFICATION_ROUTE_CONFIGS.get(str(route_type).strip().lower())

--- a/src/services/notification_diagnostics.py
+++ b/src/services/notification_diagnostics.py
@@ -8,6 +8,11 @@ from typing import List, Literal, Optional, Sequence, Tuple
 
 from src.config import Config
 from src.notification import ChannelDetector, NotificationChannel, NotificationService
+from src.notification_routing import (
+    NOTIFICATION_ROUTE_CONFIGS,
+    ROUTABLE_NOTIFICATION_CHANNELS,
+    split_notification_route_channels,
+)
 
 KeyTier = Literal["minimal", "advanced"]
 IssueSeverity = Literal["error", "warning", "info"]
@@ -174,6 +179,14 @@ KEY_SPECS: Tuple[NotificationKeySpec, ...] = tuple(
     NotificationKeySpec(key=key, tier="advanced", description="Optional channel behavior or security setting.", channel=spec.channel)
     for spec in CHANNEL_SPECS
     for key in spec.advanced_keys
+) + tuple(
+    NotificationKeySpec(
+        key=route["env_key"],
+        tier="advanced",
+        description=route["description"],
+        channel="routing",
+    )
+    for route in NOTIFICATION_ROUTE_CONFIGS.values()
 )
 
 P0_ACTIONS_ENV_KEYS: Tuple[str, ...] = (
@@ -182,6 +195,10 @@ P0_ACTIONS_ENV_KEYS: Tuple[str, ...] = (
     "FEISHU_WEBHOOK_SECRET",
     "FEISHU_WEBHOOK_KEYWORD",
     "PUSHPLUS_TOPIC",
+)
+
+P3_ROUTE_ENV_KEYS: Tuple[str, ...] = tuple(
+    route["env_key"] for route in NOTIFICATION_ROUTE_CONFIGS.values()
 )
 
 
@@ -257,7 +274,7 @@ def run_notification_diagnostics(config: Config) -> NotificationDiagnosticResult
         _issue(
             "info",
             "phase_scope",
-            "P0 只做配置基线和只读诊断；路由、降噪和 Web 一键测试留给后续 Phase。",
+            "通知诊断会检查渠道基线、只读诊断、Web 测试和 P3 路由配置；降噪和长尾渠道留给后续 Phase。",
         ),
     ]
 
@@ -359,6 +376,40 @@ def run_notification_diagnostics(config: Config) -> NotificationDiagnosticResult
                 key="ASTRBOT_URL",
             )
         )
+
+    configured_set = set(configured)
+    for route_type, route_config in NOTIFICATION_ROUTE_CONFIGS.items():
+        route_channels = getattr(config, route_config["config_attr"], []) or []
+        if not route_channels:
+            continue
+
+        valid_channels, invalid_channels = split_notification_route_channels(route_channels)
+        if invalid_channels:
+            errors.append(
+                _issue(
+                    "error",
+                    "invalid_route_channel",
+                    (
+                        f"{route_config['env_key']} 包含未知通知渠道: {', '.join(invalid_channels)}；"
+                        f"允许值: {', '.join(ROUTABLE_NOTIFICATION_CHANNELS)}。"
+                    ),
+                    key=route_config["env_key"],
+                )
+            )
+
+        disabled_channels = [channel for channel in valid_channels if channel not in configured_set]
+        if disabled_channels:
+            warnings.append(
+                _issue(
+                    "warning",
+                    "route_channel_not_configured",
+                    (
+                        f"{route_config['env_key']} 路由 {route_type} 指向未启用渠道: "
+                        f"{', '.join(disabled_channels)}；这些渠道不会收到该类型通知。"
+                    ),
+                    key=route_config["env_key"],
+                )
+            )
 
     return NotificationDiagnosticResult(
         configured_channels=configured,

--- a/src/services/system_config_service.py
+++ b/src/services/system_config_service.py
@@ -1620,6 +1620,31 @@ class SystemConfigService:
                 }
             )
 
+        if "allowed_values" in validation and value:
+            delimiter = validation.get("delimiter")
+            raw_values = value.split(delimiter) if delimiter else [value]
+            allowed_values = {str(item).strip().lower() for item in validation["allowed_values"]}
+            invalid_values = []
+            seen_invalid = set()
+            for raw_item in raw_values:
+                item = raw_item.strip().lower()
+                if not item:
+                    continue
+                if item not in allowed_values and item not in seen_invalid:
+                    invalid_values.append(item)
+                    seen_invalid.add(item)
+            if invalid_values:
+                issues.append(
+                    {
+                        "key": key,
+                        "code": "invalid_allowed_value",
+                        "message": "Value contains unsupported item(s)",
+                        "severity": "error",
+                        "expected": ",".join(str(item) for item in validation["allowed_values"]),
+                        "actual": ", ".join(invalid_values),
+                    }
+                )
+
         if validation.get("item_type") == "url":
             delimiter = validation.get("delimiter", ",")
             values = [item.strip() for item in value.split(delimiter)] if validation.get("multi_value") else [value.strip()]

--- a/tests/test_bot_market_command.py
+++ b/tests/test_bot_market_command.py
@@ -125,6 +125,7 @@ class MarketCommandRegionFilterTestCase(unittest.TestCase):
         notifier.send.assert_called_once()
         sent = notifier.send.call_args.args[0]
         self.assertIn("休市", sent)
+        self.assertEqual(notifier.send.call_args.kwargs["route_type"], "report")
 
     def test_trading_day_check_disabled_does_not_pass_override(self) -> None:
         """When TRADING_DAY_CHECK_ENABLED=false, override_region stays None."""

--- a/tests/test_config_registry.py
+++ b/tests/test_config_registry.py
@@ -213,5 +213,34 @@ class TestDiscordInteractionPublicKeyField(unittest.TestCase):
         self.assertIn("DISCORD_INTERACTIONS_PUBLIC_KEY", field_keys)
 
 
+class TestNotificationRouteFieldsRegistered(unittest.TestCase):
+    """P3 notification route keys must be visible and validated in settings schema."""
+
+    _ROUTE_KEYS = (
+        "NOTIFICATION_REPORT_CHANNELS",
+        "NOTIFICATION_ALERT_CHANNELS",
+        "NOTIFICATION_SYSTEM_ERROR_CHANNELS",
+    )
+
+    def test_field_definitions_exist(self):
+        for key in self._ROUTE_KEYS:
+            field = get_field_definition(key)
+            self.assertEqual(field["category"], "notification", f"{key} category")
+            self.assertEqual(field["data_type"], "array", f"{key} data_type")
+            self.assertFalse(field["is_sensitive"], f"{key} should not be sensitive")
+            self.assertIn("email", field["validation"]["allowed_values"])
+
+    def test_schema_response_includes_route_fields(self):
+        schema = build_schema_response()
+        notification_cat = next(
+            (c for c in schema["categories"] if c["category"] == "notification"),
+            None,
+        )
+        self.assertIsNotNone(notification_cat, "notification category missing")
+        field_keys = {f["key"] for f in notification_cat["fields"]}
+        for key in self._ROUTE_KEYS:
+            self.assertIn(key, field_keys, f"{key} missing from schema response")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_daily_analysis_workflow_notification_env.py
+++ b/tests/test_daily_analysis_workflow_notification_env.py
@@ -5,7 +5,7 @@ from pathlib import Path
 
 import yaml
 
-from src.services.notification_diagnostics import P0_ACTIONS_ENV_KEYS
+from src.services.notification_diagnostics import P0_ACTIONS_ENV_KEYS, P3_ROUTE_ENV_KEYS
 
 
 ROOT_DIR = Path(__file__).resolve().parent.parent
@@ -33,6 +33,13 @@ def test_daily_analysis_maps_p0_notification_env_keys() -> None:
     env = _load_daily_analysis_env()
 
     for key in P0_ACTIONS_ENV_KEYS:
+        assert key in env
+
+
+def test_daily_analysis_maps_p3_notification_route_env_keys() -> None:
+    env = _load_daily_analysis_env()
+
+    for key in P3_ROUTE_ENV_KEYS:
         assert key in env
 
 

--- a/tests/test_market_review.py
+++ b/tests/test_market_review.py
@@ -67,6 +67,7 @@ class MarketReviewLocalizationTestCase(unittest.TestCase):
         sent_content = notifier.send.call_args.args[0]
         self.assertTrue(sent_content.startswith("🎯 Market Review\n\n"))
         self.assertTrue(notifier.send.call_args.kwargs["email_send_to_all"])
+        self.assertEqual(notifier.send.call_args.kwargs["route_type"], "report")
 
     def test_run_market_review_merges_both_regions_with_english_wrappers(self) -> None:
         notifier = self._make_notifier()

--- a/tests/test_multi_agent.py
+++ b/tests/test_multi_agent.py
@@ -1265,6 +1265,24 @@ class TestEventMonitorConfigIntegration(unittest.TestCase):
         self.assertEqual(len(monitor.rules), 1)
         self.assertEqual(monitor.rules[0].stock_code, "600519")
 
+    def test_configured_event_monitor_notification_uses_alert_route(self):
+        from src.agent.events import TriggeredAlert, build_event_monitor_from_config
+
+        config = SimpleNamespace(
+            agent_event_monitor_enabled=True,
+            agent_event_alert_rules_json='[{"stock_code":"600519","alert_type":"price_cross","direction":"above","price":1800}]',
+        )
+        notifier = MagicMock()
+        notifier.send.return_value = True
+
+        monitor = build_event_monitor_from_config(config=config, notifier=notifier)
+
+        self.assertIsNotNone(monitor)
+        monitor._callbacks[0](TriggeredAlert(rule=monitor.rules[0], message="hit"))
+        notifier.send.assert_called_once()
+        self.assertIn("hit", notifier.send.call_args.args[0])
+        self.assertEqual(notifier.send.call_args.kwargs["route_type"], "alert")
+
     def test_build_event_monitor_from_config_accepts_price_change_percent(self):
         from src.agent.events import PriceChangeAlert, build_event_monitor_from_config
 

--- a/tests/test_notification.py
+++ b/tests/test_notification.py
@@ -139,6 +139,97 @@ class TestNotificationServiceSendToMethods(unittest.TestCase):
         mock_custom.assert_called_once_with("content")
 
     @mock.patch("src.notification.get_config")
+    def test_send_route_empty_keeps_all_configured_channels(self, mock_get_config: mock.MagicMock):
+        cfg = _make_config(
+            wechat_webhook_url="https://wechat.example/hook",
+            custom_webhook_urls=["https://example.com/webhook"],
+        )
+        mock_get_config.return_value = cfg
+
+        service = NotificationService()
+
+        with mock.patch.object(service, "send_to_wechat", return_value=True) as mock_wechat, \
+             mock.patch.object(service, "send_to_custom", return_value=True) as mock_custom:
+            ok = service.send("content", route_type="report")
+
+        self.assertTrue(ok)
+        mock_wechat.assert_called_once_with("content")
+        mock_custom.assert_called_once_with("content")
+
+    @mock.patch("src.notification.get_config")
+    def test_send_report_route_filters_static_channels(self, mock_get_config: mock.MagicMock):
+        cfg = _make_config(
+            wechat_webhook_url="https://wechat.example/hook",
+            custom_webhook_urls=["https://example.com/webhook"],
+            notification_report_channels=["custom"],
+        )
+        mock_get_config.return_value = cfg
+
+        service = NotificationService()
+
+        with mock.patch.object(service, "send_to_wechat", return_value=True) as mock_wechat, \
+             mock.patch.object(service, "send_to_custom", return_value=True) as mock_custom:
+            ok = service.send("content", route_type="report")
+
+        self.assertTrue(ok)
+        mock_wechat.assert_not_called()
+        mock_custom.assert_called_once_with("content")
+
+    @mock.patch("src.notification.get_config")
+    def test_send_alert_and_system_error_routes_filter_independently(self, mock_get_config: mock.MagicMock):
+        cfg = _make_config(
+            wechat_webhook_url="https://wechat.example/hook",
+            custom_webhook_urls=["https://example.com/webhook"],
+            notification_alert_channels=["wechat"],
+            notification_system_error_channels=["custom"],
+        )
+        mock_get_config.return_value = cfg
+
+        service = NotificationService()
+
+        with mock.patch.object(service, "send_to_wechat", return_value=True) as mock_wechat, \
+             mock.patch.object(service, "send_to_custom", return_value=True) as mock_custom:
+            self.assertTrue(service.send("alert", route_type="alert"))
+            self.assertTrue(service.send("system", route_type="system_error"))
+
+        mock_wechat.assert_called_once_with("alert")
+        mock_custom.assert_called_once_with("system")
+
+    @mock.patch("src.notification.get_config")
+    def test_send_route_with_no_matching_channel_does_not_fallback(self, mock_get_config: mock.MagicMock):
+        cfg = _make_config(
+            custom_webhook_urls=["https://example.com/webhook"],
+            notification_report_channels=["unknown-route-channel"],
+        )
+        mock_get_config.return_value = cfg
+
+        service = NotificationService()
+
+        with mock.patch.object(service, "send_to_custom", return_value=True) as mock_custom:
+            ok = service.send("content", route_type="report")
+
+        self.assertFalse(ok)
+        mock_custom.assert_not_called()
+
+    @mock.patch("src.notification.get_config")
+    def test_send_to_context_is_not_limited_by_route(self, mock_get_config: mock.MagicMock):
+        cfg = _make_config(
+            custom_webhook_urls=["https://example.com/webhook"],
+            notification_report_channels=["telegram"],
+        )
+        mock_get_config.return_value = cfg
+
+        service = NotificationService()
+
+        with mock.patch.object(service, "send_to_context", return_value=True) as mock_context, \
+             mock.patch.object(service, "send_to_custom", return_value=True) as mock_custom:
+            ok = service.send("content", route_type="report")
+
+        self.assertTrue(ok)
+        mock_context.assert_called_once_with("content")
+        mock_custom.assert_not_called()
+
+    @mock.patch("src.notification.get_config")
     @mock.patch("requests.post")
     def test_send_to_discord_via_notification_service_with_webhook(
         self, mock_post: mock.MagicMock, mock_get_config: mock.MagicMock

--- a/tests/test_notification_diagnostics.py
+++ b/tests/test_notification_diagnostics.py
@@ -9,6 +9,7 @@ from src.services.notification_diagnostics import (
     CHANNEL_SPECS,
     KEY_SPECS,
     NotificationDiagnosticResult,
+    P3_ROUTE_ENV_KEYS,
     format_notification_diagnostics,
     run_notification_diagnostics,
 )
@@ -39,6 +40,8 @@ class NotificationDiagnosticsTestCase(unittest.TestCase):
         self.assertIn(("ASTRBOT_TOKEN", "advanced"), key_tiers)
         self.assertIn(("CUSTOM_WEBHOOK_BODY_TEMPLATE", "advanced"), key_tiers)
         self.assertIn(("WEBHOOK_VERIFY_SSL", "advanced"), key_tiers)
+        for key in P3_ROUTE_ENV_KEYS:
+            self.assertIn((key, "advanced"), key_tiers)
         self.assertIn(("DISCORD_BOT_TOKEN", "minimal"), key_tiers)
         self.assertIn(("SLACK_BOT_TOKEN", "minimal"), key_tiers)
         self.assertNotIn(("DISCORD_BOT_TOKEN", "advanced"), key_tiers)
@@ -92,6 +95,32 @@ class NotificationDiagnosticsTestCase(unittest.TestCase):
         warning_keys = {item.key for item in result.warnings}
         self.assertIn("PUSHPLUS_TOKEN", warning_keys)
         self.assertIn("context_channels_runtime_only", {item.code for item in result.info})
+
+    def test_route_unknown_channel_reports_error(self):
+        result = run_notification_diagnostics(
+            _config(
+                wechat_webhook_url="https://qyapi.weixin.qq.com/cgi-bin/webhook/send?key=1",
+                notification_report_channels=["wechat", "ntfy"],
+            )
+        )
+
+        self.assertFalse(result.ok)
+        self.assertIn("invalid_route_channel", {item.code for item in result.errors})
+        self.assertIn("NOTIFICATION_REPORT_CHANNELS", {item.key for item in result.errors})
+
+    def test_route_target_not_configured_reports_warning(self):
+        result = run_notification_diagnostics(
+            _config(
+                wechat_webhook_url="https://qyapi.weixin.qq.com/cgi-bin/webhook/send?key=1",
+                notification_alert_channels=["wechat", "telegram"],
+            )
+        )
+
+        self.assertTrue(result.ok)
+        warnings = [item for item in result.warnings if item.code == "route_channel_not_configured"]
+        self.assertEqual(len(warnings), 1)
+        self.assertEqual(warnings[0].key, "NOTIFICATION_ALERT_CHANNELS")
+        self.assertIn("telegram", warnings[0].message)
 
 
 if __name__ == "__main__":

--- a/tests/test_pipeline_notification_image_routing.py
+++ b/tests/test_pipeline_notification_image_routing.py
@@ -27,6 +27,11 @@ class _FakeNotifier:
         self.save_report_to_file = MagicMock(return_value="/tmp/report.md")
         self.is_available = MagicMock(return_value=True)
         self.get_available_channels = MagicMock(return_value=[NotificationChannel.EMAIL])
+        self.get_channels_for_route = MagicMock(
+            side_effect=lambda route_type, channels=None: list(
+                channels if channels is not None else self.get_available_channels()
+            )
+        )
         self.send_to_context = MagicMock(return_value=False)
         self._should_use_image_for_channel = MagicMock(
             side_effect=lambda channel, image_bytes: (
@@ -93,6 +98,11 @@ class _FakeWechatNotifier:
         self.save_report_to_file = MagicMock(return_value="/tmp/report.md")
         self.is_available = MagicMock(return_value=True)
         self.get_available_channels = MagicMock(return_value=[NotificationChannel.WECHAT])
+        self.get_channels_for_route = MagicMock(
+            side_effect=lambda route_type, channels=None: list(
+                channels if channels is not None else self.get_available_channels()
+            )
+        )
         self.send_to_context = MagicMock(return_value=False)
         self.generate_wechat_dashboard = MagicMock(return_value="wechat-dashboard")
         self._should_use_image_for_channel = MagicMock(
@@ -136,6 +146,78 @@ class TestPipelineWechatOnlyImageRouting(unittest.TestCase):
         self.assertTrue(
             any("企业微信 Markdown 转图片失败" in str(call.args[0]) for call in mock_warning.call_args_list)
         )
+
+
+class _FakeRoutedNotifier:
+    def __init__(self, routed_channels, image_channels=None):
+        self._markdown_to_image_channels = set(image_channels or [])
+        self._markdown_to_image_max_chars = 15000
+        self.generate_dashboard_report = MagicMock(side_effect=self._generate_dashboard_report)
+        self.save_report_to_file = MagicMock(return_value="/tmp/report.md")
+        self.is_available = MagicMock(return_value=True)
+        self.get_available_channels = MagicMock(
+            return_value=[
+                NotificationChannel.WECHAT,
+                NotificationChannel.TELEGRAM,
+                NotificationChannel.EMAIL,
+            ]
+        )
+        self.get_channels_for_route = MagicMock(return_value=list(routed_channels))
+        self.send_to_context = MagicMock(return_value=False)
+        self._should_use_image_for_channel = MagicMock(
+            side_effect=lambda channel, image_bytes: (
+                channel.value in self._markdown_to_image_channels and image_bytes is not None
+            )
+        )
+        self.generate_wechat_dashboard = MagicMock(return_value="wechat-dashboard")
+        self._send_wechat_image = MagicMock(return_value=True)
+        self.send_to_wechat = MagicMock(return_value=True)
+        self._send_telegram_photo = MagicMock(return_value=True)
+        self.send_to_telegram = MagicMock(return_value=True)
+        self._send_email_with_inline_image = MagicMock(return_value=True)
+        self.send_to_email = MagicMock(return_value=True)
+
+    @staticmethod
+    def _generate_dashboard_report(results):
+        return "report:" + ",".join(r.code for r in results)
+
+
+class TestPipelineReportRouteFiltering(unittest.TestCase):
+    def test_send_notifications_applies_report_route_before_channel_iteration(self):
+        pipeline = StockAnalysisPipeline.__new__(StockAnalysisPipeline)
+        pipeline.notifier = _FakeRoutedNotifier([NotificationChannel.TELEGRAM])
+        pipeline.config = SimpleNamespace(stock_email_groups=[])
+        results = [SimpleNamespace(code="000001")]
+
+        pipeline._send_notifications(results, ReportType.SIMPLE)
+
+        pipeline.notifier.get_channels_for_route.assert_called_once_with(
+            "report",
+            channels=[
+                NotificationChannel.WECHAT,
+                NotificationChannel.TELEGRAM,
+                NotificationChannel.EMAIL,
+            ],
+        )
+        pipeline.notifier.send_to_telegram.assert_called_once_with("report:000001")
+        pipeline.notifier.send_to_wechat.assert_not_called()
+        pipeline.notifier.send_to_email.assert_not_called()
+
+    def test_markdown_to_image_uses_route_filtered_channels(self):
+        pipeline = StockAnalysisPipeline.__new__(StockAnalysisPipeline)
+        pipeline.notifier = _FakeRoutedNotifier(
+            [NotificationChannel.EMAIL],
+            image_channels={"telegram"},
+        )
+        pipeline.config = SimpleNamespace(stock_email_groups=[])
+        results = [SimpleNamespace(code="000001")]
+
+        with patch("src.md2img.markdown_to_image", return_value=b"png") as mock_md2img:
+            pipeline._send_notifications(results, ReportType.SIMPLE)
+
+        mock_md2img.assert_not_called()
+        pipeline.notifier.send_to_email.assert_called_once_with("report:000001")
+        pipeline.notifier.send_to_telegram.assert_not_called()
 
 
 if __name__ == "__main__":

--- a/tests/test_pipeline_single_notify_thread_safety.py
+++ b/tests/test_pipeline_single_notify_thread_safety.py
@@ -58,7 +58,7 @@ class _CriticalSectionTrackingNotifier:
         self._enter("generate", result.code)
         return f"single:{result.code}"
 
-    def _send(self, content: str, email_stock_codes=None) -> bool:
+    def _send(self, content: str, email_stock_codes=None, route_type=None) -> bool:
         stock_code = (email_stock_codes or ["unknown"])[0]
         self._enter("send", stock_code)
         return True

--- a/tests/test_pipeline_single_stock_notify.py
+++ b/tests/test_pipeline_single_stock_notify.py
@@ -42,7 +42,7 @@ class _TrackingNotifier:
         )
         self.send = MagicMock(side_effect=self._send)
 
-    def _send(self, content, email_stock_codes=None):
+    def _send(self, content, email_stock_codes=None, route_type=None):
         with self._lock:
             self._inflight += 1
             self.max_inflight = max(self.max_inflight, self._inflight)
@@ -142,6 +142,7 @@ class TestPipelineSingleStockNotify(unittest.TestCase):
         pipeline.notifier.send.assert_called_once_with(
             "brief:600519",
             email_stock_codes=["600519"],
+            route_type="report",
         )
 
     def test_process_single_stock_direct_path_does_not_notify_when_failed(self):

--- a/tests/test_system_config_service.py
+++ b/tests/test_system_config_service.py
@@ -349,6 +349,19 @@ class SystemConfigServiceTestCase(unittest.TestCase):
         self.assertFalse(validation["valid"])
         self.assertTrue(any(issue["code"] == "invalid_url" for issue in validation["issues"]))
 
+    def test_validate_reports_invalid_notification_route_channel(self) -> None:
+        validation = self.service.validate(
+            items=[{"key": "NOTIFICATION_REPORT_CHANNELS", "value": "wechat,ntfy,email"}]
+        )
+        self.assertFalse(validation["valid"])
+        self.assertTrue(
+            any(
+                issue["key"] == "NOTIFICATION_REPORT_CHANNELS"
+                and issue["code"] == "invalid_allowed_value"
+                for issue in validation["issues"]
+            )
+        )
+
     def test_validate_warns_when_feishu_app_credentials_are_used_without_webhook(self) -> None:
         validation = self.service.validate(
             items=[


### PR DESCRIPTION
## PR Type

- [ ] fix
- [x] feat
- [ ] refactor
- [x] docs
- [ ] chore
- [x] test

## Background And Problem

Issue #1200 P3 要求为通知网关补齐 `report` / `alert` / `system_error` 三类通知路由：默认未配置时保持所有已配置渠道推送，配置后只向指定枚举渠道发送；`send_to_context()` 不受路由限制；路由过滤需要发生在 Markdown 转图片判断之前，并保持 `MERGE_EMAIL_NOTIFICATION` 的既有语义。

此前聚合日报推送路径在 `pipeline._send_notifications()` 中独立迭代渠道，不经过 `NotificationService.send()`，因此本 PR 同时覆盖通用 `send()` 路径和 pipeline 聚合日报路径，避免 report 路由被绕过。

## Scope Of Change

- 新增 `src/notification_routing.py`，集中维护可路由通知渠道枚举、路由配置元数据和字符串解析/校验 helper。
- `Config` 新增并解析：
  - `NOTIFICATION_REPORT_CHANNELS`
  - `NOTIFICATION_ALERT_CHANNELS`
  - `NOTIFICATION_SYSTEM_ERROR_CHANNELS`
- `NotificationService.send()` 增加 `route_type` 参数，并在 Markdown 转图片和渠道循环前过滤静态渠道；`send_to_context()` 保持路由外发送。
- `pipeline._send_notifications()` 在获取静态渠道后立即应用 `report` 路由，覆盖企业微信精简路径、Email 分组路径和 Markdown-to-image 判断。
- 明确调用点：单股、聚合日报、大盘复盘、合并推送、飞书文档成功链接走 `report`；EventMonitor 走 `alert`；Agent chat 手动发送保持默认全渠道。
- 同步 config registry、SystemConfigService 保存校验、notification diagnostics、Actions env、`.env.example`、`docs/notifications.md`、中英文 full guide 和 changelog。
- 补充路由相关回归测试。

## Issue Link

Refs #1200

## Verification Commands And Results

```bash
git diff --check
python -m py_compile src/notification.py src/notification_routing.py src/config.py src/core/pipeline.py src/agent/events.py src/services/notification_diagnostics.py src/services/system_config_service.py src/core/config_registry.py
python -m pytest tests/test_pipeline_notification_image_routing.py tests/test_pipeline_single_stock_notify.py tests/test_pipeline_single_notify_thread_safety.py
./scripts/ci_gate.sh
```

关键输出/结论：

- `git diff --check`：通过。
- `py_compile`：全部列出的变更 Python 文件编译通过。
- pipeline 路由相关测试：`10 passed`。
- `./scripts/ci_gate.sh`：`backend-gate: all checks passed`，`1769 passed, 2 deselected, 47 warnings, 156 subtests passed in 39.65s`。

## Compatibility And Risk

- 默认兼容：三个新路由配置留空或未设置时，仍发送到所有已配置静态渠道。
- 显式配置后，通知只发送到“路由列表与已配置渠道”的交集；交集为空时不会 fallback 到全渠道。
- `send_to_context()` 不受路由限制，机器人会话回执语义保持不变。
- Markdown 转图片只对路由后的渠道子集生效。
- `MERGE_EMAIL_NOTIFICATION` 没有新增逻辑；只要 `email` 仍在 report 路由后的渠道中，合并邮件行为保持不变。
- 未新增自动 `system_error` 生产者，当前只提供路由能力和校验。
- 未修改第三方 API/model 兼容语义，无新增依赖，无数据迁移。

## Rollback Plan

Revert this PR 即可恢复旧的全渠道静态推送行为；不需要数据迁移。若用户已经配置了 `NOTIFICATION_*_CHANNELS`，回滚后这些环境变量会被旧版本忽略。

## EXTRACT_PROMPT Change (if applicable)

不适用，本 PR 未修改 `src/services/image_stock_extractor.py` 中的 `EXTRACT_PROMPT`。

## Checklist

- [x] 本 PR 有明确动机和业务价值 / This PR has a clear motivation and value
- [x] 已提供可复现的验证命令与结果 / Reproducible verification commands and results are included
- [x] 已评估兼容性与风险 / Compatibility and risk have been assessed
- [x] 已提供回滚方案 / A rollback plan is provided
- [x] 若涉及用户可见变更，已同步更新相关文档与 `docs/CHANGELOG.md`；`README.md` 仅在首页级信息变化时更新，细节优先写入 `docs/*.md` / If user-visible changes are included, relevant docs and `docs/CHANGELOG.md` are updated; `README.md` is updated only for homepage-level changes, with details kept in `docs/*.md`