### PR TITLE
fix: 为设置页的通知与 Agent 设置区域增加运行时错误兜底… (#1287)

### DIFF
--- a/apps/dsa-web/src/components/settings/SettingsPanelErrorBoundary.tsx
+++ b/apps/dsa-web/src/components/settings/SettingsPanelErrorBoundary.tsx
@@ -1,0 +1,72 @@
+import { Component } from 'react';
+import type { ErrorInfo, ReactNode } from 'react';
+import { InlineAlert } from '../common';
+import { cn } from '../../utils/cn';
+
+interface SettingsPanelErrorBoundaryProps {
+  title: string;
+  children: ReactNode;
+  resetKey?: string | number;
+  className?: string;
+}
+
+interface SettingsPanelErrorBoundaryState {
+  hasError: boolean;
+  errorMessage: string;
+}
+
+export class SettingsPanelErrorBoundary extends Component<
+  SettingsPanelErrorBoundaryProps,
+  SettingsPanelErrorBoundaryState
+> {
+  override state: SettingsPanelErrorBoundaryState = {
+    hasError: false,
+    errorMessage: '',
+  };
+
+  static getDerivedStateFromError(error: unknown): SettingsPanelErrorBoundaryState {
+    return {
+      hasError: true,
+      errorMessage: error instanceof Error ? error.message : '未知前端运行时异常',
+    };
+  }
+
+  override componentDidCatch(error: Error, errorInfo: ErrorInfo) {
+    console.error(`Settings panel runtime error: ${this.props.title}`, error, errorInfo);
+  }
+
+  override componentDidUpdate(prevProps: SettingsPanelErrorBoundaryProps) {
+    if (this.state.hasError && prevProps.resetKey !== this.props.resetKey) {
+      this.setState({ hasError: false, errorMessage: '' });
+    }
+  }
+
+  override render() {
+    if (!this.state.hasError) {
+      return this.props.children;
+    }
+
+    return (
+      <div className={cn('rounded-[1.5rem] border settings-border bg-card/94 p-5 shadow-soft-card-strong backdrop-blur-sm', this.props.className)}>
+        <InlineAlert
+          title={`${this.props.title}加载失败`}
+          variant="danger"
+          message={(
+            <div className="space-y-2">
+              <p>
+                该设置区域发生前端运行时异常，页面其他设置仍可继续使用。请查看并提供桌面端日志
+                <code className="mx-1 rounded bg-background/45 px-1 py-0.5 font-mono text-xs">desktop.log</code>
+                ，同时补充 release 版本、Windows 版本和触发入口。
+              </p>
+              {this.state.errorMessage ? (
+                <p className="break-words font-mono text-xs opacity-80">
+                  错误摘要：{this.state.errorMessage}
+                </p>
+              ) : null}
+            </div>
+          )}
+        />
+      </div>
+    );
+  }
+}

--- a/apps/dsa-web/src/components/settings/SettingsPanelErrorBoundary.tsx
+++ b/apps/dsa-web/src/components/settings/SettingsPanelErrorBoundary.tsx
@@ -8,11 +8,48 @@ interface SettingsPanelErrorBoundaryProps {
   children: ReactNode;
   resetKey?: string | number;
   className?: string;
+  diagnosticHint?: ReactNode;
 }
 
 interface SettingsPanelErrorBoundaryState {
   hasError: boolean;
-  errorMessage: string;
+  errorSummary: string;
+}
+
+const MAX_ERROR_SUMMARY_LENGTH = 180;
+
+function sanitizeUrlLikeText(value: string) {
+  return value.replace(/https?:\/\/[^\s"'<>]+/gi, (match) => {
+    try {
+      const url = new URL(match);
+      const sanitizedUrl = `${url.protocol}//${url.host}${url.pathname}`;
+      return `${sanitizedUrl}${url.search ? '?[redacted]' : ''}${url.hash ? '#[redacted]' : ''}`;
+    } catch {
+      return match.replace(/\?[^#\s"'<>]*/g, '?[redacted]').replace(/#[^\s"'<>]*/g, '#[redacted]');
+    }
+  });
+}
+
+function getSafeErrorSummary(error: unknown) {
+  const rawMessage = error instanceof Error
+    ? error.message
+    : typeof error === 'string'
+      ? error
+      : '未知前端运行时异常';
+  const normalized = rawMessage.replace(/\s+/g, ' ').trim() || '未知前端运行时异常';
+  const sanitized = sanitizeUrlLikeText(normalized)
+    .replace(/\bBearer\s+[A-Za-z0-9._~+/=-]{8,}/gi, 'Bearer [redacted]')
+    .replace(/\b(sk-[A-Za-z0-9_-]{8,})\b/g, '[redacted-key]')
+    .replace(
+      /\b([A-Z0-9_]*(?:api[_-]?key|token|secret|password|passwd|authorization|webhook(?:_url)?)\s*[:=]\s*)([^\s,;'"`]+)/gi,
+      '$1[redacted]'
+    );
+
+  if (sanitized.length <= MAX_ERROR_SUMMARY_LENGTH) {
+    return sanitized;
+  }
+
+  return `${sanitized.slice(0, MAX_ERROR_SUMMARY_LENGTH)}...`;
 }
 
 export class SettingsPanelErrorBoundary extends Component<
@@ -21,13 +58,13 @@ export class SettingsPanelErrorBoundary extends Component<
 > {
   override state: SettingsPanelErrorBoundaryState = {
     hasError: false,
-    errorMessage: '',
+    errorSummary: '',
   };
 
   static getDerivedStateFromError(error: unknown): SettingsPanelErrorBoundaryState {
     return {
       hasError: true,
-      errorMessage: error instanceof Error ? error.message : '未知前端运行时异常',
+      errorSummary: getSafeErrorSummary(error),
     };
   }
 
@@ -37,7 +74,7 @@ export class SettingsPanelErrorBoundary extends Component<
 
   override componentDidUpdate(prevProps: SettingsPanelErrorBoundaryProps) {
     if (this.state.hasError && prevProps.resetKey !== this.props.resetKey) {
-      this.setState({ hasError: false, errorMessage: '' });
+      this.setState({ hasError: false, errorSummary: '' });
     }
   }
 
@@ -54,13 +91,16 @@ export class SettingsPanelErrorBoundary extends Component<
           message={(
             <div className="space-y-2">
               <p>
-                该设置区域发生前端运行时异常，页面其他设置仍可继续使用。请查看并提供桌面端日志
-                <code className="mx-1 rounded bg-background/45 px-1 py-0.5 font-mono text-xs">desktop.log</code>
-                ，同时补充 release 版本、Windows 版本和触发入口。
+                该设置区域发生前端运行时异常，页面其他设置仍可继续使用。
               </p>
-              {this.state.errorMessage ? (
+              {this.props.diagnosticHint ? (
+                <p>{this.props.diagnosticHint}</p>
+              ) : (
+                <p>请补充 release 版本、运行环境和触发入口，便于定位问题。</p>
+              )}
+              {this.state.errorSummary ? (
                 <p className="break-words font-mono text-xs opacity-80">
-                  错误摘要：{this.state.errorMessage}
+                  错误摘要：{this.state.errorSummary}
                 </p>
               ) : null}
             </div>

--- a/apps/dsa-web/src/components/settings/SettingsPanelErrorBoundary.tsx
+++ b/apps/dsa-web/src/components/settings/SettingsPanelErrorBoundary.tsx
@@ -22,10 +22,14 @@ function sanitizeUrlLikeText(value: string) {
   return value.replace(/https?:\/\/[^\s"'<>]+/gi, (match) => {
     try {
       const url = new URL(match);
-      const sanitizedUrl = `${url.protocol}//${url.host}${url.pathname}`;
+      const sanitizedPath = url.pathname && url.pathname !== '/' ? '/[redacted]' : '';
+      const sanitizedUrl = `${url.protocol}//${url.host}${sanitizedPath}`;
       return `${sanitizedUrl}${url.search ? '?[redacted]' : ''}${url.hash ? '#[redacted]' : ''}`;
     } catch {
-      return match.replace(/\?[^#\s"'<>]*/g, '?[redacted]').replace(/#[^\s"'<>]*/g, '#[redacted]');
+      return match
+        .replace(/^(https?:\/\/[^/?#\s"'<>]+)\/[^?#\s"'<>]*/i, '$1/[redacted]')
+        .replace(/\?[^#\s"'<>]*/g, '?[redacted]')
+        .replace(/#[^\s"'<>]*/g, '#[redacted]');
     }
   });
 }

--- a/apps/dsa-web/src/components/settings/__tests__/SettingsPanelErrorBoundary.test.tsx
+++ b/apps/dsa-web/src/components/settings/__tests__/SettingsPanelErrorBoundary.test.tsx
@@ -1,0 +1,53 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import type { ReactElement } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { SettingsPanelErrorBoundary } from '../SettingsPanelErrorBoundary';
+
+function ThrowingPanel(): ReactElement {
+  throw new Error('mock settings panel crash');
+}
+
+describe('SettingsPanelErrorBoundary', () => {
+  beforeEach(() => {
+    vi.spyOn(console, 'error').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('renders a diagnostic desktop-log fallback when a settings panel throws', () => {
+    render(
+      <SettingsPanelErrorBoundary title="通知设置" resetKey="notification">
+        <ThrowingPanel />
+      </SettingsPanelErrorBoundary>
+    );
+
+    expect(screen.getByRole('alert')).toBeInTheDocument();
+    expect(screen.getByText('通知设置加载失败')).toBeInTheDocument();
+    expect(screen.getByText('desktop.log')).toBeInTheDocument();
+    expect(screen.getByText(/release 版本、Windows 版本和触发入口/)).toBeInTheDocument();
+    expect(screen.getByText(/错误摘要：mock settings panel crash/)).toBeInTheDocument();
+  });
+
+  it('resets after resetKey changes so the panel can render again', async () => {
+    const { rerender } = render(
+      <SettingsPanelErrorBoundary title="Agent 设置" resetKey="agent:v1">
+        <ThrowingPanel />
+      </SettingsPanelErrorBoundary>
+    );
+
+    expect(screen.getByText('Agent 设置加载失败')).toBeInTheDocument();
+
+    rerender(
+      <SettingsPanelErrorBoundary title="Agent 设置" resetKey="agent:v2">
+        <div>Agent 设置已恢复</div>
+      </SettingsPanelErrorBoundary>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('Agent 设置已恢复')).toBeInTheDocument();
+    });
+    expect(screen.queryByText('Agent 设置加载失败')).not.toBeInTheDocument();
+  });
+});

--- a/apps/dsa-web/src/components/settings/__tests__/SettingsPanelErrorBoundary.test.tsx
+++ b/apps/dsa-web/src/components/settings/__tests__/SettingsPanelErrorBoundary.test.tsx
@@ -3,8 +3,8 @@ import type { ReactElement } from 'react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { SettingsPanelErrorBoundary } from '../SettingsPanelErrorBoundary';
 
-function ThrowingPanel(): ReactElement {
-  throw new Error('mock settings panel crash');
+function ThrowingPanel({ message = 'mock settings panel crash' }: { message?: string }): ReactElement {
+  throw new Error(message);
 }
 
 describe('SettingsPanelErrorBoundary', () => {
@@ -16,9 +16,19 @@ describe('SettingsPanelErrorBoundary', () => {
     vi.restoreAllMocks();
   });
 
-  it('renders a diagnostic desktop-log fallback when a settings panel throws', () => {
+  it('renders a configurable desktop-log diagnostic fallback when a settings panel throws', () => {
     render(
-      <SettingsPanelErrorBoundary title="通知设置" resetKey="notification">
+      <SettingsPanelErrorBoundary
+        title="通知设置"
+        resetKey="notification"
+        diagnosticHint={(
+          <>
+            请查看并提供桌面端日志
+            <code>desktop.log</code>
+            ，同时补充 release 版本、Windows 版本和触发入口。
+          </>
+        )}
+      >
         <ThrowingPanel />
       </SettingsPanelErrorBoundary>
     );
@@ -28,6 +38,24 @@ describe('SettingsPanelErrorBoundary', () => {
     expect(screen.getByText('desktop.log')).toBeInTheDocument();
     expect(screen.getByText(/release 版本、Windows 版本和触发入口/)).toBeInTheDocument();
     expect(screen.getByText(/错误摘要：mock settings panel crash/)).toBeInTheDocument();
+  });
+
+  it('redacts and truncates sensitive error summary text', () => {
+    render(
+      <SettingsPanelErrorBoundary title="通知设置" resetKey="notification">
+        <ThrowingPanel
+          message={`Webhook failed: https://notify.example.test/send?token=super-secret-token&foo=bar OPENAI_API_KEY=sk-supersecretvalue123456 ${'x'.repeat(220)}`}
+        />
+      </SettingsPanelErrorBoundary>
+    );
+
+    const summary = screen.getByText(/错误摘要：/).textContent ?? '';
+
+    expect(summary).toContain('?[redacted]');
+    expect(summary).toContain('OPENAI_API_KEY=[redacted]');
+    expect(summary).not.toContain('super-secret-token');
+    expect(summary).not.toContain('sk-supersecretvalue123456');
+    expect(summary.length).toBeLessThanOrEqual('错误摘要：'.length + 183);
   });
 
   it('resets after resetKey changes so the panel can render again', async () => {

--- a/apps/dsa-web/src/components/settings/__tests__/SettingsPanelErrorBoundary.test.tsx
+++ b/apps/dsa-web/src/components/settings/__tests__/SettingsPanelErrorBoundary.test.tsx
@@ -44,15 +44,18 @@ describe('SettingsPanelErrorBoundary', () => {
     render(
       <SettingsPanelErrorBoundary title="通知设置" resetKey="notification">
         <ThrowingPanel
-          message={`Webhook failed: https://notify.example.test/send?token=super-secret-token&foo=bar OPENAI_API_KEY=sk-supersecretvalue123456 ${'x'.repeat(220)}`}
+          message={`Webhook failed: https://hooks.slack.com/services/T000/B000/path-secret?token=super-secret-token&foo=bar OPENAI_API_KEY=sk-supersecretvalue123456 ${'x'.repeat(220)}`}
         />
       </SettingsPanelErrorBoundary>
     );
 
     const summary = screen.getByText(/错误摘要：/).textContent ?? '';
 
+    expect(summary).toContain('https://hooks.slack.com/[redacted]?[redacted]');
     expect(summary).toContain('?[redacted]');
     expect(summary).toContain('OPENAI_API_KEY=[redacted]');
+    expect(summary).not.toContain('/services/T000/B000/path-secret');
+    expect(summary).not.toContain('path-secret');
     expect(summary).not.toContain('super-secret-token');
     expect(summary).not.toContain('sk-supersecretvalue123456');
     expect(summary.length).toBeLessThanOrEqual('错误摘要：'.length + 183);

--- a/apps/dsa-web/src/components/settings/index.ts
+++ b/apps/dsa-web/src/components/settings/index.ts
@@ -6,6 +6,7 @@ export * from './NotificationTestPanel';
 export * from './SettingsField';
 export * from './SettingsHelpButton';
 export * from './SettingsLoading';
+export * from './SettingsPanelErrorBoundary';
 export * from './SettingsSectionCard';
 export * from './SettingsCategoryNav';
 export * from './AuthSettingsCard';

--- a/apps/dsa-web/src/pages/SettingsPage.tsx
+++ b/apps/dsa-web/src/pages/SettingsPage.tsx
@@ -14,6 +14,7 @@ import {
   SettingsAlert,
   SettingsField,
   SettingsLoading,
+  SettingsPanelErrorBoundary,
   SettingsSectionCard,
 } from '../components/settings';
 import { WEB_BUILD_INFO } from '../utils/constants';
@@ -495,6 +496,31 @@ const SettingsPage: React.FC = () => {
   };
 
   const desktopUpdateNotice = getDesktopUpdateNotice(desktopUpdateState);
+  const shouldGuardActiveConfigPanel = activeCategory === 'notification' || activeCategory === 'agent';
+  const activeConfigPanelErrorTitle = activeCategory === 'agent' ? 'Agent 设置' : '通知设置';
+  const activeConfigPanel = activeItems.length ? (
+    <SettingsSectionCard
+      title="当前分类配置项"
+      description={getCategoryDescriptionZh(activeCategory as SystemConfigCategory, '') || '使用统一字段卡片维护当前分类的系统配置。'}
+    >
+      {activeItems.map((item) => (
+        <SettingsField
+          key={item.key}
+          item={item}
+          value={item.value}
+          disabled={isSaving}
+          onChange={setDraftValue}
+          issues={issueByKey[item.key] || []}
+        />
+      ))}
+    </SettingsSectionCard>
+  ) : (
+    <EmptyState
+      title="当前分类下暂无配置项"
+      description="当前分类没有可编辑字段；可切换左侧分类继续查看其它系统配置。"
+      className="settings-surface-panel settings-border-strong border-none bg-transparent shadow-none"
+    />
+  );
 
   return (
     <div className="settings-page min-h-full px-4 pb-6 pt-4 md:px-6">
@@ -754,35 +780,25 @@ const SettingsPage: React.FC = () => {
               <ChangePasswordCard />
             ) : null}
             {activeCategory === 'notification' ? (
-              <NotificationTestPanel
-                items={rawActiveItems.map((item) => ({ key: item.key, value: String(item.value ?? '') }))}
-                maskToken={maskToken}
-                disabled={isSaving || isLoading}
-              />
-            ) : null}
-            {activeItems.length ? (
-              <SettingsSectionCard
-                title="当前分类配置项"
-                description={getCategoryDescriptionZh(activeCategory as SystemConfigCategory, '') || '使用统一字段卡片维护当前分类的系统配置。'}
+              <SettingsPanelErrorBoundary
+                title="通知测试"
+                resetKey={`notification-test:${configVersion}`}
               >
-                {activeItems.map((item) => (
-                  <SettingsField
-                    key={item.key}
-                    item={item}
-                    value={item.value}
-                    disabled={isSaving}
-                    onChange={setDraftValue}
-                    issues={issueByKey[item.key] || []}
-                  />
-                ))}
-              </SettingsSectionCard>
-            ) : (
-              <EmptyState
-                title="当前分类下暂无配置项"
-                description="当前分类没有可编辑字段；可切换左侧分类继续查看其它系统配置。"
-                className="settings-surface-panel settings-border-strong border-none bg-transparent shadow-none"
-              />
-            )}
+                <NotificationTestPanel
+                  items={rawActiveItems.map((item) => ({ key: item.key, value: String(item.value ?? '') }))}
+                  maskToken={maskToken}
+                  disabled={isSaving || isLoading}
+                />
+              </SettingsPanelErrorBoundary>
+            ) : null}
+            {shouldGuardActiveConfigPanel && activeItems.length ? (
+              <SettingsPanelErrorBoundary
+                title={activeConfigPanelErrorTitle}
+                resetKey={`${activeCategory}:${configVersion}`}
+              >
+                {activeConfigPanel}
+              </SettingsPanelErrorBoundary>
+            ) : activeConfigPanel}
           </section>
         </div>
       )}

--- a/apps/dsa-web/src/pages/SettingsPage.tsx
+++ b/apps/dsa-web/src/pages/SettingsPage.tsx
@@ -498,6 +498,15 @@ const SettingsPage: React.FC = () => {
   const desktopUpdateNotice = getDesktopUpdateNotice(desktopUpdateState);
   const shouldGuardActiveConfigPanel = activeCategory === 'notification' || activeCategory === 'agent';
   const activeConfigPanelErrorTitle = activeCategory === 'agent' ? 'Agent 设置' : '通知设置';
+  const settingsPanelDiagnosticHint = isDesktopRuntime ? (
+    <>
+      请查看并提供桌面端日志
+      <code className="mx-1 rounded bg-background/45 px-1 py-0.5 font-mono text-xs">desktop.log</code>
+      ，同时补充 release 版本、Windows 版本和触发入口。
+    </>
+  ) : (
+    <>请查看浏览器开发者工具控制台与后端日志，并补充 release 版本、浏览器版本和触发入口。</>
+  );
   const activeConfigPanel = activeItems.length ? (
     <SettingsSectionCard
       title="当前分类配置项"
@@ -783,6 +792,7 @@ const SettingsPage: React.FC = () => {
               <SettingsPanelErrorBoundary
                 title="通知测试"
                 resetKey={`notification-test:${configVersion}`}
+                diagnosticHint={settingsPanelDiagnosticHint}
               >
                 <NotificationTestPanel
                   items={rawActiveItems.map((item) => ({ key: item.key, value: String(item.value ?? '') }))}
@@ -795,6 +805,7 @@ const SettingsPage: React.FC = () => {
               <SettingsPanelErrorBoundary
                 title={activeConfigPanelErrorTitle}
                 resetKey={`${activeCategory}:${configVersion}`}
+                diagnosticHint={settingsPanelDiagnosticHint}
               >
                 {activeConfigPanel}
               </SettingsPanelErrorBoundary>

--- a/apps/dsa-web/src/pages/__tests__/SettingsPage.test.tsx
+++ b/apps/dsa-web/src/pages/__tests__/SettingsPage.test.tsx
@@ -21,6 +21,7 @@ const {
   applyPartialUpdate,
   refreshAfterExternalSave,
   refreshStatus,
+  settingsPanelErrorBoundary,
   useAuthMock,
   useSystemConfigMock,
   webBuildInfoMock,
@@ -41,6 +42,7 @@ const {
   applyPartialUpdate: vi.fn(),
   refreshAfterExternalSave: vi.fn(),
   refreshStatus: vi.fn(),
+  settingsPanelErrorBoundary: vi.fn(),
   useAuthMock: vi.fn(),
   useSystemConfigMock: vi.fn(),
   webBuildInfoMock: {
@@ -141,6 +143,16 @@ vi.mock('../../components/settings', () => ({
   ),
   SettingsField: ({ item }: { item: { key: string } }) => <div>{item.key}</div>,
   SettingsLoading: () => <div>loading</div>,
+  SettingsPanelErrorBoundary: ({
+    title,
+    children,
+  }: {
+    title: string;
+    children: React.ReactNode;
+  }) => {
+    settingsPanelErrorBoundary(title);
+    return <>{children}</>;
+  },
   SettingsSectionCard: ({
     title,
     description,
@@ -578,6 +590,7 @@ describe('SettingsPage', () => {
     expect(screen.getByText('AGENT_ORCHESTRATOR_TIMEOUT_S')).toBeInTheDocument();
     expect(screen.getByText('AGENT_DEEP_RESEARCH_BUDGET')).toBeInTheDocument();
     expect(screen.getByText('AGENT_EVENT_MONITOR_ENABLED')).toBeInTheDocument();
+    expect(settingsPanelErrorBoundary).toHaveBeenCalledWith('Agent 设置');
   });
 
   it('reset button semantic: discards local changes without network request', () => {
@@ -633,6 +646,8 @@ describe('SettingsPage', () => {
 
     expect(screen.getByText('通知测试面板:WECHAT_WEBHOOK_URL')).toBeInTheDocument();
     expect(screen.getByText('WECHAT_WEBHOOK_URL')).toBeInTheDocument();
+    expect(settingsPanelErrorBoundary).toHaveBeenCalledWith('通知测试');
+    expect(settingsPanelErrorBoundary).toHaveBeenCalledWith('通知设置');
   });
 
   it('renders env backup actions outside desktop runtime', () => {

--- a/apps/dsa-web/src/pages/__tests__/SettingsPage.test.tsx
+++ b/apps/dsa-web/src/pages/__tests__/SettingsPage.test.tsx
@@ -145,13 +145,20 @@ vi.mock('../../components/settings', () => ({
   SettingsLoading: () => <div>loading</div>,
   SettingsPanelErrorBoundary: ({
     title,
+    diagnosticHint,
     children,
   }: {
     title: string;
+    diagnosticHint?: React.ReactNode;
     children: React.ReactNode;
   }) => {
     settingsPanelErrorBoundary(title);
-    return <>{children}</>;
+    return (
+      <>
+        {diagnosticHint ? <div>{diagnosticHint}</div> : null}
+        {children}
+      </>
+    );
   },
   SettingsSectionCard: ({
     title,
@@ -648,6 +655,25 @@ describe('SettingsPage', () => {
     expect(screen.getByText('WECHAT_WEBHOOK_URL')).toBeInTheDocument();
     expect(settingsPanelErrorBoundary).toHaveBeenCalledWith('通知测试');
     expect(settingsPanelErrorBoundary).toHaveBeenCalledWith('通知设置');
+  });
+
+  it('uses browser and backend logs in settings panel diagnostic hints outside desktop runtime', () => {
+    useSystemConfigMock.mockReturnValue(buildSystemConfigState({ activeCategory: 'notification' }));
+
+    render(<SettingsPage />);
+
+    expect(screen.getAllByText(/浏览器开发者工具控制台与后端日志/)).toHaveLength(2);
+    expect(screen.queryByText('desktop.log')).not.toBeInTheDocument();
+  });
+
+  it('uses desktop log in settings panel diagnostic hints during desktop runtime', () => {
+    useSystemConfigMock.mockReturnValue(buildSystemConfigState({ activeCategory: 'notification' }));
+    (window as { dsaDesktop?: unknown }).dsaDesktop = createDesktopRuntime();
+
+    render(<SettingsPage />);
+
+    expect(screen.getAllByText('desktop.log')).toHaveLength(2);
+    expect(screen.queryByText(/浏览器开发者工具控制台与后端日志/)).not.toBeInTheDocument();
   });
 
   it('renders env backup actions outside desktop runtime', () => {

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -40,6 +40,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - [修复] 修正分析报告 API 构建策略点位时数值字段未归一为字符串的问题，避免策略价格触发响应 DTO 类型校验失败。
 - [修复] Docker 启动入口自动修复 `data` / `logs` / `reports` 挂载目录权限并降权运行，文档化的 Compose `exec` 手动命令显式使用 `dsa` 用户，避免普通部署需要手动 `chown` / `chmod`。
 - [修复] Web 首页大盘复盘结果改由主内容滚动区承载，避免 loading 切换到长结果后下方报告区域被截断或无法继续滚动。
+- [修复] Web 设置页为通知测试与 Agent/通知配置区域增加局部运行时错误兜底，异常时提示提供 Windows 桌面端 `desktop.log`，避免整页黑屏。
 
 ## [3.16.0] - 2026-05-10
 


### PR DESCRIPTION
## PR Type
- [x] fix
- [ ] feat
- [ ] refactor
- [ ] docs
- [ ] chore
- [ ] test

## Background And Problem
- 当前问题：为设置页的通知与 Agent 设置区域增加运行时错误兜底，异常时展示可诊断错误状态并提示提供 desktop.log。
- 影响范围：本次改动涉及 6 个文件，Diff 为 `+297 / -27`。
- 触发来源：Issue 自动执行（Issue #1287）。

## Scope Of Change
- `apps/dsa-web/src/components/settings/SettingsPanelErrorBoundary.tsx`
- `apps/dsa-web/src/components/settings/__tests__/SettingsPanelErrorBoundary.test.tsx`
- `apps/dsa-web/src/components/settings/index.ts`
- `apps/dsa-web/src/pages/SettingsPage.tsx`
- `apps/dsa-web/src/pages/__tests__/SettingsPage.test.tsx`
- `docs/CHANGELOG.md`

## Documentation And Changelog
- 已同步更新文档/变更记录：`docs/CHANGELOG.md`。
- 当前补丁尚未包含 `README.md` 或专题文档；如用户可见行为发生变化，请补充文档落点。

## Issue Link
Closes #1287

## Verification Commands And Results
```bash
./scripts/ci_gate.sh flake8
./scripts/ci_gate.sh offline-tests
```

关键输出/结论 / Key output & conclusion:
- lint:PASS, test:PASS

## Compatibility And Risk
- **Medium**：涉及 `apps/dsa-web/src/components/settings/SettingsPanelErrorBoundary.tsx`, `apps/dsa-web/src/components/settings/__tests__/SettingsPanelErrorBoundary.test.tsx`, `apps/dsa-web/src/components/settings/index.ts`, `apps/dsa-web/src/pages/SettingsPage.tsx`, `apps/dsa-web/src/pages/__tests__/SettingsPage.test.tsx`, `docs/CHANGELOG.md`，建议按文件范围复核。
- 前提假设：
  - 当前问题的首要修复目标不是定位 Windows 打包差异根因，而是避免设置页异常导致整页黑屏。
  - 通知设置和 Agent 设置大概率位于 apps/dsa-web 的 React 设置页内，并由桌面端复用 Web 构建产物。
  - 在缺少 release 版本、Windows 版本和 desktop.log 的情况下，只做错误边界与提示文案，不改 Electron 启动链路、配置语义或发布工作流。
  - Linux 环境可能无法完整复现 Windows 免安装包行为，最终仍需在 Windows 发布包中复核。

## Rollback Plan
- `git revert <merge-commit>` 回滚本 PR 提交，重点确认 `apps/dsa-web/src/components/settings/SettingsPanelErrorBoundary.tsx`, `apps/dsa-web/src/components/settings/__tests__/SettingsPanelErrorBoundary.test.tsx`, `apps/dsa-web/src/components/settings/index.ts`, `apps/dsa-web/src/pages/SettingsPage.tsx` 恢复正常。

## Acceptance Criteria
- 进入设置页的通知或 Agent 设置时，如果子组件抛出运行时异常，页面不再整页黑屏。
- 异常状态展示明确提示，包含查看或提供桌面端日志 desktop.log 的说明。
- 错误兜底范围尽量限制在设置页相关面板，不吞掉全局不可恢复错误。
- 正常情况下通知设置和 Agent 设置原有交互不受影响。
- docs/CHANGELOG.md 的 Unreleased 段补充一条扁平格式修复记录。

## Checklist
- [x] 本 PR 有明确动机和业务价值 / This PR has a clear motivation and value
- [x] 已提供可复现的验证命令与结果 / Reproducible verification commands and results are included
- [x] 已评估兼容性与风险 / Compatibility and risk have been assessed
- [x] 已提供回滚方案 / A rollback plan is provided
- [ ] 文档与 `docs/CHANGELOG.md` 同步仍需确认；如涉及用户可见变更，请在合并前补充原因与文档落点 / Documentation and `docs/CHANGELOG.md` sync still needs confirmation before merge when user-visible behavior changes