### PR TITLE
feat: 新增市场阶段推断基线 #1386-P0

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - [修复] 归一腾讯实时行情成交量为股口径，避免量能变化倍数被放大并误导分析报告。
 - [改进] Web 路由页面改为按需加载，降低首包体积并增加路由加载失败恢复提示。
 - [修复] Docker 默认部署移除 `.env` 单文件挂载，避免 WebUI 保存配置时因 `os.replace` 更新挂载点触发 `Device or resource busy`。
+- [改进] 新增市场阶段推断基线并明确盘前、盘中、午休、临近收盘、盘后和非交易日语义。
 
 ## [3.18.0] - 2026-05-21
 

--- a/docs/alerts.md
+++ b/docs/alerts.md
@@ -238,7 +238,7 @@ P5 支持的 `alert_type` 与 `parameters`：
 - 首版统一使用日线 close，不做分钟线。
 - 边缘触发只比较最近两根已收盘日线；非边缘但当前 level 已满足阈值时仍返回 `not_triggered`，避免规则创建首日把历史状态误报为新触发。
 - 边缘触发包含前一根刚好等于阈值或零轴的情况：`above` / `bullish_cross` 使用 `prev <= threshold < current`，`below` / `bearish_cross` 使用 `prev >= threshold > current`。
-- partial bar 只使用服务器本地时区启发式：当前本地时间早于 16:00 时，最后一行日期等于本地今天或日期不可判定都会保守丢弃；不区分 A 股、港股、美股市场时区或交易日历。多市场盘中精确判定留到后续阶段。
+- partial bar 只使用服务器本地时区启发式：当前本地时间早于 16:00 时，最后一行日期等于本地今天或日期不可判定都会保守丢弃；不区分 A 股、港股、美股市场时区或交易日历。Issue #1386 P0 的市场阶段基线暂不接入技术指标规则，告警 partial bar 精确判定留到后续阶段。
 - `src/services/alert_indicators.py` 自行归一化 OHLCV 并计算 MA、RSI、MACD、KDJ、CCI，不依赖 fetcher 预计算的 MA5/MA10/MA20。
 - RSI 使用 Wilder's EMA / SMMA：`avg_gain = gain.ewm(alpha=1/period, adjust=False).mean()`，`avg_loss` 同理，不使用 rolling SMA。
 - MACD 使用 `EMA(fast_period) - EMA(slow_period)` 得到 DIF，DEA 为 DIF 的 `EMA(signal_period)`；金叉/死叉比较 DIF-DEA 相对 0 的边缘穿越。

--- a/docs/full-guide.md
+++ b/docs/full-guide.md
@@ -702,6 +702,37 @@ docker run -e SCHEDULE_ENABLED=true -e SCHEDULE_RUN_IMMEDIATELY=false ...
 - 交易日盘中或收盘前运行时，会以上一个已完成交易日作为复用目标；交易日收盘后运行时，当日数据已存在则可直接跳过，不存在则继续抓取
 - 覆盖方式：`TRADING_DAY_CHECK_ENABLED=false` 或 命令行 `--force-run`
 
+#### 市场阶段基线（Issue #1386 P0）
+
+P0 只新增内部市场阶段推断基线，不改变现有每日收盘报告、交易日跳过、断点续传、API、Web、Bot、Agent 或 GitHub Actions 默认行为。阶段推断用于后续 P1+ 的上下文契约准备；未安装 `exchange-calendars` 或日历异常时，阶段返回 `unknown`，但现有交易日判断和最新可复用交易日逻辑仍保持原来的 fail-open 行为。
+
+阶段枚举基于 regular session 语义：
+
+| 阶段 | 含义 |
+| --- | --- |
+| `premarket` | 常规交易时段开盘前；不代表已经获取盘前扩展时段行情 |
+| `intraday` | 常规交易时段内，且不处于午休或临近收盘窗口 |
+| `lunch_break` | 市场日历提供的午间休市窗口；无午休市场不会进入此阶段 |
+| `closing_auction` | 临近收盘启发式窗口：A 股 3 分钟、港股 10 分钟、美股 5 分钟；不代表完整交易所竞价制度 |
+| `postmarket` | 常规交易时段收盘后；不代表已经获取盘后扩展时段行情 |
+| `non_trading` | 当前市场本地日期不是交易日 |
+| `unknown` | 未知市场、日历不可用或日历异常，无法可靠推断阶段 |
+
+当前入口现状：
+
+- 普通个股分析、Agent 分析、Web 手动分析、Bot `/analyze` / `/ask`、schedule、GitHub Actions 仍沿用既有分析路径和盘后复盘口径，不会因为 P0 阶段基线自动切换 Prompt 或输出结构。
+- 大盘复盘仍按 `MARKET_REVIEW_REGION` 与交易日过滤运行，不消费市场阶段标签。
+- 跨市场混合自选股应按每个 symbol 自身市场分别推断阶段；聚合报告展示“多市场阶段不一致”留给 P1+。
+
+已知问题基线：
+
+- 盘中触发时，报告仍可能把尚未收盘的日内行情写成完整交易日复盘。
+- 输出仍可能偏向“今日走势复盘 / 明日关注”，而不是“当前盘中下一步观察”。
+- 实时行情时间戳、数据源、缓存和 stale 状态还没有统一进入阶段上下文。
+- 午间休市、临近收盘、非交易日强制运行等场景还没有被 Prompt 和报告结构显式表达。
+
+P0 不做：不接入 pipeline / Agent / API / Web / Bot，不修改报告 schema，不改告警 technical indicator 的 partial bar 判断，也不新增配置项。
+
 #### 使用 Crontab
 
 如果不想使用常驻进程，也可以使用系统的 Cron：

--- a/docs/full-guide_EN.md
+++ b/docs/full-guide_EN.md
@@ -590,6 +590,37 @@ crontab -e
 >
 > When the built-in scheduler is started via `python main.py --schedule`, `python main.py --serve --schedule`, or an equivalent local mode, saving a new `SCHEDULE_TIME` from the WebUI will rebind the daily job on the next scheduler poll without restarting the process. The previous trigger time is removed instead of being kept alongside the new one.
 
+### Market Phase Baseline (Issue #1386 P0)
+
+P0 only adds an internal market-phase inference baseline. It does not change the existing daily post-market report, trading-day skip behavior, effective trading date resolution, API, Web, Bot, Agent, or GitHub Actions defaults. The phase inference is preparation for the P1+ context contract. If `exchange-calendars` is unavailable or the calendar lookup fails, the phase returns `unknown`; the existing trading-day filter and effective-date helpers keep their current fail-open behavior.
+
+The phase labels describe regular-session state:
+
+| Phase | Meaning |
+| --- | --- |
+| `premarket` | Before the regular session opens; does not mean extended-hours quotes were fetched |
+| `intraday` | Inside the regular session and outside lunch break or the near-close window |
+| `lunch_break` | Lunch break window supplied by the market calendar; markets without lunch breaks skip this phase |
+| `closing_auction` | Near-close heuristic window: 3 minutes for CN, 10 minutes for HK, and 5 minutes for US; this is not a full exchange auction model |
+| `postmarket` | After the regular session closes; does not mean post-market quotes were fetched |
+| `non_trading` | The current market-local date is not a trading session |
+| `unknown` | Unknown market, calendar unavailable, or calendar error, so the phase cannot be inferred reliably |
+
+Current entrypoint baseline:
+
+- Regular stock analysis, Agent analysis, Web manual analysis, Bot `/analyze` / `/ask`, schedule mode, and GitHub Actions still use the existing analysis path and post-market recap wording. P0 does not switch prompts or output schema automatically.
+- Market review still follows `MARKET_REVIEW_REGION` and trading-day filtering; it does not consume market phase labels.
+- Mixed-market watchlists should infer phase per symbol market. Displaying inconsistent phases in aggregate reports is left to P1+.
+
+Known problem baseline:
+
+- Intraday runs can still describe unfinished intraday data like a complete daily recap.
+- Output may still focus on "today's recap / watch tomorrow" instead of current intraday observation.
+- Quote timestamp, source, cache, and stale state are not yet unified into a phase context.
+- Lunch break, near-close, and forced non-trading-day runs are not yet explicit in prompts or report structure.
+
+P0 does not connect this baseline to pipeline / Agent / API / Web / Bot, does not change report schemas, does not change alert technical-indicator partial-bar handling, and does not add configuration keys.
+
 ---
 
 ## Notification Channel Configuration

--- a/src/core/trading_calendar.py
+++ b/src/core/trading_calendar.py
@@ -1,21 +1,25 @@
 # -*- coding: utf-8 -*-
 """
 ===================================
-交易日历模块 (Issue #373)
+交易日历模块 (Issue #373 / Issue #1386 P0)
 ===================================
 
 职责：
 1. 按市场（A股/港股/美股）判断当日是否为交易日
 2. 按市场时区取“今日”日期，避免服务器 UTC 导致日期错误
 3. 支持 per-stock 过滤：只分析当日开市市场的股票
+4. 提供 regular-session 市场阶段推断基线，不改变现有分析入口行为
 
-依赖：exchange-calendars（可选，不可用时 fail-open）
+依赖：exchange-calendars（可选，交易日判断不可用时 fail-open，阶段推断不可用时 unknown）
 """
 
 import logging
-from datetime import date, datetime
-from typing import Optional, Set
+from datetime import date, datetime, timedelta
+from enum import Enum
+from typing import Any, Optional, Set
 from zoneinfo import ZoneInfo
+
+import pandas as pd
 
 logger = logging.getLogger(__name__)
 
@@ -39,6 +43,23 @@ MARKET_TIMEZONE = {
     "hk": "Asia/Hong_Kong",
     "us": "America/New_York",
 }
+
+# P0 market phase baseline (Issue #1386). This is an intentionally small
+# regular-session inference layer; it does not change existing fail-open
+# trading-day filtering or effective-date behavior.
+_CLOSING_AUCTION_WINDOW_MINUTES = {"cn": 3, "hk": 10, "us": 5}
+
+
+class MarketPhase(str, Enum):
+    """Regular-session market phase labels for Issue #1386 P0."""
+
+    PREMARKET = "premarket"
+    INTRADAY = "intraday"
+    LUNCH_BREAK = "lunch_break"
+    CLOSING_AUCTION = "closing_auction"
+    POSTMARKET = "postmarket"
+    NON_TRADING = "non_trading"
+    UNKNOWN = "unknown"
 
 
 def get_market_for_stock(code: str) -> Optional[str]:
@@ -162,6 +183,113 @@ def get_effective_trading_date(
     except Exception as e:
         logger.warning("trading_calendar.get_effective_trading_date fail-open: %s", e)
         return fallback_date
+
+
+def _as_market_datetime(value: Any, tz_name: str) -> Optional[datetime]:
+    """
+    Convert exchange-calendar timestamps into market-local datetimes.
+
+    Returns None for missing or pandas NaT-like values. Naive datetimes are
+    interpreted as already expressed in the target market timezone, matching
+    get_market_now()'s current_time contract.
+    """
+    if value is None:
+        return None
+    if pd.isna(value):
+        return None
+
+    try:
+        if isinstance(value, pd.Timestamp):
+            if value.tzinfo is None:
+                dt = value.to_pydatetime()
+            else:
+                dt = value.tz_convert(tz_name).to_pydatetime()
+        elif isinstance(value, datetime):
+            dt = value
+        elif hasattr(value, "to_pydatetime"):
+            dt = value.to_pydatetime()
+        else:
+            return None
+    except (AttributeError, TypeError, ValueError):
+        return None
+
+    tz = ZoneInfo(tz_name)
+    if dt.tzinfo is None:
+        return dt.replace(tzinfo=tz)
+    return dt.astimezone(tz)
+
+
+def infer_market_phase(
+    market: Optional[str], current_time: Optional[datetime] = None
+) -> MarketPhase:
+    """
+    Infer the regular-session market phase for a market.
+
+    This P0 helper is intentionally fail-closed: unknown markets, unavailable
+    exchange calendars, and calendar errors return ``MarketPhase.UNKNOWN``.
+    That differs from ``is_market_open()`` and ``get_effective_trading_date()``,
+    which keep their existing fail-open behavior for backwards compatibility.
+
+    ``premarket`` and ``postmarket`` mean before/after the regular trading
+    session only; they do not imply that extended-hours quote data is available.
+    ``closing_auction`` uses a small per-market near-close heuristic window and
+    does not model full exchange auction microstructure.
+    """
+    if market not in MARKET_EXCHANGE or market not in MARKET_TIMEZONE:
+        return MarketPhase.UNKNOWN
+    if not _XCALS_AVAILABLE:
+        return MarketPhase.UNKNOWN
+
+    ex = MARKET_EXCHANGE[market]
+    tz_name = MARKET_TIMEZONE[market]
+    market_now = get_market_now(market, current_time=current_time)
+    local_date = market_now.date()
+
+    try:
+        cal = xcals.get_calendar(ex)
+        if not cal.is_session(local_date):
+            return MarketPhase.NON_TRADING
+
+        session = cal.date_to_session(local_date, direction="previous")
+        session_open = _as_market_datetime(cal.session_open(session), tz_name)
+        session_close = _as_market_datetime(cal.session_close(session), tz_name)
+        if session_open is None or session_close is None:
+            return MarketPhase.UNKNOWN
+
+        if market_now < session_open:
+            return MarketPhase.PREMARKET
+        if market_now >= session_close:
+            return MarketPhase.POSTMARKET
+
+        # Calendars without session_has_break may still expose break timestamps.
+        has_break = True
+        if hasattr(cal, "session_has_break"):
+            has_break = bool(cal.session_has_break(session))
+
+        break_start = None
+        break_end = None
+        if has_break:
+            break_start = _as_market_datetime(cal.session_break_start(session), tz_name)
+            break_end = _as_market_datetime(cal.session_break_end(session), tz_name)
+
+        window_minutes = _CLOSING_AUCTION_WINDOW_MINUTES.get(market, 0)
+        closing_window_start = session_close - timedelta(minutes=window_minutes)
+
+        if break_start is not None and break_end is not None:
+            if market_now < break_start:
+                return MarketPhase.INTRADAY
+            if market_now < break_end:
+                return MarketPhase.LUNCH_BREAK
+            if market_now < closing_window_start:
+                return MarketPhase.INTRADAY
+            return MarketPhase.CLOSING_AUCTION
+
+        if market_now < closing_window_start:
+            return MarketPhase.INTRADAY
+        return MarketPhase.CLOSING_AUCTION
+    except Exception as e:
+        logger.warning("trading_calendar.infer_market_phase fail-closed: %s", e)
+        return MarketPhase.UNKNOWN
 
 
 def get_open_markets_today() -> Set[str]:

--- a/tests/test_trading_calendar.py
+++ b/tests/test_trading_calendar.py
@@ -3,6 +3,7 @@
 
 from datetime import date, datetime, time, timezone
 from types import SimpleNamespace
+from typing import Optional
 import unittest
 from unittest.mock import patch
 from zoneinfo import ZoneInfo
@@ -13,10 +14,21 @@ from src.core import trading_calendar
 
 
 class _FakeCalendar:
-    def __init__(self, sessions, close_hour: int, tz_name: str):
+    def __init__(
+        self,
+        sessions,
+        close_hour: int,
+        tz_name: str,
+        open_time: time = time(9, 30),
+        break_start: Optional[time] = None,
+        break_end: Optional[time] = None,
+    ):
         self._sessions = sorted(sessions)
         self._close_hour = close_hour
         self._tz_name = tz_name
+        self._open_time = open_time
+        self._break_start = break_start
+        self._break_end = break_end
 
     def is_session(self, check_date: date) -> bool:
         return check_date in self._sessions
@@ -40,6 +52,37 @@ class _FakeCalendar:
             raise ValueError("no previous session")
         return pd.Timestamp(self._sessions[index - 1])
 
+    def session_open(self, session: pd.Timestamp) -> pd.Timestamp:
+        local_open = datetime.combine(
+            session.date(),
+            self._open_time,
+            tzinfo=ZoneInfo(self._tz_name),
+        )
+        return pd.Timestamp(local_open).tz_convert("UTC")
+
+    def session_break_start(self, session: pd.Timestamp) -> pd.Timestamp:
+        if self._break_start is None:
+            return pd.NaT
+        local_break_start = datetime.combine(
+            session.date(),
+            self._break_start,
+            tzinfo=ZoneInfo(self._tz_name),
+        )
+        return pd.Timestamp(local_break_start).tz_convert("UTC")
+
+    def session_break_end(self, session: pd.Timestamp) -> pd.Timestamp:
+        if self._break_end is None:
+            return pd.NaT
+        local_break_end = datetime.combine(
+            session.date(),
+            self._break_end,
+            tzinfo=ZoneInfo(self._tz_name),
+        )
+        return pd.Timestamp(local_break_end).tz_convert("UTC")
+
+    def session_has_break(self, session: pd.Timestamp) -> bool:
+        return self._break_start is not None and self._break_end is not None
+
     def session_close(self, session: pd.Timestamp) -> pd.Timestamp:
         local_close = datetime.combine(
             session.date(),
@@ -47,6 +90,28 @@ class _FakeCalendar:
             tzinfo=ZoneInfo(self._tz_name),
         )
         return pd.Timestamp(local_close).tz_convert("UTC")
+
+
+def _calendar_namespace(fake_calendar: _FakeCalendar) -> SimpleNamespace:
+    return SimpleNamespace(get_calendar=lambda _ex: fake_calendar)
+
+
+class _InvalidOpenCalendar(_FakeCalendar):
+    def session_open(self, session: pd.Timestamp):
+        return object()
+
+
+class _BreakProbeFailureCalendar(_FakeCalendar):
+    def session_has_break(self, session: pd.Timestamp) -> bool:
+        raise RuntimeError("break metadata failed")
+
+
+class _NaiveTimestampCalendar(_FakeCalendar):
+    def session_open(self, session: pd.Timestamp) -> pd.Timestamp:
+        return pd.Timestamp(datetime.combine(session.date(), self._open_time))
+
+    def session_close(self, session: pd.Timestamp) -> pd.Timestamp:
+        return pd.Timestamp(datetime.combine(session.date(), time(self._close_hour, 0)))
 
 
 class EffectiveTradingDateTestCase(unittest.TestCase):
@@ -166,6 +231,242 @@ class EffectiveTradingDateTestCase(unittest.TestCase):
             result = trading_calendar.get_effective_trading_date("hk", current_time=current_time)
 
         self.assertEqual(result, date(2026, 3, 28))
+
+
+class InferMarketPhaseTestCase(unittest.TestCase):
+    """Tests for the Issue #1386 P0 market phase baseline."""
+
+    def _infer_with_calendar(
+        self,
+        market: str,
+        current_time: datetime,
+        fake_calendar: _FakeCalendar,
+    ) -> trading_calendar.MarketPhase:
+        with patch.object(trading_calendar, "_XCALS_AVAILABLE", True), patch.object(
+            trading_calendar,
+            "xcals",
+            _calendar_namespace(fake_calendar),
+            create=True,
+        ):
+            return trading_calendar.infer_market_phase(market, current_time=current_time)
+
+    def test_cn_phase_boundaries_include_lunch_and_closing_window(self):
+        fake_calendar = _FakeCalendar(
+            sessions=[date(2026, 3, 27)],
+            close_hour=15,
+            tz_name="Asia/Shanghai",
+            open_time=time(9, 30),
+            break_start=time(11, 30),
+            break_end=time(13, 0),
+        )
+
+        cases = (
+            (datetime(2026, 3, 27, 9, 29, tzinfo=ZoneInfo("Asia/Shanghai")), trading_calendar.MarketPhase.PREMARKET),
+            (datetime(2026, 3, 27, 9, 30, tzinfo=ZoneInfo("Asia/Shanghai")), trading_calendar.MarketPhase.INTRADAY),
+            (datetime(2026, 3, 27, 11, 29, tzinfo=ZoneInfo("Asia/Shanghai")), trading_calendar.MarketPhase.INTRADAY),
+            (
+                datetime(2026, 3, 27, 11, 30, tzinfo=ZoneInfo("Asia/Shanghai")),
+                trading_calendar.MarketPhase.LUNCH_BREAK,
+            ),
+            (
+                datetime(2026, 3, 27, 12, 59, tzinfo=ZoneInfo("Asia/Shanghai")),
+                trading_calendar.MarketPhase.LUNCH_BREAK,
+            ),
+            (datetime(2026, 3, 27, 13, 0, tzinfo=ZoneInfo("Asia/Shanghai")), trading_calendar.MarketPhase.INTRADAY),
+            (datetime(2026, 3, 27, 14, 56, tzinfo=ZoneInfo("Asia/Shanghai")), trading_calendar.MarketPhase.INTRADAY),
+            (
+                datetime(2026, 3, 27, 14, 57, tzinfo=ZoneInfo("Asia/Shanghai")),
+                trading_calendar.MarketPhase.CLOSING_AUCTION,
+            ),
+            (
+                datetime(2026, 3, 27, 15, 0, tzinfo=ZoneInfo("Asia/Shanghai")),
+                trading_calendar.MarketPhase.POSTMARKET,
+            ),
+            (
+                datetime(2026, 3, 27, 15, 1, tzinfo=ZoneInfo("Asia/Shanghai")),
+                trading_calendar.MarketPhase.POSTMARKET,
+            ),
+        )
+
+        for current_time, expected in cases:
+            with self.subTest(current_time=current_time):
+                self.assertEqual(self._infer_with_calendar("cn", current_time, fake_calendar), expected)
+
+    def test_cn_non_trading_day_returns_non_trading(self):
+        fake_calendar = _FakeCalendar(
+            sessions=[date(2026, 3, 27)],
+            close_hour=15,
+            tz_name="Asia/Shanghai",
+            break_start=time(11, 30),
+            break_end=time(13, 0),
+        )
+        current_time = datetime(2026, 3, 28, 10, 0, tzinfo=ZoneInfo("Asia/Shanghai"))
+
+        result = self._infer_with_calendar("cn", current_time, fake_calendar)
+
+        self.assertEqual(result, trading_calendar.MarketPhase.NON_TRADING)
+
+    def test_hk_phase_boundaries_include_lunch_and_ten_minute_closing_window(self):
+        fake_calendar = _FakeCalendar(
+            sessions=[date(2026, 3, 27)],
+            close_hour=16,
+            tz_name="Asia/Hong_Kong",
+            open_time=time(9, 30),
+            break_start=time(12, 0),
+            break_end=time(13, 0),
+        )
+
+        cases = (
+            (
+                datetime(2026, 3, 27, 12, 0, tzinfo=ZoneInfo("Asia/Hong_Kong")),
+                trading_calendar.MarketPhase.LUNCH_BREAK,
+            ),
+            (
+                datetime(2026, 3, 27, 13, 0, tzinfo=ZoneInfo("Asia/Hong_Kong")),
+                trading_calendar.MarketPhase.INTRADAY,
+            ),
+            (
+                datetime(2026, 3, 27, 15, 49, tzinfo=ZoneInfo("Asia/Hong_Kong")),
+                trading_calendar.MarketPhase.INTRADAY,
+            ),
+            (
+                datetime(2026, 3, 27, 15, 50, tzinfo=ZoneInfo("Asia/Hong_Kong")),
+                trading_calendar.MarketPhase.CLOSING_AUCTION,
+            ),
+            (
+                datetime(2026, 3, 27, 16, 0, tzinfo=ZoneInfo("Asia/Hong_Kong")),
+                trading_calendar.MarketPhase.POSTMARKET,
+            ),
+        )
+
+        for current_time, expected in cases:
+            with self.subTest(current_time=current_time):
+                self.assertEqual(self._infer_with_calendar("hk", current_time, fake_calendar), expected)
+
+    def test_us_phase_boundaries_skip_nat_lunch_break(self):
+        fake_calendar = _FakeCalendar(
+            sessions=[date(2026, 3, 27)],
+            close_hour=16,
+            tz_name="America/New_York",
+            open_time=time(9, 30),
+            break_start=None,
+            break_end=None,
+        )
+
+        cases = (
+            (
+                datetime(2026, 3, 27, 9, 29, tzinfo=ZoneInfo("America/New_York")),
+                trading_calendar.MarketPhase.PREMARKET,
+            ),
+            (
+                datetime(2026, 3, 27, 9, 30, tzinfo=ZoneInfo("America/New_York")),
+                trading_calendar.MarketPhase.INTRADAY,
+            ),
+            (
+                datetime(2026, 3, 27, 12, 0, tzinfo=ZoneInfo("America/New_York")),
+                trading_calendar.MarketPhase.INTRADAY,
+            ),
+            (
+                datetime(2026, 3, 27, 15, 54, tzinfo=ZoneInfo("America/New_York")),
+                trading_calendar.MarketPhase.INTRADAY,
+            ),
+            (
+                datetime(2026, 3, 27, 15, 55, tzinfo=ZoneInfo("America/New_York")),
+                trading_calendar.MarketPhase.CLOSING_AUCTION,
+            ),
+            (
+                datetime(2026, 3, 27, 16, 0, tzinfo=ZoneInfo("America/New_York")),
+                trading_calendar.MarketPhase.POSTMARKET,
+            ),
+        )
+
+        for current_time, expected in cases:
+            with self.subTest(current_time=current_time):
+                self.assertEqual(self._infer_with_calendar("us", current_time, fake_calendar), expected)
+
+    def test_unknown_market_and_calendar_failures_return_unknown(self):
+        current_time = datetime(2026, 3, 27, 10, 0, tzinfo=ZoneInfo("Asia/Shanghai"))
+
+        self.assertEqual(
+            trading_calendar.infer_market_phase(None, current_time=current_time),
+            trading_calendar.MarketPhase.UNKNOWN,
+        )
+        self.assertEqual(
+            trading_calendar.infer_market_phase("", current_time=current_time),
+            trading_calendar.MarketPhase.UNKNOWN,
+        )
+        self.assertEqual(
+            trading_calendar.infer_market_phase("invalid", current_time=current_time),
+            trading_calendar.MarketPhase.UNKNOWN,
+        )
+        with patch.object(trading_calendar, "_XCALS_AVAILABLE", False):
+            self.assertEqual(
+                trading_calendar.infer_market_phase("cn", current_time=current_time),
+                trading_calendar.MarketPhase.UNKNOWN,
+            )
+        with patch.object(trading_calendar, "_XCALS_AVAILABLE", True), patch.object(
+            trading_calendar,
+            "xcals",
+            SimpleNamespace(get_calendar=lambda _ex: (_ for _ in ()).throw(RuntimeError("boom"))),
+            create=True,
+        ):
+            self.assertEqual(
+                trading_calendar.infer_market_phase("cn", current_time=current_time),
+                trading_calendar.MarketPhase.UNKNOWN,
+            )
+
+    def test_invalid_session_open_returns_unknown(self):
+        fake_calendar = _InvalidOpenCalendar(
+            sessions=[date(2026, 3, 27)],
+            close_hour=15,
+            tz_name="Asia/Shanghai",
+        )
+        current_time = datetime(2026, 3, 27, 10, 0, tzinfo=ZoneInfo("Asia/Shanghai"))
+
+        result = self._infer_with_calendar("cn", current_time, fake_calendar)
+
+        self.assertEqual(result, trading_calendar.MarketPhase.UNKNOWN)
+
+    def test_break_probe_failure_returns_unknown(self):
+        fake_calendar = _BreakProbeFailureCalendar(
+            sessions=[date(2026, 3, 27)],
+            close_hour=15,
+            tz_name="Asia/Shanghai",
+            break_start=time(11, 30),
+            break_end=time(13, 0),
+        )
+        current_time = datetime(2026, 3, 27, 12, 0, tzinfo=ZoneInfo("Asia/Shanghai"))
+
+        result = self._infer_with_calendar("cn", current_time, fake_calendar)
+
+        self.assertEqual(result, trading_calendar.MarketPhase.UNKNOWN)
+
+    def test_naive_current_time_is_interpreted_as_market_local_time(self):
+        fake_calendar = _FakeCalendar(
+            sessions=[date(2026, 3, 27)],
+            close_hour=15,
+            tz_name="Asia/Shanghai",
+            open_time=time(9, 30),
+            break_start=time(11, 30),
+            break_end=time(13, 0),
+        )
+
+        result = self._infer_with_calendar("cn", datetime(2026, 3, 27, 9, 29), fake_calendar)
+
+        self.assertEqual(result, trading_calendar.MarketPhase.PREMARKET)
+
+    def test_naive_calendar_timestamps_are_interpreted_as_market_local_time(self):
+        fake_calendar = _NaiveTimestampCalendar(
+            sessions=[date(2026, 3, 27)],
+            close_hour=15,
+            tz_name="Asia/Shanghai",
+            open_time=time(9, 30),
+        )
+        current_time = datetime(2026, 3, 27, 9, 30, tzinfo=ZoneInfo("Asia/Shanghai"))
+
+        result = self._infer_with_calendar("cn", current_time, fake_calendar)
+
+        self.assertEqual(result, trading_calendar.MarketPhase.INTRADAY)
 
 
 class ComputeEffectiveRegionTestCase(unittest.TestCase):


### PR DESCRIPTION
## PR Type

- [ ] fix
- [x] feat
- [ ] refactor
- [x] docs
- [ ] chore
- [x] test

## Background And Problem

Refs #1386

当前 #1386 需要先落地 P0：明确盘前、盘中、午休、临近收盘、盘后、非交易日等阶段语义，并建立一个最小、可测试的市场阶段推断基线。现有分析入口仍以盘后复盘语义运行为主，P0 不改变默认行为，只为后续 P1+ 的阶段上下文、Prompt 分层和入口展示打基础。

## Scope Of Change

- 在 `src/core/trading_calendar.py` 新增 `MarketPhase` 七值枚举和 `infer_market_phase()`，按 A 股、港股、美股 regular session 推断阶段。
- 阶段推断使用 `exchange-calendars` 的交易日、开盘、收盘和午休信息；日历不可用、未知市场或异常时 fail-closed 返回 `unknown`。
- 明确 `infer_market_phase()` 与现有 `is_market_open()` / `get_effective_trading_date()` 的 fail-open 行为不同，P0 不改变既有交易日跳过或断点续传逻辑。
- 扩展 `tests/test_trading_calendar.py`，覆盖 CN/HK/US 边界、无午休市场、非交易日、unknown、calendar failure、naive time 和异常路径。
- 更新 `docs/full-guide.md` 与 `docs/full-guide_EN.md`，同步 P0 阶段定义、入口现状、跨市场混合行为、已知问题和非目标。
- 更新 `docs/alerts.md`，说明告警 technical indicator partial bar 仍未接入市场阶段精确判断。
- 更新 `docs/CHANGELOG.md` 的 `[Unreleased]` 扁平条目。

未改动 README；无 API、Web、schema、config、workflow、Docker 或 `.env.example` 变更。

## Issue Link

Refs #1386

## Verification Commands And Results

```bash
python -m py_compile src/core/trading_calendar.py
python -m pytest tests/test_trading_calendar.py -q
python -m pytest tests/test_alerts_docs.py -q
git diff --check origin/main...HEAD
PATH=/private/tmp/dsa-ci-bin:$PATH ./scripts/ci_gate.sh
```

关键输出/结论：

- `tests/test_trading_calendar.py`：23 passed
- `tests/test_alerts_docs.py`：14 passed
- `./scripts/ci_gate.sh`：2202 passed, 2 deselected, 7 warnings, 201 subtests passed
- `git diff --check origin/main...HEAD`：通过

## Compatibility And Risk

- 兼容性影响：无默认行为变化。新增函数目前不接入普通分析、Agent、Prompt、API、Web、Bot、历史 schema、任务状态或调度默认行为。
- 配置影响：无新增配置项，不更新 `.env.example`。
- 数据影响：无数据库迁移、无数据回填、无用户数据变更。
- 风险点：`closing_auction` 是 P0 启发式近收盘窗口，不是完整交易所竞价制度；`premarket` / `postmarket` 只表示 regular session 前后，不代表已获取扩展时段行情。

## Rollback Plan

Revert this PR 即可回滚；不需要额外配置回滚、数据库迁移或用户数据处理。

## EXTRACT_PROMPT Change (if applicable)

不适用。本 PR 未修改 `src/services/image_stock_extractor.py` 或 `EXTRACT_PROMPT`。

<details>
<summary>展开 / Expand: Full EXTRACT_PROMPT</summary>

```
N/A
```

</details>

## Checklist

- [x] 本 PR 有明确动机和业务价值 / This PR has a clear motivation and value
- [x] 已提供可复现的验证命令与结果 / Reproducible verification commands and results are included
- [x] 已评估兼容性与风险 / Compatibility and risk have been assessed
- [x] 已提供回滚方案 / A rollback plan is provided
- [x] 若涉及用户可见变更，已同步更新相关文档与 `docs/CHANGELOG.md`；`README.md` 仅在首页级信息变化时更新，细节优先写入 `docs/*.md` / If user-visible changes are included, relevant docs and `docs/CHANGELOG.md` are updated; `README.md` is updated only for homepage-level changes, with details kept in `docs/*.md`
