### PR TITLE
fix(data-provider): skip unavailable optional fetchers and back off longbridge reconnects

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -566,6 +566,7 @@ SCHEDULE_ENABLED=false
 # 每日执行时间（HH:MM 格式，24小时制）
 SCHEDULE_TIME=18:00
 # 定时模式启动时是否立即执行一次分析（true/false）
+# 若未显式设置，定时模式会沿用 RUN_IMMEDIATELY 的运行时覆盖语义以兼容旧配置
 SCHEDULE_RUN_IMMEDIATELY=true
 # 非定时模式启动时是否立即执行一次分析（true/false）
 RUN_IMMEDIATELY=true

--- a/.env.example
+++ b/.env.example
@@ -31,6 +31,8 @@ TUSHARE_TOKEN=
 # LONGBRIDGE_ACCESS_TOKEN=
 # static_info 进程内缓存秒数，默认 86400；0=每次请求拉取
 # LONGBRIDGE_STATIC_INFO_TTL_SECONDS=86400
+# 连接关闭类异常后的冷却秒数，默认 15；冷却期内会临时跳过 Longbridge，避免请求级频繁重连
+# LONGBRIDGE_CONNECTION_COOLDOWN_SECONDS=15
 # Longbridge SDK 语言与 REPORT_LANGUAGE（zh/en）一致；SDK 日志写入 LOG_DIR/longbridge_sdk.log
 # 接入点（与 REPORT_LANGUAGE 无关；留空则用下列默认值）：
 # LONGBRIDGE_HTTP_URL=https://openapi.longbridge.com

--- a/data_provider/base.py
+++ b/data_provider/base.py
@@ -502,6 +502,7 @@ class DataFetcherManager:
         """
         self._fetchers: List[BaseFetcher] = []
         self._fetchers_lock = RLock()
+        self._fetchers_by_name: Dict[str, BaseFetcher] = {}
         self._fetcher_call_locks: Dict[int, RLock] = {}
         self._fetcher_call_locks_lock = RLock()
         self._stock_name_cache: Dict[str, str] = {}
@@ -510,6 +511,7 @@ class DataFetcherManager:
         if fetchers:
             # 按优先级排序
             self._fetchers = sorted(fetchers, key=lambda f: f.priority)
+            self._refresh_fetcher_indexes_locked()
         else:
             # 默认数据源将在首次使用时延迟加载
             self._init_default_fetchers()
@@ -526,6 +528,8 @@ class DataFetcherManager:
         """Lazily initialize thread-safety primitives for test scaffolds using __new__."""
         if not hasattr(self, "_fetchers_lock") or self._fetchers_lock is None:
             self._fetchers_lock = RLock()
+        if not hasattr(self, "_fetchers_by_name") or self._fetchers_by_name is None:
+            self._fetchers_by_name = {}
         if not hasattr(self, "_fetcher_call_locks") or self._fetcher_call_locks is None:
             self._fetcher_call_locks = {}
         if not hasattr(self, "_fetcher_call_locks_lock") or self._fetcher_call_locks_lock is None:
@@ -539,6 +543,51 @@ class DataFetcherManager:
         self._ensure_concurrency_guards()
         with self._fetchers_lock:
             return list(getattr(self, "_fetchers", []))
+
+    def _refresh_fetcher_indexes_locked(self) -> None:
+        self._fetchers_by_name = {fetcher.name: fetcher for fetcher in self._fetchers}
+
+    def _get_fetcher_by_name(self, fetcher_name: str, capability: str = "") -> Optional[BaseFetcher]:
+        self._ensure_concurrency_guards()
+        with self._fetchers_lock:
+            fetcher = self._fetchers_by_name.get(fetcher_name)
+            if fetcher is None and self._fetchers:
+                self._refresh_fetcher_indexes_locked()
+                fetcher = self._fetchers_by_name.get(fetcher_name)
+        if fetcher is None:
+            return None
+        if not self._is_fetcher_available(fetcher, capability=capability):
+            return None
+        return fetcher
+
+    @staticmethod
+    def _call_availability_probe(fetcher: BaseFetcher, probe_name: str, capability: str) -> Optional[bool]:
+        probe = getattr(fetcher, probe_name, None)
+        if not callable(probe):
+            return None
+        try:
+            if probe_name == "is_available_for_request":
+                return bool(probe(capability))
+            return bool(probe())
+        except TypeError:
+            return bool(probe())
+        except Exception as exc:
+            logger.debug(
+                "[数据源可用性] %s.%s 检查失败(capability=%s): %s",
+                fetcher.name,
+                probe_name,
+                capability or "default",
+                exc,
+            )
+            return False
+
+    @classmethod
+    def _is_fetcher_available(cls, fetcher: BaseFetcher, capability: str = "") -> bool:
+        for probe_name in ("is_available_for_request", "is_available", "_is_available"):
+            result = cls._call_availability_probe(fetcher, probe_name, capability)
+            if result is not None:
+                return result
+        return True
 
     def _get_fetcher_call_lock(self, fetcher: BaseFetcher) -> RLock:
         self._ensure_concurrency_guards()
@@ -883,16 +932,17 @@ class DataFetcherManager:
         初始化默认数据源列表
 
         优先级动态调整逻辑：
-        - 如果配置了 TUSHARE_TOKEN：Tushare 优先级提升为 0（最高）
-        - 否则按默认优先级：
+        - 如果配置了 TUSHARE_TOKEN：实例化 TushareFetcher，并按其内部逻辑提升优先级
+        - 如果配置了 Longbridge 凭据：实例化 LongbridgeFetcher 作为美股/港股兜底
+        - 未配置的可选数据源不实例化，避免在批量拉取时反复探测无效源
+        - 默认优先级：
           0. EfinanceFetcher (Priority 0) - 最高优先级
           1. AkshareFetcher (Priority 1)
           2. PytdxFetcher (Priority 2) - 通达信
-          2. TushareFetcher (Priority 2)
           3. BaostockFetcher (Priority 3)
           4. YfinanceFetcher (Priority 4)
-          5. LongbridgeFetcher (Priority 5) - 长桥（美股/港股兜底）
         """
+        from src.config import get_config
         from .efinance_fetcher import EfinanceFetcher
         from .akshare_fetcher import AkshareFetcher
         from .tushare_fetcher import TushareFetcher
@@ -900,14 +950,30 @@ class DataFetcherManager:
         from .baostock_fetcher import BaostockFetcher
         from .yfinance_fetcher import YfinanceFetcher
         from .longbridge_fetcher import LongbridgeFetcher
+        config = get_config()
         # 创建所有数据源实例（优先级在各 Fetcher 的 __init__ 中确定）
         efinance = EfinanceFetcher()
         akshare = AkshareFetcher()
-        tushare = TushareFetcher()  # 会根据 Token 配置自动调整优先级
         pytdx = PytdxFetcher()      # 通达信数据源（可配 PYTDX_HOST/PYTDX_PORT）
         baostock = BaostockFetcher()
         yfinance = YfinanceFetcher()
-        longbridge = LongbridgeFetcher()  # 长桥（美股/港股兜底，懒加载）
+        optional_fetchers: List[BaseFetcher] = []
+
+        tushare_token = (getattr(config, "tushare_token", None) or "").strip()
+        if tushare_token:
+            optional_fetchers.append(TushareFetcher())  # 会根据 Token 配置自动调整优先级
+        else:
+            logger.debug("[数据源初始化] 跳过未配置的 TushareFetcher")
+
+        has_longbridge_creds = bool(
+            (getattr(config, "longbridge_app_key", None) or "").strip()
+            and (getattr(config, "longbridge_app_secret", None) or "").strip()
+            and (getattr(config, "longbridge_access_token", None) or "").strip()
+        )
+        if has_longbridge_creds:
+            optional_fetchers.append(LongbridgeFetcher())  # 长桥（美股/港股兜底，懒加载）
+        else:
+            logger.debug("[数据源初始化] 跳过未配置的 LongbridgeFetcher")
 
         # 初始化数据源列表
         self._ensure_concurrency_guards()
@@ -915,15 +981,15 @@ class DataFetcherManager:
             self._fetchers = [
                 efinance,
                 akshare,
-                tushare,
                 pytdx,
                 baostock,
                 yfinance,
-                longbridge,
+                *optional_fetchers,
             ]
 
             # 按优先级排序（Tushare 如果配置了 Token 且初始化成功，优先级为 0）
             self._fetchers.sort(key=lambda f: f.priority)
+            self._refresh_fetcher_indexes_locked()
 
         # 构建优先级说明
         priority_info = ", ".join([f"{f.name}(P{f.priority})" for f in self._get_fetchers_snapshot()])
@@ -935,6 +1001,7 @@ class DataFetcherManager:
         with self._fetchers_lock:
             self._fetchers.append(fetcher)
             self._fetchers.sort(key=lambda f: f.priority)
+            self._refresh_fetcher_indexes_locked()
     
     def get_daily_data(
         self, 
@@ -1248,44 +1315,29 @@ class DataFetcherManager:
                 quote = None
                 
                 if source == "efinance":
-                    # 尝试 EfinanceFetcher
-                    for fetcher in self._get_fetchers_snapshot():
-                        if fetcher.name == "EfinanceFetcher":
-                            if hasattr(fetcher, 'get_realtime_quote'):
-                                quote = self._call_fetcher_method(fetcher, 'get_realtime_quote', stock_code)
-                            break
+                    fetcher = self._get_fetcher_by_name("EfinanceFetcher", capability="realtime_quote")
+                    if fetcher is not None and hasattr(fetcher, 'get_realtime_quote'):
+                        quote = self._call_fetcher_method(fetcher, 'get_realtime_quote', stock_code)
                 
                 elif source == "akshare_em":
-                    # 尝试 AkshareFetcher 东财数据源
-                    for fetcher in self._get_fetchers_snapshot():
-                        if fetcher.name == "AkshareFetcher":
-                            if hasattr(fetcher, 'get_realtime_quote'):
-                                quote = self._call_fetcher_method(fetcher, 'get_realtime_quote', stock_code, source="em")
-                            break
+                    fetcher = self._get_fetcher_by_name("AkshareFetcher", capability="realtime_quote")
+                    if fetcher is not None and hasattr(fetcher, 'get_realtime_quote'):
+                        quote = self._call_fetcher_method(fetcher, 'get_realtime_quote', stock_code, source="em")
                 
                 elif source == "akshare_sina":
-                    # 尝试 AkshareFetcher 新浪数据源
-                    for fetcher in self._get_fetchers_snapshot():
-                        if fetcher.name == "AkshareFetcher":
-                            if hasattr(fetcher, 'get_realtime_quote'):
-                                quote = self._call_fetcher_method(fetcher, 'get_realtime_quote', stock_code, source="sina")
-                            break
+                    fetcher = self._get_fetcher_by_name("AkshareFetcher", capability="realtime_quote")
+                    if fetcher is not None and hasattr(fetcher, 'get_realtime_quote'):
+                        quote = self._call_fetcher_method(fetcher, 'get_realtime_quote', stock_code, source="sina")
                 
                 elif source in ("tencent", "akshare_qq"):
-                    # 尝试 AkshareFetcher 腾讯数据源
-                    for fetcher in self._get_fetchers_snapshot():
-                        if fetcher.name == "AkshareFetcher":
-                            if hasattr(fetcher, 'get_realtime_quote'):
-                                quote = self._call_fetcher_method(fetcher, 'get_realtime_quote', stock_code, source="tencent")
-                            break
+                    fetcher = self._get_fetcher_by_name("AkshareFetcher", capability="realtime_quote")
+                    if fetcher is not None and hasattr(fetcher, 'get_realtime_quote'):
+                        quote = self._call_fetcher_method(fetcher, 'get_realtime_quote', stock_code, source="tencent")
                 
                 elif source == "tushare":
-                    # 尝试 TushareFetcher（需要 Tushare Pro 积分）
-                    for fetcher in self._get_fetchers_snapshot():
-                        if fetcher.name == "TushareFetcher":
-                            if hasattr(fetcher, 'get_realtime_quote'):
-                                quote = self._call_fetcher_method(fetcher, 'get_realtime_quote', raw_stock_code or stock_code)
-                            break
+                    fetcher = self._get_fetcher_by_name("TushareFetcher", capability="realtime_quote")
+                    if fetcher is not None and hasattr(fetcher, 'get_realtime_quote'):
+                        quote = self._call_fetcher_method(fetcher, 'get_realtime_quote', raw_stock_code or stock_code)
                 
                 if quote is not None and quote.has_basic_data():
                     if primary_quote is None:
@@ -1367,25 +1419,22 @@ class DataFetcherManager:
         When True, non-A-share routing (US & HK) uses Longbridge as the
         primary data source with Yfinance/AkShare as fallback.
         """
-        for f in self._get_fetchers_snapshot():
-            if f.name == "LongbridgeFetcher":
-                return hasattr(f, '_is_available') and f._is_available()
-        return False
+        return self._get_fetcher_by_name(
+            "LongbridgeFetcher",
+            capability="realtime_quote",
+        ) is not None
 
     def _try_fetcher_quote(self, stock_code: str, fetcher_name: str, **kw):
         """Try to get a realtime quote from a named fetcher; returns quote or None."""
-        for f in self._get_fetchers_snapshot():
-            if f.name != fetcher_name:
-                continue
-            if not hasattr(f, 'get_realtime_quote'):
-                return None
-            try:
-                q = self._call_fetcher_method(f, 'get_realtime_quote', stock_code, **kw)
-                if q is not None and q.has_basic_data():
-                    return q
-            except Exception as e:
-                logger.debug(f"[实时行情] {stock_code} {fetcher_name} 获取失败: {e}")
+        fetcher = self._get_fetcher_by_name(fetcher_name, capability="realtime_quote")
+        if fetcher is None or not hasattr(fetcher, 'get_realtime_quote'):
             return None
+        try:
+            q = self._call_fetcher_method(fetcher, 'get_realtime_quote', stock_code, **kw)
+            if q is not None and q.has_basic_data():
+                return q
+        except Exception as e:
+            logger.debug(f"[实时行情] {stock_code} {fetcher_name} 获取失败: {e}")
         return None
 
     def _supplement_quote(self, stock_code: str, primary_quote, fetcher_name: str, **kw):
@@ -1533,6 +1582,8 @@ class DataFetcherManager:
                 continue
             if is_us and fetcher.name not in _US_CAPABLE_FETCHERS:
                 continue
+            if not self._is_fetcher_available(fetcher, capability="stock_name"):
+                continue
             try:
                 name = self._call_fetcher_method(fetcher, 'get_stock_name', stock_code)
                 if is_meaningful_stock_name(name, stock_code):
@@ -1622,31 +1673,34 @@ class DataFetcherManager:
         
         # 2. 尝试批量获取股票列表
         for fetcher in self._get_fetchers_snapshot():
-            if hasattr(fetcher, 'get_stock_list') and missing_codes:
-                try:
-                    stock_list = self._call_fetcher_method(fetcher, 'get_stock_list')
-                    if stock_list is not None and not stock_list.empty:
-                        cache_updates: Dict[str, str] = {}
-                        for _, row in stock_list.iterrows():
-                            code = row.get('code')
-                            name = row.get('name')
-                            if code and name:
-                                cache_updates[code] = name
-                                if code in missing_codes:
-                                    result[code] = name
-                                    missing_codes.discard(code)
+            if not hasattr(fetcher, 'get_stock_list') or not missing_codes:
+                continue
+            if not self._is_fetcher_available(fetcher, capability="stock_list"):
+                continue
+            try:
+                stock_list = self._call_fetcher_method(fetcher, 'get_stock_list')
+                if stock_list is not None and not stock_list.empty:
+                    cache_updates: Dict[str, str] = {}
+                    for _, row in stock_list.iterrows():
+                        code = row.get('code')
+                        name = row.get('name')
+                        if code and name:
+                            cache_updates[code] = name
+                            if code in missing_codes:
+                                result[code] = name
+                                missing_codes.discard(code)
 
-                        if cache_updates:
-                            with self._stock_name_cache_lock:
-                                self._stock_name_cache.update(cache_updates)
-                        
-                        if not missing_codes:
-                            break
-                        
-                        logger.info(f"[股票名称] 从 {fetcher.name} 批量获取完成，剩余 {len(missing_codes)} 个待查")
-                except Exception as e:
-                    logger.debug(f"[股票名称] {fetcher.name} 批量获取失败: {e}")
-                    continue
+                    if cache_updates:
+                        with self._stock_name_cache_lock:
+                            self._stock_name_cache.update(cache_updates)
+                    
+                    if not missing_codes:
+                        break
+                    
+                    logger.info(f"[股票名称] 从 {fetcher.name} 批量获取完成，剩余 {len(missing_codes)} 个待查")
+            except Exception as e:
+                logger.debug(f"[股票名称] {fetcher.name} 批量获取失败: {e}")
+                continue
         
         # 3. 逐个获取剩余的
         for code in list(missing_codes):

--- a/data_provider/base.py
+++ b/data_provider/base.py
@@ -632,6 +632,31 @@ class DataFetcherManager:
             )
         return kept
 
+    @classmethod
+    def _filter_fetchers_by_capability(
+        cls,
+        fetchers: List[BaseFetcher],
+        capability: str,
+    ) -> List[BaseFetcher]:
+        """Skip request-time unavailable fetchers before entering route-specific loops."""
+        kept: List[BaseFetcher] = []
+        skipped: List[str] = []
+
+        for fetcher in fetchers:
+            if cls._is_fetcher_available(fetcher, capability=capability):
+                kept.append(fetcher)
+            else:
+                skipped.append(fetcher.name)
+
+        if skipped:
+            logger.info(
+                "[数据源路由] %s 跳过暂不可用的数据源: %s",
+                capability or "request",
+                ", ".join(skipped),
+            )
+
+        return kept
+
     def _get_cached_stock_name(self, stock_code: str) -> Optional[str]:
         self._ensure_concurrency_guards()
         with self._stock_name_cache_lock:
@@ -1050,11 +1075,18 @@ class DataFetcherManager:
         is_hk = (not is_us) and _is_hk_market(stock_code)
         if is_hk:
             fetchers = self._filter_daily_fetchers_for_market(fetchers, "hk")
+        fetchers = self._filter_fetchers_by_capability(fetchers, capability="daily_data")
         total_fetchers = len(fetchers)
+
+        if total_fetchers == 0:
+            market_label = "美股指数" if is_us_index else "美股" if is_us else "港股" if is_hk else "A股"
+            error_summary = f"{market_label} {stock_code} 获取失败:\n暂无可用数据源"
+            logger.error(f"[数据源终止] {stock_code} 获取失败: {error_summary}")
+            raise DataFetchError(error_summary)
 
         # 美股（含美股指数）使用 Longbridge/YFinance 特殊路由；港股走下方通用数据源循环
         if is_us:
-            prefer_lb = self._longbridge_preferred() and not is_us_index
+            prefer_lb = self._longbridge_preferred(capability="daily_data") and not is_us_index
             source_order = (
                 ["LongbridgeFetcher", "YfinanceFetcher"]
                 if prefer_lb
@@ -1413,7 +1445,7 @@ class DataFetcherManager:
                     filled.append(f)
         return filled
 
-    def _longbridge_preferred(self) -> bool:
+    def _longbridge_preferred(self, capability: str = "realtime_quote") -> bool:
         """Return True when Longbridge keys are configured and available.
 
         When True, non-A-share routing (US & HK) uses Longbridge as the
@@ -1421,7 +1453,7 @@ class DataFetcherManager:
         """
         return self._get_fetcher_by_name(
             "LongbridgeFetcher",
-            capability="realtime_quote",
+            capability=capability,
         ) is not None
 
     def _try_fetcher_quote(self, stock_code: str, fetcher_name: str, **kw):

--- a/data_provider/longbridge_fetcher.py
+++ b/data_provider/longbridge_fetcher.py
@@ -36,6 +36,7 @@ from .us_index_mapping import is_us_stock_code, is_us_index_code
 logger = logging.getLogger(__name__)
 
 _DEFAULT_STATIC_INFO_TTL = 86400  # 24h
+_DEFAULT_CONNECTION_COOLDOWN_SECONDS = 15
 
 
 def _static_info_ttl_seconds() -> int:
@@ -47,6 +48,17 @@ def _static_info_ttl_seconds() -> int:
         return max(0, int(raw))
     except ValueError:
         return _DEFAULT_STATIC_INFO_TTL
+
+
+def _connection_cooldown_seconds() -> int:
+    """Cooldown after connection-close errors to avoid reconnect thrashing."""
+    raw = os.getenv("LONGBRIDGE_CONNECTION_COOLDOWN_SECONDS", "").strip()
+    if raw == "":
+        return _DEFAULT_CONNECTION_COOLDOWN_SECONDS
+    try:
+        return max(0, int(raw))
+    except ValueError:
+        return _DEFAULT_CONNECTION_COOLDOWN_SECONDS
 
 
 _REGION_URL_MAP: Dict[str, Dict[str, str]] = {
@@ -271,6 +283,7 @@ class LongbridgeFetcher(BaseFetcher):
         self._config = None
         self._ctx_lock = threading.Lock()
         self._available = None
+        self._cooldown_until = 0.0
         # {symbol: (StaticInfo, timestamp)}
         self._static_cache: Dict[str, Any] = {}
         self._static_cache_lock = threading.Lock()
@@ -284,6 +297,33 @@ class LongbridgeFetcher(BaseFetcher):
         with self._ctx_lock:
             self._ctx = None
             self._config = None
+
+    def _mark_connection_cooldown(self, exc: Exception) -> None:
+        cooldown_seconds = _connection_cooldown_seconds()
+        self._invalidate_ctx()
+        if cooldown_seconds <= 0:
+            return
+        self._cooldown_until = time.time() + cooldown_seconds
+        logger.warning(
+            "[Longbridge] 检测到连接异常，进入 %ss 冷却期以避免频繁重连: %s",
+            cooldown_seconds,
+            exc,
+        )
+
+    def is_available_for_request(self, capability: str = "") -> bool:
+        """Report request-time availability including temporary cooldown."""
+        if not self._is_available():
+            return False
+        if self._cooldown_until > time.time():
+            logger.debug(
+                "[Longbridge] %s 冷却中，暂时跳过请求，剩余 %.1fs",
+                capability or "request",
+                self._cooldown_until - time.time(),
+            )
+            return False
+        if self._cooldown_until:
+            self._cooldown_until = 0.0
+        return True
 
     def _is_available(self) -> bool:
         """Check if Longbridge credentials are configured."""
@@ -417,7 +457,7 @@ class LongbridgeFetcher(BaseFetcher):
         except Exception as e:
             logger.debug(f"[Longbridge] static_info({symbol}) 失败: {e}")
             if self._is_connection_error(e):
-                self._invalidate_ctx()
+                self._mark_connection_cooldown(e)
         return None
 
     # ------------------------------------------------------------------
@@ -499,7 +539,7 @@ class LongbridgeFetcher(BaseFetcher):
 
     def get_realtime_quote(self, stock_code: str) -> Optional[UnifiedRealtimeQuote]:
         """Fetch realtime quote from Longbridge, computing derived fields."""
-        if not self._is_available():
+        if not self.is_available_for_request("realtime_quote"):
             return None
 
         symbol = _to_longbridge_symbol(stock_code)
@@ -519,8 +559,7 @@ class LongbridgeFetcher(BaseFetcher):
         except Exception as e:
             logger.info(f"[Longbridge] quote({symbol}) 失败: {e}")
             if self._is_connection_error(e):
-                logger.warning("[Longbridge] 检测到连接已断开，将在下次调用时重建连接")
-                self._invalidate_ctx()
+                self._mark_connection_cooldown(e)
             return None
 
         price = safe_float(getattr(q, "last_done", None))
@@ -650,8 +689,7 @@ class LongbridgeFetcher(BaseFetcher):
             )
         except Exception as e:
             if self._is_connection_error(e):
-                logger.warning("[Longbridge] 检测到连接已断开，将在下次调用时重建连接")
-                self._invalidate_ctx()
+                self._mark_connection_cooldown(e)
             raise
 
         if not candles:

--- a/data_provider/longbridge_fetcher.py
+++ b/data_provider/longbridge_fetcher.py
@@ -666,6 +666,9 @@ class LongbridgeFetcher(BaseFetcher):
         self, stock_code: str, start_date: str, end_date: str
     ) -> pd.DataFrame:
         """Fetch historical candlesticks from Longbridge."""
+        if not self.is_available_for_request("daily_data"):
+            raise RuntimeError("Longbridge temporarily unavailable for daily_data")
+
         symbol = _to_longbridge_symbol(stock_code)
         if symbol is None:
             raise ValueError(f"Cannot convert {stock_code} to Longbridge symbol")

--- a/data_provider/pytdx_fetcher.py
+++ b/data_provider/pytdx_fetcher.py
@@ -16,6 +16,7 @@ PytdxFetcher - 通达信数据源 (Priority 2)
 
 import logging
 import re
+import time
 from contextlib import contextmanager
 from typing import Optional, Generator, List, Tuple
 
@@ -28,10 +29,19 @@ from tenacity import (
     before_sleep_log,
 )
 
-from .base import BaseFetcher, DataFetchError, STANDARD_COLUMNS, is_bse_code, _is_hk_market
+from .base import (
+    BaseFetcher,
+    DataFetchError,
+    DataSourceUnavailableError,
+    STANDARD_COLUMNS,
+    is_bse_code,
+    _is_hk_market,
+)
 import os
 
 logger = logging.getLogger(__name__)
+
+_PYTDX_CONNECTION_COOLDOWN_SECONDS = 15.0
 
 
 def _parse_hosts_from_env() -> Optional[List[Tuple[str, int]]]:
@@ -139,6 +149,23 @@ class PytdxFetcher(BaseFetcher):
         self._current_host_idx = 0
         self._stock_list_cache = None  # 股票列表缓存
         self._stock_name_cache = {}    # 股票名称缓存 {code: name}
+        self._unavailable_until = 0.0
+        self._last_unavailable_reason = ""
+
+    def _is_in_connection_cooldown(self) -> bool:
+        return time.time() < self._unavailable_until
+
+    def _mark_connection_cooldown(self, reason: str) -> None:
+        self._unavailable_until = time.time() + _PYTDX_CONNECTION_COOLDOWN_SECONDS
+        self._last_unavailable_reason = str(reason or "").strip()
+        logger.info(
+            "Pytdx 连接失败，进入冷却 %.0fs: %s",
+            _PYTDX_CONNECTION_COOLDOWN_SECONDS,
+            self._last_unavailable_reason or "unknown",
+        )
+
+    def is_available_for_request(self, capability: str = "") -> bool:
+        return not self._is_in_connection_cooldown()
     
     def _get_pytdx(self):
         """
@@ -167,6 +194,11 @@ class PytdxFetcher(BaseFetcher):
             with self._pytdx_session() as api:
                 # 在这里执行数据查询
         """
+        if self._is_in_connection_cooldown():
+            raise DataSourceUnavailableError(
+                f"Pytdx temporarily unavailable: {self._last_unavailable_reason or 'connection cooldown'}"
+            )
+
         TdxHq_API = self._get_pytdx()
         if TdxHq_API is None:
             raise DataFetchError("pytdx 库未安装")
@@ -191,6 +223,7 @@ class PytdxFetcher(BaseFetcher):
                     continue
             
             if not connected:
+                self._mark_connection_cooldown("Pytdx 无法连接任何服务器")
                 raise DataFetchError("Pytdx 无法连接任何服务器")
             
             yield api
@@ -400,7 +433,7 @@ class PytdxFetcher(BaseFetcher):
                     return name
                 
         except Exception as e:
-            logger.warning(f"Pytdx 获取股票名称失败 {stock_code}: {e}")
+            logger.debug(f"Pytdx 获取股票名称失败 {stock_code}: {e}")
         
         return None
     

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -39,6 +39,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - fix: Avoid unsupported built-in historical providers for Hong Kong daily data; align Beijing Stock Exchange `BJ` prefix and `.BJ` suffix validation.
 - fix: Improve Web market-review observability, Windows fallback lock probing, and market catalyst snippet rendering.
 - docs: Add the documentation index and settings-help maintenance guide; remove temporary PR/doc-sync notes from README and user-facing guides.
+- [改进] Docker 镜像支持非 root 用户 (`dsa`, UID 1000) 执行，并增强 `Dockerfile` 安全性与构建稳健性。
+- [改进] 放宽 LiteLLM 依赖约束，保留 `>=1.80.10` 最低版本并显式排除 PyPI 事故版本 `1.82.7` / `1.82.8`，允许安装后续 1.x 修复版本。
+- [改进] 补齐通知渠道 P0 基线、Actions 映射与 `--check-notify` 只读诊断，完善 AstrBot 配置入口和通知回归快照。
+- [修复] 未配置 Tushare / Longbridge 凭据时不再实例化对应可选 fetcher；Longbridge 遇到连接关闭类异常后会进入冷却期，并在美股/港股实时与日线请求中临时跳过该数据源，避免频繁重连。
+- [修复] 修正 LLM 渠道测试中 `Model disabled` 被误报为网络异常的问题，并在失败提示中展示本次实际测试模型。
+- [修复] 修正 LLM 渠道测试中 `Your request was blocked` 等服务商或网关拦截错误被误报为网络异常的问题。
+- [chore] 清理仓库根目录：移除误入库的 `.codex`、`review.md` 跟踪记录，将 smoke 测试入口迁移到 `scripts/`、环境检查脚本迁移为 `scripts/check_env.py`，并将 LiteLLM YAML 示例迁移到 `docs/examples/`。
+- [新功能] Web 设置页新增通知渠道一键测试，支持临时配置、耗时与脱敏 attempts 展示。
+- [改进] 产品化自定义 Webhook Body 模板说明，明确全局模板优先级、JSON 转义建议和 Bark / NapCat 适配示例。
+- [新功能] 系统设置页新增配置项帮助入口与多语言帮助文案基础设施，首批覆盖自选股、LLM 主模型、LLM 渠道、飞书 Webhook 与 WebUI 监听地址。
+- [改进] 设置项帮助窗口支持键盘焦点限制、Esc 关闭和关闭后焦点恢复，并移除短描述重复 hover tooltip。
+- [文档] 新增设置页配置帮助维护说明，明确帮助元数据字段、首批覆盖范围、事实源和多语言文案同步规则。
+- [测试] 补充设置项帮助元数据、API schema、前端弹窗交互测试，并修复 Bot 名称路由与调度时间 provider 测试的离线 CI 稳定性问题。
+- [修复] 港股日线跳过不支持港股的内置历史数据源，避免港股代码错配到非港股市场数据。
+- [修复] 修正分析 API 对北交所 `BJ` 前缀与 `.BJ` 后缀股票代码的校验，保持前端自动补全与 Tushare `ts_code` 调用格式一致。
+- [新功能] 新增通知路由策略，支持按 report、alert、system_error 将通知收窄到指定已配置渠道。
+- [修复] 大盘复盘“近三日催化线索”改为明确展示摘要片段、来源日期和 URL，避免把搜索摘要截断内容误呈现为完整事件。
+- [改进] 个股报告操作建议增加支撑/压力位与主力资金流校准，减少仅因单日涨跌导致买入/卖出剧烈切换，并补充“震荡观望、洗盘观察”等中性建议。
+- [文档] 本次决策稳定性与提示词约束改动仅保持运行时模型/provider/Base URL/发布语义不变，不改动配置持久化与环境语义；但涉及 `src/analyzer.py`、`src/core/pipeline.py`、`src/report_language.py` 与 `src/agent` 相关决策后处理/提示词路径的运行时行为，请回归验证决策落盘与报告口径映射。
+- [文档] 新增中文文档中心并同步英文索引，补齐快速开始、配置、使用专题、部署打包、参考开发等项目文档入口。
+- [文档] 调整 README 联系与合作区域。
 
 ## [3.15.0] - 2026-05-05
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,6 +11,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 <!-- 新条目格式：- [类型] 描述（类型取值：新功能/改进/修复/文档/测试/chore）-->
 <!-- 每条独立一行追加到本段末尾，无需分类标题，合并时冲突最小 -->
+- [修复] 未配置 Tushare / Longbridge 凭据时不再实例化对应可选 fetcher，避免缺失凭据的数据源进入候选集。
+- [修复] Longbridge 遇到连接关闭类异常后会进入冷却期，并在美股/港股实时与日线请求中临时跳过该数据源，避免请求级频繁重连。
+- [修复] Pytdx 股票名称查询在全部服务器不可达时会短暂冷却，并在冷却期内跳过重复探测，减少无效拨号与告警噪音。
+- [修复] 调度模式未显式设置 `SCHEDULE_RUN_IMMEDIATELY` 时，会继续继承 `RUN_IMMEDIATELY` 的运行时覆盖语义，避免被持久化 `.env` 别名反向覆盖。
+- [文档] 补充 Longbridge 冷却开关与调度启动兼容语义说明。
 
 ## [3.16.0] - 2026-05-10
 
@@ -39,27 +44,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - fix: Avoid unsupported built-in historical providers for Hong Kong daily data; align Beijing Stock Exchange `BJ` prefix and `.BJ` suffix validation.
 - fix: Improve Web market-review observability, Windows fallback lock probing, and market catalyst snippet rendering.
 - docs: Add the documentation index and settings-help maintenance guide; remove temporary PR/doc-sync notes from README and user-facing guides.
-- [改进] Docker 镜像支持非 root 用户 (`dsa`, UID 1000) 执行，并增强 `Dockerfile` 安全性与构建稳健性。
-- [改进] 放宽 LiteLLM 依赖约束，保留 `>=1.80.10` 最低版本并显式排除 PyPI 事故版本 `1.82.7` / `1.82.8`，允许安装后续 1.x 修复版本。
-- [改进] 补齐通知渠道 P0 基线、Actions 映射与 `--check-notify` 只读诊断，完善 AstrBot 配置入口和通知回归快照。
-- [修复] 未配置 Tushare / Longbridge 凭据时不再实例化对应可选 fetcher；Longbridge 遇到连接关闭类异常后会进入冷却期，并在美股/港股实时与日线请求中临时跳过该数据源，避免频繁重连。
-- [修复] 修正 LLM 渠道测试中 `Model disabled` 被误报为网络异常的问题，并在失败提示中展示本次实际测试模型。
-- [修复] 修正 LLM 渠道测试中 `Your request was blocked` 等服务商或网关拦截错误被误报为网络异常的问题。
-- [chore] 清理仓库根目录：移除误入库的 `.codex`、`review.md` 跟踪记录，将 smoke 测试入口迁移到 `scripts/`、环境检查脚本迁移为 `scripts/check_env.py`，并将 LiteLLM YAML 示例迁移到 `docs/examples/`。
-- [新功能] Web 设置页新增通知渠道一键测试，支持临时配置、耗时与脱敏 attempts 展示。
-- [改进] 产品化自定义 Webhook Body 模板说明，明确全局模板优先级、JSON 转义建议和 Bark / NapCat 适配示例。
-- [新功能] 系统设置页新增配置项帮助入口与多语言帮助文案基础设施，首批覆盖自选股、LLM 主模型、LLM 渠道、飞书 Webhook 与 WebUI 监听地址。
-- [改进] 设置项帮助窗口支持键盘焦点限制、Esc 关闭和关闭后焦点恢复，并移除短描述重复 hover tooltip。
-- [文档] 新增设置页配置帮助维护说明，明确帮助元数据字段、首批覆盖范围、事实源和多语言文案同步规则。
-- [测试] 补充设置项帮助元数据、API schema、前端弹窗交互测试，并修复 Bot 名称路由与调度时间 provider 测试的离线 CI 稳定性问题。
-- [修复] 港股日线跳过不支持港股的内置历史数据源，避免港股代码错配到非港股市场数据。
-- [修复] 修正分析 API 对北交所 `BJ` 前缀与 `.BJ` 后缀股票代码的校验，保持前端自动补全与 Tushare `ts_code` 调用格式一致。
-- [新功能] 新增通知路由策略，支持按 report、alert、system_error 将通知收窄到指定已配置渠道。
-- [修复] 大盘复盘“近三日催化线索”改为明确展示摘要片段、来源日期和 URL，避免把搜索摘要截断内容误呈现为完整事件。
-- [改进] 个股报告操作建议增加支撑/压力位与主力资金流校准，减少仅因单日涨跌导致买入/卖出剧烈切换，并补充“震荡观望、洗盘观察”等中性建议。
-- [文档] 本次决策稳定性与提示词约束改动仅保持运行时模型/provider/Base URL/发布语义不变，不改动配置持久化与环境语义；但涉及 `src/analyzer.py`、`src/core/pipeline.py`、`src/report_language.py` 与 `src/agent` 相关决策后处理/提示词路径的运行时行为，请回归验证决策落盘与报告口径映射。
-- [文档] 新增中文文档中心并同步英文索引，补齐快速开始、配置、使用专题、部署打包、参考开发等项目文档入口。
-- [文档] 调整 README 联系与合作区域。
 
 ## [3.15.0] - 2026-05-05
 

--- a/docs/full-guide.md
+++ b/docs/full-guide.md
@@ -632,7 +632,8 @@ python main.py --schedule --no-run-immediately
 |--------|------|:-------:|:-----:|
 | `SCHEDULE_ENABLED` | 是否启用定时任务 | `false` | `true` |
 | `SCHEDULE_TIME` | 每日执行时间 (HH:MM) | `18:00` | `09:30` |
-| `SCHEDULE_RUN_IMMEDIATELY` | 启动服务时是否立即运行一次 | `true` | `false` |
+| `SCHEDULE_RUN_IMMEDIATELY` | 定时模式启动时是否立即运行一次；未显式设置时沿用 `RUN_IMMEDIATELY` 的运行时覆盖语义 | `true` | `false` |
+| `RUN_IMMEDIATELY` | 非定时模式启动时是否立即运行一次；同时作为未显式设置 `SCHEDULE_RUN_IMMEDIATELY` 时的 legacy 回退 | `true` | `false` |
 | `TRADING_DAY_CHECK_ENABLED` | 交易日检查：非交易日跳过执行；设为 `false` 可强制执行 | `true` | `false` |
 
 例如在 Docker 中配置：
@@ -641,6 +642,8 @@ python main.py --schedule --no-run-immediately
 # 设置启动时不立即分析
 docker run -e SCHEDULE_ENABLED=true -e SCHEDULE_RUN_IMMEDIATELY=false ...
 ```
+
+> 兼容说明：如果运行时显式传入 `RUN_IMMEDIATELY`，但没有单独传 `SCHEDULE_RUN_IMMEDIATELY`，内置调度模式会继续继承前者，避免被 `.env` 中持久化的 `SCHEDULE_RUN_IMMEDIATELY` 旧值反向覆盖。
 
 #### 交易日判断（Issue #373）
 

--- a/docs/full-guide.md
+++ b/docs/full-guide.md
@@ -145,6 +145,7 @@ daily_stock_analysis/
 | `LONGBRIDGE_APP_SECRET` | Longbridge App Secret | 可选 |
 | `LONGBRIDGE_ACCESS_TOKEN` | Longbridge Access Token | 可选 |
 | `LONGBRIDGE_STATIC_INFO_TTL_SECONDS` | 长桥 `static_info` 进程内缓存秒数（默认 86400，0=不缓存） | 可选 |
+| `LONGBRIDGE_CONNECTION_COOLDOWN_SECONDS` | 长桥连接关闭类异常后的冷却秒数（默认 15；冷却期内临时跳过 Longbridge，避免频繁重连） | 可选 |
 | `LONGBRIDGE_HTTP_URL` | HTTP 接口地址（默认 `https://openapi.longbridge.com`） | 可选 |
 | `LONGBRIDGE_QUOTE_WS_URL` | 行情 WebSocket 地址（默认 `wss://openapi-quote.longbridge.com/v2`） | 可选 |
 | `LONGBRIDGE_TRADE_WS_URL` | 交易 WebSocket 地址（默认 `wss://openapi-trade.longbridge.com/v2`） | 可选 |
@@ -155,6 +156,8 @@ daily_stock_analysis/
 | `ENABLE_CHIP_DISTRIBUTION` | 启用筹码分布（Actions 默认 false；需筹码数据时在 Variables 中设为 true，接口可能不稳定） | 可选 |
 
 > **GitHub Actions：** 仓库自带 `daily_analysis.yml` 已把上表中的 `LONGBRIDGE_*` 映射到任务环境。若未在 **Settings → Secrets and variables → Actions** 中配置 `LONGBRIDGE_APP_KEY`、`LONGBRIDGE_APP_SECRET`、`LONGBRIDGE_ACCESS_TOKEN`，CI 内不会调用长桥（日志中一般看不到 `[Longbridge]` 相关行情行）。可选接入点变量（如 `LONGBRIDGE_REGION`）可放在 **Variables** 或 **Secrets**。
+
+> **Longbridge 运行时行为：** 未配置凭据时不会实例化 Longbridge 这个可选 fetcher；若运行时遇到 `client is closed`、`context closed`、`connection closed` 等连接关闭类异常，会进入冷却期（默认 15 秒，可用 `LONGBRIDGE_CONNECTION_COOLDOWN_SECONDS` 调整），冷却期内美股/港股的实时与日线请求会自动跳过 Longbridge，退回 YFinance / AkShare 等兜底链路。
 
 > 补充说明
 - TUSHARE_TOKEN，当此参数配置后，但不具备港股日线接口权限时，也会出现港股数据查询不出来或者错误的情况，和老版本提示不支持港股效果相同
@@ -305,7 +308,7 @@ daily_stock_analysis/
 | `LONGBRIDGE_APP_KEY` | [Longbridge OpenAPI](https://open.longbridge.com/) App Key；配置后美股/港股的量比、换手率、PE 等 YFinance 缺失字段会自动从长桥补充 | - | 可选 |
 | `LONGBRIDGE_APP_SECRET` | Longbridge App Secret | - | 可选 |
 | `LONGBRIDGE_ACCESS_TOKEN` | Longbridge Access Token | - | 可选 |
-| `LONGBRIDGE_*`（可选） | 见官方 [环境变量](https://open.longbridge.com/zh-CN/docs/getting-started#环境变量)；另有 `LONGBRIDGE_STATIC_INFO_TTL_SECONDS` | - | 可选 |
+| `LONGBRIDGE_*`（可选） | 见官方 [环境变量](https://open.longbridge.com/zh-CN/docs/getting-started#环境变量)；另有 `LONGBRIDGE_STATIC_INFO_TTL_SECONDS` 与 `LONGBRIDGE_CONNECTION_COOLDOWN_SECONDS` | - | 可选 |
 | `ENABLE_REALTIME_QUOTE` | 启用实时行情（关闭后使用历史收盘价分析） | `true` | 可选 |
 | `ENABLE_REALTIME_TECHNICAL_INDICATORS` | 盘中实时技术面：启用时用实时价计算 MA5/MA10/MA20 与多头排列（Issue #234）；关闭则用昨日收盘 | `true` | 可选 |
 | `ENABLE_CHIP_DISTRIBUTION` | 启用筹码分布分析（该接口不稳定，云端部署建议关闭）。GitHub Actions 用户需在 Repository Variables 中设置 `ENABLE_CHIP_DISTRIBUTION=true` 方可启用；workflow 默认关闭。 | `true` | 可选 |
@@ -897,9 +900,11 @@ PUSHOVER_API_TOKEN=your_api_token
 - 美股/港股数据兜底，补充 YFinance 缺失的量比、换手率、PE 等字段
 - 需从 [open.longbridge.com](https://open.longbridge.com/) 注册并获取 App Key / App Secret / Access Token
 - 设置 `LONGBRIDGE_APP_KEY`、`LONGBRIDGE_APP_SECRET`、`LONGBRIDGE_ACCESS_TOKEN`
+- 可选设置 `LONGBRIDGE_CONNECTION_COOLDOWN_SECONDS` 控制连接关闭类异常后的冷却秒数（默认 15）
 - 接入点可配 `LONGBRIDGE_HTTP_URL`、`LONGBRIDGE_QUOTE_WS_URL`、`LONGBRIDGE_TRADE_WS_URL`、`LONGBRIDGE_REGION`
 - 其余可选参数见官方 [环境变量说明](https://open.longbridge.com/zh-CN/docs/getting-started#环境变量)
 - 仅在 YFinance（美股）或 AkShare（港股）返回数据不完整时自动触发，不影响 A 股链路
+- 未配置凭据时不会实例化该可选数据源；若运行时出现连接关闭类异常，会在冷却期内临时跳过 Longbridge，避免请求级频繁重连
 
 ### 东财接口频繁失败时的处理
 

--- a/docs/full-guide_EN.md
+++ b/docs/full-guide_EN.md
@@ -779,6 +779,13 @@ System defaults to AkShare (free), also supports other data sources:
 - Supports US/HK stock data
 - US stock historical and real-time data both use YFinance exclusively to avoid technical indicator errors from akshare's US stock adjustment issues
 
+### Longbridge
+- Optional fallback for US/HK stocks, mainly used to supplement fields that YFinance may miss
+- Configure `LONGBRIDGE_APP_KEY`, `LONGBRIDGE_APP_SECRET`, and `LONGBRIDGE_ACCESS_TOKEN`
+- Optional knobs: `LONGBRIDGE_STATIC_INFO_TTL_SECONDS` (default `86400`) and `LONGBRIDGE_CONNECTION_COOLDOWN_SECONDS` (default `15`)
+- If credentials are absent, the optional Longbridge fetcher is not instantiated
+- When runtime errors such as `client is closed`, `context closed`, or `connection closed` occur, Longbridge enters a short cooldown window and US/HK daily or realtime requests automatically fall back to YFinance / AkShare instead of reconnecting on every request
+
 ---
 
 ## Advanced Features
@@ -791,7 +798,7 @@ Use `hk` prefix for HK stock codes:
 STOCK_LIST=600519,hk00700,hk01810
 ```
 
-HK daily history skips efinance, pytdx, baostock, and other built-in providers that do not support HK daily data, avoiding mismatches between HK symbols and non-HK market data. AkShare/Tushare/YFinance/Longbridge continue to provide HK fallback paths.
+HK daily history skips efinance, pytdx, baostock, and other built-in providers that do not support HK daily data, avoiding mismatches between HK symbols and non-HK market data. AkShare/Tushare/YFinance/Longbridge continue to provide HK fallback paths. If Longbridge is inside its connection cooldown window, the route temporarily skips it and continues with the remaining HK-capable fallbacks.
 
 ### Multi-Model Switching
 

--- a/docs/full-guide_EN.md
+++ b/docs/full-guide_EN.md
@@ -315,6 +315,8 @@ For the P0 notification baseline and diagnostics, see [Notification Baseline](no
 | `MARKET_REVIEW_REGION` | Market review region: cn (A-shares), hk (HK stocks), us (US stocks), both (all three markets) | `cn` |
 | `SCHEDULE_ENABLED` | Enable scheduled tasks | `false` |
 | `SCHEDULE_TIME` | Scheduled execution time | `18:00` |
+| `SCHEDULE_RUN_IMMEDIATELY` | Run once immediately when scheduler mode starts; when unset it keeps following the legacy `RUN_IMMEDIATELY` runtime override | `true` |
+| `RUN_IMMEDIATELY` | Run once immediately for non-scheduler startup; also acts as the legacy fallback when `SCHEDULE_RUN_IMMEDIATELY` is unset | `true` |
 | `LOG_DIR` | Log directory | `./logs` |
 
 > Behavior notes:
@@ -322,6 +324,7 @@ For the P0 notification baseline and diagnostics, see [Notification Baseline](no
 > - TickFlow behavior is capability-based rather than just key-based: limited plans can still enhance main CN indices, while plans with `CN_Equity_A` universe query support also enhance market breadth.
 > - The official quickstart documents `quotes.get(universes=["CN_Equity_A"])`, but online smoke tests confirmed two additional real-world constraints: universe access depends on plan permissions, and `quotes.get(symbols=[...])` has a per-request symbol limit.
 > - TickFlow currently returns `change_pct` / `amplitude` as ratio values; this integration normalizes them to the project's percent convention so they match AkShare / Tushare / efinance semantics.
+> - In scheduler mode, if runtime env explicitly sets `RUN_IMMEDIATELY` but does not set `SCHEDULE_RUN_IMMEDIATELY`, the scheduler keeps inheriting the legacy runtime override instead of being pulled back to a persisted `.env` alias value.
 > - CN market review reports now use a post-market workstation layout with fixed market light, market temperature, index detail, sector Top tables, news catalysts, next-session plan, and risk sections. Missing data sources degrade by omitting or simplifying only the affected block.
 > - Per-stock analysis, realtime quote priority, and sector rankings fallback remain unchanged.
 

--- a/src/config.py
+++ b/src/config.py
@@ -945,6 +945,7 @@ class Config:
     )
     _BOOTSTRAP_RUNTIME_ENV_OVERRIDES_CAPTURED = False
     _BOOTSTRAP_RUNTIME_ENV_OVERRIDES = frozenset()
+    _BOOTSTRAP_RUNTIME_ENV_PRESENT_KEYS = frozenset()
 
     def __post_init__(self) -> None:
         _log = logging.getLogger(__name__)
@@ -1296,7 +1297,6 @@ class Config:
             else True
         )
 
-        process_schedule_run_immediately_env = os.environ.get('SCHEDULE_RUN_IMMEDIATELY')
         schedule_run_immediately_env = cls._resolve_env_value(
             'SCHEDULE_RUN_IMMEDIATELY',
             prefer_env_file=True,
@@ -1307,7 +1307,7 @@ class Config:
         # legacy process value instead of being pulled back to the persisted
         # `.env` copy of SCHEDULE_RUN_IMMEDIATELY.
         if (
-            process_schedule_run_immediately_env is None
+            not cls._had_bootstrap_runtime_env_key('SCHEDULE_RUN_IMMEDIATELY')
             and cls._has_bootstrap_runtime_env_override('RUN_IMMEDIATELY')
         ):
             schedule_run_immediately = legacy_run_immediately
@@ -2014,22 +2014,30 @@ class Config:
             return
 
         explicit_overrides = set()
+        present_keys = set()
         for key in cls._WEBUI_RUNTIME_ENV_FILE_PRIORITY_KEYS:
             env_value = os.environ.get(key)
             if env_value is None:
                 continue
 
+            present_keys.add(key)
             file_value = cls._get_env_file_value(key)
             if file_value is None or env_value != file_value:
                 explicit_overrides.add(key)
 
         cls._BOOTSTRAP_RUNTIME_ENV_OVERRIDES = frozenset(explicit_overrides)
+        cls._BOOTSTRAP_RUNTIME_ENV_PRESENT_KEYS = frozenset(present_keys)
         cls._BOOTSTRAP_RUNTIME_ENV_OVERRIDES_CAPTURED = True
 
     @classmethod
     def _has_bootstrap_runtime_env_override(cls, key: str) -> bool:
         cls._capture_bootstrap_runtime_env_overrides()
         return key in cls._BOOTSTRAP_RUNTIME_ENV_OVERRIDES
+
+    @classmethod
+    def _had_bootstrap_runtime_env_key(cls, key: str) -> bool:
+        cls._capture_bootstrap_runtime_env_overrides()
+        return key in cls._BOOTSTRAP_RUNTIME_ENV_PRESENT_KEYS
 
     @classmethod
     def _resolve_report_language_env_value(
@@ -2152,6 +2160,7 @@ class Config:
         cls._instance = None
         cls._BOOTSTRAP_RUNTIME_ENV_OVERRIDES_CAPTURED = False
         cls._BOOTSTRAP_RUNTIME_ENV_OVERRIDES = frozenset()
+        cls._BOOTSTRAP_RUNTIME_ENV_PRESENT_KEYS = frozenset()
 
     def has_searxng_enabled(self) -> bool:
         """Whether SearXNG fallback is enabled via self-hosted or public mode."""

--- a/src/config.py
+++ b/src/config.py
@@ -1296,15 +1296,27 @@ class Config:
             else True
         )
 
+        process_schedule_run_immediately_env = os.environ.get('SCHEDULE_RUN_IMMEDIATELY')
         schedule_run_immediately_env = cls._resolve_env_value(
             'SCHEDULE_RUN_IMMEDIATELY',
             prefer_env_file=True,
         )
-        schedule_run_immediately = (
-            schedule_run_immediately_env.lower() == 'true'
-            if schedule_run_immediately_env is not None
-            else legacy_run_immediately
-        )
+        # Keep backward compatibility for container/process overrides:
+        # when RUN_IMMEDIATELY is explicitly provided by the runtime but the
+        # schedule-specific alias is absent, schedule mode should inherit the
+        # legacy process value instead of being pulled back to the persisted
+        # `.env` copy of SCHEDULE_RUN_IMMEDIATELY.
+        if (
+            process_schedule_run_immediately_env is None
+            and cls._has_bootstrap_runtime_env_override('RUN_IMMEDIATELY')
+        ):
+            schedule_run_immediately = legacy_run_immediately
+        else:
+            schedule_run_immediately = (
+                schedule_run_immediately_env.lower() == 'true'
+                if schedule_run_immediately_env is not None
+                else legacy_run_immediately
+            )
         schedule_time_value = cls._resolve_env_value(
             'SCHEDULE_TIME',
             default='18:00',

--- a/tests/test_config_env_compat.py
+++ b/tests/test_config_env_compat.py
@@ -122,6 +122,38 @@ class ConfigEnvCompatibilityTestCase(unittest.TestCase):
         self.assertTrue(config.run_immediately)
 
     @patch.object(Config, "_parse_litellm_yaml", return_value=[])
+    def test_schedule_run_immediately_ignores_persisted_alias_when_only_legacy_env_is_explicit(
+        self,
+        _mock_parse_yaml,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            env_path = Path(temp_dir) / ".env"
+            env_path.write_text(
+                "\n".join(
+                    [
+                        "STOCK_LIST=600519",
+                        "RUN_IMMEDIATELY=true",
+                        "SCHEDULE_RUN_IMMEDIATELY=true",
+                    ]
+                )
+                + "\n",
+                encoding="utf-8",
+            )
+
+            with patch.dict(
+                os.environ,
+                {
+                    "ENV_FILE": str(env_path),
+                    "RUN_IMMEDIATELY": "false",
+                },
+                clear=True,
+            ):
+                config = Config._load_from_env()
+
+        self.assertFalse(config.run_immediately)
+        self.assertFalse(config.schedule_run_immediately)
+
+    @patch.object(Config, "_parse_litellm_yaml", return_value=[])
     def test_blank_schedule_time_falls_back_to_default(
         self,
         _mock_parse_yaml,

--- a/tests/test_data_fetcher_prefetch_stock_names.py
+++ b/tests/test_data_fetcher_prefetch_stock_names.py
@@ -28,6 +28,19 @@ class _DummyFetcher:
         return "测试股票"
 
 
+class _FallbackNameFetcher:
+    name = "FallbackNameFetcher"
+    priority = 99
+
+    def __init__(self, name: str = "备用名称"):
+        self.return_name = name
+        self.calls = []
+
+    def get_stock_name(self, stock_code):
+        self.calls.append(stock_code)
+        return self.return_name
+
+
 class _ThreadUnsafeStockListFetcher:
     name = "ThreadUnsafeStockListFetcher"
 
@@ -209,6 +222,58 @@ class TestPrefetchStockNames(unittest.TestCase):
         self.assertEqual(fetcher._stock_name_cache["300750"], "宁德时代")
         self.assertEqual(fetcher._stock_list_cache["300750"], "宁德时代")
         api.get_finance_info.assert_not_called()
+
+    def test_pytdx_get_stock_name_enters_connection_cooldown_after_all_hosts_fail(self):
+        fetcher = PytdxFetcher(hosts=[("127.0.0.1", 7709), ("127.0.0.2", 7709)])
+        instances = []
+
+        class _FakeApi:
+            def __init__(self):
+                self.connect_calls = 0
+                instances.append(self)
+
+            def connect(self, host, port, time_out=5):
+                self.connect_calls += 1
+                return False
+
+            def disconnect(self):
+                return None
+
+        with patch.object(fetcher, "_get_pytdx", return_value=_FakeApi):
+            self.assertIsNone(fetcher.get_stock_name("159559"))
+            self.assertFalse(fetcher.is_available_for_request("stock_name"))
+            self.assertIsNone(fetcher.get_stock_name("159559"))
+
+        self.assertEqual(len(instances), 1)
+        self.assertEqual(instances[0].connect_calls, 2)
+
+    def test_manager_skips_pytdx_name_lookup_during_connection_cooldown(self):
+        pytdx = PytdxFetcher(hosts=[("127.0.0.1", 7709)])
+        fallback = _FallbackNameFetcher("创业板人工智能ETF")
+        manager = DataFetcherManager(fetchers=[pytdx, fallback])
+        instances = []
+
+        class _FakeApi:
+            def __init__(self):
+                self.connect_calls = 0
+                instances.append(self)
+
+            def connect(self, host, port, time_out=5):
+                self.connect_calls += 1
+                return False
+
+            def disconnect(self):
+                return None
+
+        with patch.object(pytdx, "_get_pytdx", return_value=_FakeApi):
+            first = manager.get_stock_name("159559", allow_realtime=False)
+            second = manager.get_stock_name("159560", allow_realtime=False)
+
+        self.assertEqual(first, "创业板人工智能ETF")
+        self.assertEqual(second, "创业板人工智能ETF")
+        self.assertEqual(fallback.calls, ["159559", "159560"])
+        self.assertEqual(len(instances), 1)
+        self.assertEqual(instances[0].connect_calls, 1)
 
     def test_batch_get_stock_names_serializes_shared_fetcher_access(self):
         manager = DataFetcherManager.__new__(DataFetcherManager)

--- a/tests/test_fetcher_source_optimization.py
+++ b/tests/test_fetcher_source_optimization.py
@@ -1,0 +1,113 @@
+# -*- coding: utf-8 -*-
+"""Regression tests for fetcher routing and optional-source pruning."""
+
+import sys
+import unittest
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+if "litellm" not in sys.modules:
+    sys.modules["litellm"] = MagicMock()
+if "json_repair" not in sys.modules:
+    sys.modules["json_repair"] = MagicMock()
+
+from data_provider.base import DataFetcherManager
+from data_provider.realtime_types import RealtimeSource, UnifiedRealtimeQuote
+
+
+class _StubFetcher:
+    def __init__(self, name: str, priority: int):
+        self.name = name
+        self.priority = priority
+
+
+def _make_quote(code: str = "AAPL") -> UnifiedRealtimeQuote:
+    return UnifiedRealtimeQuote(
+        code=code,
+        name="Apple",
+        source=RealtimeSource.FALLBACK,
+        price=188.8,
+        change_pct=1.2,
+        volume_ratio=1.0,
+        turnover_rate=0.2,
+        pe_ratio=20.0,
+        pb_ratio=3.0,
+        total_mv=1000.0,
+        circ_mv=900.0,
+        amplitude=2.0,
+    )
+
+
+class TestFetcherSourceOptimization(unittest.TestCase):
+    @patch("src.config.get_config")
+    def test_manager_skips_unconfigured_optional_fetchers(self, mock_get_config):
+        mock_get_config.return_value = SimpleNamespace(
+            tushare_token="",
+            longbridge_app_key="",
+            longbridge_app_secret="",
+            longbridge_access_token="",
+        )
+
+        with patch("data_provider.efinance_fetcher.EfinanceFetcher", return_value=_StubFetcher("EfinanceFetcher", 0)), patch(
+            "data_provider.akshare_fetcher.AkshareFetcher",
+            return_value=_StubFetcher("AkshareFetcher", 1),
+        ), patch(
+            "data_provider.pytdx_fetcher.PytdxFetcher",
+            return_value=_StubFetcher("PytdxFetcher", 2),
+        ), patch(
+            "data_provider.baostock_fetcher.BaostockFetcher",
+            return_value=_StubFetcher("BaostockFetcher", 3),
+        ), patch(
+            "data_provider.yfinance_fetcher.YfinanceFetcher",
+            return_value=_StubFetcher("YfinanceFetcher", 4),
+        ), patch(
+            "data_provider.tushare_fetcher.TushareFetcher",
+            return_value=_StubFetcher("TushareFetcher", -1),
+        ) as mock_tushare, patch(
+            "data_provider.longbridge_fetcher.LongbridgeFetcher",
+            return_value=_StubFetcher("LongbridgeFetcher", 5),
+        ) as mock_longbridge:
+            manager = DataFetcherManager()
+
+        self.assertEqual(
+            manager.available_fetchers,
+            [
+                "EfinanceFetcher",
+                "AkshareFetcher",
+                "PytdxFetcher",
+                "BaostockFetcher",
+                "YfinanceFetcher",
+            ],
+        )
+        mock_tushare.assert_not_called()
+        mock_longbridge.assert_not_called()
+
+    @patch("src.config.get_config")
+    def test_us_realtime_route_skips_temporarily_unavailable_longbridge(self, mock_get_config):
+        mock_get_config.return_value = SimpleNamespace(
+            enable_realtime_quote=True,
+            realtime_source_priority="efinance,akshare_em,tushare",
+        )
+
+        longbridge = MagicMock()
+        longbridge.name = "LongbridgeFetcher"
+        longbridge.priority = 5
+        longbridge.is_available_for_request.return_value = False
+
+        yfinance = MagicMock()
+        yfinance.name = "YfinanceFetcher"
+        yfinance.priority = 4
+        yfinance.get_realtime_quote.return_value = _make_quote("AAPL")
+
+        manager = DataFetcherManager(fetchers=[longbridge, yfinance])
+
+        quote = manager.get_realtime_quote("AAPL")
+
+        self.assertIsNotNone(quote)
+        self.assertEqual(quote.code, "AAPL")
+        yfinance.get_realtime_quote.assert_called_once_with("AAPL")
+        longbridge.get_realtime_quote.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_fetcher_source_optimization.py
+++ b/tests/test_fetcher_source_optimization.py
@@ -6,6 +6,8 @@ import unittest
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
+import pandas as pd
+
 if "litellm" not in sys.modules:
     sys.modules["litellm"] = MagicMock()
 if "json_repair" not in sys.modules:
@@ -35,6 +37,23 @@ def _make_quote(code: str = "AAPL") -> UnifiedRealtimeQuote:
         total_mv=1000.0,
         circ_mv=900.0,
         amplitude=2.0,
+    )
+
+
+def _make_daily_df() -> pd.DataFrame:
+    return pd.DataFrame(
+        [
+            {
+                "date": "2026-05-01",
+                "open": 100.0,
+                "high": 102.0,
+                "low": 99.0,
+                "close": 101.0,
+                "volume": 1000,
+                "amount": 101000.0,
+                "pct_chg": 1.0,
+            }
+        ]
     )
 
 
@@ -107,6 +126,60 @@ class TestFetcherSourceOptimization(unittest.TestCase):
         self.assertEqual(quote.code, "AAPL")
         yfinance.get_realtime_quote.assert_called_once_with("AAPL")
         longbridge.get_realtime_quote.assert_not_called()
+
+    @patch("src.config.get_config")
+    def test_us_daily_route_skips_temporarily_unavailable_longbridge(self, mock_get_config):
+        mock_get_config.return_value = SimpleNamespace(
+            longbridge_app_key="app-key",
+            longbridge_app_secret="app-secret",
+            longbridge_access_token="access-token",
+        )
+
+        longbridge = MagicMock()
+        longbridge.name = "LongbridgeFetcher"
+        longbridge.priority = 5
+        longbridge.is_available_for_request.return_value = False
+
+        yfinance = MagicMock()
+        yfinance.name = "YfinanceFetcher"
+        yfinance.priority = 4
+        yfinance.get_daily_data.return_value = _make_daily_df()
+
+        manager = DataFetcherManager(fetchers=[longbridge, yfinance])
+
+        df, source = manager.get_daily_data("AAPL", start_date="2026-05-01", end_date="2026-05-08")
+
+        self.assertFalse(df.empty)
+        self.assertEqual(source, "YfinanceFetcher")
+        yfinance.get_daily_data.assert_called_once()
+        longbridge.get_daily_data.assert_not_called()
+
+    @patch("src.config.get_config")
+    def test_hk_daily_route_skips_temporarily_unavailable_longbridge(self, mock_get_config):
+        mock_get_config.return_value = SimpleNamespace(
+            longbridge_app_key="app-key",
+            longbridge_app_secret="app-secret",
+            longbridge_access_token="access-token",
+        )
+
+        longbridge = MagicMock()
+        longbridge.name = "LongbridgeFetcher"
+        longbridge.priority = 5
+        longbridge.is_available_for_request.return_value = False
+
+        akshare = MagicMock()
+        akshare.name = "AkshareFetcher"
+        akshare.priority = 1
+        akshare.get_daily_data.return_value = _make_daily_df()
+
+        manager = DataFetcherManager(fetchers=[longbridge, akshare])
+
+        df, source = manager.get_daily_data("HK00700", start_date="2026-05-01", end_date="2026-05-08")
+
+        self.assertFalse(df.empty)
+        self.assertEqual(source, "AkshareFetcher")
+        akshare.get_daily_data.assert_called_once()
+        longbridge.get_daily_data.assert_not_called()
 
 
 if __name__ == "__main__":

--- a/tests/test_longbridge_fetcher.py
+++ b/tests/test_longbridge_fetcher.py
@@ -13,6 +13,7 @@ Verifies:
 
 import os
 import sys
+import time
 import unittest
 from unittest.mock import patch, MagicMock, PropertyMock
 from dataclasses import dataclass
@@ -209,6 +210,21 @@ class TestLongbridgeFetcherMocked(unittest.TestCase):
 
         result = fetcher.get_realtime_quote("AAPL")
         self.assertIsNone(result)
+
+    def test_connection_error_enters_cooldown_and_skips_immediate_retry(self):
+        """Connection-close failures should not trigger reconnect on every stock."""
+        fetcher, ctx = self._make_fetcher_with_mock_ctx()
+        ctx.quote.side_effect = Exception("client is closed")
+
+        with patch("data_provider.longbridge_fetcher._connection_cooldown_seconds", return_value=30):
+            first = fetcher.get_realtime_quote("AAPL")
+            second = fetcher.get_realtime_quote("AAPL")
+
+        self.assertIsNone(first)
+        self.assertIsNone(second)
+        self.assertEqual(ctx.quote.call_count, 1)
+        self.assertIsNone(fetcher._ctx)
+        self.assertGreater(fetcher._cooldown_until, time.time())
 
     def test_hk_stock_symbol(self):
         """HK stock should use .HK suffix."""

--- a/tests/test_longbridge_fetcher.py
+++ b/tests/test_longbridge_fetcher.py
@@ -226,6 +226,16 @@ class TestLongbridgeFetcherMocked(unittest.TestCase):
         self.assertIsNone(fetcher._ctx)
         self.assertGreater(fetcher._cooldown_until, time.time())
 
+    def test_daily_data_skips_request_during_cooldown(self):
+        """Daily requests should also respect the connection cooldown."""
+        fetcher, ctx = self._make_fetcher_with_mock_ctx()
+        fetcher._cooldown_until = time.time() + 30
+
+        with self.assertRaisesRegex(RuntimeError, "temporarily unavailable"):
+            fetcher._fetch_raw_data("AAPL", "2026-05-01", "2026-05-08")
+
+        ctx.history_candlesticks_by_date.assert_not_called()
+
     def test_hk_stock_symbol(self):
         """HK stock should use .HK suffix."""
         fetcher, ctx = self._make_fetcher_with_mock_ctx()


### PR DESCRIPTION
## PR Type

- [x] fix
- [ ] feat
- [ ] refactor
- [ ] docs
- [ ] chore
- [ ] test

## Background And Problem

现有数据源链路有三类稳定性问题：

- 未配置可选凭据时，Tushare / Longbridge 仍可能进入 fetcher 候选集，带来无效探测和日志噪音。
- Longbridge 在出现 `client is closed` / `context closed` / `connection closed` 一类连接关闭异常后，会在后续请求里立刻重连，容易形成短时间抖动。
- Pytdx 股票名称查询在所有服务器都不可达时，会对后续名称请求重复探测全部主机。

此外，本地完整验证中暴露了一个与本 PR 同分支存在的调度兼容问题：当运行时显式设置 `RUN_IMMEDIATELY`，但未显式设置 `SCHEDULE_RUN_IMMEDIATELY` 时，调度模式不应被 `.env` 中持久化的别名值反向覆盖。

## Scope Of Change

- 更新 `data_provider/base.py`
  - 跳过未配置的可选 fetcher 实例化
  - 按 capability 过滤临时不可用 fetcher
  - 在美股/港股实时与日线路由中统一复用可用性判断
- 更新 `data_provider/longbridge_fetcher.py`
  - 增加连接关闭类异常后的冷却窗口
  - 将冷却状态纳入请求时可用性判断
  - 日线入口在冷却期内直接拒绝重连
- 更新 `data_provider/pytdx_fetcher.py`
  - 当全部服务器不可达时进入短暂连接冷却
  - 名称查询在冷却期内跳过重复拨号
  - 降低 fetcher 级单源失败日志噪音
- 更新 `src/config.py`
  - 保持 `RUN_IMMEDIATELY` / `SCHEDULE_RUN_IMMEDIATELY` 的 legacy 兼容优先级
- 更新测试：
  - `tests/test_longbridge_fetcher.py`
  - `tests/test_fetcher_source_optimization.py`
  - `tests/test_data_fetcher_prefetch_stock_names.py`
  - 并复用 `tests/test_config_env_compat.py` 覆盖调度兼容路径
- 更新文档：
  - `.env.example`
  - `docs/full-guide.md`
  - `docs/full-guide_EN.md`
  - `docs/CHANGELOG.md`

## Issue Link

无独立 Issue。验收标准：

- 未配置 Tushare / Longbridge 凭据时不实例化对应可选 fetcher
- Longbridge 冷却同时覆盖美股/港股实时与日线路径
- Pytdx 名称查询在全部服务器不可达时进入冷却并跳过重复探测
- `SCHEDULE_RUN_IMMEDIATELY` 未显式设置时，调度模式继续继承 `RUN_IMMEDIATELY` 的运行时覆盖语义
- 离线回归与 `ci_gate.sh` 通过

## Verification Commands And Results

```bash
python3 -m py_compile \
  data_provider/base.py \
  data_provider/longbridge_fetcher.py \
  data_provider/pytdx_fetcher.py \
  src/config.py \
  tests/test_longbridge_fetcher.py \
  tests/test_fetcher_source_optimization.py \
  tests/test_data_fetcher_prefetch_stock_names.py

.venv/bin/python -m pytest \
  tests/test_config_env_compat.py \
  tests/test_longbridge_fetcher.py \
  tests/test_fetcher_source_optimization.py \
  tests/test_data_fetcher_prefetch_stock_names.py

env PATH="/Users/zhengbolin/workspace/daily_stock_analysis/.venv/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin" ./scripts/ci_gate.sh
```

关键输出 / Key output:

- 定向 pytest：`50 passed`
- `ci_gate.sh`：`backend-gate: all checks passed`
- 全量离线 pytest：`1833 passed, 2 deselected, 42 warnings, 166 subtests passed`

## Compatibility And Risk

- 影响面集中在数据源候选集、fallback 路径和调度启动标志的兼容语义。
- 新增可选配置项 `LONGBRIDGE_CONNECTION_COOLDOWN_SECONDS`，默认 15 秒；未配置时使用默认值，不迁移或覆写旧配置。
- `SCHEDULE_RUN_IMMEDIATELY` 显式设置时仍然优先；本次修复只恢复“未显式设置时继承 `RUN_IMMEDIATELY`”的 legacy 兼容行为。
- 不涉及 API schema、数据库迁移或前端协议变更。
- 未做真实 Longbridge / Pytdx 联网 smoke，当前结论基于离线回归与模拟失败场景。

## Rollback Plan

最小回滚方式：直接 revert 本 PR，无需额外数据迁移或配置清理。

## EXTRACT_PROMPT Change (if applicable)

N/A

## Checklist

- [x] 本 PR 有明确动机和业务价值 / This PR has a clear motivation and value
- [x] 已提供可复现的验证命令与结果 / Reproducible verification commands and results are included
- [x] 已评估兼容性与风险 / Compatibility and risk have been assessed
- [x] 已提供回滚方案 / A rollback plan is provided
- [x] 若涉及用户可见变更，已同步更新相关文档与 `docs/CHANGELOG.md`；`README.md` 仅在首页级信息变化时更新，细节优先写入 `docs/*.md` / If user-visible changes are included, relevant docs and `docs/CHANGELOG.md` are updated; `README.md` is updated only for homepage-level changes, with details kept in `docs/*.md`
