### PR TITLE
fix: clear AlphaVantage fetcher index name to avoid 'date' ambiguity

### DIFF
--- a/data_provider/alphavantage_fetcher.py
+++ b/data_provider/alphavantage_fetcher.py
@@ -89,6 +89,7 @@ class AlphaVantageFetcher(BaseFetcher):
 
         df = pd.DataFrame(rows)
         df.index = pd.to_datetime(df['date'])
+        df.index.name = None  # 避免与 _normalize_data 重新添加的 'date' 列冲突
         return df.drop(columns=['date'])
 
     def _normalize_data(self, df: pd.DataFrame, stock_code: str) -> pd.DataFrame:


### PR DESCRIPTION
## PR Type

- [x] fix
- [ ] feat
- [ ] refactor
- [ ] docs
- [ ] chore
- [ ] test

## Background And Problem

使用 AlphaVantage 作为美股日线数据源时，`load_history_df('AAPL')`（以及任何走 `AlphaVantageFetcher` 的路径）返回 0 行并抛错：

```
ValueError: 'date' is both an index level and a column label, which is ambiguous.
```

直接后果：美股用户若把 `ALPHAVANTAGE_API_KEY` 填上、并触发包含 AlphaVantage 的 fetcher 链路（例如 yfinance 被 Yahoo 限流时的 fallback），整条 AlphaVantage 通道是**不可用**的。最终用户在生成的报告里会缺失 K线 / MA / 技术指标等关键数据，而日志里只有一条 pandas ValueError，问题定位成本不低。

引入位置：PR #1313 (`feat: add Finnhub & AlphaVantage US market data source adapters`)。该 PR 引入 fetcher 时未跑过真实响应，所以这条路径从未真正打通过。

## Scope Of Change

- `data_provider/alphavantage_fetcher.py` —— `_fetch_raw_data` 方法新增 1 行清空索引名。
- 其他数据源（efinance / akshare / yfinance / Finnhub / Longbridge / Tushare / Pytdx / Baostock）链路**未触及**。
- 配置 / 依赖 / schema / 文档**未变动**。

```diff
 df = pd.DataFrame(rows)
 df.index = pd.to_datetime(df['date'])
+df.index.name = None  # 避免与 _normalize_data 重新添加的 'date' 列冲突
 return df.drop(columns=['date'])
```

## Issue Link

无 issue。**Motivation**：美股 fallback 数据源 AlphaVantage 当前实际不可用，影响美股用户体验，属于功能性 bug。**Acceptance**：填入有效 `ALPHAVANTAGE_API_KEY` 后，`load_history_df('<美股代码>')` 应返回 `source=AlphaVantageFetcher` 与非零行数；触发 \`/api/v1/analysis/analyze\` 对美股的报告应能包含 MA5/MA10/MA20 等技术指标字段。

## Verification Commands And Results

**Repro（修复前）**：

```bash
docker exec -u dsa stock-server python -c "
from src.services.history_loader import load_history_df
df, source = load_history_df('AAPL', days=10)
print('source:', source, '| rows:', 0 if df is None else len(df))
"
```

修复前输出（关键节选）：

```
[AlphaVantageFetcher] AAPL 获取失败: ... error_type=ValueError,
  reason='date' is both an index level and a column label, which is ambiguous.
source: none | rows: 0
```

**修复后**：

```
source: AlphaVantageFetcher | rows: 14
      date   open  close     volume
2026-05-14 299.82 298.21 35324922.0
2026-05-15 297.90 300.23 54862836.0
2026-05-18 300.24 297.84 34482959.0
```

**端到端**：以 AAPL 触发一次异步分析：

```bash
curl -X POST http://127.0.0.1:8000/api/v1/analysis/analyze \\
  -H 'Content-Type: application/json' \\
  -d '{\"stock_code\":\"AAPL\",\"async_mode\":true,\"report_type\":\"detailed\"}'
# 轮询 status 后取 /api/v1/history/<id>/markdown
```

报告里成功生成：
- 当日行情（来自 Finnhub /quote）
- **MA5(298.60) / MA10(294.87) / MA20(284.37) + 多头排列 + 趋势强度 75/100**（来自 AlphaVantage 日线本地计算）
- 完整买卖点位 / 止损 / 仓位建议

**语法校验**：

```bash
python -m py_compile data_provider/alphavantage_fetcher.py
# syntax OK
```

未执行 `./scripts/ci_gate.sh` / `pytest`：本 PR 仅 1 行 fetcher 内部清空索引 name 属性，不改变索引值或 DataFrame 内容，无相关 unit test 覆盖此具体路径（仓库 `tests/` 下没有 AlphaVantage 用例 —— 这也是本 bug 长期没被发现的原因）。如果 reviewer 希望增加针对 AlphaVantage `_fetch_raw_data` → `_normalize_data` 的最小回归测试，可在后续 PR 补齐。

## Compatibility And Risk

**风险**：极低。

- 仅清空 `DatetimeIndex.name` 属性，**不改变索引值、不改变 DataFrame 内容、不改变列顺序**。
- 不影响其他数据源链路（efinance / akshare / yfinance / Finnhub / Longbridge / Tushare / Pytdx / Baostock 路径未触及）。
- 不修改配置语义、API / Schema、provider fallback 行为、报告结构、认证、调度或发布流程。
- 不涉及第三方模型 / API 兼容语义变化，无需附官方来源链接。
- 不依赖特定 LiteLLM / OpenAI-compatible 版本窗口。
- 不触及运行时配置 save / cleanup / migration / backfill 逻辑。

## Rollback Plan

\`git revert <this-commit>\` 即可完整回滚，无需额外回滚配置或数据迁移。回滚后 AlphaVantage 通道会回到本 PR 之前的不可用状态，不影响其他数据源。

## EXTRACT_PROMPT Change (if applicable)

N/A —— 本 PR 未修改 `src/services/image_stock_extractor.py`。

## Checklist

- [x] 本 PR 有明确动机和业务价值 / This PR has a clear motivation and value
- [x] 已提供可复现的验证命令与结果 / Reproducible verification commands and results are included
- [x] 已评估兼容性与风险 / Compatibility and risk have been assessed
- [x] 已提供回滚方案 / A rollback plan is provided
- [x] 若涉及用户可见变更，已同步更新相关文档与 \`docs/CHANGELOG.md\` —— **本 PR 是内部 bug 修复，无用户可见行为变化（修复前该路径直接抛异常，用户感知到的是 "AlphaVantage 不可用"；修复后变为 "AlphaVantage 正常工作"），无需文档同步**