### PR TITLE
[codex] fix settings page error fallback

### DIFF
--- a/apps/dsa-web/src/App.tsx
+++ b/apps/dsa-web/src/App.tsx
@@ -8,7 +8,7 @@ import LoginPage from './pages/LoginPage';
 import NotFoundPage from './pages/NotFoundPage';
 import ChatPage from './pages/ChatPage';
 import PortfolioPage from './pages/PortfolioPage';
-import { ApiErrorAlert, Shell } from './components/common';
+import { ApiErrorAlert, PageErrorBoundary, Shell } from './components/common';
 import { AuthProvider, useAuth } from './contexts/AuthContext';
 import { useAgentChatStore } from './stores/agentChatStore';
 import './App.css';
@@ -65,7 +65,18 @@ const AppContent: React.FC = () => {
         <Route path="/chat" element={<ChatPage />} />
         <Route path="/portfolio" element={<PortfolioPage />} />
         <Route path="/backtest" element={<BacktestPage />} />
-        <Route path="/settings" element={<SettingsPage />} />
+        <Route
+          path="/settings"
+          element={(
+            <PageErrorBoundary
+              title="系统设置"
+              description="设置页运行时发生异常。桌面端会保留主界面，不再直接黑屏。"
+              supportHint="Windows 免安装包如果反复出现此提示，请附上 logs/desktop.log 和触发的设置分类。"
+            >
+              <SettingsPage />
+            </PageErrorBoundary>
+          )}
+        />
         <Route path="*" element={<NotFoundPage />} />
       </Route>
       <Route path="/login" element={<LoginPage />} />

--- a/apps/dsa-web/src/components/common/PageErrorBoundary.tsx
+++ b/apps/dsa-web/src/components/common/PageErrorBoundary.tsx
@@ -1,0 +1,84 @@
+import { Component } from 'react';
+import type { ErrorInfo, ReactNode } from 'react';
+import { AlertTriangle, RefreshCw } from 'lucide-react';
+import { Button } from './Button';
+
+interface PageErrorBoundaryProps {
+  title: string;
+  description?: string;
+  supportHint?: string;
+  children: ReactNode;
+  onReset?: () => void;
+}
+
+interface PageErrorBoundaryState {
+  hasError: boolean;
+  message: string;
+}
+
+export class PageErrorBoundary extends Component<PageErrorBoundaryProps, PageErrorBoundaryState> {
+  override state: PageErrorBoundaryState = {
+    hasError: false,
+    message: '',
+  };
+
+  static getDerivedStateFromError(error: unknown): PageErrorBoundaryState {
+    return {
+      hasError: true,
+      message: error instanceof Error ? error.message : String(error || ''),
+    };
+  }
+
+  override componentDidCatch(error: Error, errorInfo: ErrorInfo) {
+    console.error(`[${this.props.title}] page runtime error`, error, errorInfo);
+  }
+
+  private handleReset = () => {
+    if (this.props.onReset) {
+      this.props.onReset();
+      return;
+    }
+    window.location.reload();
+  };
+
+  override render() {
+    if (!this.state.hasError) {
+      return this.props.children;
+    }
+
+    return (
+      <div className="flex min-h-[60vh] items-center justify-center px-4 py-10">
+        <section className="w-full max-w-2xl rounded-2xl border border-danger/30 bg-card/95 p-6 shadow-soft-card-strong">
+          <div className="flex flex-col gap-4 sm:flex-row sm:items-start">
+            <div className="flex h-11 w-11 shrink-0 items-center justify-center rounded-xl border border-danger/30 bg-danger/10 text-danger">
+              <AlertTriangle className="h-5 w-5" aria-hidden="true" />
+            </div>
+            <div className="min-w-0 flex-1 space-y-4">
+              <div>
+                <h1 className="text-lg font-semibold text-foreground">{this.props.title}加载失败</h1>
+                <p className="mt-2 text-sm leading-6 text-secondary-text">
+                  {this.props.description || '页面运行时发生异常，已阻止空白页继续扩散。'}
+                </p>
+              </div>
+
+              {this.state.message ? (
+                <pre className="max-h-32 overflow-auto rounded-xl border border-danger/20 bg-danger/5 px-3 py-2 text-xs leading-5 text-danger">
+                  {this.state.message}
+                </pre>
+              ) : null}
+
+              {this.props.supportHint ? (
+                <p className="text-xs leading-6 text-muted-text">{this.props.supportHint}</p>
+              ) : null}
+
+              <Button type="button" variant="settings-secondary" onClick={this.handleReset}>
+                <RefreshCw className="h-4 w-4" aria-hidden="true" />
+                重新加载页面
+              </Button>
+            </div>
+          </div>
+        </section>
+      </div>
+    );
+  }
+}

--- a/apps/dsa-web/src/components/common/__tests__/PageErrorBoundary.test.tsx
+++ b/apps/dsa-web/src/components/common/__tests__/PageErrorBoundary.test.tsx
@@ -1,0 +1,47 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import type { ReactElement } from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { PageErrorBoundary } from '../PageErrorBoundary';
+
+function BrokenPage(): ReactElement {
+  throw new Error('settings panel crashed');
+}
+
+describe('PageErrorBoundary', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('renders children when no runtime error occurs', () => {
+    render(
+      <PageErrorBoundary title="系统设置">
+        <div>设置内容</div>
+      </PageErrorBoundary>,
+    );
+
+    expect(screen.getByText('设置内容')).toBeInTheDocument();
+  });
+
+  it('shows a diagnostic fallback instead of a blank page', () => {
+    vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    const onReset = vi.fn();
+
+    render(
+      <PageErrorBoundary
+        title="系统设置"
+        supportHint="请附上 logs/desktop.log。"
+        onReset={onReset}
+      >
+        <BrokenPage />
+      </PageErrorBoundary>,
+    );
+
+    expect(screen.getByText('系统设置加载失败')).toBeInTheDocument();
+    expect(screen.getByText('settings panel crashed')).toBeInTheDocument();
+    expect(screen.getByText('请附上 logs/desktop.log。')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: '重新加载页面' }));
+
+    expect(onReset).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/dsa-web/src/components/common/index.ts
+++ b/apps/dsa-web/src/components/common/index.ts
@@ -25,6 +25,7 @@ export * from './StatusDot';
 export * from './Tooltip';
 export * from './Pagination';
 export * from './ConfirmDialog';
+export * from './PageErrorBoundary';
 export * from '../layout/Shell';
 export * from '../layout/SidebarNav';
 export * from '../layout/ShellHeader';

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -41,6 +41,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - [修复] Docker 启动入口自动修复 `data` / `logs` / `reports` 挂载目录权限并降权运行，文档化的 Compose `exec` 手动命令显式使用 `dsa` 用户，避免普通部署需要手动 `chown` / `chmod`。
 - [修复] Web 首页大盘复盘结果改由主内容滚动区承载，避免 loading 切换到长结果后下方报告区域被截断或无法继续滚动。
 - [修复] Web 设置页为通知测试与 Agent/通知配置区域增加局部运行时错误兜底，异常时提示提供 Windows 桌面端 `desktop.log`，避免整页黑屏。
+- [修复] 设置页增加错误边界，避免桌面端进入通知或 Agent 设置时因运行时异常直接黑屏。
 
 ## [3.16.0] - 2026-05-10
 


### PR DESCRIPTION
## Summary

Fixes #1287.

- Add a reusable page-level error boundary.
- Wrap `/settings` so settings runtime errors render a diagnostic fallback instead of a blank page.
- Include a desktop-specific hint asking for `logs/desktop.log` and the failing settings category.

## Root Cause

The original Windows portable black-screen report still needs release/version logs to identify the exact failing settings branch. However, the settings route had no page error boundary, so any runtime render exception could collapse the page into a blank state.

## Validation

- `cd apps/dsa-web && npm ci`
- `cd apps/dsa-web && npm run test -- PageErrorBoundary.test.tsx` (`2 passed`)
- `cd apps/dsa-web && npm run lint`
- `cd apps/dsa-web && npm run build`

Note: `npm ci` reported existing dependency audit findings: 10 vulnerabilities (4 moderate, 6 high). No new dependencies were added.

## Risk

This prevents black-screen UX and improves diagnostics, but it does not prove the original Windows portable root cause. The follow-up still needs release version and `desktop.log` from an affected machine.

## Rollback

Revert this PR to remove the settings page error boundary.