### PR TITLE
chore: 清理 API schema 的 Pydantic v2 弃用写法 (#1394 PR-A)

### DIFF
--- a/api/v1/schemas/analysis.py
+++ b/api/v1/schemas/analysis.py
@@ -13,7 +13,7 @@
 from typing import Optional, List, Any
 from enum import Enum
 
-from pydantic import AliasChoices, BaseModel, Field
+from pydantic import AliasChoices, BaseModel, ConfigDict, Field
 from src.utils.analysis_metadata import SELECTION_SOURCE_PATTERN
 
 
@@ -31,12 +31,12 @@ class AnalyzeRequest(BaseModel):
     stock_code: Optional[str] = Field(
         None, 
         description="单只股票代码", 
-        example="600519"
+        json_schema_extra={"example": "600519"},
     )
     stock_codes: Optional[List[str]] = Field(
         None, 
         description="多只股票代码（与 stock_code 二选一）",
-        example=["600519", "000858"]
+        json_schema_extra={"example": ["600519", "000858"]},
     )
     report_type: str = Field(
         "detailed",
@@ -54,18 +54,18 @@ class AnalyzeRequest(BaseModel):
     stock_name: Optional[str] = Field(
         None,
         description="用户选中的股票名称（自动补全时提供）",
-        example="贵州茅台"
+        json_schema_extra={"example": "贵州茅台"},
     )
     original_query: Optional[str] = Field(
         None,
         description="用户原始输入（如茅台、gzmt、600519）",
-        example="茅台"
+        json_schema_extra={"example": "茅台"},
     )
     selection_source: Optional[str] = Field(
         None,
         description="股票选择来源：manual(手动输入) | autocomplete(自动补全) | import(导入) | image(图片识别)",
         pattern=SELECTION_SOURCE_PATTERN,
-        example="autocomplete"
+        json_schema_extra={"example": "autocomplete"},
     )
     notify: bool = Field(
         True,
@@ -75,23 +75,22 @@ class AnalyzeRequest(BaseModel):
         None,
         validation_alias=AliasChoices("skills", "strategies"),
         description="本次分析使用的策略 skill ID 列表；兼容 legacy strategies 字段",
-        example=["bull_trend", "growth_quality"]
+        json_schema_extra={"example": ["bull_trend", "growth_quality"]},
     )
 
-    class Config:
-        json_schema_extra = {
-            "example": {
-                "stock_code": "600519",
-                "report_type": "detailed",
-                "force_refresh": False,
-                "async_mode": False,
-                "stock_name": "贵州茅台",
-                "original_query": "茅台",
-                "selection_source": "autocomplete",
-                "notify": True,
-                "skills": ["bull_trend"]
-            }
+    model_config = ConfigDict(json_schema_extra={
+        "example": {
+            "stock_code": "600519",
+            "report_type": "detailed",
+            "force_refresh": False,
+            "async_mode": False,
+            "stock_name": "贵州茅台",
+            "original_query": "茅台",
+            "selection_source": "autocomplete",
+            "notify": True,
+            "skills": ["bull_trend"]
         }
+    })
 
 
 class MarketReviewRequest(BaseModel):
@@ -124,21 +123,20 @@ class AnalysisResultResponse(BaseModel):
     report: Optional[Any] = Field(None, description="分析报告")
     created_at: str = Field(..., description="创建时间")
     
-    class Config:
-        json_schema_extra = {
-            "example": {
-                "query_id": "abc123def456",
-                "stock_code": "600519",
-                "stock_name": "贵州茅台",
-                "report": {
-                    "summary": {
-                        "sentiment_score": 75,
-                        "operation_advice": "持有"
-                    }
-                },
-                "created_at": "2024-01-01T12:00:00"
-            }
+    model_config = ConfigDict(json_schema_extra={
+        "example": {
+            "query_id": "abc123def456",
+            "stock_code": "600519",
+            "stock_name": "贵州茅台",
+            "report": {
+                "summary": {
+                    "sentiment_score": 75,
+                    "operation_advice": "持有"
+                }
+            },
+            "created_at": "2024-01-01T12:00:00"
         }
+    })
 
 
 class TaskAccepted(BaseModel):
@@ -152,14 +150,13 @@ class TaskAccepted(BaseModel):
     )
     message: Optional[str] = Field(None, description="提示信息")
     
-    class Config:
-        json_schema_extra = {
-            "example": {
-                "task_id": "task_abc123",
-                "status": "pending",
-                "message": "Analysis task accepted"
-            }
+    model_config = ConfigDict(json_schema_extra={
+        "example": {
+            "task_id": "task_abc123",
+            "status": "pending",
+            "message": "Analysis task accepted"
         }
+    })
 
 
 class BatchTaskAcceptedItem(BaseModel):
@@ -174,15 +171,14 @@ class BatchTaskAcceptedItem(BaseModel):
     )
     message: Optional[str] = Field(None, description="提示信息")
 
-    class Config:
-        json_schema_extra = {
-            "example": {
-                "task_id": "task_abc123",
-                "stock_code": "600519",
-                "status": "pending",
-                "message": "分析任务已加入队列: 600519"
-            }
+    model_config = ConfigDict(json_schema_extra={
+        "example": {
+            "task_id": "task_abc123",
+            "stock_code": "600519",
+            "status": "pending",
+            "message": "分析任务已加入队列: 600519"
         }
+    })
 
 
 class BatchDuplicateTaskItem(BaseModel):
@@ -192,14 +188,13 @@ class BatchDuplicateTaskItem(BaseModel):
     existing_task_id: str = Field(..., description="已存在的任务 ID")
     message: str = Field(..., description="错误信息")
 
-    class Config:
-        json_schema_extra = {
-            "example": {
-                "stock_code": "600519",
-                "existing_task_id": "task_existing_123",
-                "message": "股票 600519 正在分析中 (task_id: task_existing_123)"
-            }
+    model_config = ConfigDict(json_schema_extra={
+        "example": {
+            "stock_code": "600519",
+            "existing_task_id": "task_existing_123",
+            "message": "股票 600519 正在分析中 (task_id: task_existing_123)"
         }
+    })
 
 
 class BatchTaskAcceptedResponse(BaseModel):
@@ -209,27 +204,26 @@ class BatchTaskAcceptedResponse(BaseModel):
     duplicates: List[BatchDuplicateTaskItem] = Field(default_factory=list, description="重复而跳过的任务列表")
     message: str = Field(..., description="汇总信息")
 
-    class Config:
-        json_schema_extra = {
-            "example": {
-                "accepted": [
-                    {
-                        "task_id": "task_abc123",
-                        "stock_code": "600519",
-                        "status": "pending",
-                        "message": "分析任务已加入队列: 600519"
-                    }
-                ],
-                "duplicates": [
-                    {
-                        "stock_code": "000858",
-                        "existing_task_id": "task_existing_456",
-                        "message": "股票 000858 正在分析中 (task_id: task_existing_456)"
-                    }
-                ],
-                "message": "已提交 1 个任务，1 个重复跳过"
-            }
+    model_config = ConfigDict(json_schema_extra={
+        "example": {
+            "accepted": [
+                {
+                    "task_id": "task_abc123",
+                    "stock_code": "600519",
+                    "status": "pending",
+                    "message": "分析任务已加入队列: 600519"
+                }
+            ],
+            "duplicates": [
+                {
+                    "stock_code": "000858",
+                    "existing_task_id": "task_existing_456",
+                    "message": "股票 000858 正在分析中 (task_id: task_existing_456)"
+                }
+            ],
+            "message": "已提交 1 个任务，1 个重复跳过"
         }
+    })
 
 
 class TaskStatus(BaseModel):
@@ -268,21 +262,20 @@ class TaskStatus(BaseModel):
     )
     skills: Optional[List[str]] = Field(None, description="本次任务使用的策略 skill ID 列表")
     
-    class Config:
-        json_schema_extra = {
-            "example": {
-                "task_id": "task_abc123",
-                "status": "completed",
-                "progress": 100,
-                "result": None,
-                "market_review_report": None,
-                "error": None,
-                "stock_name": "贵州茅台",
-                "original_query": "茅台",
-                "selection_source": "autocomplete",
-                "skills": ["bull_trend"]
-            }
+    model_config = ConfigDict(json_schema_extra={
+        "example": {
+            "task_id": "task_abc123",
+            "status": "completed",
+            "progress": 100,
+            "result": None,
+            "market_review_report": None,
+            "error": None,
+            "stock_name": "贵州茅台",
+            "original_query": "茅台",
+            "selection_source": "autocomplete",
+            "skills": ["bull_trend"]
         }
+    })
 
 
 class TaskInfo(BaseModel):
@@ -311,25 +304,24 @@ class TaskInfo(BaseModel):
     )
     skills: Optional[List[str]] = Field(None, description="本次任务使用的策略 skill ID 列表")
     
-    class Config:
-        json_schema_extra = {
-            "example": {
-                "task_id": "abc123def456",
-                "stock_code": "600519",
-                "stock_name": "贵州茅台",
-                "status": "processing",
-                "progress": 50,
-                "message": "正在分析中...",
-                "report_type": "detailed",
-                "created_at": "2026-02-05T10:30:00",
-                "started_at": "2026-02-05T10:30:01",
-                "completed_at": None,
-                "error": None,
-                "original_query": "茅台",
-                "selection_source": "autocomplete",
-                "skills": ["bull_trend"]
-            }
+    model_config = ConfigDict(json_schema_extra={
+        "example": {
+            "task_id": "abc123def456",
+            "stock_code": "600519",
+            "stock_name": "贵州茅台",
+            "status": "processing",
+            "progress": 50,
+            "message": "正在分析中...",
+            "report_type": "detailed",
+            "created_at": "2026-02-05T10:30:00",
+            "started_at": "2026-02-05T10:30:01",
+            "completed_at": None,
+            "error": None,
+            "original_query": "茅台",
+            "selection_source": "autocomplete",
+            "skills": ["bull_trend"]
         }
+    })
 
 
 class TaskListResponse(BaseModel):
@@ -340,15 +332,14 @@ class TaskListResponse(BaseModel):
     processing: int = Field(..., description="处理中的任务数")
     tasks: List[TaskInfo] = Field(..., description="任务列表")
     
-    class Config:
-        json_schema_extra = {
-            "example": {
-                "total": 3,
-                "pending": 1,
-                "processing": 2,
-                "tasks": []
-            }
+    model_config = ConfigDict(json_schema_extra={
+        "example": {
+            "total": 3,
+            "pending": 1,
+            "processing": 2,
+            "tasks": []
         }
+    })
 
 
 class DuplicateTaskErrorResponse(BaseModel):
@@ -359,12 +350,11 @@ class DuplicateTaskErrorResponse(BaseModel):
     stock_code: str = Field(..., description="股票代码")
     existing_task_id: str = Field(..., description="已存在的任务 ID")
     
-    class Config:
-        json_schema_extra = {
-            "example": {
-                "error": "duplicate_task",
-                "message": "股票 600519 正在分析中",
-                "stock_code": "600519",
-                "existing_task_id": "abc123def456"
-            }
+    model_config = ConfigDict(json_schema_extra={
+        "example": {
+            "error": "duplicate_task",
+            "message": "股票 600519 正在分析中",
+            "stock_code": "600519",
+            "existing_task_id": "abc123def456"
         }
+    })

--- a/api/v1/schemas/common.py
+++ b/api/v1/schemas/common.py
@@ -11,54 +11,51 @@
 
 from typing import Optional, Any
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 
 class RootResponse(BaseModel):
     """API 根路由响应"""
     
-    message: str = Field(..., description="API 运行状态消息", example="Daily Stock Analysis API is running")
-    version: Optional[str] = Field(None, description="API 版本", example="1.0.0")
+    message: str = Field(..., description="API 运行状态消息", json_schema_extra={"example": "Daily Stock Analysis API is running"})
+    version: Optional[str] = Field(None, description="API 版本", json_schema_extra={"example": "1.0.0"})
     
-    class Config:
-        json_schema_extra = {
-            "example": {
-                "message": "Daily Stock Analysis API is running",
-                "version": "1.0.0"
-            }
+    model_config = ConfigDict(json_schema_extra={
+        "example": {
+            "message": "Daily Stock Analysis API is running",
+            "version": "1.0.0"
         }
+    })
 
 
 class HealthResponse(BaseModel):
     """健康检查响应"""
     
-    status: str = Field(..., description="服务状态", example="ok")
+    status: str = Field(..., description="服务状态", json_schema_extra={"example": "ok"})
     timestamp: Optional[str] = Field(None, description="时间戳")
     
-    class Config:
-        json_schema_extra = {
-            "example": {
-                "status": "ok",
-                "timestamp": "2024-01-01T12:00:00"
-            }
+    model_config = ConfigDict(json_schema_extra={
+        "example": {
+            "status": "ok",
+            "timestamp": "2024-01-01T12:00:00"
         }
+    })
 
 
 class ErrorResponse(BaseModel):
     """错误响应"""
     
-    error: str = Field(..., description="错误类型", example="validation_error")
-    message: str = Field(..., description="错误详情", example="请求参数错误")
+    error: str = Field(..., description="错误类型", json_schema_extra={"example": "validation_error"})
+    message: str = Field(..., description="错误详情", json_schema_extra={"example": "请求参数错误"})
     detail: Optional[Any] = Field(None, description="附加错误信息")
     
-    class Config:
-        json_schema_extra = {
-            "example": {
-                "error": "not_found",
-                "message": "资源不存在",
-                "detail": None
-            }
+    model_config = ConfigDict(json_schema_extra={
+        "example": {
+            "error": "not_found",
+            "message": "资源不存在",
+            "detail": None
         }
+    })
 
 
 class SuccessResponse(BaseModel):
@@ -68,11 +65,10 @@ class SuccessResponse(BaseModel):
     message: Optional[str] = Field(None, description="成功消息")
     data: Optional[Any] = Field(None, description="响应数据")
     
-    class Config:
-        json_schema_extra = {
-            "example": {
-                "success": True,
-                "message": "操作成功",
-                "data": None
-            }
+    model_config = ConfigDict(json_schema_extra={
+        "example": {
+            "success": True,
+            "message": "操作成功",
+            "data": None
         }
+    })

--- a/api/v1/schemas/history.py
+++ b/api/v1/schemas/history.py
@@ -29,19 +29,18 @@ class HistoryItem(BaseModel):
     operation_advice: Optional[str] = Field(None, description="操作建议")
     created_at: Optional[str] = Field(None, description="创建时间")
     
-    class Config:
-        json_schema_extra = {
-            "example": {
-                "id": 1234,
-                "query_id": "abc123",
-                "stock_code": "600519",
-                "stock_name": "贵州茅台",
-                "report_type": "detailed",
-                "sentiment_score": 75,
-                "operation_advice": "持有",
-                "created_at": "2024-01-01T12:00:00"
-            }
+    model_config = ConfigDict(json_schema_extra={
+        "example": {
+            "id": 1234,
+            "query_id": "abc123",
+            "stock_code": "600519",
+            "stock_name": "贵州茅台",
+            "report_type": "detailed",
+            "sentiment_score": 75,
+            "operation_advice": "持有",
+            "created_at": "2024-01-01T12:00:00"
         }
+    })
 
 
 class HistoryListResponse(BaseModel):
@@ -52,15 +51,14 @@ class HistoryListResponse(BaseModel):
     limit: int = Field(..., description="每页数量")
     items: List[HistoryItem] = Field(default_factory=list, description="记录列表")
     
-    class Config:
-        json_schema_extra = {
-            "example": {
-                "total": 100,
-                "page": 1,
-                "limit": 20,
-                "items": []
-            }
+    model_config = ConfigDict(json_schema_extra={
+        "example": {
+            "total": 100,
+            "page": 1,
+            "limit": 20,
+            "items": []
         }
+    })
 
 
 class DeleteHistoryRequest(BaseModel):
@@ -82,14 +80,13 @@ class NewsIntelItem(BaseModel):
     snippet: str = Field("", description="新闻摘要（最多200字）")
     url: str = Field(..., description="新闻链接")
 
-    class Config:
-        json_schema_extra = {
-            "example": {
-                "title": "公司发布业绩快报，营收同比增长 20%",
-                "snippet": "公司公告显示，季度营收同比增长 20%...",
-                "url": "https://example.com/news/123"
-            }
+    model_config = ConfigDict(json_schema_extra={
+        "example": {
+            "title": "公司发布业绩快报，营收同比增长 20%",
+            "snippet": "公司公告显示，季度营收同比增长 20%...",
+            "url": "https://example.com/news/123"
         }
+    })
 
 
 class NewsIntelResponse(BaseModel):
@@ -98,13 +95,12 @@ class NewsIntelResponse(BaseModel):
     total: int = Field(..., description="新闻条数")
     items: List[NewsIntelItem] = Field(default_factory=list, description="新闻列表")
 
-    class Config:
-        json_schema_extra = {
-            "example": {
-                "total": 2,
-                "items": []
-            }
+    model_config = ConfigDict(json_schema_extra={
+        "example": {
+            "total": 2,
+            "items": []
         }
+    })
 
 
 class ReportMeta(BaseModel):
@@ -166,33 +162,32 @@ class AnalysisReport(BaseModel):
     strategy: Optional[ReportStrategy] = Field(None, description="策略点位区")
     details: Optional[ReportDetails] = Field(None, description="详情区")
 
-    class Config:
-        json_schema_extra = {
-            "example": {
-                "meta": {
-                    "query_id": "abc123",
-                    "stock_code": "600519",
-                    "stock_name": "贵州茅台",
-                    "report_type": "detailed",
-                    "report_language": "zh",
-                    "created_at": "2024-01-01T12:00:00"
-                },
-                "summary": {
-                    "analysis_summary": "技术面向好，建议持有",
-                    "operation_advice": "持有",
-                    "trend_prediction": "看多",
-                    "sentiment_score": 75,
-                    "sentiment_label": "乐观"
-                },
-                "strategy": {
-                    "ideal_buy": "1800.00",
-                    "secondary_buy": "1750.00",
-                    "stop_loss": "1700.00",
-                    "take_profit": "2000.00"
-                },
-                "details": None
-            }
+    model_config = ConfigDict(json_schema_extra={
+        "example": {
+            "meta": {
+                "query_id": "abc123",
+                "stock_code": "600519",
+                "stock_name": "贵州茅台",
+                "report_type": "detailed",
+                "report_language": "zh",
+                "created_at": "2024-01-01T12:00:00"
+            },
+            "summary": {
+                "analysis_summary": "技术面向好，建议持有",
+                "operation_advice": "持有",
+                "trend_prediction": "看多",
+                "sentiment_score": 75,
+                "sentiment_label": "乐观"
+            },
+            "strategy": {
+                "ideal_buy": "1800.00",
+                "secondary_buy": "1750.00",
+                "stop_loss": "1700.00",
+                "take_profit": "2000.00"
+            },
+            "details": None
         }
+    })
 
 
 class MarkdownReportResponse(BaseModel):
@@ -200,9 +195,8 @@ class MarkdownReportResponse(BaseModel):
 
     content: str = Field(..., description="Markdown 格式的完整报告内容")
 
-    class Config:
-        json_schema_extra = {
-            "example": {
-                "content": "# 📊 贵州茅台 (600519) 分析报告\n\n> 分析日期：**2024-01-01**\n\n..."
-            }
+    model_config = ConfigDict(json_schema_extra={
+        "example": {
+            "content": "# 📊 贵州茅台 (600519) 分析报告\n\n> 分析日期：**2024-01-01**\n\n..."
         }
+    })

--- a/api/v1/schemas/stocks.py
+++ b/api/v1/schemas/stocks.py
@@ -11,7 +11,7 @@
 
 from typing import Optional, List
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 
 class StockQuote(BaseModel):
@@ -30,23 +30,22 @@ class StockQuote(BaseModel):
     amount: Optional[float] = Field(None, description="成交额（元）")
     update_time: Optional[str] = Field(None, description="更新时间")
     
-    class Config:
-        json_schema_extra = {
-            "example": {
-                "stock_code": "600519",
-                "stock_name": "贵州茅台",
-                "current_price": 1800.00,
-                "change": 15.00,
-                "change_percent": 0.84,
-                "open": 1785.00,
-                "high": 1810.00,
-                "low": 1780.00,
-                "prev_close": 1785.00,
-                "volume": 10000000,
-                "amount": 18000000000,
-                "update_time": "2024-01-01T15:00:00"
-            }
+    model_config = ConfigDict(json_schema_extra={
+        "example": {
+            "stock_code": "600519",
+            "stock_name": "贵州茅台",
+            "current_price": 1800.00,
+            "change": 15.00,
+            "change_percent": 0.84,
+            "open": 1785.00,
+            "high": 1810.00,
+            "low": 1780.00,
+            "prev_close": 1785.00,
+            "volume": 10000000,
+            "amount": 18000000000,
+            "update_time": "2024-01-01T15:00:00"
         }
+    })
 
 
 class KLineData(BaseModel):
@@ -61,19 +60,18 @@ class KLineData(BaseModel):
     amount: Optional[float] = Field(None, description="成交额")
     change_percent: Optional[float] = Field(None, description="涨跌幅 (%)")
     
-    class Config:
-        json_schema_extra = {
-            "example": {
-                "date": "2024-01-01",
-                "open": 1785.00,
-                "high": 1810.00,
-                "low": 1780.00,
-                "close": 1800.00,
-                "volume": 10000000,
-                "amount": 18000000000,
-                "change_percent": 0.84
-            }
+    model_config = ConfigDict(json_schema_extra={
+        "example": {
+            "date": "2024-01-01",
+            "open": 1785.00,
+            "high": 1810.00,
+            "low": 1780.00,
+            "close": 1800.00,
+            "volume": 10000000,
+            "amount": 18000000000,
+            "change_percent": 0.84
         }
+    })
 
 
 class ExtractItem(BaseModel):
@@ -100,12 +98,11 @@ class StockHistoryResponse(BaseModel):
     period: str = Field(..., description="K 线周期")
     data: List[KLineData] = Field(default_factory=list, description="K 线数据列表")
     
-    class Config:
-        json_schema_extra = {
-            "example": {
-                "stock_code": "600519",
-                "stock_name": "贵州茅台",
-                "period": "daily",
-                "data": []
-            }
+    model_config = ConfigDict(json_schema_extra={
+        "example": {
+            "stock_code": "600519",
+            "stock_name": "贵州茅台",
+            "period": "daily",
+            "data": []
         }
+    })

--- a/tests/test_api_schema_pydantic.py
+++ b/tests/test_api_schema_pydantic.py
@@ -1,0 +1,29 @@
+"""Regression tests for API schema metadata under Pydantic v2."""
+
+from api.v1.schemas.analysis import AnalyzeRequest
+from api.v1.schemas.common import RootResponse
+from api.v1.schemas.history import HistoryItem
+from api.v1.schemas.stocks import StockQuote
+
+
+def test_schema_examples_remain_in_openapi_schema() -> None:
+    root_schema = RootResponse.model_json_schema()
+    analyze_schema = AnalyzeRequest.model_json_schema()
+    history_schema = HistoryItem.model_json_schema()
+    quote_schema = StockQuote.model_json_schema()
+
+    assert root_schema["properties"]["message"]["example"] == "Daily Stock Analysis API is running"
+    assert root_schema["example"]["version"] == "1.0.0"
+    assert analyze_schema["properties"]["stock_code"]["example"] == "600519"
+    assert analyze_schema["properties"]["skills"]["example"] == ["bull_trend", "growth_quality"]
+    assert history_schema["example"]["stock_code"] == "600519"
+    assert quote_schema["example"]["stock_name"] == "贵州茅台"
+
+
+def test_analyze_request_supports_legacy_strategies_dict_input() -> None:
+    request = AnalyzeRequest.model_validate({
+        "stock_code": "600519",
+        "strategies": ["bull_trend", "growth_quality"],
+    })
+
+    assert request.skills == ["bull_trend", "growth_quality"]


### PR DESCRIPTION
## PR Type

- [ ] fix
- [ ] feat
- [ ] refactor
- [ ] docs
- [x] chore
- [x] test

## Background And Problem

Issue #1394 中 PR-A 部分指出告警相关测试会触发 Pydantic v2 deprecation warnings，主要来自 API schema 中旧式写法：

- `Field(..., example=...)`
- `class Config: json_schema_extra = ...`

这些 warning 当前不阻断普通测试，但在 Pydantic v3 前会继续侵蚀回归信号质量。本 PR 只处理 PR-A 的后端 schema warning 清理，不处理 Web large chunk warning。

## Scope Of Change

- `api/v1/schemas/common.py`
- `api/v1/schemas/analysis.py`
- `api/v1/schemas/history.py`
- `api/v1/schemas/stocks.py`
- `tests/test_api_schema_pydantic.py`

主要改动：

- 将字段级 `example=` 迁移为 `json_schema_extra={"example": ...}`。
- 将模型级旧式 `class Config` 迁移为 `model_config = ConfigDict(json_schema_extra=...)`。
- 保留现有字段、默认值、alias、pattern 和 OpenAPI 示例语义。
- `history.py` 中已有的 `ReportMeta.model_config = ConfigDict(protected_namespaces=...)` 未改动。
- 新增窄回归测试，覆盖 OpenAPI 示例保留和 `AnalyzeRequest.model_validate({"strategies": ...})` 的 legacy dict 入参兼容路径。

## Issue Link

Refs #1394

## Verification Commands And Results

```bash
.venv/bin/python -m py_compile api/v1/schemas/common.py api/v1/schemas/analysis.py api/v1/schemas/history.py api/v1/schemas/stocks.py
.venv/bin/python -m pytest tests/test_api_schema_pydantic.py
.venv/bin/python -m pytest -W error::pydantic.warnings.PydanticDeprecatedSince20 tests/test_alert_api.py tests/test_alert_worker.py tests/test_alerts_docs.py tests/test_portfolio_alerts.py -ra
PATH=.venv/bin:$PATH ./scripts/ci_gate.sh
git diff --check
```

关键输出/结论：

- schema py_compile：通过
- `tests/test_api_schema_pydantic.py`：`2 passed`
- PR-A warning-as-error 验收：`97 passed, 5 subtests passed`
- backend gate：`2187 passed, 2 deselected, 9 warnings, 180 subtests passed`
- `git diff --check`：通过

说明：当前 shell 直接运行 `./scripts/ci_gate.sh` 时找不到全局 `flake8`；`.venv/bin/flake8` 存在，因此使用 `PATH=.venv/bin:$PATH ./scripts/ci_gate.sh` 复现完整 gate。backend gate 中的 9 个 warnings 不是本 PR 清理的 Pydantic deprecation warning。

## Compatibility And Risk

兼容性影响：低。

- 不变更 API 请求/响应字段。
- 不变更 alias、pattern、默认值或运行时配置。
- 不新增环境变量、迁移、数据回填或 provider fallback。
- OpenAPI 示例语义保持不变，仅迁移到 Pydantic v2 推荐写法。

风险点：

- 主要风险是 OpenAPI schema metadata 写法迁移遗漏；已通过新增 schema 回归和 issue 指定 warning-as-error 命令覆盖。
- 本 PR 不处理 #1394 的 Web large chunk warning，后续需要单独 PR-B 处理。

## Rollback Plan

如需回滚，直接 revert 本 PR 即可；无需额外回滚配置、数据或迁移状态。

## EXTRACT_PROMPT Change (if applicable)

不涉及 `src/services/image_stock_extractor.py` 或 `EXTRACT_PROMPT`。

## Checklist

- [x] 本 PR 有明确动机和业务价值 / This PR has a clear motivation and value
- [x] 已提供可复现的验证命令与结果 / Reproducible verification commands and results are included
- [x] 已评估兼容性与风险 / Compatibility and risk have been assessed
- [x] 已提供回滚方案 / A rollback plan is provided
- [x] 本 PR 不涉及用户可见能力、配置项、CLI/API 行为、部署方式、通知方式或报告结构变化，因此未更新 README / docs / CHANGELOG
