### PR TITLE
feat: 新增 AnalysisContextPack P2 artifacts 组装器

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -35,6 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - [文档] 补充 #1391 Phase 3 兼容性说明：记录后端诊断持久化、历史查询与通知回写链路变更边界与回滚策略，并补齐后端门禁级验证要求。
 - [测试] 收敛 #1391 Phase 3 后端/API 与 Web 回归检查：`./scripts/ci_gate.sh`、`test_pipeline_market_phase_context.py`、`test_analysis_api_contract.py`、`test_analysis_history.py`、`npm run lint`、`npm run build`。
 - [新功能] 新增 AnalysisContextPack P1 内部契约与脱敏序列化测试。
+- [新功能] 新增 AnalysisContextPack P2 builder，从普通分析 pipeline 已有 artifacts 组装内部上下文包。
 - [修复] 恢复 Agent/历史兼容快照中的关联板块与板块联动字段提取，修复新版首页报告缺少“板块联动”的回归问题。
 - [改进] 设置页配置帮助阶段性补齐 Web 设置页实际展示/可配置字段的中英双语文案，覆盖 Agent、回测、报告、通知路由、系统运行时、AI legacy、数据源和通知高级配置。
 - [修复] 修正 Web 设置帮助中 legacy 告警 JSON 字段名与静默时段投递语义说明。

--- a/docs/analysis-context-pack.md
+++ b/docs/analysis-context-pack.md
@@ -34,7 +34,7 @@ P1 schema 包含：
 
 - `PACK_VERSION = "1.0"`，并通过 `AnalysisContextPack.pack_version` 标记契约版本。
 - `ContextFieldStatus`：只允许 `available`、`missing`、`not_supported`、`fallback`、`stale`、`estimated`、`partial`；`fetch_failed` 仍留到 P5。
-- `AnalysisSubject`：顶层身份槽，只包含 `code`、`stock_name`、`market`；`exchange`、`currency`、`industry` 留给 P2 builder 从现有 artifacts 填充，不重复新增 `identity` block。
+- `AnalysisSubject`：顶层身份槽，只包含 `code`、`stock_name`、`market`；`exchange`、`currency`、`industry` 留给后续扩展，P2 builder 不扩 P1 schema，也不重复新增 `identity` block。
 - `AnalysisContextItem`：字段级输入项，包含 `status`、`value`、`source`、`timestamp`、`fallback_from`、`missing_reason`、`warnings`、`metadata`。
 - `AnalysisContextBlock`：数据块级分组，包含 `status`、`items`、`source`、`timestamp`、`warnings`、`metadata`，其中 `items` 是 `Dict[str, AnalysisContextItem]`。
 - `DataQuality`：P1 只保留 `warnings` 与 `metadata` 容器，不做评分、聚合计数或模型置信度限制。
@@ -71,6 +71,27 @@ P1 Block Catalog：
 - `AnalysisContextPack.to_safe_dict()` 先执行 `model_dump(mode="json")`，再调用 `redact_sensitive_mapping()`。
 - `redact_sensitive_mapping()` 只做 dict/list 的 key-based 递归脱敏，命中 `api_key`、`access_token`、`refresh_token`、`authorization_header`、`webhook_url`、`password`、`cookie`、`secret`、`token`、`sendkey`、`license_key` 等敏感键或短语时把值替换为 `[REDACTED]`。
 - P1 不扫描普通字符串值，不做 URL 正则脱敏，不把 `data_api` 或裸 `api` / `key` 当作敏感命中，避免把本契约扩展成通用 secrets engine。
+
+## P2 Builder 契约
+
+P2 新增 `AnalysisContextBuilder`，但首版只做 assembler：从普通分析 pipeline 已经拿到的 artifacts 组装内部 `AnalysisContextPack`。Issue 验收项里的“复用现有数据源”在本 slice 中解释为复用 pipeline 已 fetch 的 `realtime_quote`、`base_context`、`enhanced_context`、`trend_result`、`chip_data`、`fundamental_context`、`news_context` 等 artifacts；builder 本身 zero-fetch，不调用 DB、fetcher、SearchService、Agent 工具或具体 provider。
+
+P2 输入契约使用 `PipelineAnalysisArtifacts`：`code`、`stock_name`、`market`、`phase`、`base_context`、`enhanced_context`、`realtime_quote`、`trend_result`、`chip_data`、`fundamental_context`、`news_context`、`news_result_count`、`metadata`。单股 `build()` 与批量 `build_batch()` 复用同一结构，避免 P3 runtime 接入时再次改签名。
+
+P2 block 组装边界：
+
+- `subject` 仍只写 `code`、`stock_name`、`market` 三字段，不扩 `AnalysisSubject`。
+- `phase` 只接收传入的 `MarketPhaseContext.to_dict()` 产物，不从 `enhanced_context` 反推。
+- `quote` 从 `realtime_quote` 组装；缺失为 `missing`；`source=fallback` 映射为 `fallback`；`fallback_from` 只在 artifact/metadata 显式提供时填写，否则只记录稳定 warning code，不伪造 provider 链。
+- `quote` stale 只透传 `price_stale`、`quote_stale`、`quote_stale_seconds` 等显式 marker；builder 不推断新鲜度。
+- `daily_bars` 只表达完整日线窗口，优先读 `base_context.today`、`base_context.yesterday`、`base_context.date`、`base_context.data_missing`；date-only 放入 `value` 或 `metadata`，不写入 `timestamp`。
+- `enhanced_context.today.data_source` 为 `realtime:*` 时，只影响 `technical`：block 标 `partial`，相关 item 标 `estimated`，warning 使用 `intraday_realtime_overlay`。
+- `technical` 优先复用 `trend_result.to_dict()`；无 trend artifact 时为 `missing`。
+- `chip` 复用 `chip_data.to_dict()`；无 chip artifact 默认 `missing`，只有输入 metadata/artifact 明确 not_supported 时才标 `not_supported`。
+- `fundamentals` 只读 `fundamental_context` 参数；`ok` 映射为 `available`，`not_supported` 映射为 `not_supported`，`partial` 映射为 `partial`，`failed` 映射为 `missing` + 稳定 reason code；不写入 `errors[]` 原文。
+- `news` 非空白字符串为 `available`，空白或缺失为 `missing`；`news_result_count` 写入 pack metadata。
+
+P2 不组装 `portfolio`、`events`、`market_context`，也不把 `capital_flow` 拆成独立 block；首版只把它保留在 fundamentals 的 coverage/source chain metadata 中。P2 也不改变 Prompt、不让普通分析或 Agent runtime 消费 pack、不写入 history/task/report metadata、不暴露完整 pack 到 API/Web/Bot/Desktop/通知，不做 P5 data-quality scoring、`fetch_failed` 细分或模型置信度限制。
 
 ## 字段质量状态
 

--- a/src/services/analysis_context_builder.py
+++ b/src/services/analysis_context_builder.py
@@ -1,0 +1,518 @@
+# -*- coding: utf-8 -*-
+"""Assembler for the internal AnalysisContextPack P2 contract."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional, Sequence
+
+from src.schemas.analysis_context_pack import (
+    AnalysisContextBlock,
+    AnalysisContextItem,
+    AnalysisContextPack,
+    AnalysisSubject,
+    ContextFieldStatus,
+    DataQuality,
+)
+
+
+_REALTIME_OVERLAY_WARNING = "intraday_realtime_overlay"
+_REALTIME_FALLBACK_WARNING = "realtime_provider_fallback"
+_FUNDAMENTAL_FAILED_REASON = "fundamental_pipeline_failed"
+
+
+@dataclass(frozen=True)
+class PipelineAnalysisArtifacts:
+    """Artifacts already fetched by the stock analysis pipeline."""
+
+    code: str
+    stock_name: str
+    market: str
+    phase: Optional[Dict[str, Any]]
+    base_context: Dict[str, Any]
+    enhanced_context: Dict[str, Any]
+    realtime_quote: Optional[Any]
+    trend_result: Optional[Any]
+    chip_data: Optional[Any]
+    fundamental_context: Optional[Dict[str, Any]]
+    news_context: Optional[str]
+    news_result_count: Optional[int]
+    metadata: Dict[str, Any]
+
+
+class AnalysisContextBuilder:
+    """Build AnalysisContextPack from existing pipeline artifacts only."""
+
+    @staticmethod
+    def build(artifacts: PipelineAnalysisArtifacts) -> AnalysisContextPack:
+        metadata = dict(artifacts.metadata or {})
+        if artifacts.news_result_count is not None:
+            metadata["news_result_count"] = artifacts.news_result_count
+
+        blocks: Dict[str, AnalysisContextBlock] = {}
+        data_quality_warnings: List[str] = []
+
+        blocks["quote"] = _build_quote_block(artifacts)
+        blocks["daily_bars"] = _build_daily_bars_block(artifacts)
+        technical_block, technical_warnings = _build_technical_block(artifacts)
+        blocks["technical"] = technical_block
+        data_quality_warnings.extend(technical_warnings)
+        blocks["chip"] = _build_chip_block(artifacts)
+        blocks["fundamentals"] = _build_fundamentals_block(artifacts)
+        blocks["news"] = _build_news_block(artifacts)
+
+        return AnalysisContextPack(
+            subject=AnalysisSubject(
+                code=artifacts.code,
+                stock_name=artifacts.stock_name or None,
+                market=artifacts.market or None,
+            ),
+            phase=artifacts.phase,
+            blocks=blocks,
+            data_quality=DataQuality(warnings=data_quality_warnings),
+            metadata=metadata,
+        )
+
+    @staticmethod
+    def build_batch(items: Sequence[PipelineAnalysisArtifacts]) -> List[AnalysisContextPack]:
+        return [AnalysisContextBuilder.build(item) for item in items]
+
+
+def _build_quote_block(artifacts: PipelineAnalysisArtifacts) -> AnalysisContextBlock:
+    quote = _to_dict(artifacts.realtime_quote)
+    if not quote:
+        return AnalysisContextBlock(
+            status=ContextFieldStatus.MISSING,
+            items={
+                "quote": AnalysisContextItem(
+                    status=ContextFieldStatus.MISSING,
+                    missing_reason="realtime_quote_missing",
+                )
+            },
+        )
+
+    source = _source_text(quote.get("source"))
+    status = ContextFieldStatus.AVAILABLE
+    warnings: List[str] = []
+    fallback_from = _metadata_value(
+        quote,
+        "fallback_from",
+        "quote_fallback_from",
+        "realtime_fallback_from",
+        "fallback_provider",
+    ) or _metadata_value(
+        artifacts.metadata,
+        "quote_fallback_from",
+        "realtime_fallback_from",
+        "fallback_from",
+    )
+
+    if _has_explicit_quote_stale_marker(artifacts, quote):
+        status = ContextFieldStatus.STALE
+        warnings.append("quote_stale")
+    elif source == "fallback":
+        status = ContextFieldStatus.FALLBACK
+        if fallback_from is None:
+            warnings.append(_REALTIME_FALLBACK_WARNING)
+
+    items = {
+        key: AnalysisContextItem(
+            status=status,
+            value=value,
+            source=source,
+            fallback_from=fallback_from if status == ContextFieldStatus.FALLBACK else None,
+            warnings=list(warnings),
+        )
+        for key, value in quote.items()
+        if value is not None
+    }
+    return AnalysisContextBlock(
+        status=status,
+        items=items,
+        source=source,
+        warnings=warnings,
+        metadata=_quote_metadata(artifacts, quote),
+    )
+
+
+def _build_daily_bars_block(artifacts: PipelineAnalysisArtifacts) -> AnalysisContextBlock:
+    context = artifacts.base_context or {}
+    date_value = context.get("date")
+    metadata = {
+        key: value
+        for key, value in {
+            "date": date_value,
+            "data_missing": bool(context.get("data_missing")),
+        }.items()
+        if value not in (None, "")
+    }
+    if context.get("data_missing"):
+        return AnalysisContextBlock(
+            status=ContextFieldStatus.MISSING,
+            items={
+                "today": AnalysisContextItem(
+                    status=ContextFieldStatus.MISSING,
+                    value=context.get("today") or None,
+                    missing_reason="daily_bars_missing",
+                    metadata={"date": date_value} if date_value else {},
+                ),
+                "yesterday": AnalysisContextItem(
+                    status=ContextFieldStatus.MISSING,
+                    value=context.get("yesterday") or None,
+                    missing_reason="daily_bars_missing",
+                ),
+            },
+            source="storage.get_analysis_context",
+            metadata=metadata,
+        )
+
+    items: Dict[str, AnalysisContextItem] = {}
+    for key in ("today", "yesterday"):
+        value = context.get(key)
+        items[key] = AnalysisContextItem(
+            status=ContextFieldStatus.AVAILABLE if value else ContextFieldStatus.MISSING,
+            value=value or None,
+            source="storage.get_analysis_context",
+            missing_reason=None if value else f"{key}_missing",
+        )
+    if date_value:
+        items["date"] = AnalysisContextItem(
+            status=ContextFieldStatus.AVAILABLE,
+            value=date_value,
+            source="storage.get_analysis_context",
+            metadata={"date": date_value},
+        )
+
+    bar_statuses = [items[key].status for key in ("today", "yesterday")]
+    if all(status == ContextFieldStatus.AVAILABLE for status in bar_statuses):
+        block_status = ContextFieldStatus.AVAILABLE
+    elif any(status == ContextFieldStatus.AVAILABLE for status in bar_statuses):
+        block_status = ContextFieldStatus.PARTIAL
+    else:
+        block_status = ContextFieldStatus.MISSING
+    return AnalysisContextBlock(
+        status=block_status,
+        items=items,
+        source="storage.get_analysis_context",
+        metadata=metadata,
+    )
+
+
+def _build_technical_block(
+    artifacts: PipelineAnalysisArtifacts,
+) -> tuple[AnalysisContextBlock, List[str]]:
+    trend = _to_dict(artifacts.trend_result)
+    if not trend:
+        return (
+            AnalysisContextBlock(
+                status=ContextFieldStatus.MISSING,
+                items={
+                    "trend_result": AnalysisContextItem(
+                        status=ContextFieldStatus.MISSING,
+                        missing_reason="trend_result_missing",
+                    )
+                },
+            ),
+            [],
+        )
+
+    has_realtime_overlay = _has_realtime_overlay(artifacts.enhanced_context)
+    warnings = [_REALTIME_OVERLAY_WARNING] if has_realtime_overlay else []
+    block_status = (
+        ContextFieldStatus.PARTIAL
+        if has_realtime_overlay
+        else ContextFieldStatus.AVAILABLE
+    )
+    items: Dict[str, AnalysisContextItem] = {
+        "trend_result": AnalysisContextItem(
+            status=ContextFieldStatus.AVAILABLE,
+            value=trend,
+            warnings=list(warnings),
+        )
+    }
+    if has_realtime_overlay:
+        items["intraday_overlay"] = AnalysisContextItem(
+            status=ContextFieldStatus.ESTIMATED,
+            value=(artifacts.enhanced_context or {}).get("today"),
+            warnings=list(warnings),
+        )
+
+    return (
+        AnalysisContextBlock(
+            status=block_status,
+            items=items,
+            warnings=warnings,
+            metadata={
+                "overlay_source": _realtime_overlay_source(artifacts.enhanced_context)
+            },
+        ),
+        warnings,
+    )
+
+
+def _build_chip_block(artifacts: PipelineAnalysisArtifacts) -> AnalysisContextBlock:
+    chip = _to_dict(artifacts.chip_data)
+    if not chip:
+        not_supported = bool((artifacts.metadata or {}).get("chip_not_supported"))
+        status = (
+            ContextFieldStatus.NOT_SUPPORTED
+            if not_supported
+            else ContextFieldStatus.MISSING
+        )
+        return AnalysisContextBlock(
+            status=status,
+            items={
+                "chip_distribution": AnalysisContextItem(
+                    status=status,
+                    missing_reason=(
+                        "chip_not_supported"
+                        if not_supported
+                        else "chip_distribution_missing"
+                    ),
+                )
+            },
+        )
+
+    source = _source_text(chip.get("source"))
+    return AnalysisContextBlock(
+        status=ContextFieldStatus.AVAILABLE,
+        items={
+            key: AnalysisContextItem(
+                status=ContextFieldStatus.AVAILABLE,
+                value=value,
+                source=source,
+            )
+            for key, value in chip.items()
+            if value is not None
+        },
+        source=source,
+        metadata={"date": chip.get("date")} if chip.get("date") else {},
+    )
+
+
+def _build_fundamentals_block(artifacts: PipelineAnalysisArtifacts) -> AnalysisContextBlock:
+    context = artifacts.fundamental_context if isinstance(artifacts.fundamental_context, dict) else None
+    if not context:
+        return AnalysisContextBlock(
+            status=ContextFieldStatus.MISSING,
+            items={
+                "fundamental_context": AnalysisContextItem(
+                    status=ContextFieldStatus.MISSING,
+                    missing_reason="fundamental_context_missing",
+                )
+            },
+        )
+
+    raw_status = str(context.get("status") or "").strip().lower()
+    status = _fundamental_status(raw_status)
+    missing_reason = (
+        _FUNDAMENTAL_FAILED_REASON
+        if raw_status == "failed"
+        else ("fundamentals_not_supported" if raw_status == "not_supported" else None)
+    )
+    coverage = context.get("coverage") if isinstance(context.get("coverage"), dict) else {}
+    source_chain = context.get("source_chain") if isinstance(context.get("source_chain"), list) else []
+    source = _source_from_chain(source_chain)
+    metadata = {
+        "status": raw_status or None,
+        "coverage": coverage,
+        "source_chain": source_chain,
+    }
+    metadata = {key: value for key, value in metadata.items() if value not in (None, {}, [])}
+
+    return AnalysisContextBlock(
+        status=status,
+        items={
+            "status": AnalysisContextItem(
+                status=status,
+                value=raw_status or None,
+                source=source,
+                missing_reason=missing_reason,
+            ),
+            "coverage": AnalysisContextItem(
+                status=_fundamental_payload_status(status, bool(coverage)),
+                value=coverage or None,
+                source=source,
+                missing_reason=_fundamental_payload_missing_reason(
+                    raw_status,
+                    bool(coverage),
+                    "fundamental_coverage_missing",
+                ),
+            ),
+            "source_chain": AnalysisContextItem(
+                status=_fundamental_payload_status(status, bool(source_chain)),
+                value=source_chain or None,
+                source=source,
+                missing_reason=_fundamental_payload_missing_reason(
+                    raw_status,
+                    bool(source_chain),
+                    "fundamental_source_chain_missing",
+                ),
+            ),
+        },
+        source=source,
+        metadata=metadata,
+    )
+
+
+def _build_news_block(artifacts: PipelineAnalysisArtifacts) -> AnalysisContextBlock:
+    content = (artifacts.news_context or "").strip()
+    metadata: Dict[str, Any] = {}
+    if artifacts.news_result_count is not None:
+        metadata["news_result_count"] = artifacts.news_result_count
+
+    if not content:
+        return AnalysisContextBlock(
+            status=ContextFieldStatus.MISSING,
+            items={
+                "content": AnalysisContextItem(
+                    status=ContextFieldStatus.MISSING,
+                    missing_reason="news_context_missing",
+                )
+            },
+            metadata=metadata,
+        )
+
+    return AnalysisContextBlock(
+        status=ContextFieldStatus.AVAILABLE,
+        items={
+            "content": AnalysisContextItem(
+                status=ContextFieldStatus.AVAILABLE,
+                value=content,
+            )
+        },
+        metadata=metadata,
+    )
+
+
+def _to_dict(value: Optional[Any]) -> Dict[str, Any]:
+    if value is None:
+        return {}
+    if isinstance(value, Mapping):
+        return dict(value)
+    to_dict = getattr(value, "to_dict", None)
+    if callable(to_dict):
+        result = to_dict()
+        if not isinstance(result, Mapping):
+            raise TypeError(
+                f"{type(value).__name__}.to_dict() must return a mapping"
+            )
+        return dict(result)
+    value_dict = getattr(value, "__dict__", None)
+    if isinstance(value_dict, dict):
+        return dict(value_dict)
+    return {}
+
+
+def _source_text(value: Any) -> Optional[str]:
+    if value is None:
+        return None
+    enum_value = getattr(value, "value", None)
+    if enum_value is not None:
+        value = enum_value
+    text = str(value).strip()
+    return text or None
+
+
+def _metadata_value(metadata: Dict[str, Any], *keys: str) -> Optional[str]:
+    for key in keys:
+        value = (metadata or {}).get(key)
+        if value not in (None, ""):
+            return str(value)
+    return None
+
+
+def _has_explicit_quote_stale_marker(
+    artifacts: PipelineAnalysisArtifacts,
+    quote: Dict[str, Any],
+) -> bool:
+    metadata = artifacts.metadata or {}
+    for key in (
+        "price_stale",
+        "quote_stale",
+        "quote_stale_seconds",
+        "stale_seconds",
+    ):
+        if bool(metadata.get(key)) or bool(quote.get(key)):
+            return True
+    return False
+
+
+def _quote_metadata(
+    artifacts: PipelineAnalysisArtifacts,
+    quote: Dict[str, Any],
+) -> Dict[str, Any]:
+    metadata: Dict[str, Any] = {}
+    for key in (
+        "price_stale",
+        "quote_stale",
+        "quote_stale_seconds",
+        "stale_seconds",
+    ):
+        value = (artifacts.metadata or {}).get(key)
+        if value is None:
+            value = quote.get(key)
+        if value is not None:
+            metadata[key] = value
+    return metadata
+
+
+def _has_realtime_overlay(enhanced_context: Dict[str, Any]) -> bool:
+    today = (enhanced_context or {}).get("today")
+    if not isinstance(today, dict):
+        return False
+    data_source = today.get("data_source") or today.get("dataSource")
+    return isinstance(data_source, str) and data_source.startswith("realtime:")
+
+
+def _realtime_overlay_source(enhanced_context: Dict[str, Any]) -> Optional[str]:
+    today = (enhanced_context or {}).get("today")
+    if not isinstance(today, dict):
+        return None
+    value = today.get("data_source") or today.get("dataSource")
+    return value if isinstance(value, str) and value else None
+
+
+def _fundamental_status(status: str) -> ContextFieldStatus:
+    if status in {"ok", "available"}:
+        return ContextFieldStatus.AVAILABLE
+    if status == "not_supported":
+        return ContextFieldStatus.NOT_SUPPORTED
+    if status == "partial":
+        return ContextFieldStatus.PARTIAL
+    return ContextFieldStatus.MISSING
+
+
+def _fundamental_payload_status(
+    block_status: ContextFieldStatus,
+    has_payload: bool,
+) -> ContextFieldStatus:
+    if has_payload:
+        return block_status
+    if block_status == ContextFieldStatus.NOT_SUPPORTED:
+        return ContextFieldStatus.NOT_SUPPORTED
+    return ContextFieldStatus.MISSING
+
+
+def _fundamental_payload_missing_reason(
+    raw_status: str,
+    has_payload: bool,
+    missing_reason: str,
+) -> Optional[str]:
+    if raw_status == "failed":
+        return _FUNDAMENTAL_FAILED_REASON
+    if raw_status == "not_supported":
+        return "fundamentals_not_supported"
+    if has_payload:
+        return None
+    return missing_reason
+
+
+def _source_from_chain(source_chain: Any) -> Optional[str]:
+    if not isinstance(source_chain, list) or not source_chain:
+        return None
+    first = source_chain[0]
+    if isinstance(first, dict):
+        return _source_text(first.get("provider") or first.get("source"))
+    return _source_text(first)

--- a/tests/test_analysis_context_builder.py
+++ b/tests/test_analysis_context_builder.py
@@ -1,0 +1,373 @@
+# -*- coding: utf-8 -*-
+"""Tests for the Issue #1389 P2 AnalysisContextPack assembler."""
+
+from __future__ import annotations
+
+import builtins
+import importlib
+from dataclasses import dataclass
+
+import pytest
+
+from data_provider.realtime_types import RealtimeSource, UnifiedRealtimeQuote
+from src.schemas.analysis_context_pack import ContextFieldStatus
+import src.services.analysis_context_builder as builder_module
+from src.services.analysis_context_builder import (
+    AnalysisContextBuilder,
+    PipelineAnalysisArtifacts,
+)
+
+
+@dataclass
+class _FakeTrend:
+    data: dict
+
+    def to_dict(self) -> dict:
+        return dict(self.data)
+
+
+@dataclass
+class _FakeChip:
+    data: dict
+
+    def to_dict(self) -> dict:
+        return dict(self.data)
+
+
+class _BrokenTrend:
+    def to_dict(self) -> dict:
+        raise RuntimeError("broken trend artifact")
+
+
+class _InvalidTrend:
+    def to_dict(self) -> list:
+        return ["not", "a", "mapping"]
+
+
+def _quote(source: RealtimeSource = RealtimeSource.AKSHARE_EM) -> UnifiedRealtimeQuote:
+    return UnifiedRealtimeQuote(
+        code="600519",
+        name="贵州茅台",
+        source=source,
+        price=1880.0,
+        change_pct=1.2,
+        volume_ratio=1.3,
+        turnover_rate=0.5,
+    )
+
+
+def _artifacts(**overrides) -> PipelineAnalysisArtifacts:
+    data = {
+        "code": "600519",
+        "stock_name": "贵州茅台",
+        "market": "cn",
+        "phase": {"market": "cn", "phase": "intraday"},
+        "base_context": {
+            "code": "600519",
+            "stock_name": "贵州茅台",
+            "date": "2026-05-24",
+            "today": {"date": "2026-05-24", "close": 1880.0},
+            "yesterday": {"date": "2026-05-23", "close": 1860.0},
+        },
+        "enhanced_context": {
+            "today": {"date": "2026-05-24", "close": 1880.0},
+        },
+        "realtime_quote": _quote(),
+        "trend_result": _FakeTrend(
+            {
+                "trend_status": "多头排列",
+                "ma5": 1800.0,
+                "ma10": 1780.0,
+                "rsi_6": 66.0,
+            }
+        ),
+        "chip_data": _FakeChip(
+            {
+                "code": "600519",
+                "date": "2026-05-24",
+                "source": "akshare",
+                "profit_ratio": 0.72,
+                "avg_cost": 1700.0,
+            }
+        ),
+        "fundamental_context": {
+            "status": "ok",
+            "coverage": {"valuation": "ok"},
+            "source_chain": [{"provider": "fundamental_pipeline", "result": "ok"}],
+        },
+        "news_context": "公司公告与行业新闻摘要",
+        "news_result_count": 3,
+        "metadata": {"query_id": "q-1", "trigger_source": "api"},
+    }
+    data.update(overrides)
+    return PipelineAnalysisArtifacts(**data)
+
+
+def test_quote_block_maps_available_missing_fallback_and_explicit_stale() -> None:
+    available = AnalysisContextBuilder.build(_artifacts()).blocks["quote"]
+    assert available.status == ContextFieldStatus.AVAILABLE
+    assert available.source == "akshare_em"
+    assert available.items["price"].value == 1880.0
+
+    missing = AnalysisContextBuilder.build(
+        _artifacts(realtime_quote=None)
+    ).blocks["quote"]
+    assert missing.status == ContextFieldStatus.MISSING
+    assert missing.items["quote"].missing_reason == "realtime_quote_missing"
+
+    fallback = AnalysisContextBuilder.build(
+        _artifacts(realtime_quote=_quote(RealtimeSource.FALLBACK))
+    ).blocks["quote"]
+    assert fallback.status == ContextFieldStatus.FALLBACK
+    assert "realtime_provider_fallback" in fallback.warnings
+    assert fallback.items["price"].fallback_from is None
+
+    explicit_fallback = AnalysisContextBuilder.build(
+        _artifacts(
+            realtime_quote={
+                "source": "fallback",
+                "price": 1870.0,
+                "fallback_from": "primary_realtime_provider",
+            }
+        )
+    ).blocks["quote"]
+    assert explicit_fallback.status == ContextFieldStatus.FALLBACK
+    assert explicit_fallback.items["price"].fallback_from == "primary_realtime_provider"
+    assert "realtime_provider_fallback" not in explicit_fallback.warnings
+
+    stale = AnalysisContextBuilder.build(
+        _artifacts(metadata={"query_id": "q-1", "price_stale": True})
+    ).blocks["quote"]
+    assert stale.status == ContextFieldStatus.STALE
+    assert stale.metadata["price_stale"] is True
+    assert "quote_stale" in stale.warnings
+
+
+def test_daily_bars_uses_base_context_and_keeps_dates_out_of_timestamp() -> None:
+    pack = AnalysisContextBuilder.build(
+        _artifacts(
+            base_context={
+                "code": "600519",
+                "stock_name": "贵州茅台",
+                "date": "2026-05-24",
+                "data_missing": True,
+                "today": {},
+                "yesterday": {},
+            },
+            enhanced_context={
+                "today": {
+                    "date": "2026-05-26",
+                    "close": 1900.0,
+                    "data_source": "realtime:akshare_em",
+                }
+            },
+        )
+    )
+
+    block = pack.blocks["daily_bars"]
+    dumped = block.model_dump(mode="json")
+
+    assert block.status == ContextFieldStatus.MISSING
+    assert block.metadata["date"] == "2026-05-24"
+    assert all(item["timestamp"] is None for item in dumped["items"].values())
+    assert dumped["items"]["today"]["metadata"]["date"] == "2026-05-24"
+
+    date_only = AnalysisContextBuilder.build(
+        _artifacts(
+            base_context={
+                "date": "2026-05-24",
+                "today": {},
+                "yesterday": {},
+            }
+        )
+    ).blocks["daily_bars"]
+    assert date_only.status == ContextFieldStatus.MISSING
+    assert date_only.items["date"].status == ContextFieldStatus.AVAILABLE
+
+    one_bar = AnalysisContextBuilder.build(
+        _artifacts(
+            base_context={
+                "date": "2026-05-24",
+                "today": {"date": "2026-05-24", "close": 1880.0},
+                "yesterday": {},
+            }
+        )
+    ).blocks["daily_bars"]
+    assert one_bar.status == ContextFieldStatus.PARTIAL
+
+
+def test_technical_missing_and_realtime_overlay_statuses_are_explicit() -> None:
+    missing = AnalysisContextBuilder.build(
+        _artifacts(trend_result=None)
+    ).blocks["technical"]
+    assert missing.status == ContextFieldStatus.MISSING
+    assert missing.items["trend_result"].missing_reason == "trend_result_missing"
+
+    pack = AnalysisContextBuilder.build(
+        _artifacts(
+            enhanced_context={
+                "today": {
+                    "close": 1880.0,
+                    "data_source": "realtime:akshare_em",
+                }
+            }
+        )
+    )
+    block = pack.blocks["technical"]
+
+    assert block.status == ContextFieldStatus.PARTIAL
+    assert block.items["trend_result"].status == ContextFieldStatus.AVAILABLE
+    assert block.items["intraday_overlay"].status == ContextFieldStatus.ESTIMATED
+    assert "intraday_realtime_overlay" in block.warnings
+    assert "intraday_realtime_overlay" in pack.data_quality.warnings
+
+
+def test_chip_missing_defaults_to_missing_and_explicit_not_supported() -> None:
+    missing = AnalysisContextBuilder.build(_artifacts(chip_data=None)).blocks["chip"]
+    assert missing.status == ContextFieldStatus.MISSING
+    assert (
+        missing.items["chip_distribution"].missing_reason
+        == "chip_distribution_missing"
+    )
+
+    not_supported = AnalysisContextBuilder.build(
+        _artifacts(chip_data=None, metadata={"chip_not_supported": True})
+    ).blocks["chip"]
+    assert not_supported.status == ContextFieldStatus.NOT_SUPPORTED
+    assert (
+        not_supported.items["chip_distribution"].missing_reason
+        == "chip_not_supported"
+    )
+
+
+@pytest.mark.parametrize(
+    ("payload_status", "expected_status"),
+    (
+        ("ok", ContextFieldStatus.AVAILABLE),
+        ("not_supported", ContextFieldStatus.NOT_SUPPORTED),
+        ("partial", ContextFieldStatus.PARTIAL),
+        ("failed", ContextFieldStatus.MISSING),
+    ),
+)
+def test_fundamentals_maps_supported_statuses_without_raw_errors(
+    payload_status: str,
+    expected_status: ContextFieldStatus,
+) -> None:
+    block = AnalysisContextBuilder.build(
+        _artifacts(
+            fundamental_context={
+                "status": payload_status,
+                "coverage": {"valuation": payload_status},
+                "source_chain": [
+                    {"provider": "fundamental_pipeline", "result": payload_status}
+                ],
+                "errors": ["token=secret should not be persisted"],
+            }
+        )
+    ).blocks["fundamentals"]
+
+    assert block.status == expected_status
+    assert block.metadata["coverage"] == {"valuation": payload_status}
+    assert block.items["coverage"].status == expected_status
+    assert block.items["source_chain"].status == expected_status
+    assert "errors" not in block.metadata
+    assert "token=secret" not in str(block.model_dump(mode="json"))
+    if payload_status == "failed":
+        assert block.items["status"].missing_reason == "fundamental_pipeline_failed"
+        assert block.items["coverage"].missing_reason == "fundamental_pipeline_failed"
+        assert (
+            block.items["source_chain"].missing_reason
+            == "fundamental_pipeline_failed"
+        )
+
+
+def test_builder_does_not_hide_broken_artifact_to_dict() -> None:
+    with pytest.raises(RuntimeError, match="broken trend artifact"):
+        AnalysisContextBuilder.build(_artifacts(trend_result=_BrokenTrend()))
+
+
+def test_builder_rejects_non_mapping_artifact_to_dict() -> None:
+    with pytest.raises(TypeError, match="to_dict\\(\\) must return a mapping"):
+        AnalysisContextBuilder.build(_artifacts(trend_result=_InvalidTrend()))
+
+
+def test_news_block_treats_blank_as_missing_and_records_pack_metadata() -> None:
+    blank = AnalysisContextBuilder.build(
+        _artifacts(news_context="  ", news_result_count=0)
+    )
+    assert blank.blocks["news"].status == ContextFieldStatus.MISSING
+    assert blank.metadata["news_result_count"] == 0
+
+    available = AnalysisContextBuilder.build(
+        _artifacts(news_context="news", news_result_count=5)
+    )
+    assert available.blocks["news"].status == ContextFieldStatus.AVAILABLE
+    assert available.blocks["news"].items["content"].value == "news"
+    assert available.metadata["news_result_count"] == 5
+
+
+def test_build_batch_returns_one_pack_per_artifact() -> None:
+    packs = AnalysisContextBuilder.build_batch(
+        [
+            _artifacts(code="600519", stock_name="贵州茅台"),
+            _artifacts(code="000001", stock_name="平安银行"),
+        ]
+    )
+
+    assert [pack.subject.code for pack in packs] == ["600519", "000001"]
+
+
+def test_builder_output_safe_dict_redacts_sensitive_mapping_keys() -> None:
+    pack = AnalysisContextBuilder.build(
+        _artifacts(
+            metadata={
+                "query_id": "q-1",
+                "webhook_url": "https://hooks.example.test/secret",
+            },
+            fundamental_context={
+                "status": "ok",
+                "coverage": {
+                    "valuation": "ok",
+                    "access_token": "secret-token",
+                },
+                "source_chain": [{"provider": "fundamental_pipeline"}],
+            },
+        )
+    )
+
+    safe = pack.to_safe_dict()
+
+    assert safe["metadata"]["webhook_url"] == "[REDACTED]"
+    assert (
+        safe["blocks"]["fundamentals"]["metadata"]["coverage"]["access_token"]
+        == "[REDACTED]"
+    )
+    assert safe["blocks"]["fundamentals"]["metadata"]["coverage"]["valuation"] == "ok"
+
+
+def test_builder_module_stays_zero_fetch_and_zero_storage_import(monkeypatch) -> None:
+    forbidden_modules = (
+        "data_provider",
+        "fetcher_manager",
+        "search_service",
+        "src.storage",
+        "src.services.search_service",
+        "src.repositories",
+        "src.database",
+    )
+    real_import = builtins.__import__
+
+    def guarded_import(name, globals=None, locals=None, fromlist=(), level=0):
+        if level == 0 and any(
+            name == module or name.startswith(f"{module}.")
+            for module in forbidden_modules
+        ):
+            raise AssertionError(f"unexpected zero-fetch import: {name}")
+        return real_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr(builtins, "__import__", guarded_import)
+
+    reloaded = importlib.reload(builder_module)
+    pack = reloaded.AnalysisContextBuilder.build(_artifacts())
+
+    assert pack.blocks["quote"].status == ContextFieldStatus.AVAILABLE

--- a/tests/test_analysis_context_pack_docs.py
+++ b/tests/test_analysis_context_pack_docs.py
@@ -25,6 +25,7 @@ def test_analysis_context_pack_doc_has_required_sections() -> None:
         "## 术语与边界",
         "## P0 范围与非目标",
         "## P1 内部契约",
+        "## P2 Builder 契约",
         "## 字段质量状态",
         "## 现有状态映射",
         "## 七路径盘点",
@@ -202,6 +203,27 @@ def test_analysis_context_pack_doc_keeps_later_phases_out_of_p1() -> None:
         assert token in section
 
 
+def test_analysis_context_pack_doc_defines_p2_builder_boundaries() -> None:
+    section = _section(_read_doc(), "P2 Builder 契约")
+
+    for token in (
+        "`AnalysisContextBuilder`",
+        "assembler",
+        "pipeline 已 fetch",
+        "zero-fetch",
+        "`PipelineAnalysisArtifacts`",
+        "`code`、`stock_name`、`market`",
+        "`price_stale`",
+        "`quote_stale`",
+        "`intraday_realtime_overlay`",
+        "`fetch_failed`",
+        "P3 runtime",
+        "不改变 Prompt",
+        "不写入 history/task/report metadata",
+    ):
+        assert token in section
+
+
 def test_analysis_context_pack_doc_maps_existing_status_terms() -> None:
     section = _section(_read_doc(), "现有状态映射")
 
@@ -256,3 +278,4 @@ def test_analysis_context_pack_doc_updates_indexes_and_changelog() -> None:
     ) in index_en
     assert "[文档] 新增 AnalysisContextPack P0 上下文盘点" in changelog
     assert "[新功能] 新增 AnalysisContextPack P1 内部契约与脱敏序列化测试" in changelog
+    assert "[新功能] 新增 AnalysisContextPack P2 builder" in changelog


### PR DESCRIPTION
## PR Type

- [ ] fix
- [x] feat
- [ ] refactor
- [ ] docs
- [ ] chore
- [ ] test

## Background And Problem

Refs #1389。

本 PR 落地 #1389 的 P2 assembler slice：新增内部 `AnalysisContextBuilder`，从普通分析 pipeline 已经获取到的 artifacts 组装 `AnalysisContextPack`。本阶段只解决 pack builder 的纯组装能力，完整 P2 AC 仍待 P3 runtime 接入后闭合。

本 PR 不接入普通分析 runtime、不改 Prompt/Agent/history/API/Web/通知，也不新增平行 fetcher。

## Scope Of Change

- 新增 `src/services/analysis_context_builder.py`
  - 定义 `PipelineAnalysisArtifacts`
  - 提供 `AnalysisContextBuilder.build()` / `build_batch()`
  - 从已传入 artifacts 组装 `quote`、`daily_bars`、`technical`、`chip`、`fundamentals`、`news` blocks
  - 保持 zero-fetch：不引入 DB、fetcher、search service、storage 或 provider 依赖
- 新增 `tests/test_analysis_context_builder.py`
  - 覆盖 quote missing/fallback/stale、daily bars 缺失与 partial、technical realtime overlay、chip not_supported、fundamentals 四态、news、batch、脱敏和 zero-fetch import guard
- 更新 `docs/analysis-context-pack.md`
  - 增加 P2 Builder 契约小节
  - 明确 P2 是 assembler-only、复用 pipeline 已 fetch artifacts、subject 仍限三字段、P3/P4/P5 deferred
- 更新 `tests/test_analysis_context_pack_docs.py`
  - 增加 P2 文档契约断言
- 更新 `docs/CHANGELOG.md`
  - 增加 `[Unreleased]` 扁平条目

## Issue Link

Refs #1389

## Verification Commands And Results

```bash
python -m py_compile src/services/analysis_context_builder.py
python -m pytest tests/test_analysis_context_builder.py tests/test_analysis_context_pack_docs.py tests/test_analysis_context_pack_schema.py
python -m flake8 src/services/analysis_context_builder.py tests/test_analysis_context_builder.py tests/test_analysis_context_pack_docs.py
git diff --check
```

关键输出/结论：

- `python -m pytest ...`：`44 passed`
- `python -m py_compile ...`：通过
- `python -m flake8 ...`：通过
- `git diff --check`：通过

未完整本地复现：

- `./scripts/ci_gate.sh`：当前本地 Python 环境缺 `pypinyin`，完整 gate 未在本机跑绿；`pandas` 已安装。合并前以远端 `backend-gate` 为准。
- 未跑 pipeline E2E / runtime smoke：本 PR 是 P2 assembler slice，runtime 接入留到 P3。

## Compatibility And Risk

- 兼容性影响：无用户可见 runtime 行为变更；未修改 API、Web、Desktop、history/task/report metadata、Prompt 或 Agent。
- 数据源影响：builder 本身不 fetch；只消费调用方传入的 pipeline artifacts。
- 风险：
  - `daily_bars` date-only 场景当前表达为 block `missing`、date item `available`，表示完整日线窗口缺失但日期锚点存在。P3 runtime 接入时如需要面向 UI/Prompt 的聚合摘要，可再调整为更细的展示语义。
  - 完整 pack 仍不公开到 API/Web/通知；后续若 P4 需要展示，应暴露摘要而非完整 pack。

## Rollback Plan

如需回滚，直接 revert this PR 即可；本 PR 不新增配置、数据库迁移或运行时接线，不需要额外数据或配置回滚。

## EXTRACT_PROMPT Change (if applicable)

不适用；本 PR 未修改 `src/services/image_stock_extractor.py` 或 `EXTRACT_PROMPT`。

## Checklist

- [x] 本 PR 有明确动机和业务价值 / This PR has a clear motivation and value
- [x] 已提供可复现的验证命令与结果 / Reproducible verification commands and results are included
- [x] 已评估兼容性与风险 / Compatibility and risk have been assessed
- [x] 已提供回滚方案 / A rollback plan is provided
- [x] 若涉及用户可见变更，已同步更新相关文档与 `docs/CHANGELOG.md`；`README.md` 仅在首页级信息变化时更新，细节优先写入 `docs/*.md` / If user-visible changes are included, relevant docs and `docs/CHANGELOG.md` are updated; `README.md` is updated only for homepage-level changes, with details kept in `docs/*.md`
