### PR TITLE
refactor: pytest Pydantic 弃用警告和 Web 大 chunk 警告 (#1394)

### DIFF
--- a/api/v1/schemas/analysis.py
+++ b/api/v1/schemas/analysis.py
@@ -13,7 +13,7 @@
 from typing import Optional, List, Any
 from enum import Enum
 
-from pydantic import AliasChoices, BaseModel, Field
+from pydantic import AliasChoices, BaseModel, ConfigDict, Field
 from src.utils.analysis_metadata import SELECTION_SOURCE_PATTERN
 
 
@@ -31,12 +31,12 @@ class AnalyzeRequest(BaseModel):
     stock_code: Optional[str] = Field(
         None, 
         description="单只股票代码", 
-        example="600519"
+        json_schema_extra={"example": "600519"},
     )
     stock_codes: Optional[List[str]] = Field(
         None, 
         description="多只股票代码（与 stock_code 二选一）",
-        example=["600519", "000858"]
+        json_schema_extra={"example": ["600519", "000858"]},
     )
     report_type: str = Field(
         "detailed",
@@ -54,18 +54,18 @@ class AnalyzeRequest(BaseModel):
     stock_name: Optional[str] = Field(
         None,
         description="用户选中的股票名称（自动补全时提供）",
-        example="贵州茅台"
+        json_schema_extra={"example": "贵州茅台"},
     )
     original_query: Optional[str] = Field(
         None,
         description="用户原始输入（如茅台、gzmt、600519）",
-        example="茅台"
+        json_schema_extra={"example": "茅台"},
     )
     selection_source: Optional[str] = Field(
         None,
         description="股票选择来源：manual(手动输入) | autocomplete(自动补全) | import(导入) | image(图片识别)",
         pattern=SELECTION_SOURCE_PATTERN,
-        example="autocomplete"
+        json_schema_extra={"example": "autocomplete"},
     )
     notify: bool = Field(
         True,
@@ -75,23 +75,22 @@ class AnalyzeRequest(BaseModel):
         None,
         validation_alias=AliasChoices("skills", "strategies"),
         description="本次分析使用的策略 skill ID 列表；兼容 legacy strategies 字段",
-        example=["bull_trend", "growth_quality"]
+        json_schema_extra={"example": ["bull_trend", "growth_quality"]},
     )
 
-    class Config:
-        json_schema_extra = {
-            "example": {
-                "stock_code": "600519",
-                "report_type": "detailed",
-                "force_refresh": False,
-                "async_mode": False,
-                "stock_name": "贵州茅台",
-                "original_query": "茅台",
-                "selection_source": "autocomplete",
-                "notify": True,
-                "skills": ["bull_trend"]
-            }
+    model_config = ConfigDict(json_schema_extra={
+        "example": {
+            "stock_code": "600519",
+            "report_type": "detailed",
+            "force_refresh": False,
+            "async_mode": False,
+            "stock_name": "贵州茅台",
+            "original_query": "茅台",
+            "selection_source": "autocomplete",
+            "notify": True,
+            "skills": ["bull_trend"],
         }
+    })
 
 
 class MarketReviewRequest(BaseModel):
@@ -124,21 +123,20 @@ class AnalysisResultResponse(BaseModel):
     report: Optional[Any] = Field(None, description="分析报告")
     created_at: str = Field(..., description="创建时间")
     
-    class Config:
-        json_schema_extra = {
-            "example": {
-                "query_id": "abc123def456",
-                "stock_code": "600519",
-                "stock_name": "贵州茅台",
-                "report": {
-                    "summary": {
-                        "sentiment_score": 75,
-                        "operation_advice": "持有"
-                    }
-                },
-                "created_at": "2024-01-01T12:00:00"
-            }
+    model_config = ConfigDict(json_schema_extra={
+        "example": {
+            "query_id": "abc123def456",
+            "stock_code": "600519",
+            "stock_name": "贵州茅台",
+            "report": {
+                "summary": {
+                    "sentiment_score": 75,
+                    "operation_advice": "持有"
+                }
+            },
+            "created_at": "2024-01-01T12:00:00"
         }
+    })
 
 
 class TaskAccepted(BaseModel):
@@ -152,14 +150,13 @@ class TaskAccepted(BaseModel):
     )
     message: Optional[str] = Field(None, description="提示信息")
     
-    class Config:
-        json_schema_extra = {
-            "example": {
-                "task_id": "task_abc123",
-                "status": "pending",
-                "message": "Analysis task accepted"
-            }
+    model_config = ConfigDict(json_schema_extra={
+        "example": {
+            "task_id": "task_abc123",
+            "status": "pending",
+            "message": "Analysis task accepted",
         }
+    })
 
 
 class BatchTaskAcceptedItem(BaseModel):
@@ -174,15 +171,14 @@ class BatchTaskAcceptedItem(BaseModel):
     )
     message: Optional[str] = Field(None, description="提示信息")
 
-    class Config:
-        json_schema_extra = {
-            "example": {
-                "task_id": "task_abc123",
-                "stock_code": "600519",
-                "status": "pending",
-                "message": "分析任务已加入队列: 600519"
-            }
+    model_config = ConfigDict(json_schema_extra={
+        "example": {
+            "task_id": "task_abc123",
+            "stock_code": "600519",
+            "status": "pending",
+            "message": "分析任务已加入队列: 600519",
         }
+    })
 
 
 class BatchDuplicateTaskItem(BaseModel):
@@ -192,14 +188,13 @@ class BatchDuplicateTaskItem(BaseModel):
     existing_task_id: str = Field(..., description="已存在的任务 ID")
     message: str = Field(..., description="错误信息")
 
-    class Config:
-        json_schema_extra = {
-            "example": {
-                "stock_code": "600519",
-                "existing_task_id": "task_existing_123",
-                "message": "股票 600519 正在分析中 (task_id: task_existing_123)"
-            }
+    model_config = ConfigDict(json_schema_extra={
+        "example": {
+            "stock_code": "600519",
+            "existing_task_id": "task_existing_123",
+            "message": "股票 600519 正在分析中 (task_id: task_existing_123)",
         }
+    })
 
 
 class BatchTaskAcceptedResponse(BaseModel):
@@ -209,27 +204,26 @@ class BatchTaskAcceptedResponse(BaseModel):
     duplicates: List[BatchDuplicateTaskItem] = Field(default_factory=list, description="重复而跳过的任务列表")
     message: str = Field(..., description="汇总信息")
 
-    class Config:
-        json_schema_extra = {
-            "example": {
-                "accepted": [
-                    {
-                        "task_id": "task_abc123",
-                        "stock_code": "600519",
-                        "status": "pending",
-                        "message": "分析任务已加入队列: 600519"
-                    }
-                ],
-                "duplicates": [
-                    {
-                        "stock_code": "000858",
-                        "existing_task_id": "task_existing_456",
-                        "message": "股票 000858 正在分析中 (task_id: task_existing_456)"
-                    }
-                ],
-                "message": "已提交 1 个任务，1 个重复跳过"
-            }
+    model_config = ConfigDict(json_schema_extra={
+        "example": {
+            "accepted": [
+                {
+                    "task_id": "task_abc123",
+                    "stock_code": "600519",
+                    "status": "pending",
+                    "message": "分析任务已加入队列: 600519",
+                }
+            ],
+            "duplicates": [
+                {
+                    "stock_code": "000858",
+                    "existing_task_id": "task_existing_456",
+                    "message": "股票 000858 正在分析中 (task_id: task_existing_456)",
+                }
+            ],
+            "message": "已提交 1 个任务，1 个重复跳过",
         }
+    })
 
 
 class TaskStatus(BaseModel):
@@ -268,21 +262,20 @@ class TaskStatus(BaseModel):
     )
     skills: Optional[List[str]] = Field(None, description="本次任务使用的策略 skill ID 列表")
     
-    class Config:
-        json_schema_extra = {
-            "example": {
-                "task_id": "task_abc123",
-                "status": "completed",
-                "progress": 100,
-                "result": None,
-                "market_review_report": None,
-                "error": None,
-                "stock_name": "贵州茅台",
-                "original_query": "茅台",
-                "selection_source": "autocomplete",
-                "skills": ["bull_trend"]
-            }
+    model_config = ConfigDict(json_schema_extra={
+        "example": {
+            "task_id": "task_abc123",
+            "status": "completed",
+            "progress": 100,
+            "result": None,
+            "market_review_report": None,
+            "error": None,
+            "stock_name": "贵州茅台",
+            "original_query": "茅台",
+            "selection_source": "autocomplete",
+            "skills": ["bull_trend"],
         }
+    })
 
 
 class TaskInfo(BaseModel):
@@ -311,25 +304,24 @@ class TaskInfo(BaseModel):
     )
     skills: Optional[List[str]] = Field(None, description="本次任务使用的策略 skill ID 列表")
     
-    class Config:
-        json_schema_extra = {
-            "example": {
-                "task_id": "abc123def456",
-                "stock_code": "600519",
-                "stock_name": "贵州茅台",
-                "status": "processing",
-                "progress": 50,
-                "message": "正在分析中...",
-                "report_type": "detailed",
-                "created_at": "2026-02-05T10:30:00",
-                "started_at": "2026-02-05T10:30:01",
-                "completed_at": None,
-                "error": None,
-                "original_query": "茅台",
-                "selection_source": "autocomplete",
-                "skills": ["bull_trend"]
-            }
+    model_config = ConfigDict(json_schema_extra={
+        "example": {
+            "task_id": "abc123def456",
+            "stock_code": "600519",
+            "stock_name": "贵州茅台",
+            "status": "processing",
+            "progress": 50,
+            "message": "正在分析中...",
+            "report_type": "detailed",
+            "created_at": "2026-02-05T10:30:00",
+            "started_at": "2026-02-05T10:30:01",
+            "completed_at": None,
+            "error": None,
+            "original_query": "茅台",
+            "selection_source": "autocomplete",
+            "skills": ["bull_trend"],
         }
+    })
 
 
 class TaskListResponse(BaseModel):
@@ -340,15 +332,14 @@ class TaskListResponse(BaseModel):
     processing: int = Field(..., description="处理中的任务数")
     tasks: List[TaskInfo] = Field(..., description="任务列表")
     
-    class Config:
-        json_schema_extra = {
-            "example": {
-                "total": 3,
-                "pending": 1,
-                "processing": 2,
-                "tasks": []
-            }
+    model_config = ConfigDict(json_schema_extra={
+        "example": {
+            "total": 3,
+            "pending": 1,
+            "processing": 2,
+            "tasks": [],
         }
+    })
 
 
 class DuplicateTaskErrorResponse(BaseModel):
@@ -359,12 +350,11 @@ class DuplicateTaskErrorResponse(BaseModel):
     stock_code: str = Field(..., description="股票代码")
     existing_task_id: str = Field(..., description="已存在的任务 ID")
     
-    class Config:
-        json_schema_extra = {
-            "example": {
-                "error": "duplicate_task",
-                "message": "股票 600519 正在分析中",
-                "stock_code": "600519",
-                "existing_task_id": "abc123def456"
-            }
+    model_config = ConfigDict(json_schema_extra={
+        "example": {
+            "error": "duplicate_task",
+            "message": "股票 600519 正在分析中",
+            "stock_code": "600519",
+            "existing_task_id": "abc123def456",
         }
+    })

--- a/api/v1/schemas/common.py
+++ b/api/v1/schemas/common.py
@@ -11,54 +11,71 @@
 
 from typing import Optional, Any
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 
 class RootResponse(BaseModel):
     """API 根路由响应"""
     
-    message: str = Field(..., description="API 运行状态消息", example="Daily Stock Analysis API is running")
-    version: Optional[str] = Field(None, description="API 版本", example="1.0.0")
+    message: str = Field(
+        ...,
+        description="API 运行状态消息",
+        json_schema_extra={"example": "Daily Stock Analysis API is running"},
+    )
+    version: Optional[str] = Field(
+        None,
+        description="API 版本",
+        json_schema_extra={"example": "1.0.0"},
+    )
     
-    class Config:
-        json_schema_extra = {
-            "example": {
-                "message": "Daily Stock Analysis API is running",
-                "version": "1.0.0"
-            }
+    model_config = ConfigDict(json_schema_extra={
+        "example": {
+            "message": "Daily Stock Analysis API is running",
+            "version": "1.0.0",
         }
+    })
 
 
 class HealthResponse(BaseModel):
     """健康检查响应"""
     
-    status: str = Field(..., description="服务状态", example="ok")
+    status: str = Field(
+        ...,
+        description="服务状态",
+        json_schema_extra={"example": "ok"},
+    )
     timestamp: Optional[str] = Field(None, description="时间戳")
     
-    class Config:
-        json_schema_extra = {
-            "example": {
-                "status": "ok",
-                "timestamp": "2024-01-01T12:00:00"
-            }
+    model_config = ConfigDict(json_schema_extra={
+        "example": {
+            "status": "ok",
+            "timestamp": "2024-01-01T12:00:00",
         }
+    })
 
 
 class ErrorResponse(BaseModel):
     """错误响应"""
     
-    error: str = Field(..., description="错误类型", example="validation_error")
-    message: str = Field(..., description="错误详情", example="请求参数错误")
+    error: str = Field(
+        ...,
+        description="错误类型",
+        json_schema_extra={"example": "validation_error"},
+    )
+    message: str = Field(
+        ...,
+        description="错误详情",
+        json_schema_extra={"example": "请求参数错误"},
+    )
     detail: Optional[Any] = Field(None, description="附加错误信息")
     
-    class Config:
-        json_schema_extra = {
-            "example": {
-                "error": "not_found",
-                "message": "资源不存在",
-                "detail": None
-            }
+    model_config = ConfigDict(json_schema_extra={
+        "example": {
+            "error": "not_found",
+            "message": "资源不存在",
+            "detail": None,
         }
+    })
 
 
 class SuccessResponse(BaseModel):
@@ -68,11 +85,10 @@ class SuccessResponse(BaseModel):
     message: Optional[str] = Field(None, description="成功消息")
     data: Optional[Any] = Field(None, description="响应数据")
     
-    class Config:
-        json_schema_extra = {
-            "example": {
-                "success": True,
-                "message": "操作成功",
-                "data": None
-            }
+    model_config = ConfigDict(json_schema_extra={
+        "example": {
+            "success": True,
+            "message": "操作成功",
+            "data": None,
         }
+    })

--- a/api/v1/schemas/history.py
+++ b/api/v1/schemas/history.py
@@ -29,19 +29,18 @@ class HistoryItem(BaseModel):
     operation_advice: Optional[str] = Field(None, description="操作建议")
     created_at: Optional[str] = Field(None, description="创建时间")
     
-    class Config:
-        json_schema_extra = {
-            "example": {
-                "id": 1234,
-                "query_id": "abc123",
-                "stock_code": "600519",
-                "stock_name": "贵州茅台",
-                "report_type": "detailed",
-                "sentiment_score": 75,
-                "operation_advice": "持有",
-                "created_at": "2024-01-01T12:00:00"
-            }
+    model_config = ConfigDict(json_schema_extra={
+        "example": {
+            "id": 1234,
+            "query_id": "abc123",
+            "stock_code": "600519",
+            "stock_name": "贵州茅台",
+            "report_type": "detailed",
+            "sentiment_score": 75,
+            "operation_advice": "持有",
+            "created_at": "2024-01-01T12:00:00",
         }
+    })
 
 
 class HistoryListResponse(BaseModel):
@@ -52,15 +51,14 @@ class HistoryListResponse(BaseModel):
     limit: int = Field(..., description="每页数量")
     items: List[HistoryItem] = Field(default_factory=list, description="记录列表")
     
-    class Config:
-        json_schema_extra = {
-            "example": {
-                "total": 100,
-                "page": 1,
-                "limit": 20,
-                "items": []
-            }
+    model_config = ConfigDict(json_schema_extra={
+        "example": {
+            "total": 100,
+            "page": 1,
+            "limit": 20,
+            "items": [],
         }
+    })
 
 
 class DeleteHistoryRequest(BaseModel):
@@ -82,14 +80,13 @@ class NewsIntelItem(BaseModel):
     snippet: str = Field("", description="新闻摘要（最多200字）")
     url: str = Field(..., description="新闻链接")
 
-    class Config:
-        json_schema_extra = {
-            "example": {
-                "title": "公司发布业绩快报，营收同比增长 20%",
-                "snippet": "公司公告显示，季度营收同比增长 20%...",
-                "url": "https://example.com/news/123"
-            }
+    model_config = ConfigDict(json_schema_extra={
+        "example": {
+            "title": "公司发布业绩快报，营收同比增长 20%",
+            "snippet": "公司公告显示，季度营收同比增长 20%...",
+            "url": "https://example.com/news/123",
         }
+    })
 
 
 class NewsIntelResponse(BaseModel):
@@ -98,13 +95,12 @@ class NewsIntelResponse(BaseModel):
     total: int = Field(..., description="新闻条数")
     items: List[NewsIntelItem] = Field(default_factory=list, description="新闻列表")
 
-    class Config:
-        json_schema_extra = {
-            "example": {
-                "total": 2,
-                "items": []
-            }
+    model_config = ConfigDict(json_schema_extra={
+        "example": {
+            "total": 2,
+            "items": [],
         }
+    })
 
 
 class ReportMeta(BaseModel):
@@ -166,33 +162,32 @@ class AnalysisReport(BaseModel):
     strategy: Optional[ReportStrategy] = Field(None, description="策略点位区")
     details: Optional[ReportDetails] = Field(None, description="详情区")
 
-    class Config:
-        json_schema_extra = {
-            "example": {
-                "meta": {
-                    "query_id": "abc123",
-                    "stock_code": "600519",
-                    "stock_name": "贵州茅台",
-                    "report_type": "detailed",
-                    "report_language": "zh",
-                    "created_at": "2024-01-01T12:00:00"
-                },
-                "summary": {
-                    "analysis_summary": "技术面向好，建议持有",
-                    "operation_advice": "持有",
-                    "trend_prediction": "看多",
-                    "sentiment_score": 75,
-                    "sentiment_label": "乐观"
-                },
-                "strategy": {
-                    "ideal_buy": "1800.00",
-                    "secondary_buy": "1750.00",
-                    "stop_loss": "1700.00",
-                    "take_profit": "2000.00"
-                },
-                "details": None
-            }
+    model_config = ConfigDict(json_schema_extra={
+        "example": {
+            "meta": {
+                "query_id": "abc123",
+                "stock_code": "600519",
+                "stock_name": "贵州茅台",
+                "report_type": "detailed",
+                "report_language": "zh",
+                "created_at": "2024-01-01T12:00:00",
+            },
+            "summary": {
+                "analysis_summary": "技术面向好，建议持有",
+                "operation_advice": "持有",
+                "trend_prediction": "看多",
+                "sentiment_score": 75,
+                "sentiment_label": "乐观",
+            },
+            "strategy": {
+                "ideal_buy": "1800.00",
+                "secondary_buy": "1750.00",
+                "stop_loss": "1700.00",
+                "take_profit": "2000.00",
+            },
+            "details": None,
         }
+    })
 
 
 class MarkdownReportResponse(BaseModel):
@@ -200,9 +195,8 @@ class MarkdownReportResponse(BaseModel):
 
     content: str = Field(..., description="Markdown 格式的完整报告内容")
 
-    class Config:
-        json_schema_extra = {
-            "example": {
-                "content": "# 📊 贵州茅台 (600519) 分析报告\n\n> 分析日期：**2024-01-01**\n\n..."
-            }
+    model_config = ConfigDict(json_schema_extra={
+        "example": {
+            "content": "# 📊 贵州茅台 (600519) 分析报告\n\n> 分析日期：**2024-01-01**\n\n..."
         }
+    })

--- a/api/v1/schemas/stocks.py
+++ b/api/v1/schemas/stocks.py
@@ -11,7 +11,7 @@
 
 from typing import Optional, List
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 
 class StockQuote(BaseModel):
@@ -30,23 +30,22 @@ class StockQuote(BaseModel):
     amount: Optional[float] = Field(None, description="成交额（元）")
     update_time: Optional[str] = Field(None, description="更新时间")
     
-    class Config:
-        json_schema_extra = {
-            "example": {
-                "stock_code": "600519",
-                "stock_name": "贵州茅台",
-                "current_price": 1800.00,
-                "change": 15.00,
-                "change_percent": 0.84,
-                "open": 1785.00,
-                "high": 1810.00,
-                "low": 1780.00,
-                "prev_close": 1785.00,
-                "volume": 10000000,
-                "amount": 18000000000,
-                "update_time": "2024-01-01T15:00:00"
-            }
+    model_config = ConfigDict(json_schema_extra={
+        "example": {
+            "stock_code": "600519",
+            "stock_name": "贵州茅台",
+            "current_price": 1800.00,
+            "change": 15.00,
+            "change_percent": 0.84,
+            "open": 1785.00,
+            "high": 1810.00,
+            "low": 1780.00,
+            "prev_close": 1785.00,
+            "volume": 10000000,
+            "amount": 18000000000,
+            "update_time": "2024-01-01T15:00:00",
         }
+    })
 
 
 class KLineData(BaseModel):
@@ -61,19 +60,18 @@ class KLineData(BaseModel):
     amount: Optional[float] = Field(None, description="成交额")
     change_percent: Optional[float] = Field(None, description="涨跌幅 (%)")
     
-    class Config:
-        json_schema_extra = {
-            "example": {
-                "date": "2024-01-01",
-                "open": 1785.00,
-                "high": 1810.00,
-                "low": 1780.00,
-                "close": 1800.00,
-                "volume": 10000000,
-                "amount": 18000000000,
-                "change_percent": 0.84
-            }
+    model_config = ConfigDict(json_schema_extra={
+        "example": {
+            "date": "2024-01-01",
+            "open": 1785.00,
+            "high": 1810.00,
+            "low": 1780.00,
+            "close": 1800.00,
+            "volume": 10000000,
+            "amount": 18000000000,
+            "change_percent": 0.84,
         }
+    })
 
 
 class ExtractItem(BaseModel):
@@ -100,12 +98,11 @@ class StockHistoryResponse(BaseModel):
     period: str = Field(..., description="K 线周期")
     data: List[KLineData] = Field(default_factory=list, description="K 线数据列表")
     
-    class Config:
-        json_schema_extra = {
-            "example": {
-                "stock_code": "600519",
-                "stock_name": "贵州茅台",
-                "period": "daily",
-                "data": []
-            }
+    model_config = ConfigDict(json_schema_extra={
+        "example": {
+            "stock_code": "600519",
+            "stock_name": "贵州茅台",
+            "period": "daily",
+            "data": [],
         }
+    })

--- a/apps/dsa-web/src/App.test.tsx
+++ b/apps/dsa-web/src/App.test.tsx
@@ -1,0 +1,127 @@
+import { render, screen } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import App from './App';
+import * as AuthContext from './contexts/AuthContext';
+
+const { setCurrentRoute, useAgentChatStoreMock } = vi.hoisted(() => {
+  const setCurrentRoute = vi.fn();
+  const state = { completionBadge: false };
+  const useAgentChatStoreMock = Object.assign(
+    vi.fn((selector?: (value: typeof state) => unknown) => (selector ? selector(state) : state)),
+    { getState: () => ({ setCurrentRoute }) },
+  );
+  return { setCurrentRoute, useAgentChatStoreMock };
+});
+
+vi.mock('./contexts/AuthContext', () => ({
+  AuthProvider: ({ children }: { children: ReactNode }) => children,
+  useAuth: vi.fn(),
+}));
+
+vi.mock('./stores/agentChatStore', () => ({
+  useAgentChatStore: useAgentChatStoreMock,
+}));
+
+vi.mock('./pages/HomePage', () => ({
+  default: () => <div data-testid="home-page">Home</div>,
+}));
+
+vi.mock('./pages/ChatPage', () => ({
+  default: () => <div data-testid="chat-page">Chat</div>,
+}));
+
+vi.mock('./pages/PortfolioPage', () => ({
+  default: () => <div data-testid="portfolio-page">Portfolio</div>,
+}));
+
+vi.mock('./pages/BacktestPage', () => ({
+  default: () => <div data-testid="backtest-page">Backtest</div>,
+}));
+
+vi.mock('./pages/AlertsPage', () => ({
+  default: () => <div data-testid="alerts-page">Alerts</div>,
+}));
+
+vi.mock('./pages/SettingsPage', () => ({
+  default: () => <div data-testid="settings-page">Settings</div>,
+}));
+
+vi.mock('./pages/NotFoundPage', () => ({
+  default: () => <div data-testid="not-found-page">Not Found</div>,
+}));
+
+vi.mock('./pages/LoginPage', () => ({
+  default: () => <div data-testid="login-page">Login</div>,
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  window.history.pushState({}, '', '/');
+  vi.mocked(AuthContext.useAuth).mockReturnValue({
+    authEnabled: false,
+    loggedIn: false,
+    passwordSet: false,
+    passwordChangeable: false,
+    setupState: 'no_password',
+    isLoading: false,
+    loadError: null,
+    login: vi.fn(),
+    changePassword: vi.fn(),
+    logout: vi.fn(),
+    refreshStatus: vi.fn(),
+  });
+});
+
+describe('App routing behavior', () => {
+  it('shows loading fallback while auth status is initializing', () => {
+    vi.mocked(AuthContext.useAuth).mockReturnValue({
+      authEnabled: false,
+      loggedIn: false,
+      passwordSet: false,
+      passwordChangeable: false,
+      setupState: 'no_password',
+      isLoading: true,
+      loadError: null,
+      login: vi.fn(),
+      changePassword: vi.fn(),
+      logout: vi.fn(),
+      refreshStatus: vi.fn(),
+    });
+
+    const { container } = render(<App />);
+
+    expect(container.querySelector('.border-t-cyan')).toBeTruthy();
+  });
+
+  it('redirects protected routes to login when auth is enabled but user not logged in', async () => {
+    vi.mocked(AuthContext.useAuth).mockReturnValue({
+      authEnabled: true,
+      loggedIn: false,
+      passwordSet: false,
+      passwordChangeable: false,
+      setupState: 'enabled',
+      isLoading: false,
+      loadError: null,
+      login: vi.fn(),
+      changePassword: vi.fn(),
+      logout: vi.fn(),
+      refreshStatus: vi.fn(),
+    });
+    window.history.pushState({}, '', '/portfolio');
+
+    render(<App />);
+
+    expect(await screen.findByTestId('login-page')).toBeInTheDocument();
+  });
+
+  it('renders route-level page components through lazy routes after auth is ready', async () => {
+    window.history.pushState({}, '', '/chat');
+    render(<App />);
+
+    expect(await screen.findByTestId('chat-page')).toBeInTheDocument();
+    expect(setCurrentRoute).toHaveBeenCalledWith('/chat');
+    expect(screen.queryByTestId('login-page')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('home-page')).not.toBeInTheDocument();
+  });
+});

--- a/apps/dsa-web/src/App.tsx
+++ b/apps/dsa-web/src/App.tsx
@@ -1,18 +1,29 @@
 import type React from 'react';
-import { useEffect } from 'react';
+import { lazy, Suspense, useEffect } from 'react';
 import { BrowserRouter as Router, Navigate, Route, Routes, useLocation } from 'react-router-dom';
-import HomePage from './pages/HomePage';
-import BacktestPage from './pages/BacktestPage';
-import SettingsPage from './pages/SettingsPage';
-import LoginPage from './pages/LoginPage';
-import NotFoundPage from './pages/NotFoundPage';
-import ChatPage from './pages/ChatPage';
-import PortfolioPage from './pages/PortfolioPage';
-import AlertsPage from './pages/AlertsPage';
 import { ApiErrorAlert, Shell } from './components/common';
 import { AuthProvider, useAuth } from './contexts/AuthContext';
 import { useAgentChatStore } from './stores/agentChatStore';
 import './App.css';
+
+const HomePage = lazy(() => import('./pages/HomePage'));
+const BacktestPage = lazy(() => import('./pages/BacktestPage'));
+const SettingsPage = lazy(() => import('./pages/SettingsPage'));
+const LoginPage = lazy(() => import('./pages/LoginPage'));
+const NotFoundPage = lazy(() => import('./pages/NotFoundPage'));
+const ChatPage = lazy(() => import('./pages/ChatPage'));
+const PortfolioPage = lazy(() => import('./pages/PortfolioPage'));
+const AlertsPage = lazy(() => import('./pages/AlertsPage'));
+
+const PageLoadingFallback: React.FC = () => (
+  <div className="flex min-h-screen items-center justify-center bg-base">
+    <div className="h-8 w-8 animate-spin rounded-full border-2 border-cyan/20 border-t-cyan" />
+  </div>
+);
+
+const PageSuspense: React.FC<{ children: React.ReactNode }> = ({ children }) => (
+  <Suspense fallback={<PageLoadingFallback />}>{children}</Suspense>
+);
 
 const AppContent: React.FC = () => {
   const location = useLocation();
@@ -49,7 +60,11 @@ const AppContent: React.FC = () => {
 
   if (authEnabled && !loggedIn) {
     if (location.pathname === '/login') {
-      return <LoginPage />;
+      return (
+        <PageSuspense>
+          <LoginPage />
+        </PageSuspense>
+      );
     }
     const redirect = encodeURIComponent(location.pathname + location.search);
     return <Navigate to={`/login?redirect=${redirect}`} replace />;
@@ -60,18 +75,20 @@ const AppContent: React.FC = () => {
   }
 
   return (
-    <Routes>
-      <Route element={<Shell />}>
-        <Route path="/" element={<HomePage />} />
-        <Route path="/chat" element={<ChatPage />} />
-        <Route path="/portfolio" element={<PortfolioPage />} />
-        <Route path="/backtest" element={<BacktestPage />} />
-        <Route path="/alerts" element={<AlertsPage />} />
-        <Route path="/settings" element={<SettingsPage />} />
-        <Route path="*" element={<NotFoundPage />} />
-      </Route>
-      <Route path="/login" element={<LoginPage />} />
-    </Routes>
+    <PageSuspense>
+      <Routes>
+        <Route element={<Shell />}>
+          <Route path="/" element={<HomePage />} />
+          <Route path="/chat" element={<ChatPage />} />
+          <Route path="/portfolio" element={<PortfolioPage />} />
+          <Route path="/backtest" element={<BacktestPage />} />
+          <Route path="/alerts" element={<AlertsPage />} />
+          <Route path="/settings" element={<SettingsPage />} />
+          <Route path="*" element={<NotFoundPage />} />
+        </Route>
+        <Route path="/login" element={<LoginPage />} />
+      </Routes>
+    </PageSuspense>
   );
 };
 

--- a/apps/dsa-web/vite.config.ts
+++ b/apps/dsa-web/vite.config.ts
@@ -8,6 +8,51 @@ const packageJson = JSON.parse(
 ) as { version?: string }
 const buildTime = new Date().toISOString()
 
+const getPackageName = (id: string): string | null => {
+  const normalizedId = id.split(path.sep).join('/')
+  const marker = '/node_modules/'
+  const markerIndex = normalizedId.lastIndexOf(marker)
+  if (markerIndex === -1) {
+    return null
+  }
+
+  const packagePath = normalizedId.slice(markerIndex + marker.length)
+  const [firstPart, secondPart] = packagePath.split('/')
+  if (!firstPart) {
+    return null
+  }
+  return firstPart.startsWith('@') && secondPart ? `${firstPart}/${secondPart}` : firstPart
+}
+
+const markdownPackages = new Set([
+  'bail',
+  'ccount',
+  'character-entities',
+  'character-entities-html4',
+  'character-entities-legacy',
+  'comma-separated-tokens',
+  'decode-named-character-reference',
+  'dequal',
+  'devlop',
+  'entities',
+  'extend',
+  'hast-util-whitespace',
+  'html-url-attributes',
+  'longest-streak',
+  'markdown-table',
+  'property-information',
+  'react-markdown',
+  'remark-gfm',
+  'space-separated-tokens',
+  'stringify-entities',
+  'trim-lines',
+  'trough',
+  'unified',
+  'vfile',
+  'vfile-message',
+  'zwitch',
+])
+
 // https://vite.dev/config/
 export default defineConfig({
   define: {
@@ -35,5 +80,46 @@ export default defineConfig({
     // 打包输出到项目根目录的 static 文件夹
     outDir: path.resolve(__dirname, '../../static'),
     emptyOutDir: true,
+    rollupOptions: {
+      output: {
+        manualChunks: (id) => {
+          const packageName = getPackageName(id)
+          if (!packageName) {
+            return undefined
+          }
+
+          if (packageName === 'react' || packageName === 'react-dom' || packageName === 'scheduler') {
+            return 'vendor-react'
+          }
+          if (packageName === 'react-router' || packageName === 'react-router-dom') {
+            return 'vendor-router'
+          }
+          if (packageName === 'recharts' || packageName.startsWith('d3-')) {
+            return 'vendor-charts'
+          }
+          if (
+            packageName === 'motion'
+            || packageName === 'motion-dom'
+            || packageName === 'motion-utils'
+            || packageName === 'framer-motion'
+          ) {
+            return 'vendor-motion'
+          }
+          if (
+            packageName.startsWith('micromark')
+            || packageName.startsWith('mdast-')
+            || packageName.startsWith('hast-')
+            || packageName.startsWith('unist-')
+            || markdownPackages.has(packageName)
+          ) {
+            return 'vendor-markdown'
+          }
+          if (packageName === 'lucide-react' || packageName === '@remixicon/react') {
+            return 'vendor-icons'
+          }
+          return undefined
+        },
+      },
+    },
   },
 })

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 <!-- 新条目格式：- [类型] 描述（类型取值：新功能/改进/修复/文档/测试/chore）-->
 <!-- 每条独立一行追加到本段末尾，无需分类标题，合并时冲突最小 -->
 - [chore] 清理 Pydantic v2 弃用写法并在 Web 路由层启用 lazy load + manualChunks，减少 pytest / Vite 告警并提升首屏体积。
+- [文档] 本次改动仅涉及 API Schema 与 Web 路由分包，未修改 LLM model/provider/Base URL 或运行时配置清理/迁移逻辑；因此不会清空用户配置，不会触发模型/Provider/Base URL 自动迁移，回退路径为回滚该提交或恢复配置到提交前快照。
+- [测试] 新增 schema 回归，验证 AnalyzeRequest 仍兼容 legacy `strategies` 字段，并确认 schema 生成阶段无 Pydantic 废弃告警。
 
 ## [3.18.0] - 2026-05-21
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 <!-- 新条目格式：- [类型] 描述（类型取值：新功能/改进/修复/文档/测试/chore）-->
 <!-- 每条独立一行追加到本段末尾，无需分类标题，合并时冲突最小 -->
+- [chore] 清理 Pydantic v2 弃用写法并在 Web 路由层启用 lazy load + manualChunks，减少 pytest / Vite 告警并提升首屏体积。
 
 ## [3.18.0] - 2026-05-21
 

--- a/tests/test_api_schema_pydantic.py
+++ b/tests/test_api_schema_pydantic.py
@@ -1,3 +1,7 @@
+"""Schema compatibility regression tests for FastAPI API models."""
+
+import warnings
+
 from api.v1.schemas.analysis import AnalyzeRequest
 from api.v1.schemas.common import RootResponse
 from api.v1.schemas.history import HistoryItem
@@ -15,3 +19,20 @@ def test_schema_examples_remain_in_openapi_schema() -> None:
     assert analyze_schema["properties"]["skills"]["example"] == ["bull_trend", "growth_quality"]
     assert history_schema["example"]["stock_code"] == "600519"
     assert quote_schema["example"]["stock_name"] == "贵州茅台"
+
+
+def test_analyze_request_supports_legacy_strategies_alias_without_compat_break() -> None:
+    request = AnalyzeRequest.model_validate({
+        "stock_code": "600519",
+        "strategies": ["bull_trend", "growth_quality"],
+    })
+
+    assert request.skills == ["bull_trend", "growth_quality"]
+
+
+def test_pydantic_schema_generation_has_no_runtime_deprecated_warning() -> None:
+    with warnings.catch_warnings(record=True) as captured:
+        warnings.simplefilter("always")
+        AnalyzeRequest.model_json_schema()
+
+    assert not any("deprecated" in str(item.message).lower() for item in captured)

--- a/tests/test_api_schema_pydantic.py
+++ b/tests/test_api_schema_pydantic.py
@@ -1,0 +1,17 @@
+from api.v1.schemas.analysis import AnalyzeRequest
+from api.v1.schemas.common import RootResponse
+from api.v1.schemas.history import HistoryItem
+from api.v1.schemas.stocks import StockQuote
+
+
+def test_schema_examples_remain_in_openapi_schema() -> None:
+    root_schema = RootResponse.model_json_schema()
+    analyze_schema = AnalyzeRequest.model_json_schema()
+    history_schema = HistoryItem.model_json_schema()
+    quote_schema = StockQuote.model_json_schema()
+
+    assert root_schema["properties"]["message"]["example"] == "Daily Stock Analysis API is running"
+    assert analyze_schema["properties"]["stock_code"]["example"] == "600519"
+    assert analyze_schema["properties"]["skills"]["example"] == ["bull_trend", "growth_quality"]
+    assert history_schema["example"]["stock_code"] == "600519"
+    assert quote_schema["example"]["stock_name"] == "贵州茅台"


### PR DESCRIPTION
## PR Type
- [ ] fix
- [ ] feat
- [x] refactor
- [ ] docs
- [ ] chore
- [ ] test

## Background And Problem
- 当前问题：清理 Pydantic v2 弃用告警并通过路由级代码拆分消除 Web large chunk warning。
- 影响范围：本次改动涉及 9 个文件，Diff 为 `+547 / -279`。
- 触发来源：Issue 自动执行（Issue #1394）。

## Scope Of Change
- `api/v1/schemas/analysis.py`
- `api/v1/schemas/common.py`
- `api/v1/schemas/history.py`
- `api/v1/schemas/stocks.py`
- `apps/dsa-web/src/App.test.tsx`
- `apps/dsa-web/src/App.tsx`
- `apps/dsa-web/vite.config.ts`
- `docs/CHANGELOG.md`
- `tests/test_api_schema_pydantic.py`

## Documentation And Changelog
- 已同步更新文档/变更记录：`docs/CHANGELOG.md`。
- 当前补丁尚未包含 `README.md` 或专题文档；如用户可见行为发生变化，请补充文档落点。

## Issue Link
Closes #1394

## Verification Commands And Results
```bash
./scripts/ci_gate.sh flake8
./scripts/ci_gate.sh offline-tests
```

关键输出/结论 / Key output & conclusion:
- lint:PASS, test:PASS

## Compatibility And Risk
- **Medium**：涉及 `api/v1/schemas/analysis.py`, `api/v1/schemas/common.py`, `api/v1/schemas/history.py`, `api/v1/schemas/stocks.py`, `apps/dsa-web/src/App.test.tsx`, `apps/dsa-web/src/App.tsx`，建议按文件范围复核。
- 前提假设：
  - 当前仓库仍使用 Pydantic v2，相关 schema 可安全迁移到 ConfigDict 和 json_schema_extra。
  - OpenAPI 字段、alias、pattern、示例语义需要保持兼容，不做 API 契约重构。
  - Web 优先采用 React.lazy/Suspense 做 route-level code splitting，不通过 pytest warning ignore、依赖降级或无依据调高 chunkSizeWarningLimit 掩盖问题。
  - 如 route-level split 后仍有大 vendor chunk，可在 vite.config.ts 补充语义化 manualChunks，但保持最小配置变更。

## Rollback Plan
- `git revert <merge-commit>` 回滚本 PR 提交，重点确认 `api/v1/schemas/analysis.py`, `api/v1/schemas/common.py`, `api/v1/schemas/history.py`, `api/v1/schemas/stocks.py` 恢复正常。

## Acceptance Criteria
- 指定 pytest 命令通过，且 PydanticDeprecatedSince20 作为 error 时不再失败。
- apps/dsa-web 的 npm run lint 和 npm run build 通过。
- npm run build 不再输出 Vite large chunk warning。
- 构建产物出现合理的 route/vendor 分包，首包不再同步包含所有页面级重依赖。
- 未新增 warning ignore、未降级依赖、未无依据提高 chunkSizeWarningLimit。

## Checklist
- [x] 本 PR 有明确动机和业务价值 / This PR has a clear motivation and value
- [x] 已提供可复现的验证命令与结果 / Reproducible verification commands and results are included
- [x] 已评估兼容性与风险 / Compatibility and risk have been assessed
- [x] 已提供回滚方案 / A rollback plan is provided
- [ ] 文档与 `docs/CHANGELOG.md` 同步仍需确认；如涉及用户可见变更，请在合并前补充原因与文档落点 / Documentation and `docs/CHANGELOG.md` sync still needs confirmation before merge when user-visible behavior changes