### PR TITLE
chore: lazy load report markdown drawer #1411 PR-2

### DIFF
--- a/apps/dsa-web/src/components/report/ReportMarkdown.tsx
+++ b/apps/dsa-web/src/components/report/ReportMarkdown.tsx
@@ -1,15 +1,10 @@
 import type React from 'react';
-import { useEffect, useState, useCallback } from 'react';
-import Markdown from 'react-markdown';
-import remarkGfm from 'remark-gfm';
-import { historyApi } from '../../api/history';
-import { Drawer } from '../common/Drawer';
-import { Tooltip } from '../common/Tooltip';
-import { getReportText, normalizeReportLanguage } from '../../utils/reportLanguage';
+import { useCallback, useState } from 'react';
 import type { ReportLanguage } from '../../types/analysis';
-import { markdownToPlainText } from '../../utils/markdown';
+import { Drawer } from '../common/Drawer';
+import { ReportMarkdownPanel } from './ReportMarkdownPanel';
 
-interface ReportMarkdownProps {
+export interface ReportMarkdownProps {
   recordId: number;
   stockName: string;
   stockCode: string;
@@ -18,8 +13,8 @@ interface ReportMarkdownProps {
 }
 
 /**
- * Markdown report drawer component
- * Uses common Drawer component to display full Markdown format analysis report
+ * Compatibility wrapper for direct ReportMarkdown usage.
+ * HomePage uses ReportMarkdownDrawer to lazy-load the panel.
  */
 export const ReportMarkdown: React.FC<ReportMarkdownProps> = ({
   recordId,
@@ -28,74 +23,12 @@ export const ReportMarkdown: React.FC<ReportMarkdownProps> = ({
   onClose,
   reportLanguage = 'zh',
 }) => {
-  const text = getReportText(normalizeReportLanguage(reportLanguage));
-  const loadReportFailedText = text.loadReportFailed;
-  const [content, setContent] = useState<string>('');
-  const [isLoading, setIsLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
   const [isOpen, setIsOpen] = useState(true);
-  const [copiedType, setCopiedType] = useState<'markdown' | 'text' | null>(null);
 
-  // Handle close with animation
   const handleClose = useCallback(() => {
     setIsOpen(false);
-    // Delay actual close to allow animation to complete
     setTimeout(onClose, 300);
   }, [onClose]);
-
-  // Handle copy markdown source
-  const handleCopyMarkdown = useCallback(async () => {
-    if (!content) return;
-    try {
-      await navigator.clipboard.writeText(content);
-      setCopiedType('markdown');
-      setTimeout(() => setCopiedType(null), 2000);
-    } catch (error) {
-      console.error('Copy failed:', error);
-    }
-  }, [content]);
-
-  // Handle copy plain text
-  const handleCopyPlainText = useCallback(async () => {
-    if (!content) return;
-    try {
-      const plainText = markdownToPlainText(content);
-      await navigator.clipboard.writeText(plainText);
-      setCopiedType('text');
-      setTimeout(() => setCopiedType(null), 2000);
-    } catch (error) {
-      console.error('Copy failed:', error);
-    }
-  }, [content]);
-
-  useEffect(() => {
-    let isMounted = true;
-
-    const fetchMarkdown = async () => {
-      setIsLoading(true);
-      setError(null);
-      try {
-        const markdownContent = await historyApi.getMarkdown(recordId);
-        if (isMounted) {
-          setContent(markdownContent);
-        }
-      } catch (err) {
-        if (isMounted) {
-          setError(err instanceof Error ? err.message : loadReportFailedText);
-        }
-      } finally {
-        if (isMounted) {
-          setIsLoading(false);
-        }
-      }
-    };
-
-    fetchMarkdown();
-
-    return () => {
-      isMounted = false;
-    };
-  }, [recordId, loadReportFailedText]);
 
   return (
     <Drawer
@@ -105,128 +38,13 @@ export const ReportMarkdown: React.FC<ReportMarkdownProps> = ({
       zIndex={100}
       backdropClassName="bg-background/56 backdrop-blur-[2px]"
     >
-      {/* Custom Header */}
-      <div className="flex items-center justify-between gap-3 mb-4">
-        {/* Left: Icon + Title */}
-        <div className="flex items-center gap-3 flex-1">
-          <div className="flex h-8 w-8 items-center justify-center rounded-lg bg-[var(--home-action-report-bg)] text-[var(--home-action-report-text)]">
-            <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
-            </svg>
-          </div>
-          <div>
-            <h2 className="text-base font-semibold text-foreground">{stockName || stockCode}</h2>
-            <p className="text-xs text-muted-text">{text.fullReport}</p>
-          </div>
-        </div>
-
-        {/* Right: Toolbar */}
-        <div className="flex items-center gap-2">
-          {/* Copy Markdown button */}
-          <Tooltip content={text.copyMarkdownSource}>
-            <span className="inline-flex">
-              <button
-                type="button"
-                onClick={handleCopyMarkdown}
-                disabled={isLoading || !content || copiedType !== null}
-                className="home-surface-button flex h-10 w-10 items-center justify-center rounded-lg text-secondary-text hover:text-foreground disabled:opacity-50"
-                aria-label={text.copyMarkdownSource}
-              >
-                {copiedType === 'markdown' ? (
-                  <svg className="h-6 w-6 text-success" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
-                  </svg>
-                ) : (
-                  <svg className="h-6 w-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10 20l4-16m4 4l4 4-4 4M6 16l-4-4 4-4" />
-                  </svg>
-                )}
-              </button>
-            </span>
-          </Tooltip>
-
-          {/* Copy plain text button */}
-          <Tooltip content={text.copyPlainText}>
-            <span className="inline-flex">
-              <button
-                type="button"
-                onClick={handleCopyPlainText}
-                disabled={isLoading || !content || copiedType !== null}
-                className="home-surface-button flex h-10 w-10 items-center justify-center rounded-lg text-secondary-text hover:text-foreground disabled:opacity-50"
-                aria-label={text.copyPlainText}
-              >
-                {copiedType === 'text' ? (
-                  <svg className="h-6 w-6 text-success" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
-                  </svg>
-                ) : (
-                  <svg className="h-6 w-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
-                  </svg>
-                )}
-              </button>
-            </span>
-          </Tooltip>
-        </div>
-      </div>
-
-      {/* Content */}
-      {isLoading ? (
-        <div className="flex flex-col items-center justify-center h-64">
-          <div className="home-spinner h-10 w-10 animate-spin border-[3px]" />
-          <p className="mt-4 text-secondary-text text-sm">{text.loadingReport}</p>
-        </div>
-      ) : error ? (
-        <div className="flex flex-col items-center justify-center h-64">
-          <div className="w-12 h-12 rounded-xl bg-danger/10 flex items-center justify-center mb-3">
-            <svg className="w-6 h-6 text-danger" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
-            </svg>
-          </div>
-          <p className="text-danger text-sm">{error}</p>
-          <button
-            type="button"
-            onClick={handleClose}
-            className="home-surface-button mt-4 rounded-lg px-4 py-2 text-sm text-secondary-text"
-          >
-            {text.dismiss}
-          </button>
-        </div>
-      ) : (
-        <div
-          className="home-markdown-prose prose prose-invert prose-sm max-w-none
-            prose-headings:text-foreground prose-headings:font-semibold prose-headings:mt-4 prose-headings:mb-2
-            prose-h1:text-xl
-            prose-h2:text-lg
-            prose-h3:text-base
-            prose-p:leading-relaxed prose-p:mb-3 prose-p:last:mb-0
-            prose-strong:text-foreground prose-strong:font-semibold
-            prose-ul:my-2 prose-ol:my-2 prose-li:my-1
-            prose-code:px-1.5 prose-code:py-0.5 prose-code:rounded prose-code:before:content-none prose-code:after:content-none
-            prose-pre:border
-            prose-table:border-collapse
-            prose-hr:my-4
-            prose-a:no-underline hover:prose-a:underline
-            prose-blockquote:text-secondary-text
-            whitespace-pre-line break-words
-          "
-        >
-          <Markdown remarkPlugins={[remarkGfm]}>
-            {content}
-          </Markdown>
-        </div>
-      )}
-
-      {/* Footer */}
-      <div className="home-divider mt-6 flex justify-end border-t pt-4">
-        <button
-          type="button"
-          onClick={handleClose}
-          className="home-surface-button rounded-lg px-4 py-2 text-sm text-secondary-text hover:text-foreground"
-        >
-          {text.dismiss}
-        </button>
-      </div>
+      <ReportMarkdownPanel
+        recordId={recordId}
+        stockName={stockName}
+        stockCode={stockCode}
+        reportLanguage={reportLanguage}
+        onRequestClose={handleClose}
+      />
     </Drawer>
   );
 };

--- a/apps/dsa-web/src/components/report/ReportMarkdownDrawer.tsx
+++ b/apps/dsa-web/src/components/report/ReportMarkdownDrawer.tsx
@@ -1,12 +1,8 @@
 import type React from 'react';
-import { Component, lazy, Suspense, useCallback, useState } from 'react';
+import { Component, lazy, Suspense, useCallback, useMemo, useState } from 'react';
 import type { ReportLanguage } from '../../types/analysis';
 import { getReportText, normalizeReportLanguage } from '../../utils/reportLanguage';
 import { Drawer } from '../common/Drawer';
-
-const LazyReportMarkdownPanel = lazy(() =>
-  import('./ReportMarkdownPanel').then((m) => ({ default: m.ReportMarkdownPanel })),
-);
 
 interface ReportMarkdownDrawerProps {
   recordId: number;
@@ -95,6 +91,10 @@ export const ReportMarkdownDrawer: React.FC<ReportMarkdownDrawerProps> = ({
 }) => {
   const [isOpen, setIsOpen] = useState(true);
   const text = getReportText(normalizeReportLanguage(reportLanguage));
+  const LazyReportMarkdownPanel = useMemo(
+    () => lazy(() => import('./ReportMarkdownPanel').then((m) => ({ default: m.ReportMarkdownPanel }))),
+    [],
+  );
 
   const handleClose = useCallback(() => {
     setIsOpen(false);

--- a/apps/dsa-web/src/components/report/ReportMarkdownDrawer.tsx
+++ b/apps/dsa-web/src/components/report/ReportMarkdownDrawer.tsx
@@ -1,0 +1,134 @@
+import type React from 'react';
+import { Component, lazy, Suspense, useCallback, useState } from 'react';
+import type { ReportLanguage } from '../../types/analysis';
+import { getReportText, normalizeReportLanguage } from '../../utils/reportLanguage';
+import { Drawer } from '../common/Drawer';
+
+const LazyReportMarkdownPanel = lazy(() =>
+  import('./ReportMarkdownPanel').then((m) => ({ default: m.ReportMarkdownPanel })),
+);
+
+interface ReportMarkdownDrawerProps {
+  recordId: number;
+  stockName: string;
+  stockCode: string;
+  onClose: () => void;
+  reportLanguage?: ReportLanguage;
+}
+
+interface ReportMarkdownDrawerErrorBoundaryProps {
+  resetKey: number;
+  fallback: React.ReactNode;
+  children: React.ReactNode;
+}
+
+interface ReportMarkdownDrawerErrorBoundaryState {
+  hasError: boolean;
+}
+
+class ReportMarkdownDrawerErrorBoundary extends Component<
+  ReportMarkdownDrawerErrorBoundaryProps,
+  ReportMarkdownDrawerErrorBoundaryState
+> {
+  state: ReportMarkdownDrawerErrorBoundaryState = {
+    hasError: false,
+  };
+
+  static getDerivedStateFromError(): ReportMarkdownDrawerErrorBoundaryState {
+    return { hasError: true };
+  }
+
+  componentDidUpdate(prevProps: ReportMarkdownDrawerErrorBoundaryProps) {
+    if (prevProps.resetKey !== this.props.resetKey && this.state.hasError) {
+      this.setState({ hasError: false });
+    }
+  }
+
+  componentDidCatch(error: unknown) {
+    console.error('Report markdown drawer failed:', error);
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return this.props.fallback;
+    }
+
+    return this.props.children;
+  }
+}
+
+const ReportMarkdownLoadingState: React.FC<{ message: string }> = ({ message }) => (
+  <div className="flex h-64 flex-col items-center justify-center">
+    <div className="home-spinner h-10 w-10 animate-spin border-[3px]" />
+    <p className="mt-4 text-sm text-secondary-text">{message}</p>
+  </div>
+);
+
+const ReportMarkdownChunkErrorState: React.FC<{
+  message: string;
+  dismissText: string;
+  onRequestClose: () => void;
+}> = ({ message, dismissText, onRequestClose }) => (
+  <div className="flex h-64 flex-col items-center justify-center">
+    <div className="mb-3 flex h-12 w-12 items-center justify-center rounded-xl bg-danger/10">
+      <svg className="h-6 w-6 text-danger" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
+      </svg>
+    </div>
+    <p className="text-sm text-danger">{message}</p>
+    <button
+      type="button"
+      onClick={onRequestClose}
+      className="home-surface-button mt-4 rounded-lg px-4 py-2 text-sm text-secondary-text"
+    >
+      {dismissText}
+    </button>
+  </div>
+);
+
+export const ReportMarkdownDrawer: React.FC<ReportMarkdownDrawerProps> = ({
+  recordId,
+  stockName,
+  stockCode,
+  onClose,
+  reportLanguage = 'zh',
+}) => {
+  const [isOpen, setIsOpen] = useState(true);
+  const text = getReportText(normalizeReportLanguage(reportLanguage));
+
+  const handleClose = useCallback(() => {
+    setIsOpen(false);
+    setTimeout(onClose, 300);
+  }, [onClose]);
+
+  return (
+    <Drawer
+      isOpen={isOpen}
+      onClose={handleClose}
+      width="max-w-3xl"
+      zIndex={100}
+      backdropClassName="bg-background/56 backdrop-blur-[2px]"
+    >
+      <ReportMarkdownDrawerErrorBoundary
+        resetKey={recordId}
+        fallback={(
+          <ReportMarkdownChunkErrorState
+            message={text.loadReportFailed}
+            dismissText={text.dismiss}
+            onRequestClose={handleClose}
+          />
+        )}
+      >
+        <Suspense fallback={<ReportMarkdownLoadingState message={text.loadingReport} />}>
+          <LazyReportMarkdownPanel
+            recordId={recordId}
+            stockName={stockName}
+            stockCode={stockCode}
+            reportLanguage={reportLanguage}
+            onRequestClose={handleClose}
+          />
+        </Suspense>
+      </ReportMarkdownDrawerErrorBoundary>
+    </Drawer>
+  );
+};

--- a/apps/dsa-web/src/components/report/ReportMarkdownPanel.tsx
+++ b/apps/dsa-web/src/components/report/ReportMarkdownPanel.tsx
@@ -1,0 +1,204 @@
+import type React from 'react';
+import { useCallback, useEffect, useState } from 'react';
+import Markdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
+import { historyApi } from '../../api/history';
+import type { ReportLanguage } from '../../types/analysis';
+import { markdownToPlainText } from '../../utils/markdown';
+import { getReportText, normalizeReportLanguage } from '../../utils/reportLanguage';
+import { Tooltip } from '../common/Tooltip';
+
+export interface ReportMarkdownPanelProps {
+  recordId: number;
+  stockName: string;
+  stockCode: string;
+  onRequestClose: () => void;
+  reportLanguage?: ReportLanguage;
+}
+
+export const ReportMarkdownPanel: React.FC<ReportMarkdownPanelProps> = ({
+  recordId,
+  stockName,
+  stockCode,
+  onRequestClose,
+  reportLanguage = 'zh',
+}) => {
+  const text = getReportText(normalizeReportLanguage(reportLanguage));
+  const loadReportFailedText = text.loadReportFailed;
+  const [content, setContent] = useState<string>('');
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [copiedType, setCopiedType] = useState<'markdown' | 'text' | null>(null);
+
+  const handleCopyMarkdown = useCallback(async () => {
+    if (!content) return;
+    try {
+      await navigator.clipboard.writeText(content);
+      setCopiedType('markdown');
+      setTimeout(() => setCopiedType(null), 2000);
+    } catch (error) {
+      console.error('Copy failed:', error);
+    }
+  }, [content]);
+
+  const handleCopyPlainText = useCallback(async () => {
+    if (!content) return;
+    try {
+      const plainText = markdownToPlainText(content);
+      await navigator.clipboard.writeText(plainText);
+      setCopiedType('text');
+      setTimeout(() => setCopiedType(null), 2000);
+    } catch (error) {
+      console.error('Copy failed:', error);
+    }
+  }, [content]);
+
+  useEffect(() => {
+    let isMounted = true;
+
+    const fetchMarkdown = async () => {
+      setIsLoading(true);
+      setError(null);
+      try {
+        const markdownContent = await historyApi.getMarkdown(recordId);
+        if (isMounted) {
+          setContent(markdownContent);
+        }
+      } catch (err) {
+        if (isMounted) {
+          setError(err instanceof Error ? err.message : loadReportFailedText);
+        }
+      } finally {
+        if (isMounted) {
+          setIsLoading(false);
+        }
+      }
+    };
+
+    fetchMarkdown();
+
+    return () => {
+      isMounted = false;
+    };
+  }, [recordId, loadReportFailedText]);
+
+  return (
+    <>
+      <div className="mb-4 flex items-center justify-between gap-3">
+        <div className="flex flex-1 items-center gap-3">
+          <div className="flex h-8 w-8 items-center justify-center rounded-lg bg-[var(--home-action-report-bg)] text-[var(--home-action-report-text)]">
+            <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
+            </svg>
+          </div>
+          <div>
+            <h2 className="text-base font-semibold text-foreground">{stockName || stockCode}</h2>
+            <p className="text-xs text-muted-text">{text.fullReport}</p>
+          </div>
+        </div>
+
+        <div className="flex items-center gap-2">
+          <Tooltip content={text.copyMarkdownSource}>
+            <span className="inline-flex">
+              <button
+                type="button"
+                onClick={handleCopyMarkdown}
+                disabled={isLoading || !content || copiedType !== null}
+                className="home-surface-button flex h-10 w-10 items-center justify-center rounded-lg text-secondary-text hover:text-foreground disabled:opacity-50"
+                aria-label={text.copyMarkdownSource}
+              >
+                {copiedType === 'markdown' ? (
+                  <svg className="h-6 w-6 text-success" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
+                  </svg>
+                ) : (
+                  <svg className="h-6 w-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10 20l4-16m4 4l4 4-4 4M6 16l-4-4 4-4" />
+                  </svg>
+                )}
+              </button>
+            </span>
+          </Tooltip>
+
+          <Tooltip content={text.copyPlainText}>
+            <span className="inline-flex">
+              <button
+                type="button"
+                onClick={handleCopyPlainText}
+                disabled={isLoading || !content || copiedType !== null}
+                className="home-surface-button flex h-10 w-10 items-center justify-center rounded-lg text-secondary-text hover:text-foreground disabled:opacity-50"
+                aria-label={text.copyPlainText}
+              >
+                {copiedType === 'text' ? (
+                  <svg className="h-6 w-6 text-success" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
+                  </svg>
+                ) : (
+                  <svg className="h-6 w-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
+                  </svg>
+                )}
+              </button>
+            </span>
+          </Tooltip>
+        </div>
+      </div>
+
+      {isLoading ? (
+        <div className="flex h-64 flex-col items-center justify-center">
+          <div className="home-spinner h-10 w-10 animate-spin border-[3px]" />
+          <p className="mt-4 text-sm text-secondary-text">{text.loadingReport}</p>
+        </div>
+      ) : error ? (
+        <div className="flex h-64 flex-col items-center justify-center">
+          <div className="mb-3 flex h-12 w-12 items-center justify-center rounded-xl bg-danger/10">
+            <svg className="h-6 w-6 text-danger" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
+            </svg>
+          </div>
+          <p className="text-sm text-danger">{error}</p>
+          <button
+            type="button"
+            onClick={onRequestClose}
+            className="home-surface-button mt-4 rounded-lg px-4 py-2 text-sm text-secondary-text"
+          >
+            {text.dismiss}
+          </button>
+        </div>
+      ) : (
+        <div
+          className="home-markdown-prose prose prose-invert prose-sm max-w-none
+            prose-headings:text-foreground prose-headings:font-semibold prose-headings:mt-4 prose-headings:mb-2
+            prose-h1:text-xl
+            prose-h2:text-lg
+            prose-h3:text-base
+            prose-p:leading-relaxed prose-p:mb-3 prose-p:last:mb-0
+            prose-strong:text-foreground prose-strong:font-semibold
+            prose-ul:my-2 prose-ol:my-2 prose-li:my-1
+            prose-code:px-1.5 prose-code:py-0.5 prose-code:rounded prose-code:before:content-none prose-code:after:content-none
+            prose-pre:border
+            prose-table:border-collapse
+            prose-hr:my-4
+            prose-a:no-underline hover:prose-a:underline
+            prose-blockquote:text-secondary-text
+            whitespace-pre-line break-words
+          "
+        >
+          <Markdown remarkPlugins={[remarkGfm]}>
+            {content}
+          </Markdown>
+        </div>
+      )}
+
+      <div className="home-divider mt-6 flex justify-end border-t pt-4">
+        <button
+          type="button"
+          onClick={onRequestClose}
+          className="home-surface-button rounded-lg px-4 py-2 text-sm text-secondary-text hover:text-foreground"
+        >
+          {text.dismiss}
+        </button>
+      </div>
+    </>
+  );
+};

--- a/apps/dsa-web/src/components/report/__tests__/ReportMarkdownDrawer.test.tsx
+++ b/apps/dsa-web/src/components/report/__tests__/ReportMarkdownDrawer.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 const renderDrawer = async (onClose = vi.fn()) => {
@@ -64,6 +64,36 @@ describe('ReportMarkdownDrawer', () => {
 
       expect(screen.getByRole('dialog')).toBeInTheDocument();
       expect(await screen.findByText('加载报告失败')).toBeInTheDocument();
+    } finally {
+      consoleError.mockRestore();
+    }
+  });
+
+  it('retries loading the lazy panel after a rejected import and remount', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    let loadAttempts = 0;
+
+    vi.resetModules();
+    vi.doMock('../ReportMarkdownPanel', () => {
+      loadAttempts += 1;
+      if (loadAttempts === 1) {
+        return Promise.reject(new Error('chunk load failed'));
+      }
+
+      return {
+        ReportMarkdownPanel: () => <h2>Retried report panel</h2>,
+      };
+    });
+
+    try {
+      await renderDrawer();
+
+      expect(await screen.findByText('加载报告失败')).toBeInTheDocument();
+
+      cleanup();
+      await renderDrawer();
+
+      expect(await screen.findByRole('heading', { name: 'Retried report panel' })).toBeInTheDocument();
     } finally {
       consoleError.mockRestore();
     }

--- a/apps/dsa-web/src/components/report/__tests__/ReportMarkdownDrawer.test.tsx
+++ b/apps/dsa-web/src/components/report/__tests__/ReportMarkdownDrawer.test.tsx
@@ -1,0 +1,84 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const renderDrawer = async (onClose = vi.fn()) => {
+  const { ReportMarkdownDrawer } = await import('../ReportMarkdownDrawer');
+
+  render(
+    <ReportMarkdownDrawer
+      recordId={1}
+      stockName="贵州茅台"
+      stockCode="600519"
+      onClose={onClose}
+    />,
+  );
+
+  return onClose;
+};
+
+describe('ReportMarkdownDrawer', () => {
+  afterEach(() => {
+    vi.doUnmock('../ReportMarkdownPanel');
+    vi.doUnmock('../../../api/history');
+    vi.resetModules();
+  });
+
+  it('keeps panel render errors inside the drawer and closes with the drawer handler', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    const onClose = vi.fn();
+
+    vi.resetModules();
+    vi.doMock('../ReportMarkdownPanel', () => ({
+      ReportMarkdownPanel: () => {
+        throw new Error('panel render failed');
+      },
+    }));
+
+    try {
+      await renderDrawer(onClose);
+
+      expect(screen.getByRole('dialog')).toBeInTheDocument();
+      expect(await screen.findByText('加载报告失败')).toBeInTheDocument();
+
+      fireEvent.click(screen.getByRole('button', { name: '关闭' }));
+
+      await waitFor(() => {
+        expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+      });
+      await waitFor(() => {
+        expect(onClose).toHaveBeenCalledTimes(1);
+      });
+    } finally {
+      consoleError.mockRestore();
+    }
+  });
+
+  it('keeps rejected lazy imports inside the drawer', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+
+    vi.resetModules();
+    vi.doMock('../ReportMarkdownPanel', () => Promise.reject(new Error('chunk load failed')));
+
+    try {
+      await renderDrawer();
+
+      expect(screen.getByRole('dialog')).toBeInTheDocument();
+      expect(await screen.findByText('加载报告失败')).toBeInTheDocument();
+    } finally {
+      consoleError.mockRestore();
+    }
+  });
+
+  it('loads the real panel through the lazy boundary', async () => {
+    vi.resetModules();
+    vi.doMock('../../../api/history', () => ({
+      historyApi: {
+        getMarkdown: vi.fn().mockResolvedValue('# Lazy loaded report'),
+      },
+    }));
+
+    await renderDrawer();
+
+    expect(await screen.findByRole('heading', { name: 'Lazy loaded report' })).toBeInTheDocument();
+  });
+});

--- a/apps/dsa-web/src/pages/HomePage.tsx
+++ b/apps/dsa-web/src/pages/HomePage.tsx
@@ -10,7 +10,8 @@ import { ApiErrorAlert, ConfirmDialog, Button, EmptyState, InlineAlert } from '.
 import { DashboardStateBlock } from '../components/dashboard';
 import { StockAutocomplete } from '../components/StockAutocomplete';
 import { HistoryList } from '../components/history';
-import { ReportMarkdown, ReportSummary } from '../components/report';
+import { ReportMarkdownDrawer } from '../components/report/ReportMarkdownDrawer';
+import { ReportSummary } from '../components/report/ReportSummary';
 import { TaskPanel } from '../components/tasks';
 import { useDashboardLifecycle, useHomeDashboardState } from '../hooks';
 import type { SetupStatusResponse } from '../types/systemConfig';
@@ -844,7 +845,7 @@ const HomePage: React.FC = () => {
       </div>
 
       {markdownDrawerOpen && selectedReport?.meta.id ? (
-        <ReportMarkdown
+        <ReportMarkdownDrawer
           recordId={selectedReport.meta.id}
           stockName={selectedReport.meta.stockName || ''}
           stockCode={selectedReport.meta.stockCode}

--- a/apps/dsa-web/src/pages/HomePage.tsx
+++ b/apps/dsa-web/src/pages/HomePage.tsx
@@ -846,6 +846,7 @@ const HomePage: React.FC = () => {
 
       {markdownDrawerOpen && selectedReport?.meta.id ? (
         <ReportMarkdownDrawer
+          key={selectedReport.meta.id}
           recordId={selectedReport.meta.id}
           stockName={selectedReport.meta.stockName || ''}
           stockCode={selectedReport.meta.stockCode}

--- a/apps/dsa-web/src/pages/__tests__/HomePage.test.tsx
+++ b/apps/dsa-web/src/pages/__tests__/HomePage.test.tsx
@@ -160,6 +160,36 @@ describe('HomePage', () => {
         name: getReportText(normalizeReportLanguage(historyReport.meta.reportLanguage)).fullReport,
       }),
     ).toBeInTheDocument();
+    expect(historyApi.getMarkdown).not.toHaveBeenCalled();
+  });
+
+  it('loads markdown only after opening the full report drawer', async () => {
+    vi.mocked(historyApi.getList).mockResolvedValue({
+      total: 1,
+      page: 1,
+      limit: 20,
+      items: [historyItem],
+    });
+    vi.mocked(historyApi.getDetail).mockResolvedValue(historyReport);
+    vi.mocked(historyApi.getMarkdown).mockResolvedValue('# Full Markdown Report');
+
+    render(
+      <MemoryRouter>
+        <HomePage />
+      </MemoryRouter>,
+    );
+
+    const fullReportButton = await screen.findByRole('button', {
+      name: getReportText(normalizeReportLanguage(historyReport.meta.reportLanguage)).fullReport,
+    });
+    expect(historyApi.getMarkdown).not.toHaveBeenCalled();
+
+    fireEvent.click(fullReportButton);
+
+    await waitFor(() => {
+      expect(historyApi.getMarkdown).toHaveBeenCalledWith(historyReport.meta.id);
+    });
+    expect(await screen.findByRole('heading', { name: 'Full Markdown Report' })).toBeInTheDocument();
   });
 
   it('shows the empty report workspace when history is empty', async () => {

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - [修复] 归一腾讯实时行情成交量为股口径，避免量能变化倍数被放大并误导分析报告。
 - [改进] Web 路由页面改为按需加载，降低首包体积并增加路由加载失败恢复提示。
 - [修复] Docker 默认部署移除 `.env` 单文件挂载，避免 WebUI 保存配置时因 `os.replace` 更新挂载点触发 `Device or resource busy`。
+- [改进] Web 完整报告 Markdown 抽屉改为按需加载。
 
 ## [3.18.0] - 2026-05-21
 


### PR DESCRIPTION
## PR Type

- [ ] fix
- [ ] feat
- [ ] refactor
- [ ] docs
- [x] chore
- [x] test

## Background And Problem

Refs #1411

PR-1 #1418 已稳定 vendor chunk 分包；本 PR 完成 PR-2：避免首页常规路径静态引入完整 Markdown 报告抽屉，降低 HomePage 初始 route 对 Markdown 渲染链路的依赖。

## Scope Of Change

- 拆分 `ReportMarkdownPanel`，保留 `historyApi.getMarkdown()`、Markdown 渲染、复制、API loading/error。
- 新增 `ReportMarkdownDrawer`，负责唯一 Drawer 壳、Suspense、chunk 级 error boundary 与关闭动画。
- `HomePage` 避开 `components/report` barrel，改为直引 `ReportSummary` 与 `ReportMarkdownDrawer`。
- `HomePage` 按 `recordId` key 挂载 drawer；drawer 实例内创建 lazy panel，避免一次 chunk import reject 后整页会话内持续缓存失败。
- 增加 HomePage/drawer 回归测试。
- 更新 `docs/CHANGELOG.md`。

## Issue Link

Refs #1411

## Verification Commands And Results

```bash
cd apps/dsa-web && npm run test -- src/components/report/__tests__/ReportMarkdownDrawer.test.tsx
cd apps/dsa-web && npm run test -- src/components/report/__tests__/ReportMarkdown.test.tsx
cd apps/dsa-web && npm run test -- src/pages/__tests__/HomePage.test.tsx
cd apps/dsa-web && npm run lint
cd apps/dsa-web && npm run build
git diff --check
```

关键结果：

- `ReportMarkdownDrawer.test.tsx`: 4 passed
- `ReportMarkdown.test.tsx`: 1 passed
- `HomePage.test.tsx`: 16 passed
- lint/build 通过
- 无 Vite large chunk warning
- 无单个 `>500 kB` chunk

Build 对比 #1418 后产物：

| Chunk | #1418 后 | 当前 |
| --- | --- | --- |
| `HomePage-*.js` | 78.80 kB / gzip 26.06 kB | 75.97 kB / gzip 25.71 kB |
| `ReportMarkdownPanel-*.js` | 合在 HomePage 相关路径 | 5.96 kB / gzip 1.87 kB async |
| `vendor-markdown-*.js` | 148.72 kB / gzip 44.09 kB | 148.72 kB / gzip 44.09 kB |
| `ChatPage-*.js` | 22.41 kB / gzip 7.95 kB | 22.41 kB / gzip 7.95 kB |

`static/index.html` 初始 `modulepreload` 不含 `vendor-markdown`，HomePage route deps 也不含 `vendor-markdown`。`vendor-markdown` 仍保留给 `/chat` 和打开完整报告抽屉后的 dynamic import，这不是 PR-2 回归。

已处理 Codex connector P2：首次 lazy import reject 后，关闭/重开或切换报告可以通过新的 drawer 实例重新创建 lazy panel 并重试加载；新增测试覆盖 reject 后 remount 成功加载。

未执行：

```bash
cd apps/dsa-web && npm run test:smoke -- e2e/report-markdown.spec.ts
```

原因：当前环境缺少 `DSA_WEB_SMOKE_PASSWORD`。

## Compatibility And Risk

无 API、Schema、配置项、环境变量、后端行为变化。

用户可见变化：首次打开完整报告 Markdown 抽屉时，组件模块会按需加载；模块加载失败时错误留在抽屉内，不冒泡为整页 route error。内容请求失败仍由原 `historyApi.getMarkdown()` error UI 处理。若 lazy chunk 加载遇到瞬时失败，关闭/重开或切换报告会重新尝试加载。

风险：若部署环境 chunk 持续加载失败，用户会看到抽屉内“加载报告失败”并可关闭；不会影响首页常规浏览。

## Rollback Plan

Revert this PR. No config, data, or migration rollback is required.

## EXTRACT_PROMPT Change (if applicable)

Not applicable.

## Checklist

- [x] 本 PR 有明确动机和业务价值 / This PR has a clear motivation and value
- [x] 已提供可复现的验证命令与结果 / Reproducible verification commands and results are included
- [x] 已评估兼容性与风险 / Compatibility and risk have been assessed
- [x] 已提供回滚方案 / A rollback plan is provided
- [x] 若涉及用户可见变更，已同步更新相关文档与 `docs/CHANGELOG.md`
