### PR TITLE
fix: 修复 completed 状态下优先读取内存任务结果时 result 因字段不完整解析失败而返回null(#1382)

### DIFF
--- a/api/v1/endpoints/analysis.py
+++ b/api/v1/endpoints/analysis.py
@@ -691,6 +691,54 @@ def _format_sse_event(event_type: str, data: Dict[str, Any]) -> str:
     return f"event: {event_type}\ndata: {json.dumps(data, ensure_ascii=False)}\n\n"
 
 
+def _datetime_to_iso(value: Any) -> Optional[str]:
+    if isinstance(value, datetime):
+        return value.isoformat()
+    if isinstance(value, str) and value.strip():
+        return value
+    return None
+
+
+def _extract_report_created_at(payload: Dict[str, Any]) -> Optional[str]:
+    report = payload.get("report")
+    if not isinstance(report, dict):
+        return None
+
+    meta = report.get("meta")
+    if not isinstance(meta, dict):
+        return None
+
+    return _datetime_to_iso(meta.get("created_at"))
+
+
+def _build_task_analysis_result(task: Any) -> AnalysisResultResponse:
+    """
+    Normalize an in-memory completed task result to the public API contract.
+
+    Older AnalysisService payloads contain stock_code/stock_name/report only.
+    The status endpoint owns the task metadata, so it can supply the missing
+    response fields without waiting for the database fallback path.
+    """
+    payload = dict(task.result)
+    if not payload.get("query_id"):
+        payload["query_id"] = task.task_id
+    if not payload.get("stock_code"):
+        payload["stock_code"] = task.stock_code
+
+    if not payload.get("stock_name") and getattr(task, "stock_name", None):
+        payload["stock_name"] = task.stock_name
+
+    if not payload.get("created_at"):
+        payload["created_at"] = (
+            _extract_report_created_at(payload)
+            or _datetime_to_iso(getattr(task, "created_at", None))
+            or _datetime_to_iso(getattr(task, "completed_at", None))
+            or datetime.now().isoformat()
+        )
+
+    return AnalysisResultResponse.model_validate(payload)
+
+
 # ============================================================
 # GET /status/{task_id} - 查询单个任务状态
 # ============================================================
@@ -735,7 +783,7 @@ def get_analysis_status(task_id: str) -> TaskStatus:
                     market_review_report = report_text
             else:
                 try:
-                    result = AnalysisResultResponse.model_validate(task.result)
+                    result = _build_task_analysis_result(task)
                 except Exception:
                     logger.warning(
                         "解析任务结果失败，回退为空返回: task_id=%s",

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -49,6 +49,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - [修复] 收紧港股新闻相关度中的裸短码匹配，避免将指数点数等普通数字误判为目标股票代码。
 - [修复] 修复个股新闻相关度中美股小写 ticker 后缀识别与 A/HK 弱相关新闻中文优先比较顺序。
 - [文档] Issue #1356 的结构化检测告警为既有上下文误报：本次仅调整个股新闻检索的相关度评分与分层排序（`direct_company_news` / `sector_related_news` / `macro_market_news`），不触及模型名、provider、LiteLLM 参数、Base URL 及运行时配置清理/迁移语义；无配置回写副作用，回退路径为回滚本次提交。
+- [修复] `/api/v1/analysis/status/{task_id}` 在 completed 内存队列路径补齐 `query_id` 与 `created_at`，避免分析结果被解析为空。
 
 ## [3.17.1] - 2026-05-16
 

--- a/tests/test_analysis_api_contract.py
+++ b/tests/test_analysis_api_contract.py
@@ -279,6 +279,47 @@ class AnalysisApiContractTestCase(unittest.TestCase):
         self.assertEqual(status.market_review_report, "市场复盘报告示例文本")
         self.assertIsNone(status.result)
 
+    def test_get_analysis_status_normalizes_completed_queue_result_contract(self) -> None:
+        if get_analysis_status is None or analysis_endpoint_module is None:
+            self.skipTest("analysis endpoint helpers unavailable in this environment")
+
+        created_at = datetime(2026, 5, 21, 17, 40, 0)
+        queue = MagicMock()
+        queue.get_task.return_value = SimpleNamespace(
+            task_id="task-queue-1",
+            stock_code="600519",
+            stock_name="贵州茅台",
+            status=analysis_endpoint_module.TaskStatusEnum.COMPLETED,
+            progress=100,
+            result={
+                "stock_code": "600519",
+                "stock_name": "贵州茅台",
+                "report": {
+                    "meta": {"query_id": "task-queue-1", "stock_code": "600519"},
+                    "summary": {"analysis_summary": "summary"},
+                },
+            },
+            error=None,
+            original_query=None,
+            selection_source=None,
+            created_at=created_at,
+            completed_at=datetime(2026, 5, 21, 17, 45, 0),
+        )
+
+        with patch("api.v1.endpoints.analysis.get_task_queue", return_value=queue):
+            status = get_analysis_status("task-queue-1")
+
+        self.assertEqual(status.status, "completed")
+        self.assertIsNotNone(status.result)
+        self.assertEqual(status.result.query_id, "task-queue-1")
+        self.assertEqual(status.result.stock_code, "600519")
+        self.assertEqual(status.result.stock_name, "贵州茅台")
+        self.assertEqual(status.result.created_at, created_at.isoformat())
+        self.assertEqual(
+            status.result.report["summary"]["analysis_summary"],
+            "summary",
+        )
+
     def test_run_market_review_background_raises_when_report_is_empty(self) -> None:
         if analysis_endpoint_module is None:
             self.skipTest("analysis endpoint helpers unavailable in this environment")


### PR DESCRIPTION
## PR Type
- [x] fix
- [ ] feat
- [ ] refactor
- [ ] docs
- [ ] chore
- [ ] test

## Background And Problem
- 当前问题：修复 completed 状态下优先读取内存任务结果时 result 因字段不完整解析失败而返回 null 的问题。
- 影响范围：本次改动涉及 3 个文件，Diff 为 `+91 / -1`。
- 触发来源：显式 implement/API 执行（Issue #1382）。

## Scope Of Change
- `api/v1/endpoints/analysis.py`
- `docs/CHANGELOG.md`
- `tests/test_analysis_api_contract.py`

## Documentation And Changelog
- 已同步更新文档/变更记录：`docs/CHANGELOG.md`。
- 当前补丁尚未包含 `README.md` 或专题文档；如用户可见行为发生变化，请补充文档落点。

## Issue Link
Closes #1382

## Verification Commands And Results
```bash
./scripts/ci_gate.sh flake8
./scripts/ci_gate.sh offline-tests
```

关键输出/结论 / Key output & conclusion:
- lint:PASS, test:PASS

## Compatibility And Risk
- **Medium**：涉及 `api/v1/endpoints/analysis.py`, `docs/CHANGELOG.md`, `tests/test_analysis_api_contract.py`，建议按文件范围复核。
- 前提假设：
  - 任务队列中的 task_id 可作为 AnalysisResultResponse.query_id 使用。
  - created_at 应优先复用任务创建时间、历史记录时间或已有持久化元数据，避免仅用当前时间临时伪造。
  - 修复应优先做结果契约归一化，保持历史记录读取路径和现有客户端字段兼容。
  - 维护者已明确要求进行修复，且当前问题不需要修改 secrets、部署、迁移或工作流。

## Rollback Plan
- `git revert <merge-commit>` 回滚本 PR 提交，重点确认 `api/v1/endpoints/analysis.py`, `docs/CHANGELOG.md`, `tests/test_analysis_api_contract.py` 恢复正常。

## Acceptance Criteria
- GET /api/v1/analysis/status/{task_id} 在 status 为 completed 时，内存队列路径返回非 null 的 result。
- result 至少包含 AnalysisResultResponse 需要的 query_id、stock_code、stock_name、report、created_at 字段。
- 服务重启前后同一任务结果的 API 响应结构保持一致或兼容。
- 不再因内存结果缺少 query_id、created_at 等字段触发解析失败并回退 result:null 的 warning。
- 新增或更新测试覆盖 completed 状态直接读取 task_queue.result 的路径。

## Checklist
- [x] 本 PR 有明确动机和业务价值 / This PR has a clear motivation and value
- [x] 已提供可复现的验证命令与结果 / Reproducible verification commands and results are included
- [x] 已评估兼容性与风险 / Compatibility and risk have been assessed
- [x] 已提供回滚方案 / A rollback plan is provided
- [ ] 文档与 `docs/CHANGELOG.md` 同步仍需确认；如涉及用户可见变更，请在合并前补充原因与文档落点 / Documentation and `docs/CHANGELOG.md` sync still needs confirmation before merge when user-visible behavior changes