### PR TITLE
feat: 增加 P2 告警评估 Worker

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - [改进] LiteLLM 参数错误支持一次请求内自动修正重试，并在成功后进程内缓存策略，降低新模型参数兼容问题的人工配置成本。
 - [文档] 补充 Issue #1316 参数自愈改动的外部兼容依据、运行时配置清理边界与回滚证据；并在 `tests/test_system_config_service.py` 增加清理路径下 `LLM_TEMPERATURE` 保持不变的回归用例。
 - [文档] 补充严格 temperature 兼容语义的官方来源、运行时依赖约束与 `LLM_TEMPERATURE` 回退/不回写路径说明。
-
+- [改进] 告警中心 P2 新增后台评估 worker，schedule 模式可同时评估持久化 active rules 与 legacy JSON 规则，并记录 `triggered` / `skipped` / `degraded` / `failed` 最小评估历史。
 - [修复] 统一 Windows 桌面安装包与自动更新元数据文件名，避免 Release 中出现重复安装包并阻断 `latest.yml` 指向不存在附件。
 - [修复] 桌面端启动 WebUI 时为入口页增加 no-cache 响应头和版本化 cache-busting URL，避免安装新版后 Electron 继续复用旧 WebUI 缓存。
 

--- a/docs/alerts.md
+++ b/docs/alerts.md
@@ -1,13 +1,13 @@
 # 实时告警中心
 
-本文档记录 Issue #1202 P0 的告警中心基线、数据契约、存储评估和兼容边界。P0 只定义后续实现可以复用的契约，不新增 API、Web 页面、数据库表、触发历史写入、冷却执行或规则迁移。
+本文档记录 Issue #1202 告警中心的运行基线、数据契约、分阶段实现范围和兼容边界。
 
 ## 当前基线
 
-当前运行时告警由 `src/agent/events.py` 中的 `EventMonitor` 提供，并通过 schedule 模式后台轮询执行。
+当前运行时告警由 `src/services/alert_worker.py` 中的后台 worker 统一调度，底层规则评估复用 `src/services/alert_service.py` 与 `src/agent/events.py` 中的 EventMonitor 规则模型。
 
 - 配置入口：`AGENT_EVENT_MONITOR_ENABLED`、`AGENT_EVENT_MONITOR_INTERVAL_MINUTES`、`AGENT_EVENT_ALERT_RULES_JSON`。
-- 运行入口：`main.py` 在 schedule 模式中调用 `build_event_monitor_from_config()`，并注册 `agent_event_monitor` 后台任务。
+- 运行入口：`main.py` 在 schedule 模式中注册 `agent_event_monitor` 后台任务；后台 worker 每轮读取持久化 active rules，并继续兼容 legacy `AGENT_EVENT_ALERT_RULES_JSON`。
 - 通知投递：触发后复用 `NotificationService.send(..., route_type="alert")`，继续遵守通知网关的 alert 路由配置。
 - Web/System 配置校验：`src/services/system_config_service.py` 会对 `AGENT_EVENT_ALERT_RULES_JSON` 做 JSON 与规则语义校验。
 
@@ -23,12 +23,12 @@
 
 ## Legacy 配置兼容
 
-P0 保留 `AGENT_EVENT_ALERT_RULES_JSON` 作为唯一运行时规则来源，不自动迁移、删除、覆盖或改写用户已有 `.env` / Web 配置。
+`AGENT_EVENT_ALERT_RULES_JSON` 作为 legacy 运行时规则来源继续保留，不自动迁移、删除、覆盖或改写用户已有 `.env` / Web 配置。
 
-- 空字符串或空数组表示未配置规则；启用 EventMonitor 但没有有效规则时，schedule 模式不会注册后台告警任务。
+- 空字符串或空数组表示未配置 legacy 规则；schedule 模式仍会注册后台 worker，以便后续 API 创建的持久化 active rules 无需重启即可被评估。
 - Web/System 配置保存时执行严格校验，JSON 无效、字段缺失、方向非法、阈值非法或 unsupported rule type 都应返回配置错误。
 - 运行时加载时允许跳过单条无效规则，剩余有效规则继续工作，避免单条配置破坏整个 schedule 进程。
-- 当前规则触发后会在进程内标记为 `triggered`，这不是告警中心冷却模型，也不提供跨进程或重启后的触发历史。
+- 当前 worker 使用进程内 fingerprint 避免持续触发条件重复推送；这不是告警中心冷却模型，也不提供跨进程或重启后的冷却状态。
 
 ## 数据契约
 
@@ -150,6 +150,25 @@ P1 不做：
 - 不让 schedule worker 加载持久化 active rules，也不实现持久化规则与 legacy JSON 的合并/去重。
 - 不实现真实 `alert_trigger` / `alert_notification` 写入；P1 只提供查询接口和表结构。
 - 不实现 `alert_cooldown` 执行语义。
+- 不实现 MACD、KDJ、CCI、RSI、持仓风险或 Market Light 告警规则。
+
+## P2 告警评估 Worker
+
+P2 将 schedule 运行时从启动时一次性构建 legacy `EventMonitor`，切换为每轮后台 worker 评估持久化 active rules 与 legacy JSON 规则。
+
+- `AGENT_EVENT_MONITOR_ENABLED` 继续作为总开关，后台任务名保持 `agent_event_monitor`。
+- worker 每轮读取 DB 中 `enabled=true` 的 `alert_rules`，并重新解析 `AGENT_EVENT_ALERT_RULES_JSON`；新增 API 规则不需要重启 schedule 进程。
+- DB 规则与 legacy 规则按 `target_scope + target + alert_type + canonical(parameters)` 去重，冲突时 DB 规则优先；legacy 配置不自动迁移、删除或改写。
+- 每条规则独立评估，单条失败只写 `failed` 评估状态，不影响同轮其他规则或主分析流程。
+- `alert_triggers` 在 P2 用于记录最小评估历史：`triggered`、`skipped`、`degraded`、`failed`；正常 `not_triggered` 不写历史，避免轮询刷表。
+- 实时行情缺失、字段缺失或非可评估场景记录 `skipped`；日线数据不可用或结构不完整记录 `degraded`；诊断信息会脱敏。
+- 触发后仍调用 `NotificationService.send(..., route_type="alert")`；进程内 fingerprint 只避免持续触发条件重复推送，不执行 `cooldown_policy`。
+
+P2 不做：
+
+- 不新增 Web 告警中心页面、路由或侧边栏入口。
+- 不写 `alert_notifications`，不记录 per-channel notification attempt。
+- 不实现 `alert_cooldown`、`cooldown_policy` 或 `notification_policy` 执行语义。
 - 不实现 MACD、KDJ、CCI、RSI、持仓风险或 Market Light 告警规则。
 
 ## Phase 边界

--- a/docs/full-guide.md
+++ b/docs/full-guide.md
@@ -1291,9 +1291,9 @@ A: 检查是否启用了 Actions，以及 cron 表达式是否正确（注意是
 
 ## Agent 事件告警监控
 
-`AGENT_EVENT_MONITOR_ENABLED=true` 后，schedule 模式会按 `AGENT_EVENT_MONITOR_INTERVAL_MINUTES` 轮询 `AGENT_EVENT_ALERT_RULES_JSON` 中的规则，并把触发结果发送到现有通知渠道。当前运行时支持三类规则：
+`AGENT_EVENT_MONITOR_ENABLED=true` 后，schedule 模式会按 `AGENT_EVENT_MONITOR_INTERVAL_MINUTES` 运行告警 worker。worker 每轮读取 Alert API 创建并启用的持久化规则，同时继续兼容 `AGENT_EVENT_ALERT_RULES_JSON` 中的 legacy 规则；触发后仍发送到现有通知渠道。当前运行时支持三类规则：
 
-> 兼容与迁移说明：本节记录当前事件告警规则（含 `price_change_percent`）运行时行为，未变更模型名、provider、Base URL、LiteLLM、`OPENAI_*`、`DEEPSEEK_*`、`GEMINI_*` 等外部模型/API 配置语义。若需回退，删除或关闭 `AGENT_EVENT_MONITOR_ENABLED` 即可恢复到旧行为。
+> 兼容与迁移说明：本节记录当前事件告警规则（含 `price_change_percent`）运行时行为，未变更模型名、provider、Base URL、LiteLLM、`OPENAI_*`、`DEEPSEEK_*`、`GEMINI_*` 等外部模型/API 配置语义。legacy JSON 不会被自动迁移、删除或改写；若需回退，删除或关闭 `AGENT_EVENT_MONITOR_ENABLED` 即可停止后台告警 worker。
 
 | `alert_type` | 方向字段 | 阈值字段 | 说明 |
 | --- | --- | --- | --- |
@@ -1308,6 +1308,8 @@ AGENT_EVENT_MONITOR_ENABLED=true
 AGENT_EVENT_MONITOR_INTERVAL_MINUTES=5
 AGENT_EVENT_ALERT_RULES_JSON=[{"stock_code":"600519","alert_type":"price_cross","direction":"above","price":1800},{"stock_code":"300750","alert_type":"price_change_percent","direction":"down","change_pct":3.0},{"stock_code":"000858","alert_type":"volume_spike","multiplier":2.5}]
 ```
+
+P2 worker 会把 `triggered`、`skipped`、`degraded`、`failed` 写入 `alert_triggers` 作为最小评估历史；正常未触发不写历史。P2 不写 `alert_notifications`，也不执行 `cooldown_policy` / `notification_policy`。
 
 ## 持仓管理说明
 

--- a/docs/full-guide_EN.md
+++ b/docs/full-guide_EN.md
@@ -1152,10 +1152,10 @@ A: Check if Actions is enabled, and if cron expression is correct (note it's UTC
 
 ## Agent Event Monitor
 
-When `AGENT_EVENT_MONITOR_ENABLED=true`, schedule mode polls the rules in `AGENT_EVENT_ALERT_RULES_JSON` every `AGENT_EVENT_MONITOR_INTERVAL_MINUTES` minutes and sends triggered alerts through the existing notification channels. The runtime currently supports three rule types:
+When `AGENT_EVENT_MONITOR_ENABLED=true`, schedule mode runs the alert worker every `AGENT_EVENT_MONITOR_INTERVAL_MINUTES` minutes. The worker reads enabled rules created through the Alert API and continues to support legacy rules in `AGENT_EVENT_ALERT_RULES_JSON`; triggered alerts still go through the existing notification channels. The runtime currently supports three rule types:
 
 > Compatibility and rollback note: this section documents current Event Monitor rule behavior (including `price_change_percent`) and does not change external model/provider API semantics such as model names, providers, Base URL, LiteLLM, `OPENAI_*`, `DEEPSEEK_*`, or `GEMINI_*` configuration.
-> Rollback is explicit: clear or disable `AGENT_EVENT_MONITOR_ENABLED`/related rule config to restore previous behavior.
+> Legacy JSON is not automatically migrated, deleted, or rewritten. To roll back the background alert worker, clear or disable `AGENT_EVENT_MONITOR_ENABLED`/related rule config.
 
 | `alert_type` | Direction | Threshold | Description |
 | --- | --- | --- | --- |
@@ -1170,6 +1170,8 @@ AGENT_EVENT_MONITOR_ENABLED=true
 AGENT_EVENT_MONITOR_INTERVAL_MINUTES=5
 AGENT_EVENT_ALERT_RULES_JSON=[{"stock_code":"600519","alert_type":"price_cross","direction":"above","price":1800},{"stock_code":"300750","alert_type":"price_change_percent","direction":"down","change_pct":3.0},{"stock_code":"000858","alert_type":"volume_spike","multiplier":2.5}]
 ```
+
+The P2 worker writes `triggered`, `skipped`, `degraded`, and `failed` rows to `alert_triggers` as minimal evaluation history; normal non-triggered checks do not write history. P2 does not write `alert_notifications` and does not execute `cooldown_policy` / `notification_policy`.
 
 ---
 

--- a/main.py
+++ b/main.py
@@ -937,25 +937,23 @@ def main() -> int:
 
             background_tasks = []
             if getattr(config, 'agent_event_monitor_enabled', False):
-                from src.agent.events import build_event_monitor_from_config, run_event_monitor_once
+                from src.services.alert_worker import AlertWorker
 
-                monitor = build_event_monitor_from_config(config)
-                if monitor is not None:
-                    interval_minutes = max(1, getattr(config, 'agent_event_monitor_interval_minutes', 5))
+                interval_minutes = max(1, getattr(config, 'agent_event_monitor_interval_minutes', 5))
+                alert_worker = AlertWorker(config_provider=_reload_runtime_config)
 
-                    def event_monitor_task():
-                        triggered = run_event_monitor_once(monitor)
-                        if triggered:
-                            logger.info("[EventMonitor] 本轮触发 %d 条提醒", len(triggered))
+                def event_monitor_task():
+                    stats = alert_worker.run_once()
+                    triggered_count = stats.get("triggered", 0)
+                    if triggered_count:
+                        logger.info("[EventMonitor] 本轮触发 %d 条提醒", triggered_count)
 
-                    background_tasks.append({
-                        "task": event_monitor_task,
-                        "interval_seconds": interval_minutes * 60,
-                        "run_immediately": True,
-                        "name": "agent_event_monitor",
-                    })
-                else:
-                    logger.info("EventMonitor 已启用，但未加载到有效规则，跳过后台提醒任务")
+                background_tasks.append({
+                    "task": event_monitor_task,
+                    "interval_seconds": interval_minutes * 60,
+                    "run_immediately": True,
+                    "name": "agent_event_monitor",
+                })
 
             run_with_schedule(
                 task=scheduled_task,

--- a/src/repositories/alert_repo.py
+++ b/src/repositories/alert_repo.py
@@ -92,6 +92,30 @@ class AlertRepository:
             ).scalars().all()
             return list(rows), int(total)
 
+    def list_enabled_rules(self, *, limit: int = 1000) -> List[AlertRuleRecord]:
+        safe_limit = max(1, min(int(limit), 1000))
+        with self.db.get_session() as session:
+            rows = session.execute(
+                select(AlertRuleRecord)
+                .where(AlertRuleRecord.enabled.is_(True))
+                .order_by(desc(AlertRuleRecord.updated_at), desc(AlertRuleRecord.id))
+                .limit(safe_limit)
+            ).scalars().all()
+            return list(rows)
+
+    def create_trigger(self, fields: Dict[str, Any]) -> AlertTriggerRecord:
+        if not fields.get("target"):
+            raise ValueError("alert trigger target is required")
+        if not fields.get("status"):
+            raise ValueError("alert trigger status is required")
+
+        with self.db.get_session() as session:
+            row = AlertTriggerRecord(**fields)
+            session.add(row)
+            session.commit()
+            session.refresh(row)
+            return row
+
     def list_triggers(
         self,
         *,

--- a/src/services/alert_service.py
+++ b/src/services/alert_service.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import asyncio
 import json
 import re
+from datetime import date, datetime
 from typing import Any, Dict, Optional
 
 from src.agent.events import (
@@ -123,12 +124,18 @@ class AlertService:
         try:
             return asyncio.run(self._evaluate_rule(rule, monitor))
         except Exception as exc:
+            sanitized_message = self._sanitize_text(str(exc) or "Alert evaluation failed")
             return {
                 "rule_id": rule_id,
                 "status": "evaluation_error",
+                "record_status": "failed",
                 "triggered": False,
                 "observed_value": None,
-                "message": self._sanitize_text(str(exc) or "Alert evaluation failed"),
+                "threshold": self._threshold_for_rule(rule),
+                "data_source": self._data_source_for_rule(rule),
+                "data_timestamp": None,
+                "reason": sanitized_message,
+                "message": sanitized_message,
             }
 
     async def _evaluate_rule(self, rule, monitor: EventMonitor) -> Dict[str, Any]:
@@ -141,19 +148,46 @@ class AlertService:
         return self._evaluation_error(rule, f"unsupported runtime alert type: {rule.alert_type}")
 
     async def _evaluate_price(self, rule: PriceAlert, monitor: EventMonitor) -> Dict[str, Any]:
+        threshold = float(rule.price)
         try:
             quote = await monitor._get_realtime_quote(rule.stock_code)
         except Exception as exc:
-            return self._evaluation_error(rule, exc)
+            return self._evaluation_error(
+                rule,
+                exc,
+                threshold=threshold,
+                data_source="realtime_quote",
+            )
         if quote is None:
-            return self._not_triggered(rule, None, "No realtime quote available")
+            return self._not_triggered(
+                rule,
+                None,
+                "No realtime quote available",
+                record_status="skipped",
+                threshold=threshold,
+                data_source="realtime_quote",
+            )
 
         try:
             current_price = float(getattr(quote, "price", 0) or 0)
         except (TypeError, ValueError) as exc:
-            return self._evaluation_error(rule, exc)
+            return self._evaluation_error(
+                rule,
+                exc,
+                threshold=threshold,
+                data_source="realtime_quote",
+                data_timestamp=self._extract_quote_datetime(quote),
+            )
         if current_price <= 0:
-            return self._not_triggered(rule, None, "No valid realtime price available")
+            return self._not_triggered(
+                rule,
+                None,
+                "No valid realtime price available",
+                record_status="skipped",
+                threshold=threshold,
+                data_source="realtime_quote",
+                data_timestamp=self._extract_quote_datetime(quote),
+            )
 
         triggered = (
             (rule.direction == "above" and current_price >= rule.price)
@@ -164,20 +198,39 @@ class AlertService:
                 rule,
                 current_price,
                 f"{rule.stock_code} price {rule.direction} {rule.price}: current = {current_price}",
+                threshold=threshold,
+                data_source="realtime_quote",
+                data_timestamp=self._extract_quote_datetime(quote),
             )
         return self._not_triggered(
             rule,
             current_price,
             f"{rule.stock_code} price {current_price} did not cross {rule.direction} {rule.price}",
+            threshold=threshold,
+            data_source="realtime_quote",
+            data_timestamp=self._extract_quote_datetime(quote),
         )
 
     async def _evaluate_price_change(self, rule: PriceChangeAlert, monitor: EventMonitor) -> Dict[str, Any]:
+        threshold = abs(float(rule.change_pct))
         try:
             quote = await monitor._get_realtime_quote(rule.stock_code)
         except Exception as exc:
-            return self._evaluation_error(rule, exc)
+            return self._evaluation_error(
+                rule,
+                exc,
+                threshold=threshold,
+                data_source="realtime_quote",
+            )
         if quote is None:
-            return self._not_triggered(rule, None, "No realtime quote available")
+            return self._not_triggered(
+                rule,
+                None,
+                "No realtime quote available",
+                record_status="skipped",
+                threshold=threshold,
+                data_source="realtime_quote",
+            )
 
         current_change_pct = _read_quote_float(
             quote,
@@ -187,9 +240,16 @@ class AlertService:
             "change_rate",
         )
         if current_change_pct is None:
-            return self._not_triggered(rule, None, "No valid realtime change percent available")
+            return self._not_triggered(
+                rule,
+                None,
+                "No valid realtime change percent available",
+                record_status="skipped",
+                threshold=threshold,
+                data_source="realtime_quote",
+                data_timestamp=self._extract_quote_datetime(quote),
+            )
 
-        threshold = abs(float(rule.change_pct))
         direction = rule.direction.lower()
         triggered = (
             (direction == "up" and current_change_pct >= threshold)
@@ -200,11 +260,17 @@ class AlertService:
                 rule,
                 current_change_pct,
                 f"{rule.stock_code} change {direction} {threshold:.2f}%: current = {current_change_pct:+.2f}%",
+                threshold=threshold,
+                data_source="realtime_quote",
+                data_timestamp=self._extract_quote_datetime(quote),
             )
         return self._not_triggered(
             rule,
             current_change_pct,
             f"{rule.stock_code} change {current_change_pct:+.2f}% did not cross {direction} {threshold:.2f}%",
+            threshold=threshold,
+            data_source="realtime_quote",
+            data_timestamp=self._extract_quote_datetime(quote),
         )
 
     async def _evaluate_volume(self, rule: VolumeAlert) -> Dict[str, Any]:
@@ -216,67 +282,279 @@ class AlertService:
         try:
             result = await asyncio.to_thread(_fetch_daily_data)
         except Exception as exc:
-            return self._evaluation_error(rule, exc)
+            return self._evaluation_error(rule, exc, data_source="daily_data")
         if result is None:
-            return self._not_triggered(rule, None, "No daily volume data available")
+            return self._not_triggered(
+                rule,
+                None,
+                "No daily volume data available",
+                record_status="degraded",
+                data_source="daily_data",
+            )
+        if not isinstance(result, tuple) or len(result) != 2:
+            return self._not_triggered(
+                rule,
+                None,
+                "Malformed daily volume data response",
+                record_status="degraded",
+                data_source="daily_data",
+            )
 
         df, _source = result
         if df is None or df.empty:
-            return self._not_triggered(rule, None, "No daily volume data available")
+            return self._not_triggered(
+                rule,
+                None,
+                "No daily volume data available",
+                record_status="degraded",
+                data_source="daily_data",
+            )
         if "volume" not in df:
-            return self._evaluation_error(rule, "daily data missing volume column")
+            return self._not_triggered(
+                rule,
+                None,
+                "daily data missing volume column",
+                record_status="degraded",
+                data_source="daily_data",
+                data_timestamp=self._extract_daily_timestamp(df),
+            )
 
         try:
             avg_vol = float(df["volume"].mean())
             latest_vol = float(df["volume"].iloc[-1])
         except (TypeError, ValueError, IndexError) as exc:
-            return self._evaluation_error(rule, exc)
+            return self._evaluation_error(
+                rule,
+                exc,
+                data_source="daily_data",
+                data_timestamp=self._extract_daily_timestamp(df),
+            )
         if avg_vol <= 0:
-            return self._not_triggered(rule, latest_vol, "Average volume is not available")
+            return self._not_triggered(
+                rule,
+                latest_vol,
+                "Average volume is not available",
+                record_status="degraded",
+                data_source="daily_data",
+                data_timestamp=self._extract_daily_timestamp(df),
+            )
 
         ratio = latest_vol / avg_vol
+        threshold = avg_vol * rule.multiplier
+        data_timestamp = self._extract_daily_timestamp(df)
         if latest_vol > avg_vol * rule.multiplier:
             return self._triggered(
                 rule,
                 latest_vol,
                 f"{rule.stock_code} volume spike: {latest_vol:,.0f} ({ratio:.1f}x avg)",
+                threshold=threshold,
+                data_source="daily_data",
+                data_timestamp=data_timestamp,
             )
         return self._not_triggered(
             rule,
             latest_vol,
             f"{rule.stock_code} volume ratio {ratio:.1f}x did not exceed {rule.multiplier}x",
+            threshold=threshold,
+            data_source="daily_data",
+            data_timestamp=data_timestamp,
         )
 
-    def _triggered(self, rule, observed_value: Any, message: str) -> Dict[str, Any]:
+    def _triggered(
+        self,
+        rule,
+        observed_value: Any,
+        message: str,
+        *,
+        threshold: Optional[float] = None,
+        data_source: Optional[str] = None,
+        data_timestamp: Optional[datetime] = None,
+    ) -> Dict[str, Any]:
+        sanitized_message = self._sanitize_text(message)
         return {
             "rule_id": self._runtime_rule_id(rule),
             "status": "triggered",
+            "record_status": "triggered",
             "triggered": True,
             "observed_value": observed_value,
-            "message": self._sanitize_text(message),
+            "threshold": threshold,
+            "data_source": data_source,
+            "data_timestamp": data_timestamp,
+            "reason": sanitized_message,
+            "message": sanitized_message,
         }
 
-    def _not_triggered(self, rule, observed_value: Any, message: str) -> Dict[str, Any]:
+    def _not_triggered(
+        self,
+        rule,
+        observed_value: Any,
+        message: str,
+        *,
+        record_status: Optional[str] = None,
+        threshold: Optional[float] = None,
+        data_source: Optional[str] = None,
+        data_timestamp: Optional[datetime] = None,
+    ) -> Dict[str, Any]:
+        sanitized_message = self._sanitize_text(message)
         return {
             "rule_id": self._runtime_rule_id(rule),
             "status": "not_triggered",
+            "record_status": record_status,
             "triggered": False,
             "observed_value": observed_value,
-            "message": self._sanitize_text(message),
+            "threshold": threshold,
+            "data_source": data_source,
+            "data_timestamp": data_timestamp,
+            "reason": sanitized_message,
+            "message": sanitized_message,
         }
 
-    def _evaluation_error(self, rule, exc: Any) -> Dict[str, Any]:
+    def _evaluation_error(
+        self,
+        rule,
+        exc: Any,
+        *,
+        threshold: Optional[float] = None,
+        data_source: Optional[str] = None,
+        data_timestamp: Optional[datetime] = None,
+    ) -> Dict[str, Any]:
+        sanitized_message = self._sanitize_text(str(exc) or "Alert evaluation failed")
         return {
             "rule_id": self._runtime_rule_id(rule),
             "status": "evaluation_error",
+            "record_status": "failed",
             "triggered": False,
             "observed_value": None,
-            "message": self._sanitize_text(str(exc) or "Alert evaluation failed"),
+            "threshold": threshold if threshold is not None else self._threshold_for_rule(rule),
+            "data_source": data_source if data_source is not None else self._data_source_for_rule(rule),
+            "data_timestamp": data_timestamp,
+            "reason": sanitized_message,
+            "message": sanitized_message,
         }
 
     @staticmethod
     def _runtime_rule_id(rule) -> int:
         return int(rule.metadata.get("persisted_rule_id", 0) or 0)
+
+    @staticmethod
+    def _threshold_for_rule(rule) -> Optional[float]:
+        if isinstance(rule, PriceAlert):
+            return float(rule.price)
+        if isinstance(rule, PriceChangeAlert):
+            return abs(float(rule.change_pct))
+        return None
+
+    @staticmethod
+    def _data_source_for_rule(rule) -> Optional[str]:
+        if isinstance(rule, (PriceAlert, PriceChangeAlert)):
+            return "realtime_quote"
+        if isinstance(rule, VolumeAlert):
+            return "daily_data"
+        return None
+
+    @classmethod
+    def _extract_quote_datetime(cls, quote: Any) -> Optional[datetime]:
+        for field_name in (
+            "data_timestamp",
+            "timestamp",
+            "quote_time",
+            "trade_time",
+            "update_time",
+            "updated_at",
+            "datetime",
+            "date",
+        ):
+            raw_value = cls._read_quote_field(quote, field_name)
+            parsed = cls._coerce_datetime(raw_value)
+            if parsed is not None:
+                return parsed
+        return None
+
+    @staticmethod
+    def _read_quote_field(quote: Any, field_name: str) -> Any:
+        if quote is None:
+            return None
+        if isinstance(quote, dict):
+            return quote.get(field_name)
+        raw_value = getattr(quote, field_name, None)
+        if raw_value is not None:
+            return raw_value
+        if hasattr(quote, "to_dict"):
+            try:
+                return quote.to_dict().get(field_name)
+            except Exception:
+                return None
+        return None
+
+    @classmethod
+    def _extract_daily_timestamp(cls, df: Any) -> Optional[datetime]:
+        if df is None or getattr(df, "empty", True):
+            return None
+
+        for field_name in ("date", "trade_date", "datetime", "time"):
+            if field_name in getattr(df, "columns", []):
+                try:
+                    parsed = cls._coerce_datetime(df[field_name].iloc[-1])
+                except Exception:
+                    parsed = None
+                if parsed is not None:
+                    return parsed
+
+        try:
+            index_value = df.index[-1]
+            if isinstance(index_value, (int, float)):
+                return None
+            return cls._coerce_datetime(index_value)
+        except Exception:
+            return None
+
+    @staticmethod
+    def _coerce_datetime(value: Any) -> Optional[datetime]:
+        if value is None:
+            return None
+        if isinstance(value, datetime):
+            return value.replace(tzinfo=None) if value.tzinfo is not None else value
+        if isinstance(value, date):
+            return datetime.combine(value, datetime.min.time())
+        if hasattr(value, "to_pydatetime"):
+            try:
+                parsed = value.to_pydatetime()
+                return parsed.replace(tzinfo=None) if parsed.tzinfo is not None else parsed
+            except Exception:
+                return None
+        if isinstance(value, (int, float)) and not isinstance(value, bool):
+            try:
+                if isinstance(value, float):
+                    if not value.is_integer():
+                        return None
+                    numeric_value = int(value)
+                else:
+                    numeric_value = int(value)
+            except (OverflowError, ValueError):
+                return None
+            # Numeric provider timestamps are ambiguous (seconds, millis, or
+            # compact trade dates). Only accept the explicit YYYYMMDD shape.
+            numeric_text = str(numeric_value)
+            if re.fullmatch(r"\d{8}", numeric_text):
+                try:
+                    return datetime.strptime(numeric_text, "%Y%m%d")
+                except ValueError:
+                    return None
+            return None
+
+        text = str(value).strip()
+        if not text:
+            return None
+        if re.fullmatch(r"\d{8}", text):
+            try:
+                return datetime.strptime(text, "%Y%m%d")
+            except ValueError:
+                return None
+        try:
+            parsed = datetime.fromisoformat(text.replace("Z", "+00:00"))
+            return parsed.replace(tzinfo=None) if parsed.tzinfo is not None else parsed
+        except ValueError:
+            return None
 
     def list_triggers(
         self,

--- a/src/services/alert_worker.py
+++ b/src/services/alert_worker.py
@@ -122,6 +122,7 @@ class AlertWorker:
                 stats["triggered"] += 1
                 if self._should_notify(runtime_rule.key):
                     if self._send_notification_safely(runtime_rule, result):
+                        self._mark_notified(runtime_rule.key)
                         stats["notified"] += 1
 
         return stats
@@ -259,8 +260,10 @@ class AlertWorker:
         last_seen = self._trigger_fingerprints.get(rule_key)
         if last_seen is not None and now - last_seen < self.fingerprint_ttl_seconds:
             return False
-        self._trigger_fingerprints[rule_key] = now
         return True
+
+    def _mark_notified(self, rule_key: str) -> None:
+        self._trigger_fingerprints[rule_key] = self.now_provider()
 
     def _prune_fingerprints(self) -> None:
         now = self.now_provider()

--- a/src/services/alert_worker.py
+++ b/src/services/alert_worker.py
@@ -1,0 +1,296 @@
+# -*- coding: utf-8 -*-
+"""Background worker for persisted and legacy alert rules."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import time
+from dataclasses import dataclass
+from typing import Any, Callable, Dict, List, Optional, Tuple
+
+from src.agent.events import (
+    EventMonitor,
+    PriceAlert,
+    PriceChangeAlert,
+    VolumeAlert,
+    parse_event_alert_rules,
+    validate_event_alert_rule,
+)
+from src.services.alert_service import AlertService
+
+logger = logging.getLogger(__name__)
+
+ALERT_WORKER_FINGERPRINT_TTL_SECONDS = 24 * 60 * 60
+ALERT_WORKER_RULE_LIMIT = 1000
+WRITABLE_TRIGGER_STATUSES = frozenset({"triggered", "skipped", "degraded", "failed"})
+
+
+@dataclass
+class RuntimeAlertRule:
+    key: str
+    rule: Any
+    source: str
+
+
+class AlertWorker:
+    """Evaluate alert-center rules for schedule-mode background polling."""
+
+    def __init__(
+        self,
+        *,
+        config_provider: Optional[Callable[[], Any]] = None,
+        service: Optional[AlertService] = None,
+        notifier: Optional[Any] = None,
+        now_provider: Optional[Callable[[], float]] = None,
+        fingerprint_ttl_seconds: int = ALERT_WORKER_FINGERPRINT_TTL_SECONDS,
+    ) -> None:
+        self.config_provider = config_provider or self._default_config_provider
+        self.service = service or AlertService()
+        self.notifier = notifier
+        self.now_provider = now_provider or time.time
+        self.fingerprint_ttl_seconds = max(1, int(fingerprint_ttl_seconds))
+        self._trigger_fingerprints: Dict[str, float] = {}
+
+    @staticmethod
+    def _default_config_provider():
+        from src.config import get_config
+
+        return get_config()
+
+    def run_once(self) -> Dict[str, int]:
+        """Run one alert worker cycle.
+
+        This method is intentionally exception-contained so scheduler background
+        threads keep running even when one config or rule is bad.
+        """
+        stats = {
+            "loaded": 0,
+            "evaluated": 0,
+            "recorded": 0,
+            "triggered": 0,
+            "notified": 0,
+            "skipped": 0,
+            "degraded": 0,
+            "failed": 0,
+        }
+
+        try:
+            config = self.config_provider()
+        except Exception as exc:
+            logger.warning("[AlertWorker] Failed to load runtime config: %s", exc)
+            return stats
+
+        if not getattr(config, "agent_event_monitor_enabled", False):
+            logger.debug("[AlertWorker] Event monitor disabled; skipping")
+            return stats
+
+        self._prune_fingerprints()
+        runtime_rules = self._load_runtime_rules(config)
+        stats["loaded"] = len(runtime_rules)
+        if not runtime_rules:
+            logger.info("[AlertWorker] No active alert rules loaded")
+            return stats
+
+        monitor = EventMonitor()
+        for runtime_rule in runtime_rules:
+            stats["evaluated"] += 1
+            try:
+                result = asyncio.run(self.service._evaluate_rule(runtime_rule.rule, monitor))
+            except Exception as exc:
+                result = {
+                    "rule_id": self.service._runtime_rule_id(runtime_rule.rule),
+                    "record_status": "failed",
+                    "triggered": False,
+                    "observed_value": None,
+                    "threshold": self.service._threshold_for_rule(runtime_rule.rule),
+                    "data_source": self.service._data_source_for_rule(runtime_rule.rule),
+                    "data_timestamp": None,
+                    "reason": self.service._sanitize_text(str(exc) or "Alert evaluation failed"),
+                    "message": self.service._sanitize_text(str(exc) or "Alert evaluation failed"),
+                }
+
+            record_status = result.get("record_status")
+            if record_status in WRITABLE_TRIGGER_STATUSES:
+                if self._record_trigger_safely(runtime_rule, result, record_status):
+                    stats["recorded"] += 1
+                if record_status in stats and record_status != "triggered":
+                    stats[record_status] += 1
+
+            if record_status == "triggered":
+                stats["triggered"] += 1
+                if self._should_notify(runtime_rule.key):
+                    if self._send_notification_safely(runtime_rule, result):
+                        stats["notified"] += 1
+
+        return stats
+
+    def _load_runtime_rules(self, config: Any) -> List[RuntimeAlertRule]:
+        runtime_rules: List[RuntimeAlertRule] = []
+        seen_keys = set()
+
+        for row in self.service.repo.list_enabled_rules(limit=ALERT_WORKER_RULE_LIMIT):
+            try:
+                rule_data = self.service._serialize_rule(row)
+                key = self._semantic_key(
+                    rule_data["target_scope"],
+                    rule_data["target"],
+                    rule_data["alert_type"],
+                    rule_data["parameters"],
+                )
+                runtime_rules.append(
+                    RuntimeAlertRule(
+                        key=key,
+                        rule=self.service._to_runtime_rule(row),
+                        source="db",
+                    )
+                )
+                seen_keys.add(key)
+            except Exception as exc:
+                logger.warning("[AlertWorker] Skip invalid persisted alert rule %s: %s", getattr(row, "id", "?"), exc)
+
+        for key, rule in self._load_legacy_rules(config):
+            if key in seen_keys:
+                logger.info("[AlertWorker] Skip duplicate legacy alert rule: %s", key)
+                continue
+            runtime_rules.append(RuntimeAlertRule(key=key, rule=rule, source="legacy_env"))
+            seen_keys.add(key)
+
+        return runtime_rules
+
+    def _load_legacy_rules(self, config: Any) -> List[Tuple[str, Any]]:
+        raw_rules = getattr(config, "agent_event_alert_rules_json", "")
+        try:
+            parsed_rules = parse_event_alert_rules(raw_rules)
+        except Exception as exc:
+            logger.warning("[AlertWorker] Failed to parse legacy alert rules: %s", exc)
+            return []
+
+        legacy_rules: List[Tuple[str, Any]] = []
+        for index, entry in enumerate(parsed_rules, start=1):
+            try:
+                validate_event_alert_rule(entry)
+                stock_code = str(entry.get("stock_code") or "").strip()
+                alert_type = str(entry.get("alert_type") or "").strip().lower()
+                parameters = self.service._normalize_parameters(alert_type, entry)
+                key = self._semantic_key("single_symbol", stock_code, alert_type, parameters)
+                metadata = {"source": "legacy_env", "legacy_rule_index": index}
+                if alert_type == "price_cross":
+                    rule = PriceAlert(
+                        stock_code=stock_code,
+                        direction=str(parameters["direction"]),
+                        price=float(parameters["price"]),
+                        metadata=metadata,
+                    )
+                elif alert_type == "price_change_percent":
+                    rule = PriceChangeAlert(
+                        stock_code=stock_code,
+                        direction=str(parameters["direction"]),
+                        change_pct=float(parameters["change_pct"]),
+                        metadata=metadata,
+                    )
+                elif alert_type == "volume_spike":
+                    rule = VolumeAlert(
+                        stock_code=stock_code,
+                        multiplier=float(parameters["multiplier"]),
+                        metadata=metadata,
+                    )
+                else:
+                    raise ValueError(f"unsupported alert_type: {alert_type}")
+                legacy_rules.append((key, rule))
+            except Exception as exc:
+                logger.warning("[AlertWorker] Skip invalid legacy alert rule #%d: %s", index, exc)
+        return legacy_rules
+
+    @staticmethod
+    def _semantic_key(target_scope: str, target: str, alert_type: str, parameters: Dict[str, Any]) -> str:
+        canonical_params = json.dumps(parameters or {}, ensure_ascii=False, sort_keys=True)
+        return f"{target_scope}:{target}:{alert_type}:{canonical_params}"
+
+    def _record_trigger(self, runtime_rule: RuntimeAlertRule, result: Dict[str, Any], status: str) -> None:
+        try:
+            rule_id = int(result.get("rule_id") or 0) or None
+        except (TypeError, ValueError):
+            rule_id = None
+
+        fields = {
+            "rule_id": rule_id,
+            "target": runtime_rule.rule.stock_code,
+            "observed_value": self._optional_float(result.get("observed_value")),
+            "threshold": self._optional_float(result.get("threshold")),
+            "reason": result.get("reason") or result.get("message"),
+            "data_source": result.get("data_source"),
+            "data_timestamp": result.get("data_timestamp"),
+            "status": status,
+            "diagnostics": self._diagnostics_for_status(status, result),
+        }
+        self.service.repo.create_trigger(fields)
+
+    def _record_trigger_safely(self, runtime_rule: RuntimeAlertRule, result: Dict[str, Any], status: str) -> bool:
+        try:
+            self._record_trigger(runtime_rule, result, status)
+            return True
+        except Exception as exc:
+            logger.warning(
+                "[AlertWorker] Failed to record alert trigger for %s: %s",
+                getattr(runtime_rule.rule, "stock_code", "?"),
+                self.service._sanitize_text(str(exc) or "trigger write failed"),
+            )
+            return False
+
+    @staticmethod
+    def _optional_float(value: Any) -> Optional[float]:
+        if value is None:
+            return None
+        try:
+            return float(value)
+        except (TypeError, ValueError):
+            return None
+
+    @staticmethod
+    def _diagnostics_for_status(status: str, result: Dict[str, Any]) -> Optional[str]:
+        if status == "triggered":
+            return None
+        return result.get("message") or result.get("reason")
+
+    def _should_notify(self, rule_key: str) -> bool:
+        now = self.now_provider()
+        last_seen = self._trigger_fingerprints.get(rule_key)
+        if last_seen is not None and now - last_seen < self.fingerprint_ttl_seconds:
+            return False
+        self._trigger_fingerprints[rule_key] = now
+        return True
+
+    def _prune_fingerprints(self) -> None:
+        now = self.now_provider()
+        expired_keys = [
+            key
+            for key, last_seen in self._trigger_fingerprints.items()
+            if now - last_seen >= self.fingerprint_ttl_seconds
+        ]
+        for key in expired_keys:
+            self._trigger_fingerprints.pop(key, None)
+
+    def _send_notification(self, runtime_rule: RuntimeAlertRule, result: Dict[str, Any]) -> bool:
+        from src.notification import NotificationBuilder, NotificationService
+
+        notification_service = self.notifier or NotificationService()
+        title = f"Event Alert | {runtime_rule.rule.stock_code}"
+        content = result.get("reason") or result.get("message") or runtime_rule.rule.description or "Alert triggered"
+        alert_text = NotificationBuilder.build_simple_alert(title=title, content=content, alert_type="warning")
+        sent = notification_service.send(alert_text, route_type="alert")
+        if not sent:
+            logger.info("[AlertWorker] No notification channel available for alert: %s", title)
+        return bool(sent)
+
+    def _send_notification_safely(self, runtime_rule: RuntimeAlertRule, result: Dict[str, Any]) -> bool:
+        try:
+            return self._send_notification(runtime_rule, result)
+        except Exception as exc:
+            logger.warning(
+                "[AlertWorker] Failed to send alert notification for %s: %s",
+                getattr(runtime_rule.rule, "stock_code", "?"),
+                self.service._sanitize_text(str(exc) or "notification failed"),
+            )
+            return False

--- a/tests/test_alert_worker.py
+++ b/tests/test_alert_worker.py
@@ -1,0 +1,454 @@
+# -*- coding: utf-8 -*-
+"""Alert worker tests for Issue #1202 P2."""
+
+from __future__ import annotations
+
+import os
+import tempfile
+import unittest
+from datetime import date
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pandas as pd
+
+from src.config import Config
+from src.services.alert_service import AlertService
+from src.services.alert_worker import AlertWorker
+from src.storage import DatabaseManager
+
+
+class AlertWorkerTestCase(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.data_dir = Path(self.temp_dir.name)
+        self.env_path = self.data_dir / ".env"
+        self.db_path = self.data_dir / "alert_worker_test.db"
+        self.env_path.write_text(
+            "\n".join([
+                "STOCK_LIST=600519",
+                "GEMINI_API_KEY=test",
+                "ADMIN_AUTH_ENABLED=false",
+                f"DATABASE_PATH={self.db_path}",
+            ])
+            + "\n",
+            encoding="utf-8",
+        )
+        os.environ["ENV_FILE"] = str(self.env_path)
+        os.environ["DATABASE_PATH"] = str(self.db_path)
+        Config.reset_instance()
+        DatabaseManager.reset_instance()
+        self.service = AlertService()
+
+    def tearDown(self) -> None:
+        DatabaseManager.reset_instance()
+        Config.reset_instance()
+        os.environ.pop("ENV_FILE", None)
+        os.environ.pop("DATABASE_PATH", None)
+        self.temp_dir.cleanup()
+
+    def _config(self, raw_rules: str = "") -> SimpleNamespace:
+        return SimpleNamespace(
+            agent_event_monitor_enabled=True,
+            agent_event_alert_rules_json=raw_rules,
+        )
+
+    def _create_rule(self, **overrides) -> dict:
+        payload = {
+            "name": "Moutai breakout",
+            "target_scope": "single_symbol",
+            "target": "600519",
+            "alert_type": "price_cross",
+            "parameters": {"direction": "above", "price": 1800},
+            "severity": "warning",
+            "enabled": True,
+        }
+        payload.update(overrides)
+        return self.service.create_rule(payload)
+
+    def _triggers(self, **filters) -> list[dict]:
+        return self.service.list_triggers(page_size=100, **filters)["items"]
+
+    def test_enabled_db_rule_triggers_and_disabled_rule_is_ignored(self) -> None:
+        enabled_rule = self._create_rule(target="600519")
+        self._create_rule(
+            name="Disabled",
+            target="000001",
+            parameters={"direction": "above", "price": 10},
+            enabled=False,
+        )
+        notifier = MagicMock()
+        notifier.send.return_value = True
+        seen_codes = []
+
+        async def _quote(_monitor, stock_code):
+            seen_codes.append(stock_code)
+            return SimpleNamespace(price=1810.0)
+
+        worker = AlertWorker(config_provider=lambda: self._config(), service=self.service, notifier=notifier)
+        with patch("src.agent.events.EventMonitor._get_realtime_quote", new=_quote):
+            stats = worker.run_once()
+
+        self.assertEqual(stats["loaded"], 1)
+        self.assertEqual(stats["triggered"], 1)
+        self.assertEqual(seen_codes, ["600519"])
+        triggers = self._triggers(rule_id=enabled_rule["id"])
+        self.assertEqual(len(triggers), 1)
+        self.assertEqual(triggers[0]["status"], "triggered")
+        self.assertEqual(triggers[0]["target"], "600519")
+        self.assertEqual(triggers[0]["observed_value"], 1810.0)
+        self.assertEqual(triggers[0]["threshold"], 1800.0)
+        notifier.send.assert_called_once()
+        self.assertEqual(notifier.send.call_args.kwargs["route_type"], "alert")
+
+    def test_legacy_rules_coexist_with_db_rules_and_db_rule_wins_duplicate_key(self) -> None:
+        self._create_rule(target="600519")
+        legacy_rules = (
+            '[{"stock_code":"600519","alert_type":"price_cross","direction":"above","price":1800},'
+            '{"stock_code":"300750","alert_type":"price_change_percent","direction":"down","change_pct":3.5}]'
+        )
+
+        async def _quote(_monitor, stock_code):
+            if stock_code == "300750":
+                return {"pct_chg": "-3.75%"}
+            return SimpleNamespace(price=1810.0)
+
+        worker = AlertWorker(
+            config_provider=lambda: self._config(legacy_rules),
+            service=self.service,
+            notifier=MagicMock(send=MagicMock(return_value=True)),
+        )
+        with patch("src.agent.events.EventMonitor._get_realtime_quote", new=_quote):
+            stats = worker.run_once()
+
+        self.assertEqual(stats["loaded"], 2)
+        self.assertEqual(stats["triggered"], 2)
+        targets = {item["target"] for item in self._triggers()}
+        self.assertEqual(targets, {"600519", "300750"})
+
+    def test_legacy_json_parse_failure_does_not_crash_or_block_persisted_rules(self) -> None:
+        before = self.env_path.read_text(encoding="utf-8")
+        self._create_rule(target="600519")
+        notifier = MagicMock()
+        notifier.send.return_value = True
+        worker = AlertWorker(config_provider=lambda: self._config("[invalid"), service=self.service, notifier=notifier)
+
+        with patch(
+            "src.agent.events.EventMonitor._get_realtime_quote",
+            new=AsyncMock(return_value=SimpleNamespace(price=1810.0)),
+        ):
+            stats = worker.run_once()
+
+        self.assertEqual(stats["loaded"], 1)
+        self.assertEqual(stats["triggered"], 1)
+        self.assertEqual(len(self._triggers()), 1)
+        self.assertEqual(self.env_path.read_text(encoding="utf-8"), before)
+
+    def test_all_invalid_legacy_rules_do_not_crash(self) -> None:
+        invalid_rules = (
+            '[{"stock_code":"600519","alert_type":"price_cross","direction":"sideways","price":1800},'
+            '{"stock_code":"300750","alert_type":"price_change_percent","direction":"down","change_pct":0}]'
+        )
+        worker = AlertWorker(config_provider=lambda: self._config(invalid_rules), service=self.service)
+
+        stats = worker.run_once()
+
+        self.assertEqual(stats["loaded"], 0)
+        self.assertEqual(stats["evaluated"], 0)
+        self.assertEqual(self._triggers(), [])
+
+    def test_empty_sources_are_a_noop(self) -> None:
+        worker = AlertWorker(config_provider=lambda: self._config(), service=self.service)
+
+        stats = worker.run_once()
+
+        self.assertEqual(stats["loaded"], 0)
+        self.assertEqual(stats["evaluated"], 0)
+        self.assertEqual(self._triggers(), [])
+
+    def test_missing_quote_writes_skipped_trigger_without_notification(self) -> None:
+        self._create_rule(target="600519")
+        notifier = MagicMock()
+        notifier.send.return_value = True
+        worker = AlertWorker(config_provider=lambda: self._config(), service=self.service, notifier=notifier)
+
+        with patch("src.agent.events.EventMonitor._get_realtime_quote", new=AsyncMock(return_value=None)):
+            stats = worker.run_once()
+
+        self.assertEqual(stats["skipped"], 1)
+        triggers = self._triggers(status="skipped")
+        self.assertEqual(len(triggers), 1)
+        self.assertEqual(triggers[0]["target"], "600519")
+        self.assertIn("No realtime quote", triggers[0]["diagnostics"])
+        notifier.send.assert_not_called()
+
+    def test_price_cross_numeric_yyyymmdd_quote_date_writes_correct_timestamp(self) -> None:
+        rule = self._create_rule(target="600519")
+        notifier = MagicMock()
+        notifier.send.return_value = True
+        worker = AlertWorker(config_provider=lambda: self._config(), service=self.service, notifier=notifier)
+
+        with patch(
+            "src.agent.events.EventMonitor._get_realtime_quote",
+            new=AsyncMock(return_value=SimpleNamespace(price=1810.0, date=20260517)),
+        ):
+            stats = worker.run_once()
+
+        self.assertEqual(stats["triggered"], 1)
+        triggers = self._triggers(rule_id=rule["id"], status="triggered")
+        self.assertEqual(len(triggers), 1)
+        self.assertEqual(triggers[0]["data_timestamp"], "2026-05-17T00:00:00")
+
+    def test_price_cross_space_separated_quote_time_writes_timestamp(self) -> None:
+        rule = self._create_rule(target="600519")
+        notifier = MagicMock()
+        notifier.send.return_value = True
+        worker = AlertWorker(config_provider=lambda: self._config(), service=self.service, notifier=notifier)
+
+        with patch(
+            "src.agent.events.EventMonitor._get_realtime_quote",
+            new=AsyncMock(return_value=SimpleNamespace(price=1810.0, quote_time="2026-05-17 15:00:00")),
+        ):
+            stats = worker.run_once()
+
+        self.assertEqual(stats["triggered"], 1)
+        triggers = self._triggers(rule_id=rule["id"], status="triggered")
+        self.assertEqual(len(triggers), 1)
+        self.assertEqual(triggers[0]["data_timestamp"], "2026-05-17T15:00:00")
+
+    def test_ambiguous_numeric_quote_timestamp_is_not_written_as_epoch(self) -> None:
+        rule = self._create_rule(target="600519")
+        notifier = MagicMock()
+        notifier.send.return_value = True
+        worker = AlertWorker(config_provider=lambda: self._config(), service=self.service, notifier=notifier)
+
+        with patch(
+            "src.agent.events.EventMonitor._get_realtime_quote",
+            new=AsyncMock(return_value=SimpleNamespace(price=1810.0, timestamp=1700000000)),
+        ):
+            stats = worker.run_once()
+
+        self.assertEqual(stats["triggered"], 1)
+        triggers = self._triggers(rule_id=rule["id"], status="triggered")
+        self.assertEqual(len(triggers), 1)
+        self.assertIsNone(triggers[0]["data_timestamp"])
+
+    def test_service_test_rule_exception_uses_same_sanitized_reason_and_message(self) -> None:
+        rule = self._create_rule(target="600519")
+
+        async def _raise(_rule, _monitor):
+            raise RuntimeError("token=secret-token failed at https://example.com/webhook")
+
+        with patch.object(self.service, "_evaluate_rule", new=_raise):
+            result = self.service.test_rule(rule["id"])
+
+        self.assertEqual(result["status"], "evaluation_error")
+        self.assertEqual(result["record_status"], "failed")
+        self.assertEqual(result["reason"], result["message"])
+        self.assertNotIn("secret-token", result["reason"])
+        self.assertNotIn("example.com/webhook", result["message"])
+
+    def test_daily_data_unavailable_writes_degraded_trigger(self) -> None:
+        self._create_rule(
+            name="Volume",
+            target="000858",
+            alert_type="volume_spike",
+            parameters={"multiplier": 2.5},
+        )
+        manager = MagicMock()
+        manager.get_daily_data.return_value = None
+
+        async def _run_inline(func, *args, **kwargs):
+            return func(*args, **kwargs)
+
+        worker = AlertWorker(config_provider=lambda: self._config(), service=self.service)
+        with patch("data_provider.DataFetcherManager", return_value=manager), \
+             patch("src.services.alert_service.asyncio.to_thread", new=_run_inline):
+            stats = worker.run_once()
+
+        self.assertEqual(stats["degraded"], 1)
+        triggers = self._triggers(status="degraded")
+        self.assertEqual(len(triggers), 1)
+        self.assertEqual(triggers[0]["target"], "000858")
+        self.assertIn("No daily volume data", triggers[0]["diagnostics"])
+
+    def test_malformed_daily_data_response_writes_degraded_trigger(self) -> None:
+        self._create_rule(
+            name="Volume",
+            target="000858",
+            alert_type="volume_spike",
+            parameters={"multiplier": 2.5},
+        )
+        manager = MagicMock()
+        manager.get_daily_data.return_value = {"unexpected": "shape"}
+
+        async def _run_inline(func, *args, **kwargs):
+            return func(*args, **kwargs)
+
+        worker = AlertWorker(config_provider=lambda: self._config(), service=self.service)
+        with patch("data_provider.DataFetcherManager", return_value=manager), \
+             patch("src.services.alert_service.asyncio.to_thread", new=_run_inline):
+            stats = worker.run_once()
+
+        self.assertEqual(stats["degraded"], 1)
+        triggers = self._triggers(status="degraded")
+        self.assertEqual(len(triggers), 1)
+        self.assertEqual(triggers[0]["target"], "000858")
+        self.assertIn("Malformed daily volume data", triggers[0]["diagnostics"])
+
+    def test_volume_spike_trigger_writes_expected_trigger_fields(self) -> None:
+        rule = self._create_rule(
+            name="Volume",
+            target="000858",
+            alert_type="volume_spike",
+            parameters={"multiplier": 2.0},
+        )
+        manager = MagicMock()
+        daily = pd.DataFrame(
+            {
+                "date": [date(2026, 5, 13), date(2026, 5, 14), date(2026, 5, 15)],
+                "volume": [1000, 1000, 5000],
+            }
+        )
+        manager.get_daily_data.return_value = (daily, "test_source")
+        notifier = MagicMock()
+        notifier.send.return_value = True
+
+        async def _run_inline(func, *args, **kwargs):
+            return func(*args, **kwargs)
+
+        worker = AlertWorker(config_provider=lambda: self._config(), service=self.service, notifier=notifier)
+        with patch("data_provider.DataFetcherManager", return_value=manager), \
+             patch("src.services.alert_service.asyncio.to_thread", new=_run_inline):
+            stats = worker.run_once()
+
+        self.assertEqual(stats["triggered"], 1)
+        self.assertEqual(stats["recorded"], 1)
+        self.assertEqual(stats["notified"], 1)
+        triggers = self._triggers(rule_id=rule["id"], status="triggered")
+        self.assertEqual(len(triggers), 1)
+        self.assertEqual(triggers[0]["target"], "000858")
+        self.assertEqual(triggers[0]["observed_value"], 5000.0)
+        self.assertAlmostEqual(triggers[0]["threshold"], 4666.666666666667)
+        self.assertEqual(triggers[0]["data_source"], "daily_data")
+        self.assertEqual(triggers[0]["data_timestamp"], "2026-05-15T00:00:00")
+        notifier.send.assert_called_once()
+
+    def test_single_rule_failure_does_not_block_other_rules(self) -> None:
+        self._create_rule(target="600519")
+        self._create_rule(
+            name="CATL drop",
+            target="300750",
+            alert_type="price_change_percent",
+            parameters={"direction": "down", "change_pct": 3.0},
+        )
+        notifier = MagicMock()
+        notifier.send.return_value = True
+
+        async def _quote(_monitor, stock_code):
+            if stock_code == "600519":
+                raise RuntimeError("token=secret-token failed at https://example.com/webhook")
+            return {"pct_chg": "-3.25%"}
+
+        worker = AlertWorker(config_provider=lambda: self._config(), service=self.service, notifier=notifier)
+        with patch("src.agent.events.EventMonitor._get_realtime_quote", new=_quote):
+            stats = worker.run_once()
+
+        self.assertEqual(stats["failed"], 1)
+        self.assertEqual(stats["triggered"], 1)
+        failed = self._triggers(status="failed")
+        self.assertEqual(len(failed), 1)
+        self.assertNotIn("secret-token", failed[0]["diagnostics"])
+        self.assertNotIn("example.com/webhook", failed[0]["diagnostics"])
+        self.assertEqual(len(self._triggers(status="triggered")), 1)
+
+    def test_notification_failure_does_not_block_other_rules(self) -> None:
+        self._create_rule(target="600519")
+        self._create_rule(
+            name="CATL drop",
+            target="300750",
+            alert_type="price_change_percent",
+            parameters={"direction": "down", "change_pct": 3.0},
+        )
+        notifier = MagicMock()
+        notifier.send.side_effect = [RuntimeError("webhook secret failed"), True]
+
+        async def _quote(_monitor, stock_code):
+            if stock_code == "600519":
+                return SimpleNamespace(price=1810.0)
+            return {"pct_chg": "-3.25%"}
+
+        worker = AlertWorker(config_provider=lambda: self._config(), service=self.service, notifier=notifier)
+        with patch("src.agent.events.EventMonitor._get_realtime_quote", new=_quote):
+            stats = worker.run_once()
+
+        self.assertEqual(stats["triggered"], 2)
+        self.assertEqual(stats["recorded"], 2)
+        self.assertEqual(stats["notified"], 1)
+        self.assertEqual(len(self._triggers(status="triggered")), 2)
+        self.assertEqual(notifier.send.call_count, 2)
+
+    def test_trigger_record_failure_does_not_block_other_rules(self) -> None:
+        self._create_rule(target="600519")
+        self._create_rule(
+            name="CATL drop",
+            target="300750",
+            alert_type="price_change_percent",
+            parameters={"direction": "down", "change_pct": 3.0},
+        )
+        notifier = MagicMock()
+        notifier.send.return_value = True
+        original_create_trigger = self.service.repo.create_trigger
+
+        def _create_trigger(fields):
+            if fields["target"] == "600519":
+                raise RuntimeError("database locked")
+            return original_create_trigger(fields)
+
+        async def _quote(_monitor, stock_code):
+            if stock_code == "600519":
+                return SimpleNamespace(price=1810.0)
+            return {"pct_chg": "-3.25%"}
+
+        worker = AlertWorker(config_provider=lambda: self._config(), service=self.service, notifier=notifier)
+        with patch.object(self.service.repo, "create_trigger", side_effect=_create_trigger), \
+             patch("src.agent.events.EventMonitor._get_realtime_quote", new=_quote):
+            stats = worker.run_once()
+
+        self.assertEqual(stats["triggered"], 2)
+        self.assertEqual(stats["recorded"], 1)
+        self.assertEqual(stats["notified"], 2)
+        triggers = self._triggers(status="triggered")
+        self.assertEqual(len(triggers), 1)
+        self.assertEqual(triggers[0]["target"], "300750")
+
+    def test_fingerprint_ttl_suppresses_duplicate_notifications_but_expires(self) -> None:
+        self._create_rule(target="600519")
+        notifier = MagicMock()
+        notifier.send.return_value = True
+        now = {"value": 1000.0}
+
+        worker = AlertWorker(
+            config_provider=lambda: self._config(),
+            service=self.service,
+            notifier=notifier,
+            now_provider=lambda: now["value"],
+            fingerprint_ttl_seconds=60,
+        )
+        with patch(
+            "src.agent.events.EventMonitor._get_realtime_quote",
+            new=AsyncMock(return_value=SimpleNamespace(price=1810.0)),
+        ):
+            worker.run_once()
+            now["value"] += 30
+            worker.run_once()
+            now["value"] += 61
+            worker.run_once()
+
+        self.assertEqual(notifier.send.call_count, 2)
+        self.assertEqual(len(self._triggers(status="triggered")), 3)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_alert_worker.py
+++ b/tests/test_alert_worker.py
@@ -449,6 +449,38 @@ class AlertWorkerTestCase(unittest.TestCase):
         self.assertEqual(notifier.send.call_count, 2)
         self.assertEqual(len(self._triggers(status="triggered")), 3)
 
+    def test_failed_notification_attempts_do_not_consume_fingerprint_window(self) -> None:
+        self._create_rule(target="600519")
+        notifier = MagicMock()
+        notifier.send.side_effect = [False, RuntimeError("temporary webhook failure"), True]
+        now = {"value": 1000.0}
+
+        worker = AlertWorker(
+            config_provider=lambda: self._config(),
+            service=self.service,
+            notifier=notifier,
+            now_provider=lambda: now["value"],
+            fingerprint_ttl_seconds=60,
+        )
+        with patch(
+            "src.agent.events.EventMonitor._get_realtime_quote",
+            new=AsyncMock(return_value=SimpleNamespace(price=1810.0)),
+        ):
+            first = worker.run_once()
+            now["value"] += 10
+            second = worker.run_once()
+            now["value"] += 10
+            third = worker.run_once()
+            now["value"] += 10
+            fourth = worker.run_once()
+
+        self.assertEqual(first["notified"], 0)
+        self.assertEqual(second["notified"], 0)
+        self.assertEqual(third["notified"], 1)
+        self.assertEqual(fourth["notified"], 0)
+        self.assertEqual(notifier.send.call_count, 3)
+        self.assertEqual(len(self._triggers(status="triggered")), 4)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_alerts_docs.py
+++ b/tests/test_alerts_docs.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-"""Contract checks for the alert-center P0 documentation."""
+"""Contract checks for the alert-center documentation."""
 
 from pathlib import Path
 
@@ -15,7 +15,7 @@ def _read_doc() -> str:
 def test_alerts_doc_exists_and_links_p0_scope() -> None:
     doc = _read_doc()
 
-    assert "Issue #1202 P0" in doc
+    assert "Issue #1202" in doc
     assert "AGENT_EVENT_ALERT_RULES_JSON" in doc
     assert "EventMonitor" in doc
     assert "P1 Alert API MVP" in doc
@@ -126,6 +126,22 @@ def test_alerts_doc_keeps_p1_non_goals_explicit() -> None:
         "不实现 `alert_cooldown` 执行语义",
         "不实现 MACD、KDJ、CCI、RSI",
         "不自动迁移、删除、覆盖或改写 legacy 配置",
+    ):
+        assert token in doc
+
+
+def test_alerts_doc_defines_p2_worker_scope() -> None:
+    doc = _read_doc()
+
+    for token in (
+        "## P2 告警评估 Worker",
+        "src/services/alert_worker.py",
+        "agent_event_monitor",
+        "持久化 active rules",
+        "legacy JSON",
+        "`triggered`、`skipped`、`degraded`、`failed`",
+        "不写 `alert_notifications`",
+        "不执行 `cooldown_policy`",
     ):
         assert token in doc
 

--- a/tests/test_main_schedule_mode.py
+++ b/tests/test_main_schedule_mode.py
@@ -183,7 +183,8 @@ class MainScheduleModeTestCase(unittest.TestCase):
             agent_event_monitor_enabled=True,
             agent_event_monitor_interval_minutes=7,
         )
-        monitor = object()
+        worker = MagicMock()
+        worker.run_once.return_value = {"triggered": 2}
         scheduled_call = {}
 
         def fake_run_with_schedule(
@@ -202,17 +203,17 @@ class MainScheduleModeTestCase(unittest.TestCase):
 
         with patch("main.parse_arguments", return_value=args), \
              patch("main.get_config", return_value=config), \
-             patch("main._reload_runtime_config", return_value=config), \
+             patch("main._reload_runtime_config", return_value=config) as reload_config, \
              patch("main._build_schedule_time_provider", return_value=lambda: "18:00"), \
              patch("main.setup_logging"), \
              patch("main.run_full_analysis") as run_full_analysis, \
-             patch("src.agent.events.build_event_monitor_from_config", return_value=monitor) as build_monitor, \
-             patch("src.agent.events.run_event_monitor_once", return_value=["triggered"]) as run_monitor, \
+             patch("src.services.alert_worker.AlertWorker", return_value=worker) as worker_cls, \
              patch("src.scheduler.run_with_schedule", side_effect=fake_run_with_schedule):
             exit_code = main.main()
 
         self.assertEqual(exit_code, 0)
-        build_monitor.assert_called_once_with(config)
+        worker_cls.assert_called_once()
+        self.assertIs(worker_cls.call_args.kwargs["config_provider"], reload_config)
         run_full_analysis.assert_not_called()
         self.assertEqual(scheduled_call["schedule_time"], "18:00")
         self.assertEqual(scheduled_call["run_immediately"], True)
@@ -223,16 +224,21 @@ class MainScheduleModeTestCase(unittest.TestCase):
         self.assertEqual(background_task["interval_seconds"], 7 * 60)
         self.assertEqual(background_task["run_immediately"], True)
 
-        background_task["task"]()
+        with patch("main.logger.info") as info_log:
+            background_task["task"]()
 
-        run_monitor.assert_called_once_with(monitor)
+        worker.run_once.assert_called_once_with()
+        info_log.assert_any_call("[EventMonitor] 本轮触发 %d 条提醒", 2)
 
-    def test_schedule_mode_skips_event_monitor_background_task_without_valid_rules(self) -> None:
+    def test_schedule_mode_registers_event_monitor_worker_without_legacy_rules(self) -> None:
         args = self._make_args(schedule=True)
         config = self._make_config(
             schedule_enabled=False,
             agent_event_monitor_enabled=True,
+            agent_event_alert_rules_json="",
         )
+        worker = MagicMock()
+        worker.run_once.return_value = {"triggered": 0}
         scheduled_call = {}
 
         def fake_run_with_schedule(
@@ -250,18 +256,15 @@ class MainScheduleModeTestCase(unittest.TestCase):
              patch("main._build_schedule_time_provider", return_value=lambda: "18:00"), \
              patch("main.setup_logging"), \
              patch("main.run_full_analysis") as run_full_analysis, \
-             patch("main.logger.info") as info_log, \
-             patch("src.agent.events.build_event_monitor_from_config", return_value=None) as build_monitor, \
-             patch("src.agent.events.run_event_monitor_once") as run_monitor, \
+             patch("src.services.alert_worker.AlertWorker", return_value=worker) as worker_cls, \
              patch("src.scheduler.run_with_schedule", side_effect=fake_run_with_schedule):
             exit_code = main.main()
 
         self.assertEqual(exit_code, 0)
-        build_monitor.assert_called_once_with(config)
-        run_monitor.assert_not_called()
+        worker_cls.assert_called_once()
         run_full_analysis.assert_not_called()
-        self.assertEqual(scheduled_call["background_tasks"], [])
-        info_log.assert_any_call("EventMonitor 已启用，但未加载到有效规则，跳过后台提醒任务")
+        self.assertEqual(len(scheduled_call["background_tasks"]), 1)
+        self.assertEqual(scheduled_call["background_tasks"][0]["name"], "agent_event_monitor")
 
     def test_check_notify_returns_before_other_modes(self) -> None:
         args = self._make_args(check_notify=True, serve=True, schedule=True, market_review=True)


### PR DESCRIPTION
## PR Type

- [ ] fix
- [x] feat
- [ ] refactor
- [ ] docs
- [ ] chore
- [ ] test

## Background And Problem

Issue #1202 的 P1 API 基础已经合入，但 schedule 运行时仍停留在启动时一次性构建 legacy `EventMonitor` 的路径。P2 需要让后台告警评估每轮读取 DB enabled rules 与 legacy `AGENT_EVENT_ALERT_RULES_JSON`，并写入最小 `alert_triggers` 评估历史，为后续 P4 通知记录、冷却策略和查询扩展打基础。

## Scope Of Change

- `main.py`：schedule 模式用 P2 `AlertWorker` 取代旧 `build_event_monitor_from_config()` + `run_event_monitor_once()` 路径；保留 `AGENT_EVENT_MONITOR_ENABLED` 总开关和 `agent_event_monitor` 后台任务名。
- `src/services/alert_worker.py`：新增 worker，合并 DB enabled rules 与 legacy JSON，执行评估、写 `alert_triggers`，触发 `route_type="alert"` 通知，并用 24h 进程内 fingerprint 避免重复推送；fingerprint 只在通知成功后写入，失败发送会在后续轮询中重试。
- `src/services/alert_service.py` / `src/repositories/alert_repo.py`：扩展内部评估结果字段、trigger 写入和 enabled rules 读取能力；dry-run API 保持 P1 响应契约。
- `tests/`：补充 worker、schedule 注册、docs 和 dry-run 回归覆盖，包括通知失败不消耗 fingerprint 的回归测试。
- `docs/alerts.md`、`docs/full-guide.md`、`docs/full-guide_EN.md`、`docs/CHANGELOG.md`：同步 P2 行为边界和文档说明。

## Issue Link

Refs #1202

## Verification Commands And Results

```bash
python -m pytest tests/test_alert_worker.py tests/test_alert_api.py tests/test_main_schedule_mode.py tests/test_alerts_docs.py
python -m py_compile src/services/alert_worker.py tests/test_alert_worker.py
git diff --check
./scripts/ci_gate.sh
```

关键输出/结论：

- 定向 worker：`18 passed in 1.16s`
- 定向回归：`62 passed, 34 warnings in 4.86s`
- `py_compile` 通过
- `git diff --check` 通过
- `./scripts/ci_gate.sh`：`2021 passed, 2 deselected, 40 warnings, 166 subtests passed in 62.58s`，`backend-gate: all checks passed`

## Compatibility And Risk

- 不新增配置项，未修改 `.env.example`。
- `AGENT_EVENT_MONITOR_ENABLED` 继续作为总开关；后台任务名保持 `agent_event_monitor`。
- P2 只写 `alert_triggers`；不写 `alert_notifications`，不执行 `cooldown_policy` / `notification_policy`。
- legacy JSON 仍只作为兼容输入读取，不会被 worker 重写。
- 风险点：worker 会在 schedule 进程中实际写入触发历史；如数据源返回字段缺失或日线结构不完整，会写入 `skipped` / `degraded` 诊断记录，正常未触发规则不写历史。

## Rollback Plan

Revert this PR 即可恢复旧 schedule EventMonitor 路径。无需配置回滚或数据迁移；如需要清理本 PR 运行期间产生的 `alert_triggers` 诊断记录，可按时间窗口或状态手动删除。

## EXTRACT_PROMPT Change (if applicable)

不适用。本 PR 未修改 `src/services/image_stock_extractor.py` 或 `EXTRACT_PROMPT`。

## Checklist

- [x] 本 PR 有明确动机和业务价值 / This PR has a clear motivation and value
- [x] 已提供可复现的验证命令与结果 / Reproducible verification commands and results are included
- [x] 已评估兼容性与风险 / Compatibility and risk have been assessed
- [x] 已提供回滚方案 / A rollback plan is provided
- [x] 若涉及用户可见变更，已同步更新相关文档与 `docs/CHANGELOG.md`；`README.md` 仅在首页级信息变化时更新，细节优先写入 `docs/*.md` / If user-visible changes are included, relevant docs and `docs/CHANGELOG.md` are updated; `README.md` is updated only for homepage-level changes, with details kept in `docs/*.md`
