### PR TITLE
feat: 新增 P7 大盘红绿灯结构化告警

### DIFF
--- a/api/v1/schemas/alerts.py
+++ b/api/v1/schemas/alerts.py
@@ -8,7 +8,7 @@ from typing import Any, Dict, List, Literal, Optional
 from pydantic import BaseModel, Field
 
 
-TargetScopeValue = Literal["single_symbol", "watchlist", "portfolio_holdings", "portfolio_account"]
+TargetScopeValue = Literal["single_symbol", "watchlist", "portfolio_holdings", "portfolio_account", "market"]
 SeverityValue = Literal["info", "warning", "critical"]
 DryRunStatusValue = Literal["triggered", "not_triggered", "evaluation_error"]
 TargetRecordStatusValue = Literal["triggered", "skipped", "degraded", "failed"]

--- a/apps/dsa-web/src/api/__tests__/alerts.test.ts
+++ b/apps/dsa-web/src/api/__tests__/alerts.test.ts
@@ -162,6 +162,77 @@ describe('alertsApi', () => {
     });
   });
 
+  it('creates market light rules with market scope and min_drop parameter fields', async () => {
+    post
+      .mockResolvedValueOnce({
+        data: {
+          id: 6,
+          name: 'market status',
+          target_scope: 'market',
+          target: 'cn',
+          alert_type: 'market_light_status',
+          parameters: { statuses: ['red', 'yellow'] },
+          severity: 'critical',
+          enabled: true,
+          source: 'api',
+        },
+      })
+      .mockResolvedValueOnce({
+        data: {
+          id: 7,
+          name: 'market score drop',
+          target_scope: 'market',
+          target: 'us',
+          alert_type: 'market_light_score_drop',
+          parameters: { min_drop: 12 },
+          severity: 'warning',
+          enabled: true,
+          source: 'api',
+        },
+      });
+
+    const statusRule = await alertsApi.createRule({
+      name: 'market status',
+      targetScope: 'market',
+      target: 'cn',
+      alertType: 'market_light_status',
+      parameters: { statuses: ['red', 'yellow'] },
+      severity: 'critical',
+      enabled: true,
+    });
+    const scoreDropRule = await alertsApi.createRule({
+      name: 'market score drop',
+      targetScope: 'market',
+      target: 'us',
+      alertType: 'market_light_score_drop',
+      parameters: { minDrop: 12 },
+      severity: 'warning',
+      enabled: true,
+    });
+
+    expect(post).toHaveBeenNthCalledWith(1, '/api/v1/alerts/rules', {
+      name: 'market status',
+      target_scope: 'market',
+      target: 'cn',
+      alert_type: 'market_light_status',
+      parameters: { statuses: ['red', 'yellow'] },
+      severity: 'critical',
+      enabled: true,
+    });
+    expect(post).toHaveBeenNthCalledWith(2, '/api/v1/alerts/rules', {
+      name: 'market score drop',
+      target_scope: 'market',
+      target: 'us',
+      alert_type: 'market_light_score_drop',
+      parameters: { min_drop: 12 },
+      severity: 'warning',
+      enabled: true,
+    });
+    expect(statusRule.targetScope).toBe('market');
+    expect(statusRule.parameters.statuses).toEqual(['red', 'yellow']);
+    expect(scoreDropRule.parameters.minDrop).toBe(12);
+  });
+
   it('creates portfolio alert rules and maps batch dry-run fields', async () => {
     post
       .mockResolvedValueOnce({

--- a/apps/dsa-web/src/api/alerts.ts
+++ b/apps/dsa-web/src/api/alerts.ts
@@ -42,6 +42,8 @@ function toSnakeRulePayload(payload: AlertRuleCreateRequest): Record<string, unk
       k_period: payload.parameters.kPeriod,
       d_period: payload.parameters.dPeriod,
       mode: payload.parameters.mode,
+      statuses: payload.parameters.statuses,
+      min_drop: payload.parameters.minDrop,
     });
   }
   return request;

--- a/apps/dsa-web/src/components/alerts/AlertRuleForm.tsx
+++ b/apps/dsa-web/src/components/alerts/AlertRuleForm.tsx
@@ -6,6 +6,8 @@ import type {
   AlertSeverity,
   AlertTargetScope,
   AlertType,
+  MarketLightStatus,
+  MarketRegion,
   PortfolioStopLossMode,
 } from '../../types/alerts';
 import type { PortfolioAccountItem } from '../../types/portfolio';
@@ -30,11 +32,17 @@ const PORTFOLIO_ALERT_TYPE_OPTIONS = [
   { value: 'portfolio_price_stale', label: '组合价格状态' },
 ];
 
+const MARKET_ALERT_TYPE_OPTIONS = [
+  { value: 'market_light_status', label: '大盘红绿灯状态' },
+  { value: 'market_light_score_drop', label: '大盘红绿灯分数下降' },
+];
+
 const TARGET_SCOPE_OPTIONS = [
   { value: 'single_symbol', label: '单标的' },
   { value: 'watchlist', label: '自选股' },
   { value: 'portfolio_holdings', label: '持仓标的' },
   { value: 'portfolio_account', label: '持仓账户' },
+  { value: 'market', label: '大盘市场' },
 ];
 
 const SEVERITY_OPTIONS = [
@@ -68,6 +76,17 @@ const STOP_LOSS_MODE_OPTIONS = [
   { value: 'breach', label: '已触发止损' },
 ];
 
+const MARKET_REGION_OPTIONS = [
+  { value: 'cn', label: 'A 股（cn）' },
+  { value: 'hk', label: '港股（hk）' },
+  { value: 'us', label: '美股（us）' },
+];
+
+const MARKET_LIGHT_STATUS_OPTIONS: Array<{ value: MarketLightStatus; label: string }> = [
+  { value: 'red', label: '红灯' },
+  { value: 'yellow', label: '黄灯' },
+];
+
 const MAX_REQUESTED_DAYS = 365;
 
 interface AlertRuleFormProps {
@@ -80,10 +99,12 @@ function isPortfolioScope(scope: AlertTargetScope): boolean {
 }
 
 function defaultAlertTypeForScope(scope: AlertTargetScope): AlertType {
+  if (scope === 'market') return 'market_light_status';
   return scope === 'portfolio_account' ? 'portfolio_stop_loss' : 'price_cross';
 }
 
 function optionsForScope(scope: AlertTargetScope) {
+  if (scope === 'market') return MARKET_ALERT_TYPE_OPTIONS;
   return scope === 'portfolio_account' ? PORTFOLIO_ALERT_TYPE_OPTIONS : SYMBOL_ALERT_TYPE_OPTIONS;
 }
 
@@ -92,6 +113,7 @@ export const AlertRuleForm: React.FC<AlertRuleFormProps> = ({ onSubmit, isSubmit
   const [targetScope, setTargetScope] = useState<AlertTargetScope>('single_symbol');
   const [target, setTarget] = useState('');
   const [portfolioTarget, setPortfolioTarget] = useState('all');
+  const [marketRegion, setMarketRegion] = useState<MarketRegion>('cn');
   const [accounts, setAccounts] = useState<PortfolioAccountItem[]>([]);
   const [accountsError, setAccountsError] = useState<string | null>(null);
   const [alertType, setAlertType] = useState<AlertType>('price_cross');
@@ -113,6 +135,8 @@ export const AlertRuleForm: React.FC<AlertRuleFormProps> = ({ onSubmit, isSubmit
   const [signalPeriod, setSignalPeriod] = useState('9');
   const [kPeriod, setKPeriod] = useState('3');
   const [dPeriod, setDPeriod] = useState('3');
+  const [marketLightStatuses, setMarketLightStatuses] = useState<MarketLightStatus[]>(['red', 'yellow']);
+  const [minDrop, setMinDrop] = useState('10');
   const [formError, setFormError] = useState<string | null>(null);
 
   useEffect(() => {
@@ -175,7 +199,19 @@ export const AlertRuleForm: React.FC<AlertRuleFormProps> = ({ onSubmit, isSubmit
       setThreshold('');
     } else if (nextType === 'portfolio_stop_loss') {
       setStopLossMode('near');
+    } else if (nextType === 'market_light_status') {
+      setMarketLightStatuses(['red', 'yellow']);
+    } else if (nextType === 'market_light_score_drop') {
+      setMinDrop('10');
     }
+  };
+
+  const toggleMarketLightStatus = (status: MarketLightStatus) => {
+    setMarketLightStatuses((current) => (
+      current.includes(status)
+        ? current.filter((item) => item !== status)
+        : [...current, status]
+    ));
   };
 
   const parsePositiveNumber = (value: string, label: string): number | null => {
@@ -288,6 +324,18 @@ export const AlertRuleForm: React.FC<AlertRuleFormProps> = ({ onSubmit, isSubmit
     if (alertType === 'portfolio_stop_loss') {
       return { mode: stopLossMode };
     }
+    if (alertType === 'market_light_status') {
+      if (marketLightStatuses.length === 0) {
+        setFormError('至少选择一个红绿灯状态');
+        return null;
+      }
+      return { statuses: marketLightStatuses };
+    }
+    if (alertType === 'market_light_score_drop') {
+      const parsedMinDrop = parsePositiveNumber(minDrop, 'Score 下降阈值');
+      if (parsedMinDrop == null) return null;
+      return { minDrop: parsedMinDrop };
+    }
     return {};
   };
 
@@ -297,6 +345,7 @@ export const AlertRuleForm: React.FC<AlertRuleFormProps> = ({ onSubmit, isSubmit
     setTargetScope(nextScope);
     setAlertType(nextType);
     setPortfolioTarget('all');
+    setMarketRegion('cn');
     resetParameters(nextType);
     setFormError(null);
   };
@@ -313,6 +362,8 @@ export const AlertRuleForm: React.FC<AlertRuleFormProps> = ({ onSubmit, isSubmit
       resolvedTarget = targetValidation.normalized;
     } else if (targetScope === 'watchlist') {
       resolvedTarget = 'default';
+    } else if (targetScope === 'market') {
+      resolvedTarget = marketRegion;
     } else {
       resolvedTarget = portfolioTarget;
     }
@@ -334,6 +385,7 @@ export const AlertRuleForm: React.FC<AlertRuleFormProps> = ({ onSubmit, isSubmit
     setName('');
     setTarget('');
     setPortfolioTarget('all');
+    setMarketRegion('cn');
     setPrice('');
     setChangePct('');
     setMultiplier('');
@@ -345,6 +397,8 @@ export const AlertRuleForm: React.FC<AlertRuleFormProps> = ({ onSubmit, isSubmit
     setSignalPeriod('9');
     setKPeriod('3');
     setDPeriod('3');
+    setMarketLightStatuses(['red', 'yellow']);
+    setMinDrop('10');
     resetParameters(alertType);
     setEnabled(true);
   };
@@ -368,6 +422,17 @@ export const AlertRuleForm: React.FC<AlertRuleFormProps> = ({ onSubmit, isSubmit
           value="default"
           onChange={() => undefined}
           disabled
+        />
+      );
+    }
+    if (targetScope === 'market') {
+      return (
+        <Select
+          label="市场区域"
+          value={marketRegion}
+          options={MARKET_REGION_OPTIONS}
+          disabled={isSubmitting}
+          onChange={(value) => setMarketRegion(value as MarketRegion)}
         />
       );
     }
@@ -653,6 +718,36 @@ export const AlertRuleForm: React.FC<AlertRuleFormProps> = ({ onSubmit, isSubmit
             options={STOP_LOSS_MODE_OPTIONS}
             disabled={isSubmitting}
             onChange={(value) => setStopLossMode(value as PortfolioStopLossMode)}
+          />
+        ) : null}
+
+        {alertType === 'market_light_status' ? (
+          <div className="space-y-2">
+            <div className="text-sm font-medium text-foreground">触发状态</div>
+            <div className="grid gap-3 sm:grid-cols-2">
+              {MARKET_LIGHT_STATUS_OPTIONS.map((option) => (
+                <Checkbox
+                  key={option.value}
+                  label={option.label}
+                  checked={marketLightStatuses.includes(option.value)}
+                  disabled={isSubmitting}
+                  onChange={() => toggleMarketLightStatus(option.value)}
+                />
+              ))}
+            </div>
+          </div>
+        ) : null}
+
+        {alertType === 'market_light_score_drop' ? (
+          <Input
+            label="Score 下降阈值"
+            type="number"
+            min="0"
+            max="100"
+            step="1"
+            value={minDrop}
+            onChange={(event) => setMinDrop(event.target.value)}
+            disabled={isSubmitting}
           />
         ) : null}
 

--- a/apps/dsa-web/src/components/alerts/AlertRuleList.tsx
+++ b/apps/dsa-web/src/components/alerts/AlertRuleList.tsx
@@ -34,6 +34,8 @@ const ALERT_TYPE_FILTER_OPTIONS = [
   { value: 'portfolio_concentration', label: '组合集中度' },
   { value: 'portfolio_drawdown', label: '组合回撤' },
   { value: 'portfolio_price_stale', label: '组合价格状态' },
+  { value: 'market_light_status', label: '大盘红绿灯状态' },
+  { value: 'market_light_score_drop', label: '大盘红绿灯分数下降' },
 ];
 
 const typeLabel: Record<AlertType, string> = {
@@ -49,6 +51,8 @@ const typeLabel: Record<AlertType, string> = {
   portfolio_concentration: '组合集中度',
   portfolio_drawdown: '组合回撤',
   portfolio_price_stale: '组合价格状态',
+  market_light_status: '大盘红绿灯状态',
+  market_light_score_drop: '大盘红绿灯分数下降',
 };
 
 const severityLabel: Record<string, string> = {
@@ -62,9 +66,30 @@ const scopeLabel: Record<string, string> = {
   watchlist: '自选股',
   portfolio_holdings: '持仓标的',
   portfolio_account: '持仓账户',
+  market: '大盘市场',
+};
+
+const marketRegionLabel: Record<string, string> = {
+  cn: 'A 股',
+  hk: '港股',
+  us: '美股',
+};
+
+const marketLightStatusLabel: Record<string, string> = {
+  yellow: '黄灯',
+  red: '红灯',
 };
 
 function formatParameters(rule: AlertRuleItem): string {
+  if (rule.alertType === 'market_light_status') {
+    const statuses = rule.parameters.statuses ?? [];
+    return statuses.length > 0
+      ? statuses.map((status) => marketLightStatusLabel[status] ?? status).join(' / ')
+      : '--';
+  }
+  if (rule.alertType === 'market_light_score_drop') {
+    return `Score 下降 >= ${rule.parameters.minDrop ?? '--'}`;
+  }
   if (rule.alertType === 'price_cross') {
     return `${rule.parameters.direction === 'below' ? '下破' : '上破'} ${rule.parameters.price ?? '--'}`;
   }
@@ -101,6 +126,7 @@ function isCoolingDown(rule: AlertRuleItem): boolean {
 }
 
 function formatTarget(rule: AlertRuleItem): string {
+  if (rule.targetScope === 'market') return marketRegionLabel[rule.target] ?? rule.target;
   if (rule.targetScope === 'watchlist') return 'default';
   if (rule.targetScope === 'portfolio_account' || rule.targetScope === 'portfolio_holdings') {
     return rule.target === 'all' ? '全部账户' : `账户 ${rule.target}`;

--- a/apps/dsa-web/src/components/alerts/__tests__/AlertRuleForm.test.tsx
+++ b/apps/dsa-web/src/components/alerts/__tests__/AlertRuleForm.test.tsx
@@ -210,6 +210,42 @@ describe('AlertRuleForm', () => {
     });
   });
 
+  it('submits a market light status rule payload', async () => {
+    render(<AlertRuleForm onSubmit={onSubmit} />);
+
+    fireEvent.change(screen.getByLabelText('目标范围'), { target: { value: 'market' } });
+    fireEvent.change(screen.getByLabelText('市场区域'), { target: { value: 'hk' } });
+    fireEvent.click(screen.getByRole('button', { name: '创建规则' }));
+
+    await waitFor(() => {
+      expect(onSubmit).toHaveBeenCalledWith(expect.objectContaining({
+        targetScope: 'market',
+        target: 'hk',
+        alertType: 'market_light_status',
+        parameters: { statuses: ['red', 'yellow'] },
+      }));
+    });
+  });
+
+  it('submits a market light score-drop rule payload', async () => {
+    render(<AlertRuleForm onSubmit={onSubmit} />);
+
+    fireEvent.change(screen.getByLabelText('目标范围'), { target: { value: 'market' } });
+    fireEvent.change(screen.getByLabelText('市场区域'), { target: { value: 'us' } });
+    fireEvent.change(screen.getByLabelText('规则类型'), { target: { value: 'market_light_score_drop' } });
+    fireEvent.change(screen.getByLabelText('Score 下降阈值'), { target: { value: '12' } });
+    fireEvent.click(screen.getByRole('button', { name: '创建规则' }));
+
+    await waitFor(() => {
+      expect(onSubmit).toHaveBeenCalledWith(expect.objectContaining({
+        targetScope: 'market',
+        target: 'us',
+        alertType: 'market_light_score_drop',
+        parameters: { minDrop: 12 },
+      }));
+    });
+  });
+
   it('keeps all account option when account loading fails', async () => {
     getAccounts.mockRejectedValueOnce(new Error('boom'));
     render(<AlertRuleForm onSubmit={onSubmit} />);

--- a/apps/dsa-web/src/components/alerts/__tests__/AlertRuleList.test.tsx
+++ b/apps/dsa-web/src/components/alerts/__tests__/AlertRuleList.test.tsx
@@ -154,6 +154,48 @@ describe('AlertRuleList', () => {
     expect(screen.getByText('已触发止损')).toBeInTheDocument();
   });
 
+  it('renders market scope labels, filters, and parameters', () => {
+    renderList({
+      rules: [
+        {
+          id: 6,
+          name: 'A 股红黄灯',
+          targetScope: 'market',
+          target: 'cn',
+          alertType: 'market_light_status',
+          parameters: { statuses: ['red', 'yellow'] },
+          severity: 'critical',
+          enabled: true,
+          source: 'api',
+          cooldownActive: false,
+        },
+        {
+          id: 7,
+          name: '美股分数下降',
+          targetScope: 'market',
+          target: 'us',
+          alertType: 'market_light_score_drop',
+          parameters: { minDrop: 15 },
+          severity: 'warning',
+          enabled: true,
+          source: 'api',
+          cooldownActive: false,
+        },
+      ],
+    });
+
+    expect(screen.getByText('A 股')).toBeInTheDocument();
+    expect(screen.getByText('美股')).toBeInTheDocument();
+    expect(screen.getAllByText('大盘市场').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('大盘红绿灯状态').length).toBeGreaterThan(0);
+    expect(screen.getByText('红灯 / 黄灯')).toBeInTheDocument();
+    expect(screen.getByText('Score 下降 >= 15')).toBeInTheDocument();
+
+    fireEvent.change(screen.getByLabelText('规则类型'), { target: { value: 'market_light_score_drop' } });
+
+    expect(onAlertTypeFilterChange).toHaveBeenCalledWith('market_light_score_drop');
+  });
+
   it('runs test and toggles enabled state', () => {
     renderList();
 

--- a/apps/dsa-web/src/types/alerts.ts
+++ b/apps/dsa-web/src/types/alerts.ts
@@ -10,11 +10,15 @@ export type AlertType =
   | 'portfolio_stop_loss'
   | 'portfolio_concentration'
   | 'portfolio_drawdown'
-  | 'portfolio_price_stale';
+  | 'portfolio_price_stale'
+  | 'market_light_status'
+  | 'market_light_score_drop';
 export type AlertSeverity = 'info' | 'warning' | 'critical';
-export type AlertTargetScope = 'single_symbol' | 'watchlist' | 'portfolio_holdings' | 'portfolio_account';
+export type AlertTargetScope = 'single_symbol' | 'watchlist' | 'portfolio_holdings' | 'portfolio_account' | 'market';
 export type AlertDirection = 'above' | 'below' | 'up' | 'down' | 'bullish_cross' | 'bearish_cross';
 export type PortfolioStopLossMode = 'near' | 'breach';
+export type MarketRegion = 'cn' | 'hk' | 'us';
+export type MarketLightStatus = 'yellow' | 'red';
 export type AlertDryRunStatus = 'triggered' | 'not_triggered' | 'evaluation_error';
 export type AlertTriggerStatus = 'triggered' | 'skipped' | 'degraded' | 'failed';
 
@@ -32,6 +36,8 @@ export interface AlertRuleParameters {
   kPeriod?: number;
   dPeriod?: number;
   mode?: PortfolioStopLossMode;
+  statuses?: MarketLightStatus[];
+  minDrop?: number;
 }
 
 export interface AlertRuleItem {

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - [修复] 归一腾讯实时行情成交量为股口径，避免量能变化倍数被放大并误导分析报告。
 - [改进] Web 路由页面改为按需加载，降低首包体积并增加路由加载失败恢复提示。
 - [修复] Docker 默认部署移除 `.env` 单文件挂载，避免 WebUI 保存配置时因 `os.replace` 更新挂载点触发 `Device or resource busy`。
+- [新功能] 告警中心新增 P7 大盘红绿灯结构化规则，支持 `market_light_status` 与 `market_light_score_drop` 并复用现有 worker、触发历史、通知和冷却链路。
 
 ## [3.18.0] - 2026-05-21
 

--- a/docs/alerts.md
+++ b/docs/alerts.md
@@ -331,6 +331,48 @@ P6 不做：
 - 不做 sector 级集中度告警；P6 集中度使用 symbol 维度 `top_weight_pct`。
 - 不做跨规则同标的通知合并、分钟线、多市场时区精确判定或 legacy JSON 扩展。
 
+## P7 大盘红绿灯结构化告警
+
+P7 在现有 Alert API、Web 告警中心和 `src/services/alert_worker.py` 中新增 `target_scope=market`，消费结构化 `MarketLightSnapshot`，不解析 Markdown，不扩展 legacy `AGENT_EVENT_ALERT_RULES_JSON`，不新增表。大盘复盘历史仍写一条 `analysis_history(code=MARKET, report_type=market_review)`；多市场复盘通过 `context_snapshot.market_light_snapshots` 按 region 保存本次实际复盘的快照 map。
+
+### P7 scope/type 矩阵
+
+| `target_scope` | `target` | 允许的 `alert_type` | 参数 | 触发语义 |
+| --- | --- | --- | --- | --- |
+| `market` | `cn` / `hk` / `us` | `market_light_status` | `statuses=["red","yellow"]`，只允许 `red/yellow`，默认 `["red","yellow"]` | 当前 `MarketLightSnapshot.status` 命中列表时触发 |
+| `market` | `cn` / `hk` / `us` | `market_light_score_drop` | `min_drop > 0` | `prev.score - current.score >= min_drop`，且 `prev.trade_date < current.trade_date` |
+
+scope/type 校验是双向约束：`target_scope=market` 只能使用两类 Market Light 规则；`market_light_*` 规则也只能使用 `target_scope=market`。`target` 会 `strip().lower()` 后严格限定为 `cn|hk|us`，非法 target 返回 HTTP 400 + `validation_error`。
+
+### `MarketLightSnapshot` 契约
+
+结构化快照字段为：`region`、`trade_date`、`status`、`score`、`label`、`temperature_label`、`reasons`、`guidance`、`dimensions`、`data_quality`。`trade_date` 首版固定取 `MarketOverview.date`；P7 不解析 provider quote as-of。
+
+`dimensions` 使用 canonical scorer 单一来源，`build_market_light_snapshot()`、大盘复盘注入块和告警 service 不重复实现 scoring。`_build_market_temperature()` 只是 thin wrapper；红绿灯 `status` 阈值保持 `60/40`，temperature label 阈值保持 `70/55/40`。
+
+| dimension | `available=true` 条件 | fallback score |
+| --- | --- | --- |
+| `breadth` | `has_market_stats && (up_count + down_count) > 0` | `50` |
+| `index` | `indices` 非空且至少一个 `change_pct != None` | `50` |
+| `limit` | `has_market_stats && (limit_up_count + limit_down_count) > 0` | `50` |
+
+`data_quality=unavailable` 表示 `index.available=false`，两类 market rule 都返回 `skipped` 且不触发通知；`partial` 表示至少一个维度 fallback，`ok` 表示三项均 available。`market_light_status` 在 `ok/partial` 下可触发；`partial` 触发时 diagnostics 必含 `missing_dimensions`。`market_light_score_drop` 直接比较 canonical aggregate score；任一侧 `partial` 仍允许比较，但 diagnostics 必含 `partial_comparison=true` 和 `missing_dimensions`。
+
+### 基线、交易日与去重
+
+- 大盘复盘持久化必须使用与报告生成共用的同一份 `MarketOverview` 生成 `MarketLightSnapshot`，禁止 persist 阶段二次拉行情。
+- `load_previous_snapshot(region, before_trade_date)` 扫描 `analysis_history(code=MARKET, report_type=market_review)`，跳过缺少 `context_snapshot.market_light_snapshots[region]` 的 legacy 记录，先选出小于 `before_trade_date` 的最大 `snapshot.trade_date`，再在同一 `trade_date` 内按 `created_at DESC, id DESC` 取最新 valid 快照；更晚插入的旧交易日 backfill 不会覆盖正确基线。
+- 若目标 `trade_date` 只有损坏快照，`market_light_score_drop` 返回 `degraded`，不会自动退回更旧交易日做 best-effort 比较。
+- `market_light_score_drop` 首版只做跨交易日比较；无上一交易日基线或同日基线返回 `skipped`，查询/解析异常返回 `degraded`。
+- worker 对 `target_scope=market` 做 region 交易日 gate，并尊重 `TRADING_DAY_CHECK_ENABLED` / `config.trading_day_check_enabled`；检查关闭时允许评估，检查开启且 region 非交易日时返回 `skipped`，不拉取当前快照。
+- 触发历史写 `target=<region>`、`observed_value=<score>`、`data_source=market_light`、`data_timestamp=<trade_date 00:00:00>`，继续复用 P4 的 `rule_id + target + data_source + data_timestamp` 去重。
+
+### Web 与回滚边界
+
+- Web 告警中心新增 `market` scope、region 选择、两类 market rule 参数控件、类型筛选、region 展示和参数展示；API snake_case 映射使用 `statuses` 与 `min_drop`。
+- legacy `AGENT_EVENT_ALERT_RULES_JSON` 不支持 market 规则；P7 不更新 `.env.example`，因为没有新增配置项。
+- P7 不做指数跌幅、板块异动、涨跌停结构恶化、分钟线、多市场时区精确 quote as-of 解析，也不新增 DSL/规则引擎。
+
 ## Phase 边界
 
 - P0：本文档、契约、存储评估和兼容测试。
@@ -361,3 +403,4 @@ P6 不做：
 - P4 新增 `alert_cooldowns` SQLite 表并开始写入 `alert_notifications`。最小回滚方式是 revert P4 PR；已经创建的 `alert_cooldowns`、`alert_triggers`、`alert_notifications` 数据不会自动删除。如需清理，需要维护者确认后手动删除对应表或记录。
 - P5 新增 Alert API/Web 支持的技术指标规则。最小回滚方式是 revert P5 PR；已创建的 P5 `alert_rules` 记录不会自动删除，旧代码会在 worker 加载阶段 skip unsupported `alert_type`，不影响 legacy 三类规则执行。如需清理，需要维护者确认后手动删除相关规则记录。
 - P6 新增 Alert API/Web 支持的 watchlist、portfolio holdings 与 portfolio account 规则。最小回滚方式是 revert P6 PR；没有新表或迁移，已创建的 P6 `alert_rules` 会保留。回滚前建议 disable/delete 非 `single_symbol` 的 P6 规则；否则旧 worker 可能把 `watchlist` / `portfolio_holdings` 的父级 `target` 当作股票代码评估并产生 failed/skipped 噪声，portfolio 专用 `alert_type` 会在 worker 加载阶段被 skip。
+- P7 新增 Alert API/Web 支持的 `market` 规则和大盘复盘 `market_light_snapshots` 历史快照。最小回滚方式是 revert P7 PR；没有新表或迁移，已创建的 P7 `alert_rules` 会保留。回滚前建议 disable/delete `target_scope=market` 规则；旧 worker 会 skip unsupported `market_light_*` 类型或因 scope/type 不识别产生配置噪声。

--- a/src/core/market_review.py
+++ b/src/core/market_review.py
@@ -12,7 +12,7 @@
 
 import logging
 from datetime import datetime
-from typing import Optional
+from typing import Any, Dict, Optional
 import uuid
 
 from src.config import get_config
@@ -27,6 +27,13 @@ logger = logging.getLogger(__name__)
 
 MARKET_REVIEW_HISTORY_CODE = "MARKET"
 MARKET_REVIEW_REPORT_TYPE = "market_review"
+_MARKET_REVIEW_MARKETS = (
+    ('cn', 'cn_title', 'A 股'),
+    ('hk', 'hk_title', '港股'),
+    ('us', 'us_title', '美股'),
+)
+_MARKET_REVIEW_REGION_ORDER = tuple(market for market, _, _ in _MARKET_REVIEW_MARKETS)
+_VALID_MARKET_REVIEW_REGIONS = frozenset(_MARKET_REVIEW_REGION_ORDER)
 
 
 def _get_market_review_text(language: str) -> dict[str, str]:
@@ -48,6 +55,24 @@ def _get_market_review_text(language: str) -> dict[str, str]:
         "hk_title": "# 港股大盘复盘",
         "separator": "> 以下为下一市场大盘复盘",
     }
+
+
+def _resolve_market_review_regions(raw_region: Optional[str]) -> list[str]:
+    """Normalize MARKET_REVIEW_REGION into an ordered, non-empty region list."""
+
+    region = str(raw_region or 'cn').strip().lower()
+    if region == 'both':
+        return list(_MARKET_REVIEW_REGION_ORDER)
+    if ',' in region:
+        requested = {
+            item.strip().lower()
+            for item in region.split(',')
+            if item.strip().lower() in _VALID_MARKET_REVIEW_REGIONS
+        }
+        return [market for market in _MARKET_REVIEW_REGION_ORDER if market in requested] or ['cn']
+    if region in _VALID_MARKET_REVIEW_REGIONS:
+        return [region]
+    return ['cn']
 
 
 def run_market_review(
@@ -77,37 +102,29 @@ def run_market_review(
     logger.info("开始执行大盘复盘分析...")
     config = get_config()
     review_text = _get_market_review_text(getattr(config, "report_language", "zh"))
-    region = (
+    raw_region = (
         override_region
         if override_region is not None
         else (getattr(config, 'market_review_region', 'cn') or 'cn')
     )
-    _ALL_MARKETS = [('cn', 'cn_title', 'A 股'), ('hk', 'hk_title', '港股'), ('us', 'us_title', '美股')]
-    _VALID_SINGLES = {'cn', 'us', 'hk'}
-
-    # Determine which markets to run.
-    # region can be: 'cn', 'hk', 'us', 'both', or a comma-joined subset like 'cn,us'.
-    if ',' in region:
-        run_markets = [m.strip() for m in region.split(',') if m.strip() in _VALID_SINGLES]
-    elif region == 'both':
-        run_markets = list(_VALID_SINGLES)
-    elif region in _VALID_SINGLES:
-        run_markets = [region]
-    else:
-        run_markets = ['cn']
+    run_markets = _resolve_market_review_regions(raw_region)
+    persist_region = ','.join(run_markets) if len(run_markets) > 1 else run_markets[0]
 
     try:
         if len(run_markets) > 1:
             # 多市场顺序执行，合并报告
             parts = []
-            for mkt, title_key, label in _ALL_MARKETS:
+            market_light_snapshots: Dict[str, Dict[str, Any]] = {}
+            for mkt, title_key, label in _MARKET_REVIEW_MARKETS:
                 if mkt not in run_markets:
                     continue
                 logger.info("生成 %s 大盘复盘报告...", label)
                 mkt_analyzer = MarketAnalyzer(
                     search_service=search_service, analyzer=analyzer, region=mkt
                 )
-                mkt_report = mkt_analyzer.run_daily_review()
+                review_result = mkt_analyzer.run_daily_review_with_snapshot()
+                mkt_report = review_result.report
+                market_light_snapshots[mkt] = review_result.market_light_snapshot
                 if mkt_report:
                     parts.append(f"{review_text[title_key]}\n\n{mkt_report}")
             if parts:
@@ -115,12 +132,15 @@ def run_market_review(
             else:
                 review_report = None
         else:
+            run_region = run_markets[0]
             market_analyzer = MarketAnalyzer(
                 search_service=search_service,
                 analyzer=analyzer,
-                region=region,
+                region=run_region,
             )
-            review_report = market_analyzer.run_daily_review()
+            review_result = market_analyzer.run_daily_review_with_snapshot()
+            review_report = review_result.report
+            market_light_snapshots = {run_region: review_result.market_light_snapshot}
         
         if review_report:
             # 保存报告到文件
@@ -135,9 +155,10 @@ def run_market_review(
             _persist_market_review_history(
                 review_report=review_report,
                 markdown_report=f"{review_text['root_title']}\n\n{review_report}",
-                region=region,
+                region=persist_region,
                 config=config,
                 query_id=query_id,
+                market_light_snapshots=market_light_snapshots,
             )
             
             # 推送通知（合并模式下跳过，由 main 层统一发送）
@@ -170,6 +191,7 @@ def _persist_market_review_history(
     region: str,
     config: object,
     query_id: Optional[str] = None,
+    market_light_snapshots: Optional[Dict[str, Dict[str, Any]]] = None,
 ) -> int:
     """Persist market review output into the existing analysis history table."""
     try:
@@ -205,6 +227,8 @@ def _persist_market_review_history(
             "market_review_region": region,
             "report_language": report_language,
         }
+        if market_light_snapshots:
+            context_snapshot["market_light_snapshots"] = market_light_snapshots
 
         saved = DatabaseManager.get_instance().save_analysis_history(
             result=result,

--- a/src/market_analyzer.py
+++ b/src/market_analyzer.py
@@ -23,6 +23,7 @@ from src.report_language import normalize_report_language
 from src.search_service import SearchService
 from src.core.market_profile import get_profile, MarketProfile
 from src.core.market_strategy import get_market_strategy_blueprint
+from src.schemas.market_light import MarketLightSnapshot
 from data_provider.base import DataFetcherManager
 
 logger = logging.getLogger(__name__)
@@ -91,6 +92,15 @@ class MarketOverview:
     # 板块涨幅榜
     top_sectors: List[Dict] = field(default_factory=list)     # 涨幅前5板块
     bottom_sectors: List[Dict] = field(default_factory=list)  # 跌幅前5板块
+
+
+@dataclass
+class MarketLightReviewResult:
+    """Internal market-review parts built from one overview fetch."""
+
+    overview: MarketOverview
+    report: str
+    market_light_snapshot: Dict[str, Any]
 
 
 class MarketAnalyzer:
@@ -587,7 +597,9 @@ Focus on index trend, liquidity, and sector rotation to shape the next-session t
 
     def build_market_light_snapshot(self, overview: MarketOverview) -> Dict[str, Any]:
         """Build a deterministic market-light snapshot from structured breadth data."""
-        score, temperature_label = self._build_market_temperature(overview)
+        scores = self._build_market_light_scores(overview)
+        score = int(scores["score"])
+        temperature_label = str(scores["temperature_label"])
         if score >= 60:
             status = "green"
         elif score >= 40:
@@ -620,14 +632,19 @@ Focus on index trend, liquidity, and sector rotation to shape the next-session t
             }
             reasons = self._build_market_light_reasons_zh(overview, score)
 
-        return {
-            "status": status,
-            "label": label_map[status],
-            "score": score,
-            "temperature_label": temperature_label,
-            "reasons": reasons,
-            "guidance": guidance_map[status],
-        }
+        snapshot = MarketLightSnapshot(
+            region=self.region,
+            trade_date=overview.date,
+            status=status,
+            label=label_map[status],
+            score=score,
+            temperature_label=temperature_label,
+            reasons=reasons,
+            guidance=guidance_map[status],
+            dimensions=scores["dimensions"],
+            data_quality=str(scores["data_quality"]),
+        )
+        return snapshot.model_dump()
 
     def _build_market_light_reasons_zh(self, overview: MarketOverview, score: int) -> List[str]:
         participation = overview.up_count + overview.down_count
@@ -640,8 +657,9 @@ Focus on index trend, liquidity, and sector rotation to shape the next-session t
                 reasons.append(f"上涨家数占比 {up_ratio:.0%}，亏钱效应较强")
             else:
                 reasons.append(f"上涨家数占比 {up_ratio:.0%}，市场分化")
-        if overview.indices:
-            avg_change = sum(idx.change_pct for idx in overview.indices) / len(overview.indices)
+        index_changes = [idx.change_pct for idx in overview.indices if idx.change_pct is not None]
+        if index_changes:
+            avg_change = sum(index_changes) / len(index_changes)
             reasons.append(f"主要指数平均涨跌幅 {avg_change:+.2f}%")
         if overview.limit_up_count or overview.limit_down_count:
             reasons.append(f"涨跌停差 {overview.limit_up_count - overview.limit_down_count:+d}")
@@ -662,8 +680,9 @@ Focus on index trend, liquidity, and sector rotation to shape the next-session t
                 reasons.append(f"advancers ratio {up_ratio:.0%}, downside pressure dominates")
             else:
                 reasons.append(f"advancers ratio {up_ratio:.0%}, breadth is mixed")
-        if overview.indices:
-            avg_change = sum(idx.change_pct for idx in overview.indices) / len(overview.indices)
+        index_changes = [idx.change_pct for idx in overview.indices if idx.change_pct is not None]
+        if index_changes:
+            avg_change = sum(index_changes) / len(index_changes)
             reasons.append(f"average major-index change {avg_change:+.2f}%")
         if overview.limit_up_count or overview.limit_down_count:
             reasons.append(f"limit-up/down spread {overview.limit_up_count - overview.limit_down_count:+d}")
@@ -823,22 +842,40 @@ Focus on index trend, liquidity, and sector rotation to shape the next-session t
             return "缩量观望"
         return "暂无数据"
 
-    def _build_market_temperature(self, overview: MarketOverview) -> tuple[int, str]:
+    def _build_market_light_scores(self, overview: MarketOverview) -> Dict[str, Any]:
+        """Build the canonical Market Light scores used by reports and alerts."""
+
         participants = overview.up_count + overview.down_count
+        breadth_available = bool(self.profile.has_market_stats and participants > 0)
         breadth_score = 50
-        if participants:
+        if breadth_available:
             breadth_score = int(overview.up_count / participants * 100)
 
         index_changes = [idx.change_pct for idx in overview.indices if idx.change_pct is not None]
+        index_available = bool(overview.indices and index_changes)
         index_score = 50
-        if index_changes:
+        if index_available:
             avg_change = sum(index_changes) / len(index_changes)
             index_score = int(max(0, min(100, 50 + avg_change * 12)))
 
         limit_total = overview.limit_up_count + overview.limit_down_count
+        limit_available = bool(self.profile.has_market_stats and limit_total > 0)
         limit_score = 50
-        if limit_total:
+        if limit_available:
             limit_score = int(overview.limit_up_count / limit_total * 100)
+
+        dimensions = {
+            "breadth": {"score": breadth_score, "available": breadth_available},
+            "index": {"score": index_score, "available": index_available},
+            "limit": {"score": limit_score, "available": limit_available},
+        }
+
+        if not index_available:
+            data_quality = "unavailable"
+        elif all(dimension["available"] for dimension in dimensions.values()):
+            data_quality = "ok"
+        else:
+            data_quality = "partial"
 
         score = int(round(breadth_score * 0.45 + index_score * 0.35 + limit_score * 0.20))
         if self._get_review_language() == "en":
@@ -859,6 +896,17 @@ Focus on index trend, liquidity, and sector rotation to shape the next-session t
                 label = "震荡"
             else:
                 label = "偏弱"
+        return {
+            "score": score,
+            "temperature_label": label,
+            "dimensions": dimensions,
+            "data_quality": data_quality,
+        }
+
+    def _build_market_temperature(self, overview: MarketOverview) -> tuple[int, str]:
+        scores = self._build_market_light_scores(overview)
+        score = int(scores["score"])
+        label = str(scores["temperature_label"])
         return score, label
 
     def _build_review_prompt(self, overview: MarketOverview, news: List) -> str:
@@ -1186,27 +1234,40 @@ Market conditions can change quickly. The data above is for reference only and d
 *复盘时间: {datetime.now().strftime('%H:%M')}*
 """
     
+    def _run_daily_review_parts(self) -> MarketLightReviewResult:
+        """Run market review once and keep report/snapshot on the same overview."""
+        logger.info("========== 开始大盘复盘分析 ==========")
+
+        # 1. 获取市场概览
+        overview = self.get_market_overview()
+
+        # 2. 搜索市场新闻
+        news = self.search_market_news()
+
+        # 3. 生成复盘报告
+        report = self.generate_market_review(overview, news)
+        snapshot = self.build_market_light_snapshot(overview)
+
+        logger.info("========== 大盘复盘分析完成 ==========")
+
+        return MarketLightReviewResult(
+            overview=overview,
+            report=report,
+            market_light_snapshot=snapshot,
+        )
+
     def run_daily_review(self) -> str:
         """
         执行每日大盘复盘流程
-        
+
         Returns:
             复盘报告文本
         """
-        logger.info("========== 开始大盘复盘分析 ==========")
-        
-        # 1. 获取市场概览
-        overview = self.get_market_overview()
-        
-        # 2. 搜索市场新闻
-        news = self.search_market_news()
-        
-        # 3. 生成复盘报告
-        report = self.generate_market_review(overview, news)
-        
-        logger.info("========== 大盘复盘分析完成 ==========")
-        
-        return report
+        return self.run_daily_review_with_snapshot().report
+
+    def run_daily_review_with_snapshot(self) -> MarketLightReviewResult:
+        """Run daily review and return the report plus its structured Market Light snapshot."""
+        return self._run_daily_review_parts()
 
 
 # 测试入口

--- a/src/schemas/market_light.py
+++ b/src/schemas/market_light.py
@@ -1,0 +1,43 @@
+# -*- coding: utf-8 -*-
+"""Structured Market Light snapshot schema."""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import BaseModel, Field
+
+
+MarketRegion = Literal["cn", "hk", "us"]
+MarketLightStatus = Literal["green", "yellow", "red"]
+MarketLightDataQuality = Literal["ok", "partial", "unavailable"]
+
+
+class MarketLightDimension(BaseModel):
+    """A single Market Light scoring dimension."""
+
+    score: int = Field(ge=0, le=100)
+    available: bool
+
+
+class MarketLightDimensions(BaseModel):
+    """Canonical Market Light dimension scores."""
+
+    breadth: MarketLightDimension
+    index: MarketLightDimension
+    limit: MarketLightDimension
+
+
+class MarketLightSnapshot(BaseModel):
+    """Structured Market Light snapshot persisted and consumed by alerts."""
+
+    region: MarketRegion
+    trade_date: str
+    status: MarketLightStatus
+    score: int = Field(ge=0, le=100)
+    label: str
+    temperature_label: str
+    reasons: list[str]
+    guidance: str
+    dimensions: MarketLightDimensions
+    data_quality: MarketLightDataQuality

--- a/src/services/alert_service.py
+++ b/src/services/alert_service.py
@@ -47,6 +47,15 @@ from src.services.portfolio_alerts import (
     portfolio_effective_target,
     result_to_target_result,
 )
+from src.services.market_light_alerts import (
+    MARKET_ALERT_TYPES,
+    MARKET_LIGHT_DATA_SOURCE,
+    MarketLightAlert,
+    evaluate_market_light_alert,
+    make_market_light_payload,
+    normalize_market_alert_parameters,
+)
+from src.services.market_light_service import normalize_market_region
 from src.storage import (
     AlertCooldownRecord,
     AlertNotificationRecord,
@@ -59,8 +68,8 @@ from src.utils.sanitize import sanitize_diagnostic_text
 
 LEGACY_RUNTIME_ALERT_TYPES = frozenset({"price_cross", "price_change_percent", "volume_spike"})
 SYMBOL_ALERT_TYPES = LEGACY_RUNTIME_ALERT_TYPES | TECHNICAL_ALERT_TYPES
-SUPPORTED_ALERT_TYPES = SYMBOL_ALERT_TYPES | PORTFOLIO_ALERT_TYPES
-SUPPORTED_TARGET_SCOPES = frozenset({"single_symbol", "watchlist", "portfolio_holdings", "portfolio_account"})
+SUPPORTED_ALERT_TYPES = SYMBOL_ALERT_TYPES | PORTFOLIO_ALERT_TYPES | MARKET_ALERT_TYPES
+SUPPORTED_TARGET_SCOPES = frozenset({"single_symbol", "watchlist", "portfolio_holdings", "portfolio_account", "market"})
 SUPPORTED_SEVERITIES = frozenset({"info", "warning", "critical"})
 NULLABLE_RULE_UPDATE_FIELDS = frozenset({"cooldown_policy", "notification_policy"})
 
@@ -192,7 +201,7 @@ class AlertService:
         self,
         rule,
         monitor: EventMonitor,
-        daily_cache: Optional[Dict[tuple[str, int], Any]] = None,
+        daily_cache: Optional[Dict[Any, Any]] = None,
     ) -> Dict[str, Any]:
         if isinstance(rule, PriceAlert):
             return await self._evaluate_price(rule, monitor)
@@ -204,6 +213,8 @@ class AlertService:
             return await self._evaluate_technical_indicator(rule, daily_cache=daily_cache)
         if isinstance(rule, PortfolioRiskAlert):
             return await asyncio.to_thread(evaluate_portfolio_risk_alert, rule)
+        if isinstance(rule, MarketLightAlert):
+            return await asyncio.to_thread(evaluate_market_light_alert, rule, cache=daily_cache)
         if isinstance(rule, StaticAlertEvaluation):
             return evaluate_static_alert(rule)
         return self._evaluation_error(rule, f"unsupported runtime alert type: {rule.alert_type}")
@@ -214,7 +225,7 @@ class AlertService:
         monitor: EventMonitor,
     ) -> List[Dict[str, Any]]:
         semaphore = asyncio.Semaphore(8)
-        daily_cache: Dict[tuple[str, int], Any] = {}
+        daily_cache: Dict[Any, Any] = {}
 
         async def _evaluate_one(payload: RuntimeAlertPayload) -> Dict[str, Any]:
             async with semaphore:
@@ -680,6 +691,10 @@ class AlertService:
             return threshold_for_indicator(rule.alert_type, rule.indicator_params)
         if isinstance(rule, PortfolioRiskAlert):
             return None
+        if isinstance(rule, MarketLightAlert):
+            if rule.alert_type == "market_light_score_drop":
+                return float(rule.parameters.get("min_drop", 0) or 0)
+            return None
         return None
 
     @staticmethod
@@ -692,6 +707,8 @@ class AlertService:
             return "daily_data"
         if isinstance(rule, PortfolioRiskAlert):
             return "portfolio_risk"
+        if isinstance(rule, MarketLightAlert):
+            return MARKET_LIGHT_DATA_SOURCE
         return None
 
     @classmethod
@@ -895,6 +912,12 @@ class AlertService:
 
     @staticmethod
     def _validate_scope_alert_type(target_scope: str, alert_type: str) -> None:
+        if target_scope == "market":
+            if alert_type not in MARKET_ALERT_TYPES:
+                raise AlertServiceError("market target_scope only supports market alert types")
+            return
+        if alert_type in MARKET_ALERT_TYPES:
+            raise AlertServiceError("market alert types require target_scope=market")
         if target_scope == "portfolio_account":
             if alert_type not in PORTFOLIO_ALERT_TYPES:
                 raise AlertServiceError("portfolio_account only supports portfolio alert types")
@@ -907,6 +930,11 @@ class AlertService:
     def _normalize_target(self, target_scope: str, target: str) -> str:
         if target_scope == "single_symbol":
             return target.strip()
+        if target_scope == "market":
+            try:
+                return normalize_market_region(target)
+            except ValueError as exc:
+                raise AlertServiceError(str(exc)) from exc
         try:
             normalized = normalize_batch_target_scope_target(target_scope, target)
             if target_scope in {"portfolio_holdings", "portfolio_account"}:
@@ -949,6 +977,12 @@ class AlertService:
             except ValueError as exc:
                 raise AlertServiceError(str(exc)) from exc
 
+        if alert_type in MARKET_ALERT_TYPES:
+            try:
+                return normalize_market_alert_parameters(alert_type, parameters)
+            except ValueError as exc:
+                raise AlertServiceError(str(exc)) from exc
+
         raise UnsupportedAlertTypeError(f"unsupported alert_type for Alert API: {alert_type}")
 
     @staticmethod
@@ -978,6 +1012,9 @@ class AlertService:
 
         if data["alert_type"] in PORTFOLIO_ALERT_TYPES:
             return [make_portfolio_risk_payload(parent_key=parent_key, data=data)]
+
+        if data["alert_type"] in MARKET_ALERT_TYPES:
+            return [make_market_light_payload(parent_key=parent_key, data=data, config=config)]
 
         if data["target_scope"] in SYMBOL_BATCH_TARGET_SCOPES:
             if config is None:
@@ -1222,6 +1259,11 @@ class AlertService:
             return f"{target} portfolio drawdown"
         if alert_type == "portfolio_price_stale":
             return f"{target} portfolio stale price"
+        if alert_type == "market_light_status":
+            statuses = ",".join(parameters.get("statuses") or ["red", "yellow"])
+            return f"{target} market light status {statuses}"
+        if alert_type == "market_light_score_drop":
+            return f"{target} market light score drop {parameters['min_drop']}"
         return f"{target} {alert_type}"
 
     @staticmethod

--- a/src/services/alert_worker.py
+++ b/src/services/alert_worker.py
@@ -119,7 +119,7 @@ class AlertWorker:
             return stats
 
         monitor = EventMonitor()
-        daily_cache: Dict[tuple[str, int], Any] = {}
+        daily_cache: Dict[Any, Any] = {}
         for runtime_rule in runtime_rules:
             stats["evaluated"] += 1
             try:

--- a/src/services/market_light_alerts.py
+++ b/src/services/market_light_alerts.py
@@ -1,0 +1,362 @@
+# -*- coding: utf-8 -*-
+"""Runtime helpers for Market Light alert rules."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Any, Dict, Optional
+
+from src.core.trading_calendar import get_open_markets_today
+from src.schemas.market_light import MarketLightSnapshot
+from src.services.market_light_service import (
+    build_current_snapshot,
+    load_previous_snapshot,
+    normalize_market_region,
+)
+from src.services.portfolio_alerts import RuntimeAlertPayload
+
+
+MARKET_ALERT_TYPES = frozenset({"market_light_status", "market_light_score_drop"})
+MARKET_STATUS_VALUES = frozenset({"red", "yellow"})
+MARKET_REGION_LABELS = {
+    "cn": "A股大盘",
+    "hk": "港股大盘",
+    "us": "美股大盘",
+}
+MARKET_LIGHT_DATA_SOURCE = "market_light"
+
+
+@dataclass
+class MarketLightAlert:
+    """Runtime alert for market-level Market Light rules."""
+
+    target_scope: str
+    target: str
+    alert_type: str
+    parameters: Dict[str, Any]
+    metadata: Dict[str, Any] = field(default_factory=dict)
+    description: str = ""
+    stock_code: str = ""
+
+    def __post_init__(self) -> None:
+        self.target = normalize_market_region(self.target)
+        self.stock_code = self.target
+
+
+def normalize_market_alert_parameters(alert_type: str, parameters: Dict[str, Any]) -> Dict[str, Any]:
+    if alert_type not in MARKET_ALERT_TYPES:
+        raise ValueError(f"unsupported market alert_type: {alert_type}")
+    if not isinstance(parameters, dict):
+        raise ValueError("parameters must be an object")
+
+    if alert_type == "market_light_status":
+        raw_statuses = parameters.get("statuses")
+        if raw_statuses is None:
+            raw_statuses = ["red", "yellow"]
+        if isinstance(raw_statuses, str):
+            raw_statuses = [raw_statuses]
+        if not isinstance(raw_statuses, list) or not raw_statuses:
+            raise ValueError("market_light_status statuses must be a non-empty list")
+        statuses = []
+        for raw_status in raw_statuses:
+            status = str(raw_status or "").strip().lower()
+            if status not in MARKET_STATUS_VALUES:
+                raise ValueError("market_light_status statuses only supports red or yellow")
+            if status not in statuses:
+                statuses.append(status)
+        return {"statuses": statuses}
+
+    min_drop = _positive_float(parameters.get("min_drop"), "min_drop")
+    return {"min_drop": min_drop}
+
+
+def make_market_light_payload(
+    *,
+    parent_key: str,
+    data: Dict[str, Any],
+    config: Optional[Any] = None,
+) -> RuntimeAlertPayload:
+    region = normalize_market_region(data["target"])
+    if config is None:
+        from src.config import get_config
+
+        config = get_config()
+    trading_day_check_enabled = bool(getattr(config, "trading_day_check_enabled", True))
+    market_is_open = True
+    if trading_day_check_enabled:
+        market_is_open = region in get_open_markets_today()
+
+    display_target = MARKET_REGION_LABELS.get(region, region)
+    rule = MarketLightAlert(
+        target_scope=data["target_scope"],
+        target=region,
+        alert_type=data["alert_type"],
+        parameters=dict(data.get("parameters") or {}),
+        metadata={
+            "persisted_rule_id": data["id"],
+            "effective_target": region,
+            "display_target": display_target,
+            "trading_day_check_enabled": trading_day_check_enabled,
+            "market_is_open": market_is_open,
+        },
+        description=data.get("name") or data["alert_type"],
+    )
+    return RuntimeAlertPayload(
+        key=f"{parent_key}|{region}",
+        rule=rule,
+        effective_target=region,
+        display_target=display_target,
+    )
+
+
+def evaluate_market_light_alert(
+    rule: MarketLightAlert,
+    *,
+    current_snapshot: Optional[Dict[str, Any]] = None,
+    cache: Optional[Dict[Any, Any]] = None,
+) -> Dict[str, Any]:
+    if rule.metadata.get("trading_day_check_enabled") and not rule.metadata.get("market_is_open", True):
+        return _market_result(
+            rule,
+            triggered=False,
+            observed_value=None,
+            threshold=_threshold(rule),
+            message=f"{rule.target} market is not a trading day",
+            record_status="skipped",
+            diagnostics={"region": rule.target, "trading_day_check": "closed"},
+        )
+
+    try:
+        snapshot = current_snapshot or _cached_current_snapshot(rule.target, cache)
+        current = MarketLightSnapshot.model_validate(snapshot)
+        data_timestamp = parse_trade_date_to_datetime(current.trade_date)
+    except Exception as exc:
+        return _market_result(
+            rule,
+            triggered=False,
+            observed_value=None,
+            threshold=_threshold(rule),
+            message=f"market light snapshot unavailable: {exc}",
+            record_status="degraded",
+            diagnostics={"region": rule.target, "error": str(exc)[:200]},
+        )
+
+    if current.data_quality == "unavailable":
+        return _market_result(
+            rule,
+            triggered=False,
+            observed_value=None,
+            threshold=_threshold(rule),
+            message="market light data is unavailable",
+            record_status="skipped",
+            data_timestamp=data_timestamp,
+            diagnostics=_base_diagnostics(current),
+        )
+
+    if rule.alert_type == "market_light_status":
+        return _evaluate_status(rule, current, data_timestamp)
+    if rule.alert_type == "market_light_score_drop":
+        return _evaluate_score_drop(rule, current, data_timestamp)
+
+    return _market_result(
+        rule,
+        triggered=False,
+        observed_value=None,
+        threshold=None,
+        message=f"unsupported market alert_type: {rule.alert_type}",
+        record_status="failed",
+        diagnostics={"region": rule.target, "error": "unsupported_market_alert_type"},
+    )
+
+
+def parse_trade_date_to_datetime(trade_date: str) -> datetime:
+    return datetime.fromisoformat(str(trade_date))
+
+
+def _cached_current_snapshot(region: str, cache: Optional[Dict[Any, Any]]) -> Dict[str, Any]:
+    if cache is None:
+        return build_current_snapshot(region)
+    cache_key = ("market_light", region)
+    if cache_key not in cache:
+        cache[cache_key] = build_current_snapshot(region)
+    return cache[cache_key]
+
+
+def _evaluate_status(
+    rule: MarketLightAlert,
+    current: MarketLightSnapshot,
+    data_timestamp: datetime,
+) -> Dict[str, Any]:
+    statuses = set(rule.parameters.get("statuses") or ["red", "yellow"])
+    triggered = current.status in statuses
+    diagnostics = _base_diagnostics(current)
+    if current.data_quality == "partial":
+        diagnostics["missing_dimensions"] = _missing_dimensions(current)
+    return _market_result(
+        rule,
+        triggered=triggered,
+        observed_value=float(current.score),
+        threshold=None,
+        message=(
+            f"Market Light status {current.status} matched {sorted(statuses)}"
+            if triggered
+            else f"Market Light status {current.status} did not match {sorted(statuses)}"
+        ),
+        data_timestamp=data_timestamp,
+        diagnostics=diagnostics,
+    )
+
+
+def _evaluate_score_drop(
+    rule: MarketLightAlert,
+    current: MarketLightSnapshot,
+    data_timestamp: datetime,
+) -> Dict[str, Any]:
+    min_drop = float(rule.parameters["min_drop"])
+    try:
+        raw_previous = load_previous_snapshot(rule.target, before_trade_date=current.trade_date)
+        previous = MarketLightSnapshot.model_validate(raw_previous) if raw_previous else None
+    except Exception as exc:
+        return _market_result(
+            rule,
+            triggered=False,
+            observed_value=float(current.score),
+            threshold=min_drop,
+            message=f"previous market light snapshot unavailable: {exc}",
+            record_status="degraded",
+            data_timestamp=data_timestamp,
+            diagnostics={**_base_diagnostics(current), "error": str(exc)[:200]},
+        )
+
+    if previous is None:
+        return _market_result(
+            rule,
+            triggered=False,
+            observed_value=float(current.score),
+            threshold=min_drop,
+            message="previous market light snapshot not found",
+            record_status="skipped",
+            data_timestamp=data_timestamp,
+            diagnostics=_base_diagnostics(current),
+        )
+
+    if previous.trade_date >= current.trade_date:
+        return _market_result(
+            rule,
+            triggered=False,
+            observed_value=float(current.score),
+            threshold=min_drop,
+            message="previous market light snapshot is not before current trade_date",
+            record_status="skipped",
+            data_timestamp=data_timestamp,
+            diagnostics={
+                **_base_diagnostics(current),
+                "prev_trade_date": previous.trade_date,
+                "prev_score": previous.score,
+            },
+        )
+
+    if previous.data_quality == "unavailable":
+        return _market_result(
+            rule,
+            triggered=False,
+            observed_value=float(current.score),
+            threshold=min_drop,
+            message="previous market light data is unavailable",
+            record_status="skipped",
+            data_timestamp=data_timestamp,
+            diagnostics={
+                **_base_diagnostics(current),
+                "prev_trade_date": previous.trade_date,
+                "prev_score": previous.score,
+                "prev_data_quality": previous.data_quality,
+            },
+        )
+
+    drop = float(previous.score - current.score)
+    triggered = drop >= min_drop
+    partial_comparison = current.data_quality == "partial" or previous.data_quality == "partial"
+    diagnostics = {
+        **_base_diagnostics(current),
+        "prev_trade_date": previous.trade_date,
+        "prev_score": previous.score,
+        "drop": drop,
+    }
+    if partial_comparison:
+        diagnostics["partial_comparison"] = True
+        diagnostics["missing_dimensions"] = sorted(
+            set(_missing_dimensions(current)) | set(_missing_dimensions(previous))
+        )
+    return _market_result(
+        rule,
+        triggered=triggered,
+        observed_value=float(current.score),
+        threshold=min_drop,
+        message=(
+            f"Market Light score dropped {drop:.1f} points from {previous.score} to {current.score}"
+            if triggered
+            else f"Market Light score drop {drop:.1f} points is below {min_drop:g}"
+        ),
+        data_timestamp=data_timestamp,
+        diagnostics=diagnostics,
+    )
+
+
+def _market_result(
+    rule: MarketLightAlert,
+    *,
+    triggered: bool,
+    observed_value: Optional[float],
+    threshold: Optional[float],
+    message: str,
+    record_status: Optional[str] = None,
+    data_timestamp: Optional[datetime] = None,
+    diagnostics: Optional[Dict[str, Any]] = None,
+) -> Dict[str, Any]:
+    effective_status = "triggered" if triggered else "not_triggered"
+    if triggered and record_status is None:
+        record_status = "triggered"
+    return {
+        "rule_id": int(rule.metadata.get("persisted_rule_id", 0) or 0),
+        "status": effective_status,
+        "record_status": record_status,
+        "triggered": triggered,
+        "observed_value": observed_value,
+        "threshold": threshold,
+        "data_source": MARKET_LIGHT_DATA_SOURCE,
+        "data_timestamp": data_timestamp,
+        "reason": message,
+        "message": message,
+        "diagnostics": json.dumps(diagnostics or {}, ensure_ascii=False, sort_keys=True),
+    }
+
+
+def _threshold(rule: MarketLightAlert) -> Optional[float]:
+    if rule.alert_type == "market_light_score_drop":
+        return float(rule.parameters.get("min_drop", 0) or 0)
+    return None
+
+
+def _base_diagnostics(snapshot: MarketLightSnapshot) -> Dict[str, Any]:
+    return {
+        "region": snapshot.region,
+        "trade_date": snapshot.trade_date,
+        "data_quality": snapshot.data_quality,
+    }
+
+
+def _missing_dimensions(snapshot: MarketLightSnapshot) -> list[str]:
+    dimensions = snapshot.dimensions.model_dump()
+    return sorted(name for name, item in dimensions.items() if not item.get("available"))
+
+
+def _positive_float(value: Any, field_name: str) -> float:
+    try:
+        number = float(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"invalid {field_name}: {value}") from exc
+    if number <= 0:
+        raise ValueError(f"{field_name} must be > 0")
+    return number

--- a/src/services/market_light_service.py
+++ b/src/services/market_light_service.py
@@ -1,0 +1,129 @@
+# -*- coding: utf-8 -*-
+"""Market Light snapshot service for structured alerts."""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any, Dict, Optional
+
+from sqlalchemy import desc
+
+from src.core.market_review import MARKET_REVIEW_HISTORY_CODE, MARKET_REVIEW_REPORT_TYPE
+from src.market_analyzer import MarketAnalyzer
+from src.schemas.market_light import MarketLightSnapshot
+from src.storage import AnalysisHistory, DatabaseManager
+
+
+logger = logging.getLogger(__name__)
+
+MARKET_LIGHT_REGIONS = frozenset({"cn", "hk", "us"})
+MARKET_LIGHT_HISTORY_BATCH_SIZE = 100
+
+
+def normalize_market_region(region: str) -> str:
+    value = str(region or "").strip().lower()
+    if value not in MARKET_LIGHT_REGIONS:
+        raise ValueError(f"market target must be one of cn, hk, us: {region}")
+    return value
+
+
+def build_current_snapshot(region: str) -> Dict[str, Any]:
+    """Build the current structured Market Light snapshot without LLM review."""
+
+    normalized_region = normalize_market_region(region)
+    analyzer = MarketAnalyzer(region=normalized_region)
+    overview = analyzer.get_market_overview()
+    return analyzer.build_market_light_snapshot(overview)
+
+
+def load_previous_snapshot(
+    region: str,
+    *,
+    before_trade_date: str,
+    db_manager: Optional[DatabaseManager] = None,
+    limit: Optional[int] = None,
+) -> Optional[Dict[str, Any]]:
+    """Load the latest persisted Market Light snapshot before ``before_trade_date``.
+
+    Legacy market-review history rows without ``market_light_snapshots[region]`` are
+    skipped while scanning newer rows.
+    """
+
+    normalized_region = normalize_market_region(region)
+    cutoff = str(before_trade_date or "").strip()
+    if not cutoff:
+        return None
+
+    db = db_manager or DatabaseManager.get_instance()
+    best_trade_date: Optional[str] = None
+    best_snapshot: Optional[Dict[str, Any]] = None
+    invalid_target_error: Optional[Exception] = None
+
+    with db.get_session() as session:
+        query = (
+            session.query(AnalysisHistory)
+            .filter(
+                AnalysisHistory.code == MARKET_REVIEW_HISTORY_CODE,
+                AnalysisHistory.report_type == MARKET_REVIEW_REPORT_TYPE,
+            )
+            .order_by(desc(AnalysisHistory.created_at), desc(AnalysisHistory.id))
+        )
+        if limit is not None:
+            query = query.limit(limit)
+        for row in query.yield_per(MARKET_LIGHT_HISTORY_BATCH_SIZE):
+            snapshot = _extract_region_snapshot(row.context_snapshot, normalized_region)
+            if snapshot is None:
+                continue
+            trade_date = str(snapshot.get("trade_date") or "").strip()
+            if not trade_date or trade_date >= cutoff:
+                continue
+            if best_trade_date is None or trade_date > best_trade_date:
+                best_trade_date = trade_date
+                best_snapshot = None
+                invalid_target_error = None
+            elif trade_date < best_trade_date:
+                continue
+            try:
+                candidate = MarketLightSnapshot.model_validate(snapshot).model_dump()
+            except Exception as exc:
+                logger.warning(
+                    "invalid persisted market light snapshot: row_id=%s region=%s trade_date=%s error=%s",
+                    getattr(row, "id", "?"),
+                    normalized_region,
+                    trade_date,
+                    exc,
+                )
+                if best_snapshot is None:
+                    invalid_target_error = exc
+                continue
+            if best_snapshot is None:
+                best_snapshot = candidate
+
+    if best_snapshot is not None:
+        return best_snapshot
+    if best_trade_date is not None and invalid_target_error is not None:
+        raise ValueError(
+            f"invalid persisted market light snapshot for {normalized_region} on {best_trade_date}"
+        ) from invalid_target_error
+    return None
+
+
+def _extract_region_snapshot(raw_context_snapshot: Any, region: str) -> Optional[Dict[str, Any]]:
+    if not raw_context_snapshot:
+        return None
+    try:
+        payload = (
+            json.loads(raw_context_snapshot)
+            if isinstance(raw_context_snapshot, str)
+            else raw_context_snapshot
+        )
+    except (TypeError, json.JSONDecodeError):
+        return None
+    if not isinstance(payload, dict):
+        return None
+    snapshots = payload.get("market_light_snapshots")
+    if not isinstance(snapshots, dict):
+        return None
+    snapshot = snapshots.get(region)
+    return snapshot if isinstance(snapshot, dict) else None

--- a/tests/test_alert_api.py
+++ b/tests/test_alert_api.py
@@ -482,6 +482,99 @@ class AlertApiTestCase(unittest.TestCase):
         )
         self.assertEqual(missing_target.status_code, 422)
 
+    def test_market_alert_scope_type_matrix_and_target_normalization(self) -> None:
+        created = self._create_rule({
+            "name": "Market red/yellow",
+            "target_scope": "market",
+            "target": " CN ",
+            "alert_type": "market_light_status",
+            "parameters": {"statuses": ["red", "yellow"]},
+        })
+        self.assertEqual(created["target"], "cn")
+        self.assertEqual(created["parameters"], {"statuses": ["red", "yellow"]})
+
+        invalid_symbol_rule = self.client.post(
+            "/api/v1/alerts/rules",
+            json={
+                "target_scope": "market",
+                "target": "cn",
+                "alert_type": "price_cross",
+                "parameters": {"direction": "above", "price": 10},
+            },
+        )
+        self.assertEqual(invalid_symbol_rule.status_code, 400, invalid_symbol_rule.text)
+        self.assertEqual(invalid_symbol_rule.json()["error"], "validation_error")
+
+        invalid_market_rule = self.client.post(
+            "/api/v1/alerts/rules",
+            json={
+                "target_scope": "single_symbol",
+                "target": "600519",
+                "alert_type": "market_light_status",
+                "parameters": {"statuses": ["red"]},
+            },
+        )
+        self.assertEqual(invalid_market_rule.status_code, 400, invalid_market_rule.text)
+        self.assertEqual(invalid_market_rule.json()["error"], "validation_error")
+
+        invalid_target = self.client.post(
+            "/api/v1/alerts/rules",
+            json={
+                "target_scope": "market",
+                "target": "eu",
+                "alert_type": "market_light_score_drop",
+                "parameters": {"min_drop": 10},
+            },
+        )
+        self.assertEqual(invalid_target.status_code, 400, invalid_target.text)
+        self.assertEqual(invalid_target.json()["error"], "validation_error")
+
+    def test_dry_run_market_light_rule_uses_snapshot_and_does_not_write_history(self) -> None:
+        rule = self._create_rule({
+            "name": "Market risk-off",
+            "target_scope": "market",
+            "target": "cn",
+            "alert_type": "market_light_status",
+            "parameters": {"statuses": ["red", "yellow"]},
+        })
+        snapshot = {
+            "region": "cn",
+            "trade_date": "2026-03-07",
+            "status": "red",
+            "score": 35,
+            "label": "偏防守",
+            "temperature_label": "偏弱",
+            "reasons": ["test"],
+            "guidance": "test",
+            "dimensions": {
+                "breadth": {"score": 20, "available": True},
+                "index": {"score": 30, "available": True},
+                "limit": {"score": 10, "available": True},
+            },
+            "data_quality": "ok",
+        }
+
+        with patch("src.services.market_light_alerts.get_open_markets_today", return_value={"cn"}), patch(
+            "src.services.market_light_alerts.build_current_snapshot", return_value=snapshot
+        ) as build_snapshot:
+            resp = self.client.post(f"/api/v1/alerts/rules/{rule['id']}/test")
+
+        self.assertEqual(resp.status_code, 200, resp.text)
+        payload = resp.json()
+        self.assertEqual(payload["target_scope"], "market")
+        self.assertTrue(payload["triggered"])
+        self.assertEqual(payload["status"], "triggered")
+        self.assertEqual(payload["observed_value"], 35.0)
+        self.assertEqual(payload["evaluated_count"], 1)
+        self.assertEqual(payload["triggered_count"], 1)
+        self.assertEqual(payload["target_results"][0]["target"], "cn")
+        self.assertEqual(payload["target_results"][0]["display_target"], "A股大盘")
+        self.assertEqual(payload["target_results"][0]["observed_value"], 35.0)
+        build_snapshot.assert_called_once_with("cn")
+
+        self.assertEqual(self.client.get("/api/v1/alerts/triggers").json()["total"], 0)
+        self.assertEqual(self.client.get("/api/v1/alerts/notifications").json()["total"], 0)
+
     def test_dry_run_price_cross_uses_mocked_quote_and_does_not_write_history(self) -> None:
         rule = self._create_rule()
 

--- a/tests/test_alert_worker.py
+++ b/tests/test_alert_worker.py
@@ -254,6 +254,7 @@ class AlertWorkerTestCase(unittest.TestCase):
         return SimpleNamespace(
             agent_event_monitor_enabled=True,
             agent_event_alert_rules_json=raw_rules,
+            trading_day_check_enabled=False,
         )
 
     def _create_rule(self, **overrides) -> dict:
@@ -994,6 +995,74 @@ class AlertWorkerTestCase(unittest.TestCase):
         self.assertEqual(stats["loaded"], 0)
         self.assertEqual(stats["evaluated"], 0)
         self.assertEqual(self._triggers(), [])
+
+    def test_market_light_rule_triggers_with_market_payload_and_deduplicates_trade_date(self) -> None:
+        rule = self._create_rule(
+            name="Market risk-off",
+            target_scope="market",
+            target="cn",
+            alert_type="market_light_status",
+            parameters={"statuses": ["red", "yellow"]},
+        )
+        snapshot = {
+            "region": "cn",
+            "trade_date": "2026-03-07",
+            "status": "red",
+            "score": 35,
+            "label": "偏防守",
+            "temperature_label": "偏弱",
+            "reasons": ["test"],
+            "guidance": "test",
+            "dimensions": {
+                "breadth": {"score": 20, "available": True},
+                "index": {"score": 30, "available": True},
+                "limit": {"score": 10, "available": True},
+            },
+            "data_quality": "ok",
+        }
+        worker = AlertWorker(config_provider=lambda: self._config(), service=self.service)
+
+        with patch("src.services.market_light_alerts.build_current_snapshot", return_value=snapshot):
+            first = worker.run_once()
+            second = worker.run_once()
+
+        self.assertEqual(first["triggered"], 1)
+        self.assertEqual(first["recorded"], 1)
+        self.assertEqual(second["triggered"], 1)
+        self.assertEqual(second["recorded"], 0)
+        triggers = self._triggers(rule_id=rule["id"], status="triggered")
+        self.assertEqual(len(triggers), 1)
+        self.assertEqual(triggers[0]["target"], "cn")
+        self.assertEqual(triggers[0]["observed_value"], 35.0)
+        self.assertEqual(triggers[0]["data_source"], "market_light")
+        self.assertEqual(triggers[0]["data_timestamp"], "2026-03-07T00:00:00")
+
+    def test_market_light_rule_skips_non_trading_day_when_check_enabled(self) -> None:
+        self._create_rule(
+            name="Market risk-off",
+            target_scope="market",
+            target="cn",
+            alert_type="market_light_status",
+            parameters={"statuses": ["red"]},
+        )
+        config = SimpleNamespace(
+            agent_event_monitor_enabled=True,
+            agent_event_alert_rules_json="",
+            trading_day_check_enabled=True,
+        )
+        worker = AlertWorker(config_provider=lambda: config, service=self.service)
+
+        with patch("src.services.market_light_alerts.get_open_markets_today", return_value=set()), patch(
+            "src.services.market_light_alerts.build_current_snapshot"
+        ) as build_snapshot:
+            stats = worker.run_once()
+
+        self.assertEqual(stats["skipped"], 1)
+        build_snapshot.assert_not_called()
+        triggers = self._triggers(status="skipped")
+        self.assertEqual(len(triggers), 1)
+        self.assertEqual(triggers[0]["target"], "cn")
+        self.assertEqual(triggers[0]["data_source"], "market_light")
 
     def test_single_rule_failure_does_not_block_other_rules(self) -> None:
         self._create_rule(target="600519")

--- a/tests/test_alerts_docs.py
+++ b/tests/test_alerts_docs.py
@@ -249,6 +249,36 @@ def test_alerts_doc_defines_p6_portfolio_and_watchlist_scope() -> None:
         assert token in doc
 
 
+def test_alerts_doc_defines_p7_market_light_scope() -> None:
+    doc = _read_doc()
+
+    for token in (
+        "## P7 大盘红绿灯结构化告警",
+        "MarketLightSnapshot",
+        "`target_scope=market`",
+        "`market_light_status`",
+        "`market_light_score_drop`",
+        "`statuses=[\"red\",\"yellow\"]`",
+        "`min_drop > 0`",
+        "`cn` / `hk` / `us`",
+        "双向约束",
+        "`context_snapshot.market_light_snapshots`",
+        "`data_quality=unavailable`",
+        "`partial_comparison=true`",
+        "`missing_dimensions`",
+        "canonical scorer",
+        "thin wrapper",
+        "`load_previous_snapshot(region, before_trade_date)`",
+        "最大 `snapshot.trade_date`",
+        "旧交易日 backfill",
+        "`TRADING_DAY_CHECK_ENABLED`",
+        "`data_source=market_light`",
+        "legacy `AGENT_EVENT_ALERT_RULES_JSON` 不支持 market 规则",
+        "revert P7 PR",
+    ):
+        assert token in doc
+
+
 def test_changelog_mentions_alert_p6_release_note() -> None:
     changelog = (PROJECT_ROOT / "docs" / "CHANGELOG.md").read_text(encoding="utf-8")
 

--- a/tests/test_market_analyzer_generate_text.py
+++ b/tests/test_market_analyzer_generate_text.py
@@ -1262,6 +1262,12 @@ Sector text.
         assert snapshot["status"] == "red"
         assert snapshot["label"] == "偏防守"
         assert snapshot["score"] < 40
+        assert snapshot["region"] == "cn"
+        assert snapshot["trade_date"] == "2026-03-06"
+        assert snapshot["data_quality"] == "ok"
+        assert snapshot["dimensions"]["breadth"]["available"] is True
+        assert snapshot["dimensions"]["index"]["available"] is True
+        assert snapshot["dimensions"]["limit"]["available"] is True
         assert any("亏钱效应" in reason for reason in snapshot["reasons"])
 
     def test_market_light_snapshot_uses_english_labels_and_reasons(self):
@@ -1294,6 +1300,27 @@ Sector text.
             reason.startswith("advancers ratio ") and "downside pressure dominates" in reason
             for reason in snapshot["reasons"]
         )
+
+    def test_market_light_snapshot_marks_us_without_breadth_as_partial(self):
+        from src.core.market_profile import US_PROFILE
+        from src.market_analyzer import MarketIndex, MarketOverview
+
+        ma = self._make_market_analyzer_with_mock_generate_text(return_value="review")
+        ma.region = "us"
+        ma.profile = US_PROFILE
+        ma.config.report_language = "en"
+        overview = MarketOverview(
+            date="2026-03-06",
+            indices=[MarketIndex(code="SPX", name="S&P 500", current=5000, change_pct=0.5)],
+        )
+
+        snapshot = ma.build_market_light_snapshot(overview)
+
+        assert snapshot["region"] == "us"
+        assert snapshot["data_quality"] == "partial"
+        assert snapshot["dimensions"]["breadth"] == {"score": 50, "available": False}
+        assert snapshot["dimensions"]["index"]["available"] is True
+        assert snapshot["dimensions"]["limit"] == {"score": 50, "available": False}
 
     def test_us_english_indices_do_not_label_turnover_as_cny(self):
         from src.core.market_profile import US_PROFILE

--- a/tests/test_market_light_alerts.py
+++ b/tests/test_market_light_alerts.py
@@ -1,0 +1,133 @@
+# -*- coding: utf-8 -*-
+"""Tests for Market Light alert evaluation."""
+
+from __future__ import annotations
+
+import json
+import unittest
+from unittest.mock import patch
+
+from src.services.market_light_alerts import (
+    MarketLightAlert,
+    evaluate_market_light_alert,
+    normalize_market_alert_parameters,
+)
+
+
+def _snapshot(
+    *,
+    trade_date: str = "2026-03-07",
+    score: int = 45,
+    status: str = "yellow",
+    data_quality: str = "ok",
+    breadth_available: bool = True,
+    index_available: bool = True,
+    limit_available: bool = True,
+) -> dict:
+    return {
+        "region": "cn",
+        "trade_date": trade_date,
+        "status": status,
+        "score": score,
+        "label": "需观察",
+        "temperature_label": "震荡",
+        "reasons": ["test"],
+        "guidance": "test",
+        "dimensions": {
+            "breadth": {"score": 50, "available": breadth_available},
+            "index": {"score": 50, "available": index_available},
+            "limit": {"score": 50, "available": limit_available},
+        },
+        "data_quality": data_quality,
+    }
+
+
+class MarketLightAlertsTestCase(unittest.TestCase):
+    def _rule(self, alert_type: str, parameters: dict) -> MarketLightAlert:
+        return MarketLightAlert(
+            target_scope="market",
+            target="cn",
+            alert_type=alert_type,
+            parameters=parameters,
+            metadata={"persisted_rule_id": 7, "trading_day_check_enabled": False},
+        )
+
+    def test_normalize_status_rejects_green(self) -> None:
+        with self.assertRaisesRegex(ValueError, "red or yellow"):
+            normalize_market_alert_parameters("market_light_status", {"statuses": ["green"]})
+
+    def test_status_unavailable_is_skipped(self) -> None:
+        result = evaluate_market_light_alert(
+            self._rule("market_light_status", {"statuses": ["red", "yellow"]}),
+            current_snapshot=_snapshot(data_quality="unavailable", index_available=False),
+        )
+
+        self.assertFalse(result["triggered"])
+        self.assertEqual(result["record_status"], "skipped")
+        self.assertEqual(result["data_source"], "market_light")
+
+    def test_status_partial_triggers_with_missing_dimensions_diagnostics(self) -> None:
+        result = evaluate_market_light_alert(
+            self._rule("market_light_status", {"statuses": ["yellow"]}),
+            current_snapshot=_snapshot(data_quality="partial", breadth_available=False, limit_available=False),
+        )
+
+        self.assertTrue(result["triggered"])
+        diagnostics = json.loads(result["diagnostics"])
+        self.assertEqual(diagnostics["data_quality"], "partial")
+        self.assertEqual(diagnostics["missing_dimensions"], ["breadth", "limit"])
+        self.assertEqual(result["data_timestamp"].isoformat(), "2026-03-07T00:00:00")
+
+    def test_score_drop_uses_previous_trade_date_and_allows_partial_comparison(self) -> None:
+        previous = _snapshot(
+            trade_date="2026-03-06",
+            score=75,
+            status="green",
+            data_quality="partial",
+            limit_available=False,
+        )
+        current = _snapshot(trade_date="2026-03-07", score=55, data_quality="partial", breadth_available=False)
+
+        with patch("src.services.market_light_alerts.load_previous_snapshot", return_value=previous):
+            result = evaluate_market_light_alert(
+                self._rule("market_light_score_drop", {"min_drop": 10.0}),
+                current_snapshot=current,
+            )
+
+        self.assertTrue(result["triggered"])
+        self.assertEqual(result["observed_value"], 55.0)
+        self.assertEqual(result["threshold"], 10.0)
+        diagnostics = json.loads(result["diagnostics"])
+        self.assertTrue(diagnostics["partial_comparison"])
+        self.assertEqual(diagnostics["prev_score"], 75)
+        self.assertEqual(diagnostics["prev_trade_date"], "2026-03-06")
+        self.assertEqual(diagnostics["missing_dimensions"], ["breadth", "limit"])
+
+    def test_score_drop_without_previous_snapshot_is_skipped(self) -> None:
+        with patch("src.services.market_light_alerts.load_previous_snapshot", return_value=None):
+            result = evaluate_market_light_alert(
+                self._rule("market_light_score_drop", {"min_drop": 10.0}),
+                current_snapshot=_snapshot(),
+            )
+
+        self.assertFalse(result["triggered"])
+        self.assertEqual(result["record_status"], "skipped")
+
+    def test_score_drop_previous_snapshot_parse_error_is_degraded(self) -> None:
+        with patch(
+            "src.services.market_light_alerts.load_previous_snapshot",
+            side_effect=ValueError("invalid persisted market light snapshot"),
+        ):
+            result = evaluate_market_light_alert(
+                self._rule("market_light_score_drop", {"min_drop": 10.0}),
+                current_snapshot=_snapshot(),
+            )
+
+        self.assertFalse(result["triggered"])
+        self.assertEqual(result["record_status"], "degraded")
+        diagnostics = json.loads(result["diagnostics"])
+        self.assertIn("invalid persisted market light snapshot", diagnostics["error"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_market_light_service.py
+++ b/tests/test_market_light_service.py
@@ -1,0 +1,210 @@
+# -*- coding: utf-8 -*-
+"""Tests for structured Market Light snapshot service."""
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+import unittest
+from datetime import datetime, timedelta
+from pathlib import Path
+from unittest.mock import patch
+
+from src.config import Config
+from src.core.market_review import MARKET_REVIEW_HISTORY_CODE, MARKET_REVIEW_REPORT_TYPE
+from src.market_analyzer import MarketIndex, MarketOverview
+from src.services.market_light_service import (
+    MARKET_LIGHT_HISTORY_BATCH_SIZE,
+    build_current_snapshot,
+    load_previous_snapshot,
+)
+from src.storage import AnalysisHistory, DatabaseManager
+
+
+def _snapshot(region: str, trade_date: str, score: int = 50) -> dict:
+    return {
+        "region": region,
+        "trade_date": trade_date,
+        "status": "yellow",
+        "score": score,
+        "label": "需观察",
+        "temperature_label": "震荡",
+        "reasons": ["test"],
+        "guidance": "test",
+        "dimensions": {
+            "breadth": {"score": 50, "available": True},
+            "index": {"score": 50, "available": True},
+            "limit": {"score": 50, "available": True},
+        },
+        "data_quality": "ok",
+    }
+
+
+class MarketLightServiceTestCase(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.db_path = Path(self.temp_dir.name) / "market_light.db"
+        os.environ["DATABASE_PATH"] = str(self.db_path)
+        Config.reset_instance()
+        DatabaseManager.reset_instance()
+        self.db = DatabaseManager.get_instance()
+
+    def tearDown(self) -> None:
+        DatabaseManager.reset_instance()
+        Config.reset_instance()
+        os.environ.pop("DATABASE_PATH", None)
+        self.temp_dir.cleanup()
+
+    def _add_history(self, *, created_at: datetime, context_snapshot: dict | None) -> None:
+        with self.db.get_session() as session:
+            session.add(
+                AnalysisHistory(
+                    query_id=f"q-{created_at.timestamp()}",
+                    code=MARKET_REVIEW_HISTORY_CODE,
+                    name="大盘复盘",
+                    report_type=MARKET_REVIEW_REPORT_TYPE,
+                    sentiment_score=50,
+                    operation_advice="查看复盘",
+                    trend_prediction="大盘复盘",
+                    analysis_summary="summary",
+                    raw_result="{}",
+                    news_content="body",
+                    context_snapshot=json.dumps(context_snapshot, ensure_ascii=False)
+                    if context_snapshot is not None
+                    else None,
+                    created_at=created_at,
+                )
+            )
+            session.commit()
+
+    def test_load_previous_snapshot_skips_same_day_and_legacy_history(self) -> None:
+        self._add_history(
+            created_at=datetime(2026, 3, 7, 18, 0),
+            context_snapshot={"market_light_snapshots": {"cn": _snapshot("cn", "2026-03-07", 30)}},
+        )
+        self._add_history(
+            created_at=datetime(2026, 3, 7, 17, 0),
+            context_snapshot={"report_kind": "market_review", "market_review_region": "cn"},
+        )
+        self._add_history(
+            created_at=datetime(2026, 3, 6, 18, 0),
+            context_snapshot={"market_light_snapshots": {"cn": _snapshot("cn", "2026-03-06", 72)}},
+        )
+
+        previous = load_previous_snapshot("cn", before_trade_date="2026-03-07", db_manager=self.db)
+
+        self.assertIsNotNone(previous)
+        assert previous is not None
+        self.assertEqual(previous["trade_date"], "2026-03-06")
+        self.assertEqual(previous["score"], 72)
+
+    def test_load_previous_snapshot_prefers_latest_trade_date_over_newer_backfill(self) -> None:
+        self._add_history(
+            created_at=datetime(2026, 3, 10, 20, 0),
+            context_snapshot={"market_light_snapshots": {"cn": _snapshot("cn", "2026-03-05", 99)}},
+        )
+        self._add_history(
+            created_at=datetime(2026, 3, 9, 18, 0),
+            context_snapshot={"market_light_snapshots": {"cn": _snapshot("cn", "2026-03-09", 72)}},
+        )
+        self._add_history(
+            created_at=datetime(2026, 3, 8, 18, 0),
+            context_snapshot={"market_light_snapshots": {"cn": _snapshot("cn", "2026-03-08", 80)}},
+        )
+
+        previous = load_previous_snapshot("cn", before_trade_date="2026-03-10", db_manager=self.db)
+
+        self.assertIsNotNone(previous)
+        assert previous is not None
+        self.assertEqual(previous["trade_date"], "2026-03-09")
+        self.assertEqual(previous["score"], 72)
+
+    def test_load_previous_snapshot_uses_latest_valid_snapshot_for_target_trade_date(self) -> None:
+        self._add_history(
+            created_at=datetime(2026, 3, 9, 19, 0),
+            context_snapshot={"market_light_snapshots": {"cn": _snapshot("cn", "2026-03-09", 66)}},
+        )
+        self._add_history(
+            created_at=datetime(2026, 3, 9, 18, 0),
+            context_snapshot={"market_light_snapshots": {"cn": _snapshot("cn", "2026-03-09", 72)}},
+        )
+        self._add_history(
+            created_at=datetime(2026, 3, 10, 20, 0),
+            context_snapshot={"market_light_snapshots": {"cn": _snapshot("cn", "2026-03-05", 99)}},
+        )
+
+        previous = load_previous_snapshot("cn", before_trade_date="2026-03-10", db_manager=self.db)
+
+        self.assertIsNotNone(previous)
+        assert previous is not None
+        self.assertEqual(previous["trade_date"], "2026-03-09")
+        self.assertEqual(previous["score"], 66)
+
+    def test_load_previous_snapshot_degrades_when_target_trade_date_has_no_valid_snapshot(self) -> None:
+        self._add_history(
+            created_at=datetime(2026, 3, 8, 18, 0),
+            context_snapshot={"market_light_snapshots": {"cn": _snapshot("cn", "2026-03-08", 80)}},
+        )
+        self._add_history(
+            created_at=datetime(2026, 3, 9, 18, 0),
+            context_snapshot={
+                "market_light_snapshots": {
+                    "cn": {
+                        "region": "cn",
+                        "trade_date": "2026-03-09",
+                        "status": "yellow",
+                        "score": 72,
+                    }
+                }
+            },
+        )
+
+        with self.assertRaisesRegex(ValueError, "invalid persisted market light snapshot"):
+            load_previous_snapshot("cn", before_trade_date="2026-03-10", db_manager=self.db)
+
+    def test_load_previous_snapshot_scans_beyond_batch_without_default_cap(self) -> None:
+        newest = datetime(2026, 3, 7, 18, 0)
+        for index in range(MARKET_LIGHT_HISTORY_BATCH_SIZE + 5):
+            self._add_history(
+                created_at=newest - timedelta(minutes=index),
+                context_snapshot={"report_kind": "market_review", "market_review_region": "cn"},
+            )
+        self._add_history(
+            created_at=datetime(2026, 3, 6, 18, 0),
+            context_snapshot={"market_light_snapshots": {"cn": _snapshot("cn", "2026-03-06", 72)}},
+        )
+
+        previous = load_previous_snapshot("cn", before_trade_date="2026-03-07", db_manager=self.db)
+
+        self.assertIsNotNone(previous)
+        assert previous is not None
+        self.assertEqual(previous["trade_date"], "2026-03-06")
+        self.assertEqual(previous["score"], 72)
+
+    def test_build_current_snapshot_uses_market_analyzer_without_review(self) -> None:
+        overview = MarketOverview(
+            date="2026-03-07",
+            indices=[MarketIndex(code="000001", name="上证指数", current=3200, change_pct=-1.0)],
+            up_count=1000,
+            down_count=3000,
+            limit_up_count=10,
+            limit_down_count=80,
+        )
+
+        with patch("src.services.market_light_service.MarketAnalyzer") as analyzer_cls:
+            analyzer = analyzer_cls.return_value
+            analyzer.get_market_overview.return_value = overview
+            analyzer.build_market_light_snapshot.return_value = _snapshot("cn", "2026-03-07", 33)
+
+            snapshot = build_current_snapshot("CN")
+
+        analyzer_cls.assert_called_once_with(region="cn")
+        analyzer.get_market_overview.assert_called_once()
+        analyzer.build_market_light_snapshot.assert_called_once_with(overview)
+        self.assertEqual(snapshot["region"], "cn")
+        self.assertEqual(snapshot["score"], 33)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_market_review.py
+++ b/tests/test_market_review.py
@@ -53,10 +53,33 @@ class MarketReviewLocalizationTestCase(unittest.TestCase):
         notifier.send.return_value = True
         return notifier
 
+    def test_resolve_market_review_regions_returns_ordered_non_empty_list(self) -> None:
+        cases = [
+            (None, ["cn"]),
+            ("", ["cn"]),
+            ("both", ["cn", "hk", "us"]),
+            (" CN,US,cn ", ["cn", "us"]),
+            ("us,cn,us", ["cn", "us"]),
+            ("eu,apac", ["cn"]),
+            (",,", ["cn"]),
+            ("HK", ["hk"]),
+            ("invalid", ["cn"]),
+        ]
+
+        for raw_region, expected in cases:
+            with self.subTest(raw_region=raw_region):
+                self.assertEqual(
+                    market_review_module._resolve_market_review_regions(raw_region),
+                    expected,
+                )
+
     def test_run_market_review_uses_english_notification_title(self) -> None:
         notifier = self._make_notifier()
         market_analyzer = MagicMock()
-        market_analyzer.run_daily_review.return_value = "## 2026-04-10 A-share Market Recap\n\nBody"
+        market_analyzer.run_daily_review_with_snapshot.return_value = SimpleNamespace(
+            report="## 2026-04-10 A-share Market Recap\n\nBody",
+            market_light_snapshot={"region": "cn", "trade_date": "2026-04-10", "score": 60},
+        )
 
         with patch.object(
             market_review_module,
@@ -82,11 +105,20 @@ class MarketReviewLocalizationTestCase(unittest.TestCase):
     def test_run_market_review_merges_both_regions_with_english_wrappers(self) -> None:
         notifier = self._make_notifier()
         cn_analyzer = MagicMock()
-        cn_analyzer.run_daily_review.return_value = "CN body"
+        cn_analyzer.run_daily_review_with_snapshot.return_value = SimpleNamespace(
+            report="CN body",
+            market_light_snapshot={"region": "cn", "trade_date": "2026-03-06", "score": 60},
+        )
         hk_analyzer = MagicMock()
-        hk_analyzer.run_daily_review.return_value = "HK body"
+        hk_analyzer.run_daily_review_with_snapshot.return_value = SimpleNamespace(
+            report="HK body",
+            market_light_snapshot={"region": "hk", "trade_date": "2026-03-06", "score": 58},
+        )
         us_analyzer = MagicMock()
-        us_analyzer.run_daily_review.return_value = "US body"
+        us_analyzer.run_daily_review_with_snapshot.return_value = SimpleNamespace(
+            report="US body",
+            market_light_snapshot={"region": "us", "trade_date": "2026-03-06", "score": 55},
+        )
 
         with patch.object(
             market_review_module,
@@ -112,9 +144,15 @@ class MarketReviewLocalizationTestCase(unittest.TestCase):
         must produce A-share + US report without HK."""
         notifier = self._make_notifier()
         cn_analyzer = MagicMock()
-        cn_analyzer.run_daily_review.return_value = "CN body"
+        cn_analyzer.run_daily_review_with_snapshot.return_value = SimpleNamespace(
+            report="CN body",
+            market_light_snapshot={"region": "cn", "trade_date": "2026-03-06", "score": 60},
+        )
         us_analyzer = MagicMock()
-        us_analyzer.run_daily_review.return_value = "US body"
+        us_analyzer.run_daily_review_with_snapshot.return_value = SimpleNamespace(
+            report="US body",
+            market_light_snapshot={"region": "us", "trade_date": "2026-03-06", "score": 55},
+        )
 
         with patch.object(
             market_review_module,
@@ -139,9 +177,15 @@ class MarketReviewLocalizationTestCase(unittest.TestCase):
         must produce A-share + HK report without US."""
         notifier = self._make_notifier()
         cn_analyzer = MagicMock()
-        cn_analyzer.run_daily_review.return_value = "CN body"
+        cn_analyzer.run_daily_review_with_snapshot.return_value = SimpleNamespace(
+            report="CN body",
+            market_light_snapshot={"region": "cn", "trade_date": "2026-03-06", "score": 60},
+        )
         hk_analyzer = MagicMock()
-        hk_analyzer.run_daily_review.return_value = "HK body"
+        hk_analyzer.run_daily_review_with_snapshot.return_value = SimpleNamespace(
+            report="HK body",
+            market_light_snapshot={"region": "hk", "trade_date": "2026-03-06", "score": 58},
+        )
 
         with patch.object(
             market_review_module,
@@ -161,6 +205,101 @@ class MarketReviewLocalizationTestCase(unittest.TestCase):
         self.assertNotIn("美股", result)
         self.assertNotIn("US Market", result)
 
+    def test_run_market_review_persists_only_current_run_market_light_snapshots(self) -> None:
+        notifier = self._make_notifier()
+        cn_analyzer = MagicMock()
+        cn_analyzer.run_daily_review_with_snapshot.return_value = SimpleNamespace(
+            report="CN body",
+            market_light_snapshot={"region": "cn", "trade_date": "2026-03-06", "score": 60},
+        )
+        us_analyzer = MagicMock()
+        us_analyzer.run_daily_review_with_snapshot.return_value = SimpleNamespace(
+            report="US body",
+            market_light_snapshot={"region": "us", "trade_date": "2026-03-06", "score": 55},
+        )
+
+        with patch.object(
+            market_review_module,
+            "get_config",
+            return_value=SimpleNamespace(report_language="zh", market_review_region="cn"),
+        ), patch.object(
+            market_review_module,
+            "MarketAnalyzer",
+            side_effect=[cn_analyzer, us_analyzer],
+        ), patch.object(market_review_module, "_persist_market_review_history") as persist_history:
+            run_market_review(notifier, send_notification=False, override_region="cn,us")
+
+        snapshots = persist_history.call_args.kwargs["market_light_snapshots"]
+        self.assertEqual(set(snapshots), {"cn", "us"})
+        self.assertEqual(snapshots["cn"]["score"], 60)
+        self.assertEqual(snapshots["us"]["score"], 55)
+
+    def test_run_market_review_normalizes_single_region_snapshot_key(self) -> None:
+        notifier = self._make_notifier()
+        market_analyzer = MagicMock()
+        market_analyzer.run_daily_review_with_snapshot.return_value = SimpleNamespace(
+            report="CN body",
+            market_light_snapshot={
+                "region": "cn",
+                "trade_date": "2026-03-06",
+                "score": 60,
+            },
+        )
+
+        with patch.object(
+            market_review_module,
+            "get_config",
+            return_value=SimpleNamespace(report_language="zh", market_review_region="cn"),
+        ), patch.object(
+            market_review_module,
+            "MarketAnalyzer",
+            return_value=market_analyzer,
+        ) as analyzer_cls, patch.object(
+            market_review_module, "_persist_market_review_history"
+        ) as persist_history:
+            run_market_review(notifier, send_notification=False, override_region="CN")
+
+        self.assertEqual(analyzer_cls.call_args.kwargs["region"], "cn")
+        persist_history.assert_called_once()
+        self.assertEqual(persist_history.call_args.kwargs["region"], "cn")
+        snapshots = persist_history.call_args.kwargs["market_light_snapshots"]
+        self.assertEqual(set(snapshots), {"cn"})
+        self.assertEqual(snapshots["cn"]["trade_date"], "2026-03-06")
+
+    def test_run_market_review_invalid_comma_subset_falls_back_to_cn(self) -> None:
+        notifier = self._make_notifier()
+        market_analyzer = MagicMock()
+        market_analyzer.run_daily_review_with_snapshot.return_value = SimpleNamespace(
+            report="CN body",
+            market_light_snapshot={
+                "region": "cn",
+                "trade_date": "2026-03-06",
+                "score": 60,
+            },
+        )
+
+        with patch.object(
+            market_review_module,
+            "get_config",
+            return_value=SimpleNamespace(report_language="zh", market_review_region="cn"),
+        ), patch.object(
+            market_review_module,
+            "MarketAnalyzer",
+            return_value=market_analyzer,
+        ) as analyzer_cls, patch.object(
+            market_review_module, "_persist_market_review_history"
+        ) as persist_history:
+            result = run_market_review(
+                notifier, send_notification=False, override_region="eu,apac"
+            )
+
+        self.assertEqual(result, "CN body")
+        self.assertEqual(analyzer_cls.call_args.kwargs["region"], "cn")
+        persist_history.assert_called_once()
+        self.assertEqual(persist_history.call_args.kwargs["region"], "cn")
+        snapshots = persist_history.call_args.kwargs["market_light_snapshots"]
+        self.assertEqual(set(snapshots), {"cn"})
+
     def test_persist_market_review_history_saves_markdown_report(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
             old_db_path = os.environ.get("DATABASE_PATH")
@@ -174,6 +313,24 @@ class MarketReviewLocalizationTestCase(unittest.TestCase):
                     region="cn",
                     config=SimpleNamespace(report_language="zh"),
                     query_id="market-task-001",
+                    market_light_snapshots={
+                        "cn": {
+                            "region": "cn",
+                            "trade_date": "2026-03-06",
+                            "status": "red",
+                            "score": 30,
+                            "label": "偏防守",
+                            "temperature_label": "偏弱",
+                            "reasons": ["test"],
+                            "guidance": "test",
+                            "dimensions": {
+                                "breadth": {"score": 20, "available": True},
+                                "index": {"score": 30, "available": True},
+                                "limit": {"score": 10, "available": True},
+                            },
+                            "data_quality": "ok",
+                        }
+                    },
                 )
 
                 self.assertEqual(saved, 1)
@@ -188,6 +345,8 @@ class MarketReviewLocalizationTestCase(unittest.TestCase):
                     self.assertEqual(row.report_type, market_review_module.MARKET_REVIEW_REPORT_TYPE)
                     self.assertEqual(row.news_content, "## 今日大盘\n\n复盘正文")
                     self.assertIn("# 🎯 大盘复盘", row.raw_result)
+                    self.assertIn('"market_light_snapshots"', row.context_snapshot)
+                    self.assertIn('"trade_date": "2026-03-06"', row.context_snapshot)
             finally:
                 DatabaseManager.reset_instance()
                 Config._instance = None


### PR DESCRIPTION
## PR Type

- [ ] fix
- [x] feat
- [ ] refactor
- [x] docs
- [ ] chore
- [x] test

## Background And Problem

Issue #1202 的 P7 需要让告警中心消费结构化 `MarketLightSnapshot`，支持大盘红灯/黄灯状态与大盘红绿灯 score 跨交易日下降告警。现有实现只把大盘复盘输出为 Markdown，告警 worker 无法稳定读取大盘状态，也无法按市场日期和数据源记录触发历史。

本 PR 从最新 `upstream/main` 重新整理为一个 clean branch，保留 P7 的最小范围：不解析 Markdown，不扩展 legacy `AGENT_EVENT_ALERT_RULES_JSON`，不新增数据库表，不把多市场复盘拆成多条历史记录。

## Scope Of Change

- 新增 `MarketLightSnapshot` schema、canonical Market Light scorer 与 `market_light_service`，统一产出 status、score、dimensions 和 data_quality。
- 更新大盘复盘持久化：在 `analysis_history.context_snapshot.market_light_snapshots` 中按 region 写入本次实际复盘市场的结构化快照，并保证报告与快照共用同一份 overview。
- 新增 `market_light_status` 与 `market_light_score_drop` 两类 market scope 告警规则，接入 Alert API、AlertService、worker、触发历史、冷却和 P4 去重语义。
- 增加 `target_scope=market` 的 API/Web 支持，包括 region 选择、参数控件、列表展示、类型标签和 snake_case 映射。
- 补充 P7 文档、scope/type 矩阵、data_quality 语义、回滚说明与 CHANGELOG。
- 补充后端与 Web 回归测试，覆盖 scope/type 双向校验、交易日 gate、同 trade_date 去重、T-1 基线读取、legacy history 跳过、多市场 snapshot 持久化和前端表单/列表。

## Issue Link

Refs #1202

## Verification Commands And Results

```bash
PATH=/opt/homebrew/opt/python@3.13/libexec/bin:/private/tmp/dsa-ci-tools:$PATH ./scripts/ci_gate.sh
```

关键输出/结论：

```text
2215 passed, 2 deselected, 7 warnings, 189 subtests passed in 75.03s
backend-gate: all checks passed
```

```bash
python -m pytest tests/test_alert_api.py tests/test_alert_worker.py tests/test_market_review.py tests/test_market_light_service.py tests/test_market_light_alerts.py tests/test_alerts_docs.py tests/test_bot_market_command.py tests/test_main_schedule_mode.py tests/test_analysis_api_contract.py -q
```

关键输出/结论：

```text
197 passed, 1 warning in 8.32s
```

```bash
cd apps/dsa-web
npm run test -- src/api/__tests__/alerts.test.ts src/components/alerts/__tests__/AlertRuleForm.test.tsx src/components/alerts/__tests__/AlertRuleList.test.tsx
npm run lint
npm run build
```

关键输出/结论：

```text
Test Files  3 passed
Tests       29 passed
npm run lint passed
npm run build passed
```

```bash
git diff --check
```

关键输出/结论：通过，无 whitespace error。

## Compatibility And Risk

- 不新增配置项，因此未更新 `.env.example`。
- 不新增数据库表或 migration；结构化快照写入既有 `analysis_history.context_snapshot.market_light_snapshots`，旧历史记录缺少该字段时会被跳过。
- 不扩展 legacy `AGENT_EVENT_ALERT_RULES_JSON`；P7 market 规则只走 Alert API / worker 路径。
- `MarketLightSnapshot.trade_date` 首版取自 `MarketOverview.date`，不解析 provider quote as-of；worker 会按现有交易日检查配置跳过非交易日。
- `market_light_status` 是 level trigger，依赖 `rule_id + target + data_source + data_timestamp` 去重控制同一市场同一交易日最多一条真实触发。
- `market_light_score_drop` 首版只比较跨交易日 aggregate score，不支持同日盘中降幅。
- US/HK 因 breadth/limit 数据不足可能为 `partial`，告警 diagnostics 会带 `data_quality` 与缺失维度。

## Rollback Plan

如需回滚，先 disable/delete 已创建的 `target_scope=market` 规则，再 revert this PR。已写入历史记录的 `context_snapshot.market_light_snapshots` 是附加 JSON 字段，旧代码不读取时可保留，无需数据迁移。

## EXTRACT_PROMPT Change (if applicable)

不适用，未修改 `src/services/image_stock_extractor.py` 或 `EXTRACT_PROMPT`。

<details>
<summary>展开 / Expand: Full EXTRACT_PROMPT</summary>

```text
N/A
```

</details>

## Checklist

- [x] 本 PR 有明确动机和业务价值 / This PR has a clear motivation and value
- [x] 已提供可复现的验证命令与结果 / Reproducible verification commands and results are included
- [x] 已评估兼容性与风险 / Compatibility and risk have been assessed
- [x] 已提供回滚方案 / A rollback plan is provided
- [x] 若涉及用户可见变更，已同步更新相关文档与 `docs/CHANGELOG.md`；`README.md` 仅在首页级信息变化时更新，细节优先写入 `docs/*.md` / If user-visible changes are included, relevant docs and `docs/CHANGELOG.md` are updated; `README.md` is updated only for homepage-level changes, with details kept in `docs/*.md`
