### PR TITLE
fix: Docker 挂载 .env 文件时 os.replace()… (#1399)

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -16,7 +16,8 @@ x-common: &common
     dockerfile: docker/Dockerfile
   restart: unless-stopped
 
-  # 环境变量（从 .env 文件加载）
+  # 环境变量（从 .env 文件加载）。不要将 ../.env 作为单文件 volume 挂载到 /app/.env，
+  # 否则 Docker mount point 会阻止配置保存时的 os.replace 原子更新。
   env_file:
     - ../.env
 
@@ -24,7 +25,6 @@ x-common: &common
     - ../data:/app/data
     - ../logs:/app/logs
     - ../reports:/app/reports
-    - ../.env:/app/.env
     - ../strategies:/app/strategies:ro
     # 如需覆盖前端静态资源，可挂载本地 static 目录
     # - ../static:/app/static:ro

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 <!-- 新条目格式：- [类型] 描述（类型取值：新功能/改进/修复/文档/测试/chore）-->
 <!-- 每条独立一行追加到本段末尾，无需分类标题，合并时冲突最小 -->
 - [改进] Web 路由页面改为按需加载，降低首包体积并增加路由加载失败恢复提示。
+- [修复] Docker 默认部署移除 `.env` 单文件挂载，避免 WebUI 保存配置时因 `os.replace` 更新挂载点触发 `Device or resource busy`。
 
 ## [3.18.0] - 2026-05-21
 

--- a/docs/full-guide.md
+++ b/docs/full-guide.md
@@ -454,7 +454,6 @@ docker run -d \
   -v "$(pwd)/data:/app/data" \
   -v "$(pwd)/logs:/app/logs" \
   -v "$(pwd)/reports:/app/reports" \
-  -v "$(pwd)/.env:/app/.env" \
   zhulinsen/daily_stock_analysis:latest \
   python main.py --serve-only --host 0.0.0.0 --port 8000
 
@@ -465,7 +464,6 @@ docker run -d \
   -v "$(pwd)/data:/app/data" \
   -v "$(pwd)/logs:/app/logs" \
   -v "$(pwd)/reports:/app/reports" \
-  -v "$(pwd)/.env:/app/.env" \
   zhulinsen/daily_stock_analysis:latest
 ```
 
@@ -499,7 +497,7 @@ x-common: &common
     - ../data:/app/data
     - ../logs:/app/logs
     - ../reports:/app/reports
-    - ../.env:/app/.env
+    - ../strategies:/app/strategies:ro
 
 services:
   # 定时任务模式
@@ -511,19 +509,20 @@ services:
   server:
     <<: *common
     container_name: stock-server
-    command: ["python", "main.py", "--serve-only", "--host", "0.0.0.0", "--port", "8000"]
+    command: ["python", "main.py", "--serve-only", "--host", "0.0.0.0", "--port", "${API_PORT:-8000}"]
     ports:
-      - "8000:8000"
+      - "${API_PORT:-8000}:${API_PORT:-8000}"
 ```
 
 ### `.env` 与数据目录映射说明
 
-无论你使用 `docker run` 还是 Compose，建议同时保留下面两种映射：
+无论你使用 `docker run` 还是 Compose，都需要区分启动环境变量注入和运行时文件写入：
 
 - 环境变量注入：`--env-file .env` 或 Compose 的 `env_file`
   作用：把 `.env` 中的键值作为容器启动时的环境变量传入 Python 进程。
-- 文件映射：`-v "$(pwd)/.env:/app/.env"` 或 Compose 的 `../.env:/app/.env`
-  作用：让容器内的 Web 设置页和后端读写同一份 `.env` 文件，修改后可持久化到宿主机。
+- 运行时配置写入：不要把宿主机 `.env` 作为单文件 bind mount 覆盖容器内 `.env` 路径。Docker 会把单文件挂载目标作为 mount point，配置保存时的 `os.replace()` 原子更新可能失败并报 `Device or resource busy`，回退写入也可能受权限限制。
+
+默认 Compose 和 `docker run` 示例仅使用 `env_file` / `--env-file` 注入启动配置，不再把宿主机 `.env` 单文件挂载进容器。WebUI 中保存的运行时配置默认写入容器内部配置文件，不等同于回写宿主机 `.env`；删除或重建容器后仍以启动时注入的 `.env` 为准。若需要持久化运行时配置，请将写入目标放到可写数据卷中（例如通过 `ENV_FILE=/app/data/runtime.env` 指向 `data` volume 中的文件），不要使用 `.env` 单文件 bind mount。
 
 推荐同时映射这几个目录：
 
@@ -568,7 +567,6 @@ docker run -d \
   -v "$(pwd)/data:/app/data" \
   -v "$(pwd)/logs:/app/logs" \
   -v "$(pwd)/reports:/app/reports" \
-  -v "$(pwd)/.env:/app/.env" \
   stock-analysis \
   python main.py --serve-only --host 0.0.0.0 --port 8000
 ```

--- a/docs/full-guide_EN.md
+++ b/docs/full-guide_EN.md
@@ -404,7 +404,6 @@ docker run -d \
   -v "$(pwd)/data:/app/data" \
   -v "$(pwd)/logs:/app/logs" \
   -v "$(pwd)/reports:/app/reports" \
-  -v "$(pwd)/.env:/app/.env" \
   zhulinsen/daily_stock_analysis:latest \
   python main.py --serve-only --host 0.0.0.0 --port 8000
 
@@ -415,7 +414,6 @@ docker run -d \
   -v "$(pwd)/data:/app/data" \
   -v "$(pwd)/logs:/app/logs" \
   -v "$(pwd)/reports:/app/reports" \
-  -v "$(pwd)/.env:/app/.env" \
   zhulinsen/daily_stock_analysis:latest
 ```
 
@@ -449,7 +447,6 @@ x-common: &common
     - ../data:/app/data
     - ../logs:/app/logs
     - ../reports:/app/reports
-    - ../.env:/app/.env
     - ../strategies:/app/strategies:ro
 
 services:
@@ -469,12 +466,13 @@ services:
 
 ### `.env` and Volume Mapping
 
-For both `docker run` and Compose, keep these two layers in mind:
+For both `docker run` and Compose, keep startup environment injection separate from runtime file writes:
 
 - Environment injection: `--env-file .env` or Compose `env_file`
   This passes key/value pairs from `.env` into the container process environment.
-- File mapping: `-v "$(pwd)/.env:/app/.env"` or Compose `../.env:/app/.env`
-  This mounts the same `.env` file into the container so the Web settings page and backend read/write the same persisted config file.
+- Runtime config writes: do not bind-mount the host `.env` as a single file over the container's `.env` path. Docker treats the target as a mount point, so the `os.replace()` atomic update used during config saves can fail with `Device or resource busy`; fallback in-place writes can also fail on permissions.
+
+The default Compose and `docker run` examples only use `env_file` / `--env-file` for startup config injection and no longer mount the host `.env` file into the container. Runtime config saved from the WebUI is written to the container-local config file by default and is not the same as writing back to the host `.env`; after deleting or recreating the container, startup still uses the injected `.env` file. If you need persistent runtime config, point `ENV_FILE` at a writable data volume file such as `/app/data/runtime.env` instead of using a single-file `.env` bind mount.
 
 Recommended host mappings:
 
@@ -519,7 +517,6 @@ docker run -d \
   -v "$(pwd)/data:/app/data" \
   -v "$(pwd)/logs:/app/logs" \
   -v "$(pwd)/reports:/app/reports" \
-  -v "$(pwd)/.env:/app/.env" \
   stock-analysis \
   python main.py --serve-only --host 0.0.0.0 --port 8000
 ```

--- a/tests/test_docker_entrypoint.py
+++ b/tests/test_docker_entrypoint.py
@@ -3,6 +3,8 @@ import re
 import subprocess
 from pathlib import Path
 
+import yaml
+
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 
@@ -32,6 +34,31 @@ def test_docker_entrypoint_repairs_ownership_and_user_permissions() -> None:
     assert re.search(r"\bchown\s+-R\b", entrypoint)
     assert re.search(r"\bchmod\s+-R\s+u\+rwX\b", entrypoint)
     assert re.search(r"gosu\s+\"\$APP_USER:\$APP_GROUP\"\s+test\s+-w", entrypoint)
+
+
+def test_docker_compose_injects_env_without_single_file_env_mount() -> None:
+    compose_text = (REPO_ROOT / "docker" / "docker-compose.yml").read_text(encoding="utf-8")
+    compose = yaml.safe_load(compose_text)
+    common = compose["x-common"]
+
+    assert "../.env" in common["env_file"]
+    assert "../.env:/app/.env" not in common["volumes"]
+    assert not any(str(volume).startswith("../.env:") for volume in common["volumes"])
+
+
+def test_docker_guides_do_not_recommend_single_file_env_bind_mount() -> None:
+    forbidden_mount_patterns = [
+        r"\$\(pwd\)/\.env:/app/\.env",
+        r"\.\./\.env:/app/\.env",
+    ]
+
+    for doc_path in ("docs/full-guide.md", "docs/full-guide_EN.md"):
+        doc = (REPO_ROOT / doc_path).read_text(encoding="utf-8")
+
+        assert "--env-file .env" in doc
+        assert "env_file:" in doc
+        for pattern in forbidden_mount_patterns:
+            assert re.search(pattern, doc) is None
 
 
 def test_documented_compose_exec_commands_run_as_dsa() -> None:


### PR DESCRIPTION
## PR Type
- [x] fix
- [ ] feat
- [ ] refactor
- [ ] docs
- [ ] chore
- [ ] test

## Background And Problem
- 当前问题：避免 Docker 默认部署将 `.env` 作为单文件 bind mount 挂载到 `/app/.env`，使 WebUI 配置更新不再触发 mount point replace 错误。
- 影响范围：本次改动涉及 5 个文件，Diff 为 `+41 / -18`。
- 触发来源：Issue 自动执行（Issue #1399）。

## Scope Of Change
- `docker/docker-compose.yml`
- `docs/CHANGELOG.md`
- `docs/full-guide.md`
- `docs/full-guide_EN.md`
- `tests/test_docker_entrypoint.py`

## Documentation And Changelog
- 已同步更新文档/变更记录：`docs/CHANGELOG.md`, `docs/full-guide.md`, `docs/full-guide_EN.md`。

## Issue Link
Closes #1399

## Verification Commands And Results
```bash
./scripts/ci_gate.sh flake8
./scripts/ci_gate.sh offline-tests
```

关键输出/结论 / Key output & conclusion:
- lint:PASS, test:PASS

## Compatibility And Risk
- **Medium**：涉及 `docker/docker-compose.yml`, `docs/CHANGELOG.md`, `docs/full-guide.md`, `docs/full-guide_EN.md`, `tests/test_docker_entrypoint.py`，建议按文件范围复核。
- 前提假设：
  - 保留 `env_file: ../.env` 足以满足容器启动时环境变量注入需求。
  - 运行时配置持久化如需支持，应优先使用已有可写数据目录或后续单独设计，不在本次修复中扩大为配置存储架构改造。
  - 不修改 secrets、GitHub Actions workflow、发布流程或数据库迁移。

## Rollback Plan
- `git revert <merge-commit>` 回滚本 PR 提交，重点确认 `docker/docker-compose.yml`, `docs/CHANGELOG.md`, `docs/full-guide.md`, `docs/full-guide_EN.md` 恢复正常。

## Acceptance Criteria
- `docker/docker-compose.yml` 默认配置不再包含 `../.env:/app/.env` 单文件 bind mount。
- Docker 启动仍通过 `env_file: ../.env` 注入环境变量。
- 相关 Docker 部署文档说明 `.env` 不应以单文件 bind mount 方式挂载，并说明运行时配置持久化边界。
- `docs/CHANGELOG.md` 的 `[Unreleased]` 段新增一条扁平格式修复记录。
- 现有配置管理单元测试不因该调整回归。

## Checklist
- [x] 本 PR 有明确动机和业务价值 / This PR has a clear motivation and value
- [x] 已提供可复现的验证命令与结果 / Reproducible verification commands and results are included
- [x] 已评估兼容性与风险 / Compatibility and risk have been assessed
- [x] 已提供回滚方案 / A rollback plan is provided
- [x] 已同步更新相关文档与 `docs/CHANGELOG.md`，并在 PR 描述中说明文档落点 / Relevant docs and `docs/CHANGELOG.md` are updated, and the documentation location is stated in this PR