### PR TITLE
feat: add market review data sources

### DIFF
--- a/data_provider/akshare_fetcher.py
+++ b/data_provider/akshare_fetcher.py
@@ -1847,19 +1847,19 @@ class AkshareFetcher(BaseFetcher):
         import akshare as ak
 
         fetch_attempts = (
-            lambda top_n: self._get_eastmoney_hot_stocks(ak, top_n),
-            lambda top_n: self._get_eastmoney_hot_up_stocks(ak, top_n),
-            lambda top_n: self._get_xueqiu_hot_stocks(ak, top_n),
+            ("东方财富人气榜", lambda top_n: self._get_eastmoney_hot_stocks(ak, top_n)),
+            ("东方财富飙升榜", lambda top_n: self._get_eastmoney_hot_up_stocks(ak, top_n)),
+            ("雪球关注榜", lambda top_n: self._get_xueqiu_hot_stocks(ak, top_n)),
         )
         last_error = ""
-        for fetch in fetch_attempts:
+        for source, fetch in fetch_attempts:
             try:
                 rows = fetch(n)
                 if rows:
                     return rows[:n]
             except Exception as e:
-                last_error = str(e)
-                logger.debug("[Akshare] 人气股候选源失败: %s", e)
+                last_error = f"{source}: {e}"
+                logger.debug("[Akshare] 人气股候选源失败 source=%s: %s", source, e)
         if last_error:
             logger.warning("[Akshare] 获取人气股全部候选源失败: %s", last_error)
         return None
@@ -1979,7 +1979,7 @@ class AkshareFetcher(BaseFetcher):
                     'turnover_rate': self._safe_float(row.get('换手率')),
                     'seal_amount': self._safe_float(row.get('封板资金')),
                     'first_limit_time': str(row.get('首次封板时间', '')).strip(),
-                    'last_limit_time': str(row.get('最后封板时间', '')).strip(),
+                    'last_limit_time': self._normalize_limit_time_value(row.get('最后封板时间')),
                     'break_count': self._safe_int(row.get('炸板次数')),
                     'limit_stat': str(row.get('涨停统计', '')).strip(),
                     'consecutive_boards': self._safe_int(row.get('连板数')),

--- a/data_provider/akshare_fetcher.py
+++ b/data_provider/akshare_fetcher.py
@@ -1805,6 +1805,254 @@ class AkshareFetcher(BaseFetcher):
             logger.error(f"[Akshare] 新浪接口获取板块排行也失败: {e}")
             return None
 
+    def get_concept_rankings(self, n: int = 5) -> Optional[Tuple[List[Dict], List[Dict]]]:
+        """获取概念/题材涨跌榜。"""
+        import akshare as ak
+
+        try:
+            self._set_random_user_agent()
+            self._enforce_rate_limit()
+
+            logger.info("[API调用] ak.stock_board_concept_name_em() 获取概念排行...")
+            df = ak.stock_board_concept_name_em()
+            if df is None or df.empty:
+                return None
+
+            change_col = '涨跌幅'
+            name_col = '板块名称'
+            if change_col not in df.columns or name_col not in df.columns:
+                return None
+
+            df = df.copy()
+            df[change_col] = pd.to_numeric(df[change_col], errors='coerce')
+            df = df.dropna(subset=[change_col])
+            top = df.nlargest(n, change_col)
+            bottom = df.nsmallest(n, change_col)
+            return (
+                [
+                    {'name': str(row[name_col]), 'change_pct': float(row[change_col])}
+                    for _, row in top.iterrows()
+                ],
+                [
+                    {'name': str(row[name_col]), 'change_pct': float(row[change_col])}
+                    for _, row in bottom.iterrows()
+                ],
+            )
+        except Exception as e:
+            logger.warning(f"[Akshare] 获取概念排行失败: {e}")
+            return None
+
+    def get_hot_stocks(self, n: int = 10) -> Optional[List[Dict[str, Any]]]:
+        """获取人气股榜，按免配置热榜数据源降级。"""
+        import akshare as ak
+
+        fetch_attempts = (
+            lambda top_n: self._get_eastmoney_hot_stocks(ak, top_n),
+            lambda top_n: self._get_eastmoney_hot_up_stocks(ak, top_n),
+            lambda top_n: self._get_xueqiu_hot_stocks(ak, top_n),
+        )
+        last_error = ""
+        for fetch in fetch_attempts:
+            try:
+                rows = fetch(n)
+                if rows:
+                    return rows[:n]
+            except Exception as e:
+                last_error = str(e)
+                logger.debug("[Akshare] 人气股候选源失败: %s", e)
+        if last_error:
+            logger.warning("[Akshare] 获取人气股全部候选源失败: %s", last_error)
+        return None
+
+    def _get_eastmoney_hot_stocks(self, ak: Any, n: int = 10) -> Optional[List[Dict[str, Any]]]:
+        """获取东方财富人气股榜。"""
+        self._set_random_user_agent()
+        self._enforce_rate_limit()
+
+        logger.info("[API调用] ak.stock_hot_rank_em() 获取东方财富人气股...")
+        df = ak.stock_hot_rank_em()
+        if df is None or df.empty:
+            return None
+
+        rows: List[Dict[str, Any]] = []
+        for _, row in df.head(n).iterrows():
+            rows.append({
+                'rank': self._safe_int(row.get('当前排名')),
+                'code': str(row.get('代码', '')).strip(),
+                'name': str(row.get('股票名称', '')).strip(),
+                'price': self._safe_float(row.get('最新价')),
+                'change_pct': self._safe_float(row.get('涨跌幅')),
+                'source': '东方财富人气榜',
+            })
+        return rows
+
+    def _get_eastmoney_hot_up_stocks(self, ak: Any, n: int = 10) -> Optional[List[Dict[str, Any]]]:
+        """获取东方财富飙升榜。"""
+        self._set_random_user_agent()
+        self._enforce_rate_limit()
+
+        logger.info("[API调用] ak.stock_hot_up_em() 获取东方财富飙升榜...")
+        df = ak.stock_hot_up_em()
+        if df is None or df.empty:
+            return None
+
+        code_col = self._find_first_column(df, ("代码", "股票代码"))
+        name_col = self._find_first_column(df, ("股票名称", "名称", "股票简称"))
+        rank_col = self._find_first_column(df, ("当前排名", "排名", "序号"))
+        price_col = self._find_first_column(df, ("最新价", "现价"))
+        change_col = self._find_column_containing(df, ("涨跌幅",))
+        if not code_col or not name_col:
+            return None
+
+        rows: List[Dict[str, Any]] = []
+        for _, row in df.head(n).iterrows():
+            rows.append({
+                'rank': self._safe_int(row.get(rank_col)) if rank_col else len(rows) + 1,
+                'code': str(row.get(code_col, '')).strip(),
+                'name': str(row.get(name_col, '')).strip(),
+                'price': self._safe_float(row.get(price_col)) if price_col else None,
+                'change_pct': self._safe_float(row.get(change_col)) if change_col else None,
+                'source': '东方财富飙升榜',
+            })
+        return rows
+
+    def _get_xueqiu_hot_stocks(self, ak: Any, n: int = 10) -> Optional[List[Dict[str, Any]]]:
+        """获取雪球关注榜兜底。该接口较慢，仅在人气榜失败后尝试。"""
+        self._set_random_user_agent()
+        self._enforce_rate_limit()
+
+        logger.info("[API调用] ak.stock_hot_follow_xq() 获取雪球关注榜...")
+        df = ak.stock_hot_follow_xq(symbol='最热门')
+        if df is None or df.empty:
+            return None
+
+        rows: List[Dict[str, Any]] = []
+        for idx, (_, row) in enumerate(df.head(n).iterrows(), 1):
+            rows.append({
+                'rank': idx,
+                'code': str(row.get('股票代码', '')).strip(),
+                'name': str(row.get('股票简称', '')).strip(),
+                'price': self._safe_float(row.get('最新价')),
+                'change_pct': None,
+                'source': '雪球关注榜',
+            })
+        return rows
+
+    def get_limit_up_pool(
+        self,
+        date: Optional[str] = None,
+        n: int = 20,
+    ) -> Optional[List[Dict[str, Any]]]:
+        """获取涨停池，优先按连板数和封板时间展示。"""
+        import akshare as ak
+
+        query_date = date or datetime.now().strftime('%Y%m%d')
+        try:
+            self._set_random_user_agent()
+            self._enforce_rate_limit()
+
+            logger.info("[API调用] ak.stock_zt_pool_em(date=%s) 获取涨停池...", query_date)
+            df = ak.stock_zt_pool_em(date=query_date)
+            if df is None or df.empty:
+                return None
+
+            df = df.copy()
+            for col in ('连板数', '封板资金', '成交额', '换手率', '涨跌幅'):
+                if col in df.columns:
+                    df[col] = pd.to_numeric(df[col], errors='coerce')
+            if '首次封板时间' in df.columns:
+                df['首次封板时间'] = df['首次封板时间'].map(self._normalize_limit_time_value)
+                df['_首次封板时间排序'] = df['首次封板时间'].where(df['首次封板时间'] != '', '999999')
+            sort_cols = [col for col in ('连板数', '_首次封板时间排序') if col in df.columns]
+            if sort_cols:
+                ascending = [False if col == '连板数' else True for col in sort_cols]
+                df = df.sort_values(sort_cols, ascending=ascending)
+
+            rows: List[Dict[str, Any]] = []
+            for _, row in df.head(n).iterrows():
+                rows.append({
+                    'code': str(row.get('代码', '')).strip(),
+                    'name': str(row.get('名称', '')).strip(),
+                    'change_pct': self._safe_float(row.get('涨跌幅')),
+                    'price': self._safe_float(row.get('最新价')),
+                    'amount': self._safe_float(row.get('成交额')),
+                    'turnover_rate': self._safe_float(row.get('换手率')),
+                    'seal_amount': self._safe_float(row.get('封板资金')),
+                    'first_limit_time': str(row.get('首次封板时间', '')).strip(),
+                    'last_limit_time': str(row.get('最后封板时间', '')).strip(),
+                    'break_count': self._safe_int(row.get('炸板次数')),
+                    'limit_stat': str(row.get('涨停统计', '')).strip(),
+                    'consecutive_boards': self._safe_int(row.get('连板数')),
+                    'industry': str(row.get('所属行业', '')).strip(),
+                })
+            return rows
+        except Exception as e:
+            logger.warning(f"[Akshare] 获取涨停池失败: {e}")
+            return None
+
+    @staticmethod
+    def _normalize_limit_time_value(value: Any) -> str:
+        """Normalize AkShare HHMMSS-like seal time values to zero-padded HHMMSS."""
+        try:
+            if pd.isna(value):
+                return ""
+        except TypeError:
+            pass
+
+        text = str(value).strip()
+        if not text or text.lower() in {"nan", "nat", "none", "null", "-", "--"}:
+            return ""
+
+        if ":" in text:
+            parts = text.split(":")
+            try:
+                hour = int(parts[0])
+                minute = int(parts[1]) if len(parts) > 1 else 0
+                second = int(parts[2]) if len(parts) > 2 else 0
+                return f"{hour:02d}{minute:02d}{second:02d}"
+            except (TypeError, ValueError):
+                return text
+
+        try:
+            return f"{int(float(text)):06d}"
+        except (TypeError, ValueError):
+            digits = "".join(ch for ch in text if ch.isdigit())
+            return digits.zfill(6) if digits else text
+
+    @staticmethod
+    def _safe_float(value: Any) -> Optional[float]:
+        try:
+            if pd.isna(value):
+                return None
+            return float(value)
+        except (TypeError, ValueError):
+            return None
+
+    @staticmethod
+    def _safe_int(value: Any) -> int:
+        try:
+            if pd.isna(value):
+                return 0
+            return int(float(value))
+        except (TypeError, ValueError):
+            return 0
+
+    @staticmethod
+    def _find_first_column(df: pd.DataFrame, candidates: Tuple[str, ...]) -> Optional[str]:
+        columns = [str(col) for col in df.columns]
+        for candidate in candidates:
+            if candidate in columns:
+                return candidate
+        return None
+
+    @staticmethod
+    def _find_column_containing(df: pd.DataFrame, keywords: Tuple[str, ...]) -> Optional[str]:
+        for col in df.columns:
+            col_text = str(col)
+            if all(keyword in col_text for keyword in keywords):
+                return col
+        return None
+
 
 if __name__ == "__main__":
     # 测试代码

--- a/data_provider/base.py
+++ b/data_provider/base.py
@@ -325,6 +325,38 @@ class BaseFetcher(ABC):
         """
         return None
 
+    def get_concept_rankings(self, n: int = 5) -> Optional[Tuple[List[Dict], List[Dict]]]:
+        """
+        获取概念/题材涨跌榜。
+
+        Returns:
+            Tuple: (领涨概念列表, 领跌概念列表)
+        """
+        return None
+
+    def get_hot_stocks(self, n: int = 10) -> Optional[List[Dict[str, Any]]]:
+        """
+        获取市场人气股榜。
+
+        Returns:
+            List[Dict]: 人气股列表
+        """
+        return None
+
+    def get_limit_up_pool(
+        self,
+        date: Optional[str] = None,
+        n: int = 20,
+    ) -> Optional[List[Dict[str, Any]]]:
+        """
+        获取涨停池/连板梯队。
+
+        Args:
+            date: YYYYMMDD，默认由具体数据源决定
+            n: 返回条数
+        """
+        return None
+
     def get_daily_data(
         self,
         stock_code: str, 
@@ -2623,3 +2655,61 @@ class DataFetcherManager:
             return top, bottom
         logger.warning(f"[板块排行] 所有数据源均失败，最终错误: {last_error}")
         return [], []
+
+    def get_concept_rankings(self, n: int = 5) -> Tuple[List[Dict], List[Dict]]:
+        """获取概念/题材涨跌榜（自动切换数据源）。"""
+        last_error = ""
+        for fetcher in self._fetchers:
+            try:
+                data = fetcher.get_concept_rankings(n)
+                if data and (data[0] or data[1]):
+                    logger.info(f"[{fetcher.name}] 获取概念排行成功")
+                    return data[0] or [], data[1] or []
+                last_error = f"{fetcher.name}返回空结果"
+            except Exception as e:
+                error_type, error_reason = summarize_exception(e)
+                last_error = f"{fetcher.name} ({error_type}) {error_reason}"
+                logger.warning(f"[{fetcher.name}] 获取概念排行失败: {error_reason}")
+        if last_error:
+            logger.warning(f"[概念排行] 所有数据源均失败，最终错误: {last_error}")
+        return [], []
+
+    def get_hot_stocks(self, n: int = 10) -> List[Dict[str, Any]]:
+        """获取市场人气股榜（自动切换数据源）。"""
+        last_error = ""
+        for fetcher in self._fetchers:
+            try:
+                data = fetcher.get_hot_stocks(n)
+                if data:
+                    logger.info(f"[{fetcher.name}] 获取人气股成功")
+                    return data[:n]
+                last_error = f"{fetcher.name}返回空结果"
+            except Exception as e:
+                error_type, error_reason = summarize_exception(e)
+                last_error = f"{fetcher.name} ({error_type}) {error_reason}"
+                logger.warning(f"[{fetcher.name}] 获取人气股失败: {error_reason}")
+        if last_error:
+            logger.warning(f"[人气股] 所有数据源均失败，最终错误: {last_error}")
+        return []
+
+    def get_limit_up_pool(
+        self,
+        date: Optional[str] = None,
+        n: int = 20,
+    ) -> List[Dict[str, Any]]:
+        """获取涨停池与连板梯队（自动切换数据源）。"""
+        last_error = ""
+        for fetcher in self._fetchers:
+            try:
+                data = fetcher.get_limit_up_pool(date=date, n=n)
+                if data:
+                    logger.info(f"[{fetcher.name}] 获取涨停池成功")
+                    return data[:n]
+                last_error = f"{fetcher.name}返回空结果"
+            except Exception as e:
+                error_type, error_reason = summarize_exception(e)
+                last_error = f"{fetcher.name} ({error_type}) {error_reason}"
+                logger.warning(f"[{fetcher.name}] 获取涨停池失败: {error_reason}")
+        if last_error:
+            logger.warning(f"[涨停池] 所有数据源均失败，最终错误: {last_error}")
+        return []

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - [修复] Pytdx 股票名称查询在全部服务器不可达时会短暂冷却，并在冷却期内跳过重复探测，减少无效拨号与告警噪音。
 - [修复] 调度模式未显式设置 `SCHEDULE_RUN_IMMEDIATELY` 时，会继续继承 `RUN_IMMEDIATELY` 的运行时覆盖语义，避免被持久化 `.env` 别名反向覆盖。
 - [文档] 补充 Longbridge 冷却开关与调度启动兼容语义说明。
+- [文档] 明确本轮仅新增市场复盘底层数据源能力（概念排行、人气股、涨停池），未修改模型名、provider、Base URL、LLM 运行时入口或 `.env` 兼容语义；回退路径为回滚本次变更版本，不需要执行配置迁移。
 - [新功能] Windows 桌面安装版接入 electron-updater，发现新版本后可后台下载并在用户确认后重启安装；Release 工作流同步上传自动更新所需元数据。
 - [测试] 完善桌面端更新链路验收说明：补充 `apps/dsa-desktop` 与打包产物元数据的本地验证步骤（Web 构建、桌面测试/构建、`latest.yml` 与 `*.blockmap` 检查），并明确 Windows/NSIS 部分需在 Windows 发布链路复核。
 - [测试] 补充 `docs/desktop-package.md` 对 Windows NSIS 与 `desktop-release` 链路的发布级复核要求：注明 Linux 环境不能直接产出 Windows 安装器，要求在 Windows 环境补齐 `latest.yml`/`*.blockmap` 与 installer 的版本一致性与附件核对。

--- a/tests/test_akshare_realtime_logging.py
+++ b/tests/test_akshare_realtime_logging.py
@@ -154,6 +154,8 @@ def test_tencent_realtime_success_logs_endpoint(caplog, monkeypatch, akshare_fet
 
 
 def test_hot_stocks_uses_eastmoney_hot_ranking_when_available(monkeypatch, akshare_fetcher):
+    fake_akshare = SimpleNamespace()
+    monkeypatch.setitem(sys.modules, "akshare", fake_akshare)
     monkeypatch.setattr(
         akshare_fetcher,
         "_get_eastmoney_hot_stocks",
@@ -232,3 +234,4 @@ def test_limit_up_pool_zero_pads_first_seal_times_before_sorting(monkeypatch, ak
 
     assert [row["code"] for row in result] == ["000001", "000003", "000002"]
     assert result[0]["first_limit_time"] == "092500"
+    assert result[0]["last_limit_time"] == "093000"

--- a/tests/test_akshare_realtime_logging.py
+++ b/tests/test_akshare_realtime_logging.py
@@ -177,6 +177,49 @@ def test_hot_stocks_uses_eastmoney_hot_ranking_when_available(monkeypatch, aksha
     assert result[0]["name"] == "中国长城"
 
 
+def test_hot_stocks_falls_back_to_xueqiu_when_primary_sources_empty(monkeypatch, akshare_fetcher):
+    call_order = []
+
+    def _eastmoney(_ak, _n):
+        call_order.append("eastmoney_hot")
+        return None
+
+    def _up(_ak, _n):
+        call_order.append("eastmoney_hot_up")
+        return []
+
+    def _xueqiu(_ak, _n):
+        call_order.append("xueqiu")
+        return [
+            {
+                "rank": 1,
+                "code": "SH600004",
+                "name": "华夏银行",
+                "price": 7.21,
+                "change_pct": None,
+                "source": "雪球关注榜",
+            }
+        ]
+
+    monkeypatch.setattr(akshare_fetcher, "_get_eastmoney_hot_stocks", _eastmoney)
+    monkeypatch.setattr(akshare_fetcher, "_get_eastmoney_hot_up_stocks", _up)
+    monkeypatch.setattr(akshare_fetcher, "_get_xueqiu_hot_stocks", _xueqiu)
+
+    result = akshare_fetcher.get_hot_stocks(5)
+
+    assert call_order == ["eastmoney_hot", "eastmoney_hot_up", "xueqiu"]
+    assert result == [
+        {
+            "rank": 1,
+            "code": "SH600004",
+            "name": "华夏银行",
+            "price": 7.21,
+            "change_pct": None,
+            "source": "雪球关注榜",
+        }
+    ]
+
+
 def test_limit_up_pool_zero_pads_first_seal_times_before_sorting(monkeypatch, akshare_fetcher):
     df = pd.DataFrame(
         [

--- a/tests/test_akshare_realtime_logging.py
+++ b/tests/test_akshare_realtime_logging.py
@@ -1,5 +1,8 @@
 import logging
+import sys
+from types import SimpleNamespace
 
+import pandas as pd
 import pytest
 import requests
 
@@ -148,3 +151,84 @@ def test_tencent_realtime_success_logs_endpoint(caplog, monkeypatch, akshare_fet
     assert breaker.successes == ["akshare_tencent"]
     assert f"endpoint={TENCENT_REALTIME_ENDPOINT}" in caplog.text
     assert "[实时行情-腾讯] 601006 大秦铁路:" in caplog.text
+
+
+def test_hot_stocks_uses_eastmoney_hot_ranking_when_available(monkeypatch, akshare_fetcher):
+    monkeypatch.setattr(
+        akshare_fetcher,
+        "_get_eastmoney_hot_stocks",
+        lambda _ak, n: [
+            {
+                "rank": 1,
+                "code": "SZ000066",
+                "name": "中国长城",
+                "price": 21.8,
+                "change_pct": 9.99,
+                "source": "东方财富人气榜",
+            }
+        ],
+    )
+
+    result = akshare_fetcher.get_hot_stocks(5)
+
+    assert result[0]["source"] == "东方财富人气榜"
+    assert result[0]["name"] == "中国长城"
+
+
+def test_limit_up_pool_zero_pads_first_seal_times_before_sorting(monkeypatch, akshare_fetcher):
+    df = pd.DataFrame(
+        [
+            {
+                "代码": "000002",
+                "名称": "午后股",
+                "涨跌幅": 10.0,
+                "最新价": 12.3,
+                "成交额": 1,
+                "换手率": 2,
+                "封板资金": 3,
+                "首次封板时间": 141354,
+                "最后封板时间": 141500,
+                "炸板次数": 0,
+                "涨停统计": "1/1",
+                "连板数": 1,
+                "所属行业": "地产",
+            },
+            {
+                "代码": "000001",
+                "名称": "竞价股",
+                "涨跌幅": 10.0,
+                "最新价": 10.0,
+                "成交额": 1,
+                "换手率": 2,
+                "封板资金": 3,
+                "首次封板时间": 92500,
+                "最后封板时间": 93000,
+                "炸板次数": 0,
+                "涨停统计": "1/1",
+                "连板数": 1,
+                "所属行业": "计算机",
+            },
+            {
+                "代码": "000003",
+                "名称": "早盘股",
+                "涨跌幅": 10.0,
+                "最新价": 11.0,
+                "成交额": 1,
+                "换手率": 2,
+                "封板资金": 3,
+                "首次封板时间": 101500,
+                "最后封板时间": 102000,
+                "炸板次数": 0,
+                "涨停统计": "1/1",
+                "连板数": 1,
+                "所属行业": "电子",
+            },
+        ]
+    )
+    fake_akshare = SimpleNamespace(stock_zt_pool_em=lambda date: df)
+    monkeypatch.setitem(sys.modules, "akshare", fake_akshare)
+
+    result = akshare_fetcher.get_limit_up_pool(date="20260511", n=3)
+
+    assert [row["code"] for row in result] == ["000001", "000003", "000002"]
+    assert result[0]["first_limit_time"] == "092500"


### PR DESCRIPTION
## PR Type

- [ ] fix
- [x] feat
- [ ] refactor
- [ ] docs
- [ ] chore
- [x] test

## Background And Problem

拆分自 PR #1265。本 PR 只补齐 A 股大盘复盘后续会用到的底层数据源能力：概念/题材排行、人气股排行、涨停池/连板梯队。当前 PR 不修改报告结构、不修改飞书推送展示，便于单独审查和回滚。

## Scope Of Change

- `data_provider/base.py`：为 `BaseFetcher` 和 `DataFetcherManager` 增加概念排行、人气股、涨停池接口及失败降级。
- `data_provider/akshare_fetcher.py`：增加 AkShare 免配置数据源实现，包含东方财富人气榜、东方财富飙升榜、雪球关注榜 fallback，以及涨停池封板时间标准化排序。
- `tests/test_akshare_realtime_logging.py`：补充人气股来源选择和涨停池首次封板时间排序回归测试。

## Issue Link

无独立 issue。拆分 PR #1265，验收标准是数据源能力可独立编译并通过对应回归测试。

## Verification Commands And Results

```bash
python -m py_compile data_provider/akshare_fetcher.py data_provider/base.py
python -m pytest tests/test_akshare_realtime_logging.py
git diff --check
```

关键输出/结论：

- `py_compile` passed.
- `tests/test_akshare_realtime_logging.py`: 6 passed, 3 warnings.
- `git diff --check` passed.

## Compatibility And Risk

- 不新增配置项，不需要 Cookie、账号或密钥。
- 新增数据源方法均按 best-effort/fallback 处理，所有候选源失败时返回空列表，不阻断后续流程。
- 本 PR 只增加底层能力，尚不改变用户可见报告结构或通知内容。
- 风险主要来自 AkShare 上游字段变化；当前实现对列名、数值和封板时间做了基础容错。

## Rollback Plan

Revert this PR. No configuration, database, or migration rollback is required.

## EXTRACT_PROMPT Change (if applicable)

Not applicable. This PR does not change `src/services/image_stock_extractor.py` or `EXTRACT_PROMPT`.

## Checklist

- [x] 本 PR 有明确动机和业务价值 / This PR has a clear motivation and value
- [x] 已提供可复现的验证命令与结果 / Reproducible verification commands and results are included
- [x] 已评估兼容性与风险 / Compatibility and risk have been assessed
- [x] 已提供回滚方案 / A rollback plan is provided
- [x] 若涉及用户可见变更，已同步更新相关文档与 `docs/CHANGELOG.md`；本 PR 暂不改变用户可见输出，因此不更新文档 / User-visible output is unchanged, so docs are not updated in this split PR
