### PR TITLE
fix: macOS 桌面端打包缺失 strategies 目录 (#1377)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 <!-- 新条目格式：- [类型] 描述（类型取值：新功能/改进/修复/文档/测试/chore）-->
 <!-- 每条独立一行追加到本段末尾，无需分类标题，合并时冲突最小 -->
 - [改进] 邮件等静态渠道单股/仪表盘报告补充财务摘要、股东回报和关联板块三块结构化数据，沿用 `fundamental_context` 字段，缺失时自动隐藏，对应小节支持中英双语。
+- [修复] macOS 桌面端后端 PyInstaller 打包补充 `strategies/` 内置策略目录，并在打包后校验策略 YAML 数量，避免 Agent 启动后加载 0 个内置策略。
 - [新功能] 港股/美股基本面接入 yfinance 适配器：`get_fundamental_context` 对 HK/US 返回 `valuation/growth/earnings/belong_boards`（institution/capital_flow/dragon_tiger/boards 暂无对应数据源仍标记 `not_supported`），财务摘要、股东回报与关联板块出现在邮件报告中。
 - [改进] yfinance 适配器拆分财报币种与分红币种：`earnings.financial_report.currency` 来自 `info.financialCurrency`，`earnings.dividend.currency` 来自 `info.currency`；HK ADR 财报 CNY、分红 HKD 不再混淆；通知层 per-share 渲染读取 `dividend.currency`，金额按 USD/HKD/CNY 分别后缀 美元/港元/元。
 - [改进] yfinance 分红 TTM 收益率改为按 `ttm_cash / latest_price * 100`（同币种）重算，仅在 TTM cash 或 latest price 缺失时回退到 `trailingAnnualDividendYield`/`dividendYield`，避免与 TTM cash 口径错位。

--- a/scripts/build-backend-macos.sh
+++ b/scripts/build-backend-macos.sh
@@ -103,7 +103,7 @@ for module in "${hidden_imports[@]}"; do
 done
 
 pushd "${ROOT_DIR}" >/dev/null
-cmd=("${PYTHON_BIN}" -m PyInstaller --name stock_analysis --onedir --noconfirm --noconsole --add-data "static:static" --collect-data litellm --collect-data tiktoken)
+cmd=("${PYTHON_BIN}" -m PyInstaller --name stock_analysis --onedir --noconfirm --noconsole --add-data "static:static" --add-data "strategies:strategies" --collect-data litellm --collect-data tiktoken)
 cmd+=("${hidden_import_args[@]}" "main.py")
 
 echo "Running: ${cmd[*]}"
@@ -121,6 +121,22 @@ if [[ -d "${packaged_static}" ]]; then
   "${PYTHON_BIN}" "${SCRIPT_DIR}/check_static_assets.py" "${packaged_static}"
 else
   log "WARNING: could not locate packaged static directory under dist/backend/stock_analysis; skipping post-package check."
+fi
+
+log "Verifying packaged built-in strategies..."
+source_strategy_count="$(find "${ROOT_DIR}/strategies" -maxdepth 1 -type f -name '*.yaml' | wc -l | tr -d '[:space:]')"
+packaged_strategies="${ROOT_DIR}/dist/backend/stock_analysis/_internal/strategies"
+if [[ ! -d "${packaged_strategies}" ]]; then
+  packaged_strategies="${ROOT_DIR}/dist/backend/stock_analysis/strategies"
+fi
+if [[ ! -d "${packaged_strategies}" ]]; then
+  echo "ERROR: packaged strategies directory not found under dist/backend/stock_analysis."
+  exit 1
+fi
+packaged_strategy_count="$(find "${packaged_strategies}" -maxdepth 1 -type f -name '*.yaml' | wc -l | tr -d '[:space:]')"
+if [[ "${packaged_strategy_count}" != "${source_strategy_count}" ]]; then
+  echo "ERROR: packaged strategies count mismatch: expected ${source_strategy_count}, got ${packaged_strategy_count}."
+  exit 1
 fi
 
 log "Backend build completed."

--- a/scripts/build-backend.ps1
+++ b/scripts/build-backend.ps1
@@ -112,6 +112,7 @@ $pyInstallerArgs = @(
   '--noconfirm',
   '--noconsole',
   '--add-data', 'static;static',
+  '--add-data', 'strategies;strategies',
   '--collect-data', 'litellm',
   '--collect-data', 'tiktoken'
 )
@@ -142,6 +143,20 @@ if (Test-Path $packagedStatic) {
   }
 } else {
   Write-Warning "Could not locate packaged static directory under dist\backend\stock_analysis; skipping post-package check."
+}
+
+Write-Host 'Verifying packaged built-in strategies...'
+$sourceStrategyCount = @(Get-ChildItem -Path 'strategies' -Filter '*.yaml' -File).Count
+$packagedStrategies = Join-Path 'dist\backend\stock_analysis' '_internal\strategies'
+if (-not (Test-Path $packagedStrategies)) {
+  $packagedStrategies = Join-Path 'dist\backend\stock_analysis' 'strategies'
+}
+if (-not (Test-Path $packagedStrategies)) {
+  throw 'Packaged strategies directory not found under dist\backend\stock_analysis.'
+}
+$packagedStrategyCount = @(Get-ChildItem -Path $packagedStrategies -Filter '*.yaml' -File).Count
+if ($packagedStrategyCount -ne $sourceStrategyCount) {
+  throw "Packaged strategies count mismatch: expected $sourceStrategyCount, got $packagedStrategyCount."
 }
 
 Write-Host 'Backend build completed.'

--- a/tests/test_agent_frozen_context.py
+++ b/tests/test_agent_frozen_context.py
@@ -6,6 +6,7 @@ import json
 import threading
 import unittest
 from datetime import date
+from pathlib import Path
 
 from src.agent.tools.registry import ToolDefinition, ToolRegistry
 from src.services.history_loader import (
@@ -107,6 +108,35 @@ class ExecuteToolsFrozenContextTestCase(unittest.TestCase):
 
         self.assertEqual(len(observed), num_tools)
         self.assertTrue(all(d == frozen_date for d in observed))
+
+
+class DesktopBackendPackagingAssetsTestCase(unittest.TestCase):
+    """Guard desktop PyInstaller packaging inputs for built-in Agent skills."""
+
+    repo_root = Path(__file__).resolve().parent.parent
+
+    def test_builtin_strategy_yaml_inventory_matches_expected_desktop_bundle(self):
+        strategies_dir = self.repo_root / "strategies"
+        strategy_names = sorted(path.stem for path in strategies_dir.glob("*.yaml"))
+
+        self.assertEqual(len(strategy_names), 15)
+        self.assertIn("bottom_volume", strategy_names)
+        self.assertIn("chan_theory", strategy_names)
+        self.assertIn("ma_golden_cross", strategy_names)
+        self.assertIn("wave_theory", strategy_names)
+
+    def test_backend_pyinstaller_scripts_include_strategies_data_directory(self):
+        macos_script = (self.repo_root / "scripts" / "build-backend-macos.sh").read_text(
+            encoding="utf-8"
+        )
+        windows_script = (self.repo_root / "scripts" / "build-backend.ps1").read_text(
+            encoding="utf-8"
+        )
+
+        self.assertIn('--add-data "strategies:strategies"', macos_script)
+        self.assertIn("--add-data', 'strategies;strategies'", windows_script)
+        self.assertIn("_internal/strategies", macos_script)
+        self.assertIn("_internal\\strategies", windows_script)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## PR Type
- [x] fix
- [ ] feat
- [ ] refactor
- [ ] docs
- [ ] chore
- [ ] test

## Background And Problem
- 当前问题：在桌面端 PyInstaller 打包链路中把 strategies/*.yaml 作为数据文件随 backend 打入 .app，并保持运行时相对路径为 strategies/。
- 影响范围：本次改动涉及 4 个文件，Diff 为 `+63 / -1`。
- 触发来源：显式 implement/API 执行（Issue #1377）。

## Scope Of Change
- `docs/CHANGELOG.md`
- `scripts/build-backend-macos.sh`
- `scripts/build-backend.ps1`
- `tests/test_agent_frozen_context.py`

## Documentation And Changelog
- 已同步更新文档/变更记录：`docs/CHANGELOG.md`。
- 当前补丁尚未包含 `README.md` 或专题文档；如用户可见行为发生变化，请补充文档落点。

## Issue Link
Closes #1377

## Verification Commands And Results
```bash
./scripts/ci_gate.sh flake8
./scripts/ci_gate.sh offline-tests
```

关键输出/结论 / Key output & conclusion:
- lint:PASS, test:PASS

## Compatibility And Risk
- **High**：涉及 `docs/CHANGELOG.md`, `scripts/build-backend-macos.sh`, `scripts/build-backend.ps1`, `tests/test_agent_frozen_context.py`，请重点审查变更范围、验证覆盖与发布影响。
- 前提假设：
  - 维护者已明确要求进行修复，且优先采用最小打包配置改动。
  - tickflow dist-info WARNING 属于独立问题 #795，本任务不顺带处理。
  - 运行时代码已按 frozen 路径查找 _internal/strategies，本次优先不改 src/agent/skills/base.py 或 src/agent/factory.py，除非验证发现路径映射仍不正确。
  - 若仓库中 PyInstaller spec 与桌面构建脚本分离，应只修改实际用于 macOS .app 构建的 spec 或脚本。

## Rollback Plan
- `git revert <merge-commit>` 回滚本 PR 提交，重点确认 `docs/CHANGELOG.md`, `scripts/build-backend-macos.sh`, `scripts/build-backend.ps1`, `tests/test_agent_frozen_context.py` 恢复正常。

## Acceptance Criteria
- macOS 桌面端构建产物中存在 backend/stock_analysis/_internal/strategies/ 目录。
- 构建产物内包含 15 个内置 YAML 策略文件，包括 bottom_volume、ma_golden_cross、chan_theory、wave_theory 等。
- 启动 Agent 后日志不再出现 strategies 目录不存在的 WARNING，SkillManager 可加载 15 个内置策略。
- 不改变 Docker、源码部署和运行时策略加载语义。
- docs/CHANGELOG.md 的 [Unreleased] 段新增扁平格式修复记录。

## Notes
- Risk is marked as high. Please review scope, validation coverage, and release impact carefully.

## Checklist
- [x] 本 PR 有明确动机和业务价值 / This PR has a clear motivation and value
- [x] 已提供可复现的验证命令与结果 / Reproducible verification commands and results are included
- [x] 已评估兼容性与风险 / Compatibility and risk have been assessed
- [x] 已提供回滚方案 / A rollback plan is provided
- [ ] 文档与 `docs/CHANGELOG.md` 同步仍需确认；如涉及用户可见变更，请在合并前补充原因与文档落点 / Documentation and `docs/CHANGELOG.md` sync still needs confirmation before merge when user-visible behavior changes