### PR TITLE
feat: add OAuth 2.0 support for Longbridge data source

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -26,6 +26,11 @@ TUSHARE_TOKEN=
 # TICKFLOW_API_KEY=
 # Longbridge OpenAPI（可选，美股/港股量比、换手率、PE 等字段兜底）
 # 从 https://open.longbridge.com/ 获取
+# OAuth 2.0（推荐）：
+# LONGBRIDGE_OAUTH_CLIENT_ID=
+# LONGBRIDGE_REGION=hk
+# LONGBRIDGE_HTTP_URL=https://openapi.longbridge.com
+# Legacy API Key（已废弃，仅兼容旧版）：
 # LONGBRIDGE_APP_KEY=
 # LONGBRIDGE_APP_SECRET=
 # LONGBRIDGE_ACCESS_TOKEN=

--- a/data_provider/base.py
+++ b/data_provider/base.py
@@ -1027,7 +1027,10 @@ class DataFetcherManager:
             and (getattr(config, "longbridge_app_secret", None) or "").strip()
             and (getattr(config, "longbridge_access_token", None) or "").strip()
         )
-        if has_longbridge_creds:
+        has_longbridge_oauth = bool(
+            (getattr(config, "longbridge_oauth_client_id", None) or "").strip()
+        )
+        if has_longbridge_creds or has_longbridge_oauth:
             optional_fetchers.append(LongbridgeFetcher())  # 长桥（美股/港股兜底，懒加载）
         else:
             logger.debug("[数据源初始化] 跳过未配置的 LongbridgeFetcher")

--- a/data_provider/longbridge_fetcher.py
+++ b/data_provider/longbridge_fetcher.py
@@ -14,7 +14,7 @@ LongbridgeFetcher - 长桥兜底数据源 (Priority 5)
 3. 懒加载 QuoteContext，首次调用时才建立连接
 4. static_info 进程内短缓存，减少重复请求（默认 24h，可调；见 LONGBRIDGE_STATIC_INFO_TTL_SECONDS）
 
-凭证：`LONGBRIDGE_APP_KEY` / `LONGBRIDGE_APP_SECRET` / `LONGBRIDGE_ACCESS_TOKEN`。
+凭证：优先 `LONGBRIDGE_OAUTH_CLIENT_ID`（OAuth 2.0，推荐），Legacy API Key 三件套（`LONGBRIDGE_APP_KEY` / `LONGBRIDGE_APP_SECRET` / `LONGBRIDGE_ACCESS_TOKEN`）仍兼容。
 可选：`LONGBRIDGE_STATIC_INFO_TTL_SECONDS`；SDK `language` 取自 `REPORT_LANGUAGE`，`log_path` 为 `{LOG_DIR}/longbridge_sdk.log`；
 `LONGBRIDGE_HTTP_URL` / `LONGBRIDGE_QUOTE_WS_URL` / `LONGBRIDGE_TRADE_WS_URL` / `LONGBRIDGE_REGION` （见官方文档默认值）。
 """
@@ -326,23 +326,29 @@ class LongbridgeFetcher(BaseFetcher):
         return True
 
     def _is_available(self) -> bool:
-        """Check if Longbridge credentials are configured."""
+        """Check if Longbridge credentials are configured (Legacy API Key or OAuth)."""
         if self._available is not None:
             return self._available
         try:
             from src.config import get_config
             config = get_config()
-            has_creds = bool(
+            has_legacy = bool(
                 config.longbridge_app_key
                 and config.longbridge_app_secret
                 and config.longbridge_access_token
             )
+            has_oauth = bool(
+                (getattr(config, "longbridge_oauth_client_id", None) or "").strip()
+            )
+            has_creds = has_legacy or has_oauth
         except Exception:
-            has_creds = bool(
+            has_legacy = bool(
                 os.getenv("LONGBRIDGE_APP_KEY")
                 and os.getenv("LONGBRIDGE_APP_SECRET")
                 and os.getenv("LONGBRIDGE_ACCESS_TOKEN")
             )
+            has_oauth = bool((os.getenv("LONGBRIDGE_OAUTH_CLIENT_ID") or "").strip())
+            has_creds = has_legacy or has_oauth
         self._available = has_creds
         return has_creds
 
@@ -384,25 +390,61 @@ class LongbridgeFetcher(BaseFetcher):
                 # ── 3. Build Config ──
                 extra_kw = _longbridge_config_kwargs()
                 lb_config = None
+                oauth_client_id = (
+                    os.getenv("LONGBRIDGE_OAUTH_CLIENT_ID") or ""
+                ).strip()
 
-                # Prefer from_apikey_env() — reads all LONGBRIDGE_* env vars
-                # (credentials + URLs + options) including .env files.
-                # Available in longbridge >= 4.x.  from_env() only exists on
-                # the unreleased master branch.
-                for factory_name in ("from_apikey_env", "from_env"):
-                    factory = getattr(Config, factory_name, None)
-                    if factory is None:
-                        continue
-                    try:
-                        lb_config = factory()
-                        logger.info("[Longbridge] Config.%s() 成功", factory_name)
-                        break
-                    except Exception as e:
-                        logger.debug(
-                            "[Longbridge] Config.%s() 失败: %s", factory_name, e
+                if oauth_client_id:
+                    # ── 3a. Prefer OAuth (client_id + saved token file) ──
+                    token_cache = (
+                        Path.home() / ".longbridge" / "openapi" / "tokens" / oauth_client_id
+                    )
+                    if not token_cache.exists():
+                        logger.warning(
+                            "[Longbridge] OAuth token 缓存不存在 (%s)，跳过 OAuth 认证。"
+                            "请先在本地执行 scripts/generate_longbridge_token.py 生成 token，"
+                            "或配置 Legacy API Key 三件套作为回退。",
+                            token_cache,
                         )
+                    else:
+                        try:
+                            from longbridge.openapi import OAuthBuilder
+                            oauth = OAuthBuilder(oauth_client_id).build(
+                                lambda url: logger.info(
+                                    "[Longbridge] OAuth URL: %s", url
+                                )
+                            )
+                            lb_config = Config.from_oauth(oauth)
+                            logger.info(
+                                "[Longbridge] Config.from_oauth() 创建成功 (client_id=%s)",
+                                oauth_client_id,
+                            )
+                        except Exception as oauth_err:
+                            logger.warning(
+                                "[Longbridge] OAuth 失败: %s；将回退 Legacy API Key",
+                                oauth_err,
+                            )
 
                 if lb_config is None:
+                    # ── 3b. Fallback to Legacy API Key ──
+                    # Prefer from_apikey_env() — reads all LONGBRIDGE_* env vars
+                    # (credentials + URLs + options) including .env files.
+                    # Available in longbridge >= 4.x.  from_env() only exists on
+                    # the unreleased master branch.
+                    for factory_name in ("from_apikey_env", "from_env"):
+                        factory = getattr(Config, factory_name, None)
+                        if factory is None:
+                            continue
+                        try:
+                            lb_config = factory()
+                            logger.info("[Longbridge] Config.%s() 成功", factory_name)
+                            break
+                        except Exception as e:
+                            logger.debug(
+                                "[Longbridge] Config.%s() 失败: %s", factory_name, e
+                            )
+
+                if lb_config is None and app_key and app_secret and access_token:
                     lb_config = Config.from_apikey(
                         app_key,
                         app_secret,

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -26,6 +26,9 @@ x-common: &common
     - ../reports:/app/reports
     - ../.env:/app/.env
     - ../strategies:/app/strategies:ro
+    # 长桥 OAuth Token 持久化：entrypoint.sh 启动时自动修复容器内权限（dsa 用户）
+    # 首次部署前建议在宿主机执行：mkdir -p ./longbridge_tokens
+    - ../longbridge_tokens:/home/dsa/.longbridge
     # 如需覆盖前端静态资源，可挂载本地 static 目录
     # - ../static:/app/static:ro
 

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -5,7 +5,7 @@ APP_USER="dsa"
 APP_GROUP="dsa"
 APP_UID="1000"
 APP_GID="1000"
-WRITABLE_DIRS="/app/data /app/logs /app/reports"
+WRITABLE_DIRS="/app/data /app/logs /app/reports /home/dsa/.longbridge"
 DATABASE_FILE="${DATABASE_PATH:-/app/data/stock_analysis.db}"
 
 warn() {

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -16,6 +16,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - [文档] 补充 Issue #1316 参数自愈改动的外部兼容依据、运行时配置清理边界与回滚证据；并在 `tests/test_system_config_service.py` 增加清理路径下 `LLM_TEMPERATURE` 保持不变的回归用例。
 - [文档] 补充严格 temperature 兼容语义的官方来源、运行时依赖约束与 `LLM_TEMPERATURE` 回退/不回写路径说明。
 - [改进] 告警中心 P2 新增后台评估 worker，schedule 模式可同时评估持久化 active rules 与 legacy JSON 规则，并记录 `triggered` / `skipped` / `degraded` / `failed` 最小评估历史。
+
+- [新功能] Longbridge 数据源新增 OAuth 2.0 认证方式（`LONGBRIDGE_OAUTH_CLIENT_ID`），Token 自动加载本地缓存文件，无需浏览器交互；原有 Legacy API Key 仍兼容。
+- [改进] Docker entrypoint 自动修复 Longbridge Token 持久化目录权限，确保非 root 容器可写入 OAuth Token。
+- [改进] OAuth 认证路径优先于 Legacy API Key，避免配置了 OAuth 后仍命中已废弃凭据。
 - [修复] 统一 Windows 桌面安装包与自动更新元数据文件名，避免 Release 中出现重复安装包并阻断 `latest.yml` 指向不存在附件。
 - [修复] 桌面端启动 WebUI 时为入口页增加 no-cache 响应头和版本化 cache-busting URL，避免安装新版后 Electron 继续复用旧 WebUI 缓存。
 

--- a/src/config.py
+++ b/src/config.py
@@ -534,6 +534,7 @@ class Config:
     longbridge_app_key: Optional[str] = None
     longbridge_app_secret: Optional[str] = None
     longbridge_access_token: Optional[str] = None
+    longbridge_oauth_client_id: Optional[str] = None
 
     # === AI 分析配置 ===
     # LiteLLM unified model config (provider/model format, e.g. gemini/gemini-3.1-pro-preview)
@@ -1292,6 +1293,7 @@ class Config:
             longbridge_app_key=os.getenv('LONGBRIDGE_APP_KEY') or None,
             longbridge_app_secret=os.getenv('LONGBRIDGE_APP_SECRET') or None,
             longbridge_access_token=os.getenv('LONGBRIDGE_ACCESS_TOKEN') or None,
+            longbridge_oauth_client_id=os.getenv('LONGBRIDGE_OAUTH_CLIENT_ID') or None,
             litellm_model=litellm_model,
             litellm_fallback_models=litellm_fallback_models,
             llm_temperature=resolve_unified_llm_temperature(litellm_model),


### PR DESCRIPTION
<!--
For Chinese contributors: 请直接用中文填写。
-->
## PR Type
- [ ] fix
- [x] feat
- [ ] refactor
- [ ] docs
- [ ] chore
- [ ] test

## Background And Problem
长桥 OpenAPI 已废弃 Legacy API Key 认证模式，后台不再展示 Access Token。原有 `longbridge_fetcher.py` 仅支持 `LONGBRIDGE_APP_KEY` + `LONGBRIDGE_APP_SECRET` + `LONGBRIDGE_ACCESS_TOKEN` 三件套，新用户无法接入长桥数据源，影响港股和美股的数据覆盖。

## Scope Of Change
- `src/config.py`：新增 `longbridge_oauth_client_id` 字段
- `data_provider/base.py`：初始化时检查 OAuth client_id，激活 LongbridgeFetcher
- `data_provider/longbridge_fetcher.py`：`_is_available()` 和 `_get_ctx()` 支持 OAuth，优先 OAuth 后回退 Legacy
- `docker/docker-compose.yml`：挂载 longbridge_tokens 持久化 Token
- `.env.example`：文档化新环境变量
- `docs/CHANGELOG.md`：changelog 条目
- `docker/entrypoint.sh`：修复 Longbridge Token 持久化目录在非 root 容器中的写入权限

## Issue Link
无 Issue。长桥平台强制废弃 Legacy API Key 导致数据源不可用，本 PR 适配 OAuth 2.0 恢复长桥接入。

## Verification Commands And Results
```bash
# 1. 验证 OAuth Token 可从本地缓存加载（无浏览器交互）
python3 -c "
from longbridge.openapi import OAuthBuilder, Config, QuoteContext
oauth = OAuthBuilder('07ffc96d-...').build(lambda url: print(url))
config = Config.from_oauth(oauth)
ctx = QuoteContext(config)
print(ctx.quote(['700.HK'])[0].last_done)   # → 456.400
print(ctx.quote(['AAPL.US'])[0].last_done)  # → 300.230
"
```

# 2. 语法检查通过
python -m py_compile src/config.py data_provider/base.py data_provider/longbridge_fetcher.py

关键输出：港股 [700.HK](http://700.hk/) 456.4、美股 [AAPL.US](http://aapl.us/) 300.23 均成功获取，OAuth 流程正确跳过浏览器交互。
# Compatibility And Risk
- 完全向后兼容：Legacy API Key 路径保留，有 Token 的老用户不受影响
- OAuth Token 默认 90 天过期，SDK 自动用 refresh_token 续期；容器重启需挂载 longbridge_tokens 卷否则 Token 丢失需重新授权
- 长桥 OAuth 2.0 认证文档：https://open.longbridge.com/docs/getting-started#authentication-methods
- 无配置迁移：不配置 LONGBRIDGE_OAUTH_CLIENT_ID 时行为与之前完全一致
#  Rollback Plan
`revert this PR` 即可，无需额外配置回滚。Legacy API Key 路径未被删除，回退后老用户仍可正常使用。
#  Checklist
- [x] 本 PR 有明确动机和业务价值
- [x] 已提供可复现的验证命令与结果
- [x] 已评估兼容性与风险
- [x] 已提供回滚方案
- [x] 已同步更新 .env.example 和 docs/CHANGELOG.md