### PR TITLE
chore: 拆分 Web 首包加载 (#1394 PR-B)

### DIFF
--- a/apps/dsa-web/src/App.test.tsx
+++ b/apps/dsa-web/src/App.test.tsx
@@ -1,0 +1,131 @@
+import { render, screen } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import App from './App';
+import * as AuthContext from './contexts/AuthContext';
+
+type AuthState = ReturnType<typeof AuthContext.useAuth>;
+
+const { setCurrentRoute, useAgentChatStoreMock } = vi.hoisted(() => {
+  const setCurrentRoute = vi.fn();
+  const state = { completionBadge: false };
+  const useAgentChatStoreMock = Object.assign(
+    vi.fn((selector?: (value: typeof state) => unknown) => (selector ? selector(state) : state)),
+    { getState: () => ({ setCurrentRoute }) },
+  );
+  return { setCurrentRoute, useAgentChatStoreMock };
+});
+
+vi.mock('./contexts/AuthContext', () => ({
+  AuthProvider: ({ children }: { children: ReactNode }) => children,
+  useAuth: vi.fn(),
+}));
+
+vi.mock('./stores/agentChatStore', () => ({
+  useAgentChatStore: useAgentChatStoreMock,
+}));
+
+vi.mock('./pages/HomePage', () => ({
+  default: () => <div data-testid="home-page">Home</div>,
+}));
+
+vi.mock('./pages/ChatPage', () => ({
+  default: () => <div data-testid="chat-page">Chat</div>,
+}));
+
+vi.mock('./pages/PortfolioPage', () => ({
+  default: () => <div data-testid="portfolio-page">Portfolio</div>,
+}));
+
+vi.mock('./pages/BacktestPage', () => ({
+  default: () => <div data-testid="backtest-page">Backtest</div>,
+}));
+
+vi.mock('./pages/AlertsPage', () => ({
+  default: () => <div data-testid="alerts-page">Alerts</div>,
+}));
+
+vi.mock('./pages/SettingsPage', () => ({
+  default: () => <div data-testid="settings-page">Settings</div>,
+}));
+
+vi.mock('./pages/NotFoundPage', () => ({
+  default: () => <div data-testid="not-found-page">Not Found</div>,
+}));
+
+vi.mock('./pages/LoginPage', () => ({
+  default: () => <div data-testid="login-page">Login</div>,
+}));
+
+function makeAuthState(overrides: Partial<AuthState> = {}): AuthState {
+  return {
+    authEnabled: false,
+    loggedIn: false,
+    passwordSet: false,
+    passwordChangeable: false,
+    setupState: 'no_password',
+    isLoading: false,
+    loadError: null,
+    login: vi.fn().mockResolvedValue({ success: true }),
+    changePassword: vi.fn().mockResolvedValue({ success: true }),
+    logout: vi.fn().mockResolvedValue(undefined),
+    refreshStatus: vi.fn().mockResolvedValue(undefined),
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  window.history.pushState({}, '', '/');
+  vi.mocked(AuthContext.useAuth).mockReturnValue(makeAuthState());
+});
+
+describe('App routing behavior', () => {
+  it('shows loading fallback while auth status is initializing', () => {
+    vi.mocked(AuthContext.useAuth).mockReturnValue(makeAuthState({ isLoading: true }));
+
+    const { container } = render(<App />);
+
+    expect(container.querySelector('.border-t-cyan')).toBeInTheDocument();
+  });
+
+  it('redirects protected routes to login when auth is enabled but user is not logged in', async () => {
+    vi.mocked(AuthContext.useAuth).mockReturnValue(makeAuthState({
+      authEnabled: true,
+      loggedIn: false,
+      setupState: 'enabled',
+    }));
+    window.history.pushState({}, '', '/portfolio');
+
+    render(<App />);
+
+    expect(await screen.findByTestId('login-page')).toBeInTheDocument();
+    expect(window.location.pathname).toBe('/login');
+    expect(window.location.search).toBe('?redirect=%2Fportfolio');
+  });
+
+  it('renders route-level page components through lazy routes after auth is ready', async () => {
+    window.history.pushState({}, '', '/chat');
+
+    render(<App />);
+
+    expect(await screen.findByTestId('chat-page')).toBeInTheDocument();
+    expect(setCurrentRoute).toHaveBeenCalledWith('/chat');
+    expect(screen.queryByTestId('login-page')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('home-page')).not.toBeInTheDocument();
+  });
+
+  it('redirects authenticated login visits back to the home page', async () => {
+    vi.mocked(AuthContext.useAuth).mockReturnValue(makeAuthState({
+      authEnabled: true,
+      loggedIn: true,
+      setupState: 'enabled',
+    }));
+    window.history.pushState({}, '', '/login');
+
+    render(<App />);
+
+    expect(await screen.findByTestId('home-page')).toBeInTheDocument();
+    expect(screen.queryByTestId('login-page')).not.toBeInTheDocument();
+  });
+});

--- a/apps/dsa-web/src/App.tsx
+++ b/apps/dsa-web/src/App.tsx
@@ -1,18 +1,29 @@
 import type React from 'react';
-import { useEffect } from 'react';
+import { lazy, Suspense, useEffect } from 'react';
 import { BrowserRouter as Router, Navigate, Route, Routes, useLocation } from 'react-router-dom';
-import HomePage from './pages/HomePage';
-import BacktestPage from './pages/BacktestPage';
-import SettingsPage from './pages/SettingsPage';
-import LoginPage from './pages/LoginPage';
-import NotFoundPage from './pages/NotFoundPage';
-import ChatPage from './pages/ChatPage';
-import PortfolioPage from './pages/PortfolioPage';
-import AlertsPage from './pages/AlertsPage';
 import { ApiErrorAlert, Shell } from './components/common';
 import { AuthProvider, useAuth } from './contexts/AuthContext';
 import { useAgentChatStore } from './stores/agentChatStore';
 import './App.css';
+
+const HomePage = lazy(() => import('./pages/HomePage'));
+const BacktestPage = lazy(() => import('./pages/BacktestPage'));
+const SettingsPage = lazy(() => import('./pages/SettingsPage'));
+const LoginPage = lazy(() => import('./pages/LoginPage'));
+const NotFoundPage = lazy(() => import('./pages/NotFoundPage'));
+const ChatPage = lazy(() => import('./pages/ChatPage'));
+const PortfolioPage = lazy(() => import('./pages/PortfolioPage'));
+const AlertsPage = lazy(() => import('./pages/AlertsPage'));
+
+const PageLoadingFallback: React.FC = () => (
+  <div className="flex min-h-screen items-center justify-center bg-base">
+    <div className="h-8 w-8 animate-spin rounded-full border-2 border-cyan/20 border-t-cyan" />
+  </div>
+);
+
+const PageSuspense: React.FC<{ children: React.ReactNode }> = ({ children }) => (
+  <Suspense fallback={<PageLoadingFallback />}>{children}</Suspense>
+);
 
 const AppContent: React.FC = () => {
   const location = useLocation();
@@ -23,11 +34,7 @@ const AppContent: React.FC = () => {
   }, [location.pathname]);
 
   if (isLoading) {
-    return (
-      <div className="flex min-h-screen items-center justify-center bg-base">
-        <div className="h-8 w-8 animate-spin rounded-full border-2 border-cyan/20 border-t-cyan" />
-      </div>
-    );
+    return <PageLoadingFallback />;
   }
 
   if (loadError) {
@@ -49,7 +56,11 @@ const AppContent: React.FC = () => {
 
   if (authEnabled && !loggedIn) {
     if (location.pathname === '/login') {
-      return <LoginPage />;
+      return (
+        <PageSuspense>
+          <LoginPage />
+        </PageSuspense>
+      );
     }
     const redirect = encodeURIComponent(location.pathname + location.search);
     return <Navigate to={`/login?redirect=${redirect}`} replace />;
@@ -60,18 +71,20 @@ const AppContent: React.FC = () => {
   }
 
   return (
-    <Routes>
-      <Route element={<Shell />}>
-        <Route path="/" element={<HomePage />} />
-        <Route path="/chat" element={<ChatPage />} />
-        <Route path="/portfolio" element={<PortfolioPage />} />
-        <Route path="/backtest" element={<BacktestPage />} />
-        <Route path="/alerts" element={<AlertsPage />} />
-        <Route path="/settings" element={<SettingsPage />} />
-        <Route path="*" element={<NotFoundPage />} />
-      </Route>
-      <Route path="/login" element={<LoginPage />} />
-    </Routes>
+    <PageSuspense>
+      <Routes>
+        <Route element={<Shell />}>
+          <Route path="/" element={<HomePage />} />
+          <Route path="/chat" element={<ChatPage />} />
+          <Route path="/portfolio" element={<PortfolioPage />} />
+          <Route path="/backtest" element={<BacktestPage />} />
+          <Route path="/alerts" element={<AlertsPage />} />
+          <Route path="/settings" element={<SettingsPage />} />
+          <Route path="*" element={<NotFoundPage />} />
+        </Route>
+        <Route path="/login" element={<LoginPage />} />
+      </Routes>
+    </PageSuspense>
   );
 };
 


### PR DESCRIPTION
## PR Type

- [ ] fix
- [ ] feat
- [ ] refactor
- [ ] docs
- [x] chore
- [ ] test

## Background And Problem

#1394 同时记录了后端 Pydantic v2 弃用告警和 Web Vite large chunk warning。本 PR 只处理 PR-B：拆分 `apps/dsa-web` 首包。

当前 `App.tsx` 静态导入全部页面，导致 `PortfolioPage`、`SettingsPage`、`ChatPage` 等页面依赖随主入口一起进入首包，`npm run build` 会输出 large chunk warning。这里改为 route-level lazy loading，让非当前路由页面按需加载。

## Scope Of Change

- `apps/dsa-web/src/App.tsx`
  - 将页面路由改为 `React.lazy`。
  - 增加统一的 `PageLoadingFallback` / `PageSuspense`。
  - 保留现有 auth loading、load error、未登录 redirect、已登录访问 `/login` 跳首页、`setCurrentRoute(location.pathname)` 行为。
- `apps/dsa-web/src/App.test.tsx`
  - 新增 App 路由级回归测试，覆盖 lazy loading 后的登录态路由行为。

未修改：

- `apps/dsa-web/vite.config.ts`
- `docs/CHANGELOG.md`
- 后端 API / schema / 配置文件

route-level lazy 已满足验收，因此本 PR 未启用 `manualChunks`，也未调整 `chunkSizeWarningLimit`。

## Issue Link

Refs #1394

## Verification Commands And Results

```bash
cd apps/dsa-web
npm run test -- src/App.test.tsx
npm run lint
npm run test
npm run build
```

关键输出/结论：

- `npm run test -- src/App.test.tsx`：1 file passed，4 tests passed。
- `npm run lint`：通过。
- `npm run test`：52 files passed，454 tests passed，2 skipped。
- `npm run build`：通过，且不再输出 `Some chunks are larger than 500 kB after minification`。

构建产物关键体积：

```text
../../static/assets/index-BrJRM7GD.js          477.59 kB | gzip: 158.49 kB
../../static/assets/PortfolioPage-BG3kR6Fq.js  361.44 kB | gzip: 108.00 kB
../../static/assets/SettingsPage-PVzlP-W-.js   132.07 kB | gzip:  44.74 kB
../../static/assets/HomePage-Cyn73cug.js        81.89 kB | gzip:  27.31 kB
../../static/assets/ChatPage-D_fIbMBX.js        22.18 kB | gzip:   7.85 kB
```

补充说明：当前 CI `web-gate` 只覆盖 `npm run lint` 和 `npm run build`，不覆盖 Vitest；因此本地已额外补跑完整 `npm run test`。

## Compatibility And Risk

兼容性影响：

- 无后端/API/schema/public type 变更。
- 无配置项、环境变量、数据迁移或用户数据改写。
- 无依赖新增或锁文件变更。

风险与取舍：

- lazy 页面首次进入时会显示全屏 spinner。
- 当前 Suspense 包住主 `Routes`，页面 chunk 加载期间 Shell 会短暂被全屏 spinner 替换；这是本 PR 为保持改动最小接受的 UX 取舍。后续如需要更细的体验优化，可再把 Suspense 下沉到 Shell/Outlet 层。

未执行：

- 未运行 `npm run test:smoke`。本 PR 未改 API 联调或 Playwright 流程，已用单元测试、lint、完整 Vitest 和生产 build 覆盖本次改动面。

## Rollback Plan

如出现线上路由加载或首屏体验问题，直接 revert 本 PR 即可恢复原来的静态页面导入方式；不需要额外回滚配置、依赖或数据。

## EXTRACT_PROMPT Change (if applicable)

不适用。本 PR 未修改 `src/services/image_stock_extractor.py` 或 `EXTRACT_PROMPT`。

## Checklist

- [x] 本 PR 有明确动机和业务价值 / This PR has a clear motivation and value
- [x] 已提供可复现的验证命令与结果 / Reproducible verification commands and results are included
- [x] 已评估兼容性与风险 / Compatibility and risk have been assessed
- [x] 已提供回滚方案 / A rollback plan is provided
- [x] 若涉及用户可见变更，已同步更新相关文档与 `docs/CHANGELOG.md`；`README.md` 仅在首页级信息变化时更新，细节优先写入 `docs/*.md` / If user-visible changes are included, relevant docs and `docs/CHANGELOG.md` are updated; `README.md` is updated only for homepage-level changes, with details kept in `docs/*.md`

说明：本 PR 只调整 Web 路由分包与构建输出，不改变用户功能、API、配置、部署方式或报告契约，因此未更新 README / docs / CHANGELOG。
