### PR TITLE
feat: improve: 提升个股新闻检索与标的关联度 (#1356)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -38,6 +38,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - [文档] 同步说明 fallback pricing 注册与 MiniMax / 小米 MiMo 兼容配置边界，补充相关 provider 示例与回退触发条件，限定为本次 #1282 修复范围内更新。
 - [改进] 个股新闻检索新增可解释相关度评分与 direct_company_news / sector_related_news / macro_market_news 分层，优先展示命中股票代码或公司主体的新闻。
 - [修复] 收紧港股新闻相关度中的裸短码匹配，避免将指数点数等普通数字误判为目标股票代码。
+- [修复] 修复个股新闻相关度中美股小写 ticker 后缀识别与 A/HK 弱相关新闻中文优先比较顺序。
 - [文档] Issue #1356 的结构化检测告警为既有上下文误报：本次仅调整个股新闻检索的相关度评分与分层排序（`direct_company_news` / `sector_related_news` / `macro_market_news`），不触及模型名、provider、LiteLLM 参数、Base URL 及运行时配置清理/迁移语义；无配置回写副作用，回退路径为回滚本次提交。
 
 ## [3.17.1] - 2026-05-16

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -36,6 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - [修复] 修复 DatabaseManager 冷启动并发初始化竞态，避免首批并发请求偶发拿到半初始化数据库实例。
 - [修复] 为 OpenAI-compatible 渠道补充 MiMo / LiteLLM fallback pricing 注册路径：在 Tool / Analyzer / 系统配置联调测试路径复用 `register_fallback_model_pricing`，避免未知模型因缺失计费信息导致调用失败。
 - [文档] 同步说明 fallback pricing 注册与 MiniMax / 小米 MiMo 兼容配置边界，补充相关 provider 示例与回退触发条件，限定为本次 #1282 修复范围内更新。
+- [改进] 个股新闻检索新增可解释相关度评分与 direct_company_news / sector_related_news / macro_market_news 分层，优先展示命中股票代码或公司主体的新闻。
 
 ## [3.17.1] - 2026-05-16
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -37,6 +37,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - [修复] 为 OpenAI-compatible 渠道补充 MiMo / LiteLLM fallback pricing 注册路径：在 Tool / Analyzer / 系统配置联调测试路径复用 `register_fallback_model_pricing`，避免未知模型因缺失计费信息导致调用失败。
 - [文档] 同步说明 fallback pricing 注册与 MiniMax / 小米 MiMo 兼容配置边界，补充相关 provider 示例与回退触发条件，限定为本次 #1282 修复范围内更新。
 - [改进] 个股新闻检索新增可解释相关度评分与 direct_company_news / sector_related_news / macro_market_news 分层，优先展示命中股票代码或公司主体的新闻。
+- [修复] 收紧港股新闻相关度中的裸短码匹配，避免将指数点数等普通数字误判为目标股票代码。
 
 ## [3.17.1] - 2026-05-16
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -38,6 +38,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - [文档] 同步说明 fallback pricing 注册与 MiniMax / 小米 MiMo 兼容配置边界，补充相关 provider 示例与回退触发条件，限定为本次 #1282 修复范围内更新。
 - [改进] 个股新闻检索新增可解释相关度评分与 direct_company_news / sector_related_news / macro_market_news 分层，优先展示命中股票代码或公司主体的新闻。
 - [修复] 收紧港股新闻相关度中的裸短码匹配，避免将指数点数等普通数字误判为目标股票代码。
+- [文档] Issue #1356 的结构化检测告警为既有上下文误报：本次仅调整个股新闻检索的相关度评分与分层排序（`direct_company_news` / `sector_related_news` / `macro_market_news`），不触及模型名、provider、LiteLLM 参数、Base URL 及运行时配置清理/迁移语义；无配置回写副作用，回退路径为回滚本次提交。
 
 ## [3.17.1] - 2026-05-16
 

--- a/docs/full-guide.md
+++ b/docs/full-guide.md
@@ -324,6 +324,23 @@ daily_stock_analysis/
 
 > 行为说明：搜索服务与社交舆情服务为可选增强链路。任一服务初始化失败时，系统会记录 warning 并降级为跳过该服务，仅影响对应环节，不会阻塞技术面主链路和主任务流。
 
+### 新闻检索可解释排序（Issue #1356）
+
+`search_stock_news` 对每条候选新闻会计算「可解释相关度」并落地为 3 类标签：
+
+- `direct_company_news`：命中目标代码、公司名（含官方/交易所来源加权）；
+- `sector_related_news`：命中行业板块语义；
+- `macro_market_news`：未命中目标主体时的宏观/市场语境新闻。
+
+排序策略为：先按类别优先级（direct > sector > macro）排序，再按语言偏好（中文优先）再按分数排序，因此当同一时窗内存在明确标的命中的新闻时会优先展示。
+
+调试入口：
+
+- 每条返回会保留 `relevance_score` / `relevance_category` / `relevance_reasons` 元数据，最终 `to_text()` 与情报上下文会附带对应「关联度」说明；
+- 搜索链路日志会输出 `[新闻相关度]` 统计，便于复盘为何该批次触发了 direct/sector/macro 分层。
+
+兼容与回退说明：该改动不新增/修改模型、provider、Base URL、LiteLLM route、配置清理或回写逻辑；若出现异常，只能通过回滚本次提交恢复旧排序行为，不涉及历史配置迁移。
+
 ### 数据源配置
 
 | 变量名 | 说明 | 默认值 | 必填 |

--- a/src/search_service.py
+++ b/src/search_service.py
@@ -2617,10 +2617,11 @@ class SearchService:
             return False
 
         if cls._US_STOCK_RE.match(term) and term.upper() == term and not term.startswith("$"):
+            ticker_pattern = f"(?:{re.escape(term)}|{re.escape(term.lower())})"
             pattern = (
                 r"(?<![A-Za-z0-9$:.])"
-                + re.escape(term)
-                + r"(?=$|[^A-Za-z0-9.]|\.(?:US|O|N|NYSE|NASDAQ|AMEX)\b)"
+                + ticker_pattern
+                + r"(?=$|[^A-Za-z0-9.]|\.(?:US|us|O|o|N|n|NYSE|nyse|NASDAQ|nasdaq|AMEX|amex)\b)"
             )
             return bool(re.search(pattern, text))
 
@@ -2867,10 +2868,10 @@ class SearchService:
             and candidate_stats["preferred_direct_count"] != best_stats["preferred_direct_count"]
         ):
             return candidate_stats["preferred_direct_count"] > best_stats["preferred_direct_count"]
-        if candidate_stats["max_score"] != best_stats["max_score"]:
-            return candidate_stats["max_score"] > best_stats["max_score"]
         if prefer_chinese and candidate_stats["preferred_count"] != best_stats["preferred_count"]:
             return candidate_stats["preferred_count"] > best_stats["preferred_count"]
+        if candidate_stats["max_score"] != best_stats["max_score"]:
+            return candidate_stats["max_score"] > best_stats["max_score"]
         return candidate_stats["result_count"] > best_stats["result_count"]
 
     @staticmethod

--- a/src/search_service.py
+++ b/src/search_service.py
@@ -113,11 +113,22 @@ class SearchResult:
     url: str
     source: str  # 来源网站
     published_date: Optional[str] = None
+    relevance_score: Optional[int] = None
+    relevance_category: Optional[str] = None
+    relevance_reasons: Optional[List[str]] = None
     
     def to_text(self) -> str:
         """转换为文本格式"""
         date_str = f" ({self.published_date})" if self.published_date else ""
-        return f"【{self.source}】{self.title}{date_str}\n{self.snippet}"
+        relevance_parts: List[str] = []
+        if self.relevance_category:
+            relevance_parts.append(self.relevance_category)
+        if self.relevance_score is not None:
+            relevance_parts.append(f"score={self.relevance_score}")
+        if self.relevance_reasons:
+            relevance_parts.append(f"依据: {'；'.join(self.relevance_reasons[:3])}")
+        relevance_str = f"\n关联度: {'; '.join(relevance_parts)}" if relevance_parts else ""
+        return f"【{self.source}】{self.title}{date_str}\n{self.snippet}{relevance_str}"
 
 
 @dataclass 
@@ -2116,6 +2127,35 @@ class SearchService:
     FUTURE_TOLERANCE_DAYS = 1
     _CHINESE_TEXT_RE = re.compile(r"[\u3400-\u4dbf\u4e00-\u9fff]")
     _US_STOCK_RE = re.compile(r"^[A-Za-z]{1,5}(\.[A-Za-z])?$")
+    _DIRECT_NEWS_CATEGORY = "direct_company_news"
+    _SECTOR_NEWS_CATEGORY = "sector_related_news"
+    _MACRO_NEWS_CATEGORY = "macro_market_news"
+    _NEWS_CATEGORY_PRIORITY = {
+        _DIRECT_NEWS_CATEGORY: 0,
+        _SECTOR_NEWS_CATEGORY: 1,
+        _MACRO_NEWS_CATEGORY: 2,
+    }
+    _AMBIGUOUS_EN_COMPANY_NAMES = {"apple", "meta", "square", "target", "gap"}
+    _COMPANY_EVENT_TERMS = (
+        "公告", "披露", "发布", "收购", "回购", "减持", "增持", "诉讼", "处罚",
+        "业绩", "财报", "营收", "净利润", "分红", "董事会", "股东大会", "订单",
+        "合作", "中标", "earnings", "revenue", "profit", "guidance", "filing",
+        "sec", "shares", "stock", "buyback", "dividend", "lawsuit", "merger",
+        "acquisition", "results", "quarterly", "annual", "announces", "launches",
+    )
+    _SECTOR_NEWS_TERMS = (
+        "行业", "板块", "产业链", "龙头", "概念股", "赛道", "sector", "industry",
+        "peers", "competitors", "supply chain", "market share",
+    )
+    _MACRO_NEWS_TERMS = (
+        "大盘", "市场", "指数", "宏观", "央行", "利率", "通胀", "a股", "港股",
+        "美股", "纳指", "标普", "market", "index", "fed", "inflation",
+        "interest rate", "nasdaq", "s&p 500", "dow jones",
+    )
+    _OFFICIAL_SOURCE_TERMS = (
+        "cninfo", "sse.com", "szse.cn", "hkexnews", "sec.gov", "nasdaq.com",
+        "nyse.com", "上交所", "深交所", "港交所", "证券交易所",
+    )
 
     def __init__(
         self,
@@ -2447,6 +2487,320 @@ class SearchService:
         return max(target, min(target * cls.NEWS_OVERSAMPLE_FACTOR, cls.NEWS_OVERSAMPLE_MAX))
 
     @staticmethod
+    def _append_unique(values: List[str], value: Optional[str]) -> None:
+        cleaned = (value or "").strip()
+        if cleaned and cleaned not in values:
+            values.append(cleaned)
+
+    @classmethod
+    def _stock_code_identity_terms(cls, stock_code: str) -> List[str]:
+        """Return code/ticker variants that should count as strong identity hits."""
+        raw = (stock_code or "").strip()
+        if not raw:
+            return []
+
+        terms: List[str] = []
+        cls._append_unique(terms, raw)
+        cls._append_unique(terms, raw.upper())
+
+        lower = raw.lower()
+        hk_digits = ""
+        if lower.startswith("hk"):
+            hk_digits = re.sub(r"\D", "", raw)
+        elif raw.isdigit() and len(raw) == 5:
+            hk_digits = raw
+
+        if hk_digits:
+            padded = hk_digits.zfill(5)
+            short = str(int(hk_digits)) if hk_digits.isdigit() else hk_digits.lstrip("0")
+            cls._append_unique(terms, padded)
+            cls._append_unique(terms, short)
+            cls._append_unique(terms, f"HK{padded}")
+            cls._append_unique(terms, f"{padded}.HK")
+            cls._append_unique(terms, f"{short}.HK")
+            cls._append_unique(terms, f"HKEX:{short}")
+            return terms
+
+        if raw.isdigit() and len(raw) == 6:
+            suffix = ".SH" if raw.startswith(("5", "6", "9")) else ".SZ"
+            cls._append_unique(terms, f"{raw}{suffix}")
+            return terms
+
+        upper = raw.upper()
+        if cls._US_STOCK_RE.match(upper):
+            cls._append_unique(terms, f"${upper}")
+            cls._append_unique(terms, f"NASDAQ:{upper}")
+            cls._append_unique(terms, f"NYSE:{upper}")
+            return terms
+
+        return terms
+
+    @classmethod
+    def _company_identity_terms(cls, stock_name: str) -> List[str]:
+        """Return conservative company-name variants for relevance matching."""
+        raw = (stock_name or "").strip()
+        if not raw:
+            return []
+
+        terms: List[str] = []
+        cls._append_unique(terms, raw)
+
+        without_market_suffix = re.sub(r"[-－（(].*$", "", raw).strip()
+        cls._append_unique(terms, without_market_suffix)
+
+        if cls._contains_chinese_text(raw):
+            cleaned = re.sub(
+                r"(股份有限公司|有限责任公司|有限公司|控股集团|控股|集团|股份|公司)$",
+                "",
+                without_market_suffix,
+            ).strip()
+            if len(cleaned) >= 4:
+                cls._append_unique(terms, cleaned)
+        else:
+            cleaned = re.sub(
+                r"\b(incorporated|inc|corporation|corp|company|co|plc|ltd|limited|holdings?)\.?$",
+                "",
+                without_market_suffix,
+                flags=re.IGNORECASE,
+            ).strip()
+            if len(cleaned) >= 3:
+                cls._append_unique(terms, cleaned)
+
+        return terms
+
+    @classmethod
+    def _contains_identity_term(cls, text: str, term: str) -> bool:
+        if not text or not term:
+            return False
+
+        if cls._contains_chinese_text(term):
+            start = 0
+            while True:
+                index = text.find(term, start)
+                if index < 0:
+                    return False
+                next_char = text[index + len(term):index + len(term) + 1]
+                if next_char not in {"镇", "村", "县"}:
+                    return True
+                start = index + len(term)
+
+        lower_text = text.lower()
+        lower_term = term.lower()
+        if lower_term.startswith("$"):
+            return lower_term in lower_text
+
+        pattern = r"(?<![A-Za-z0-9])" + re.escape(lower_term) + r"(?![A-Za-z0-9])"
+        return bool(re.search(pattern, lower_text))
+
+    @classmethod
+    def _contains_any_news_term(cls, text: str, terms: Tuple[str, ...]) -> bool:
+        lower = (text or "").lower()
+        return any(term.lower() in lower for term in terms)
+
+    @classmethod
+    def _score_news_relevance(
+        cls,
+        item: SearchResult,
+        *,
+        stock_code: str,
+        stock_name: str,
+    ) -> SearchResult:
+        """Attach conservative, explainable relevance metadata to one news item."""
+        title = item.title or ""
+        snippet = item.snippet or ""
+        url = item.url or ""
+        source = item.source or ""
+        full_text = " ".join([title, snippet, url, source])
+
+        score = 0
+        direct_signal = 0
+        reasons: List[str] = []
+
+        def add_reason(reason: str) -> None:
+            if reason not in reasons and len(reasons) < 5:
+                reasons.append(reason)
+
+        for term in cls._stock_code_identity_terms(stock_code):
+            if cls._contains_identity_term(title, term):
+                score += 55
+                direct_signal += 55
+                add_reason(f"标题命中股票代码 {term}")
+                break
+        else:
+            for term in cls._stock_code_identity_terms(stock_code):
+                if cls._contains_identity_term(snippet, term):
+                    score += 34
+                    direct_signal += 34
+                    add_reason(f"摘要命中股票代码 {term}")
+                    break
+            else:
+                for term in cls._stock_code_identity_terms(stock_code):
+                    if cls._contains_identity_term(url, term):
+                        score += 18
+                        direct_signal += 18
+                        add_reason(f"链接命中股票代码 {term}")
+                        break
+
+        for term in cls._company_identity_terms(stock_name):
+            ambiguous_en = (
+                not cls._contains_chinese_text(term)
+                and term.lower() in cls._AMBIGUOUS_EN_COMPANY_NAMES
+            )
+            title_score = 26 if ambiguous_en else 45
+            snippet_score = 16 if ambiguous_en else 28
+            if cls._contains_identity_term(title, term):
+                score += title_score
+                direct_signal += title_score
+                add_reason(f"标题命中公司名 {term}")
+                break
+            if cls._contains_identity_term(snippet, term):
+                score += snippet_score
+                direct_signal += snippet_score
+                add_reason(f"摘要命中公司名 {term}")
+                break
+
+        has_company_event = cls._contains_any_news_term(full_text, cls._COMPANY_EVENT_TERMS)
+        if has_company_event and direct_signal > 0:
+            score += 12
+            direct_signal += 12
+            add_reason("命中公告/财报/交易等公司事件词")
+
+        if cls._contains_any_news_term(f"{source} {url}", cls._OFFICIAL_SOURCE_TERMS):
+            score += 8
+            add_reason("来源接近公告或交易所渠道")
+
+        has_sector_signal = cls._contains_any_news_term(full_text, cls._SECTOR_NEWS_TERMS)
+        has_macro_signal = cls._contains_any_news_term(full_text, cls._MACRO_NEWS_TERMS)
+
+        if direct_signal >= 38:
+            category = cls._DIRECT_NEWS_CATEGORY
+        elif has_macro_signal and not direct_signal:
+            category = cls._MACRO_NEWS_CATEGORY
+            score = max(0, score - 12)
+            add_reason("未命中目标公司身份，归为宏观/市场新闻")
+        else:
+            category = cls._SECTOR_NEWS_CATEGORY
+            if has_sector_signal:
+                score += 6
+                add_reason("仅命中行业或板块背景")
+            else:
+                add_reason("未命中股票代码或公司全称，降级为背景新闻")
+
+        score = max(0, min(100, score))
+        return SearchResult(
+            title=item.title,
+            snippet=item.snippet,
+            url=item.url,
+            source=item.source,
+            published_date=item.published_date,
+            relevance_score=score,
+            relevance_category=category,
+            relevance_reasons=reasons,
+        )
+
+    @classmethod
+    def _rank_news_response(
+        cls,
+        response: SearchResponse,
+        *,
+        stock_code: str,
+        stock_name: str,
+        prefer_chinese: bool,
+        max_results: int,
+        log_scope: str,
+    ) -> SearchResponse:
+        """Score and sort news so direct company items are not crowded out."""
+        if not response.success or not response.results:
+            return response
+
+        scored_results = [
+            cls._score_news_relevance(item, stock_code=stock_code, stock_name=stock_name)
+            for item in response.results
+        ]
+
+        indexed_results = list(enumerate(scored_results))
+
+        def sort_key(entry: Tuple[int, SearchResult]) -> Tuple[int, int, int, int]:
+            index, result = entry
+            category = result.relevance_category or cls._SECTOR_NEWS_CATEGORY
+            category_rank = cls._NEWS_CATEGORY_PRIORITY.get(category, 9)
+            language_rank = 0 if prefer_chinese and cls._is_chinese_news_result(result) else 1
+            if not prefer_chinese:
+                language_rank = 0
+            score = result.relevance_score or 0
+            return (category_rank, -score, language_rank, index)
+
+        ranked_results = [result for _, result in sorted(indexed_results, key=sort_key)]
+        limited_results = ranked_results[:max_results]
+        category_counts = {
+            cls._DIRECT_NEWS_CATEGORY: 0,
+            cls._SECTOR_NEWS_CATEGORY: 0,
+            cls._MACRO_NEWS_CATEGORY: 0,
+        }
+        for result in limited_results:
+            if result.relevance_category in category_counts:
+                category_counts[result.relevance_category] += 1
+        if limited_results:
+            top = limited_results[0]
+            logger.info(
+                "[新闻相关度] %s: direct=%s, sector=%s, macro=%s, top_score=%s, top_category=%s, reasons=%s",
+                log_scope,
+                category_counts[cls._DIRECT_NEWS_CATEGORY],
+                category_counts[cls._SECTOR_NEWS_CATEGORY],
+                category_counts[cls._MACRO_NEWS_CATEGORY],
+                top.relevance_score,
+                top.relevance_category,
+                "；".join(top.relevance_reasons or []),
+            )
+
+        return SearchResponse(
+            query=response.query,
+            results=limited_results,
+            provider=response.provider,
+            success=response.success,
+            error_message=response.error_message,
+            search_time=response.search_time,
+        )
+
+    @classmethod
+    def _news_relevance_stats(
+        cls,
+        response: SearchResponse,
+        *,
+        prefer_chinese: bool,
+    ) -> Dict[str, int]:
+        results = response.results if response and response.results else []
+        return {
+            "direct_count": sum(
+                1 for item in results if item.relevance_category == cls._DIRECT_NEWS_CATEGORY
+            ),
+            "preferred_count": sum(
+                1 for item in results if prefer_chinese and cls._is_chinese_news_result(item)
+            ),
+            "max_score": max((item.relevance_score or 0 for item in results), default=0),
+            "result_count": len(results),
+        }
+
+    @classmethod
+    def _is_better_ranked_news_response(
+        cls,
+        candidate: SearchResponse,
+        *,
+        candidate_stats: Dict[str, int],
+        best_response: Optional[SearchResponse],
+        best_stats: Optional[Dict[str, int]],
+        prefer_chinese: bool,
+    ) -> bool:
+        if best_response is None or best_stats is None:
+            return True
+        for key in ("direct_count", "max_score"):
+            if candidate_stats[key] != best_stats[key]:
+                return candidate_stats[key] > best_stats[key]
+        if prefer_chinese and candidate_stats["preferred_count"] != best_stats["preferred_count"]:
+            return candidate_stats["preferred_count"] > best_stats["preferred_count"]
+        return candidate_stats["result_count"] > best_stats["result_count"]
+
+    @staticmethod
     def _parse_relative_news_date(text: str, now: datetime) -> Optional[date]:
         """Parse common Chinese/English relative-time strings."""
         raw = (text or "").strip()
@@ -2627,6 +2981,9 @@ class SearchService:
                     url=item.url,
                     source=item.source,
                     published_date=published.isoformat(),
+                    relevance_score=item.relevance_score,
+                    relevance_category=item.relevance_category,
+                    relevance_reasons=item.relevance_reasons,
                 )
             )
             if len(filtered) >= max_results:
@@ -2677,6 +3034,9 @@ class SearchService:
                     published_date=(
                         normalized_date.isoformat() if normalized_date is not None else item.published_date
                     ),
+                    relevance_score=item.relevance_score,
+                    relevance_category=item.relevance_category,
+                    relevance_reasons=item.relevance_reasons,
                 )
             )
 
@@ -2772,7 +3132,10 @@ class SearchService:
         )
 
         cache_key = self._cache_key(
-            f"{query}|news_pref={'zh' if prefer_chinese else 'default'}",
+            (
+                f"{query}|target={stock_code}:{stock_name}|"
+                f"news_pref={'zh' if prefer_chinese else 'default'}"
+            ),
             max_results,
             search_days,
         )
@@ -2794,9 +3157,8 @@ class SearchService:
         try:
             # 依次尝试各个搜索引擎（若过滤后为空，继续尝试下一引擎）
             had_provider_success = False
-            fallback_response: Optional[SearchResponse] = None
-            best_preferred_response: Optional[SearchResponse] = None
-            best_preferred_count = 0
+            best_ranked_response: Optional[SearchResponse] = None
+            best_ranked_stats: Optional[Dict[str, int]] = None
             for provider in self._providers:
                 if not provider.is_available:
                     continue
@@ -2822,46 +3184,62 @@ class SearchService:
                 had_provider_success = had_provider_success or bool(response.success)
 
                 if filtered_response.success and filtered_response.results:
-                    prioritized_response, preferred_count = self._prioritize_news_language(
+                    language_response, _preferred_count = self._prioritize_news_language(
                         filtered_response,
                         prefer_chinese=prefer_chinese,
                     )
+                    ranked_response = self._rank_news_response(
+                        language_response,
+                        stock_code=stock_code,
+                        stock_name=stock_name,
+                        prefer_chinese=prefer_chinese,
+                        max_results=provider_max_results,
+                        log_scope=f"{stock_code}:{provider.name}:stock_news",
+                    )
                     limited_response = self._limit_search_response(
-                        prioritized_response,
+                        ranked_response,
                         max_results=max_results,
                     )
-                    visible_preferred_count = min(preferred_count, len(limited_response.results))
+                    stats = self._news_relevance_stats(
+                        limited_response,
+                        prefer_chinese=prefer_chinese,
+                    )
+                    if self._is_better_ranked_news_response(
+                        limited_response,
+                        candidate_stats=stats,
+                        best_response=best_ranked_response,
+                        best_stats=best_ranked_stats,
+                        prefer_chinese=prefer_chinese,
+                    ):
+                        best_ranked_response = limited_response
+                        best_ranked_stats = stats
 
-                    if not prefer_chinese:
-                        logger.info(f"使用 {provider.name} 搜索成功")
+                    if stats["direct_count"] > 0:
+                        logger.info(
+                            "%s 搜索成功，识别到 %s 条直接个股新闻，优先返回",
+                            provider.name,
+                            stats["direct_count"],
+                        )
                         self._put_cache(cache_key, limited_response)
                         return limited_response
 
-                    if fallback_response is None:
-                        fallback_response = limited_response
-
-                    if visible_preferred_count > 0:
+                    if prefer_chinese and stats["preferred_count"] >= max_results:
                         logger.info(
-                            "%s 搜索成功，识别到 %s/%s 条中文新闻",
+                            "%s 搜索成功，中文结果已满足目标条数但缺少直接个股命中，继续尝试下一引擎",
                             provider.name,
-                            visible_preferred_count,
+                        )
+                        continue
+
+                    if prefer_chinese and stats["preferred_count"] > 0:
+                        logger.info(
+                            "%s 搜索成功，识别到 %s/%s 条中文新闻但缺少直接个股命中，继续尝试下一引擎",
+                            provider.name,
+                            stats["preferred_count"],
                             len(limited_response.results),
                         )
-                        if self._is_better_preferred_news_response(
-                            limited_response,
-                            candidate_preferred_count=visible_preferred_count,
-                            best_response=best_preferred_response,
-                            best_preferred_count=best_preferred_count,
-                        ):
-                            best_preferred_response = limited_response
-                            best_preferred_count = visible_preferred_count
-
-                        if visible_preferred_count >= max_results:
-                            self._put_cache(cache_key, limited_response)
-                            return limited_response
                     else:
                         logger.info(
-                            "%s 搜索成功但结果仍以英文为主，继续尝试下一引擎",
+                            "%s 搜索成功但未识别直接个股新闻，继续尝试下一引擎",
                             provider.name,
                         )
                 else:
@@ -2877,11 +3255,9 @@ class SearchService:
                             response.error_message,
                         )
 
-            if prefer_chinese:
-                best_to_return = best_preferred_response or fallback_response
-                if best_to_return is not None:
-                    self._put_cache(cache_key, best_to_return)
-                    return best_to_return
+            if best_ranked_response is not None:
+                self._put_cache(cache_key, best_ranked_response)
+                return best_ranked_response
 
             if had_provider_success:
                 return SearchResponse(
@@ -3138,14 +3514,22 @@ class SearchService:
                 filtered_response = self._filter_news_response(
                     response,
                     search_days=search_days,
-                    max_results=target_per_dimension,
+                    max_results=provider_max_results,
                     log_scope=f"{stock_code}:{provider.name}:{dim['name']}",
                 )
             else:
                 filtered_response = self._normalize_and_limit_response(
                     response,
-                    max_results=target_per_dimension,
+                    max_results=provider_max_results,
                 )
+            filtered_response = self._rank_news_response(
+                filtered_response,
+                stock_code=stock_code,
+                stock_name=stock_name,
+                prefer_chinese=self._should_prefer_chinese_news(stock_code, stock_name),
+                max_results=target_per_dimension,
+                log_scope=f"{stock_code}:{provider.name}:{dim['name']}:rank",
+            )
             results[dim['name']] = filtered_response
             search_count += 1
             
@@ -3207,6 +3591,15 @@ class SearchService:
                     # 如果摘要太短，可能信息量不足
                     snippet = r.snippet[:150] if len(r.snippet) > 20 else r.snippet
                     lines.append(f"     {snippet}...")
+                    if r.relevance_category or r.relevance_reasons:
+                        relevance_parts = []
+                        if r.relevance_category:
+                            relevance_parts.append(r.relevance_category)
+                        if r.relevance_score is not None:
+                            relevance_parts.append(f"score={r.relevance_score}")
+                        if r.relevance_reasons:
+                            relevance_parts.append(f"依据: {'；'.join(r.relevance_reasons[:3])}")
+                        lines.append(f"     关联度: {'; '.join(relevance_parts)}")
             else:
                 lines.append("  未找到相关信息")
         

--- a/src/search_service.py
+++ b/src/search_service.py
@@ -2505,8 +2505,8 @@ class SearchService:
 
         terms: List[str] = []
         upper = raw.upper()
-        is_one_letter_us_ticker = bool(len(upper) == 1 and cls._US_STOCK_RE.match(upper))
-        if not is_one_letter_us_ticker:
+        is_us_ticker = bool(cls._US_STOCK_RE.match(upper))
+        if not is_us_ticker:
             cls._append_unique(terms, raw)
             cls._append_unique(terms, upper)
 
@@ -2537,6 +2537,8 @@ class SearchService:
             cls._append_unique(terms, f"${upper}")
             cls._append_unique(terms, f"NASDAQ:{upper}")
             cls._append_unique(terms, f"NYSE:{upper}")
+            if len(upper) > 1:
+                cls._append_unique(terms, upper)
             return terms
 
         return terms
@@ -2599,6 +2601,17 @@ class SearchService:
         return bool(re.search(pattern, lower_text))
 
     @classmethod
+    def _contains_stock_code_identity_term(cls, text: str, term: str) -> bool:
+        if not text or not term:
+            return False
+
+        if cls._US_STOCK_RE.match(term) and term.upper() == term and not term.startswith("$"):
+            pattern = r"(?<![A-Za-z0-9$:.])" + re.escape(term) + r"(?![A-Za-z0-9.])"
+            return bool(re.search(pattern, text))
+
+        return cls._contains_identity_term(text, term)
+
+    @classmethod
     def _contains_any_news_term(cls, text: str, terms: Tuple[str, ...]) -> bool:
         lower = (text or "").lower()
         return any(term.lower() in lower for term in terms)
@@ -2630,7 +2643,7 @@ class SearchService:
                 reasons.append(reason)
 
         for term in cls._stock_code_identity_terms(stock_code):
-            if cls._contains_identity_term(title, term):
+            if cls._contains_stock_code_identity_term(title, term):
                 score += 55
                 direct_signal += 55
                 has_stock_code_signal = True
@@ -2638,7 +2651,7 @@ class SearchService:
                 break
         else:
             for term in cls._stock_code_identity_terms(stock_code):
-                if cls._contains_identity_term(snippet, term):
+                if cls._contains_stock_code_identity_term(snippet, term):
                     score += 34
                     direct_signal += 34
                     has_stock_code_signal = True
@@ -2646,7 +2659,7 @@ class SearchService:
                     break
             else:
                 for term in cls._stock_code_identity_terms(stock_code):
-                    if cls._contains_identity_term(url, term):
+                    if cls._contains_stock_code_identity_term(url, term):
                         score += 18
                         direct_signal += 18
                         has_stock_code_signal = True
@@ -2758,7 +2771,7 @@ class SearchService:
             if not prefer_chinese:
                 language_rank = 0
             score = result.relevance_score or 0
-            return (category_rank, -score, language_rank, index)
+            return (category_rank, language_rank, -score, index)
 
         ranked_results = [result for _, result in sorted(indexed_results, key=sort_key)]
         limited_results = ranked_results[:max_results]

--- a/src/search_service.py
+++ b/src/search_service.py
@@ -2533,7 +2533,6 @@ class SearchService:
             padded = hk_digits.zfill(5)
             short = str(int(hk_digits)) if hk_digits.isdigit() else hk_digits.lstrip("0")
             cls._append_unique(terms, padded)
-            cls._append_unique(terms, short)
             cls._append_unique(terms, f"HK{padded}")
             cls._append_unique(terms, f"{padded}.HK")
             cls._append_unique(terms, f"{short}.HK")

--- a/src/search_service.py
+++ b/src/search_service.py
@@ -2136,6 +2136,10 @@ class SearchService:
         _MACRO_NEWS_CATEGORY: 2,
     }
     _AMBIGUOUS_EN_COMPANY_NAMES = {"apple", "meta", "square", "target", "gap"}
+    _AMBIGUOUS_EN_CONFIRMING_EVENT_TERMS = (
+        "earnings", "revenue", "profit", "guidance", "filing", "buyback",
+        "dividend", "lawsuit", "merger", "acquisition",
+    )
     _COMPANY_EVENT_TERMS = (
         "公告", "披露", "发布", "收购", "回购", "减持", "增持", "诉讼", "处罚",
         "业绩", "财报", "营收", "净利润", "分红", "董事会", "股东大会", "订单",
@@ -2615,6 +2619,9 @@ class SearchService:
         score = 0
         direct_signal = 0
         reasons: List[str] = []
+        has_stock_code_signal = False
+        has_unambiguous_company_signal = False
+        has_ambiguous_company_signal = False
 
         def add_reason(reason: str) -> None:
             if reason not in reasons and len(reasons) < 5:
@@ -2624,6 +2631,7 @@ class SearchService:
             if cls._contains_identity_term(title, term):
                 score += 55
                 direct_signal += 55
+                has_stock_code_signal = True
                 add_reason(f"标题命中股票代码 {term}")
                 break
         else:
@@ -2631,6 +2639,7 @@ class SearchService:
                 if cls._contains_identity_term(snippet, term):
                     score += 34
                     direct_signal += 34
+                    has_stock_code_signal = True
                     add_reason(f"摘要命中股票代码 {term}")
                     break
             else:
@@ -2638,6 +2647,7 @@ class SearchService:
                     if cls._contains_identity_term(url, term):
                         score += 18
                         direct_signal += 18
+                        has_stock_code_signal = True
                         add_reason(f"链接命中股票代码 {term}")
                         break
 
@@ -2651,18 +2661,36 @@ class SearchService:
             if cls._contains_identity_term(title, term):
                 score += title_score
                 direct_signal += title_score
+                if ambiguous_en:
+                    has_ambiguous_company_signal = True
+                else:
+                    has_unambiguous_company_signal = True
                 add_reason(f"标题命中公司名 {term}")
                 break
             if cls._contains_identity_term(snippet, term):
                 score += snippet_score
                 direct_signal += snippet_score
+                if ambiguous_en:
+                    has_ambiguous_company_signal = True
+                else:
+                    has_unambiguous_company_signal = True
                 add_reason(f"摘要命中公司名 {term}")
                 break
 
         has_company_event = cls._contains_any_news_term(full_text, cls._COMPANY_EVENT_TERMS)
         if has_company_event and direct_signal > 0:
             score += 12
-            direct_signal += 12
+            ambiguous_name_only = (
+                has_ambiguous_company_signal
+                and not has_stock_code_signal
+                and not has_unambiguous_company_signal
+            )
+            has_confirming_event = cls._contains_any_news_term(
+                full_text,
+                cls._AMBIGUOUS_EN_CONFIRMING_EVENT_TERMS,
+            )
+            if not ambiguous_name_only or has_confirming_event:
+                direct_signal += 12
             add_reason("命中公告/财报/交易等公司事件词")
 
         if cls._contains_any_news_term(f"{source} {url}", cls._OFFICIAL_SOURCE_TERMS):

--- a/src/search_service.py
+++ b/src/search_service.py
@@ -2504,8 +2504,11 @@ class SearchService:
             return []
 
         terms: List[str] = []
-        cls._append_unique(terms, raw)
-        cls._append_unique(terms, raw.upper())
+        upper = raw.upper()
+        is_one_letter_us_ticker = bool(len(upper) == 1 and cls._US_STOCK_RE.match(upper))
+        if not is_one_letter_us_ticker:
+            cls._append_unique(terms, raw)
+            cls._append_unique(terms, upper)
 
         lower = raw.lower()
         hk_digits = ""
@@ -2530,7 +2533,6 @@ class SearchService:
             cls._append_unique(terms, f"{raw}{suffix}")
             return terms
 
-        upper = raw.upper()
         if cls._US_STOCK_RE.match(upper):
             cls._append_unique(terms, f"${upper}")
             cls._append_unique(terms, f"NASDAQ:{upper}")
@@ -2802,6 +2804,15 @@ class SearchService:
             "direct_count": sum(
                 1 for item in results if item.relevance_category == cls._DIRECT_NEWS_CATEGORY
             ),
+            "preferred_direct_count": sum(
+                1
+                for item in results
+                if (
+                    prefer_chinese
+                    and item.relevance_category == cls._DIRECT_NEWS_CATEGORY
+                    and cls._is_chinese_news_result(item)
+                )
+            ),
             "preferred_count": sum(
                 1 for item in results if prefer_chinese and cls._is_chinese_news_result(item)
             ),
@@ -2821,9 +2832,15 @@ class SearchService:
     ) -> bool:
         if best_response is None or best_stats is None:
             return True
-        for key in ("direct_count", "max_score"):
-            if candidate_stats[key] != best_stats[key]:
-                return candidate_stats[key] > best_stats[key]
+        if candidate_stats["direct_count"] != best_stats["direct_count"]:
+            return candidate_stats["direct_count"] > best_stats["direct_count"]
+        if (
+            prefer_chinese
+            and candidate_stats["preferred_direct_count"] != best_stats["preferred_direct_count"]
+        ):
+            return candidate_stats["preferred_direct_count"] > best_stats["preferred_direct_count"]
+        if candidate_stats["max_score"] != best_stats["max_score"]:
+            return candidate_stats["max_score"] > best_stats["max_score"]
         if prefer_chinese and candidate_stats["preferred_count"] != best_stats["preferred_count"]:
             return candidate_stats["preferred_count"] > best_stats["preferred_count"]
         return candidate_stats["result_count"] > best_stats["result_count"]
@@ -3242,7 +3259,9 @@ class SearchService:
                         best_ranked_response = limited_response
                         best_ranked_stats = stats
 
-                    if stats["direct_count"] > 0:
+                    if stats["direct_count"] > 0 and (
+                        not prefer_chinese or stats["preferred_direct_count"] > 0
+                    ):
                         logger.info(
                             "%s 搜索成功，识别到 %s 条直接个股新闻，优先返回",
                             provider.name,
@@ -3250,6 +3269,14 @@ class SearchService:
                         )
                         self._put_cache(cache_key, limited_response)
                         return limited_response
+
+                    if prefer_chinese and stats["direct_count"] > 0:
+                        logger.info(
+                            "%s 搜索成功，识别到 %s 条直接个股新闻但缺少中文直接命中，继续尝试下一引擎",
+                            provider.name,
+                            stats["direct_count"],
+                        )
+                        continue
 
                     if prefer_chinese and stats["preferred_count"] >= max_results:
                         logger.info(

--- a/src/search_service.py
+++ b/src/search_service.py
@@ -2505,17 +2505,29 @@ class SearchService:
 
         terms: List[str] = []
         upper = raw.upper()
-        is_us_ticker = bool(cls._US_STOCK_RE.match(upper))
+        code_for_variants = upper
+        if "." in upper:
+            base, suffix = upper.rsplit(".", 1)
+            if suffix == "HK" and base.isdigit() and 1 <= len(base) <= 5:
+                code_for_variants = f"HK{base.zfill(5)}"
+            elif suffix in {"SH", "SZ", "SS", "BJ"} and base.isdigit() and len(base) == 6:
+                code_for_variants = base
+            elif suffix == "US" and re.fullmatch(r"[A-Z]{1,5}", base):
+                code_for_variants = base
+
+        is_us_ticker = bool(cls._US_STOCK_RE.match(code_for_variants))
         if not is_us_ticker:
             cls._append_unique(terms, raw)
             cls._append_unique(terms, upper)
+            if code_for_variants != upper:
+                cls._append_unique(terms, code_for_variants)
 
-        lower = raw.lower()
+        lower = code_for_variants.lower()
         hk_digits = ""
         if lower.startswith("hk"):
-            hk_digits = re.sub(r"\D", "", raw)
-        elif raw.isdigit() and len(raw) == 5:
-            hk_digits = raw
+            hk_digits = re.sub(r"\D", "", code_for_variants)
+        elif code_for_variants.isdigit() and len(code_for_variants) == 5:
+            hk_digits = code_for_variants
 
         if hk_digits:
             padded = hk_digits.zfill(5)
@@ -2528,17 +2540,17 @@ class SearchService:
             cls._append_unique(terms, f"HKEX:{short}")
             return terms
 
-        if raw.isdigit() and len(raw) == 6:
-            suffix = ".SH" if raw.startswith(("5", "6", "9")) else ".SZ"
-            cls._append_unique(terms, f"{raw}{suffix}")
+        if code_for_variants.isdigit() and len(code_for_variants) == 6:
+            suffix = ".SH" if code_for_variants.startswith(("5", "6", "9")) else ".SZ"
+            cls._append_unique(terms, f"{code_for_variants}{suffix}")
             return terms
 
-        if cls._US_STOCK_RE.match(upper):
-            cls._append_unique(terms, f"${upper}")
-            cls._append_unique(terms, f"NASDAQ:{upper}")
-            cls._append_unique(terms, f"NYSE:{upper}")
-            if len(upper) > 1:
-                cls._append_unique(terms, upper)
+        if cls._US_STOCK_RE.match(code_for_variants):
+            cls._append_unique(terms, f"${code_for_variants}")
+            cls._append_unique(terms, f"NASDAQ:{code_for_variants}")
+            cls._append_unique(terms, f"NYSE:{code_for_variants}")
+            if len(code_for_variants) > 1:
+                cls._append_unique(terms, code_for_variants)
             return terms
 
         return terms
@@ -2606,7 +2618,11 @@ class SearchService:
             return False
 
         if cls._US_STOCK_RE.match(term) and term.upper() == term and not term.startswith("$"):
-            pattern = r"(?<![A-Za-z0-9$:.])" + re.escape(term) + r"(?![A-Za-z0-9.])"
+            pattern = (
+                r"(?<![A-Za-z0-9$:.])"
+                + re.escape(term)
+                + r"(?=$|[^A-Za-z0-9.]|\.(?:US|O|N|NYSE|NASDAQ|AMEX)\b)"
+            )
             return bool(re.search(pattern, text))
 
         return cls._contains_identity_term(text, term)

--- a/tests/test_search_news_freshness.py
+++ b/tests/test_search_news_freshness.py
@@ -19,12 +19,19 @@ if "newspaper" not in sys.modules:
 from src.search_service import SearchResponse, SearchResult, SearchService
 
 
-def _result(title: str, published_date: str | None) -> SearchResult:
+def _result(
+    title: str,
+    published_date: str | None,
+    *,
+    snippet: str = "snippet",
+    url: str | None = None,
+    source: str = "example.com",
+) -> SearchResult:
     return SearchResult(
         title=title,
-        snippet="snippet",
-        url=f"https://example.com/{title}",
-        source="example.com",
+        snippet=snippet,
+        url=url or f"https://example.com/{title}",
+        source=source,
         published_date=published_date,
     )
 
@@ -249,7 +256,7 @@ class SearchNewsFreshnessTestCase(unittest.TestCase):
         resp = service.search_stock_news("600519", "贵州茅台", max_results=1)
         self.assertEqual([r.title for r in resp.results], ["中文快讯"])
         p1.search.assert_called_once()
-        p2.search.assert_not_called()
+        p2.search.assert_called_once()
 
     def test_search_stock_news_keeps_english_provider_order_for_us_stock(self) -> None:
         """English stock searches should keep the first successful provider result."""
@@ -277,6 +284,150 @@ class SearchNewsFreshnessTestCase(unittest.TestCase):
         self.assertEqual([r.title for r in resp.results], ["Apple earnings beat"])
         p1.search.assert_called_once()
         p2.search.assert_not_called()
+
+    def test_a_share_direct_company_news_beats_sector_provider_fallback(self) -> None:
+        """A-share direct company hits should beat generic sector news from earlier providers."""
+        fresh = datetime.now().date().isoformat()
+        service = SearchService(
+            bocha_keys=["dummy_key"],
+            searxng_public_instances_enabled=False,
+            news_max_age_days=3,
+            news_strategy_profile="short",
+        )
+
+        p1 = SimpleNamespace(
+            is_available=True,
+            name="P1",
+            search=MagicMock(
+                return_value=_response(
+                    [
+                        _result(
+                            "白酒行业景气度回暖 多只龙头上涨",
+                            fresh,
+                            snippet="消费板块获得资金关注。",
+                        )
+                    ]
+                )
+            ),
+        )
+        p2 = SimpleNamespace(
+            is_available=True,
+            name="P2",
+            search=MagicMock(
+                return_value=_response(
+                    [
+                        _result("沪指震荡收涨，市场情绪回暖", fresh),
+                        _result(
+                            "贵州茅台 600519 发布回购公告",
+                            fresh,
+                            snippet="贵州茅台披露公司公告，董事会审议通过回购方案。",
+                            source="cninfo",
+                        ),
+                    ]
+                )
+            ),
+        )
+        service._providers = [p1, p2]
+
+        resp = service.search_stock_news("600519", "贵州茅台", max_results=2)
+
+        self.assertEqual(resp.results[0].title, "贵州茅台 600519 发布回购公告")
+        self.assertEqual(resp.results[0].relevance_category, "direct_company_news")
+        self.assertIn("股票代码", "；".join(resp.results[0].relevance_reasons or []))
+        p1.search.assert_called_once()
+        p2.search.assert_called_once()
+
+    def test_hk_stock_relevance_avoids_similar_name_noise(self) -> None:
+        """HK stock matching should prefer exact company/code over similar-name news."""
+        fresh = datetime.now().date().isoformat()
+        service = SearchService(
+            bocha_keys=["dummy_key"],
+            searxng_public_instances_enabled=False,
+            news_max_age_days=3,
+            news_strategy_profile="short",
+        )
+        provider = SimpleNamespace(
+            is_available=True,
+            name="HKProvider",
+            search=MagicMock(
+                return_value=_response(
+                    [
+                        _result(
+                            "腾讯音乐发布新专辑合作计划",
+                            fresh,
+                            snippet="腾讯音乐娱乐集团宣布内容合作。",
+                        ),
+                        _result(
+                            "腾讯控股 00700 公告：回购股份",
+                            fresh,
+                            snippet="腾讯控股在港交所披露股份回购公告。",
+                            source="hkexnews",
+                        ),
+                    ]
+                )
+            ),
+        )
+        service._providers = [provider]
+
+        resp = service.search_stock_news("hk00700", "腾讯控股", max_results=2)
+
+        self.assertEqual(resp.results[0].title, "腾讯控股 00700 公告：回购股份")
+        self.assertEqual(resp.results[0].relevance_category, "direct_company_news")
+        self.assertEqual(resp.results[1].relevance_category, "sector_related_news")
+
+    def test_us_stock_ticker_relevance_beats_ambiguous_company_word(self) -> None:
+        """US ticker hits should outrank ambiguous common-word company-name noise."""
+        fresh = datetime.now().date().isoformat()
+        service = SearchService(
+            bocha_keys=["dummy_key"],
+            searxng_public_instances_enabled=False,
+            news_max_age_days=3,
+            news_strategy_profile="short",
+        )
+        provider = SimpleNamespace(
+            is_available=True,
+            name="USProvider",
+            search=MagicMock(
+                return_value=_response(
+                    [
+                        _result(
+                            "Apple growers face lower fruit prices",
+                            fresh,
+                            snippet="Agriculture market report on orchards.",
+                        ),
+                        _result(
+                            "AAPL Apple earnings beat analyst expectations",
+                            fresh,
+                            snippet="Apple shares rose after quarterly revenue guidance improved.",
+                        ),
+                    ]
+                )
+            ),
+        )
+        service._providers = [provider]
+
+        resp = service.search_stock_news("AAPL", "Apple", max_results=2)
+
+        self.assertEqual(resp.results[0].title, "AAPL Apple earnings beat analyst expectations")
+        self.assertEqual(resp.results[0].relevance_category, "direct_company_news")
+        self.assertEqual(resp.results[1].relevance_category, "sector_related_news")
+
+    def test_relevance_metadata_is_visible_in_news_context(self) -> None:
+        result = SearchResult(
+            title="贵州茅台 600519 发布公告",
+            snippet="公司披露董事会决议。",
+            url="https://example.com/news",
+            source="cninfo",
+            published_date=datetime.now().date().isoformat(),
+            relevance_score=100,
+            relevance_category="direct_company_news",
+            relevance_reasons=["标题命中股票代码 600519", "标题命中公司名 贵州茅台"],
+        )
+        context = SearchResponse(query="贵州茅台", results=[result], provider="Unit").to_context()
+
+        self.assertIn("关联度", context)
+        self.assertIn("direct_company_news", context)
+        self.assertIn("标题命中股票代码 600519", context)
 
     def test_search_stock_news_brave_locale_matches_market_context(self) -> None:
         """Brave locale should follow Chinese-preferred vs US-stock contexts."""

--- a/tests/test_search_news_freshness.py
+++ b/tests/test_search_news_freshness.py
@@ -296,6 +296,56 @@ class SearchNewsFreshnessTestCase(unittest.TestCase):
         self.assertEqual(resp.results[0].relevance_category, "direct_company_news")
         provider.search.assert_called_once()
 
+    def test_a_share_chinese_sector_provider_beats_higher_scored_english_sector(self) -> None:
+        """When no direct hit exists, Chinese-preferred flows should compare language before score."""
+        fresh = datetime.now().date().isoformat()
+        service = SearchService(
+            bocha_keys=["dummy_key"],
+            searxng_public_instances_enabled=False,
+            news_max_age_days=3,
+            news_strategy_profile="short",
+        )
+
+        p1 = SimpleNamespace(
+            is_available=True,
+            name="EnglishSector",
+            search=MagicMock(
+                return_value=_response(
+                    [
+                        _result(
+                            "Baijiu industry quarterly results improve",
+                            fresh,
+                            snippet="Sector peers report better market share.",
+                            source="sec.gov",
+                        )
+                    ]
+                )
+            ),
+        )
+        p2 = SimpleNamespace(
+            is_available=True,
+            name="ChineseSector",
+            search=MagicMock(
+                return_value=_response(
+                    [
+                        _result(
+                            "白酒板块资金回暖",
+                            fresh,
+                            snippet="消费行业反弹。",
+                        )
+                    ]
+                )
+            ),
+        )
+        service._providers = [p1, p2]
+
+        resp = service.search_stock_news("600519", "贵州茅台", max_results=1)
+
+        self.assertEqual([r.title for r in resp.results], ["白酒板块资金回暖"])
+        self.assertEqual(resp.results[0].relevance_category, "sector_related_news")
+        p1.search.assert_called_once()
+        p2.search.assert_called_once()
+
     def test_search_stock_news_keeps_english_provider_order_for_us_stock(self) -> None:
         """English stock searches should keep the first successful provider result."""
         fresh = datetime.now().date().isoformat()
@@ -514,6 +564,26 @@ class SearchNewsFreshnessTestCase(unittest.TestCase):
         self.assertEqual(resp.results[0].relevance_category, "direct_company_news")
         self.assertEqual(resp.results[1].relevance_category, "sector_related_news")
 
+    def test_ambiguous_company_name_with_generic_event_terms_stays_background(self) -> None:
+        """Generic event words should not make ambiguous company names direct without ticker."""
+        scored = SearchService._score_news_relevance(
+            _result(
+                "Apple stock results harvest",
+                datetime.now().date().isoformat(),
+                snippet="Agriculture market report on orchards.",
+            ),
+            stock_code="AAPL",
+            stock_name="Apple",
+        )
+
+        self.assertNotEqual(scored.relevance_category, "direct_company_news")
+        self.assertFalse(
+            any(
+                reason.startswith(("标题命中股票代码", "摘要命中股票代码", "链接命中股票代码"))
+                for reason in (scored.relevance_reasons or [])
+            )
+        )
+
     def test_suffixed_stock_codes_keep_canonical_identity_terms(self) -> None:
         """Suffixed market codes should still emit canonical direct-match variants."""
         cases = (
@@ -554,11 +624,32 @@ class SearchNewsFreshnessTestCase(unittest.TestCase):
             SearchService._contains_stock_code_identity_term("AAPL.US shares rally", "AAPL")
         )
         self.assertTrue(
+            SearchService._contains_stock_code_identity_term("aapl.us shares rally", "AAPL")
+        )
+        self.assertTrue(
+            SearchService._contains_stock_code_identity_term("aapl shares rally", "AAPL")
+        )
+        self.assertTrue(
             SearchService._contains_stock_code_identity_term("TSLA.O gains after results", "TSLA")
+        )
+        self.assertTrue(
+            SearchService._contains_stock_code_identity_term("tsla.o gains after results", "TSLA")
         )
         self.assertFalse(
             SearchService._contains_stock_code_identity_term("AAPL.COM launches update", "AAPL")
         )
+
+        scored = SearchService._score_news_relevance(
+            _result(
+                "msft.us earnings beat expectations",
+                datetime.now().date().isoformat(),
+                snippet="Quarterly revenue guidance improved.",
+            ),
+            stock_code="MSFT",
+            stock_name="Microsoft",
+        )
+        self.assertEqual(scored.relevance_category, "direct_company_news")
+        self.assertIn("股票代码", "；".join(scored.relevance_reasons or []))
 
     def test_one_letter_us_ticker_does_not_match_common_article_words(self) -> None:
         """Bare one-letter US tickers should not make ordinary words direct hits."""

--- a/tests/test_search_news_freshness.py
+++ b/tests/test_search_news_freshness.py
@@ -258,6 +258,44 @@ class SearchNewsFreshnessTestCase(unittest.TestCase):
         p1.search.assert_called_once()
         p2.search.assert_called_once()
 
+    def test_search_stock_news_prefers_chinese_direct_hit_before_score_truncation(self) -> None:
+        """Chinese direct hits should outrank higher-scored English direct hits before limiting."""
+        fresh = datetime.now().date().isoformat()
+        service = SearchService(
+            bocha_keys=["dummy_key"],
+            searxng_public_instances_enabled=False,
+            news_max_age_days=3,
+            news_strategy_profile="short",
+        )
+
+        provider = SimpleNamespace(
+            is_available=True,
+            name="MixedDirect",
+            search=MagicMock(
+                return_value=_response(
+                    [
+                        _result(
+                            "Kweichow Moutai 600519 announces buyback",
+                            fresh,
+                            snippet="The company reported an updated share repurchase plan.",
+                        ),
+                        _result(
+                            "贵州茅台 发布回购公告",
+                            fresh,
+                            snippet="公司披露回购方案。",
+                        ),
+                    ]
+                )
+            ),
+        )
+        service._providers = [provider]
+
+        resp = service.search_stock_news("600519", "贵州茅台", max_results=1)
+
+        self.assertEqual([r.title for r in resp.results], ["贵州茅台 发布回购公告"])
+        self.assertEqual(resp.results[0].relevance_category, "direct_company_news")
+        provider.search.assert_called_once()
+
     def test_search_stock_news_keeps_english_provider_order_for_us_stock(self) -> None:
         """English stock searches should keep the first successful provider result."""
         fresh = datetime.now().date().isoformat()
@@ -505,6 +543,54 @@ class SearchNewsFreshnessTestCase(unittest.TestCase):
         resp = service.search_stock_news("A", "Agilent Technologies", max_results=1)
 
         self.assertEqual(resp.results[0].title, "Agilent Technologies announces quarterly earnings")
+        self.assertEqual(resp.results[0].relevance_category, "direct_company_news")
+        p1.search.assert_called_once()
+        p2.search.assert_called_once()
+
+    def test_common_word_us_ticker_does_not_match_title_case_words(self) -> None:
+        """Bare alphabetic tickers should not turn ordinary words into direct hits."""
+        fresh = datetime.now().date().isoformat()
+        service = SearchService(
+            bocha_keys=["dummy_key"],
+            searxng_public_instances_enabled=False,
+            news_max_age_days=3,
+            news_strategy_profile="short",
+        )
+        p1 = SimpleNamespace(
+            is_available=True,
+            name="GenericProvider",
+            search=MagicMock(
+                return_value=_response(
+                    [
+                        _result(
+                            "All investors brace for inflation data",
+                            fresh,
+                            snippet="Market participants watch a broad macro update.",
+                        )
+                    ]
+                )
+            ),
+        )
+        p2 = SimpleNamespace(
+            is_available=True,
+            name="CompanyProvider",
+            search=MagicMock(
+                return_value=_response(
+                    [
+                        _result(
+                            "ALL Allstate quarterly earnings beat expectations",
+                            fresh,
+                            snippet="Allstate revenue guidance improved after quarterly results.",
+                        )
+                    ]
+                )
+            ),
+        )
+        service._providers = [p1, p2]
+
+        resp = service.search_stock_news("ALL", "Allstate", max_results=1)
+
+        self.assertEqual(resp.results[0].title, "ALL Allstate quarterly earnings beat expectations")
         self.assertEqual(resp.results[0].relevance_category, "direct_company_news")
         p1.search.assert_called_once()
         p2.search.assert_called_once()

--- a/tests/test_search_news_freshness.py
+++ b/tests/test_search_news_freshness.py
@@ -462,6 +462,21 @@ class SearchNewsFreshnessTestCase(unittest.TestCase):
         self.assertEqual(resp.results[0].relevance_category, "direct_company_news")
         self.assertEqual(resp.results[1].relevance_category, "sector_related_news")
 
+    def test_hk_stock_bare_short_code_does_not_match_index_points(self) -> None:
+        """Bare HK short codes should not make index-point headlines direct hits."""
+        result = SearchService._score_news_relevance(
+            _result(
+                "恒生指数大涨700点 科技股普遍反弹",
+                datetime.now().date().isoformat(),
+                snippet="港股市场情绪回暖，指数走强。",
+            ),
+            stock_code="hk00700",
+            stock_name="腾讯控股",
+        )
+
+        self.assertNotEqual(result.relevance_category, "direct_company_news")
+        self.assertNotIn("股票代码 700", "；".join(result.relevance_reasons or []))
+
     def test_us_stock_ticker_relevance_beats_ambiguous_company_word(self) -> None:
         """US ticker hits should outrank ambiguous common-word company-name noise."""
         fresh = datetime.now().date().isoformat()

--- a/tests/test_search_news_freshness.py
+++ b/tests/test_search_news_freshness.py
@@ -412,6 +412,54 @@ class SearchNewsFreshnessTestCase(unittest.TestCase):
         self.assertEqual(resp.results[0].relevance_category, "direct_company_news")
         self.assertEqual(resp.results[1].relevance_category, "sector_related_news")
 
+    def test_ambiguous_english_name_generic_event_does_not_stop_provider_fallback(self) -> None:
+        """Ambiguous title-only names plus broad event words should not count as direct hits."""
+        fresh = datetime.now().date().isoformat()
+        service = SearchService(
+            bocha_keys=["dummy_key"],
+            searxng_public_instances_enabled=False,
+            news_max_age_days=3,
+            news_strategy_profile="short",
+        )
+        p1 = SimpleNamespace(
+            is_available=True,
+            name="AmbiguousProvider",
+            search=MagicMock(
+                return_value=_response(
+                    [
+                        _result(
+                            "Apple stock results improve after harvest update",
+                            fresh,
+                            snippet="Fruit market coverage tracks inventory and crop supply.",
+                        )
+                    ]
+                )
+            ),
+        )
+        p2 = SimpleNamespace(
+            is_available=True,
+            name="TickerProvider",
+            search=MagicMock(
+                return_value=_response(
+                    [
+                        _result(
+                            "AAPL Apple earnings beat analyst expectations",
+                            fresh,
+                            snippet="Apple revenue guidance improved after quarterly earnings.",
+                        )
+                    ]
+                )
+            ),
+        )
+        service._providers = [p1, p2]
+
+        resp = service.search_stock_news("AAPL", "Apple", max_results=1)
+
+        self.assertEqual(resp.results[0].title, "AAPL Apple earnings beat analyst expectations")
+        self.assertEqual(resp.results[0].relevance_category, "direct_company_news")
+        p1.search.assert_called_once()
+        p2.search.assert_called_once()
+
     def test_relevance_metadata_is_visible_in_news_context(self) -> None:
         result = SearchResult(
             title="贵州茅台 600519 发布公告",

--- a/tests/test_search_news_freshness.py
+++ b/tests/test_search_news_freshness.py
@@ -337,6 +337,55 @@ class SearchNewsFreshnessTestCase(unittest.TestCase):
         p1.search.assert_called_once()
         p2.search.assert_called_once()
 
+    def test_a_share_chinese_direct_news_beats_english_direct_provider_fallback(self) -> None:
+        """Chinese-preferred queries should keep looking past English-only direct hits."""
+        fresh = datetime.now().date().isoformat()
+        service = SearchService(
+            bocha_keys=["dummy_key"],
+            searxng_public_instances_enabled=False,
+            news_max_age_days=3,
+            news_strategy_profile="short",
+        )
+
+        p1 = SimpleNamespace(
+            is_available=True,
+            name="EnglishDirect",
+            search=MagicMock(
+                return_value=_response(
+                    [
+                        _result(
+                            "Kweichow Moutai 600519 announces buyback",
+                            fresh,
+                            snippet="The company reported an updated share repurchase plan.",
+                        )
+                    ]
+                )
+            ),
+        )
+        p2 = SimpleNamespace(
+            is_available=True,
+            name="ChineseDirect",
+            search=MagicMock(
+                return_value=_response(
+                    [
+                        _result(
+                            "贵州茅台 600519 发布回购公告",
+                            fresh,
+                            snippet="贵州茅台披露公司回购公告。",
+                        )
+                    ]
+                )
+            ),
+        )
+        service._providers = [p1, p2]
+
+        resp = service.search_stock_news("600519", "贵州茅台", max_results=1)
+
+        self.assertEqual(resp.results[0].title, "贵州茅台 600519 发布回购公告")
+        self.assertEqual(resp.results[0].relevance_category, "direct_company_news")
+        p1.search.assert_called_once()
+        p2.search.assert_called_once()
+
     def test_hk_stock_relevance_avoids_similar_name_noise(self) -> None:
         """HK stock matching should prefer exact company/code over similar-name news."""
         fresh = datetime.now().date().isoformat()
@@ -411,6 +460,54 @@ class SearchNewsFreshnessTestCase(unittest.TestCase):
         self.assertEqual(resp.results[0].title, "AAPL Apple earnings beat analyst expectations")
         self.assertEqual(resp.results[0].relevance_category, "direct_company_news")
         self.assertEqual(resp.results[1].relevance_category, "sector_related_news")
+
+    def test_one_letter_us_ticker_does_not_match_common_article_words(self) -> None:
+        """Bare one-letter US tickers should not make ordinary words direct hits."""
+        fresh = datetime.now().date().isoformat()
+        service = SearchService(
+            bocha_keys=["dummy_key"],
+            searxng_public_instances_enabled=False,
+            news_max_age_days=3,
+            news_strategy_profile="short",
+        )
+        p1 = SimpleNamespace(
+            is_available=True,
+            name="GenericProvider",
+            search=MagicMock(
+                return_value=_response(
+                    [
+                        _result(
+                            "A new investing playbook emerges",
+                            fresh,
+                            snippet="Markets weigh a broad macro update.",
+                        )
+                    ]
+                )
+            ),
+        )
+        p2 = SimpleNamespace(
+            is_available=True,
+            name="CompanyProvider",
+            search=MagicMock(
+                return_value=_response(
+                    [
+                        _result(
+                            "Agilent Technologies announces quarterly earnings",
+                            fresh,
+                            snippet="Agilent Technologies revenue guidance improved.",
+                        )
+                    ]
+                )
+            ),
+        )
+        service._providers = [p1, p2]
+
+        resp = service.search_stock_news("A", "Agilent Technologies", max_results=1)
+
+        self.assertEqual(resp.results[0].title, "Agilent Technologies announces quarterly earnings")
+        self.assertEqual(resp.results[0].relevance_category, "direct_company_news")
+        p1.search.assert_called_once()
+        p2.search.assert_called_once()
 
     def test_ambiguous_english_name_generic_event_does_not_stop_provider_fallback(self) -> None:
         """Ambiguous title-only names plus broad event words should not count as direct hits."""

--- a/tests/test_search_news_freshness.py
+++ b/tests/test_search_news_freshness.py
@@ -499,6 +499,52 @@ class SearchNewsFreshnessTestCase(unittest.TestCase):
         self.assertEqual(resp.results[0].relevance_category, "direct_company_news")
         self.assertEqual(resp.results[1].relevance_category, "sector_related_news")
 
+    def test_suffixed_stock_codes_keep_canonical_identity_terms(self) -> None:
+        """Suffixed market codes should still emit canonical direct-match variants."""
+        cases = (
+            ("00700.HK", {"00700", "HK00700"}),
+            ("600519.SH", {"600519", "600519.SH"}),
+            ("AAPL.US", {"AAPL", "NASDAQ:AAPL", "NYSE:AAPL"}),
+        )
+        for stock_code, expected_terms in cases:
+            with self.subTest(stock_code=stock_code):
+                terms = set(SearchService._stock_code_identity_terms(stock_code))
+                self.assertTrue(expected_terms.issubset(terms))
+
+    def test_suffixed_market_codes_score_canonical_code_hits_as_direct(self) -> None:
+        """Canonical code hits from suffixed inputs should be direct company news."""
+        fresh = datetime.now().date().isoformat()
+        cases = (
+            ("00700.HK", "HK00700 announces buyback"),
+            ("600519.SH", "600519 发布回购公告"),
+            ("AAPL.US", "AAPL announces quarterly results"),
+        )
+        for stock_code, title in cases:
+            with self.subTest(stock_code=stock_code):
+                scored = SearchService._score_news_relevance(
+                    _result(
+                        title,
+                        fresh,
+                        snippet="The company reported a share buyback and quarterly results.",
+                    ),
+                    stock_code=stock_code,
+                    stock_name="Unmatched Name",
+                )
+                self.assertEqual(scored.relevance_category, "direct_company_news")
+                self.assertIn("股票代码", "；".join(scored.relevance_reasons or []))
+
+    def test_us_ticker_matches_before_known_dotted_market_suffix(self) -> None:
+        """Ticker boundaries should allow explicit market suffixes from news feeds."""
+        self.assertTrue(
+            SearchService._contains_stock_code_identity_term("AAPL.US shares rally", "AAPL")
+        )
+        self.assertTrue(
+            SearchService._contains_stock_code_identity_term("TSLA.O gains after results", "TSLA")
+        )
+        self.assertFalse(
+            SearchService._contains_stock_code_identity_term("AAPL.COM launches update", "AAPL")
+        )
+
     def test_one_letter_us_ticker_does_not_match_common_article_words(self) -> None:
         """Bare one-letter US tickers should not make ordinary words direct hits."""
         fresh = datetime.now().date().isoformat()

--- a/tests/test_search_service_concurrency.py
+++ b/tests/test_search_service_concurrency.py
@@ -191,7 +191,11 @@ class SearchServiceConcurrencyTestCase(unittest.TestCase):
             news_strategy_profile="short",
         )
         search_days = service._effective_news_window_days()
-        cache_key = service._cache_key("贵州茅台 600519 股票 最新消息|news_pref=zh", 3, search_days)
+        cache_key = service._cache_key(
+            "贵州茅台 600519 股票 最新消息|target=600519:贵州茅台|news_pref=zh",
+            3,
+            search_days,
+        )
         cached_response = SearchResponse(
             query="贵州茅台 600519 股票 最新消息",
             results=[


### PR DESCRIPTION
## PR Type
- [ ] fix
- [x] feat
- [ ] refactor
- [ ] docs
- [ ] chore
- [ ] test

## Background And Problem
- 当前问题：在现有个股新闻检索链路中加入保守的相关度评分、新闻分类和排序解释，优先展示直接关联目标公司的新闻。
- 影响范围：本次改动涉及 5 个文件，Diff 为 `+984 / -41`。
- 触发来源：Issue 自动执行（Issue #1356）。

## Scope Of Change
- `docs/CHANGELOG.md`
- `docs/full-guide.md`
- `src/search_service.py`
- `tests/test_search_news_freshness.py`
- `tests/test_search_service_concurrency.py`

## Documentation And Changelog
- 已同步更新文档/变更记录：`docs/CHANGELOG.md`, `docs/full-guide.md`。

## Issue Link
Closes #1356

## Verification Commands And Results
```bash
./scripts/ci_gate.sh flake8
./scripts/ci_gate.sh offline-tests
```

关键输出/结论 / Key output & conclusion:
- lint:PASS, test:PASS

## Compatibility And Risk
- **Medium**：涉及 `docs/CHANGELOG.md`, `docs/full-guide.md`, `src/search_service.py`, `tests/test_search_news_freshness.py`, `tests/test_search_service_concurrency.py`，建议按文件范围复核。
- 前提假设：
  - 复用现有新闻检索、股票元数据和报告生成链路，不新增平行新闻系统。
  - 不修改 secrets、workflow、部署流程或数据源凭据配置。
  - 若现有新闻数据只有标题和摘要，则先基于标题、摘要、链接、来源、发布时间和股票标识做可解释评分；有正文时再纳入正文命中位置。
  - 弱关联行业或宏观新闻不一定完全删除，可降级为行业背景或排在直接公司新闻之后。

## Rollback Plan
- `git revert <merge-commit>` 回滚本 PR 提交，重点确认 `docs/CHANGELOG.md`, `docs/full-guide.md`, `src/search_service.py`, `tests/test_search_news_freshness.py` 恢复正常。

## Acceptance Criteria
- 给定明确股票代码或公司名时，直接命中目标公司的新闻排序优先于泛行业新闻。
- 新闻结果能区分 direct_company_news、sector_related_news、macro_market_news 或等价分类。
- 报告或调试日志能展示主要新闻的相关度依据，例如命中代码、公司全称、简称、英文名、公告主体或来源可信度。
- 覆盖 A 股、港股、美股至少各一组回归用例，包含同名或近似名、英文 ticker、泛行业新闻降权场景。

## Checklist
- [x] 本 PR 有明确动机和业务价值 / This PR has a clear motivation and value
- [x] 已提供可复现的验证命令与结果 / Reproducible verification commands and results are included
- [x] 已评估兼容性与风险 / Compatibility and risk have been assessed
- [x] 已提供回滚方案 / A rollback plan is provided
- [x] 已同步更新相关文档与 `docs/CHANGELOG.md`，并在 PR 描述中说明文档落点 / Relevant docs and `docs/CHANGELOG.md` are updated, and the documentation location is stated in this PR