### PR TITLE
fix analyzer content block responses

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -45,6 +45,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - [修复] 资金流数据不可用时将直接买入结论降级为观察，避免缺失数据被误读为高置信买入依据。
 - [修复] 调高基本面聚合默认超时预算，降低 Windows/Docker 环境下整段基本面 timeout 的概率。
 - [修复] 正式分析链路兼容 OpenAI-compatible `content_blocks` 响应，避免 `message.content=null` 时被误判为空回复。
+- [文档] Issue #1279 外部响应兼容补证据：本次修复以 `litellm>=1.80.10,!=1.82.7,!=1.82.8,<2.0.0` 为运行时前提，交叉参照 [LiteLLM OpenAI-compatible](https://docs.litellm.ai/docs/providers/openai_compatible) / [OpenAI Chat Completion API](https://platform.openai.com/docs/api-reference/chat)、并以 `tests/test_market_analyzer_generate_text.py` 的 `content_blocks` 与 `list content` 回归样例为复现依据，保留 `message.content` 回退逻辑避免兼容断层。
 
 ## [3.16.0] - 2026-05-10
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -44,6 +44,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - [修复] Web 设置页为通知测试与 Agent/通知配置区域增加局部运行时错误兜底，异常时提示提供 Windows 桌面端 `desktop.log`，避免整页黑屏。
 - [修复] 资金流数据不可用时将直接买入结论降级为观察，避免缺失数据被误读为高置信买入依据。
 - [修复] 调高基本面聚合默认超时预算，降低 Windows/Docker 环境下整段基本面 timeout 的概率。
+- [修复] 正式分析链路兼容 OpenAI-compatible `content_blocks` 响应，避免 `message.content=null` 时被误判为空回复。
 
 ## [3.16.0] - 2026-05-10
 

--- a/src/analyzer.py
+++ b/src/analyzer.py
@@ -2282,7 +2282,7 @@ class GeminiAnalyzer:
 
                 content = self._extract_completion_text(response)
                 if content:
-                    usage = self._normalize_usage(getattr(response, "usage", None))
+                    usage = self._normalize_usage(self._get_response_field(response, "usage"))
                     last_response_text = content
                     last_model = model
                     last_usage = usage

--- a/src/analyzer.py
+++ b/src/analyzer.py
@@ -2011,6 +2011,67 @@ class GeminiAnalyzer:
             "total_tokens": _get_value("total_tokens"),
         }
 
+    @staticmethod
+    def _get_response_field(obj: Any, key: str) -> Any:
+        """Read a field from dict-like or object-like LiteLLM payloads."""
+        if isinstance(obj, dict):
+            return obj.get(key)
+        return getattr(obj, key, None)
+
+    def _extract_text_blocks(self, blocks: Any) -> str:
+        """Extract text from OpenAI-compatible content block lists."""
+        if not blocks:
+            return ""
+
+        parts: List[str] = []
+        for block in blocks:
+            if isinstance(block, str):
+                parts.append(block)
+                continue
+
+            text = None
+            if isinstance(block, dict):
+                text = block.get("text")
+                if text is None:
+                    text = block.get("content")
+            else:
+                text = getattr(block, "text", None)
+                if text is None:
+                    text = getattr(block, "content", None)
+
+            if isinstance(text, str) and text:
+                parts.append(text)
+
+        return "".join(parts).strip()
+
+    def _extract_completion_text(self, response: Any) -> str:
+        """Extract text from non-stream LiteLLM completion responses."""
+        choices = self._get_response_field(response, "choices")
+        if not choices:
+            return ""
+
+        choice = choices[0]
+        message = self._get_response_field(choice, "message")
+
+        content_blocks = self._get_response_field(choice, "content_blocks")
+        if content_blocks is None and message is not None:
+            content_blocks = self._get_response_field(message, "content_blocks")
+        block_text = self._extract_text_blocks(content_blocks)
+        if block_text:
+            return block_text
+
+        content = None
+        if message is not None:
+            content = self._get_response_field(message, "content")
+        if content is None:
+            content = self._get_response_field(choice, "content")
+
+        if isinstance(content, list):
+            return self._extract_text_blocks(content)
+        if isinstance(content, str):
+            return content.strip()
+        return str(content).strip() if content is not None else ""
+
     def _extract_stream_text(self, chunk: Any) -> str:
         """Extract provider-agnostic text delta from a LiteLLM streaming chunk."""
         choices = chunk.get("choices") if isinstance(chunk, dict) else getattr(chunk, "choices", None)
@@ -2219,8 +2280,8 @@ class GeminiAnalyzer:
                     router_model_names=router_model_names,
                 )
 
-                if response and response.choices and response.choices[0].message.content:
-                    content = response.choices[0].message.content
+                content = self._extract_completion_text(response)
+                if content:
                     usage = self._normalize_usage(getattr(response, "usage", None))
                     last_response_text = content
                     last_model = model

--- a/tests/test_market_analyzer_generate_text.py
+++ b/tests/test_market_analyzer_generate_text.py
@@ -20,6 +20,46 @@ for _mod in ("litellm", "google.generativeai", "google.genai", "anthropic"):
 import pytest
 from unittest.mock import PropertyMock
 
+_OPENAI_COMPATIBILITY_PAYLOAD_FIXTURES = [
+    # Repro case 1 (Issue #1279): OpenAI-compatible provider message.content is None while text is in content_blocks.
+    (
+        "openai/cpa-compatible",
+        {
+            "choices": [
+                {
+                    "message": {
+                        "content": None,
+                        "content_blocks": [
+                            {"type": "text", "text": "block "},
+                            {"type": "text", "text": "response"},
+                        ],
+                    },
+                }
+            ],
+            "usage": {"prompt_tokens": 2, "completion_tokens": 3, "total_tokens": 5},
+        },
+        "block response",
+    ),
+    # Repro case 2: OpenAI-compatible provider returns message.content as list-of-blocks.
+    (
+        "openai/list-content-provider",
+        {
+            "choices": [
+                {
+                    "message": {
+                        "content": [
+                            {"type": "text", "text": "list "},
+                            {"type": "text", "text": "response"},
+                        ],
+                    },
+                }
+            ],
+            "usage": {"prompt_tokens": 3, "completion_tokens": 4, "total_tokens": 7},
+        },
+        "list response",
+    ),
+]
+
 
 # ---------------------------------------------------------------------------
 # Analyzer.generate_text()
@@ -141,37 +181,27 @@ class TestAnalyzerGenerateText:
         assert dispatch_calls[0]["stream"] is True
         assert "stream" not in dispatch_calls[1]
 
-    def test_call_litellm_extracts_message_content_blocks_when_content_is_null(self):
+    @pytest.mark.parametrize(
+        "provider_model,response_payload,expected_text",
+        _OPENAI_COMPATIBILITY_PAYLOAD_FIXTURES,
+        ids=["issue1279-message-content-null", "issue1279-message-content-list"],
+    )
+    def test_call_litellm_extracts_external_provider_text_shapes(self, provider_model, response_payload, expected_text):
         analyzer = self._make_analyzer()
         analyzer._config_override = SimpleNamespace(
-            litellm_model="openai/cpa-compatible",
+            litellm_model=provider_model,
             litellm_fallback_models=[],
             llm_model_list=[],
         )
-        response = SimpleNamespace(
-            choices=[
-                SimpleNamespace(
-                    message=SimpleNamespace(
-                        content=None,
-                        content_blocks=[
-                            {"type": "text", "text": "block "},
-                            {"type": "text", "text": "response"},
-                        ],
-                    ),
-                )
-            ],
-            usage=SimpleNamespace(prompt_tokens=2, completion_tokens=3, total_tokens=5),
-        )
-
-        with patch.object(analyzer, "_dispatch_litellm_completion", return_value=response):
+        with patch.object(analyzer, "_dispatch_litellm_completion", return_value=response_payload):
             text, model_used, usage = analyzer._call_litellm(
                 "prompt",
                 {"max_tokens": 128, "temperature": 0.2},
             )
 
-        assert text == "block response"
-        assert model_used == "openai/cpa-compatible"
-        assert usage == {"prompt_tokens": 2, "completion_tokens": 3, "total_tokens": 5}
+        assert text == expected_text
+        assert model_used == provider_model
+        assert usage == response_payload["usage"]
 
     def test_call_litellm_falls_back_to_message_content_when_blocks_empty(self):
         analyzer = self._make_analyzer()
@@ -199,37 +229,6 @@ class TestAnalyzerGenerateText:
         assert text == "message response"
         assert model_used == "openai/deepseek-chat"
         assert usage == {}
-
-    def test_call_litellm_extracts_list_message_content_from_dict_response(self):
-        analyzer = self._make_analyzer()
-        analyzer._config_override = SimpleNamespace(
-            litellm_model="openai/list-content-provider",
-            litellm_fallback_models=[],
-            llm_model_list=[],
-        )
-        response = {
-            "choices": [
-                {
-                    "message": {
-                        "content": [
-                            {"type": "text", "text": "list "},
-                            {"type": "text", "text": "response"},
-                        ],
-                    },
-                }
-            ],
-            "usage": {"prompt_tokens": 3, "completion_tokens": 4, "total_tokens": 7},
-        }
-
-        with patch.object(analyzer, "_dispatch_litellm_completion", return_value=response):
-            text, model_used, usage = analyzer._call_litellm(
-                "prompt",
-                {"max_tokens": 128, "temperature": 0.2},
-            )
-
-        assert text == "list response"
-        assert model_used == "openai/list-content-provider"
-        assert usage == {"prompt_tokens": 3, "completion_tokens": 4, "total_tokens": 7}
 
     def test_call_litellm_normalizes_kimi_k26_temperature(self):
         analyzer = self._make_analyzer()

--- a/tests/test_market_analyzer_generate_text.py
+++ b/tests/test_market_analyzer_generate_text.py
@@ -141,6 +141,65 @@ class TestAnalyzerGenerateText:
         assert dispatch_calls[0]["stream"] is True
         assert "stream" not in dispatch_calls[1]
 
+    def test_call_litellm_extracts_message_content_blocks_when_content_is_null(self):
+        analyzer = self._make_analyzer()
+        analyzer._config_override = SimpleNamespace(
+            litellm_model="openai/cpa-compatible",
+            litellm_fallback_models=[],
+            llm_model_list=[],
+        )
+        response = SimpleNamespace(
+            choices=[
+                SimpleNamespace(
+                    message=SimpleNamespace(
+                        content=None,
+                        content_blocks=[
+                            {"type": "text", "text": "block "},
+                            {"type": "text", "text": "response"},
+                        ],
+                    ),
+                )
+            ],
+            usage=SimpleNamespace(prompt_tokens=2, completion_tokens=3, total_tokens=5),
+        )
+
+        with patch.object(analyzer, "_dispatch_litellm_completion", return_value=response):
+            text, model_used, usage = analyzer._call_litellm(
+                "prompt",
+                {"max_tokens": 128, "temperature": 0.2},
+            )
+
+        assert text == "block response"
+        assert model_used == "openai/cpa-compatible"
+        assert usage == {"prompt_tokens": 2, "completion_tokens": 3, "total_tokens": 5}
+
+    def test_call_litellm_falls_back_to_message_content_when_blocks_empty(self):
+        analyzer = self._make_analyzer()
+        analyzer._config_override = SimpleNamespace(
+            litellm_model="openai/deepseek-chat",
+            litellm_fallback_models=[],
+            llm_model_list=[],
+        )
+        response = SimpleNamespace(
+            choices=[
+                SimpleNamespace(
+                    content_blocks=[],
+                    message=SimpleNamespace(content="message response"),
+                )
+            ],
+            usage=None,
+        )
+
+        with patch.object(analyzer, "_dispatch_litellm_completion", return_value=response):
+            text, model_used, usage = analyzer._call_litellm(
+                "prompt",
+                {"max_tokens": 128, "temperature": 0.2},
+            )
+
+        assert text == "message response"
+        assert model_used == "openai/deepseek-chat"
+        assert usage == {}
+
     def test_call_litellm_normalizes_kimi_k26_temperature(self):
         analyzer = self._make_analyzer()
         analyzer._config_override = SimpleNamespace(

--- a/tests/test_market_analyzer_generate_text.py
+++ b/tests/test_market_analyzer_generate_text.py
@@ -200,6 +200,37 @@ class TestAnalyzerGenerateText:
         assert model_used == "openai/deepseek-chat"
         assert usage == {}
 
+    def test_call_litellm_extracts_list_message_content_from_dict_response(self):
+        analyzer = self._make_analyzer()
+        analyzer._config_override = SimpleNamespace(
+            litellm_model="openai/list-content-provider",
+            litellm_fallback_models=[],
+            llm_model_list=[],
+        )
+        response = {
+            "choices": [
+                {
+                    "message": {
+                        "content": [
+                            {"type": "text", "text": "list "},
+                            {"type": "text", "text": "response"},
+                        ],
+                    },
+                }
+            ],
+            "usage": {"prompt_tokens": 3, "completion_tokens": 4, "total_tokens": 7},
+        }
+
+        with patch.object(analyzer, "_dispatch_litellm_completion", return_value=response):
+            text, model_used, usage = analyzer._call_litellm(
+                "prompt",
+                {"max_tokens": 128, "temperature": 0.2},
+            )
+
+        assert text == "list response"
+        assert model_used == "openai/list-content-provider"
+        assert usage == {"prompt_tokens": 3, "completion_tokens": 4, "total_tokens": 7}
+
     def test_call_litellm_normalizes_kimi_k26_temperature(self):
         analyzer = self._make_analyzer()
         analyzer._config_override = SimpleNamespace(


### PR DESCRIPTION
## Summary

- Fixes #1279.
- Adds provider-agnostic non-stream LiteLLM response extraction in `src/analyzer.py`.
- Supports choice/message `content_blocks` when `message.content` is `null`, while preserving fallback to `message.content` when blocks are empty.
- Adds regression tests for the formal analyzer path and records the user-visible fix in `docs/CHANGELOG.md`.

## Root Cause

The formal analysis path only read `response.choices[0].message.content`. Some OpenAI-compatible providers return `message.content = null` and place the text in `content_blocks`, so the analyzer treated a valid response as `LLM returned empty response`. The channel test and Agent paths already handled this shape more gracefully, which made the behavior inconsistent.

## Validation

- `python -m py_compile src/analyzer.py`
- `python -m pytest tests/test_market_analyzer_generate_text.py -q` — 33 passed
- `./scripts/ci_gate.sh` — 1884 passed, 2 deselected, 61 warnings, 166 subtests passed

## Risks

- If a provider returns both non-empty `content_blocks` and `message.content`, the analyzer now prefers `content_blocks`, matching the existing test-channel behavior.

## Rollback

- Revert this PR to restore the previous `message.content`-only analyzer parsing behavior.