### PR TITLE
chore: 稳定 Web vendor chunk 分包 PR - 1

### DIFF
--- a/apps/dsa-web/vite.config.ts
+++ b/apps/dsa-web/vite.config.ts
@@ -8,6 +8,87 @@ const packageJson = JSON.parse(
 ) as { version?: string }
 const buildTime = new Date().toISOString()
 
+const vendorChunkByPackage: Record<string, string> = {
+  react: 'vendor-react',
+  'react-dom': 'vendor-react',
+  scheduler: 'vendor-react',
+  'react-router': 'vendor-router',
+  'react-router-dom': 'vendor-router',
+  motion: 'vendor-motion',
+  'framer-motion': 'vendor-motion',
+  'motion-dom': 'vendor-motion',
+  'motion-utils': 'vendor-motion',
+  'lucide-react': 'vendor-icons',
+  recharts: 'vendor-charts',
+  'victory-vendor': 'vendor-charts',
+  '@reduxjs/toolkit': 'vendor-charts',
+  'decimal.js-light': 'vendor-charts',
+  'es-toolkit': 'vendor-charts',
+  eventemitter3: 'vendor-charts',
+  immer: 'vendor-charts',
+  'react-redux': 'vendor-charts',
+  reselect: 'vendor-charts',
+  'tiny-invariant': 'vendor-charts',
+  'use-sync-external-store': 'vendor-charts',
+  // Markdown renderer dependencies that are not covered by prefix rules below.
+  'react-markdown': 'vendor-markdown',
+  unified: 'vendor-markdown',
+  vfile: 'vendor-markdown',
+  'remove-markdown': 'vendor-markdown',
+  bail: 'vendor-markdown',
+  'comma-separated-tokens': 'vendor-markdown',
+  'decode-named-character-reference': 'vendor-markdown',
+  devlop: 'vendor-markdown',
+  'html-url-attributes': 'vendor-markdown',
+  'property-information': 'vendor-markdown',
+  'space-separated-tokens': 'vendor-markdown',
+  'trim-lines': 'vendor-markdown',
+  'vfile-message': 'vendor-markdown',
+}
+
+const vendorChunkByPackagePrefix: Array<[string, string]> = [
+  ['d3-', 'vendor-charts'],
+  ['remark-', 'vendor-markdown'],
+  ['micromark', 'vendor-markdown'],
+  ['mdast-util-', 'vendor-markdown'],
+  ['hast-util-', 'vendor-markdown'],
+  ['unist-util-', 'vendor-markdown'],
+]
+
+const getVendorPackageName = (id: string): string | undefined => {
+  const normalizedId = id.replace(/\\/g, '/')
+  const marker = '/node_modules/'
+  const markerIndex = normalizedId.lastIndexOf(marker)
+  if (markerIndex === -1) {
+    return undefined
+  }
+
+  const packagePath = normalizedId.slice(markerIndex + marker.length)
+  const [firstSegment, secondSegment] = packagePath.split('/')
+  if (!firstSegment) {
+    return undefined
+  }
+
+  if (firstSegment.startsWith('@')) {
+    return secondSegment ? `${firstSegment}/${secondSegment}` : undefined
+  }
+
+  return firstSegment
+}
+
+const getVendorChunkName = (id: string): string | undefined => {
+  const packageName = getVendorPackageName(id)
+  if (!packageName) {
+    return undefined
+  }
+
+  return (
+    vendorChunkByPackage[packageName]
+    ?? vendorChunkByPackagePrefix.find(([prefix]) => packageName.startsWith(prefix))?.[1]
+    ?? 'vendor'
+  )
+}
+
 // https://vite.dev/config/
 export default defineConfig({
   define: {
@@ -35,5 +116,10 @@ export default defineConfig({
     // 打包输出到项目根目录的 static 文件夹
     outDir: path.resolve(__dirname, '../../static'),
     emptyOutDir: true,
+    rollupOptions: {
+      output: {
+        manualChunks: getVendorChunkName,
+      },
+    },
   },
 })


### PR DESCRIPTION
## PR Type

- [ ] fix
- [ ] feat
- [ ] refactor
- [ ] docs
- [x] chore
- [ ] test

## Background And Problem

#1410 完成 route-level lazy loading 后，Web 构建已不再输出 Vite large chunk warning，但主入口 chunk 仍约 `479.47 kB / gzip 159.10 kB`，距离 Vite 默认 `500 kB` warning 阈值只剩约 20 kB。

本 PR 只处理 #1411 的 PR-1：稳定 vendor chunk 分包预算，让入口 chunk 远离 warning 阈值，并把主要第三方依赖拆到命名稳定的 vendor bucket 中。

需要特别说明：本 PR 的目标不是证明首屏总 JS 下载量显著下降。`manualChunks` 会把入口文件拆小，但同步 preload 的 vendor chunk 仍属于首屏同步加载路径。Markdown 首页成本继续留给后续 PR-2 的 `ReportMarkdown` lazy loading 处理。

## Scope Of Change

- 仅修改 `apps/dsa-web/vite.config.ts`
- 新增 `build.rollupOptions.output.manualChunks`
- 按依赖边界拆分：
  - `vendor-react`
  - `vendor-router`
  - `vendor-motion`
  - `vendor-icons`
  - `vendor-charts`
  - `vendor-markdown`
  - 通用 `vendor`
- 未修改 `chunkSizeWarningLimit`
- 未修改页面组件、后端 API、报告生成逻辑、运行时配置或测试代码

## Issue Link

Refs #1411

## Verification Commands And Results

```bash
cd apps/dsa-web && npm run lint
cd apps/dsa-web && npm run build
git diff --check
```

关键输出/结论：

- `npm run lint`：通过
- `npm run build`：通过
- `git diff --check`：通过
- 构建无 Vite large chunk warning
- 无单个 `>500 kB` chunk

### Bundle 体积对比

基线（#1410 / main）：

| Chunk | Raw | Gzip |
| --- | ---: | ---: |
| 主入口 `index-*.js` | `479.47 kB` | `159.09 kB` |

当前结果：

| Chunk | Raw | Gzip |
| --- | ---: | ---: |
| 主入口 `index-*.js` | `49.41 kB` | `17.72 kB` |
| `vendor-react` | `193.20 kB` | `60.61 kB` |
| `vendor-router` | `36.23 kB` | `13.09 kB` |
| `vendor-motion` | `123.08 kB` | `40.27 kB` |
| `vendor-icons` | `7.68 kB` | `3.10 kB` |
| 通用 `vendor` | `91.95 kB` | `33.35 kB` |
| `vendor-markdown` | `148.72 kB` | `44.09 kB` |
| `vendor-charts` | `323.62 kB` | `97.54 kB` |
| `HomePage` | `78.80 kB` | `26.06 kB` |
| `ChatPage` | `22.41 kB` | `7.95 kB` |
| `PortfolioPage` | `32.20 kB` | `8.93 kB` |

首屏同步 JS 合计口径：

- 基线：入口单文件约 `479.47 kB / gzip 159.09 kB`
- 当前：entry + `modulepreload` vendor chunks 约 `501.55 kB / gzip 168.14 kB`
- 结论：本 PR 的收益是入口 chunk 预算 headroom 和 vendor/shared chunk 命名稳定，不应解读为首屏总 JS 下载量下降。

Phase B 拆分原因：

- 仅做 Phase A（React / Router / Motion / Icons / 通用 vendor）时，通用 `vendor` 达到 `564.58 kB / gzip 174.59 kB`，重新触发 Vite large chunk warning。
- 因此本 PR 增加 `vendor-charts` 和 `vendor-markdown`，把最大 chunk 控制到 `323.62 kB`，并清除 warning。

## Compatibility And Risk

- API / Schema / 环境变量 / 数据迁移：无影响。
- 用户可见功能：无变化。
- 构建行为：生产构建会生成更多 vendor chunk，浏览器缓存边界更稳定；首屏同步 preload 总量不作为性能下降/提升结论单独使用。
- 主要风险：后续新增大型依赖时，如果继续落入通用 `vendor`，可能再次接近 warning 阈值；届时应按实际 build 输出评估是否需要新的分包，而不是调高 `chunkSizeWarningLimit`。

## Documentation And Changelog

未更新 README 或 `docs/CHANGELOG.md`。本 PR 只调整构建分包预算和产物命名边界，不改变用户可见功能、配置、API、部署方式或报告结构。

## Rollback Plan

如出现构建产物加载或缓存回归，直接 revert 本 PR 即可；无需回滚配置、数据或迁移。

## EXTRACT_PROMPT Change (if applicable)

不适用。

## Checklist

- [x] 本 PR 有明确动机和业务价值 / This PR has a clear motivation and value
- [x] 已提供可复现的验证命令与结果 / Reproducible verification commands and results are included
- [x] 已评估兼容性与风险 / Compatibility and risk have been assessed
- [x] 已提供回滚方案 / A rollback plan is provided
- [x] 不涉及用户可见功能变化；无需同步 README 或 `docs/CHANGELOG.md`
