### PR TITLE
fix: 为 Akshare 历史兜底接口增加超时保护

### DIFF
--- a/data_provider/akshare_fetcher.py
+++ b/data_provider/akshare_fetcher.py
@@ -315,6 +315,7 @@ def _akshare_call_with_timeout(
     """Run an akshare call with a bounded wait time."""
     wait_seconds = _AKSHARE_HISTORY_CALL_TIMEOUT if timeout is None else float(timeout)
 
+    multiprocessing.freeze_support()
     ctx = multiprocessing.get_context(_AKSHARE_TIMEOUT_PROCESS_START_METHOD)
     parent_conn, child_conn = ctx.Pipe(duplex=False)
     process = ctx.Process(

--- a/data_provider/akshare_fetcher.py
+++ b/data_provider/akshare_fetcher.py
@@ -24,10 +24,9 @@ AkshareFetcher - 主数据源 (Priority 1)
 """
 
 import logging
+import multiprocessing
 import os
-import queue
 import random
-import threading
 import time
 from dataclasses import dataclass, field
 from datetime import datetime
@@ -63,6 +62,7 @@ logger = logging.getLogger(__name__)
 SINA_REALTIME_ENDPOINT = "hq.sinajs.cn/list"
 TENCENT_REALTIME_ENDPOINT = "qt.gtimg.cn/q"
 _AKSHARE_HISTORY_CALL_TIMEOUT = 30.0
+_AKSHARE_TIMEOUT_PROCESS_JOIN_GRACE = 1.0
 
 
 # User-Agent 池，用于随机轮换
@@ -313,29 +313,64 @@ def _akshare_call_with_timeout(
 ):
     """Run an akshare call with a bounded wait time."""
     wait_seconds = _AKSHARE_HISTORY_CALL_TIMEOUT if timeout is None else float(timeout)
-    result_queue = queue.Queue(maxsize=1)
 
-    def _target() -> None:
-        try:
-            result_queue.put((True, func(*args, **kwargs)))
-        except BaseException as exc:
-            result_queue.put((False, exc))
-
-    thread = threading.Thread(
-        target=_target,
+    ctx = (
+        multiprocessing.get_context("fork")
+        if "fork" in multiprocessing.get_all_start_methods()
+        else multiprocessing.get_context()
+    )
+    parent_conn, child_conn = ctx.Pipe(duplex=False)
+    process = ctx.Process(
+        target=_akshare_timeout_worker,
+        args=(child_conn, func, args, kwargs),
         name=f"akshare-{call_name}",
         daemon=True,
     )
-    thread.start()
-    thread.join(wait_seconds)
 
-    if thread.is_alive():
-        raise TimeoutError(f"{call_name} 调用超过 {wait_seconds:g}s，已放弃等待")
+    process.start()
+    child_conn.close()
 
-    ok, value = result_queue.get_nowait()
+    try:
+        if not parent_conn.poll(wait_seconds):
+            _terminate_akshare_process(process)
+            raise TimeoutError(f"{call_name} 调用超过 {wait_seconds:g}s，已放弃等待")
+
+        try:
+            ok, value = parent_conn.recv()
+        except EOFError as exc:
+            raise RuntimeError(f"{call_name} 调用进程未返回结果") from exc
+    finally:
+        parent_conn.close()
+        process.join(_AKSHARE_TIMEOUT_PROCESS_JOIN_GRACE)
+        _terminate_akshare_process(process)
+
     if ok:
         return value
     raise value
+
+
+def _akshare_timeout_worker(conn, func, args, kwargs) -> None:
+    try:
+        conn.send((True, func(*args, **kwargs)))
+    except BaseException as exc:
+        try:
+            conn.send((False, exc))
+        except BaseException:
+            try:
+                conn.send((False, RuntimeError(f"{type(exc).__name__}: {exc}")))
+            except BaseException:
+                pass
+    finally:
+        conn.close()
+
+
+def _terminate_akshare_process(process) -> None:
+    if process.is_alive():
+        process.terminate()
+        process.join(_AKSHARE_TIMEOUT_PROCESS_JOIN_GRACE)
+    if process.is_alive():
+        process.kill()
+        process.join(_AKSHARE_TIMEOUT_PROCESS_JOIN_GRACE)
 
 
 class AkshareFetcher(BaseFetcher):

--- a/data_provider/akshare_fetcher.py
+++ b/data_provider/akshare_fetcher.py
@@ -314,11 +314,7 @@ def _akshare_call_with_timeout(
     """Run an akshare call with a bounded wait time."""
     wait_seconds = _AKSHARE_HISTORY_CALL_TIMEOUT if timeout is None else float(timeout)
 
-    ctx = (
-        multiprocessing.get_context("fork")
-        if "fork" in multiprocessing.get_all_start_methods()
-        else multiprocessing.get_context()
-    )
+    ctx = multiprocessing.get_context()
     parent_conn, child_conn = ctx.Pipe(duplex=False)
     process = ctx.Process(
         target=_akshare_timeout_worker,

--- a/data_provider/akshare_fetcher.py
+++ b/data_provider/akshare_fetcher.py
@@ -25,7 +25,9 @@ AkshareFetcher - 主数据源 (Priority 1)
 
 import logging
 import os
+import queue
 import random
+import threading
 import time
 from dataclasses import dataclass, field
 from datetime import datetime
@@ -60,6 +62,7 @@ logger = logging.getLogger(__name__)
 
 SINA_REALTIME_ENDPOINT = "hq.sinajs.cn/list"
 TENCENT_REALTIME_ENDPOINT = "qt.gtimg.cn/q"
+_AKSHARE_HISTORY_CALL_TIMEOUT = 30.0
 
 
 # User-Agent 池，用于随机轮换
@@ -301,6 +304,40 @@ def _build_realtime_failure_message(
     )
 
 
+def _akshare_call_with_timeout(
+    func,
+    *args,
+    timeout: Optional[float] = None,
+    call_name: str = "akshare",
+    **kwargs,
+):
+    """Run an akshare call with a bounded wait time."""
+    wait_seconds = _AKSHARE_HISTORY_CALL_TIMEOUT if timeout is None else float(timeout)
+    result_queue = queue.Queue(maxsize=1)
+
+    def _target() -> None:
+        try:
+            result_queue.put((True, func(*args, **kwargs)))
+        except BaseException as exc:
+            result_queue.put((False, exc))
+
+    thread = threading.Thread(
+        target=_target,
+        name=f"akshare-{call_name}",
+        daemon=True,
+    )
+    thread.start()
+    thread.join(wait_seconds)
+
+    if thread.is_alive():
+        raise TimeoutError(f"{call_name} 调用超过 {wait_seconds:g}s，已放弃等待")
+
+    ok, value = result_queue.get_nowait()
+    if ok:
+        return value
+    raise value
+
+
 class AkshareFetcher(BaseFetcher):
     """
     Akshare 数据源实现
@@ -328,6 +365,7 @@ class AkshareFetcher(BaseFetcher):
         self.sleep_min = sleep_min
         self.sleep_max = sleep_max
         self._last_request_time: Optional[float] = None
+        self._history_call_timeout = _AKSHARE_HISTORY_CALL_TIMEOUT
         # 东财补丁开启才执行打补丁操作
         if get_config().enable_eastmoney_patch:
             eastmoney_patch()
@@ -495,11 +533,14 @@ class AkshareFetcher(BaseFetcher):
         self._enforce_rate_limit()
 
         try:
-            df = ak.stock_zh_a_daily(
+            df = _akshare_call_with_timeout(
+                ak.stock_zh_a_daily,
                 symbol=symbol,
                 start_date=start_date.replace('-', ''),
                 end_date=end_date.replace('-', ''),
-                adjust="qfq"
+                adjust="qfq",
+                timeout=self._history_call_timeout,
+                call_name="ak.stock_zh_a_daily",
             )
 
             # 标准化新浪数据列名
@@ -541,11 +582,14 @@ class AkshareFetcher(BaseFetcher):
         self._enforce_rate_limit()
 
         try:
-            df = ak.stock_zh_a_hist_tx(
+            df = _akshare_call_with_timeout(
+                ak.stock_zh_a_hist_tx,
                 symbol=symbol,
                 start_date=start_date.replace('-', ''),
                 end_date=end_date.replace('-', ''),
-                adjust="qfq"
+                adjust="qfq",
+                timeout=self._history_call_timeout,
+                call_name="ak.stock_zh_a_hist_tx",
             )
 
             # 标准化腾讯数据列名

--- a/data_provider/akshare_fetcher.py
+++ b/data_provider/akshare_fetcher.py
@@ -63,6 +63,7 @@ SINA_REALTIME_ENDPOINT = "hq.sinajs.cn/list"
 TENCENT_REALTIME_ENDPOINT = "qt.gtimg.cn/q"
 _AKSHARE_HISTORY_CALL_TIMEOUT = 30.0
 _AKSHARE_TIMEOUT_PROCESS_JOIN_GRACE = 1.0
+_AKSHARE_TIMEOUT_PROCESS_START_METHOD = "spawn"
 
 
 # User-Agent 池，用于随机轮换
@@ -314,7 +315,7 @@ def _akshare_call_with_timeout(
     """Run an akshare call with a bounded wait time."""
     wait_seconds = _AKSHARE_HISTORY_CALL_TIMEOUT if timeout is None else float(timeout)
 
-    ctx = multiprocessing.get_context()
+    ctx = multiprocessing.get_context(_AKSHARE_TIMEOUT_PROCESS_START_METHOD)
     parent_conn, child_conn = ctx.Pipe(duplex=False)
     process = ctx.Process(
         target=_akshare_timeout_worker,

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -45,6 +45,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - [改进] P2-min：LLM Prompt 注入市场阶段上下文。
 - [修复] 问股 single-agent 新增 provider-aware trace 分轨，跨轮保留 DeepSeek V4 thinking + tool-call 的 `reasoning_content` 与工具协议材料。
 - [新功能] 股票自动补全索引默认支持从 GitHub main 远程刷新并缓存到本地，Web/CLI 分析入口失败时自动降级到内置索引，降低摘帽和更名后旧简称污染分析的概率。
+- [修复] 为 Akshare 新浪/腾讯 A 股历史兜底接口增加调用级超时，并补齐 Tushare `605xxx` 沪市代码路由回归测试，避免定时分析因数据源无响应而挂起。
 
 ## [3.18.0] - 2026-05-21
 

--- a/main.py
+++ b/main.py
@@ -23,6 +23,7 @@ A股自选股智能分析系统 - 主调度程序
 """
 from __future__ import annotations
 
+import multiprocessing
 import os
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional, Tuple
@@ -1013,4 +1014,5 @@ def main() -> int:
 
 
 if __name__ == "__main__":
+    multiprocessing.freeze_support()
     sys.exit(main())

--- a/tests/test_akshare_history_timeout.py
+++ b/tests/test_akshare_history_timeout.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 """Regression tests for Akshare historical fallback timeout handling."""
 
+import multiprocessing
 import sys
 import time
 from types import SimpleNamespace
@@ -15,17 +16,41 @@ ensure_litellm_stub()
 from data_provider.akshare_fetcher import AkshareFetcher, _akshare_call_with_timeout
 
 
+def _sleep_for(seconds: float) -> None:
+    time.sleep(seconds)
+
+
 def test_akshare_call_with_timeout_returns_promptly() -> None:
     started = time.monotonic()
 
     with pytest.raises(TimeoutError, match="unit-hang"):
         _akshare_call_with_timeout(
-            lambda: time.sleep(0.2),
+            _sleep_for,
+            0.2,
             timeout=0.01,
             call_name="unit-hang",
         )
 
     assert time.monotonic() - started < 0.5
+
+
+def test_akshare_call_with_timeout_reaps_timed_out_worker_process() -> None:
+    call_name = "unit-hang-reap"
+
+    with pytest.raises(TimeoutError, match=call_name):
+        _akshare_call_with_timeout(
+            _sleep_for,
+            5,
+            timeout=0.01,
+            call_name=call_name,
+        )
+
+    leaked = [
+        process
+        for process in multiprocessing.active_children()
+        if process.name == f"akshare-{call_name}"
+    ]
+    assert leaked == []
 
 
 @pytest.mark.parametrize(

--- a/tests/test_akshare_history_timeout.py
+++ b/tests/test_akshare_history_timeout.py
@@ -26,6 +26,7 @@ def _return_value(value):
 
 def test_akshare_call_with_timeout_uses_spawn_context(monkeypatch) -> None:
     requested_methods = []
+    call_order = []
 
     class FakeConnection:
         def __init__(self, messages):
@@ -75,12 +76,20 @@ def test_akshare_call_with_timeout_uses_spawn_context(monkeypatch) -> None:
         Process = FakeProcess
 
     def fake_get_context(method=None):
+        call_order.append("get_context")
         requested_methods.append(method)
         return FakeContext()
+
+    def fake_freeze_support():
+        call_order.append("freeze_support")
 
     monkeypatch.setattr(
         "data_provider.akshare_fetcher.multiprocessing.get_context",
         fake_get_context,
+    )
+    monkeypatch.setattr(
+        "data_provider.akshare_fetcher.multiprocessing.freeze_support",
+        fake_freeze_support,
     )
 
     result = _akshare_call_with_timeout(
@@ -92,6 +101,7 @@ def test_akshare_call_with_timeout_uses_spawn_context(monkeypatch) -> None:
 
     assert result == "ok"
     assert requested_methods == ["spawn"]
+    assert call_order == ["freeze_support", "get_context"]
 
 
 def test_akshare_call_with_timeout_returns_promptly() -> None:

--- a/tests/test_akshare_history_timeout.py
+++ b/tests/test_akshare_history_timeout.py
@@ -20,6 +20,80 @@ def _sleep_for(seconds: float) -> None:
     time.sleep(seconds)
 
 
+def _return_value(value):
+    return value
+
+
+def test_akshare_call_with_timeout_uses_runtime_default_context(monkeypatch) -> None:
+    requested_methods = []
+
+    class FakeConnection:
+        def __init__(self, messages):
+            self.messages = messages
+
+        def send(self, value):
+            self.messages.append(value)
+
+        def poll(self, timeout):
+            return bool(self.messages)
+
+        def recv(self):
+            if not self.messages:
+                raise EOFError
+            return self.messages.pop(0)
+
+        def close(self):
+            pass
+
+    class FakeProcess:
+        def __init__(self, target, args, name, daemon):
+            self.target = target
+            self.args = args
+            self.name = name
+            self.daemon = daemon
+
+        def start(self):
+            self.target(*self.args)
+
+        def join(self, timeout=None):
+            pass
+
+        def is_alive(self):
+            return False
+
+        def terminate(self):
+            pass
+
+        def kill(self):
+            pass
+
+    class FakeContext:
+        def Pipe(self, duplex=False):
+            messages = []
+            return FakeConnection(messages), FakeConnection(messages)
+
+        Process = FakeProcess
+
+    def fake_get_context(method=None):
+        requested_methods.append(method)
+        return FakeContext()
+
+    monkeypatch.setattr(
+        "data_provider.akshare_fetcher.multiprocessing.get_context",
+        fake_get_context,
+    )
+
+    result = _akshare_call_with_timeout(
+        _return_value,
+        "ok",
+        timeout=1,
+        call_name="unit-default-context",
+    )
+
+    assert result == "ok"
+    assert requested_methods == [None]
+
+
 def test_akshare_call_with_timeout_returns_promptly() -> None:
     started = time.monotonic()
 

--- a/tests/test_akshare_history_timeout.py
+++ b/tests/test_akshare_history_timeout.py
@@ -1,0 +1,98 @@
+# -*- coding: utf-8 -*-
+"""Regression tests for Akshare historical fallback timeout handling."""
+
+import sys
+import time
+from types import SimpleNamespace
+
+import pandas as pd
+import pytest
+
+from tests.litellm_stub import ensure_litellm_stub
+
+ensure_litellm_stub()
+
+from data_provider.akshare_fetcher import AkshareFetcher, _akshare_call_with_timeout
+
+
+def test_akshare_call_with_timeout_returns_promptly() -> None:
+    started = time.monotonic()
+
+    with pytest.raises(TimeoutError, match="unit-hang"):
+        _akshare_call_with_timeout(
+            lambda: time.sleep(0.2),
+            timeout=0.01,
+            call_name="unit-hang",
+        )
+
+    assert time.monotonic() - started < 0.5
+
+
+@pytest.mark.parametrize(
+    ("method_name", "api_name", "call_name"),
+    [
+        ("_fetch_stock_data_sina", "stock_zh_a_daily", "ak.stock_zh_a_daily"),
+        ("_fetch_stock_data_tx", "stock_zh_a_hist_tx", "ak.stock_zh_a_hist_tx"),
+    ],
+)
+def test_sina_and_tencent_history_calls_use_timeout_wrapper(
+    monkeypatch,
+    method_name: str,
+    api_name: str,
+    call_name: str,
+) -> None:
+    captured = {}
+
+    def fake_call(func, *args, timeout=None, call_name="", **kwargs):
+        captured["func"] = func
+        captured["timeout"] = timeout
+        captured["call_name"] = call_name
+        captured["kwargs"] = kwargs
+        return pd.DataFrame(
+            {
+                "date": ["2026-05-25"],
+                "open": [10.0],
+                "high": [10.5],
+                "low": [9.8],
+                "close": [10.2],
+                "volume": [1000],
+                "amount": [20000],
+            }
+        )
+
+    fake_api_func = object()
+    fake_akshare = SimpleNamespace(**{api_name: fake_api_func})
+    monkeypatch.setitem(sys.modules, "akshare", fake_akshare)
+    monkeypatch.setattr("data_provider.akshare_fetcher._akshare_call_with_timeout", fake_call)
+
+    fetcher = AkshareFetcher(sleep_min=0, sleep_max=0)
+    fetcher._history_call_timeout = 7
+
+    method = getattr(fetcher, method_name)
+    df = method("605218", "2026-05-01", "2026-05-25")
+
+    assert captured["func"] is fake_api_func
+    assert captured["timeout"] == 7
+    assert captured["call_name"] == call_name
+    assert captured["kwargs"]["symbol"] == "sh605218"
+    assert captured["kwargs"]["start_date"] == "20260501"
+    assert captured["kwargs"]["end_date"] == "20260525"
+    assert captured["kwargs"]["adjust"] == "qfq"
+    assert list(df.columns)[:7] == ["日期", "开盘", "最高", "最低", "收盘", "成交量", "成交额"]
+
+
+def test_stock_data_falls_back_after_sina_timeout(monkeypatch) -> None:
+    fetcher = AkshareFetcher(sleep_min=0, sleep_max=0)
+    tx_df = pd.DataFrame({"日期": ["2026-05-25"], "收盘": [10.2]})
+
+    monkeypatch.setattr(fetcher, "_fetch_stock_data_em", lambda *args: pd.DataFrame())
+    monkeypatch.setattr(
+        fetcher,
+        "_fetch_stock_data_sina",
+        lambda *args: (_ for _ in ()).throw(TimeoutError("sina timeout")),
+    )
+    monkeypatch.setattr(fetcher, "_fetch_stock_data_tx", lambda *args: tx_df)
+
+    result = fetcher._fetch_stock_data("605218", "2026-05-01", "2026-05-25")
+
+    assert result is tx_df

--- a/tests/test_akshare_history_timeout.py
+++ b/tests/test_akshare_history_timeout.py
@@ -24,7 +24,7 @@ def _return_value(value):
     return value
 
 
-def test_akshare_call_with_timeout_uses_runtime_default_context(monkeypatch) -> None:
+def test_akshare_call_with_timeout_uses_spawn_context(monkeypatch) -> None:
     requested_methods = []
 
     class FakeConnection:
@@ -91,7 +91,7 @@ def test_akshare_call_with_timeout_uses_runtime_default_context(monkeypatch) -> 
     )
 
     assert result == "ok"
-    assert requested_methods == [None]
+    assert requested_methods == ["spawn"]
 
 
 def test_akshare_call_with_timeout_returns_promptly() -> None:

--- a/tests/test_tushare_fetcher_followups.py
+++ b/tests/test_tushare_fetcher_followups.py
@@ -159,6 +159,7 @@ class TestTushareFetcherFollowUps(unittest.TestCase):
 
         self.assertEqual(fetcher._convert_stock_code("SZ000001"), "000001.SZ")
         self.assertEqual(fetcher._convert_stock_code("SH600519"), "600519.SH")
+        self.assertEqual(fetcher._convert_stock_code("605218"), "605218.SH")
         self.assertEqual(fetcher._convert_stock_code("600519.SS"), "600519.SH")
 
     @patch.dict(sys.modules, {"tushare": MagicMock()})


### PR DESCRIPTION
## PR Type

- [x] fix
- [ ] feat
- [ ] refactor
- [ ] docs
- [ ] chore
- [ ] test

## Background And Problem

Issue #1464 反馈：自选股包含 `605xxx` 沪市股票时，定时分析在数据源 fallback 阶段可能长时间挂起，后续大盘复盘和通知推送无法继续执行。

本 PR 聚焦解决其中的 Akshare hang 风险：

- 当前 base 已包含 `605xxx -> .SH` 的 Tushare 路由逻辑；本 PR 为该路径补充回归测试，避免后续退化。
- Akshare 新浪 `stock_zh_a_daily` 与腾讯 `stock_zh_a_hist_tx` 历史兜底接口没有可靠的请求级 timeout；当底层请求无响应时，调度线程可能无限等待。
- 本 PR 为这两个兜底接口增加调用级硬超时，使单个数据源卡住时能失败退出，并继续走现有 fallback / `DataFetchError` 语义。
- 最新补丁补充 `multiprocessing.freeze_support()`，增强 `spawn` 子进程方案在 Windows / PyInstaller / frozen runtime 场景下的兼容性。

## Scope Of Change

- `data_provider/akshare_fetcher.py`
  - 新增 `_akshare_call_with_timeout()`，通过 `multiprocessing` 的 `spawn` 子进程隔离 Akshare 调用。
  - 默认 30s 超时；超时后终止并回收子进程，避免后台调用继续占用资源。
  - 调用 `multiprocessing.freeze_support()` 后再创建 spawn 上下文。
  - 将新浪和腾讯 A 股历史 fallback 调用改为走超时 wrapper。
- `main.py`
  - 在 CLI 入口 `if __name__ == "__main__"` 下调用 `multiprocessing.freeze_support()`。
- `tests/test_akshare_history_timeout.py`
  - 覆盖 spawn 上下文、freeze_support 调用顺序、超时快速返回、子进程回收、Sina/Tx wrapper 参数和 fallback 继续执行。
- `tests/test_tushare_fetcher_followups.py`
  - 补充 `605218 -> 605218.SH` 回归测试。
- `docs/CHANGELOG.md`
  - 在 `[Unreleased]` 下追加扁平格式修复记录。

## Issue Link

Closes #1464

## Verification Commands And Results

```bash
gh pr checks 1465 --repo ZhuLinsen/daily_stock_analysis
```

关键输出/结论 / Key output & conclusion:

- `backend-gate`: PASS
- `docker-build`: PASS
- `ai-governance`: PASS
- PR Review `安全检查` / `静态检查` / `AI 代码审查` / `审查报告`: PASS
- `web-gate`: SKIPPED（本 PR 未修改 `apps/dsa-web/`）

PR 原始验证记录：

```bash
./scripts/ci_gate.sh flake8
./scripts/ci_gate.sh offline-tests
```

关键输出/结论：`lint:PASS, test:PASS`

## Compatibility And Risk

- API / Schema / Web / Desktop：无 API、Schema、Web 前端或桌面端界面改动。
- 配置 / Docker / GitHub Actions：无新增配置项、环境变量或 workflow 语义变化。
- 数据源 fallback：保持现有数据源优先级和 fallback 顺序不变，只给 Akshare 新浪/腾讯历史兜底调用增加有界等待。
- 运行时资源：使用 `spawn` 子进程隔离阻塞调用，超时后 terminate/kill 并 join；新增测试覆盖进程回收，避免早期线程式 timeout 无法回收后台调用的问题。
- `freeze_support()`：标准 multiprocessing 兼容性入口；在非 frozen runtime 下基本为 no-op，在 frozen runtime 下可避免 spawn 子进程启动异常。
- 已知边界：本 PR 没有给 Akshare 东方财富 `stock_zh_a_hist` 增加同类硬超时；本次 issue 日志中的挂起路径主要落在新浪/腾讯 fallback，因此该边界不阻断本 PR。
- 605xxx 路由：当前 base 已有 `605xxx -> .SH` 实现，本 PR 仅补充回归测试，避免后续退化。
- 文档：已同步 `docs/CHANGELOG.md`；README 不更新，因为这是数据源稳定性修复，不属于首页级信息变化。

## Rollback Plan

- 执行 `git revert <merge-commit>` 回滚本 PR 即可恢复原行为。
- 不涉及配置、数据迁移或用户本地状态改写；无需额外回滚环境变量、数据库或缓存。

## EXTRACT_PROMPT Change (if applicable)

未修改 `src/services/image_stock_extractor.py` 中的 `EXTRACT_PROMPT`。

## Checklist

- [x] 本 PR 有明确动机和业务价值 / This PR has a clear motivation and value
- [x] 已提供可复现的验证命令与结果 / Reproducible verification commands and results are included
- [x] 已评估兼容性与风险 / Compatibility and risk have been assessed
- [x] 已提供回滚方案 / A rollback plan is provided
- [x] 若涉及用户可见变更，已同步更新相关文档与 `docs/CHANGELOG.md`；`README.md` 仅在首页级信息变化时更新，细节优先写入 `docs/*.md` / If user-visible changes are included, relevant docs and `docs/CHANGELOG.md` are updated; `README.md` is updated only for homepage-level changes, with details kept in `docs/*.md`