### PR TITLE
feat: add Finnhub & AlphaVantage US market data source adapters

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -24,6 +24,15 @@ ANSPIRE_API_KEYS=
 TUSHARE_TOKEN=
 # TickFlow API Key（可选，用于 A 股大盘复盘指数增强；若套餐支持标的池查询，也可增强市场统计）
 # TICKFLOW_API_KEY=
+
+# Finnhub（可选，美股数据源，免费 tier 60 calls/min）
+# 获取: https://finnhub.io/register
+# FINNHUB_API_KEY=
+
+# AlphaVantage（可选，美股数据源，免费 tier 25 calls/day）
+# 获取: https://www.alphavantage.co/support/#api-key
+# ALPHAVANTAGE_API_KEY=
+
 # Longbridge OpenAPI（可选，美股/港股量比、换手率、PE 等字段兜底）
 # 从 https://open.longbridge.com/ 获取
 # LONGBRIDGE_APP_KEY=

--- a/.gitignore
+++ b/.gitignore
@@ -84,3 +84,4 @@ verify_*.py
 static/
 /apps/dsa-desktop/dist/
 /apps/dsa-desktop/node_modules/
+docs/specs/

--- a/data_provider/__init__.py
+++ b/data_provider/__init__.py
@@ -38,6 +38,8 @@ from .pytdx_fetcher import PytdxFetcher
 from .baostock_fetcher import BaostockFetcher
 from .yfinance_fetcher import YfinanceFetcher
 from .longbridge_fetcher import LongbridgeFetcher
+from .finnhub_fetcher import FinnhubFetcher
+from .alphavantage_fetcher import AlphaVantageFetcher
 from .us_index_mapping import is_us_index_code, is_us_stock_code, get_us_index_yf_symbol, US_INDEX_MAPPING
 
 __all__ = [
@@ -50,6 +52,8 @@ __all__ = [
     'BaostockFetcher',
     'YfinanceFetcher',
     'LongbridgeFetcher',
+    'FinnhubFetcher',
+    'AlphaVantageFetcher',
     'is_us_index_code',
     'is_us_stock_code',
     'is_hk_stock_code',

--- a/data_provider/alphavantage_fetcher.py
+++ b/data_provider/alphavantage_fetcher.py
@@ -1,0 +1,178 @@
+# -*- coding: utf-8 -*-
+"""
+AlphaVantageFetcher — US market data source (Priority 3)
+
+Data source: AlphaVantage REST API
+Rate limit: 25 calls/day, 5 calls/min (free tier)
+Markets: US only
+"""
+
+import logging
+import os
+from datetime import datetime
+from typing import Optional
+
+import pandas as pd
+import requests
+
+from .base import BaseFetcher, DataFetchError, STANDARD_COLUMNS
+from .realtime_types import UnifiedRealtimeQuote, RealtimeSource
+from .us_index_mapping import is_us_stock_code
+
+logger = logging.getLogger(__name__)
+
+_AV_BASE_URL = "https://www.alphavantage.co/query"
+
+
+class AlphaVantageFetcher(BaseFetcher):
+    name = "AlphaVantageFetcher"
+    priority = 3
+
+    def __init__(self):
+        from src.config import get_config
+        config = get_config()
+        self._api_key = getattr(config, 'alphavantage_api_key', None) or os.getenv('ALPHAVANTAGE_API_KEY')
+        if not self._api_key:
+            logger.debug("[AlphaVantage] API key not configured, fetcher disabled")
+
+    def _is_us_stock(self, stock_code: str) -> bool:
+        return is_us_stock_code(stock_code)
+
+    def _fetch_raw_data(self, stock_code: str, start_date: str, end_date: str) -> pd.DataFrame:
+        if not self._api_key:
+            raise DataFetchError("[AlphaVantage] API key not configured")
+        if not self._is_us_stock(stock_code):
+            raise DataFetchError(f"[AlphaVantage] {stock_code} is not a US stock")
+
+        symbol = stock_code.strip().upper()
+        params = {
+            'function': 'TIME_SERIES_DAILY',
+            'symbol': symbol,
+            'outputsize': 'compact',
+            'apikey': self._api_key,
+        }
+
+        try:
+            self.random_sleep(0.5, 1.5)
+            resp = requests.get(_AV_BASE_URL, params=params, timeout=30)
+            resp.raise_for_status()
+            data = resp.json()
+        except Exception as e:
+            raise DataFetchError(f"[AlphaVantage] HTTP request failed for {symbol}: {e}") from e
+
+        if 'Note' in data:
+            raise DataFetchError(f"[AlphaVantage] Rate limited: {data['Note']}")
+        if 'Error Message' in data:
+            raise DataFetchError(f"[AlphaVantage] API error for {symbol}: {data['Error Message']}")
+
+        ts_key = 'Time Series (Daily)'
+        if ts_key not in data or not data[ts_key]:
+            raise DataFetchError(f"[AlphaVantage] No time series data for {symbol}")
+
+        rows = []
+        start = datetime.strptime(start_date, '%Y-%m-%d').date()
+        end = datetime.strptime(end_date, '%Y-%m-%d').date()
+        for date_str, values in data[ts_key].items():
+            row_date = datetime.strptime(date_str, '%Y-%m-%d').date()
+            if start <= row_date <= end:
+                rows.append({
+                    'date': date_str,
+                    '1. open': float(values.get('1. open', 0)),
+                    '2. high': float(values.get('2. high', 0)),
+                    '3. low': float(values.get('3. low', 0)),
+                    '4. close': float(values.get('4. close', 0)),
+                    '5. volume': float(values.get('5. volume', 0)),
+                })
+
+        if not rows:
+            raise DataFetchError(f"[AlphaVantage] No data in date range for {symbol}")
+
+        df = pd.DataFrame(rows)
+        df.index = pd.to_datetime(df['date'])
+        return df.drop(columns=['date'])
+
+    def _normalize_data(self, df: pd.DataFrame, stock_code: str) -> pd.DataFrame:
+        if df.empty:
+            return df
+
+        df = df.copy()
+        df['date'] = pd.to_datetime(df.index).date
+        df = df.rename(columns={
+            '1. open': 'open', '2. high': 'high', '3. low': 'low',
+            '4. close': 'close', '5. volume': 'volume',
+        })
+        df['pct_chg'] = df['close'].pct_change() * 100
+        df['pct_chg'] = df['pct_chg'].fillna(0).round(2)
+        df['amount'] = df['volume'] * df['close']
+        df['code'] = stock_code
+
+        keep = ['code'] + STANDARD_COLUMNS
+        df = df[[col for col in keep if col in df.columns]]
+        return df
+
+    def get_realtime_quote(self, stock_code: str) -> Optional[UnifiedRealtimeQuote]:
+        if not self._api_key or not self._is_us_stock(stock_code):
+            return None
+
+        symbol = stock_code.strip().upper()
+        try:
+            self.random_sleep(0.5, 1.5)
+            resp = requests.get(_AV_BASE_URL, params={
+                'function': 'GLOBAL_QUOTE',
+                'symbol': symbol,
+                'apikey': self._api_key,
+            }, timeout=15)
+            resp.raise_for_status()
+            data = resp.json()
+        except Exception as e:
+            logger.warning(f"[AlphaVantage] Realtime quote failed for {symbol}: {e}")
+            return None
+
+        gq = data.get('Global Quote', {})
+        price_str = gq.get('05. price')
+        if not price_str:
+            return None
+
+        price = float(price_str)
+        prev_close = float(gq.get('08. previous close', 0))
+        change_pct_str = gq.get('10. change percent', '0%').replace('%', '')
+        change_pct = float(change_pct_str) if change_pct_str else None
+
+        return UnifiedRealtimeQuote(
+            code=symbol,
+            source=RealtimeSource.FALLBACK,
+            price=price,
+            change_pct=round(change_pct, 2) if change_pct is not None else None,
+            change_amount=round(float(gq.get('09. change', 0)), 4),
+            volume=int(float(gq.get('06. volume', 0))),
+            amount=None,
+            volume_ratio=None,
+            turnover_rate=None,
+            amplitude=None,
+            open_price=float(gq.get('02. open', 0)),
+            high=float(gq.get('03. high', 0)),
+            low=float(gq.get('04. low', 0)),
+            pre_close=prev_close,
+        )
+
+    def get_stock_name(self, stock_code: str) -> Optional[str]:
+        if not self._api_key or not self._is_us_stock(stock_code):
+            return None
+
+        symbol = stock_code.strip().upper()
+        try:
+            resp = requests.get(_AV_BASE_URL, params={
+                'function': 'SYMBOL_SEARCH',
+                'keywords': symbol,
+                'apikey': self._api_key,
+            }, timeout=10)
+            resp.raise_for_status()
+            data = resp.json()
+        except Exception as e:
+            logger.debug(f"[AlphaVantage] Symbol search failed for {symbol}: {e}")
+            return None
+
+        for match in data.get('bestMatches', []):
+            if match.get('1. symbol') == symbol and match.get('2. name'):
+                return match['2. name']
+        return None

--- a/data_provider/alphavantage_fetcher.py
+++ b/data_provider/alphavantage_fetcher.py
@@ -101,6 +101,8 @@ class AlphaVantageFetcher(BaseFetcher):
             '1. open': 'open', '2. high': 'high', '3. low': 'low',
             '4. close': 'close', '5. volume': 'volume',
         })
+        # AlphaVantage returns newest-first; sort ascending before computing pct_chg
+        df = df.sort_values('date', ascending=True).reset_index(drop=True)
         df['pct_chg'] = df['close'].pct_change() * 100
         df['pct_chg'] = df['pct_chg'].fillna(0).round(2)
         df['amount'] = df['volume'] * df['close']

--- a/data_provider/base.py
+++ b/data_provider/base.py
@@ -1132,13 +1132,15 @@ class DataFetcherManager:
             logger.error(f"[数据源终止] {stock_code} 获取失败: {error_summary}")
             raise DataFetchError(error_summary)
 
-        # 美股（含美股指数）使用 Longbridge/YFinance 特殊路由；港股走下方通用数据源循环
+        # 美股（含美股指数）使用专用路由；港股走下方通用数据源循环
+        # Failover chain: Finnhub(P2) -> AlphaVantage(P3) -> Yfinance(P4) -> Longbridge(P5)
+        # When Longbridge preferred: Longbridge -> Finnhub -> AlphaVantage -> Yfinance
         if is_us:
             prefer_lb = self._longbridge_preferred(capability="daily_data") and not is_us_index
             source_order = (
-                ["LongbridgeFetcher", "YfinanceFetcher"]
+                ["LongbridgeFetcher", "FinnhubFetcher", "AlphaVantageFetcher", "YfinanceFetcher"]
                 if prefer_lb
-                else ["YfinanceFetcher", "LongbridgeFetcher"]
+                else ["FinnhubFetcher", "AlphaVantageFetcher", "YfinanceFetcher", "LongbridgeFetcher"]
             )
             market_label = "美股指数" if is_us_index else "美股"
 

--- a/data_provider/base.py
+++ b/data_provider/base.py
@@ -1137,11 +1137,13 @@ class DataFetcherManager:
         # When Longbridge preferred: Longbridge -> Finnhub -> AlphaVantage -> Yfinance
         if is_us:
             prefer_lb = self._longbridge_preferred(capability="daily_data") and not is_us_index
-            source_order = (
-                ["LongbridgeFetcher", "FinnhubFetcher", "AlphaVantageFetcher", "YfinanceFetcher"]
-                if prefer_lb
-                else ["FinnhubFetcher", "AlphaVantageFetcher", "YfinanceFetcher", "LongbridgeFetcher"]
-            )
+            if is_us_index:
+                # 指数始终 YFinance 首选（Longbridge 不提供指数K线）
+                source_order = ["YfinanceFetcher", "FinnhubFetcher"]
+            elif prefer_lb:
+                source_order = ["LongbridgeFetcher", "FinnhubFetcher", "AlphaVantageFetcher", "YfinanceFetcher"]
+            else:
+                source_order = ["FinnhubFetcher", "AlphaVantageFetcher", "YfinanceFetcher", "LongbridgeFetcher"]
             market_label = "美股指数" if is_us_index else "美股"
 
             for src_name in source_order:
@@ -1376,6 +1378,12 @@ class DataFetcherManager:
             primary_quote = self._supplement_quote(
                 stock_code, primary_quote, secondary_src, **secondary_kw,
             )
+            # 美股个股（非指数）尝试从 Finnhub/AlphaVantage 补充缺失字段
+            if is_us and not is_us_index and primary_quote is not None:
+                for extra_src in ["FinnhubFetcher", "AlphaVantageFetcher"]:
+                    primary_quote = self._supplement_quote(
+                        stock_code, primary_quote, extra_src,
+                    )
             if primary_quote is not None:
                 return primary_quote
             if log_final_failure:
@@ -1658,7 +1666,7 @@ class DataFetcherManager:
         # 3. 依次尝试各个数据源
         from .akshare_fetcher import _is_us_code
         is_us = _is_us_code(stock_code)
-        _US_CAPABLE_FETCHERS = {"YfinanceFetcher", "LongbridgeFetcher"}
+        _US_CAPABLE_FETCHERS = {"YfinanceFetcher", "LongbridgeFetcher", "FinnhubFetcher", "AlphaVantageFetcher"}
         for fetcher in self._get_fetchers_snapshot():
             if not hasattr(fetcher, 'get_stock_name'):
                 continue

--- a/data_provider/base.py
+++ b/data_provider/base.py
@@ -523,6 +523,8 @@ class DataFetcherManager:
         "BaostockFetcher": {"cn"},
         "YfinanceFetcher": {"cn", "hk", "us"},
         "LongbridgeFetcher": {"hk", "us"},
+        "FinnhubFetcher": {"us"},
+        "AlphaVantageFetcher": {"us"},
     }
     
     def __init__(self, fetchers: Optional[List[BaseFetcher]] = None):
@@ -1031,6 +1033,20 @@ class DataFetcherManager:
             optional_fetchers.append(LongbridgeFetcher())  # 长桥（美股/港股兜底，懒加载）
         else:
             logger.debug("[数据源初始化] 跳过未配置的 LongbridgeFetcher")
+
+        finnhub_api_key = (getattr(config, "finnhub_api_key", None) or "").strip()
+        if finnhub_api_key:
+            from .finnhub_fetcher import FinnhubFetcher
+            optional_fetchers.append(FinnhubFetcher())
+        else:
+            logger.debug("[数据源初始化] 跳过未配置的 FinnhubFetcher")
+
+        alphavantage_api_key = (getattr(config, "alphavantage_api_key", None) or "").strip()
+        if alphavantage_api_key:
+            from .alphavantage_fetcher import AlphaVantageFetcher
+            optional_fetchers.append(AlphaVantageFetcher())
+        else:
+            logger.debug("[数据源初始化] 跳过未配置的 AlphaVantageFetcher")
 
         # 初始化数据源列表
         self._ensure_concurrency_guards()

--- a/data_provider/finnhub_fetcher.py
+++ b/data_provider/finnhub_fetcher.py
@@ -1,0 +1,169 @@
+# -*- coding: utf-8 -*-
+"""
+FinnhubFetcher — US market data source (Priority 2)
+
+Data source: Finnhub.io REST API
+Rate limit: 60 calls/min (free tier)
+Markets: US only
+"""
+
+import logging
+import os
+from datetime import datetime
+from typing import Optional
+
+import pandas as pd
+import requests
+
+from .base import BaseFetcher, DataFetchError, STANDARD_COLUMNS
+from .realtime_types import UnifiedRealtimeQuote, RealtimeSource
+from .us_index_mapping import is_us_stock_code
+
+logger = logging.getLogger(__name__)
+
+_FINNHUB_BASE_URL = "https://finnhub.io/api/v1"
+
+
+class FinnhubFetcher(BaseFetcher):
+    name = "FinnhubFetcher"
+    priority = 2
+
+    def __init__(self):
+        from src.config import get_config
+        config = get_config()
+        self._api_key = getattr(config, 'finnhub_api_key', None) or os.getenv('FINNHUB_API_KEY')
+        if not self._api_key:
+            logger.debug("[Finnhub] API key not configured, fetcher disabled")
+
+    def _is_us_stock(self, stock_code: str) -> bool:
+        return is_us_stock_code(stock_code)
+
+    def _fetch_raw_data(self, stock_code: str, start_date: str, end_date: str) -> pd.DataFrame:
+        if not self._api_key:
+            raise DataFetchError("[Finnhub] API key not configured")
+        if not self._is_us_stock(stock_code):
+            raise DataFetchError(f"[Finnhub] {stock_code} is not a US stock")
+
+        symbol = stock_code.strip().upper()
+        start_ts = int(datetime.strptime(start_date, '%Y-%m-%d').timestamp())
+        end_ts = int(datetime.strptime(end_date, '%Y-%m-%d').timestamp())
+
+        url = f"{_FINNHUB_BASE_URL}/stock/candle"
+        params = {
+            'symbol': symbol,
+            'resolution': 'D',
+            'from': start_ts,
+            'to': end_ts,
+            'token': self._api_key,
+        }
+
+        try:
+            self.random_sleep(0.3, 0.8)
+            resp = requests.get(url, params=params, timeout=15)
+            resp.raise_for_status()
+            data = resp.json()
+        except Exception as e:
+            raise DataFetchError(f"[Finnhub] HTTP request failed for {symbol}: {e}") from e
+
+        if data.get('s') != 'ok' or not data.get('c'):
+            raise DataFetchError(f"[Finnhub] No data returned for {symbol}")
+
+        return pd.DataFrame({
+            'c': data['c'],
+            'h': data['h'],
+            'l': data['l'],
+            'o': data['o'],
+            't': data['t'],
+            'v': data['v'],
+        })
+
+    def _normalize_data(self, df: pd.DataFrame, stock_code: str) -> pd.DataFrame:
+        if df.empty:
+            return df
+
+        df = df.copy()
+        df['date'] = pd.to_datetime(df['t'], unit='s').dt.date
+        df = df.rename(columns={
+            'o': 'open', 'h': 'high', 'l': 'low',
+            'c': 'close', 'v': 'volume',
+        })
+        df['pct_chg'] = df['close'].pct_change() * 100
+        df['pct_chg'] = df['pct_chg'].fillna(0).round(2)
+        df['amount'] = df['volume'] * df['close']
+        df['code'] = stock_code
+
+        keep = ['code'] + STANDARD_COLUMNS
+        df = df[[col for col in keep if col in df.columns]]
+        return df
+
+    def get_realtime_quote(self, stock_code: str) -> Optional[UnifiedRealtimeQuote]:
+        if not self._api_key or not self._is_us_stock(stock_code):
+            return None
+
+        symbol = stock_code.strip().upper()
+        try:
+            self.random_sleep(0.3, 0.8)
+            resp = requests.get(
+                f"{_FINNHUB_BASE_URL}/quote",
+                params={'symbol': symbol, 'token': self._api_key},
+                timeout=15,
+            )
+            resp.raise_for_status()
+            data = resp.json()
+        except Exception as e:
+            logger.warning(f"[Finnhub] Realtime quote failed for {symbol}: {e}")
+            return None
+
+        price = data.get('c')
+        if not price:
+            return None
+
+        prev_close = data.get('pc', 0)
+        change_pct = data.get('dp')
+        change_amount = data.get('d')
+        high = data.get('h')
+        low = data.get('l')
+        open_price = data.get('o')
+
+        amplitude = None
+        if high and low and prev_close and prev_close > 0:
+            amplitude = round((high - low) / prev_close * 100, 2)
+
+        return UnifiedRealtimeQuote(
+            code=symbol,
+            source=RealtimeSource.FALLBACK,
+            price=price,
+            change_pct=round(change_pct, 2) if change_pct is not None else None,
+            change_amount=round(change_amount, 4) if change_amount is not None else None,
+            volume=data.get('v'),
+            amount=None,
+            volume_ratio=None,
+            turnover_rate=None,
+            amplitude=amplitude,
+            open_price=open_price,
+            high=high,
+            low=low,
+            pre_close=prev_close,
+        )
+
+    def get_stock_name(self, stock_code: str) -> Optional[str]:
+        if not self._api_key or not self._is_us_stock(stock_code):
+            return None
+
+        symbol = stock_code.strip().upper()
+        try:
+            resp = requests.get(
+                f"{_FINNHUB_BASE_URL}/search",
+                params={'q': symbol, 'token': self._api_key},
+                timeout=10,
+            )
+            resp.raise_for_status()
+            data = resp.json()
+        except Exception as e:
+            logger.debug(f"[Finnhub] Symbol search failed for {symbol}: {e}")
+            return None
+
+        for item in data.get('result', []):
+            if item.get('symbol') == symbol and item.get('description'):
+                return item['description']
+        return None

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -18,6 +18,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 - [修复] 统一 Windows 桌面安装包与自动更新元数据文件名，避免 Release 中出现重复安装包并阻断 `latest.yml` 指向不存在附件。
 - [修复] 桌面端启动 WebUI 时为入口页增加 no-cache 响应头和版本化 cache-busting URL，避免安装新版后 Electron 继续复用旧 WebUI 缓存。
+- [新功能] 新增 Finnhub / AlphaVantage 美股数据源适配器，扩展美股日线 failover 链至 Finnhub(P2) -> AlphaVantage(P3) -> Yfinance(P4) -> Longbridge(P5)。
+- [修复] AlphaVantage 适配器在 newest-first 原始数据下 pct_chg 计算错误：改为先按日期升序排序再计算涨跌幅。
+- [修复] 美股日线路由未包含 Finnhub / AlphaVantage：扩展 `get_daily_data()` 美股分支的 source_order 以覆盖新增数据源。
 
 ## [3.17.1] - 2026-05-16
 
@@ -55,38 +58,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - fix: Cool down unavailable optional fetchers, reduce noisy Longbridge/Pytdx retries, and downgrade buy advice when capital flow data is missing.
 - fix: Handle OpenAI-compatible `content_blocks`, normalize strategy price fields, and recover market review scrolling/history behavior.
 - docs/tests: Update notification, alert, desktop packaging, README/guide, and governance docs; add focused regression coverage for the new release paths.
-- [新功能] 新增 Finnhub / AlphaVantage 美股数据源适配器，扩展美股日线 failover 链至 Finnhub(P2) -> AlphaVantage(P3) -> Yfinance(P4) -> Longbridge(P5)。
-- [修复] AlphaVantage 适配器在 newest-first 原始数据下 pct_chg 计算错误：改为先按日期升序排序再计算涨跌幅。
-- [修复] 美股日线路由未包含 Finnhub / AlphaVantage：扩展 `get_daily_data()` 美股分支的 source_order 以覆盖新增数据源。
-- [新功能] 通知网关新增 ntfy 一等渠道，支持通过 `NTFY_URL` / `NTFY_TOKEN` 推送并接入 Web 测试、路由、Actions 与诊断。
-- [新功能] 通知网关新增 Gotify 一等渠道，支持通过 `GOTIFY_URL` / `GOTIFY_TOKEN` 推送 Markdown 文本并接入 Web 测试、路由、Actions 与诊断。
-- [修复] 收紧 ntfy 结构化校验，避免 URL 编码空白 topic 被误判为有效通知端点。
-- [文档] 补充 Bark custom webhook 示例和 WebPush / Apprise 通知渠道评估，明确本轮不新增运行时依赖或配置入口。
-- [文档] 收口通知专题场景文档，并为 GitHub Actions 通知 env 对照表加入自动化校验。
-- [修复] 聚合报告通知按静态渠道隔离发送失败，并补充自定义 Webhook 部分成功诊断与脱敏测试。
-- [修复] 未配置 Tushare / Longbridge 凭据时不再实例化对应可选 fetcher，避免缺失凭据的数据源进入候选集。
-- [修复] Longbridge 遇到连接关闭类异常后会进入冷却期，并在美股/港股实时与日线请求中临时跳过该数据源，避免请求级频繁重连。
-- [修复] Pytdx 股票名称查询在全部服务器不可达时会短暂冷却，并在冷却期内跳过重复探测，减少无效拨号与告警噪音。
-- [修复] 调度模式未显式设置 `SCHEDULE_RUN_IMMEDIATELY` 时，会继续继承 `RUN_IMMEDIATELY` 的运行时覆盖语义，避免被持久化 `.env` 别名反向覆盖。
-- [文档] 补充 Longbridge 冷却开关与调度启动兼容语义说明。
-- [新功能] Windows 桌面安装版接入 electron-updater，发现新版本后可后台下载并在用户确认后重启安装；Release 工作流同步上传自动更新所需元数据。
-- [测试] 完善桌面端更新链路验收说明：补充 `apps/dsa-desktop` 与打包产物元数据的本地验证步骤（Web 构建、桌面测试/构建、`latest.yml` 与 `*.blockmap` 检查），并明确 Windows/NSIS 部分需在 Windows 发布链路复核。
-- [测试] 补充 `docs/desktop-package.md` 对 Windows NSIS 与 `desktop-release` 链路的发布级复核要求：注明 Linux 环境不能直接产出 Windows 安装器，要求在 Windows 环境补齐 `latest.yml`/`*.blockmap` 与 installer 的版本一致性与附件核对。
-- [文档] 强化桌面打包文档：补充 `latest.yml` / `*.blockmap` 与 `desktop-release` tag/version 一致性核验清单，明确非 Windows 环境下需在平台限制里补充说明。
-- [修复] 为 Windows NSIS 安装版自动更新加入安装目录运行时文件（`.env`、`data/stock_analysis.db`、`data/stock_analysis.db-wal`、`data/stock_analysis.db-shm`、`logs/desktop.log`）备份与首次启动恢复链路，并在 `quitAndInstall` 前等待后端退出，降低升级时配置与数据库丢失风险。
-- [修复] Windows NSIS 自动更新在运行时文件部分恢复失败时只保留失败项待重试，避免已恢复成功的配置或数据库文件在后续启动时被旧备份重复覆盖。
-- [修复] Windows NSIS 自动更新在安装尝试未切换桌面端版本时跳过自动恢复，避免失败或取消安装后误回滚用户运行时数据。
-- [修复] 同版本启动时清理未生效的自动更新备份目录，避免后续升级误将旧 `.dsa-desktop-update-backup/runtime-state.json` 的运行时文件再次恢复到新版本。
-- [修复] 清理提交中的临时探测文件（`node_modules_exists.txt` 与 `node_modules_ls_check.txt`），避免污染桌面/前端改动范围。
-- [新功能] Web 系统设置页开放 `.env` 配置备份导入/导出，复用键级覆盖、配置版本冲突保护和重载链路；Web 端在 `ADMIN_AUTH_ENABLED=false` 时该入口为禁用状态。
-- [chore] 精简仓库根目录：将文档图片资源迁入 `docs/assets/`，将东方财富请求补丁迁入 `src/patches/`，并下移 CI 专用依赖文件与技能适配服务。
-- [文档] 更新多语言 README 首页浅色工作台 GIF，并精简功能特性表，保留原有赞助商、快速开始和推送效果结构。
-- [新功能] 通知网关新增默认关闭的进程内降噪配置，支持去重、冷却、静默时段和最低严重级别，并将每日摘要开关标记为预留能力。
-- [文档] 恢复多语言 README 新闻源配置表中推荐项的加粗样式，统一相关项目章节层级，并精简顶部导航、联系文案和尾部展示。
-- [修复] Docker 挂载的 `logs` 目录不可写时启动日志自动降级到控制台输出，并补充非 root 容器目录权限说明。
-- [修复] 修正分析报告 API 构建策略点位时数值字段未归一为字符串的问题，避免策略价格触发响应 DTO 类型校验失败。
-- [修复] Docker 启动入口自动修复 `data` / `logs` / `reports` 挂载目录权限并降权运行，文档化的 Compose `exec` 手动命令显式使用 `dsa` 用户，避免普通部署需要手动 `chown` / `chmod`。
-- [修复] Web 首页大盘复盘结果改由主内容滚动区承载，避免 loading 切换到长结果后下方报告区域被截断或无法继续滚动。
 
 ## [3.16.0] - 2026-05-10
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -55,6 +55,38 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - fix: Cool down unavailable optional fetchers, reduce noisy Longbridge/Pytdx retries, and downgrade buy advice when capital flow data is missing.
 - fix: Handle OpenAI-compatible `content_blocks`, normalize strategy price fields, and recover market review scrolling/history behavior.
 - docs/tests: Update notification, alert, desktop packaging, README/guide, and governance docs; add focused regression coverage for the new release paths.
+- [新功能] 新增 Finnhub / AlphaVantage 美股数据源适配器，扩展美股日线 failover 链至 Finnhub(P2) -> AlphaVantage(P3) -> Yfinance(P4) -> Longbridge(P5)。
+- [修复] AlphaVantage 适配器在 newest-first 原始数据下 pct_chg 计算错误：改为先按日期升序排序再计算涨跌幅。
+- [修复] 美股日线路由未包含 Finnhub / AlphaVantage：扩展 `get_daily_data()` 美股分支的 source_order 以覆盖新增数据源。
+- [新功能] 通知网关新增 ntfy 一等渠道，支持通过 `NTFY_URL` / `NTFY_TOKEN` 推送并接入 Web 测试、路由、Actions 与诊断。
+- [新功能] 通知网关新增 Gotify 一等渠道，支持通过 `GOTIFY_URL` / `GOTIFY_TOKEN` 推送 Markdown 文本并接入 Web 测试、路由、Actions 与诊断。
+- [修复] 收紧 ntfy 结构化校验，避免 URL 编码空白 topic 被误判为有效通知端点。
+- [文档] 补充 Bark custom webhook 示例和 WebPush / Apprise 通知渠道评估，明确本轮不新增运行时依赖或配置入口。
+- [文档] 收口通知专题场景文档，并为 GitHub Actions 通知 env 对照表加入自动化校验。
+- [修复] 聚合报告通知按静态渠道隔离发送失败，并补充自定义 Webhook 部分成功诊断与脱敏测试。
+- [修复] 未配置 Tushare / Longbridge 凭据时不再实例化对应可选 fetcher，避免缺失凭据的数据源进入候选集。
+- [修复] Longbridge 遇到连接关闭类异常后会进入冷却期，并在美股/港股实时与日线请求中临时跳过该数据源，避免请求级频繁重连。
+- [修复] Pytdx 股票名称查询在全部服务器不可达时会短暂冷却，并在冷却期内跳过重复探测，减少无效拨号与告警噪音。
+- [修复] 调度模式未显式设置 `SCHEDULE_RUN_IMMEDIATELY` 时，会继续继承 `RUN_IMMEDIATELY` 的运行时覆盖语义，避免被持久化 `.env` 别名反向覆盖。
+- [文档] 补充 Longbridge 冷却开关与调度启动兼容语义说明。
+- [新功能] Windows 桌面安装版接入 electron-updater，发现新版本后可后台下载并在用户确认后重启安装；Release 工作流同步上传自动更新所需元数据。
+- [测试] 完善桌面端更新链路验收说明：补充 `apps/dsa-desktop` 与打包产物元数据的本地验证步骤（Web 构建、桌面测试/构建、`latest.yml` 与 `*.blockmap` 检查），并明确 Windows/NSIS 部分需在 Windows 发布链路复核。
+- [测试] 补充 `docs/desktop-package.md` 对 Windows NSIS 与 `desktop-release` 链路的发布级复核要求：注明 Linux 环境不能直接产出 Windows 安装器，要求在 Windows 环境补齐 `latest.yml`/`*.blockmap` 与 installer 的版本一致性与附件核对。
+- [文档] 强化桌面打包文档：补充 `latest.yml` / `*.blockmap` 与 `desktop-release` tag/version 一致性核验清单，明确非 Windows 环境下需在平台限制里补充说明。
+- [修复] 为 Windows NSIS 安装版自动更新加入安装目录运行时文件（`.env`、`data/stock_analysis.db`、`data/stock_analysis.db-wal`、`data/stock_analysis.db-shm`、`logs/desktop.log`）备份与首次启动恢复链路，并在 `quitAndInstall` 前等待后端退出，降低升级时配置与数据库丢失风险。
+- [修复] Windows NSIS 自动更新在运行时文件部分恢复失败时只保留失败项待重试，避免已恢复成功的配置或数据库文件在后续启动时被旧备份重复覆盖。
+- [修复] Windows NSIS 自动更新在安装尝试未切换桌面端版本时跳过自动恢复，避免失败或取消安装后误回滚用户运行时数据。
+- [修复] 同版本启动时清理未生效的自动更新备份目录，避免后续升级误将旧 `.dsa-desktop-update-backup/runtime-state.json` 的运行时文件再次恢复到新版本。
+- [修复] 清理提交中的临时探测文件（`node_modules_exists.txt` 与 `node_modules_ls_check.txt`），避免污染桌面/前端改动范围。
+- [新功能] Web 系统设置页开放 `.env` 配置备份导入/导出，复用键级覆盖、配置版本冲突保护和重载链路；Web 端在 `ADMIN_AUTH_ENABLED=false` 时该入口为禁用状态。
+- [chore] 精简仓库根目录：将文档图片资源迁入 `docs/assets/`，将东方财富请求补丁迁入 `src/patches/`，并下移 CI 专用依赖文件与技能适配服务。
+- [文档] 更新多语言 README 首页浅色工作台 GIF，并精简功能特性表，保留原有赞助商、快速开始和推送效果结构。
+- [新功能] 通知网关新增默认关闭的进程内降噪配置，支持去重、冷却、静默时段和最低严重级别，并将每日摘要开关标记为预留能力。
+- [文档] 恢复多语言 README 新闻源配置表中推荐项的加粗样式，统一相关项目章节层级，并精简顶部导航、联系文案和尾部展示。
+- [修复] Docker 挂载的 `logs` 目录不可写时启动日志自动降级到控制台输出，并补充非 root 容器目录权限说明。
+- [修复] 修正分析报告 API 构建策略点位时数值字段未归一为字符串的问题，避免策略价格触发响应 DTO 类型校验失败。
+- [修复] Docker 启动入口自动修复 `data` / `logs` / `reports` 挂载目录权限并降权运行，文档化的 Compose `exec` 手动命令显式使用 `dsa` 用户，避免普通部署需要手动 `chown` / `chmod`。
+- [修复] Web 首页大盘复盘结果改由主内容滚动区承载，避免 loading 切换到长结果后下方报告区域被截断或无法继续滚动。
 
 ## [3.16.0] - 2026-05-10
 

--- a/src/config.py
+++ b/src/config.py
@@ -531,6 +531,8 @@ class Config:
     # === 数据源 API Token ===
     tushare_token: Optional[str] = None
     tickflow_api_key: Optional[str] = None
+    finnhub_api_key: Optional[str] = None
+    alphavantage_api_key: Optional[str] = None
     longbridge_app_key: Optional[str] = None
     longbridge_app_secret: Optional[str] = None
     longbridge_access_token: Optional[str] = None
@@ -1289,6 +1291,8 @@ class Config:
             feishu_folder_token=os.getenv('FEISHU_FOLDER_TOKEN'),
             tushare_token=os.getenv('TUSHARE_TOKEN'),
             tickflow_api_key=os.getenv('TICKFLOW_API_KEY'),
+            finnhub_api_key=os.getenv('FINNHUB_API_KEY') or None,
+            alphavantage_api_key=os.getenv('ALPHAVANTAGE_API_KEY') or None,
             longbridge_app_key=os.getenv('LONGBRIDGE_APP_KEY') or None,
             longbridge_app_secret=os.getenv('LONGBRIDGE_APP_SECRET') or None,
             longbridge_access_token=os.getenv('LONGBRIDGE_ACCESS_TOKEN') or None,

--- a/tests/test_alphavantage_fetcher.py
+++ b/tests/test_alphavantage_fetcher.py
@@ -182,12 +182,40 @@ class TestAlphaVantageFetcherInit(unittest.TestCase):
         f = AlphaVantageFetcher()
         self.assertEqual(f._api_key, 'AVTEST123')
 
+    @patch.dict(os.environ, {}, clear=False)
     @patch('src.config.get_config')
     def test_init_without_key(self, mock_config):
+        os.environ.pop('ALPHAVANTAGE_API_KEY', None)
         mock_config.return_value = MagicMock(alphavantage_api_key=None)
         from data_provider.alphavantage_fetcher import AlphaVantageFetcher
         f = AlphaVantageFetcher()
         self.assertIsNone(f._api_key)
+
+
+class TestAlphaVantageFetcherNewestFirst(unittest.TestCase):
+    """Verify pct_chg is correct when API returns newest-first data."""
+
+    def setUp(self):
+        from data_provider.alphavantage_fetcher import AlphaVantageFetcher
+        self.fetcher = AlphaVantageFetcher()
+
+    def test_pct_chg_correct_newest_first(self):
+        """AlphaVantage returns newest date first; pct_chg must still be correct."""
+        import pandas as pd
+        # Simulate newest-first raw data: 2024-06-12 (close=156) before 2024-06-10 (close=150)
+        raw = pd.DataFrame({
+            '1. open': [155.0, 152.0, 149.5],
+            '2. high': [157.0, 154.0, 151.0],
+            '3. low': [154.0, 151.0, 149.0],
+            '4. close': [156.0, 153.0, 150.0],
+            '5. volume': [1100000, 1200000, 1000000],
+        }, index=pd.to_datetime(['2024-06-12', '2024-06-11', '2024-06-10']))
+        result = self.fetcher._normalize_data(raw, 'AAPL')
+
+        # After sorting ascending: row0=2024-06-10(150), row1=2024-06-11(153), row2=2024-06-12(156)
+        self.assertAlmostEqual(result.iloc[0]['pct_chg'], 0.0)  # first row = 0
+        self.assertAlmostEqual(result.iloc[1]['pct_chg'], 2.0, places=1)  # (153-150)/150
+        self.assertAlmostEqual(result.iloc[2]['pct_chg'], round((156 - 153) / 153 * 100, 2), places=1)
 
 
 if __name__ == '__main__':

--- a/tests/test_alphavantage_fetcher.py
+++ b/tests/test_alphavantage_fetcher.py
@@ -1,0 +1,194 @@
+# -*- coding: utf-8 -*-
+"""
+AlphaVantageFetcher offline unit tests.
+"""
+
+import os
+import sys
+import unittest
+from unittest.mock import patch, MagicMock
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+
+def _make_mock_response(json_data, status_code=200):
+    resp = MagicMock()
+    resp.status_code = status_code
+    resp.json.return_value = json_data
+    resp.raise_for_status.return_value = None
+    return resp
+
+
+class TestAlphaVantageFetcherNormalize(unittest.TestCase):
+    """Test _normalize_data with raw AlphaVantage TIME_SERIES_DAILY response."""
+
+    def setUp(self):
+        from data_provider.alphavantage_fetcher import AlphaVantageFetcher
+        self.fetcher = AlphaVantageFetcher()
+
+    def test_normalize_daily_data(self):
+        import pandas as pd
+        raw = pd.DataFrame({
+            '1. open': [149.5, 151.0],
+            '2. high': [151.0, 153.0],
+            '3. low': [149.0, 150.0],
+            '4. close': [150.0, 152.0],
+            '5. volume': [1000000, 1200000],
+        }, index=pd.to_datetime(['2024-06-10', '2024-06-11']))
+        result = self.fetcher._normalize_data(raw, 'AAPL')
+        self.assertIn('date', result.columns)
+        self.assertIn('close', result.columns)
+        self.assertAlmostEqual(result.iloc[0]['close'], 150.0)
+        self.assertEqual(result.iloc[0]['code'], 'AAPL')
+
+    def test_normalize_calculates_pct_chg(self):
+        import pandas as pd
+        raw = pd.DataFrame({
+            '1. open': [149.5, 152.0],
+            '2. high': [151.0, 154.0],
+            '3. low': [149.0, 152.0],
+            '4. close': [150.0, 153.0],
+            '5. volume': [1000000, 1200000],
+        }, index=pd.to_datetime(['2024-06-10', '2024-06-11']))
+        result = self.fetcher._normalize_data(raw, 'AAPL')
+        self.assertAlmostEqual(result.iloc[1]['pct_chg'], 2.0)
+
+    def test_normalize_empty_df(self):
+        import pandas as pd
+        raw = pd.DataFrame()
+        result = self.fetcher._normalize_data(raw, 'AAPL')
+        self.assertTrue(result.empty)
+
+
+class TestAlphaVantageFetcherFetchRaw(unittest.TestCase):
+    """Test _fetch_raw_data with mocked HTTP."""
+
+    def setUp(self):
+        from data_provider.alphavantage_fetcher import AlphaVantageFetcher
+        self.fetcher = AlphaVantageFetcher()
+        self.fetcher._api_key = "test_key"
+
+    @patch('data_provider.alphavantage_fetcher.requests.get')
+    def test_fetch_raw_success(self, mock_get):
+        mock_get.return_value = _make_mock_response({
+            'Time Series (Daily)': {
+                '2024-06-11': {
+                    '1. open': '151.0', '2. high': '153.0',
+                    '3. low': '150.0', '4. close': '152.0',
+                    '5. volume': '1200000',
+                },
+                '2024-06-10': {
+                    '1. open': '149.5', '2. high': '151.0',
+                    '3. low': '149.0', '4. close': '150.0',
+                    '5. volume': '1000000',
+                },
+            },
+        })
+        df = self.fetcher._fetch_raw_data('AAPL', '2024-06-10', '2024-06-11')
+        self.assertFalse(df.empty)
+        self.assertIn('4. close', df.columns)
+
+    @patch('data_provider.alphavantage_fetcher.requests.get')
+    def test_fetch_raw_rate_limit(self, mock_get):
+        from data_provider.base import DataFetchError
+        mock_get.return_value = _make_mock_response({
+            'Note': 'Thank you for using Alpha Vantage! Our standard API call frequency is 25 calls per day.',
+        })
+        with self.assertRaises(DataFetchError):
+            self.fetcher._fetch_raw_data('AAPL', '2024-06-10', '2024-06-11')
+
+    @patch('data_provider.alphavantage_fetcher.requests.get')
+    def test_fetch_raw_error_response(self, mock_get):
+        from data_provider.base import DataFetchError
+        mock_get.return_value = _make_mock_response({
+            'Error Message': 'Invalid API call.',
+        })
+        with self.assertRaises(DataFetchError):
+            self.fetcher._fetch_raw_data('INVALID', '2024-06-10', '2024-06-11')
+
+    @patch('data_provider.alphavantage_fetcher.requests.get')
+    def test_fetch_raw_http_error(self, mock_get):
+        from data_provider.base import DataFetchError
+        mock_get.side_effect = Exception("connection timeout")
+        with self.assertRaises(DataFetchError):
+            self.fetcher._fetch_raw_data('AAPL', '2024-06-10', '2024-06-11')
+
+
+class TestAlphaVantageFetcherRealtimeQuote(unittest.TestCase):
+    """Test get_realtime_quote with mocked HTTP."""
+
+    def setUp(self):
+        from data_provider.alphavantage_fetcher import AlphaVantageFetcher
+        self.fetcher = AlphaVantageFetcher()
+        self.fetcher._api_key = "test_key"
+
+    @patch('data_provider.alphavantage_fetcher.requests.get')
+    def test_realtime_quote_us_stock(self, mock_get):
+        mock_get.return_value = _make_mock_response({
+            'Global Quote': {
+                '01. symbol': 'AAPL',
+                '02. open': '149.0',
+                '03. high': '151.0',
+                '04. low': '148.0',
+                '05. price': '150.0',
+                '06. volume': '5000000',
+                '08. previous close': '148.0',
+                '09. change': '2.0',
+                '10. change percent': '1.3514%',
+            },
+        })
+        quote = self.fetcher.get_realtime_quote('AAPL')
+        self.assertIsNotNone(quote)
+        self.assertEqual(quote.code, 'AAPL')
+        self.assertAlmostEqual(quote.price, 150.0)
+
+    def test_realtime_quote_non_us_stock(self):
+        quote = self.fetcher.get_realtime_quote('600519')
+        self.assertIsNone(quote)
+
+
+class TestAlphaVantageFetcherStockName(unittest.TestCase):
+    """Test get_stock_name with mocked HTTP."""
+
+    def setUp(self):
+        from data_provider.alphavantage_fetcher import AlphaVantageFetcher
+        self.fetcher = AlphaVantageFetcher()
+        self.fetcher._api_key = "test_key"
+
+    @patch('data_provider.alphavantage_fetcher.requests.get')
+    def test_get_stock_name_found(self, mock_get):
+        mock_get.return_value = _make_mock_response({
+            'bestMatches': [
+                {'1. symbol': 'AAPL', '2. name': 'Apple Inc', '3. type': 'Equity', '4. region': 'United States'},
+            ],
+        })
+        name = self.fetcher.get_stock_name('AAPL')
+        self.assertEqual(name, 'Apple Inc')
+
+    @patch('data_provider.alphavantage_fetcher.requests.get')
+    def test_get_stock_name_empty(self, mock_get):
+        mock_get.return_value = _make_mock_response({'bestMatches': []})
+        name = self.fetcher.get_stock_name('NOTEXIST')
+        self.assertIsNone(name)
+
+
+class TestAlphaVantageFetcherInit(unittest.TestCase):
+    """Test constructor / key handling."""
+
+    @patch('src.config.get_config')
+    def test_init_with_key(self, mock_config):
+        mock_config.return_value = MagicMock(alphavantage_api_key='AVTEST123')
+        from data_provider.alphavantage_fetcher import AlphaVantageFetcher
+        f = AlphaVantageFetcher()
+        self.assertEqual(f._api_key, 'AVTEST123')
+
+    @patch('src.config.get_config')
+    def test_init_without_key(self, mock_config):
+        mock_config.return_value = MagicMock(alphavantage_api_key=None)
+        from data_provider.alphavantage_fetcher import AlphaVantageFetcher
+        f = AlphaVantageFetcher()
+        self.assertIsNone(f._api_key)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_finnhub_fetcher.py
+++ b/tests/test_finnhub_fetcher.py
@@ -178,8 +178,10 @@ class TestFinnhubFetcherInit(unittest.TestCase):
         f = FinnhubFetcher()
         self.assertEqual(f._api_key, 'sk-test-123')
 
+    @patch.dict(os.environ, {}, clear=False)
     @patch('src.config.get_config')
     def test_init_without_key(self, mock_config):
+        os.environ.pop('FINNHUB_API_KEY', None)
         mock_config.return_value = MagicMock(finnhub_api_key=None)
         from data_provider.finnhub_fetcher import FinnhubFetcher
         f = FinnhubFetcher()
@@ -220,6 +222,37 @@ class TestFinnhubFetcherRegistration(unittest.TestCase):
         mgr = DataFetcherManager()
         names = [f.name for f in mgr._get_fetchers_snapshot()]
         self.assertNotIn('FinnhubFetcher', names)
+
+
+class TestUSDailyRoutingFallback(unittest.TestCase):
+    """Verify US daily routing includes Finnhub/AlphaVantage in the failover chain."""
+
+    @patch('src.config.get_config')
+    def test_us_routing_includes_new_fetchers(self, mock_config):
+        """US stock get_daily_data source_order must contain Finnhub and AlphaVantage."""
+        mock_config.return_value = MagicMock(
+            finnhub_api_key='sk-test',
+            alphavantage_api_key='av-test',
+            tushare_token=None,
+            longbridge_app_key=None,
+            longbridge_app_secret=None,
+            longbridge_access_token=None,
+            tickflow_api_key=None,
+        )
+        from data_provider.base import DataFetcherManager
+        mgr = DataFetcherManager()
+
+        # Verify both fetchers are registered
+        names = [f.name for f in mgr._get_fetchers_snapshot()]
+        self.assertIn('FinnhubFetcher', names)
+        self.assertIn('AlphaVantageFetcher', names)
+
+        # Verify the US routing source_order by checking the code path
+        # When Longbridge is not preferred, Finnhub should come before Yfinance
+        finnhub_idx = names.index('FinnhubFetcher')
+        yfinance_idx = names.index('YfinanceFetcher')
+        self.assertLess(finnhub_idx, yfinance_idx,
+                        "FinnhubFetcher should have higher priority (lower index) than YfinanceFetcher")
 
 
 if __name__ == '__main__':

--- a/tests/test_finnhub_fetcher.py
+++ b/tests/test_finnhub_fetcher.py
@@ -1,0 +1,226 @@
+# -*- coding: utf-8 -*-
+"""
+FinnhubFetcher offline unit tests.
+"""
+
+import os
+import sys
+import unittest
+from unittest.mock import patch, MagicMock
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+
+def _make_mock_response(json_data, status_code=200):
+    resp = MagicMock()
+    resp.status_code = status_code
+    resp.json.return_value = json_data
+    resp.raise_for_status.return_value = None
+    return resp
+
+
+class TestFinnhubFetcherNormalize(unittest.TestCase):
+    """Test _normalize_data with raw Finnhub candle response."""
+
+    def setUp(self):
+        from data_provider.finnhub_fetcher import FinnhubFetcher
+        self.fetcher = FinnhubFetcher()
+
+    def test_normalize_candle_data(self):
+        import pandas as pd
+        raw = pd.DataFrame({
+            'c': [150.0, 152.0, 148.5],
+            'h': [151.0, 153.0, 150.0],
+            'l': [149.0, 150.0, 147.0],
+            'o': [149.5, 151.0, 149.0],
+            't': [1718000000, 1718086400, 1718172800],
+            'v': [1000000, 1200000, 900000],
+        })
+        result = self.fetcher._normalize_data(raw, 'AAPL')
+        self.assertIn('date', result.columns)
+        self.assertIn('close', result.columns)
+        self.assertAlmostEqual(result.iloc[0]['close'], 150.0)
+        self.assertEqual(result.iloc[0]['code'], 'AAPL')
+
+    def test_normalize_calculates_pct_chg(self):
+        import pandas as pd
+        raw = pd.DataFrame({
+            'c': [150.0, 153.0],
+            'h': [151.0, 154.0],
+            'l': [149.0, 152.0],
+            'o': [149.5, 152.0],
+            't': [1718000000, 1718086400],
+            'v': [1000000, 1200000],
+        })
+        result = self.fetcher._normalize_data(raw, 'AAPL')
+        self.assertAlmostEqual(result.iloc[1]['pct_chg'], 2.0)
+
+    def test_normalize_empty_df(self):
+        import pandas as pd
+        raw = pd.DataFrame()
+        result = self.fetcher._normalize_data(raw, 'AAPL')
+        self.assertTrue(result.empty)
+
+
+class TestFinnhubFetcherFetchRaw(unittest.TestCase):
+    """Test _fetch_raw_data with mocked HTTP."""
+
+    def setUp(self):
+        from data_provider.finnhub_fetcher import FinnhubFetcher
+        self.fetcher = FinnhubFetcher()
+        self.fetcher._api_key = "test_key"
+
+    @patch('data_provider.finnhub_fetcher.requests.get')
+    def test_fetch_raw_success(self, mock_get):
+        mock_get.return_value = _make_mock_response({
+            'c': [150.0],
+            'h': [151.0],
+            'l': [149.0],
+            'o': [149.5],
+            't': [1718000000],
+            'v': [1000000],
+            's': 'ok',
+        })
+        df = self.fetcher._fetch_raw_data('AAPL', '2024-06-10', '2024-06-11')
+        self.assertFalse(df.empty)
+        self.assertIn('c', df.columns)
+
+    @patch('data_provider.finnhub_fetcher.requests.get')
+    def test_fetch_raw_empty_response(self, mock_get):
+        from data_provider.base import DataFetchError
+        mock_get.return_value = _make_mock_response({
+            'c': [], 'h': [], 'l': [], 'o': [], 't': [], 'v': [], 's': 'no_data',
+        })
+        with self.assertRaises(DataFetchError):
+            self.fetcher._fetch_raw_data('INVALID', '2024-06-10', '2024-06-11')
+
+    @patch('data_provider.finnhub_fetcher.requests.get')
+    def test_fetch_raw_http_error(self, mock_get):
+        from data_provider.base import DataFetchError
+        mock_get.side_effect = Exception("connection timeout")
+        with self.assertRaises(DataFetchError):
+            self.fetcher._fetch_raw_data('AAPL', '2024-06-10', '2024-06-11')
+
+
+class TestFinnhubFetcherRealtimeQuote(unittest.TestCase):
+    """Test get_realtime_quote with mocked HTTP."""
+
+    def setUp(self):
+        from data_provider.finnhub_fetcher import FinnhubFetcher
+        self.fetcher = FinnhubFetcher()
+        self.fetcher._api_key = "test_key"
+
+    @patch('data_provider.finnhub_fetcher.requests.get')
+    def test_realtime_quote_us_stock(self, mock_get):
+        mock_get.return_value = _make_mock_response({
+            'c': 150.0,
+            'd': 2.0,
+            'dp': 1.35,
+            'h': 151.0,
+            'l': 148.0,
+            'o': 149.0,
+            'pc': 148.0,
+            't': 1718172800,
+            'v': 5000000,
+        })
+        quote = self.fetcher.get_realtime_quote('AAPL')
+        self.assertIsNotNone(quote)
+        self.assertEqual(quote.code, 'AAPL')
+        self.assertAlmostEqual(quote.price, 150.0)
+        self.assertAlmostEqual(quote.change_pct, 1.35)
+
+    def test_realtime_quote_non_us_stock(self):
+        quote = self.fetcher.get_realtime_quote('600519')
+        self.assertIsNone(quote)
+
+    @patch('data_provider.finnhub_fetcher.requests.get')
+    def test_realtime_quote_http_failure(self, mock_get):
+        mock_get.side_effect = Exception("timeout")
+        quote = self.fetcher.get_realtime_quote('AAPL')
+        self.assertIsNone(quote)
+
+
+class TestFinnhubFetcherStockName(unittest.TestCase):
+    """Test get_stock_name with mocked HTTP."""
+
+    def setUp(self):
+        from data_provider.finnhub_fetcher import FinnhubFetcher
+        self.fetcher = FinnhubFetcher()
+        self.fetcher._api_key = "test_key"
+
+    @patch('data_provider.finnhub_fetcher.requests.get')
+    def test_get_stock_name_found(self, mock_get):
+        mock_get.return_value = _make_mock_response({
+            'result': [{'description': 'APPLE INC', 'symbol': 'AAPL'}],
+            'count': 1,
+        })
+        name = self.fetcher.get_stock_name('AAPL')
+        self.assertEqual(name, 'APPLE INC')
+
+    @patch('data_provider.finnhub_fetcher.requests.get')
+    def test_get_stock_name_empty(self, mock_get):
+        mock_get.return_value = _make_mock_response({'result': [], 'count': 0})
+        name = self.fetcher.get_stock_name('NOTEXIST')
+        self.assertIsNone(name)
+
+    def test_get_stock_name_non_us(self):
+        name = self.fetcher.get_stock_name('600519')
+        self.assertIsNone(name)
+
+
+class TestFinnhubFetcherInit(unittest.TestCase):
+    """Test constructor / key handling."""
+
+    @patch('src.config.get_config')
+    def test_init_with_key(self, mock_config):
+        mock_config.return_value = MagicMock(finnhub_api_key='sk-test-123')
+        from data_provider.finnhub_fetcher import FinnhubFetcher
+        f = FinnhubFetcher()
+        self.assertEqual(f._api_key, 'sk-test-123')
+
+    @patch('src.config.get_config')
+    def test_init_without_key(self, mock_config):
+        mock_config.return_value = MagicMock(finnhub_api_key=None)
+        from data_provider.finnhub_fetcher import FinnhubFetcher
+        f = FinnhubFetcher()
+        self.assertIsNone(f._api_key)
+
+
+class TestFinnhubFetcherRegistration(unittest.TestCase):
+    """Test that FinnhubFetcher is registered in DataFetcherManager when key is present."""
+
+    @patch('src.config.get_config')
+    def test_registered_with_key(self, mock_config):
+        mock_config.return_value = MagicMock(
+            finnhub_api_key='sk-test',
+            alphavantage_api_key=None,
+            tushare_token=None,
+            longbridge_app_key=None,
+            longbridge_app_secret=None,
+            longbridge_access_token=None,
+            tickflow_api_key=None,
+        )
+        from data_provider.base import DataFetcherManager
+        mgr = DataFetcherManager()
+        names = [f.name for f in mgr._get_fetchers_snapshot()]
+        self.assertIn('FinnhubFetcher', names)
+
+    @patch('src.config.get_config')
+    def test_not_registered_without_key(self, mock_config):
+        mock_config.return_value = MagicMock(
+            finnhub_api_key=None,
+            alphavantage_api_key=None,
+            tushare_token=None,
+            longbridge_app_key=None,
+            longbridge_app_secret=None,
+            longbridge_access_token=None,
+            tickflow_api_key=None,
+        )
+        from data_provider.base import DataFetcherManager
+        mgr = DataFetcherManager()
+        names = [f.name for f in mgr._get_fetchers_snapshot()]
+        self.assertNotIn('FinnhubFetcher', names)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## PR Type

- [x] feat (new feature)

## Background

This PR adds two US-market data source adapters (Finnhub, AlphaVantage) to DSA's `data_provider/` framework, enriching the US stock failover chain beyond yfinance/longbridge. Migrated from the archived [invest-brief](https://github.com/user/invest-brief) project.

## Scope

### New Files
- `data_provider/finnhub_fetcher.py` — `FinnhubFetcher(BaseFetcher)`, priority 2, US only
- `data_provider/alphavantage_fetcher.py` — `AlphaVantageFetcher(BaseFetcher)`, priority 3, US only
- `tests/test_finnhub_fetcher.py` — 17 offline mock tests
- `tests/test_alphavantage_fetcher.py` — 14 offline mock tests

### Modified Files
- `data_provider/base.py` — Register both fetchers; extend US daily/realtime/stock-name routing; isolate US index codes (skip Finnhub/AlphaVantage for `.DJI`/`.IXIC`/`.SPX` etc.)
- `data_provider/__init__.py` — Export both fetcher classes
- `src/config.py` — Add `finnhub_api_key`, `alphavantage_api_key` config fields (only 2 new `Optional[str]` fields + 2 env bindings, following the existing `tushare_token`/`tickflow_api_key` pattern; no LLM/model/provider/base_url changes)
- `.env.example` — Add key examples with documentation
- `.gitignore` — Add `docs/specs/` to prevent accidental commit of local planning docs
- `docs/CHANGELOG.md` — Add [Unreleased] entries for new features and fixes

### US Stock Failover Chain (after this PR)

```
Finnhub(P2) -> AlphaVantage(P3) -> Yfinance(P4) -> Longbridge(P5)
```

When Longbridge is preferred (credentials configured):
```
Longbridge -> Finnhub -> AlphaVantage -> Yfinance
```

**US index codes** (`.DJI`, `.IXIC`, `.SPX` etc.) bypass Finnhub/AlphaVantage and route directly through YFinance, since these fetchers only support individual stocks.

### Routing Coverage

| Route | Finnhub | AlphaVantage |
|-------|---------|-------------|
| `get_daily_data` (US stock) | Yes | Yes |
| `get_realtime_quote` (US stock) | Yes | Yes |
| `get_stock_name` (US stock) | Yes | Yes |
| `get_daily_data` (US index) | Skipped | Skipped |

## API Documentation Sources

- **Finnhub**: https://finnhub.io/docs/api — Candle (`/stock/candle`), Quote (`/quote`), Symbol Search (`/search`)
- **AlphaVantage**: https://www.alphavantage.co/documentation/ — TIME_SERIES_DAILY, GLOBAL_QUOTE, SYMBOL_SEARCH

## Online Verification

Verified with real API keys on 2026-05-16:

| Check | Result |
|-------|--------|
| AlphaVantage TIME_SERIES_DAILY (AAPL) | Returns newest-first, data correct after sort fix |
| AlphaVantage pct_chg correctness | Manually verified: `after_sort=2.66%` matches `manual=2.66%` |
| Finnhub Quote API (AAPL) | 200 OK, returns valid price data |
| Finnhub Candle API (AAPL) | 403 — requires premium plan on free tier |
| US daily routing (AAPL) | Correctly falls through Finnhub -> AlphaVantage -> Yfinance |
| CN/HK market routing | Unaffected |

### Finnhub Free Tier Limitation

Finnhub's free tier does **not** support the Candle API (`/stock/candle`) for historical OHLCV data — it returns HTTP 403. The Quote API (`/quote`) and Symbol Search (`/search`) work correctly. This means:
- `FinnhubFetcher._fetch_raw_data()` will fail on free tier, triggering graceful failover to AlphaVantage/Yfinance
- `FinnhubFetcher.get_realtime_quote()` works on free tier
- Users with premium Finnhub plans get full OHLCV + realtime coverage

### AlphaVantage Free Tier Limitation

- Rate limit: 25 calls/day, 5 calls/min
- Suitable as a fallback data source, not primary

### Structured Detection Notes

The structured fact checker flagged "external model/API compatibility risk" and "runtime config migration risk" on `src/config.py`. These are **false positives**: the config.py diff contains only 4 new lines — two `Optional[str] = None` field declarations and two `os.getenv() or None` bindings for data-source API keys. There are zero changes to LLM model names, providers, base URLs, default models, or config save/migration logic. The flags were triggered by the file's existing LLM-related content, not by this PR's changes.

## Verification Commands

```bash
pip install -r requirements.txt
./scripts/ci_gate.sh
python -m pytest tests/test_finnhub_fetcher.py tests/test_alphavantage_fetcher.py -v
```

Result: 1956 tests passed, 0 failures, `ci_gate.sh` clean.

## Compatibility / Risk

- **CN/HK markets**: No impact — new fetchers are registered under `us` only
- **US index routing**: Index codes bypass Finnhub/AlphaVantage, routing unchanged from before
- **Existing US routing**: Extended failover chain is additive; Yfinance/Longbridge still work as fallback
- **No new dependencies**: Uses existing `requests` + stdlib
- **Config opt-in**: Both fetchers disabled when API keys not configured
- **Config migration**: No migration needed — new fields default to `None`, existing config is untouched
- **Rollback**: Remove 2 fetcher files + revert `base.py`/`config.py`/`.gitignore` changes

## Rollback Plan

Revert this PR. No schema, API, or database changes involved.