### PR TITLE
fix: prevent desktop WebUI stale cache

### DIFF
--- a/api/app.py
+++ b/api/app.py
@@ -40,6 +40,18 @@ _INDEX_ASSET_REF_PATTERN = re.compile(
     re.IGNORECASE,
 )
 _SAFE_MISSING_ASSET_MEDIA_TYPES = frozenset({"text/css", "text/javascript"})
+_FRONTEND_INDEX_NO_CACHE_HEADERS = {
+    "Cache-Control": "no-store, no-cache, must-revalidate, max-age=0",
+    "Pragma": "no-cache",
+    "Expires": "0",
+}
+
+
+def _frontend_index_response(static_dir: Path) -> FileResponse:
+    return FileResponse(
+        static_dir / "index.html",
+        headers=_FRONTEND_INDEX_NO_CACHE_HEADERS,
+    )
 
 
 def _check_frontend_assets_consistency(static_dir: Path) -> List[str]:
@@ -210,7 +222,7 @@ def create_app(static_dir: Optional[Path] = None) -> FastAPI:
         @app.get("/", include_in_schema=False)
         async def root():
             """根路由 - 返回前端页面"""
-            return FileResponse(static_dir / "index.html")
+            return _frontend_index_response(static_dir)
     else:
         _FRONTEND_NOT_BUILT_HTML = """<!DOCTYPE html>
 <html lang="zh-CN"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
@@ -312,12 +324,14 @@ def create_app(static_dir: Optional[Path] = None) -> FastAPI:
             # the bundle root if served unchecked.
             file_path = _resolve_asset_path(static_dir, full_path) if full_path else None
             if file_path is not None and file_path.is_file():
+                if file_path == (static_dir / "index.html").resolve():
+                    return _frontend_index_response(static_dir)
                 # Issue #520: Explicitly resolve MIME type to avoid
                 # browsers rejecting JS modules served as text/plain.
                 content_type, _ = mimetypes.guess_type(str(file_path))
                 return FileResponse(file_path, media_type=content_type)
 
-            return FileResponse(static_dir / "index.html")
+            return _frontend_index_response(static_dir)
     
     return app
 

--- a/apps/dsa-desktop/main.js
+++ b/apps/dsa-desktop/main.js
@@ -996,6 +996,13 @@ function resolveDesktopVersion() {
   return String(app.getVersion() || '').trim();
 }
 
+function buildMainPageUrl(port, timestamp = Date.now()) {
+  const url = new URL(`http://127.0.0.1:${port}/`);
+  url.searchParams.set('desktop_version', resolveDesktopVersion() || 'unknown');
+  url.searchParams.set('cache_bust', String(timestamp));
+  return url.toString();
+}
+
 function isWindowsNsisInstalledApp() {
   if (!isWindows || !app.isPackaged) {
     return false;
@@ -1563,8 +1570,9 @@ async function createWindow() {
     );
     logStartup(`Backend ready in ${healthInfo.elapsedMs}ms (${healthInfo.attempts} probes)`);
     const mainPageStartedAt = Date.now();
-    await mainWindow.loadURL(`http://127.0.0.1:${port}/`);
-    logStartup(`Main page loadURL resolved in ${Date.now() - mainPageStartedAt}ms`);
+    const mainPageUrl = buildMainPageUrl(port);
+    await mainWindow.loadURL(mainPageUrl);
+    logStartup(`Main page loadURL resolved in ${Date.now() - mainPageStartedAt}ms url=${mainPageUrl}`);
     logStartup(`Main UI loaded in ${Date.now() - startupStartedAt}ms`);
     if (!restoreFailed) {
       void performDesktopUpdateCheck({ notify: true });
@@ -1610,6 +1618,7 @@ module.exports = {
   evaluateReleaseUpdate,
   extractReleaseMetadata,
   fetchLatestReleaseJson,
+  buildMainPageUrl,
   normalizeVersionString,
   parseSemver,
   restorePackagedRuntimeStateFromBackup,

--- a/apps/dsa-desktop/tests/main.test.js
+++ b/apps/dsa-desktop/tests/main.test.js
@@ -123,6 +123,19 @@ test('compareVersions follows semantic version ordering', (t) => {
   assert.equal(mainModule.compareVersions('3.13.0-beta.2', '3.13.0-beta.10'), -1);
 });
 
+test('buildMainPageUrl includes desktop version and cache buster', (t) => {
+  const mainModule = loadMainModule(t, {
+    app: {
+      getVersion: () => ' 3.17.1 ',
+    },
+  });
+
+  assert.equal(
+    mainModule.buildMainPageUrl(8123, 1234567890),
+    'http://127.0.0.1:8123/?desktop_version=3.17.1&cache_bust=1234567890'
+  );
+});
+
 test('extractReleaseMetadata ignores releases without semver tags', (t) => {
   const mainModule = loadMainModule(t);
 
@@ -654,6 +667,10 @@ test('createWindow startup path does not throw ReferenceError after restore resu
 
   assert.equal(loadedFiles.length >= 1, true);
   assert.equal(loadedUrls.length >= 1, true);
+  assert.match(
+    loadedUrls[0],
+    /^http:\/\/127\.0\.0\.1:\d+\/\?desktop_version=3\.12\.0&cache_bust=\d+$/
+  );
   assert.equal(updateCheckRequested, true);
   assert.equal(startupError, undefined);
   assert.equal(fs.existsSync(backupRoot), false);

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 <!-- 每条独立一行追加到本段末尾，无需分类标题，合并时冲突最小 -->
 
 - [修复] 统一 Windows 桌面安装包与自动更新元数据文件名，避免 Release 中出现重复安装包并阻断 `latest.yml` 指向不存在附件。
+- [修复] 桌面端启动 WebUI 时为入口页增加 no-cache 响应头和版本化 cache-busting URL，避免安装新版后 Electron 继续复用旧 WebUI 缓存。
 
 ## [3.17.1] - 2026-05-16
 

--- a/tests/test_static_assets_consistency.py
+++ b/tests/test_static_assets_consistency.py
@@ -235,6 +235,33 @@ def test_existing_asset_supports_head_and_conditional_requests(tmp_path: Path) -
     assert cached_response.headers["etag"] == etag
 
 
+def test_frontend_index_responses_are_not_cacheable(tmp_path: Path) -> None:
+    from api.app import create_app
+
+    static_dir = tmp_path / "static"
+    assets_dir = static_dir / "assets"
+    assets_dir.mkdir(parents=True)
+    (assets_dir / "index-abc.js").write_text("// ok", encoding="utf-8")
+    (assets_dir / "index-abc.css").write_text("/* ok */", encoding="utf-8")
+    _write_index(static_dir, _vite_index("index-abc.js", "index-abc.css"))
+
+    client = TestClient(create_app(static_dir=static_dir))
+
+    root_response = client.get("/")
+    direct_index_response = client.get("/index.html")
+    fallback_response = client.get("/analysis/history")
+
+    assert root_response.status_code == 200
+    assert direct_index_response.status_code == 200
+    assert fallback_response.status_code == 200
+    for response in (root_response, direct_index_response, fallback_response):
+        assert response.headers["cache-control"] == (
+            "no-store, no-cache, must-revalidate, max-age=0"
+        )
+        assert response.headers["pragma"] == "no-cache"
+        assert response.headers["expires"] == "0"
+
+
 @pytest.mark.parametrize(
     "request_path",
     [


### PR DESCRIPTION
## Summary
- Serve the WebUI SPA entry (`index.html`) with no-cache headers from both root and fallback routes.
- Load the desktop WebUI with `desktop_version` and `cache_bust` query parameters so Electron does not reuse a stale cached entry after upgrades.
- Add backend and desktop regression coverage, plus an Unreleased changelog note.

## Root cause
The v3.17.1 installed package and backend static response contained the latest WebUI bundle, but the Electron profile still had an older 2026-05-05 WebUI entry in Chromium cache. Because the desktop app loaded the bare `/` URL and the backend did not mark the SPA entry as non-cacheable, Electron could continue rendering stale WebUI code after installing a newer package.

## Validation
- `python -m py_compile api/app.py`
- `python -m pytest tests/test_static_assets_consistency.py` (16 passed)
- `cd apps/dsa-desktop && npm test -- --runInBand` (20 passed)
- `cd apps/dsa-web && npm run lint`
- `cd apps/dsa-web && npm run build`
- `git diff --check`

## Not run
- `cd apps/dsa-desktop && npm run build`: this checkout does not currently have `dist/backend/stock_analysis`, which is required by the Electron `extraResources` packaging config.

## Rollback
Revert this PR. The app will return to loading the bare desktop WebUI URL and serving `index.html` with the default `FileResponse` cache behavior.