### PR TITLE
Refactor: isolate MiMo fallback pricing hook and complete #1282 fix

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -232,6 +232,7 @@ GEMINI_API_KEY=
 # LLM_MIMO_API_KEY=sk-xxx
 # LLM_MIMO_MODELS=mimo-xxx
 # LITELLM_MODEL=openai/mimo-xxx
+# 注：仓库默认 daily_analysis workflow 未显式透传 LLM_MIMO_*，该示例默认适用于本地 .env、Docker 或自托管脚本；Actions 使用请同步补齐 workflow 映射。
 #
 # 火山方舟 / 豆包（OpenAI Compatible，按实际开通地域调整 endpoint）
 # 来源：火山方舟在线推理 / Responses API 文档 https://www.volcengine.com/docs/82379/2121998

--- a/.env.example
+++ b/.env.example
@@ -224,6 +224,15 @@ GEMINI_API_KEY=
 # LLM_MINIMAX_MODELS=MiniMax-M2.7,MiniMax-M2.7-highspeed
 # LITELLM_MODEL=openai/MiniMax-M2.7
 #
+# 小米 MiMo（OpenAI Compatible）
+# Base URL 与模型名请以 MiMo 官方文档/控制台为准。
+# LLM_CHANNELS=mimo
+# LLM_MIMO_PROTOCOL=openai
+# LLM_MIMO_BASE_URL=
+# LLM_MIMO_API_KEY=sk-xxx
+# LLM_MIMO_MODELS=mimo-xxx
+# LITELLM_MODEL=openai/mimo-xxx
+#
 # 火山方舟 / 豆包（OpenAI Compatible，按实际开通地域调整 endpoint）
 # 来源：火山方舟在线推理 / Responses API 文档 https://www.volcengine.com/docs/82379/2121998
 # LiteLLM 通过 openai/<model> 路由到兼容 Chat Completions 的 Base URL。

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -35,6 +35,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - [修复] 持仓快照实时行情重算：当日快照先按实时行情重算估值并回传价格元数据，实时价缺失时退回收盘价/历史快照，避免 stale 价格污染市值与未实现盈亏。
 - [修复] 为 OpenAI-compatible 渠道补充 MiMo / LiteLLM fallback pricing 注册路径：在 Tool / Analyzer / 系统配置联调测试路径复用 `register_fallback_model_pricing`，避免未知模型因缺失计费信息导致调用失败。
 - [文档] 同步说明 fallback pricing 注册与 MiniMax / 小米 MiMo 兼容配置边界，补充相关 provider 示例与回退触发条件，限定为本次 #1282 修复范围内更新。
+- [新功能] Web 首页历史报告区新增重新分析入口，支持基于原始 prompt 重做同一只股票同日期的分析
+- [新功能] Web 首页与设置页新增首次启动最小配置引导：展示基础配置缺口、支持测试当前 LLM、快速保存 1-3 只试跑股票，并执行不产出正式报告的 dry-run 验证
+- [修复] 系统设置接口默认对敏感配置值返回掩码，并在 LLM 测试 / 模型发现错误中自动清理 API Key 等敏感信息
+- [新功能] Windows/macOS 桌面端新增 GitHub Release 更新提醒，启动后自动检测新版本并支持从设置页手动检查后跳转下载页
+- [修复] Pipeline Agent 5 个 K 线工具（get_daily_history / analyze_trend / calculate_ma / get_volume_analysis / analyze_pattern）改为 DB-first 加载，消除同一只股票 9x5=45 次重复 HTTP 请求 (Fixes #1066)
+- [修复] Pipeline Agent 执行前按需预热 240 天 K 线历史到 DB，正常情况下 K 线工具调用无需重复网络请求
+- [修复] 冻结 target_date 通过 ContextVar 透传到 Pipeline Agent K 线工具线程，消除跨收盘边界时间漂移
+- [修复] 修复 Windows 桌面端转抄后端 stdout/stderr 时中文日志可能乱码的问题，统一优先使用 UTF-8 并兼容本地代码页回退
+- [改进] Docker 发布工作流收敛为更清晰的正式发布与手动补发链路，并统一官方 Docker Hub 镜像名为 `zhulinsen/daily_stock_analysis`
+- [文档] 补充官方镜像拉取、`docker run` 用法与 `.env` / 数据目录映射说明，不再仅覆盖 Compose 部署路径
+- [改进] Agent 日线工具优先复用本地缓存，并持久化新获取的日线与新闻情报
+- [修复] GitHub Actions 每日分析工作流补齐 `LLM_CHANNELS`、多 Key 与常用 `LLM_<NAME>_*` 渠道变量透传，避免本地可用的多模型配置在云端定时任务中失效（Fixes #1063, #872）
+- [文档] 修正 `feishu_sender.py` 中飞书自定义机器人 Webhook 消息格式示例为 interactive card JSON，并补充飞书自动化 Webhook 触发器配置教程（参数 JSON 与 `card.elements[0].text.content` 字段映射）。
+- [修复] 历史报告详情接口修正 `change_pct` 取值：使用 `is None` 判断避免把 0.0（平盘）当作缺失值丢弃，移除错误的 `change_60d` 兜底，并在 `enhanced_context.realtime` 缺涨跌幅时回退到 `realtime_quote_raw.change_pct` / `pct_chg`，避免历史详情页“不显示涨跌幅” (Fixes #1084)
+- [修复] DeepSeek 官方渠道预设与示例配置同步到 V4，保留 legacy `deepseek-chat` 默认值并增加废弃提示，同时修正模型发现后旧运行时选择导致保存失败的问题 (Fixes #1108, #1109)
+- [文档] 优化根 README 结构，保留功能特性、技术栈、快速开始、推送效果、Web、Agent、赞助商和新闻源链接入口，将细配置、交易纪律和基本面语义收口到完整指南，并将 Docker 徽章指向官方镜像页
+- [文档] 同步英文与繁中 README 的精简入口结构，并补齐完整指南中的 LLM 用量 API 与持仓管理说明
+- [文档] 调整 AI 协作与 PR 模板中的 README 维护规则，明确 README 非必要不更新，细节优先进入专题文档
 
 ## [3.17.1] - 2026-05-16
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -34,6 +34,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - [改进] 大盘复盘近三日市场线索改为标题与来源链接列表，移除摘要片段，降低中英混排和误读风险。
 - [修复] 为 OpenAI-compatible 渠道补充 MiMo / LiteLLM fallback pricing 注册路径：在 Tool / Analyzer / 系统配置联调测试路径复用 `register_fallback_model_pricing`，避免未知模型因缺失计费信息导致调用失败。
 - [文档] 同步说明 fallback pricing 注册与 MiniMax / 小米 MiMo 兼容配置边界，补充相关 provider 示例与回退触发条件，限定为本次 #1282 修复范围内更新。
+- [新功能] 通知网关新增 ntfy 一等渠道，支持通过 `NTFY_URL` / `NTFY_TOKEN` 推送并接入 Web 测试、路由、Actions 与诊断。
+- [新功能] 通知网关新增 Gotify 一等渠道，支持通过 `GOTIFY_URL` / `GOTIFY_TOKEN` 推送 Markdown 文本并接入 Web 测试、路由、Actions 与诊断。
+- [修复] 收紧 ntfy 结构化校验，避免 URL 编码空白 topic 被误判为有效通知端点。
+- [文档] 补充 Bark custom webhook 示例和 WebPush / Apprise 通知渠道评估，明确本轮不新增运行时依赖或配置入口。
+- [文档] 收口通知专题场景文档，并为 GitHub Actions 通知 env 对照表加入自动化校验。
+- [修复] 聚合报告通知按静态渠道隔离发送失败，并补充自定义 Webhook 部分成功诊断与脱敏测试。
+- [修复] 未配置 Tushare / Longbridge 凭据时不再实例化对应可选 fetcher，避免缺失凭据的数据源进入候选集。
+- [修复] Longbridge 遇到连接关闭类异常后会进入冷却期，并在美股/港股实时与日线请求中临时跳过该数据源，避免请求级频繁重连。
+- [修复] Pytdx 股票名称查询在全部服务器不可达时会短暂冷却，并在冷却期内跳过重复探测，减少无效拨号与告警噪音。
+- [修复] 调度模式未显式设置 `SCHEDULE_RUN_IMMEDIATELY` 时，会继续继承 `RUN_IMMEDIATELY` 的运行时覆盖语义，避免被持久化 `.env` 别名反向覆盖。
+- [文档] 补充 Longbridge 冷却开关与调度启动兼容语义说明。
+- [新功能] Windows 桌面安装版接入 electron-updater，发现新版本后可后台下载并在用户确认后重启安装；Release 工作流同步上传自动更新所需元数据。
+- [测试] 完善桌面端更新链路验收说明：补充 `apps/dsa-desktop` 与打包产物元数据的本地验证步骤（Web 构建、桌面测试/构建、`latest.yml` 与 `*.blockmap` 检查），并明确 Windows/NSIS 部分需在 Windows 发布链路复核。
+- [测试] 补充 `docs/desktop-package.md` 对 Windows NSIS 与 `desktop-release` 链路的发布级复核要求：注明 Linux 环境不能直接产出 Windows 安装器，要求在 Windows 环境补齐 `latest.yml`/`*.blockmap` 与 installer 的版本一致性与附件核对。
+- [文档] 强化桌面打包文档：补充 `latest.yml` / `*.blockmap` 与 `desktop-release` tag/version 一致性核验清单，明确非 Windows 环境下需在平台限制里补充说明。
+- [修复] 为 Windows NSIS 安装版自动更新加入安装目录运行时文件（`.env`、`data/stock_analysis.db`、`data/stock_analysis.db-wal`、`data/stock_analysis.db-shm`、`logs/desktop.log`）备份与首次启动恢复链路，并在 `quitAndInstall` 前等待后端退出，降低升级时配置与数据库丢失风险。
+- [修复] Windows NSIS 自动更新在运行时文件部分恢复失败时只保留失败项待重试，避免已恢复成功的配置或数据库文件在后续启动时被旧备份重复覆盖。
+- [修复] Windows NSIS 自动更新在安装尝试未切换桌面端版本时跳过自动恢复，避免失败或取消安装后误回滚用户运行时数据。
+- [修复] 同版本启动时清理未生效的自动更新备份目录，避免后续升级误将旧 `.dsa-desktop-update-backup/runtime-state.json` 的运行时文件再次恢复到新版本。
+- [修复] 清理提交中的临时探测文件（`node_modules_exists.txt` 与 `node_modules_ls_check.txt`），避免污染桌面/前端改动范围。
+- [新功能] Web 系统设置页开放 `.env` 配置备份导入/导出，复用键级覆盖、配置版本冲突保护和重载链路；Web 端在 `ADMIN_AUTH_ENABLED=false` 时该入口为禁用状态。
+- [chore] 精简仓库根目录：将文档图片资源迁入 `docs/assets/`，将东方财富请求补丁迁入 `src/patches/`，并下移 CI 专用依赖文件与技能适配服务。
+- [文档] 更新多语言 README 首页浅色工作台 GIF，并精简功能特性表，保留原有赞助商、快速开始和推送效果结构。
+- [新功能] 通知网关新增默认关闭的进程内降噪配置，支持去重、冷却、静默时段和最低严重级别，并将每日摘要开关标记为预留能力。
+- [文档] 恢复多语言 README 新闻源配置表中推荐项的加粗样式，统一相关项目章节层级，并精简顶部导航、联系文案和尾部展示。
+- [修复] Docker 挂载的 `logs` 目录不可写时启动日志自动降级到控制台输出，并补充非 root 容器目录权限说明。
+- [修复] 修正分析报告 API 构建策略点位时数值字段未归一为字符串的问题，避免策略价格触发响应 DTO 类型校验失败。
+- [修复] Docker 启动入口自动修复 `data` / `logs` / `reports` 挂载目录权限并降权运行，文档化的 Compose `exec` 手动命令显式使用 `dsa` 用户，避免普通部署需要手动 `chown` / `chmod`。
+- [修复] Web 首页大盘复盘结果改由主内容滚动区承载，避免 loading 切换到长结果后下方报告区域被截断或无法继续滚动。
+- [修复] 为 OpenAI-compatible 未知模型注册兜底计费信息，避免 cost 计算异常影响返回正文，并补充 MiMo 渠道示例配置。
 
 ## [3.17.1] - 2026-05-16
 
@@ -71,36 +101,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - fix: Cool down unavailable optional fetchers, reduce noisy Longbridge/Pytdx retries, and downgrade buy advice when capital flow data is missing.
 - fix: Handle OpenAI-compatible `content_blocks`, normalize strategy price fields, and recover market review scrolling/history behavior.
 - docs/tests: Update notification, alert, desktop packaging, README/guide, and governance docs; add focused regression coverage for the new release paths.
-- [新功能] 通知网关新增 ntfy 一等渠道，支持通过 `NTFY_URL` / `NTFY_TOKEN` 推送并接入 Web 测试、路由、Actions 与诊断。
-- [新功能] 通知网关新增 Gotify 一等渠道，支持通过 `GOTIFY_URL` / `GOTIFY_TOKEN` 推送 Markdown 文本并接入 Web 测试、路由、Actions 与诊断。
-- [修复] 收紧 ntfy 结构化校验，避免 URL 编码空白 topic 被误判为有效通知端点。
-- [文档] 补充 Bark custom webhook 示例和 WebPush / Apprise 通知渠道评估，明确本轮不新增运行时依赖或配置入口。
-- [文档] 收口通知专题场景文档，并为 GitHub Actions 通知 env 对照表加入自动化校验。
-- [修复] 聚合报告通知按静态渠道隔离发送失败，并补充自定义 Webhook 部分成功诊断与脱敏测试。
-- [修复] 未配置 Tushare / Longbridge 凭据时不再实例化对应可选 fetcher，避免缺失凭据的数据源进入候选集。
-- [修复] Longbridge 遇到连接关闭类异常后会进入冷却期，并在美股/港股实时与日线请求中临时跳过该数据源，避免请求级频繁重连。
-- [修复] Pytdx 股票名称查询在全部服务器不可达时会短暂冷却，并在冷却期内跳过重复探测，减少无效拨号与告警噪音。
-- [修复] 调度模式未显式设置 `SCHEDULE_RUN_IMMEDIATELY` 时，会继续继承 `RUN_IMMEDIATELY` 的运行时覆盖语义，避免被持久化 `.env` 别名反向覆盖。
-- [文档] 补充 Longbridge 冷却开关与调度启动兼容语义说明。
-- [新功能] Windows 桌面安装版接入 electron-updater，发现新版本后可后台下载并在用户确认后重启安装；Release 工作流同步上传自动更新所需元数据。
-- [测试] 完善桌面端更新链路验收说明：补充 `apps/dsa-desktop` 与打包产物元数据的本地验证步骤（Web 构建、桌面测试/构建、`latest.yml` 与 `*.blockmap` 检查），并明确 Windows/NSIS 部分需在 Windows 发布链路复核。
-- [测试] 补充 `docs/desktop-package.md` 对 Windows NSIS 与 `desktop-release` 链路的发布级复核要求：注明 Linux 环境不能直接产出 Windows 安装器，要求在 Windows 环境补齐 `latest.yml`/`*.blockmap` 与 installer 的版本一致性与附件核对。
-- [文档] 强化桌面打包文档：补充 `latest.yml` / `*.blockmap` 与 `desktop-release` tag/version 一致性核验清单，明确非 Windows 环境下需在平台限制里补充说明。
-- [修复] 为 Windows NSIS 安装版自动更新加入安装目录运行时文件（`.env`、`data/stock_analysis.db`、`data/stock_analysis.db-wal`、`data/stock_analysis.db-shm`、`logs/desktop.log`）备份与首次启动恢复链路，并在 `quitAndInstall` 前等待后端退出，降低升级时配置与数据库丢失风险。
-- [修复] Windows NSIS 自动更新在运行时文件部分恢复失败时只保留失败项待重试，避免已恢复成功的配置或数据库文件在后续启动时被旧备份重复覆盖。
-- [修复] Windows NSIS 自动更新在安装尝试未切换桌面端版本时跳过自动恢复，避免失败或取消安装后误回滚用户运行时数据。
-- [修复] 同版本启动时清理未生效的自动更新备份目录，避免后续升级误将旧 `.dsa-desktop-update-backup/runtime-state.json` 的运行时文件再次恢复到新版本。
-- [修复] 清理提交中的临时探测文件（`node_modules_exists.txt` 与 `node_modules_ls_check.txt`），避免污染桌面/前端改动范围。
-- [新功能] Web 系统设置页开放 `.env` 配置备份导入/导出，复用键级覆盖、配置版本冲突保护和重载链路；Web 端在 `ADMIN_AUTH_ENABLED=false` 时该入口为禁用状态。
-- [chore] 精简仓库根目录：将文档图片资源迁入 `docs/assets/`，将东方财富请求补丁迁入 `src/patches/`，并下移 CI 专用依赖文件与技能适配服务。
-- [文档] 更新多语言 README 首页浅色工作台 GIF，并精简功能特性表，保留原有赞助商、快速开始和推送效果结构。
-- [新功能] 通知网关新增默认关闭的进程内降噪配置，支持去重、冷却、静默时段和最低严重级别，并将每日摘要开关标记为预留能力。
-- [文档] 恢复多语言 README 新闻源配置表中推荐项的加粗样式，统一相关项目章节层级，并精简顶部导航、联系文案和尾部展示。
-- [修复] Docker 挂载的 `logs` 目录不可写时启动日志自动降级到控制台输出，并补充非 root 容器目录权限说明。
-- [修复] 修正分析报告 API 构建策略点位时数值字段未归一为字符串的问题，避免策略价格触发响应 DTO 类型校验失败。
-- [修复] Docker 启动入口自动修复 `data` / `logs` / `reports` 挂载目录权限并降权运行，文档化的 Compose `exec` 手动命令显式使用 `dsa` 用户，避免普通部署需要手动 `chown` / `chmod`。
-- [修复] Web 首页大盘复盘结果改由主内容滚动区承载，避免 loading 切换到长结果后下方报告区域被截断或无法继续滚动。
-- [修复] 为 OpenAI-compatible 未知模型注册兜底计费信息，避免 cost 计算异常影响返回正文，并补充 MiMo 渠道示例配置。
 
 ## [3.16.0] - 2026-05-10
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -32,8 +32,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - [改进] 将 RSI 计算口径从 SMA 调整为 Wilder's EMA / SMMA，统一分析报告与告警阈值口径。
 - [改进] 大盘复盘将红绿灯与盘面温度合并为终端友好的盘面信号分数，移除色块进度条与重复温度行。
 - [改进] 大盘复盘近三日市场线索改为标题与来源链接列表，移除摘要片段，降低中英混排和误读风险。
+- [修复] 持仓快照实时行情重算：当日快照先按实时行情重算估值并回传价格元数据，实时价缺失时退回收盘价/历史快照，避免 stale 价格污染市值与未实现盈亏。
 - [修复] 为 OpenAI-compatible 渠道补充 MiMo / LiteLLM fallback pricing 注册路径：在 Tool / Analyzer / 系统配置联调测试路径复用 `register_fallback_model_pricing`，避免未知模型因缺失计费信息导致调用失败。
 - [文档] 同步说明 fallback pricing 注册与 MiniMax / 小米 MiMo 兼容配置边界，补充相关 provider 示例与回退触发条件，限定为本次 #1282 修复范围内更新。
+- [新功能] 告警中心 P5 技术指标规则：扩展 Alert API 与告警中心，新增 MA / RSI / MACD / KDJ / CCI 等日线技术指标告警能力，并沿用 P2-P4 的触发历史与通知冷却链路。
 
 ## [3.17.1] - 2026-05-16
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -32,6 +32,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - [改进] 将 RSI 计算口径从 SMA 调整为 Wilder's EMA / SMMA，统一分析报告与告警阈值口径。
 - [改进] 大盘复盘将红绿灯与盘面温度合并为终端友好的盘面信号分数，移除色块进度条与重复温度行。
 - [改进] 大盘复盘近三日市场线索改为标题与来源链接列表，移除摘要片段，降低中英混排和误读风险。
+- [修复] 为 OpenAI-compatible 渠道补充 MiMo / LiteLLM fallback pricing 注册路径：在 Tool / Analyzer / 系统配置联调测试路径复用 `register_fallback_model_pricing`，避免未知模型因缺失计费信息导致调用失败。
+- [文档] 同步说明 fallback pricing 注册与 MiniMax / 小米 MiMo 兼容配置边界，补充相关 provider 示例与回退触发条件，限定为本次 #1282 修复范围内更新。
 
 ## [3.17.1] - 2026-05-16
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -35,24 +35,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - [修复] 持仓快照实时行情重算：当日快照先按实时行情重算估值并回传价格元数据，实时价缺失时退回收盘价/历史快照，避免 stale 价格污染市值与未实现盈亏。
 - [修复] 为 OpenAI-compatible 渠道补充 MiMo / LiteLLM fallback pricing 注册路径：在 Tool / Analyzer / 系统配置联调测试路径复用 `register_fallback_model_pricing`，避免未知模型因缺失计费信息导致调用失败。
 - [文档] 同步说明 fallback pricing 注册与 MiniMax / 小米 MiMo 兼容配置边界，补充相关 provider 示例与回退触发条件，限定为本次 #1282 修复范围内更新。
-- [新功能] Web 首页历史报告区新增重新分析入口，支持基于原始 prompt 重做同一只股票同日期的分析
-- [新功能] Web 首页与设置页新增首次启动最小配置引导：展示基础配置缺口、支持测试当前 LLM、快速保存 1-3 只试跑股票，并执行不产出正式报告的 dry-run 验证
-- [修复] 系统设置接口默认对敏感配置值返回掩码，并在 LLM 测试 / 模型发现错误中自动清理 API Key 等敏感信息
-- [新功能] Windows/macOS 桌面端新增 GitHub Release 更新提醒，启动后自动检测新版本并支持从设置页手动检查后跳转下载页
-- [修复] Pipeline Agent 5 个 K 线工具（get_daily_history / analyze_trend / calculate_ma / get_volume_analysis / analyze_pattern）改为 DB-first 加载，消除同一只股票 9x5=45 次重复 HTTP 请求 (Fixes #1066)
-- [修复] Pipeline Agent 执行前按需预热 240 天 K 线历史到 DB，正常情况下 K 线工具调用无需重复网络请求
-- [修复] 冻结 target_date 通过 ContextVar 透传到 Pipeline Agent K 线工具线程，消除跨收盘边界时间漂移
-- [修复] 修复 Windows 桌面端转抄后端 stdout/stderr 时中文日志可能乱码的问题，统一优先使用 UTF-8 并兼容本地代码页回退
-- [改进] Docker 发布工作流收敛为更清晰的正式发布与手动补发链路，并统一官方 Docker Hub 镜像名为 `zhulinsen/daily_stock_analysis`
-- [文档] 补充官方镜像拉取、`docker run` 用法与 `.env` / 数据目录映射说明，不再仅覆盖 Compose 部署路径
-- [改进] Agent 日线工具优先复用本地缓存，并持久化新获取的日线与新闻情报
-- [修复] GitHub Actions 每日分析工作流补齐 `LLM_CHANNELS`、多 Key 与常用 `LLM_<NAME>_*` 渠道变量透传，避免本地可用的多模型配置在云端定时任务中失效（Fixes #1063, #872）
-- [文档] 修正 `feishu_sender.py` 中飞书自定义机器人 Webhook 消息格式示例为 interactive card JSON，并补充飞书自动化 Webhook 触发器配置教程（参数 JSON 与 `card.elements[0].text.content` 字段映射）。
-- [修复] 历史报告详情接口修正 `change_pct` 取值：使用 `is None` 判断避免把 0.0（平盘）当作缺失值丢弃，移除错误的 `change_60d` 兜底，并在 `enhanced_context.realtime` 缺涨跌幅时回退到 `realtime_quote_raw.change_pct` / `pct_chg`，避免历史详情页“不显示涨跌幅” (Fixes #1084)
-- [修复] DeepSeek 官方渠道预设与示例配置同步到 V4，保留 legacy `deepseek-chat` 默认值并增加废弃提示，同时修正模型发现后旧运行时选择导致保存失败的问题 (Fixes #1108, #1109)
-- [文档] 优化根 README 结构，保留功能特性、技术栈、快速开始、推送效果、Web、Agent、赞助商和新闻源链接入口，将细配置、交易纪律和基本面语义收口到完整指南，并将 Docker 徽章指向官方镜像页
-- [文档] 同步英文与繁中 README 的精简入口结构，并补齐完整指南中的 LLM 用量 API 与持仓管理说明
-- [文档] 调整 AI 协作与 PR 模板中的 README 维护规则，明确 README 非必要不更新，细节优先进入专题文档
 
 ## [3.17.1] - 2026-05-16
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -69,6 +69,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - fix: Cool down unavailable optional fetchers, reduce noisy Longbridge/Pytdx retries, and downgrade buy advice when capital flow data is missing.
 - fix: Handle OpenAI-compatible `content_blocks`, normalize strategy price fields, and recover market review scrolling/history behavior.
 - docs/tests: Update notification, alert, desktop packaging, README/guide, and governance docs; add focused regression coverage for the new release paths.
+- [新功能] 通知网关新增 ntfy 一等渠道，支持通过 `NTFY_URL` / `NTFY_TOKEN` 推送并接入 Web 测试、路由、Actions 与诊断。
+- [新功能] 通知网关新增 Gotify 一等渠道，支持通过 `GOTIFY_URL` / `GOTIFY_TOKEN` 推送 Markdown 文本并接入 Web 测试、路由、Actions 与诊断。
+- [修复] 收紧 ntfy 结构化校验，避免 URL 编码空白 topic 被误判为有效通知端点。
+- [文档] 补充 Bark custom webhook 示例和 WebPush / Apprise 通知渠道评估，明确本轮不新增运行时依赖或配置入口。
+- [文档] 收口通知专题场景文档，并为 GitHub Actions 通知 env 对照表加入自动化校验。
+- [修复] 聚合报告通知按静态渠道隔离发送失败，并补充自定义 Webhook 部分成功诊断与脱敏测试。
+- [修复] 未配置 Tushare / Longbridge 凭据时不再实例化对应可选 fetcher，避免缺失凭据的数据源进入候选集。
+- [修复] Longbridge 遇到连接关闭类异常后会进入冷却期，并在美股/港股实时与日线请求中临时跳过该数据源，避免请求级频繁重连。
+- [修复] Pytdx 股票名称查询在全部服务器不可达时会短暂冷却，并在冷却期内跳过重复探测，减少无效拨号与告警噪音。
+- [修复] 调度模式未显式设置 `SCHEDULE_RUN_IMMEDIATELY` 时，会继续继承 `RUN_IMMEDIATELY` 的运行时覆盖语义，避免被持久化 `.env` 别名反向覆盖。
+- [文档] 补充 Longbridge 冷却开关与调度启动兼容语义说明。
+- [新功能] Windows 桌面安装版接入 electron-updater，发现新版本后可后台下载并在用户确认后重启安装；Release 工作流同步上传自动更新所需元数据。
+- [测试] 完善桌面端更新链路验收说明：补充 `apps/dsa-desktop` 与打包产物元数据的本地验证步骤（Web 构建、桌面测试/构建、`latest.yml` 与 `*.blockmap` 检查），并明确 Windows/NSIS 部分需在 Windows 发布链路复核。
+- [测试] 补充 `docs/desktop-package.md` 对 Windows NSIS 与 `desktop-release` 链路的发布级复核要求：注明 Linux 环境不能直接产出 Windows 安装器，要求在 Windows 环境补齐 `latest.yml`/`*.blockmap` 与 installer 的版本一致性与附件核对。
+- [文档] 强化桌面打包文档：补充 `latest.yml` / `*.blockmap` 与 `desktop-release` tag/version 一致性核验清单，明确非 Windows 环境下需在平台限制里补充说明。
+- [修复] 为 Windows NSIS 安装版自动更新加入安装目录运行时文件（`.env`、`data/stock_analysis.db`、`data/stock_analysis.db-wal`、`data/stock_analysis.db-shm`、`logs/desktop.log`）备份与首次启动恢复链路，并在 `quitAndInstall` 前等待后端退出，降低升级时配置与数据库丢失风险。
+- [修复] Windows NSIS 自动更新在运行时文件部分恢复失败时只保留失败项待重试，避免已恢复成功的配置或数据库文件在后续启动时被旧备份重复覆盖。
+- [修复] Windows NSIS 自动更新在安装尝试未切换桌面端版本时跳过自动恢复，避免失败或取消安装后误回滚用户运行时数据。
+- [修复] 同版本启动时清理未生效的自动更新备份目录，避免后续升级误将旧 `.dsa-desktop-update-backup/runtime-state.json` 的运行时文件再次恢复到新版本。
+- [修复] 清理提交中的临时探测文件（`node_modules_exists.txt` 与 `node_modules_ls_check.txt`），避免污染桌面/前端改动范围。
+- [新功能] Web 系统设置页开放 `.env` 配置备份导入/导出，复用键级覆盖、配置版本冲突保护和重载链路；Web 端在 `ADMIN_AUTH_ENABLED=false` 时该入口为禁用状态。
+- [chore] 精简仓库根目录：将文档图片资源迁入 `docs/assets/`，将东方财富请求补丁迁入 `src/patches/`，并下移 CI 专用依赖文件与技能适配服务。
+- [文档] 更新多语言 README 首页浅色工作台 GIF，并精简功能特性表，保留原有赞助商、快速开始和推送效果结构。
+- [新功能] 通知网关新增默认关闭的进程内降噪配置，支持去重、冷却、静默时段和最低严重级别，并将每日摘要开关标记为预留能力。
+- [文档] 恢复多语言 README 新闻源配置表中推荐项的加粗样式，统一相关项目章节层级，并精简顶部导航、联系文案和尾部展示。
+- [修复] Docker 挂载的 `logs` 目录不可写时启动日志自动降级到控制台输出，并补充非 root 容器目录权限说明。
+- [修复] 修正分析报告 API 构建策略点位时数值字段未归一为字符串的问题，避免策略价格触发响应 DTO 类型校验失败。
+- [修复] Docker 启动入口自动修复 `data` / `logs` / `reports` 挂载目录权限并降权运行，文档化的 Compose `exec` 手动命令显式使用 `dsa` 用户，避免普通部署需要手动 `chown` / `chmod`。
+- [修复] Web 首页大盘复盘结果改由主内容滚动区承载，避免 loading 切换到长结果后下方报告区域被截断或无法继续滚动。
+- [修复] 为 OpenAI-compatible 未知模型注册兜底计费信息，避免 cost 计算异常影响返回正文，并补充 MiMo 渠道示例配置。
 
 ## [3.16.0] - 2026-05-10
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -32,7 +32,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - [改进] 将 RSI 计算口径从 SMA 调整为 Wilder's EMA / SMMA，统一分析报告与告警阈值口径。
 - [改进] 大盘复盘将红绿灯与盘面温度合并为终端友好的盘面信号分数，移除色块进度条与重复温度行。
 - [改进] 大盘复盘近三日市场线索改为标题与来源链接列表，移除摘要片段，降低中英混排和误读风险。
-- [修复] 持仓快照实时行情重算：当日快照先按实时行情重算估值并回传价格元数据，实时价缺失时退回收盘价/历史快照，避免 stale 价格污染市值与未实现盈亏。
 - [修复] 为 OpenAI-compatible 渠道补充 MiMo / LiteLLM fallback pricing 注册路径：在 Tool / Analyzer / 系统配置联调测试路径复用 `register_fallback_model_pricing`，避免未知模型因缺失计费信息导致调用失败。
 - [文档] 同步说明 fallback pricing 注册与 MiniMax / 小米 MiMo 兼容配置边界，补充相关 provider 示例与回退触发条件，限定为本次 #1282 修复范围内更新。
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -34,36 +34,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - [改进] 大盘复盘近三日市场线索改为标题与来源链接列表，移除摘要片段，降低中英混排和误读风险。
 - [修复] 为 OpenAI-compatible 渠道补充 MiMo / LiteLLM fallback pricing 注册路径：在 Tool / Analyzer / 系统配置联调测试路径复用 `register_fallback_model_pricing`，避免未知模型因缺失计费信息导致调用失败。
 - [文档] 同步说明 fallback pricing 注册与 MiniMax / 小米 MiMo 兼容配置边界，补充相关 provider 示例与回退触发条件，限定为本次 #1282 修复范围内更新。
-- [新功能] 通知网关新增 ntfy 一等渠道，支持通过 `NTFY_URL` / `NTFY_TOKEN` 推送并接入 Web 测试、路由、Actions 与诊断。
-- [新功能] 通知网关新增 Gotify 一等渠道，支持通过 `GOTIFY_URL` / `GOTIFY_TOKEN` 推送 Markdown 文本并接入 Web 测试、路由、Actions 与诊断。
-- [修复] 收紧 ntfy 结构化校验，避免 URL 编码空白 topic 被误判为有效通知端点。
-- [文档] 补充 Bark custom webhook 示例和 WebPush / Apprise 通知渠道评估，明确本轮不新增运行时依赖或配置入口。
-- [文档] 收口通知专题场景文档，并为 GitHub Actions 通知 env 对照表加入自动化校验。
-- [修复] 聚合报告通知按静态渠道隔离发送失败，并补充自定义 Webhook 部分成功诊断与脱敏测试。
-- [修复] 未配置 Tushare / Longbridge 凭据时不再实例化对应可选 fetcher，避免缺失凭据的数据源进入候选集。
-- [修复] Longbridge 遇到连接关闭类异常后会进入冷却期，并在美股/港股实时与日线请求中临时跳过该数据源，避免请求级频繁重连。
-- [修复] Pytdx 股票名称查询在全部服务器不可达时会短暂冷却，并在冷却期内跳过重复探测，减少无效拨号与告警噪音。
-- [修复] 调度模式未显式设置 `SCHEDULE_RUN_IMMEDIATELY` 时，会继续继承 `RUN_IMMEDIATELY` 的运行时覆盖语义，避免被持久化 `.env` 别名反向覆盖。
-- [文档] 补充 Longbridge 冷却开关与调度启动兼容语义说明。
-- [新功能] Windows 桌面安装版接入 electron-updater，发现新版本后可后台下载并在用户确认后重启安装；Release 工作流同步上传自动更新所需元数据。
-- [测试] 完善桌面端更新链路验收说明：补充 `apps/dsa-desktop` 与打包产物元数据的本地验证步骤（Web 构建、桌面测试/构建、`latest.yml` 与 `*.blockmap` 检查），并明确 Windows/NSIS 部分需在 Windows 发布链路复核。
-- [测试] 补充 `docs/desktop-package.md` 对 Windows NSIS 与 `desktop-release` 链路的发布级复核要求：注明 Linux 环境不能直接产出 Windows 安装器，要求在 Windows 环境补齐 `latest.yml`/`*.blockmap` 与 installer 的版本一致性与附件核对。
-- [文档] 强化桌面打包文档：补充 `latest.yml` / `*.blockmap` 与 `desktop-release` tag/version 一致性核验清单，明确非 Windows 环境下需在平台限制里补充说明。
-- [修复] 为 Windows NSIS 安装版自动更新加入安装目录运行时文件（`.env`、`data/stock_analysis.db`、`data/stock_analysis.db-wal`、`data/stock_analysis.db-shm`、`logs/desktop.log`）备份与首次启动恢复链路，并在 `quitAndInstall` 前等待后端退出，降低升级时配置与数据库丢失风险。
-- [修复] Windows NSIS 自动更新在运行时文件部分恢复失败时只保留失败项待重试，避免已恢复成功的配置或数据库文件在后续启动时被旧备份重复覆盖。
-- [修复] Windows NSIS 自动更新在安装尝试未切换桌面端版本时跳过自动恢复，避免失败或取消安装后误回滚用户运行时数据。
-- [修复] 同版本启动时清理未生效的自动更新备份目录，避免后续升级误将旧 `.dsa-desktop-update-backup/runtime-state.json` 的运行时文件再次恢复到新版本。
-- [修复] 清理提交中的临时探测文件（`node_modules_exists.txt` 与 `node_modules_ls_check.txt`），避免污染桌面/前端改动范围。
-- [新功能] Web 系统设置页开放 `.env` 配置备份导入/导出，复用键级覆盖、配置版本冲突保护和重载链路；Web 端在 `ADMIN_AUTH_ENABLED=false` 时该入口为禁用状态。
-- [chore] 精简仓库根目录：将文档图片资源迁入 `docs/assets/`，将东方财富请求补丁迁入 `src/patches/`，并下移 CI 专用依赖文件与技能适配服务。
-- [文档] 更新多语言 README 首页浅色工作台 GIF，并精简功能特性表，保留原有赞助商、快速开始和推送效果结构。
-- [新功能] 通知网关新增默认关闭的进程内降噪配置，支持去重、冷却、静默时段和最低严重级别，并将每日摘要开关标记为预留能力。
-- [文档] 恢复多语言 README 新闻源配置表中推荐项的加粗样式，统一相关项目章节层级，并精简顶部导航、联系文案和尾部展示。
-- [修复] Docker 挂载的 `logs` 目录不可写时启动日志自动降级到控制台输出，并补充非 root 容器目录权限说明。
-- [修复] 修正分析报告 API 构建策略点位时数值字段未归一为字符串的问题，避免策略价格触发响应 DTO 类型校验失败。
-- [修复] Docker 启动入口自动修复 `data` / `logs` / `reports` 挂载目录权限并降权运行，文档化的 Compose `exec` 手动命令显式使用 `dsa` 用户，避免普通部署需要手动 `chown` / `chmod`。
-- [修复] Web 首页大盘复盘结果改由主内容滚动区承载，避免 loading 切换到长结果后下方报告区域被截断或无法继续滚动。
-- [修复] 为 OpenAI-compatible 未知模型注册兜底计费信息，避免 cost 计算异常影响返回正文，并补充 MiMo 渠道示例配置。
 
 ## [3.17.1] - 2026-05-16
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -35,7 +35,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - [修复] 持仓快照实时行情重算：当日快照先按实时行情重算估值并回传价格元数据，实时价缺失时退回收盘价/历史快照，避免 stale 价格污染市值与未实现盈亏。
 - [修复] 为 OpenAI-compatible 渠道补充 MiMo / LiteLLM fallback pricing 注册路径：在 Tool / Analyzer / 系统配置联调测试路径复用 `register_fallback_model_pricing`，避免未知模型因缺失计费信息导致调用失败。
 - [文档] 同步说明 fallback pricing 注册与 MiniMax / 小米 MiMo 兼容配置边界，补充相关 provider 示例与回退触发条件，限定为本次 #1282 修复范围内更新。
-- [新功能] 告警中心 P5 技术指标规则：扩展 Alert API 与告警中心，新增 MA / RSI / MACD / KDJ / CCI 等日线技术指标告警能力，并沿用 P2-P4 的触发历史与通知冷却链路。
 
 ## [3.17.1] - 2026-05-16
 

--- a/docs/llm-providers.md
+++ b/docs/llm-providers.md
@@ -70,6 +70,7 @@ OpenAI-compatible Base URL 只填到服务商兼容入口，不额外拼接 `/ch
 | 通义千问 / DashScope | `dashscope` | `openai` | `https://dashscope.aliyuncs.com/compatible-mode/v1` | `qwen3.6-plus,qwen3.6-flash` |
 | 智谱 GLM | `zhipu` | `openai` | `https://open.bigmodel.cn/api/paas/v4` | `glm-5.1,glm-4.7-flash` |
 | MiniMax | `minimax` | `openai` | `https://api.minimax.io/v1` | `MiniMax-M2.7,MiniMax-M2.7-highspeed` |
+| 小米 MiMo | `mimo` | `openai` | 官方控制台提供 | 官方文档/控制台为准 |
 | 火山方舟 / 豆包 | `volcengine` | `openai` | `https://ark.cn-beijing.volces.com/api/v3` | `doubao-seed-1-6-251015,doubao-seed-1-6-thinking-251015` |
 | 硅基流动 / SiliconFlow | `siliconflow` | `openai` | `https://api.siliconflow.cn/v1` | `deepseek-ai/DeepSeek-V3.2,Qwen/Qwen3-235B-A22B-Thinking-2507` |
 | OpenRouter | `openrouter` | `openai` | `https://openrouter.ai/api/v1` | `~anthropic/claude-sonnet-latest,~openai/gpt-latest` |
@@ -88,6 +89,7 @@ OpenAI-compatible Base URL 只填到服务商兼容入口，不额外拼接 `/ch
 | 通义千问 / DashScope | [文本生成](https://help.aliyun.com/zh/model-studio/text-generation-model/) | 百炼推荐 `qwen3.6-plus`，确认效果后可用 `qwen3.6-flash` 降低成本。 |
 | 智谱 GLM | [模型概览](https://docs.bigmodel.cn/cn/guide/start/model-overview)、[GLM-5.1](https://docs.bigmodel.cn/cn/guide/models/text/glm-5.1) | `glm-5.1` 是当前旗舰；`glm-4.7-flash` 作为轻量/免费模型示例。 |
 | MiniMax | [OpenAI API 兼容](https://platform.minimax.io/docs/api-reference/text-chat)、[获取模型列表](https://platform.minimax.io/docs/api-reference/models/openai/list-models) | 官方 OpenAI-compatible Base URL 为 `https://api.minimax.io/v1`，并列出 `MiniMax-M2.7`、`MiniMax-M2.7-highspeed`。中国区 Coding 工具场景可能使用 `.com`/Anthropic 专用入口，以控制台为准。 |
+| 小米 MiMo | 官方文档 / 控制台 | 当前按 OpenAI-compatible 方式接入，Base URL、模型名与权限以 MiMo 官方文档/控制台为准。 |
 | 火山方舟 / 豆包 | [在线推理（常规）](https://www.volcengine.com/docs/82379/2121998)、[模型列表](https://www.volcengine.com/docs/82379/1949118) | 官方示例使用 `https://ark.cn-beijing.volces.com/api/v3` 与 `doubao-seed-1-6-251015`；如使用 Coding Plan，请改用其专用 Base URL 和模型名，不要套用本表的在线推理模板。 |
 | SiliconFlow | [模型列表](https://docs.siliconflow.cn/quickstart/models)、[获取模型列表 API](https://docs.siliconflow.cn/cn/api-reference/models/get-model-list) | 平台模型实时更新且 `/models` 需要 API Key；模板只给常见新模型示例，保存前建议在 Web 设置页点击「获取模型」确认账号可见性。 |
 | OpenRouter | [Models API](https://openrouter.ai/docs/api/api-reference/models/get-models) | OpenRouter 支持 `~anthropic/claude-sonnet-latest`、`~openai/gpt-latest` 等 latest router alias；2026-05-03 的一次手动 live smoke 以 Claude Sonnet latest 作为默认示例通过，GPT latest 保留为可按账号权限切换的备选。 |

--- a/docs/llm-providers.md
+++ b/docs/llm-providers.md
@@ -55,6 +55,7 @@ LLM_MY_PROXY_MODELS=gpt-5.5,claude-sonnet-4-6
 ```
 
 OpenAI-compatible Base URL 只填到服务商兼容入口，不额外拼接 `/chat/completions`。本地 `.env`、Docker 和自托管脚本可以直接使用自定义 channel；GitHub Actions 需要 workflow 显式透传同名 `LLM_MY_PROXY_*` 变量。
+小米 MiMo 示例同理：适用于本地 `.env`、Docker 或自托管脚本；若在 GitHub Actions 使用 `LLM_CHANNELS=mimo`，需要在 workflow 中手动补齐 `LLM_MIMO_*` 映射后方可生效。
 
 ## 常用服务商预设
 
@@ -70,7 +71,7 @@ OpenAI-compatible Base URL 只填到服务商兼容入口，不额外拼接 `/ch
 | 通义千问 / DashScope | `dashscope` | `openai` | `https://dashscope.aliyuncs.com/compatible-mode/v1` | `qwen3.6-plus,qwen3.6-flash` |
 | 智谱 GLM | `zhipu` | `openai` | `https://open.bigmodel.cn/api/paas/v4` | `glm-5.1,glm-4.7-flash` |
 | MiniMax | `minimax` | `openai` | `https://api.minimax.io/v1` | `MiniMax-M2.7,MiniMax-M2.7-highspeed` |
-| 小米 MiMo | `mimo` | `openai` | 官方控制台提供 | 官方文档/控制台为准 |
+| 小米 MiMo | `mimo` | `openai` | 官方控制台提供（Actions 默认未映射） | 官方文档/控制台为准 |
 | 火山方舟 / 豆包 | `volcengine` | `openai` | `https://ark.cn-beijing.volces.com/api/v3` | `doubao-seed-1-6-251015,doubao-seed-1-6-thinking-251015` |
 | 硅基流动 / SiliconFlow | `siliconflow` | `openai` | `https://api.siliconflow.cn/v1` | `deepseek-ai/DeepSeek-V3.2,Qwen/Qwen3-235B-A22B-Thinking-2507` |
 | OpenRouter | `openrouter` | `openai` | `https://openrouter.ai/api/v1` | `~anthropic/claude-sonnet-latest,~openai/gpt-latest` |
@@ -89,7 +90,7 @@ OpenAI-compatible Base URL 只填到服务商兼容入口，不额外拼接 `/ch
 | 通义千问 / DashScope | [文本生成](https://help.aliyun.com/zh/model-studio/text-generation-model/) | 百炼推荐 `qwen3.6-plus`，确认效果后可用 `qwen3.6-flash` 降低成本。 |
 | 智谱 GLM | [模型概览](https://docs.bigmodel.cn/cn/guide/start/model-overview)、[GLM-5.1](https://docs.bigmodel.cn/cn/guide/models/text/glm-5.1) | `glm-5.1` 是当前旗舰；`glm-4.7-flash` 作为轻量/免费模型示例。 |
 | MiniMax | [OpenAI API 兼容](https://platform.minimax.io/docs/api-reference/text-chat)、[获取模型列表](https://platform.minimax.io/docs/api-reference/models/openai/list-models) | 官方 OpenAI-compatible Base URL 为 `https://api.minimax.io/v1`，并列出 `MiniMax-M2.7`、`MiniMax-M2.7-highspeed`。中国区 Coding 工具场景可能使用 `.com`/Anthropic 专用入口，以控制台为准。 |
-| 小米 MiMo | 官方文档 / 控制台 | 当前按 OpenAI-compatible 方式接入，Base URL、模型名与权限以 MiMo 官方文档/控制台为准。 |
+| 小米 MiMo | 官方文档 / 控制台 | 当前按 OpenAI-compatible 方式接入，Base URL、模型名与权限以 MiMo 官方文档/控制台为准；`mimo` 渠道在仓库默认 workflow 中未显式映射，Actions 使用请按本文“GitHub Actions 配置”补齐自定义映射。 |
 | 火山方舟 / 豆包 | [在线推理（常规）](https://www.volcengine.com/docs/82379/2121998)、[模型列表](https://www.volcengine.com/docs/82379/1949118) | 官方示例使用 `https://ark.cn-beijing.volces.com/api/v3` 与 `doubao-seed-1-6-251015`；如使用 Coding Plan，请改用其专用 Base URL 和模型名，不要套用本表的在线推理模板。 |
 | SiliconFlow | [模型列表](https://docs.siliconflow.cn/quickstart/models)、[获取模型列表 API](https://docs.siliconflow.cn/cn/api-reference/models/get-model-list) | 平台模型实时更新且 `/models` 需要 API Key；模板只给常见新模型示例，保存前建议在 Web 设置页点击「获取模型」确认账号可见性。 |
 | OpenRouter | [Models API](https://openrouter.ai/docs/api/api-reference/models/get-models) | OpenRouter 支持 `~anthropic/claude-sonnet-latest`、`~openai/gpt-latest` 等 latest router alias；2026-05-03 的一次手动 live smoke 以 Claude Sonnet latest 作为默认示例通过，GPT latest 保留为可按账号权限切换的备选。 |
@@ -121,7 +122,7 @@ OpenAI-compatible Base URL 只填到服务商兼容入口，不额外拼接 `/ch
 | `LITELLM_CONFIG` | Variables 或 Secrets | YAML 文件路径；配合 `LITELLM_CONFIG_YAML` 使用时，workflow 会写入该路径。 |
 | `LITELLM_CONFIG_YAML` | Secrets 优先 | YAML 内容本身可能包含私有网关或 header，建议放 Secrets。 |
 
-默认 workflow 已显式映射 `primary`、`secondary`、`aihubmix`、`anspire`、`deepseek`、`dashscope`、`zhipu`、`moonshot`、`minimax`、`volcengine`、`siliconflow`、`openrouter`、`gemini`、`anthropic`、`openai`、`ollama`。如果使用自定义渠道名（如 `my_proxy`），仅在 Repository Secrets / Variables 中新增 `LLM_MY_PROXY_*` 不会自动生效，需要同步扩展 workflow 的 `env:` 映射；本地 `.env`、Docker 和自托管脚本不受这个限制。
+默认 workflow 已显式映射 `primary`、`secondary`、`aihubmix`、`anspire`、`deepseek`、`dashscope`、`zhipu`、`moonshot`、`minimax`、`volcengine`、`siliconflow`、`openrouter`、`gemini`、`anthropic`、`openai`、`ollama`；`mimo` 未在默认 workflow 中映射。若使用 `mimo`（或任何未列渠道名），除了在 Variables/Secrets 配置同名 `LLM_<CHANNEL>_*` 外，还需在 workflow 中同步补齐对应 env 映射；本地 `.env`、Docker 和自托管脚本不受这个限制。
 
 Ollama 默认 Base URL `http://127.0.0.1:11434` 主要面向本地、Docker 或能访问该服务的 self-hosted runner。GitHub-hosted runner 通常没有本地 Ollama 服务，直接配置 `LLM_CHANNELS=ollama` 大概率会连接失败。
 

--- a/src/agent/llm_adapter.py
+++ b/src/agent/llm_adapter.py
@@ -635,11 +635,17 @@ def register_fallback_model_pricing(models: Iterable[str]) -> None:
             continue
         if not wire_model or wire_model.startswith("__legacy_"):
             continue
-        if (
-            wire_model in _CUSTOM_MODEL_PRICING
-            or wire_model in cost_map
-            or wire_model in _FALLBACK_MODEL_PRICING_REGISTERED
-        ):
+        custom_pricing = _CUSTOM_MODEL_PRICING.get(wire_model)
+        if custom_pricing is not None:
+            if wire_model in cost_map:
+                continue
+            try:
+                register({wire_model: dict(custom_pricing)})
+                logger.debug("Registered custom pricing for %s", wire_model)
+            except Exception as exc:
+                logger.debug("Custom pricing registration skipped for %s: %s", wire_model, exc)
+            continue
+        if wire_model in cost_map or wire_model in _FALLBACK_MODEL_PRICING_REGISTERED:
             continue
         try:
             register({wire_model: dict(_FALLBACK_MODEL_PRICING)})

--- a/src/agent/llm_adapter.py
+++ b/src/agent/llm_adapter.py
@@ -11,7 +11,7 @@ import logging
 import time
 import uuid
 from dataclasses import dataclass, field
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, Iterable, List, Optional, Tuple
 
 import litellm
 from litellm import Router
@@ -102,6 +102,28 @@ _CUSTOM_MODEL_PRICING: Dict[str, dict] = {
     },
 }
 
+_FALLBACK_MODEL_PRICING: Dict[str, Any] = {
+    "supports_function_calling": True,
+    "supports_vision": False,
+    "supports_audio_input": False,
+    "supports_audio_output": False,
+    "context_window": 100000,
+    "max_tokens": 10000,
+    "input_cost_per_token": 0.0,
+    "output_cost_per_token": 0.0,
+}
+_FALLBACK_MODEL_PRICING_REGISTERED: set[str] = set()
+
+
+def _split_provider_model(model: str) -> Tuple[str, str]:
+    normalized = (model or "").strip()
+    if not normalized:
+        return "", ""
+    if "/" in normalized:
+        provider, remainder = normalized.split("/", 1)
+        return provider.lower(), remainder.strip()
+    return "openai", normalized
+
 
 def _model_matches(model: str, entries: List[str]) -> bool:
     """Check if model name matches any entry (exact or prefix with version suffix)."""
@@ -178,7 +200,6 @@ class LLMToolAdapter:
                 logger.debug(f"Registered custom pricing for {model_name}")
             except Exception as e:
                 logger.debug(f"Model {model_name} may already be registered or pricing error: {e}")
-
     def _has_channel_config(self) -> bool:
         """Check if multi-channel config (channels / YAML) is active."""
         return bool(self._config.llm_model_list) and not all(
@@ -596,3 +617,30 @@ class LLMToolAdapter:
             model=model,
             raw=response,
         )
+
+
+def register_fallback_model_pricing(models: Iterable[str]) -> None:
+    """Register zero-cost pricing for unknown OpenAI-compatible models."""
+    if not models:
+        return
+    LLMToolAdapter._register_custom_model_pricing()
+    register = getattr(litellm, "register_model", None)
+    if not callable(register):
+        return
+    cost_map = getattr(litellm, "model_cost", {})
+    if not isinstance(cost_map, dict):
+        cost_map = {}
+    for model in models:
+        provider, wire_model = _split_provider_model(str(model))
+        if provider != "openai":
+            continue
+        if not wire_model or wire_model.startswith("__legacy_"):
+            continue
+        if wire_model in cost_map or wire_model in _FALLBACK_MODEL_PRICING_REGISTERED:
+            continue
+        try:
+            register({wire_model: dict(_FALLBACK_MODEL_PRICING)})
+            _FALLBACK_MODEL_PRICING_REGISTERED.add(wire_model)
+            logger.debug("Registered fallback pricing for %s", wire_model)
+        except Exception as exc:
+            logger.debug("Fallback pricing registration skipped for %s: %s", wire_model, exc)

--- a/src/agent/llm_adapter.py
+++ b/src/agent/llm_adapter.py
@@ -164,6 +164,39 @@ def get_thinking_extra_body(model: str) -> Optional[dict]:
     return _get_opt_in_payload(model, _OPT_IN_THINKING_MODELS)
 
 
+def resolve_fallback_litellm_wire_models(
+    model: str,
+    model_list: Optional[List[Dict[str, Any]]] = None,
+) -> List[str]:
+    """Resolve all wire models reachable from a configured alias."""
+    normalized_model = (model or "").strip()
+    if not normalized_model:
+        return []
+
+    resolved: List[str] = []
+    if model_list:
+        for entry in model_list:
+            if not isinstance(entry, dict):
+                continue
+            entry_model_name = str(entry.get("model_name", "") or "").strip()
+            if not entry_model_name:
+                entry_params = entry.get("litellm_params", {}) or {}
+                entry_model_name = str(entry_params.get("model") or "").strip()
+            if entry_model_name != normalized_model:
+                continue
+
+            entry_params = entry.get("litellm_params", {}) or {}
+            wire_model = str(entry_params.get("model") or normalized_model).strip()
+            if wire_model and wire_model not in resolved:
+                resolved.append(wire_model)
+
+    if not resolved:
+        wire_model = resolve_litellm_wire_model(normalized_model, model_list)
+        if wire_model and wire_model not in resolved:
+            resolved.append(wire_model)
+    return resolved
+
+
 # ============================================================
 # LLM Tool Adapter
 # ============================================================
@@ -464,9 +497,9 @@ class LLMToolAdapter:
             self._get_temperature() if temperature is None else temperature,
             model_list=recovery_model_list,
         )
-        register_fallback_model_pricing([
-            resolve_litellm_wire_model(model, self._config.llm_model_list)
-        ])
+        register_fallback_model_pricing(
+            resolve_fallback_litellm_wire_models(model, self._config.llm_model_list)
+        )
         if use_channel_router and self._router and model in _router_model_names:
             # Channel / YAML path: Router manages all models in its model_list
             response = call_litellm_with_param_recovery(

--- a/src/agent/llm_adapter.py
+++ b/src/agent/llm_adapter.py
@@ -623,7 +623,6 @@ def register_fallback_model_pricing(models: Iterable[str]) -> None:
     """Register zero-cost pricing for unknown OpenAI-compatible models."""
     if not models:
         return
-    LLMToolAdapter._register_custom_model_pricing()
     register = getattr(litellm, "register_model", None)
     if not callable(register):
         return
@@ -636,7 +635,11 @@ def register_fallback_model_pricing(models: Iterable[str]) -> None:
             continue
         if not wire_model or wire_model.startswith("__legacy_"):
             continue
-        if wire_model in cost_map or wire_model in _FALLBACK_MODEL_PRICING_REGISTERED:
+        if (
+            wire_model in _CUSTOM_MODEL_PRICING
+            or wire_model in cost_map
+            or wire_model in _FALLBACK_MODEL_PRICING_REGISTERED
+        ):
             continue
         try:
             register({wire_model: dict(_FALLBACK_MODEL_PRICING)})

--- a/src/agent/llm_adapter.py
+++ b/src/agent/llm_adapter.py
@@ -23,6 +23,7 @@ from src.config import (
     get_configured_llm_models,
     get_effective_agent_models_to_try,
     get_effective_agent_primary_model,
+    resolve_litellm_wire_model,
 )
 from src.llm.errors import call_litellm_with_param_recovery
 from src.llm.generation_params import apply_litellm_generation_params
@@ -463,6 +464,9 @@ class LLMToolAdapter:
             self._get_temperature() if temperature is None else temperature,
             model_list=recovery_model_list,
         )
+        register_fallback_model_pricing([
+            resolve_litellm_wire_model(model, self._config.llm_model_list)
+        ])
         if use_channel_router and self._router and model in _router_model_names:
             # Channel / YAML path: Router manages all models in its model_list
             response = call_litellm_with_param_recovery(

--- a/src/agent/llm_adapter.py
+++ b/src/agent/llm_adapter.py
@@ -647,8 +647,13 @@ def register_fallback_model_pricing(models: Iterable[str]) -> None:
                 register({wire_model: dict(custom_pricing)})
                 logger.debug("Registered custom pricing for %s", wire_model)
             except Exception as exc:
-                logger.debug("Custom pricing registration skipped for %s: %s", wire_model, exc)
-            continue
+                logger.debug(
+                    "Custom pricing registration failed for %s, will try fallback pricing: %s",
+                    wire_model,
+                    exc,
+                )
+            else:
+                continue
         if wire_model in cost_map or wire_model in _FALLBACK_MODEL_PRICING_REGISTERED:
             continue
         try:

--- a/src/analyzer.py
+++ b/src/analyzer.py
@@ -22,7 +22,7 @@ import litellm
 from json_repair import repair_json
 from litellm import Router
 
-from src.agent.llm_adapter import get_thinking_extra_body
+from src.agent.llm_adapter import get_thinking_extra_body, register_fallback_model_pricing
 from src.agent.skills.defaults import CORE_TRADING_SKILL_POLICY_ZH
 from src.config import (
     Config,
@@ -30,6 +30,8 @@ from src.config import (
     get_api_keys_for_model,
     get_config,
     get_configured_llm_models,
+    normalize_litellm_temperature,
+    resolve_litellm_wire_model,
     resolve_news_window_days,
 )
 from src.llm.generation_params import apply_litellm_generation_params
@@ -2047,6 +2049,8 @@ class GeminiAnalyzer:
         router_model_names: set[str],
     ) -> Any:
         """Dispatch a LiteLLM completion through router or direct fallback."""
+        wire_model = resolve_litellm_wire_model(model, config.llm_model_list)
+        register_fallback_model_pricing([wire_model])
         effective_kwargs = dict(call_kwargs)
         if use_channel_router and self._router and model in router_model_names:
             return self._router.completion(**effective_kwargs)

--- a/src/analyzer.py
+++ b/src/analyzer.py
@@ -22,7 +22,11 @@ import litellm
 from json_repair import repair_json
 from litellm import Router
 
-from src.agent.llm_adapter import get_thinking_extra_body, register_fallback_model_pricing
+from src.agent.llm_adapter import (
+    get_thinking_extra_body,
+    resolve_fallback_litellm_wire_models,
+    register_fallback_model_pricing,
+)
 from src.agent.skills.defaults import CORE_TRADING_SKILL_POLICY_ZH
 from src.config import (
     Config,
@@ -2049,8 +2053,8 @@ class GeminiAnalyzer:
         router_model_names: set[str],
     ) -> Any:
         """Dispatch a LiteLLM completion through router or direct fallback."""
-        wire_model = resolve_litellm_wire_model(model, config.llm_model_list)
-        register_fallback_model_pricing([wire_model])
+        wire_models = resolve_fallback_litellm_wire_models(model, config.llm_model_list)
+        register_fallback_model_pricing(wire_models)
         effective_kwargs = dict(call_kwargs)
         if use_channel_router and self._router and model in router_model_names:
             return self._router.completion(**effective_kwargs)

--- a/src/services/system_config_service.py
+++ b/src/services/system_config_service.py
@@ -740,12 +740,10 @@ class SystemConfigService:
 
         try:
             import litellm
-            from src.agent.llm_adapter import LLMToolAdapter
+            from src.agent.llm_adapter import register_fallback_model_pricing
 
-            # Register custom model pricing for MiniMax models not in LiteLLM's built-in list
-            # This must be done before litellm.completion() to prevent cost calculation errors
-            # Reuses the registration logic from LLMToolAdapter to avoid code duplication
-            LLMToolAdapter._register_custom_model_pricing()
+            # Register fallback pricing for OpenAI-compatible models to prevent cost calculation errors
+            register_fallback_model_pricing([resolved_model])
 
             started_at = time.perf_counter()
             response = call_litellm_with_param_recovery(

--- a/src/services/system_config_service.py
+++ b/src/services/system_config_service.py
@@ -740,10 +740,21 @@ class SystemConfigService:
 
         try:
             import litellm
-            from src.agent.llm_adapter import register_fallback_model_pricing
+            from src.agent.llm_adapter import (
+                resolve_fallback_litellm_wire_models,
+                register_fallback_model_pricing,
+            )
 
             # Register fallback pricing for OpenAI-compatible models to prevent cost calculation errors
-            register_fallback_model_pricing([resolved_model])
+            config_model_list = None
+            if getattr(self, "_config", None) is not None:
+                config_model_list = getattr(self._config, "llm_model_list", None)
+            register_fallback_model_pricing(
+                resolve_fallback_litellm_wire_models(
+                    resolved_model,
+                    config_model_list,
+                )
+            )
 
             started_at = time.perf_counter()
             response = call_litellm_with_param_recovery(

--- a/tests/test_litellm_fallback_pricing.py
+++ b/tests/test_litellm_fallback_pricing.py
@@ -15,7 +15,7 @@ from src.agent import llm_adapter
 
 
 class LiteLLMFallbackPricingTestCase(unittest.TestCase):
-    def test_register_fallback_pricing_registers_openai_model(self) -> None:
+    def test_register_fallback_pricing_registers_unknown_openai_model(self) -> None:
         registered = []
 
         def _register(payload):
@@ -27,3 +27,17 @@ class LiteLLMFallbackPricingTestCase(unittest.TestCase):
                 llm_adapter.register_fallback_model_pricing(["openai/mimo-alpha"])
 
         self.assertTrue(any("mimo-alpha" in payload for payload in registered))
+
+    def test_register_fallback_pricing_skips_custom_pricing_models(self) -> None:
+        registered = []
+
+        def _register(payload):
+            registered.append(payload)
+
+        with patch.object(llm_adapter.litellm, "register_model", side_effect=_register, create=True):
+            with patch.object(llm_adapter.litellm, "model_cost", {"MiniMax-M2.7": {"input_cost_per_token": 1.0}}, create=True):
+                llm_adapter._FALLBACK_MODEL_PRICING_REGISTERED.clear()
+                llm_adapter.register_fallback_model_pricing(["openai/MiniMax-M2.7", "openai/mimo-beta"])
+
+        self.assertFalse(any("MiniMax-M2.7" in payload for payload in registered))
+        self.assertTrue(any("mimo-beta" in payload for payload in registered))

--- a/tests/test_litellm_fallback_pricing.py
+++ b/tests/test_litellm_fallback_pricing.py
@@ -41,3 +41,19 @@ class LiteLLMFallbackPricingTestCase(unittest.TestCase):
 
         self.assertFalse(any("MiniMax-M2.7" in payload for payload in registered))
         self.assertTrue(any("mimo-beta" in payload for payload in registered))
+
+    def test_register_fallback_pricing_registers_unknown_custom_pricing_model(self) -> None:
+        registered = []
+
+        def _register(payload):
+            registered.append(payload)
+
+        with patch.object(llm_adapter.litellm, "register_model", side_effect=_register, create=True):
+            with patch.object(llm_adapter.litellm, "model_cost", {}, create=True):
+                llm_adapter._FALLBACK_MODEL_PRICING_REGISTERED.clear()
+                llm_adapter.register_fallback_model_pricing(["openai/MiniMax-M2.7"])
+
+        self.assertEqual(
+            registered,
+            [{"MiniMax-M2.7": llm_adapter._CUSTOM_MODEL_PRICING["MiniMax-M2.7"]}],
+        )

--- a/tests/test_litellm_fallback_pricing.py
+++ b/tests/test_litellm_fallback_pricing.py
@@ -1,0 +1,29 @@
+# -*- coding: utf-8 -*-
+"""Tests for fallback LiteLLM pricing registration."""
+
+import unittest
+from unittest.mock import patch
+
+try:
+    import litellm  # noqa: F401
+except ModuleNotFoundError:
+    from tests.litellm_stub import ensure_litellm_stub
+
+    ensure_litellm_stub()
+
+from src.agent import llm_adapter
+
+
+class LiteLLMFallbackPricingTestCase(unittest.TestCase):
+    def test_register_fallback_pricing_registers_openai_model(self) -> None:
+        registered = []
+
+        def _register(payload):
+            registered.append(payload)
+
+        with patch.object(llm_adapter.litellm, "register_model", side_effect=_register, create=True):
+            with patch.object(llm_adapter.litellm, "model_cost", {}, create=True):
+                llm_adapter._FALLBACK_MODEL_PRICING_REGISTERED.clear()
+                llm_adapter.register_fallback_model_pricing(["openai/mimo-alpha"])
+
+        self.assertTrue(any("mimo-alpha" in payload for payload in registered))

--- a/tests/test_litellm_fallback_pricing.py
+++ b/tests/test_litellm_fallback_pricing.py
@@ -175,3 +175,44 @@ class LiteLLMFallbackPricingTestCase(unittest.TestCase):
 
         self.assertEqual(result.content, "agent ok")
         self.assertEqual(events[:2], [("register", ["openai/mimo-router"]), ("router", "mimo_alias")])
+
+    def test_llm_tool_adapter_registers_fallback_pricing_for_router_wire_models(self) -> None:
+        adapter = llm_adapter.LLMToolAdapter.__new__(llm_adapter.LLMToolAdapter)
+        adapter._config = _fake_agent_config(
+            litellm_model="mimo_alias",
+            llm_model_list=[
+                {
+                    "model_name": "mimo_alias",
+                    "litellm_params": {"model": "openai/mimo-alpha"},
+                },
+                {
+                    "model_name": "mimo_alias",
+                    "litellm_params": {"model": "openai/mimo-beta"},
+                },
+            ],
+        )
+        adapter._legacy_router_model_list = []
+
+        events = []
+
+        def _register(models):
+            events.append(("register", list(models)))
+
+        def _router_completion(**_kwargs):
+            events.append(("router", _kwargs["model"]))
+            return _fake_litellm_response()
+
+        adapter._router = SimpleNamespace(completion=_router_completion)
+
+        with patch.object(llm_adapter, "register_fallback_model_pricing", side_effect=_register):
+            result = adapter._call_litellm_model(
+                [{"role": "user", "content": "hi"}],
+                [],
+                "mimo_alias",
+            )
+
+        self.assertEqual(result.content, "agent ok")
+        self.assertEqual(
+            events[:2],
+            [("register", ["openai/mimo-alpha", "openai/mimo-beta"]), ("router", "mimo_alias")],
+        )

--- a/tests/test_litellm_fallback_pricing.py
+++ b/tests/test_litellm_fallback_pricing.py
@@ -2,6 +2,7 @@
 """Tests for fallback LiteLLM pricing registration."""
 
 import unittest
+from types import SimpleNamespace
 from unittest.mock import patch
 
 try:
@@ -12,6 +13,37 @@ except ModuleNotFoundError:
     ensure_litellm_stub()
 
 from src.agent import llm_adapter
+
+
+def _fake_litellm_response(content: str = "agent ok") -> SimpleNamespace:
+    return SimpleNamespace(
+        choices=[
+            SimpleNamespace(
+                message=SimpleNamespace(
+                    content=content,
+                    tool_calls=[],
+                )
+            )
+        ],
+        usage=SimpleNamespace(prompt_tokens=1, completion_tokens=2, total_tokens=3),
+    )
+
+
+def _fake_agent_config(**overrides) -> SimpleNamespace:
+    config = {
+        "agent_litellm_model": "",
+        "litellm_model": "openai/mimo-alpha",
+        "litellm_fallback_models": [],
+        "llm_model_list": [],
+        "llm_temperature": 0.7,
+        "gemini_api_keys": [],
+        "anthropic_api_keys": [],
+        "openai_api_keys": [],
+        "deepseek_api_keys": [],
+        "openai_base_url": None,
+    }
+    config.update(overrides)
+    return SimpleNamespace(**config)
 
 
 class LiteLLMFallbackPricingTestCase(unittest.TestCase):
@@ -57,3 +89,63 @@ class LiteLLMFallbackPricingTestCase(unittest.TestCase):
             registered,
             [{"MiniMax-M2.7": llm_adapter._CUSTOM_MODEL_PRICING["MiniMax-M2.7"]}],
         )
+
+    def test_llm_tool_adapter_registers_fallback_pricing_before_direct_completion(self) -> None:
+        adapter = llm_adapter.LLMToolAdapter.__new__(llm_adapter.LLMToolAdapter)
+        adapter._config = _fake_agent_config()
+        adapter._router = None
+        adapter._legacy_router_model_list = []
+
+        events = []
+
+        def _register(models):
+            events.append(("register", list(models)))
+
+        def _completion(**_kwargs):
+            events.append(("completion", _kwargs["model"]))
+            return _fake_litellm_response()
+
+        with patch.object(llm_adapter, "register_fallback_model_pricing", side_effect=_register):
+            with patch.object(llm_adapter.litellm, "completion", side_effect=_completion):
+                result = adapter._call_litellm_model(
+                    [{"role": "user", "content": "hi"}],
+                    [],
+                    "openai/mimo-alpha",
+                )
+
+        self.assertEqual(result.content, "agent ok")
+        self.assertEqual(events[:2], [("register", ["openai/mimo-alpha"]), ("completion", "openai/mimo-alpha")])
+
+    def test_llm_tool_adapter_registers_fallback_pricing_for_router_wire_model(self) -> None:
+        adapter = llm_adapter.LLMToolAdapter.__new__(llm_adapter.LLMToolAdapter)
+        adapter._config = _fake_agent_config(
+            litellm_model="mimo_alias",
+            llm_model_list=[
+                {
+                    "model_name": "mimo_alias",
+                    "litellm_params": {"model": "openai/mimo-router"},
+                }
+            ],
+        )
+        adapter._legacy_router_model_list = []
+
+        events = []
+
+        def _register(models):
+            events.append(("register", list(models)))
+
+        def _router_completion(**_kwargs):
+            events.append(("router", _kwargs["model"]))
+            return _fake_litellm_response()
+
+        adapter._router = SimpleNamespace(completion=_router_completion)
+
+        with patch.object(llm_adapter, "register_fallback_model_pricing", side_effect=_register):
+            result = adapter._call_litellm_model(
+                [{"role": "user", "content": "hi"}],
+                [],
+                "mimo_alias",
+            )
+
+        self.assertEqual(result.content, "agent ok")
+        self.assertEqual(events[:2], [("register", ["openai/mimo-router"]), ("router", "mimo_alias")])

--- a/tests/test_litellm_fallback_pricing.py
+++ b/tests/test_litellm_fallback_pricing.py
@@ -90,6 +90,32 @@ class LiteLLMFallbackPricingTestCase(unittest.TestCase):
             [{"MiniMax-M2.7": llm_adapter._CUSTOM_MODEL_PRICING["MiniMax-M2.7"]}],
         )
 
+    def test_register_fallback_pricing_falls_back_to_zero_cost_when_custom_pricing_registration_fails(self) -> None:
+        registered: list[dict] = []
+        attempts = 0
+
+        def _register(payload):
+            nonlocal attempts
+            attempts += 1
+            registered.append(payload)
+            if attempts == 1:
+                raise RuntimeError("register failed")
+
+        with patch.object(llm_adapter.litellm, "register_model", side_effect=_register, create=True):
+            with patch.object(llm_adapter.litellm, "model_cost", {}, create=True):
+                llm_adapter._FALLBACK_MODEL_PRICING_REGISTERED.clear()
+                llm_adapter.register_fallback_model_pricing(["openai/MiniMax-M2.7"])
+
+        self.assertEqual(len(registered), 2)
+        self.assertEqual(
+            registered[0],
+            {"MiniMax-M2.7": llm_adapter._CUSTOM_MODEL_PRICING["MiniMax-M2.7"]},
+        )
+        self.assertEqual(
+            registered[1],
+            {"MiniMax-M2.7": llm_adapter._FALLBACK_MODEL_PRICING},
+        )
+
     def test_llm_tool_adapter_registers_fallback_pricing_before_direct_completion(self) -> None:
         adapter = llm_adapter.LLMToolAdapter.__new__(llm_adapter.LLMToolAdapter)
         adapter._config = _fake_agent_config()


### PR DESCRIPTION
Refs #1282

## What changed
- Add MiniMax-compatible fallback pricing registration logic in `src/agent/llm_adapter.py` as a shared helper `register_fallback_model_pricing(...)`.
- Ensure `LLMToolAdapter._call_litellm_model()` calls fallback pricing registration with resolved wire model before each tool call.
- Ensure `src/analyzer.py` and `src/services/system_config_service.py` call fallback pricing registration before LiteLLM completion in analyzer path and channel test path.
- Add regression tests in `tests/test_litellm_fallback_pricing.py` for:
  - unknown OpenAI-compatible model fallback registration
  - known custom-priced model registration behavior
  - alias model name resolving to wire model before registration
- Update `.env.example` and `docs/llm-providers.md` to document Xiaomi MiMo OpenAI-compatible setup with official links and constraints.
- Narrow `docs/CHANGELOG.md` Unreleased entries to only this PR scope.

## Compatibility / risk assessment
- Scope: applies only to OpenAI-compatible flows in fallback paths where `wire_model` is missing from `litellm.model_cost`.
- It does **not** change non-OpenAI provider routing semantics.
- Compatibility assumptions:
  - `litellm>=1.80.10,!=1.82.7,!=1.82.8,<2.0.0` (repo baseline)
  - MiMo OpenAI-compatible syntax follows upstream docs and is resolved via wire model mapping before registration.
- Official references:
  - MiMo OpenAI compatible quick start: https://www.mimo-v2.com/zh/docs/quick-start/first-api-call
  - MiMo pricing and limits: https://www.mimo-v2.com/zh/docs/pricing
  - MiMo model parameters: https://www.mimo-v2.com/zh/docs/quick-start/model-parameters

## Rollback plan
- Preferred: revert this PR / commit.
- Alternative: remove `register_fallback_model_pricing(...)` calls in `src/agent/llm_adapter.py`, `src/analyzer.py`, and `src/services/system_config_service.py`.

## CI / verification
- Not executed in this session. Please run `./scripts/ci_gate.sh` and PR checks before merge.
