### PR TITLE
fix: 大盘分析的历史执行记录丢失 (#1306)

### DIFF
--- a/api/v1/endpoints/analysis.py
+++ b/api/v1/endpoints/analysis.py
@@ -20,6 +20,7 @@ import asyncio
 import json
 import logging
 import re
+import uuid
 from datetime import datetime
 from pathlib import Path
 from typing import Optional, Union, Dict, Any
@@ -116,6 +117,7 @@ def _run_market_review_background(
     override_region: Optional[str] = None,
     lock_token: Optional[_MarketReviewExecutionLock] = None,
     config: Optional[Config] = None,
+    query_id: Optional[str] = None,
 ) -> None:
     """Run market review after the API response has been accepted."""
     from src.core.market_review import run_market_review
@@ -123,13 +125,16 @@ def _run_market_review_background(
     runtime_config = config or get_config_dep()
     try:
         notifier, analyzer, search_service = _build_market_review_runtime(runtime_config)
-        report = run_market_review(
-            notifier=notifier,
-            analyzer=analyzer,
-            search_service=search_service,
-            send_notification=send_notification,
-            override_region=override_region,
-        )
+        review_kwargs = {
+            "notifier": notifier,
+            "analyzer": analyzer,
+            "search_service": search_service,
+            "send_notification": send_notification,
+            "override_region": override_region,
+        }
+        if query_id:
+            review_kwargs["query_id"] = query_id
+        report = run_market_review(**review_kwargs)
         if not report:
             raise RuntimeError("大盘复盘未返回可持久化报告")
         return {"result": report}
@@ -500,16 +505,19 @@ def trigger_market_review(
         )
 
     try:
+        task_id = uuid.uuid4().hex
         task = get_task_queue().submit_background_task(
             lambda: _run_market_review_background(
                 request.send_notification,
                 override_region=override_region,
                 lock_token=lock_token,
                 config=config,
+                query_id=task_id,
             ),
             stock_code="market_review",
             stock_name="大盘复盘",
             message="大盘复盘任务已提交",
+            task_id=task_id,
         )
     except Exception:
         _release_market_review_lock(lock_token)
@@ -751,6 +759,25 @@ def get_analysis_status(task_id: str) -> TaskStatus:
         if records:
             record = records[0]
             raw_result = parse_json_field(record.raw_result)
+            if getattr(record, "report_type", None) == "market_review":
+                market_review_report = None
+                if isinstance(raw_result, dict):
+                    report_text = raw_result.get("raw_response") or raw_result.get("market_review_report")
+                    if isinstance(report_text, str) and report_text.strip():
+                        market_review_report = report_text
+                if not market_review_report and record.news_content:
+                    market_review_report = record.news_content
+
+                return TaskStatus(
+                    task_id=task_id,
+                    status="completed",
+                    progress=100,
+                    result=None,
+                    market_review_report=market_review_report,
+                    error=None,
+                    stock_name=record.name,
+                )
+
             model_used = normalize_model_used(
                 (raw_result or {}).get("model_used") if isinstance(raw_result, dict) else None
             )

--- a/apps/dsa-web/src/pages/HomePage.tsx
+++ b/apps/dsa-web/src/pages/HomePage.tsx
@@ -162,7 +162,7 @@ const HomePage: React.FC = () => {
   );
 
   const handleAskFollowUp = useCallback(() => {
-    if (selectedReport?.meta.id === undefined) {
+    if (selectedReport?.meta.id === undefined || selectedReport.meta.reportType === 'market_review') {
       return;
     }
 
@@ -596,7 +596,7 @@ const HomePage: React.FC = () => {
                   <Button
                     variant="home-action-ai"
                     size="sm"
-                    disabled={selectedReport.meta.id === undefined}
+                    disabled={selectedReport.meta.id === undefined || isMarketReviewHistoryReport}
                     onClick={handleAskFollowUp}
                   >
                     <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">

--- a/apps/dsa-web/src/pages/HomePage.tsx
+++ b/apps/dsa-web/src/pages/HomePage.tsx
@@ -119,6 +119,7 @@ const HomePage: React.FC = () => {
 
   const reportLanguage = normalizeReportLanguage(selectedReport?.meta.reportLanguage);
   const reportText = getReportText(reportLanguage);
+  const isMarketReviewHistoryReport = selectedReport?.meta.reportType === 'market_review';
   const setupNeedsAction = setupStatus ? !setupStatus.isComplete : false;
   const setupMissingLabels = useMemo(() => {
     if (!setupStatus) {
@@ -172,7 +173,7 @@ const HomePage: React.FC = () => {
   }, [navigate, selectedReport]);
 
   const handleReanalyze = useCallback(() => {
-    if (!selectedReport) {
+    if (!selectedReport || selectedReport.meta.reportType === 'market_review') {
       return;
     }
 
@@ -584,7 +585,7 @@ const HomePage: React.FC = () => {
                   <Button
                     variant="home-action-ai"
                     size="sm"
-                    disabled={isAnalyzing || selectedReport.meta.id === undefined}
+                    disabled={isAnalyzing || selectedReport.meta.id === undefined || isMarketReviewHistoryReport}
                     onClick={handleReanalyze}
                   >
                     <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">

--- a/apps/dsa-web/src/pages/__tests__/HomePage.test.tsx
+++ b/apps/dsa-web/src/pages/__tests__/HomePage.test.tsx
@@ -519,7 +519,7 @@ describe('HomePage', () => {
     }));
   });
 
-  it('disables stock reanalysis for market review history reports', async () => {
+  it('disables stock reanalysis and follow-up for market review history reports', async () => {
     vi.mocked(historyApi.getList).mockResolvedValue({
       total: 1,
       page: 1,
@@ -536,11 +536,15 @@ describe('HomePage', () => {
 
     await screen.findByText('大盘复盘摘要');
     const reanalyzeButton = screen.getByRole('button', { name: '重新分析' });
+    const followUpButton = screen.getByRole('button', { name: '追问 AI' });
 
     expect(reanalyzeButton).toBeDisabled();
+    expect(followUpButton).toBeDisabled();
 
     fireEvent.click(reanalyzeButton);
+    fireEvent.click(followUpButton);
 
     expect(analysisApi.analyzeAsync).not.toHaveBeenCalled();
+    expect(navigateMock).not.toHaveBeenCalled();
   });
 });

--- a/apps/dsa-web/src/pages/__tests__/HomePage.test.tsx
+++ b/apps/dsa-web/src/pages/__tests__/HomePage.test.tsx
@@ -78,6 +78,33 @@ const historyReport = {
   },
 };
 
+const marketReviewHistoryItem = {
+  id: 2,
+  queryId: 'market-review-q-1',
+  stockCode: 'MARKET',
+  stockName: '大盘复盘',
+  reportType: 'market_review' as const,
+  createdAt: '2026-03-18T08:00:00Z',
+};
+
+const marketReviewHistoryReport = {
+  meta: {
+    id: 2,
+    queryId: 'market-review-q-1',
+    stockCode: 'MARKET',
+    stockName: '大盘复盘',
+    reportType: 'market_review' as const,
+    reportLanguage: 'zh' as const,
+    createdAt: '2026-03-18T08:00:00Z',
+  },
+  summary: {
+    analysisSummary: '大盘复盘摘要',
+    operationAdvice: '查看复盘',
+    trendPrediction: '大盘复盘',
+    sentimentScore: 50,
+  },
+};
+
 describe('HomePage', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -490,5 +517,30 @@ describe('HomePage', () => {
       originalQuery: '600519',
       forceRefresh: true,
     }));
+  });
+
+  it('disables stock reanalysis for market review history reports', async () => {
+    vi.mocked(historyApi.getList).mockResolvedValue({
+      total: 1,
+      page: 1,
+      limit: 20,
+      items: [marketReviewHistoryItem],
+    });
+    vi.mocked(historyApi.getDetail).mockResolvedValue(marketReviewHistoryReport);
+
+    render(
+      <MemoryRouter>
+        <HomePage />
+      </MemoryRouter>,
+    );
+
+    await screen.findByText('大盘复盘摘要');
+    const reanalyzeButton = screen.getByRole('button', { name: '重新分析' });
+
+    expect(reanalyzeButton).toBeDisabled();
+
+    fireEvent.click(reanalyzeButton);
+
+    expect(analysisApi.analyzeAsync).not.toHaveBeenCalled();
   });
 });

--- a/apps/dsa-web/src/types/analysis.ts
+++ b/apps/dsa-web/src/types/analysis.ts
@@ -5,12 +5,13 @@
 
 // ============ Request Types ============
 
-export type ReportType = 'simple' | 'detailed' | 'full' | 'brief' | 'market_review';
+export type StockReportType = 'simple' | 'detailed' | 'full' | 'brief';
+export type ReportType = StockReportType | 'market_review';
 
 export interface AnalysisRequest {
   stockCode?: string;
   stockCodes?: string[];
-  reportType?: ReportType;
+  reportType?: StockReportType;
   forceRefresh?: boolean;
   asyncMode?: boolean;
   stockName?: string;

--- a/apps/dsa-web/src/types/analysis.ts
+++ b/apps/dsa-web/src/types/analysis.ts
@@ -5,10 +5,12 @@
 
 // ============ Request Types ============
 
+export type ReportType = 'simple' | 'detailed' | 'full' | 'brief' | 'market_review';
+
 export interface AnalysisRequest {
   stockCode?: string;
   stockCodes?: string[];
-  reportType?: 'simple' | 'detailed' | 'full' | 'brief';
+  reportType?: ReportType;
   forceRefresh?: boolean;
   asyncMode?: boolean;
   stockName?: string;
@@ -38,7 +40,7 @@ export interface ReportMeta {
   queryId: string;
   stockCode: string;
   stockName: string;
-  reportType: 'simple' | 'detailed' | 'full' | 'brief';
+  reportType: ReportType;
   reportLanguage?: ReportLanguage;
   createdAt: string;
   currentPrice?: number;
@@ -206,7 +208,7 @@ export interface HistoryItem {
   queryId: string;  // Linked analysis query ID
   stockCode: string;
   stockName?: string;
-  reportType?: string;
+  reportType?: ReportType;
   sentimentScore?: number;
   operationAdvice?: string;
   createdAt: string;

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -47,6 +47,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - [修复] 调高基本面聚合默认超时预算，降低 Windows/Docker 环境下整段基本面 timeout 的概率。
 - [修复] 正式分析链路兼容 OpenAI-compatible `content_blocks` 响应，避免 `message.content=null` 时被误判为空回复。
 - [文档] Issue #1279 外部响应兼容补证据：本次修复以 `litellm>=1.80.10,!=1.82.7,!=1.82.8,<2.0.0` 为运行时前提，交叉参照 [LiteLLM OpenAI-compatible](https://docs.litellm.ai/docs/providers/openai_compatible) / [OpenAI Chat Completion API](https://platform.openai.com/docs/api-reference/chat)、并以 `tests/test_market_analyzer_generate_text.py` 的 `content_blocks` 与 `list content` 回归样例为复现依据，保留 `message.content` 回退逻辑避免兼容断层。
+- [文档] Issue #1306 明确本轮仅持久化大盘复盘历史，不改 LLM 模型名、provider、Base URL、LiteLLM 运行时清理逻辑；兼容性依据为本仓库 `requirements.txt` 锁定版本与现有 `docs/LLM_CONFIG_GUIDE*.md` 兼容说明，回退路径为回滚本版本，见 `tests/test_analysis_api_contract.py`、`tests/test_analysis_history.py`、`tests/test_market_review.py`。
 - [改进] 大盘复盘新增 `MARKET_REVIEW_COLOR_SCHEME` 配置，可在指数涨跌幅中选择绿涨红跌或红涨绿跌。
 - [文档] 明确 `MARKET_REVIEW_COLOR_SCHEME` 仅为大盘复盘展示配置，枚举为 `green_up`/`red_up`（默认 `green_up`），属于文案与颜色语义层面变更；本次未调整模型名、provider、Base URL、LLM 运行时迁移或运行时清理逻辑。
 - [修复] 大盘复盘执行结果写入现有分析历史，Web 历史列表可直接查看已生成复盘，避免重复触发分析。

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -49,6 +49,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - [文档] Issue #1279 外部响应兼容补证据：本次修复以 `litellm>=1.80.10,!=1.82.7,!=1.82.8,<2.0.0` 为运行时前提，交叉参照 [LiteLLM OpenAI-compatible](https://docs.litellm.ai/docs/providers/openai_compatible) / [OpenAI Chat Completion API](https://platform.openai.com/docs/api-reference/chat)、并以 `tests/test_market_analyzer_generate_text.py` 的 `content_blocks` 与 `list content` 回归样例为复现依据，保留 `message.content` 回退逻辑避免兼容断层。
 - [改进] 大盘复盘新增 `MARKET_REVIEW_COLOR_SCHEME` 配置，可在指数涨跌幅中选择绿涨红跌或红涨绿跌。
 - [文档] 明确 `MARKET_REVIEW_COLOR_SCHEME` 仅为大盘复盘展示配置，枚举为 `green_up`/`red_up`（默认 `green_up`），属于文案与颜色语义层面变更；本次未调整模型名、provider、Base URL、LLM 运行时迁移或运行时清理逻辑。
+- [修复] 大盘复盘执行结果写入现有分析历史，Web 历史列表可直接查看已生成复盘，避免重复触发分析。
 
 ## [3.16.0] - 2026-05-10
 

--- a/docs/full-guide.md
+++ b/docs/full-guide.md
@@ -208,6 +208,7 @@ daily_stock_analysis/
 ### AI 模型配置
 
 > 完整说明见 [LLM 配置指南](LLM_CONFIG_GUIDE.md)（三层配置、渠道模式、Vision、Agent、排错）；常用服务商预设、Actions 变量对照和错误排障见 [LLM 服务商配置指南](llm-providers.md)。
+> 兼容性说明（Issue #1306）：本次改动只复用已有历史写入链路展示大盘复盘结果，不修改模型名、provider、Base URL、`LiteLLM` 清理/兼容语义。回退路径为回滚本版本。兼容验证来源见 `requirements.txt`（`litellm` 版本约束）、`docs/LLM_CONFIG_GUIDE*.md`，以及回归用例 `tests/test_analysis_api_contract.py`、`tests/test_analysis_history.py`、`tests/test_market_review.py`；官方源参考：[LiteLLM OpenAI-compatible](https://docs.litellm.ai/docs/providers/openai_compatible)、[OpenAI Chat Completion API](https://platform.openai.com/docs/api-reference/chat)。
 > 本节仅同步模型/渠道配置清单，不额外引入新的外部 provider / Base URL 兼容约定；兼容语义以当前仓库 `requirements.txt` 依赖约束和相关测试为准，历史回退路径见上述两份文档中“回退/恢复”说明。
 
 | 变量名 | 说明 | 默认值 | 必填 |

--- a/docs/full-guide.md
+++ b/docs/full-guide.md
@@ -1151,6 +1151,7 @@ FastAPI 提供 RESTful API 服务，支持配置管理和触发分析。
 - 🧭 **首次配置提示** - 首页会读取只读配置状态，缺少 LLM 主渠道、自选股等基础项时提示缺口并引导进入系统设置
 - 📊 **实时进度** - 分析任务状态实时更新，支持多任务并行；普通分析链路在进入 LLM 阶段后会优先尝试 LiteLLM 流式生成，并通过任务 SSE 回灌更细粒度的 `message/progress`
 - 🗂️ **大盘复盘任务可见性** - 首页触发大盘复盘后会返回 `task_id` 并轮询 `GET /api/v1/analysis/status/{task_id}`，在进行中/完成/失败场景给出可见反馈，失败时直接透出报错内容
+- 🧾 **市场复盘历史可复用** - 大盘复盘任务会持久化到分析历史，`report_type` 为 `market_review`，可直接通过历史列表/详情打开对应 Markdown 或详情页，不会重新触发分析重算
 - 📈 **回测验证** - 评估历史分析准确率，查询方向胜率与模拟收益
 - 🔗 **API 文档** - 访问 `/docs` 查看 Swagger UI
 
@@ -1177,6 +1178,7 @@ FastAPI 提供 RESTful API 服务，支持配置管理和触发分析。
 > 说明：`POST /api/v1/analysis/analyze` 在 `async_mode=false` 时仅支持单只股票；批量 `stock_codes` 需使用 `async_mode=true`。异步 `202` 响应对单股返回 `task_id`，对批量返回 `accepted` / `duplicates` 汇总结构。
 > 说明：`POST /api/v1/analysis/market-review` 采用后端与 CLI/Bot 共用的配置路径（`GeminiAnalyzer(config=...)` 与同样的搜索/提示词构造入口）。Provider 兼容路由会优先识别并使用 `litellm_model`、`llm_model_list`，若未配置则回退 legacy `GEMINI_*`、`OPENAI_*`、`ANTHROPIC_*`、`DEEPSEEK_*` 键；不会新增/调整 provider、Base URL 或 LiteLLM 路由语义。
 > 审计依据：优先级与回退语义以 `src/config.py` 的 `Config._load_from_env()` 为准（`LITELLM_CONFIG` > `LLM_CHANNELS` > legacy）。配套回归见 `tests/test_llm_channel_config.py`（配置源解析）与 `tests/test_market_review_runtime.py`（共享装配路径）。该接口当前仅提供单进程/单机级防重复能力，若为多实例部署需通过外部任务队列或分布式锁补齐全局幂等。
+> 说明：`POST /api/v1/analysis/market-review` 触发后，报告会以 `report_type=market_review` 写入历史库；你可直接查询 `/api/v1/history` 或 `/api/v1/history/{record_id}` 获取历史 Markdown，避免再次触发分析重算。
 > 说明：该端点若返回 `task_id`，WebUI 会轮询 `GET /api/v1/analysis/status/{task_id}` 展示状态。状态为 `completed` 时给出完成提示（报告已生成并按配置推送），状态为 `failed` 时在前端错误区域显示 `error` 原因。
 
 > 兼容性审计证据：

--- a/docs/full-guide_EN.md
+++ b/docs/full-guide_EN.md
@@ -184,6 +184,7 @@ Default schedule: Every weekday at **18:00 (Beijing Time)** automatic execution.
 ### AI Model Configuration
 
 > Full details: [LLM Config Guide](LLM_CONFIG_GUIDE_EN.md) (three-tier config, channels, Vision, Agent, troubleshooting).
+> Compatibility note for Issue #1306: this change only persists and exposes existing market-review output via history paths, and does not alter model name, provider, base URL, LiteLLM cleanup rules, or `.env` runtime migration semantics. Rollback is to revert this change set. Runtime compatibility references are `requirements.txt` (`litellm` constraints), `docs/LLM_CONFIG_GUIDE_EN.md`, and regression tests in `tests/test_analysis_api_contract.py`, `tests/test_analysis_history.py`, `tests/test_market_review.py`; official references: [LiteLLM OpenAI-compatible](https://docs.litellm.ai/docs/providers/openai_compatible), [OpenAI Chat Completion API](https://platform.openai.com/docs/api-reference/chat).
 
 | Variable | Description | Default | Required |
 |--------|------|--------|:----:|

--- a/docs/full-guide_EN.md
+++ b/docs/full-guide_EN.md
@@ -1010,6 +1010,7 @@ FastAPI provides RESTful API service for configuration management and triggering
 - **First-run Setup Hint** - The Home page reads the read-only setup status and points users to Settings when required items such as the primary LLM channel or watchlist are missing
 - **Real-time Progress** - Analysis task status updates in real-time, supports parallel tasks; the regular stock-analysis path now prefers LiteLLM streaming during the LLM stage and pushes finer-grained `message/progress` updates through task SSE
 - **Market Review visibility** - After clicking Market Review, the API returns a `task_id` and the UI polls `GET /api/v1/analysis/status/{task_id}` to show progress; completed/failure states are rendered explicitly and failure messages are shown directly in the UI error area.
+- **Market review history replay** - Market review results are persisted with `report_type=market_review` and can be reopened from history list/detail or Markdown endpoints directly, without re-triggering a fresh analysis run.
 - **Backtest Validation** - Evaluate historical analysis accuracy, query direction win rate and simulated returns
 - **API Documentation** - Visit `/docs` for Swagger UI
 
@@ -1034,6 +1035,7 @@ FastAPI provides RESTful API service for configuration management and triggering
 > Note: `POST /api/v1/analysis/analyze` supports only one stock when `async_mode=false`; batch `stock_codes` requires `async_mode=true`. The async `202` response returns a single `task_id` for one stock, or an `accepted` / `duplicates` summary for batch requests.
 > Note: `POST /api/v1/analysis/market-review` follows the same runtime configuration path as CLI/Bot market review (`GeminiAnalyzer(config=...)`, search setup, and prompt/rendering pipeline). The provider compatibility path prioritizes `litellm_model` and `llm_model_list`, then falls back to existing legacy keys (`GEMINI_*`, `OPENAI_*`, `ANTHROPIC_*`, `DEEPSEEK_*`) when those are not set; provider names, Base URL, and LiteLLM routing semantics are otherwise unchanged.
 > Audit note: priority and fallback are defined by `Config._load_from_env()` in `src/config.py` (`LITELLM_CONFIG` > `LLM_CHANNELS` > legacy). Regression coverage is in `tests/test_llm_channel_config.py` (configuration source parsing) and `tests/test_market_review_runtime.py` (shared runtime assembly). The endpoint lock is process/host-level only; multi-instance deployments still need external distributed idempotency controls.
+> Note: Once `/api/v1/analysis/market-review` completes, the report is persisted with `report_type=market_review`; open `/api/v1/history` and `/api/v1/history/{record_id}` (or Markdown history endpoints) to view it directly without re-running analysis.
 > Note: when `/api/v1/analysis/market-review` returns a `task_id`, the WebUI polls `GET /api/v1/analysis/status/{task_id}`. The UI renders clear `pending/processing` progress, shows completion feedback when status becomes `completed`, and surfaces `error` content on `failed`.
 
 > Compatibility audit evidence:

--- a/src/core/market_review.py
+++ b/src/core/market_review.py
@@ -13,16 +13,20 @@
 import logging
 from datetime import datetime
 from typing import Optional
+import uuid
 
 from src.config import get_config
 from src.notification import NotificationService
 from src.market_analyzer import MarketAnalyzer
 from src.report_language import normalize_report_language
 from src.search_service import SearchService
-from src.analyzer import GeminiAnalyzer
+from src.analyzer import AnalysisResult, GeminiAnalyzer
 
 
 logger = logging.getLogger(__name__)
+
+MARKET_REVIEW_HISTORY_CODE = "MARKET"
+MARKET_REVIEW_REPORT_TYPE = "market_review"
 
 
 def _get_market_review_text(language: str) -> dict[str, str]:
@@ -53,6 +57,7 @@ def run_market_review(
     send_notification: bool = True,
     merge_notification: bool = False,
     override_region: Optional[str] = None,
+    query_id: Optional[str] = None,
 ) -> Optional[str]:
     """
     执行大盘复盘分析
@@ -64,6 +69,7 @@ def run_market_review(
         send_notification: 是否发送通知
         merge_notification: 是否合并推送（跳过本次推送，由 main 层合并个股+大盘后统一发送，Issue #190）
         override_region: 覆盖 config 的 market_review_region（Issue #373 交易日过滤后有效子集）
+        query_id: 历史记录关联 ID；API 后台任务会传入 task_id，CLI/Bot 为空时自动生成
 
     Returns:
         复盘报告文本
@@ -125,6 +131,14 @@ def run_market_review(
                 report_filename
             )
             logger.info(f"大盘复盘报告已保存: {filepath}")
+
+            _persist_market_review_history(
+                review_report=review_report,
+                markdown_report=f"{review_text['root_title']}\n\n{review_report}",
+                region=region,
+                config=config,
+                query_id=query_id,
+            )
             
             # 推送通知（合并模式下跳过，由 main 层统一发送）
             if merge_notification and send_notification:
@@ -147,3 +161,72 @@ def run_market_review(
         logger.error(f"大盘复盘分析失败: {e}")
     
     return None
+
+
+def _persist_market_review_history(
+    *,
+    review_report: str,
+    markdown_report: str,
+    region: str,
+    config: object,
+    query_id: Optional[str] = None,
+) -> int:
+    """Persist market review output into the existing analysis history table."""
+    try:
+        from src.storage import DatabaseManager
+
+        report_language = normalize_report_language(getattr(config, "report_language", "zh"))
+        summary = _summarize_market_review(review_report, report_language)
+        if report_language == "en":
+            stock_name = "Market Review"
+            operation_advice = "View review"
+            trend_prediction = "Market review"
+        else:
+            stock_name = "大盘复盘"
+            operation_advice = "查看复盘"
+            trend_prediction = "大盘复盘"
+
+        result = AnalysisResult(
+            code=MARKET_REVIEW_HISTORY_CODE,
+            name=stock_name,
+            sentiment_score=50,
+            trend_prediction=trend_prediction,
+            operation_advice=operation_advice,
+            analysis_summary=summary,
+            report_language=report_language,
+            news_summary=review_report,
+            raw_response=markdown_report,
+            data_sources="market_review",
+        )
+
+        history_query_id = query_id or f"market_review_{uuid.uuid4().hex}"
+        context_snapshot = {
+            "report_kind": MARKET_REVIEW_REPORT_TYPE,
+            "market_review_region": region,
+            "report_language": report_language,
+        }
+
+        saved = DatabaseManager.get_instance().save_analysis_history(
+            result=result,
+            query_id=history_query_id,
+            report_type=MARKET_REVIEW_REPORT_TYPE,
+            news_content=review_report,
+            context_snapshot=context_snapshot,
+            save_snapshot=True,
+        )
+        if saved:
+            logger.info("大盘复盘历史记录已保存: query_id=%s", history_query_id)
+        else:
+            logger.warning("大盘复盘历史记录保存失败: query_id=%s", history_query_id)
+        return saved
+    except Exception as exc:
+        logger.warning("大盘复盘历史记录保存异常，报告文件与推送流程继续: %s", exc, exc_info=True)
+        return 0
+
+
+def _summarize_market_review(review_report: str, report_language: str) -> str:
+    for line in (review_report or "").splitlines():
+        text = line.strip().lstrip("#").strip()
+        if text and not text.startswith("---") and not text.startswith(">"):
+            return text[:200]
+    return "Market review report generated." if report_language == "en" else "大盘复盘报告已生成。"

--- a/src/repositories/backtest_repo.py
+++ b/src/repositories/backtest_repo.py
@@ -17,6 +17,8 @@ from src.storage import BacktestResult, BacktestSummary, DatabaseManager, Analys
 
 logger = logging.getLogger(__name__)
 
+MARKET_REVIEW_REPORT_TYPE = "market_review"
+
 
 class BacktestRepository:
     """DB access layer for backtesting."""
@@ -41,6 +43,7 @@ class BacktestRepository:
             conditions = [AnalysisHistory.created_at <= cutoff_dt]
             if code:
                 conditions.append(AnalysisHistory.code == code)
+            conditions.append(AnalysisHistory.report_type != MARKET_REVIEW_REPORT_TYPE)
 
             query = select(AnalysisHistory).where(and_(*conditions))
 

--- a/src/repositories/backtest_repo.py
+++ b/src/repositories/backtest_repo.py
@@ -11,7 +11,7 @@ import logging
 from datetime import date, datetime, timedelta
 from typing import List, Optional, Tuple
 
-from sqlalchemy import and_, delete, desc, func, select
+from sqlalchemy import and_, delete, desc, func, or_, select
 
 from src.storage import BacktestResult, BacktestSummary, DatabaseManager, AnalysisHistory
 
@@ -43,7 +43,12 @@ class BacktestRepository:
             conditions = [AnalysisHistory.created_at <= cutoff_dt]
             if code:
                 conditions.append(AnalysisHistory.code == code)
-            conditions.append(AnalysisHistory.report_type != MARKET_REVIEW_REPORT_TYPE)
+            conditions.append(
+                or_(
+                    AnalysisHistory.report_type.is_(None),
+                    AnalysisHistory.report_type != MARKET_REVIEW_REPORT_TYPE,
+                )
+            )
 
             query = select(AnalysisHistory).where(and_(*conditions))
 

--- a/src/services/history_service.py
+++ b/src/services/history_service.py
@@ -470,6 +470,18 @@ class HistoryService:
                 record_id=record_id
             )
 
+        if getattr(record, "report_type", None) == "market_review":
+            markdown_report = raw_result.get("raw_response") or raw_result.get("market_review_report")
+            if isinstance(markdown_report, str) and markdown_report.strip():
+                return markdown_report
+            if record.news_content:
+                return record.news_content
+            logger.error(f"get_markdown_report: market review report is empty for {record_id}")
+            raise MarkdownReportGenerationError(
+                f"market review report is empty for record {record_id}",
+                record_id=record_id,
+            )
+
         try:
             result = self._rebuild_analysis_result(raw_result, record)
         except Exception as e:

--- a/src/services/history_service.py
+++ b/src/services/history_service.py
@@ -250,6 +250,20 @@ class HistoryService:
             display_points[field] = str(db_value) if db_value is not None else None
         return display_points
 
+    @staticmethod
+    def _extract_market_review_content(record, raw_result: Any) -> Optional[str]:
+        """Return persisted market review content from raw_result or news_content."""
+        if isinstance(raw_result, dict):
+            for field in ("raw_response", "market_review_report"):
+                content = raw_result.get(field)
+                if isinstance(content, str) and content.strip():
+                    return content
+
+        news_content = getattr(record, "news_content", None)
+        if isinstance(news_content, str) and news_content.strip():
+            return news_content
+        return None
+
     def _record_to_detail_dict(self, record) -> Dict[str, Any]:
         """
         Convert an AnalysisHistory ORM record to a detail response dict.
@@ -267,6 +281,10 @@ class HistoryService:
             except json.JSONDecodeError:
                 context_snapshot = record.context_snapshot
 
+        market_review_content = None
+        if getattr(record, "report_type", None) == "market_review":
+            market_review_content = self._extract_market_review_content(record, raw_result)
+
         return {
             "id": record.id,
             "query_id": record.query_id,
@@ -275,7 +293,7 @@ class HistoryService:
             "report_type": record.report_type,
             "created_at": record.created_at.isoformat() if record.created_at else None,
             "model_used": model_used,
-            "analysis_summary": record.analysis_summary,
+            "analysis_summary": market_review_content or record.analysis_summary,
             "operation_advice": record.operation_advice,
             "trend_prediction": record.trend_prediction,
             "sentiment_score": record.sentiment_score,
@@ -284,7 +302,7 @@ class HistoryService:
             "secondary_buy": sniper_points.get("secondary_buy"),
             "stop_loss": sniper_points.get("stop_loss"),
             "take_profit": sniper_points.get("take_profit"),
-            "news_content": record.news_content,
+            "news_content": market_review_content or record.news_content,
             "raw_result": raw_result,
             "context_snapshot": context_snapshot,
         }
@@ -471,11 +489,9 @@ class HistoryService:
             )
 
         if getattr(record, "report_type", None) == "market_review":
-            markdown_report = raw_result.get("raw_response") or raw_result.get("market_review_report")
-            if isinstance(markdown_report, str) and markdown_report.strip():
+            markdown_report = self._extract_market_review_content(record, raw_result)
+            if markdown_report:
                 return markdown_report
-            if record.news_content:
-                return record.news_content
             logger.error(f"get_markdown_report: market review report is empty for {record_id}")
             raise MarkdownReportGenerationError(
                 f"market review report is empty for record {record_id}",

--- a/src/services/task_queue.py
+++ b/src/services/task_queue.py
@@ -418,6 +418,7 @@ class AnalysisTaskQueue:
         stock_name: Optional[str] = None,
         report_type: str = "detailed",
         message: Optional[str] = "任务已加入队列",
+        task_id: Optional[str] = None,
     ) -> TaskInfo:
         """
         Submit a generic background callable with task lifecycle tracking.
@@ -425,7 +426,7 @@ class AnalysisTaskQueue:
         This is used by callers that need task status visibility but do not
         map to standard per-stock async analysis flow.
         """
-        task_id = uuid.uuid4().hex
+        task_id = task_id or uuid.uuid4().hex
         task_info = TaskInfo(
             task_id=task_id,
             stock_code=stock_code,
@@ -436,6 +437,8 @@ class AnalysisTaskQueue:
         )
 
         with self._data_lock:
+            if task_id in self._tasks:
+                raise ValueError(f"任务 ID 已存在: {task_id}")
             self._tasks[task_id] = task_info
             try:
                 future = self.executor.submit(self._execute_background_task, task_id, run_task)

--- a/tests/test_analysis_api_contract.py
+++ b/tests/test_analysis_api_contract.py
@@ -405,6 +405,33 @@ class AnalysisApiContractTestCase(unittest.TestCase):
         self.assertEqual(result.result.report["meta"]["current_price"], 1234.5)
         self.assertEqual(result.result.report["meta"]["change_pct"], 0.0)
 
+    def test_get_analysis_status_returns_market_review_report_from_db(self) -> None:
+        if get_analysis_status is None:
+            self.skipTest("analysis endpoint helpers unavailable in this environment")
+
+        mock_queue = MagicMock()
+        mock_queue.get_task.return_value = None
+        mock_db = MagicMock()
+        mock_db.get_analysis_history.return_value = [
+            SimpleNamespace(
+                id=10,
+                code="MARKET",
+                name="大盘复盘",
+                report_type="market_review",
+                raw_result={"raw_response": "# 🎯 大盘复盘\n\n复盘正文"},
+                news_content="复盘正文",
+                created_at=None,
+            )
+        ]
+
+        with patch("api.v1.endpoints.analysis.get_task_queue", return_value=mock_queue), \
+             patch("src.storage.DatabaseManager.get_instance", return_value=mock_db):
+            result = get_analysis_status("market-task-1")
+
+        self.assertEqual(result.status, "completed")
+        self.assertEqual(result.market_review_report, "# 🎯 大盘复盘\n\n复盘正文")
+        self.assertIsNone(result.result)
+
     def test_get_analysis_status_completed_db_snapshot_reads_change_pct_from_raw_when_price_present(self) -> None:
         if get_analysis_status is None:
             self.skipTest("analysis endpoint helpers unavailable in this environment")

--- a/tests/test_analysis_history.py
+++ b/tests/test_analysis_history.py
@@ -613,6 +613,40 @@ class AnalysisHistoryTestCase(unittest.TestCase):
         self.assertIn("Unnamed Stock (AAPL)", markdown)
         self.assertNotIn("核心结论", markdown)
 
+    def test_history_markdown_returns_persisted_market_review_report(self) -> None:
+        """Market review history should return the saved Markdown without rebuilding a stock report."""
+        result = AnalysisResult(
+            code="MARKET",
+            name="大盘复盘",
+            sentiment_score=50,
+            trend_prediction="大盘复盘",
+            operation_advice="查看复盘",
+            analysis_summary="今日大盘复盘",
+            raw_response="# 🎯 大盘复盘\n\n## 今日大盘\n\n复盘正文",
+        )
+
+        saved = self.db.save_analysis_history(
+            result=result,
+            query_id="market_review_query_001",
+            report_type="market_review",
+            news_content="## 今日大盘\n\n复盘正文",
+            context_snapshot=None,
+            save_snapshot=False,
+        )
+        self.assertEqual(saved, 1)
+
+        with self.db.get_session() as session:
+            row = session.query(AnalysisHistory).filter(
+                AnalysisHistory.query_id == "market_review_query_001"
+            ).first()
+            if row is None:
+                self.fail("未找到保存的历史记录")
+            record_id = row.id
+
+        markdown = HistoryService(self.db).get_markdown_report(str(record_id))
+
+        self.assertEqual(markdown, "# 🎯 大盘复盘\n\n## 今日大盘\n\n复盘正文")
+
     def test_history_detail_localizes_english_summary_fields(self) -> None:
         """History detail should localize summary enums for English reports."""
         if get_history_detail is None:

--- a/tests/test_analysis_history.py
+++ b/tests/test_analysis_history.py
@@ -647,6 +647,46 @@ class AnalysisHistoryTestCase(unittest.TestCase):
 
         self.assertEqual(markdown, "# 🎯 大盘复盘\n\n## 今日大盘\n\n复盘正文")
 
+    def test_history_detail_returns_persisted_market_review_report(self) -> None:
+        """Market review detail should surface the saved recap content for Web history clicks."""
+        if get_history_detail is None:
+            self.skipTest("fastapi is not installed in this test environment")
+
+        report_content = "# 🎯 大盘复盘\n\n## 今日大盘\n\n复盘正文"
+        result = AnalysisResult(
+            code="MARKET",
+            name="大盘复盘",
+            sentiment_score=50,
+            trend_prediction="大盘复盘",
+            operation_advice="查看复盘",
+            analysis_summary="今日大盘复盘",
+            raw_response=report_content,
+        )
+
+        saved = self.db.save_analysis_history(
+            result=result,
+            query_id="market_review_query_detail_001",
+            report_type="market_review",
+            news_content="## 今日大盘\n\n复盘正文",
+            context_snapshot=None,
+            save_snapshot=False,
+        )
+        self.assertEqual(saved, 1)
+
+        with self.db.get_session() as session:
+            row = session.query(AnalysisHistory).filter(
+                AnalysisHistory.query_id == "market_review_query_detail_001"
+            ).first()
+            if row is None:
+                self.fail("未找到保存的历史记录")
+            record_id = row.id
+
+        report = get_history_detail(str(record_id), db_manager=self.db)
+
+        self.assertEqual(report.meta.report_type, "market_review")
+        self.assertEqual(report.summary.analysis_summary, report_content)
+        self.assertEqual(report.details.news_content, report_content)
+
     def test_history_detail_localizes_english_summary_fields(self) -> None:
         """History detail should localize summary enums for English reports."""
         if get_history_detail is None:

--- a/tests/test_backtest_service.py
+++ b/tests/test_backtest_service.py
@@ -500,6 +500,38 @@ class BacktestServiceTestCase(unittest.TestCase):
             self.assertEqual(overall.completed_count, 2)
             self.assertEqual(overall.win_count, 2)
 
+    def test_run_backtest_excludes_market_review_records(self) -> None:
+        with self.db.get_session() as session:
+            session.add(
+                AnalysisHistory(
+                    query_id="q-market-review",
+                    code="MARKET",
+                    name="大盘复盘",
+                    report_type="market_review",
+                    sentiment_score=50,
+                    operation_advice="查看复盘",
+                    trend_prediction="大盘复盘",
+                    analysis_summary="market review summary",
+                    stop_loss=None,
+                    take_profit=None,
+                    created_at=datetime(2024, 1, 3, 0, 0, 0),
+                    context_snapshot='{"enhanced_context": {"date": "2024-01-03"}}',
+                )
+            )
+            session.commit()
+
+        service = BacktestService(self.db)
+        stats = service.run_backtest(code=None, force=False, eval_window_days=3, min_age_days=0, limit=10)
+
+        self.assertEqual(stats["processed"], 1)
+        self.assertEqual(stats["saved"], 1)
+        self.assertEqual(self._count_results(), 1)
+        with self.db.get_session() as session:
+            self.assertEqual(
+                session.query(BacktestResult).filter(BacktestResult.code == "MARKET").count(),
+                0,
+            )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_backtest_service.py
+++ b/tests/test_backtest_service.py
@@ -532,6 +532,43 @@ class BacktestServiceTestCase(unittest.TestCase):
                 0,
             )
 
+    def test_run_backtest_includes_null_report_type_records(self) -> None:
+        with self.db.get_session() as session:
+            session.add(
+                AnalysisHistory(
+                    query_id="q-null-report-type",
+                    code="000858",
+                    name="五粮液",
+                    report_type=None,
+                    sentiment_score=60,
+                    operation_advice="持有",
+                    trend_prediction="震荡",
+                    analysis_summary="legacy null report_type row",
+                    stop_loss=None,
+                    take_profit=None,
+                    created_at=datetime(2024, 1, 3, 0, 0, 0),
+                    context_snapshot='{"enhanced_context": {"date": "2024-01-03"}}',
+                )
+            )
+            session.add_all(
+                [
+                    StockDaily(code="000858", date=date(2024, 1, 3), open=12.0, high=12.8, low=11.5, close=12.2),
+                    StockDaily(code="000858", date=date(2024, 1, 4), open=12.2, high=13.0, low=12.0, close=12.6),
+                    StockDaily(code="000858", date=date(2024, 1, 5), open=12.6, high=12.9, low=11.9, close=12.4),
+                ]
+            )
+            session.commit()
+
+        service = BacktestService(self.db)
+        stats = service.run_backtest(code=None, force=False, eval_window_days=3, min_age_days=0, limit=10)
+        self.assertGreaterEqual(stats["processed"], 2)
+        self.assertGreaterEqual(stats["saved"], 2)
+        with self.db.get_session() as session:
+            self.assertEqual(
+                session.query(BacktestResult).filter(BacktestResult.code == "000858").count(),
+                1,
+            )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_market_review.py
+++ b/tests/test_market_review.py
@@ -2,7 +2,9 @@
 """Tests for localized market review wrappers."""
 
 import importlib
+import os
 import sys
+import tempfile
 import unittest
 from types import ModuleType, SimpleNamespace
 from unittest.mock import MagicMock, patch
@@ -37,6 +39,8 @@ def _build_optional_module_stubs() -> dict[str, ModuleType]:
 
 sys.modules.update(_build_optional_module_stubs())
 import src.core.market_review as market_review_module
+from src.config import Config
+from src.storage import AnalysisHistory, DatabaseManager
 
 run_market_review = market_review_module.run_market_review
 
@@ -58,7 +62,11 @@ class MarketReviewLocalizationTestCase(unittest.TestCase):
             market_review_module,
             "get_config",
             return_value=SimpleNamespace(report_language="en", market_review_region="cn"),
-        ), patch.object(market_review_module, "MarketAnalyzer", return_value=market_analyzer):
+        ), patch.object(
+            market_review_module,
+            "MarketAnalyzer",
+            return_value=market_analyzer,
+        ), patch.object(market_review_module, "_persist_market_review_history") as persist_history:
             result = run_market_review(notifier, send_notification=True)
 
         self.assertEqual(result, "## 2026-04-10 A-share Market Recap\n\nBody")
@@ -68,6 +76,8 @@ class MarketReviewLocalizationTestCase(unittest.TestCase):
         self.assertTrue(sent_content.startswith("🎯 Market Review\n\n"))
         self.assertTrue(notifier.send.call_args.kwargs["email_send_to_all"])
         self.assertEqual(notifier.send.call_args.kwargs["route_type"], "report")
+        persist_history.assert_called_once()
+        self.assertEqual(persist_history.call_args.kwargs["query_id"], None)
 
     def test_run_market_review_merges_both_regions_with_english_wrappers(self) -> None:
         notifier = self._make_notifier()
@@ -86,7 +96,7 @@ class MarketReviewLocalizationTestCase(unittest.TestCase):
             market_review_module,
             "MarketAnalyzer",
             side_effect=[cn_analyzer, hk_analyzer, us_analyzer],
-        ):
+        ), patch.object(market_review_module, "_persist_market_review_history"):
             result = run_market_review(notifier, send_notification=False)
 
         self.assertIn("# A-share Market Recap\n\nCN body", result)
@@ -114,7 +124,7 @@ class MarketReviewLocalizationTestCase(unittest.TestCase):
             market_review_module,
             "MarketAnalyzer",
             side_effect=[cn_analyzer, us_analyzer],
-        ):
+        ), patch.object(market_review_module, "_persist_market_review_history"):
             result = run_market_review(
                 notifier, send_notification=False, override_region="cn,us"
             )
@@ -141,7 +151,7 @@ class MarketReviewLocalizationTestCase(unittest.TestCase):
             market_review_module,
             "MarketAnalyzer",
             side_effect=[cn_analyzer, hk_analyzer],
-        ):
+        ), patch.object(market_review_module, "_persist_market_review_history"):
             result = run_market_review(
                 notifier, send_notification=False, override_region="cn,hk"
             )
@@ -150,6 +160,41 @@ class MarketReviewLocalizationTestCase(unittest.TestCase):
         self.assertIn("# 港股大盘复盘\n\nHK body", result)
         self.assertNotIn("美股", result)
         self.assertNotIn("US Market", result)
+
+    def test_persist_market_review_history_saves_markdown_report(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            old_db_path = os.environ.get("DATABASE_PATH")
+            os.environ["DATABASE_PATH"] = os.path.join(temp_dir, "market_review_history.db")
+            Config._instance = None
+            DatabaseManager.reset_instance()
+            try:
+                saved = market_review_module._persist_market_review_history(
+                    review_report="## 今日大盘\n\n复盘正文",
+                    markdown_report="# 🎯 大盘复盘\n\n## 今日大盘\n\n复盘正文",
+                    region="cn",
+                    config=SimpleNamespace(report_language="zh"),
+                    query_id="market-task-001",
+                )
+
+                self.assertEqual(saved, 1)
+                db = DatabaseManager.get_instance()
+                with db.get_session() as session:
+                    row = session.query(AnalysisHistory).filter(
+                        AnalysisHistory.query_id == "market-task-001"
+                    ).first()
+                    self.assertIsNotNone(row)
+                    self.assertEqual(row.code, market_review_module.MARKET_REVIEW_HISTORY_CODE)
+                    self.assertEqual(row.name, "大盘复盘")
+                    self.assertEqual(row.report_type, market_review_module.MARKET_REVIEW_REPORT_TYPE)
+                    self.assertEqual(row.news_content, "## 今日大盘\n\n复盘正文")
+                    self.assertIn("# 🎯 大盘复盘", row.raw_result)
+            finally:
+                DatabaseManager.reset_instance()
+                Config._instance = None
+                if old_db_path is None:
+                    os.environ.pop("DATABASE_PATH", None)
+                else:
+                    os.environ["DATABASE_PATH"] = old_db_path
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## PR Type
- [x] fix
- [ ] feat
- [ ] refactor
- [ ] docs
- [ ] chore
- [ ] test

## Background And Problem
- 当前问题：复用现有历史记录/数据库机制持久化大盘分析执行结果，并让用户能在 Web/API 中查看历史记录，避免重复执行。
- 影响范围：本次改动涉及 15 个文件，Diff 为 `+455 / -23`。
- 触发来源：Issue 自动执行（Issue #1306）。

## Scope Of Change
- `api/v1/endpoints/analysis.py`
- `apps/dsa-web/src/pages/HomePage.tsx`
- `apps/dsa-web/src/pages/__tests__/HomePage.test.tsx`
- `apps/dsa-web/src/types/analysis.ts`
- `docs/CHANGELOG.md`
- `docs/full-guide.md`
- `docs/full-guide_EN.md`
- `src/core/market_review.py`
- `src/repositories/backtest_repo.py`
- `src/services/history_service.py`
- `src/services/task_queue.py`
- `tests/test_analysis_api_contract.py`
- ... and 3 more files

## Documentation And Changelog
- 已同步更新文档/变更记录：`docs/CHANGELOG.md`, `docs/full-guide.md`, `docs/full-guide_EN.md`。

## Issue Link
Closes #1306

## Verification Commands And Results
```bash
./scripts/ci_gate.sh flake8
./scripts/ci_gate.sh offline-tests
```

关键输出/结论 / Key output & conclusion:
- lint:PASS, test:PASS

## Compatibility And Risk
- **Medium**：涉及 `api/v1/endpoints/analysis.py`, `apps/dsa-web/src/pages/HomePage.tsx`, `apps/dsa-web/src/pages/__tests__/HomePage.test.tsx`, `apps/dsa-web/src/types/analysis.ts`, `docs/CHANGELOG.md`, `docs/full-guide.md`，建议按文件范围复核。
- 前提假设：
  - 仓库已有普通股票分析历史记录或报告持久化机制，应优先复用，不新增平行存储方案。
  - 大盘分析入口可能由 `python main.py --market-review`、API 或 Web 页面触发，修复需覆盖实际触发路径。
  - 若现有数据库 schema 已支持区分报告类型，优先新增/使用 market review 类型；若不支持，再做最小兼容扩展。
  - 该修复不修改 secrets、部署流程或 GitHub Actions。

## Rollback Plan
- `git revert <merge-commit>` 回滚本 PR 提交，重点确认 `api/v1/endpoints/analysis.py`, `apps/dsa-web/src/pages/HomePage.tsx`, `apps/dsa-web/src/pages/__tests__/HomePage.test.tsx`, `apps/dsa-web/src/types/analysis.ts` 恢复正常。

## Acceptance Criteria
- 执行大盘分析后，分析结果会被写入现有数据库或报告历史存储。
- 重新打开页面或重新请求历史接口后，仍能看到已完成的大盘分析记录。
- 查看历史大盘分析时不需要重新触发分析任务。
- 普通个股分析历史记录行为不回归。
- 相关用户可见行为变更记录到 `docs/CHANGELOG.md` 的 `[Unreleased]` 扁平条目。

## Checklist
- [x] 本 PR 有明确动机和业务价值 / This PR has a clear motivation and value
- [x] 已提供可复现的验证命令与结果 / Reproducible verification commands and results are included
- [x] 已评估兼容性与风险 / Compatibility and risk have been assessed
- [x] 已提供回滚方案 / A rollback plan is provided
- [x] 已同步更新相关文档与 `docs/CHANGELOG.md`，并在 PR 描述中说明文档落点 / Relevant docs and `docs/CHANGELOG.md` are updated, and the documentation location is stated in this PR