### PR TITLE
fix: 将报告和告警中的 RSI 计算统一为 Wilder's EMA/SMMA 口径… (#1341)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - [新功能] 新增热点题材、事件驱动、成长质量和预期重估策略。
 - [新功能] Web 新增告警中心 MVP，支持现有三类告警规则的创建、列表、启停、删除、dry-run 测试和触发历史查看。
 - [新功能] 告警中心 P4 记录真实通知尝试结果，并为持久化规则新增可查询的业务冷却状态。
+- [改进] RSI 计算统一改为 Wilder's EMA/SMMA 口径，分析报告与后续技术指标告警基线对齐 TradingView / 券商软件。
 
 ## [3.17.1] - 2026-05-16
 

--- a/docs/alerts.md
+++ b/docs/alerts.md
@@ -21,6 +21,21 @@
 
 `sentiment_shift`、`risk_flag`、`custom` 等类型只作为未来扩展占位；当前运行时不接受这些类型作为可执行规则。
 
+## 技术指标口径
+
+RSI 使用 Wilder's EMA/SMMA 平滑口径，与 TradingView 和常见券商软件对齐，不使用简单移动平均窗口口径。
+
+公式约定：
+
+- `delta = close.diff()`
+- `gain = delta.where(delta > 0, 0.0)`
+- `loss = -delta.where(delta < 0, 0.0)`
+- `avg_gain = gain.ewm(alpha=1/period, adjust=False).mean()`
+- `avg_loss = loss.ewm(alpha=1/period, adjust=False).mean()`
+- `RSI = 100 - (100 / (1 + avg_gain / avg_loss))`
+
+该口径适用于分析报告中的 `RSI_6 / RSI_12 / RSI_24`，也作为后续 P5 `rsi_threshold` 告警规则的计算基线；当前运行时尚未开放 `rsi_threshold` 作为可执行规则。
+
 ## Legacy 配置兼容
 
 `AGENT_EVENT_ALERT_RULES_JSON` 作为 legacy 运行时规则来源继续保留，不自动迁移、删除、覆盖或改写用户已有 `.env` / Web 配置。

--- a/src/services/alert_indicators.py
+++ b/src/services/alert_indicators.py
@@ -1,0 +1,45 @@
+# -*- coding: utf-8 -*-
+"""Shared technical indicator helpers for reports and alert rules."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+
+import pandas as pd
+
+
+def calculate_wilder_rsi(close: pd.Series, period: int) -> pd.Series:
+    """Calculate RSI with Wilder's EMA/SMMA smoothing."""
+    if period <= 0:
+        raise ValueError("period must be > 0")
+
+    close_series = pd.Series(close, copy=False)
+    delta = close_series.diff()
+    gain = delta.where(delta > 0, 0.0)
+    loss = -delta.where(delta < 0, 0.0)
+
+    avg_gain = gain.ewm(alpha=1 / period, adjust=False).mean()
+    avg_loss = loss.ewm(alpha=1 / period, adjust=False).mean()
+    rs = avg_gain / avg_loss
+    rsi = 100 - (100 / (1 + rs))
+
+    return rsi.fillna(50)
+
+
+def calculate_rsi(close: pd.Series, period: int) -> pd.Series:
+    """Backward-compatible alias for the project RSI implementation."""
+    return calculate_wilder_rsi(close, period)
+
+
+def add_rsi_columns(
+    df: pd.DataFrame,
+    periods: Iterable[int],
+    *,
+    price_column: str = "close",
+    column_prefix: str = "RSI",
+) -> pd.DataFrame:
+    """Return a copy of ``df`` with Wilder RSI columns for each period."""
+    result = df.copy()
+    for period in periods:
+        result[f"{column_prefix}_{period}"] = calculate_wilder_rsi(result[price_column], int(period))
+    return result

--- a/src/stock_analyzer.py
+++ b/src/stock_analyzer.py
@@ -25,6 +25,7 @@ import pandas as pd
 import numpy as np
 
 from src.config import get_config
+from src.services.alert_indicators import add_rsi_columns
 
 logger = logging.getLogger(__name__)
 
@@ -306,35 +307,13 @@ class StockTrendAnalyzer:
         计算 RSI 指标
 
         公式：
+        - 平均上涨/下跌幅度使用 Wilder's EMA/SMMA
+        - avg_gain = gain.ewm(alpha=1/period, adjust=False).mean()
+        - avg_loss = loss.ewm(alpha=1/period, adjust=False).mean()
         - RS = 平均上涨幅度 / 平均下跌幅度
         - RSI = 100 - (100 / (1 + RS))
         """
-        df = df.copy()
-
-        for period in [self.RSI_SHORT, self.RSI_MID, self.RSI_LONG]:
-            # 计算价格变化
-            delta = df['close'].diff()
-
-            # 分离上涨和下跌
-            gain = delta.where(delta > 0, 0)
-            loss = -delta.where(delta < 0, 0)
-
-            # 计算平均涨跌幅
-            avg_gain = gain.rolling(window=period).mean()
-            avg_loss = loss.rolling(window=period).mean()
-
-            # 计算 RS 和 RSI
-            rs = avg_gain / avg_loss
-            rsi = 100 - (100 / (1 + rs))
-
-            # 填充 NaN 值
-            rsi = rsi.fillna(50)  # 默认中性值
-
-            # 添加到 DataFrame
-            col_name = f'RSI_{period}'
-            df[col_name] = rsi
-
-        return df
+        return add_rsi_columns(df, [self.RSI_SHORT, self.RSI_MID, self.RSI_LONG])
     
     def _analyze_trend(self, df: pd.DataFrame, result: TrendAnalysisResult) -> None:
         """

--- a/tests/test_alert_worker.py
+++ b/tests/test_alert_worker.py
@@ -15,9 +15,11 @@ import pandas as pd
 
 from src.config import Config
 from src.notification import ChannelAttemptResult, NotificationDispatchResult
+from src.services.alert_indicators import calculate_wilder_rsi
 from src.services.alert_service import AlertService
 from src.services.alert_worker import AlertWorker
 from src.storage import DatabaseManager
+from src.stock_analyzer import StockTrendAnalyzer
 
 
 class AlertWorkerTestCase(unittest.TestCase):
@@ -743,6 +745,41 @@ class AlertWorkerTestCase(unittest.TestCase):
         self.assertEqual(fourth["notified"], 0)
         self.assertEqual(notifier.send_with_results.call_count, 3)
         self.assertEqual(len(self._triggers(status="triggered")), 4)
+
+    def test_rsi_uses_wilder_ema_and_matches_report_columns(self) -> None:
+        closes = pd.Series(
+            [
+                10.0, 11.0, 10.5, 12.0, 11.0,
+                13.0, 12.5, 14.0, 13.5, 15.0,
+                14.0, 16.0, 15.5, 17.0, 16.0,
+                18.0, 17.5, 19.0, 18.0, 20.0,
+            ]
+        )
+        period = 12
+        delta = closes.diff()
+        gain = delta.where(delta > 0, 0.0)
+        loss = -delta.where(delta < 0, 0.0)
+        avg_gain = gain.ewm(alpha=1 / period, adjust=False).mean()
+        avg_loss = loss.ewm(alpha=1 / period, adjust=False).mean()
+        expected = 100 - (
+            100 / (1 + avg_gain / avg_loss)
+        )
+        expected = expected.fillna(50)
+
+        actual = calculate_wilder_rsi(closes, period)
+
+        pd.testing.assert_series_equal(actual, expected)
+        self.assertAlmostEqual(actual.iloc[-1], 72.23735318958683)
+
+        sma_avg_gain = gain.rolling(window=period).mean()
+        sma_avg_loss = loss.rolling(window=period).mean()
+        sma_rsi = (100 - (100 / (1 + sma_avg_gain / sma_avg_loss))).fillna(50)
+        self.assertGreater(abs(actual.iloc[-1] - sma_rsi.iloc[-1]), 1.0)
+
+        report_df = StockTrendAnalyzer()._calculate_rsi(pd.DataFrame({"close": closes}))
+        self.assertAlmostEqual(report_df["RSI_12"].iloc[-1], actual.iloc[-1])
+        self.assertIn("RSI_6", report_df)
+        self.assertIn("RSI_24", report_df)
 
 
 if __name__ == "__main__":

--- a/tests/test_alerts_docs.py
+++ b/tests/test_alerts_docs.py
@@ -177,3 +177,18 @@ def test_alerts_doc_defines_p4_notification_and_cooldown_scope() -> None:
         "最小回滚方式是 revert P4 PR",
     ):
         assert token in doc
+
+
+def test_alerts_doc_documents_rsi_wilder_smoothing() -> None:
+    doc = _read_doc()
+
+    for token in (
+        "## 技术指标口径",
+        "RSI",
+        "Wilder's EMA/SMMA",
+        "alpha=1/period",
+        "adjust=False",
+        "RSI_6 / RSI_12 / RSI_24",
+        "rsi_threshold",
+    ):
+        assert token in doc


### PR DESCRIPTION
## PR Type
- [x] fix
- [ ] feat
- [ ] refactor
- [ ] docs
- [ ] chore
- [ ] test

## Background And Problem
- 当前问题：将报告和告警中的 RSI 计算统一为 Wilder's EMA/SMMA 口径，并补齐测试与用户可见说明。
- 影响范围：本次改动涉及 6 个文件，Diff 为 `+118 / -26`。
- 触发来源：Issue 自动执行（Issue #1341）。

## Scope Of Change
- `docs/CHANGELOG.md`
- `docs/alerts.md`
- `src/services/alert_indicators.py`
- `src/stock_analyzer.py`
- `tests/test_alert_worker.py`
- `tests/test_alerts_docs.py`

## Documentation And Changelog
- 已同步更新文档/变更记录：`docs/CHANGELOG.md`, `docs/alerts.md`。

## Issue Link
Closes #1341

## Verification Commands And Results
```bash
./scripts/ci_gate.sh flake8
./scripts/ci_gate.sh offline-tests
```

关键输出/结论 / Key output & conclusion:
- lint:PASS, test:PASS

## Compatibility And Risk
- **Medium**：涉及 `docs/CHANGELOG.md`, `docs/alerts.md`, `src/services/alert_indicators.py`, `src/stock_analyzer.py`, `tests/test_alert_worker.py`, `tests/test_alerts_docs.py`，建议按文件范围复核。
- 前提假设：
  - 当前维护者若决定处理该 issue，应按 issue 建议同步修改分析报告和告警评估两处 RSI 计算，避免口径再次分裂。
  - 该变更会改变用户可见 RSI_6、RSI_12、RSI_24 数值以及 rsi_threshold 告警触发时机，但不涉及 API 字段、配置项、数据库迁移、workflow、secrets 或部署流程。
  - docs/alerts.md 需要补充 RSI 计算公式；如项目要求用户可见行为变化记录，也应更新 docs/CHANGELOG.md 的 [Unreleased] 扁平条目。

## Rollback Plan
- `git revert <merge-commit>` 回滚本 PR 提交，重点确认 `docs/CHANGELOG.md`, `docs/alerts.md`, `src/services/alert_indicators.py`, `src/stock_analyzer.py` 恢复正常。

## Acceptance Criteria
- src/stock_analyzer.py 中 RSI_6/RSI_12/RSI_24 使用 alpha=1/period、adjust=False 的 Wilder's EMA 方式计算平均涨跌幅。
- src/services/alert_indicators.py 中告警 RSI 计算使用同一 Wilder's EMA 口径。
- 报告 RSI 与告警 RSI 在相同输入和周期下保持一致。
- 更新 tests/test_alert_worker.py 中 RSI 相关 golden 断言，必要时补充一个确定性样本验证 Wilder's EMA 数值。
- docs/alerts.md 明确标注 RSI 使用 Wilder's EMA/SMMA 公式，便于用户与 TradingView、券商软件交叉验证。

## Checklist
- [x] 本 PR 有明确动机和业务价值 / This PR has a clear motivation and value
- [x] 已提供可复现的验证命令与结果 / Reproducible verification commands and results are included
- [x] 已评估兼容性与风险 / Compatibility and risk have been assessed
- [x] 已提供回滚方案 / A rollback plan is provided
- [x] 已同步更新相关文档与 `docs/CHANGELOG.md`，并在 PR 描述中说明文档落点 / Relevant docs and `docs/CHANGELOG.md` are updated, and the documentation location is stated in this PR