### PR TITLE
fix: [issue #1446] 支持股票自动补全索引远程刷新

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -60,6 +60,9 @@ TUSHARE_TOKEN=
 # 设为 1 / true / yes 开启 SDK 详细行情包日志（调试长桥连接时使用）
 # LONGBRIDGE_PRINT_QUOTE_PACKAGES=false
 
+# 股票自动补全索引远程更新（默认开启；GitHub 不可访问时自动降级到本地内置索引）
+STOCK_INDEX_REMOTE_UPDATE_ENABLED=true
+
 # ===================================
 # AI 模型配置
 # ===================================

--- a/api/app.py
+++ b/api/app.py
@@ -15,11 +15,12 @@ FastAPI 应用工厂模块
     app = create_app()
 """
 
+import asyncio
 import logging
 import mimetypes
 import os
 import re
-from contextlib import asynccontextmanager
+from contextlib import asynccontextmanager, suppress
 from datetime import datetime
 from pathlib import Path
 from urllib.parse import unquote
@@ -29,6 +30,7 @@ from fastapi import FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import FileResponse, HTMLResponse, JSONResponse, Response
 from fastapi.staticfiles import StaticFiles
+from starlette.concurrency import run_in_threadpool
 
 logger = logging.getLogger(__name__)
 
@@ -125,15 +127,61 @@ from api.middlewares.auth import add_auth_middleware
 from api.middlewares.error_handler import add_error_handlers
 from api.v1.schemas.common import HealthResponse
 from src.services.system_config_service import SystemConfigService
+from src.services.stock_index_remote_service import (
+    get_remote_stock_index_cache_path,
+    is_valid_remote_stock_index_file,
+    refresh_remote_stock_index_cache,
+    settings_from_config,
+)
+
+
+_STOCK_INDEX_FILENAME = "stocks.index.json"
+_STOCK_INDEX_HEADERS = {
+    "Cache-Control": "no-cache",
+}
+
+
+def _bundled_stock_index_path() -> Path:
+    return Path(__file__).parent.parent / "apps" / "dsa-web" / "public" / _STOCK_INDEX_FILENAME
+
+
+async def _refresh_stock_index_cache_in_background(reason: str) -> None:
+    try:
+        from src.config import get_config
+
+        settings = settings_from_config(get_config())
+        result = await run_in_threadpool(refresh_remote_stock_index_cache, settings)
+        if result.refreshed:
+            logger.info("[stock-index] background refresh completed (%s): %s", reason, result.cache_path)
+    except asyncio.CancelledError:
+        raise
+    except Exception as exc:  # noqa: BLE001 - index refresh must stay best-effort.
+        logger.warning("[stock-index] background refresh failed (%s): %s", reason, exc)
+
+
+def _schedule_stock_index_background_refresh(app: FastAPI, reason: str) -> None:
+    task = getattr(app.state, "stock_index_refresh_task", None)
+    if task is not None and not task.done():
+        return
+
+    app.state.stock_index_refresh_task = asyncio.create_task(
+        _refresh_stock_index_cache_in_background(reason)
+    )
 
 
 @asynccontextmanager
 async def app_lifespan(app: FastAPI):
     """Initialize and release shared services for the app lifecycle."""
     app.state.system_config_service = SystemConfigService()
+    _schedule_stock_index_background_refresh(app, "startup")
     try:
         yield
     finally:
+        refresh_task = getattr(app.state, "stock_index_refresh_task", None)
+        if refresh_task is not None and not refresh_task.done():
+            refresh_task.cancel()
+            with suppress(asyncio.CancelledError):
+                await refresh_task
         if hasattr(app.state, "system_config_service"):
             delattr(app.state, "system_config_service")
 
@@ -268,6 +316,47 @@ def create_app(static_dir: Optional[Path] = None) -> FastAPI:
         return HealthResponse(
             status="ok",
             timestamp=datetime.now().isoformat()
+        )
+
+    def _stock_index_candidate_paths() -> tuple[Path, ...]:
+        return (
+            get_remote_stock_index_cache_path(),
+            static_dir / _STOCK_INDEX_FILENAME,
+            _bundled_stock_index_path(),
+        )
+
+    def _find_existing_stock_index_path() -> Optional[Path]:
+        remote_cache_path = get_remote_stock_index_cache_path()
+        if remote_cache_path.is_file() and is_valid_remote_stock_index_file(remote_cache_path):
+            return remote_cache_path
+
+        for candidate in _stock_index_candidate_paths():
+            if candidate == remote_cache_path:
+                continue
+            if candidate.is_file():
+                return candidate
+        return None
+
+    @app.api_route(
+        f"/{_STOCK_INDEX_FILENAME}",
+        methods=["GET", "HEAD"],
+        include_in_schema=False,
+    )
+    async def serve_stock_index():
+        """Serve the freshest available stock autocomplete index."""
+        _schedule_stock_index_background_refresh(app, "serve-stock-index")
+
+        index_path = _find_existing_stock_index_path()
+        if index_path is None:
+            return Response(
+                content="stock index not found",
+                status_code=404,
+                media_type="text/plain",
+            )
+        return FileResponse(
+            index_path,
+            media_type="application/json",
+            headers=_STOCK_INDEX_HEADERS,
         )
     
     # ============================================================

--- a/api/app.py
+++ b/api/app.py
@@ -319,10 +319,16 @@ def create_app(static_dir: Optional[Path] = None) -> FastAPI:
         )
 
     def _stock_index_candidate_paths() -> tuple[Path, ...]:
-        return (
-            get_remote_stock_index_cache_path(),
+        local_candidates = (
             static_dir / _STOCK_INDEX_FILENAME,
             _bundled_stock_index_path(),
+        )
+        local_path = next((path for path in local_candidates if path.is_file()), None)
+        if local_path is None:
+            return (get_remote_stock_index_cache_path(),)
+        return (
+            get_remote_stock_index_cache_path(),
+            local_path,
         )
 
     def _find_existing_stock_index_path() -> Optional[Path]:

--- a/api/app.py
+++ b/api/app.py
@@ -126,10 +126,10 @@ from api.v1 import api_v1_router
 from api.middlewares.auth import add_auth_middleware
 from api.middlewares.error_handler import add_error_handlers
 from api.v1.schemas.common import HealthResponse
+from src.data.stock_index_loader import find_existing_stock_index_path
 from src.services.system_config_service import SystemConfigService
 from src.services.stock_index_remote_service import (
     get_remote_stock_index_cache_path,
-    is_valid_remote_stock_index_file,
     refresh_remote_stock_index_cache,
     settings_from_config,
 )
@@ -327,15 +327,10 @@ def create_app(static_dir: Optional[Path] = None) -> FastAPI:
 
     def _find_existing_stock_index_path() -> Optional[Path]:
         remote_cache_path = get_remote_stock_index_cache_path()
-        if remote_cache_path.is_file() and is_valid_remote_stock_index_file(remote_cache_path):
-            return remote_cache_path
-
-        for candidate in _stock_index_candidate_paths():
-            if candidate == remote_cache_path:
-                continue
-            if candidate.is_file():
-                return candidate
-        return None
+        return find_existing_stock_index_path(
+            _stock_index_candidate_paths(),
+            remote_cache_path=remote_cache_path,
+        )
 
     @app.api_route(
         f"/{_STOCK_INDEX_FILENAME}",

--- a/apps/dsa-web/src/locales/settingsHelp.ts
+++ b/apps/dsa-web/src/locales/settingsHelp.ts
@@ -168,6 +168,14 @@ const settingsHelpZhCN: SettingsHelpMap = {
     impact: ['影响大盘复盘和市场统计增强数据的覆盖度。'],
     notes: ['不要在 issue、日志或截图中暴露真实 Key。'],
   },
+  'settings.data_source.stock_index_remote': {
+    title: '股票索引远程更新',
+    summary: '从 GitHub main 分支获取最新股票自动补全索引，并缓存到本地。',
+    usage: '默认开启；如运行环境无法访问 GitHub raw，可关闭开关。远程 URL、检查频率和超时时间均为系统内置值。',
+    valueNotes: ['系统默认 48 小时检查一次更新，避免频繁访问 GitHub。', '远程检查失败不会阻断 WebUI 或分析流程。'],
+    impact: ['影响 Web 自动补全和后端股票名称解析使用的股票简称新鲜度。'],
+    notes: ['远程下载失败时会继续使用已有缓存或随应用打包的内置索引。'],
+  },
   'settings.data_source.REALTIME_SOURCE_PRIORITY': {
     title: '实时行情源优先级',
     summary: '配置多个实时行情源的尝试顺序。',
@@ -996,6 +1004,14 @@ const settingsHelpEnUS: SettingsHelpMap = {
     valueNotes: ['This key is an optional enhancement, not required for the main analysis flow.'],
     impact: ['Affects market-review and market-statistics coverage.'],
     notes: ['Do not expose real keys in issues, logs, or screenshots.'],
+  },
+  'settings.data_source.stock_index_remote': {
+    title: 'Remote Stock Index',
+    summary: 'Fetches the latest stock autocomplete index from GitHub main and caches it locally.',
+    usage: 'Enabled by default. If GitHub raw is unreachable, disable it. The URL, check frequency, and timeout are built-in system values.',
+    valueNotes: ['The system checks for updates every 48 hours to avoid frequent GitHub access.', 'Remote check failures do not block WebUI or analysis.'],
+    impact: ['Affects stock-name freshness for Web autocomplete and backend stock-name resolution.'],
+    notes: ['When remote download fails, the app keeps using an existing cache or the bundled index.'],
   },
   'settings.data_source.REALTIME_SOURCE_PRIORITY': {
     title: 'Realtime Source Priority',

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -43,6 +43,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - [新功能] 问股新增默认关闭的可见对话上下文压缩，支持 Web 开关、Agent 高级 preset、滚动摘要和最近轮次原文保护，降低长会话 token 消耗。
 - [改进] P2-min：LLM Prompt 注入市场阶段上下文。
 - [修复] 问股 single-agent 新增 provider-aware trace 分轨，跨轮保留 DeepSeek V4 thinking + tool-call 的 `reasoning_content` 与工具协议材料。
+- [新功能] 股票自动补全索引默认支持从 GitHub main 远程刷新并缓存到本地，Web/CLI 分析入口失败时自动降级到内置索引，降低摘帽和更名后旧简称污染分析的概率。
 
 ## [3.18.0] - 2026-05-21
 

--- a/docs/TUSHARE_STOCK_LIST_GUIDE.md
+++ b/docs/TUSHARE_STOCK_LIST_GUIDE.md
@@ -129,11 +129,23 @@ python3 scripts/generate_index_from_csv.py --test  # 先测试
 python3 scripts/generate_index_from_csv.py         # 确认后生成
 ```
 
+### 本地客户端自动获取最新索引
+
+新版客户端默认会从项目 GitHub `main` 分支读取最新的 `apps/dsa-web/public/stocks.index.json`，并缓存到本地 `data/cache/stocks.index.json`。前端仍访问本地 `/stocks.index.json`，不需要直接跨域请求 GitHub。
+
+远程索引地址、检查频率和网络超时时间为系统内置值，不提供用户配置项；用户只需要决定是否启用：
+
+```bash
+STOCK_INDEX_REMOTE_UPDATE_ENABLED=true
+```
+
+默认开启时，系统最多每 48 小时检查一次更新。若运行环境无法访问 GitHub raw、请求超时、返回内容不是合法股票索引，应用会保留已有缓存；如果没有远程缓存，则继续使用随应用打包的内置索引。远程更新失败不会阻断 WebUI 启动、股票自动补全或分析流程；连续失败达到系统内置阈值后，会在本进程内暂停重试直到下一轮 48 小时窗口。
+
 ## 注意事项
 
 1. **积分要求**：确保账号积分足够（A股/港股2000，美股120试用）
 2. **请求限制**：注意 API 的每分钟请求次数限制
-3. **数据更新**：建议每月更新一次数据
+3. **数据更新**：维护者建议每三天刷新一次并提交到仓库；本地客户端默认最多每 48 小时检查一次 GitHub `main` 上的索引更新。后续可通过 GitHub Actions workflow 自动化刷新与提交 PR
 4. **网络连接**：需要稳定的网络连接
 
 ## 常见问题
@@ -155,7 +167,10 @@ python3 scripts/generate_index_from_csv.py         # 确认后生成
 4. 当前脚本不会自动重试；单次请求失败后会输出错误并结束，请排查原因后重新运行
 
 ### Q: 数据更新频率？
-**A**: 建议每月更新一次，或根据需求调整
+**A**: 对维护者本地 CSV 与仓库索引，建议每三天更新一次并提交到仓库；遇到摘帽/更名等高影响事件可临时刷新。未来可通过 GitHub Actions workflow 自动化刷新与提交 PR。对普通本地客户端，系统默认最多每 48 小时从 GitHub `main` 检查一次最新索引。
+
+### Q: 无法访问 GitHub raw 会影响使用吗？
+**A**: 不会。远程索引更新是 best-effort：失败时会继续使用已有远程缓存或随应用打包的内置索引；如果索引完全不可用，Web 自动补全会进入现有 fallback，股票代码仍可手动输入。
 
 ## 相关链接
 

--- a/docs/settings-help.md
+++ b/docs/settings-help.md
@@ -33,7 +33,7 @@ PR2 继续覆盖高频、易填错配置项：
 
 - AI 模型运行时：Agent 主模型、fallback 模型、高级 YAML 路由、temperature、provider API Key、OpenAI-compatible Base URL。
 - LLM Channels 编辑器内部字段：渠道名、协议、Base URL、API Key、模型列表、运行时能力检测、主模型、Agent 主模型、fallback、Vision 和 temperature。
-- 数据源与搜索：Tushare、实时行情优先级、实时技术指标、搜索 API Key、SearXNG、筹码分布、新闻窗口。
+- 数据源与搜索：Tushare、股票索引远程更新开关、实时行情优先级、实时技术指标、搜索 API Key、SearXNG、筹码分布、新闻窗口。
 - 通知：Webhook、Telegram、邮件、Discord/Slack 等聊天平台、报告输出、Webhook SSL 校验。
 - WebUI / auth / schedule / proxy：Host、Port、登录保护、可信反向代理、定时任务、交易日检查、网络代理。
 

--- a/main.py
+++ b/main.py
@@ -447,6 +447,23 @@ def _run_market_review_with_shared_lock(
         release_market_review_lock(lock_token)
 
 
+def _refresh_stock_index_cache_for_analysis(config: Config) -> None:
+    """Best-effort stock-index refresh for CLI/scheduled analysis paths."""
+    try:
+        from src.services.stock_index_remote_service import (
+            refresh_remote_stock_index_cache,
+            settings_from_config,
+        )
+
+        result = refresh_remote_stock_index_cache(settings_from_config(config))
+        if result.refreshed:
+            logger.info("[stock-index] 分析前已刷新股票索引缓存: %s", result.cache_path)
+        elif result.error:
+            logger.debug("[stock-index] 分析前刷新未完成，继续使用本地索引: %s", result.error)
+    except Exception as exc:  # noqa: BLE001 - stock index freshness must not block analysis.
+        logger.warning("[stock-index] 分析前刷新股票索引失败，继续执行分析: %s", exc)
+
+
 def run_full_analysis(
     config: Config,
     args: argparse.Namespace,
@@ -463,6 +480,8 @@ def run_full_analysis(
     from src.core.pipeline import StockAnalysisPipeline
 
     try:
+        _refresh_stock_index_cache_for_analysis(config)
+
         # Issue #529: Hot-reload STOCK_LIST from .env on each scheduled run
         if stock_codes is None:
             config.refresh_stock_list()

--- a/src/config.py
+++ b/src/config.py
@@ -625,6 +625,7 @@ class Config:
     longbridge_app_key: Optional[str] = None
     longbridge_app_secret: Optional[str] = None
     longbridge_access_token: Optional[str] = None
+    stock_index_remote_update_enabled: bool = True
 
     # === AI 分析配置 ===
     # LiteLLM unified model config (provider/model format, e.g. gemini/gemini-3.1-pro-preview)
@@ -1414,6 +1415,10 @@ class Config:
             longbridge_app_key=os.getenv('LONGBRIDGE_APP_KEY') or None,
             longbridge_app_secret=os.getenv('LONGBRIDGE_APP_SECRET') or None,
             longbridge_access_token=os.getenv('LONGBRIDGE_ACCESS_TOKEN') or None,
+            stock_index_remote_update_enabled=parse_env_bool(
+                os.getenv('STOCK_INDEX_REMOTE_UPDATE_ENABLED'),
+                default=True,
+            ),
             litellm_model=litellm_model,
             litellm_fallback_models=litellm_fallback_models,
             llm_temperature=resolve_unified_llm_temperature(litellm_model),

--- a/src/core/config_registry.py
+++ b/src/core/config_registry.py
@@ -439,6 +439,32 @@ _FIELD_DEFINITIONS: Dict[str, Dict[str, Any]] = {
         "validation": {},
         "display_order": 15,
     },
+    "STOCK_INDEX_REMOTE_UPDATE_ENABLED": {
+        "title": "Remote Stock Index Updates",
+        "description": "Automatically refresh the local stock autocomplete index from the built-in GitHub main source.",
+        "category": "data_source",
+        "data_type": "boolean",
+        "ui_control": "switch",
+        "is_sensitive": False,
+        "is_required": False,
+        "is_editable": True,
+        "default_value": "true",
+        "options": [],
+        "validation": {},
+        "display_order": 16,
+        "help_key": "settings.data_source.stock_index_remote",
+        "examples": [
+            "STOCK_INDEX_REMOTE_UPDATE_ENABLED=true",
+            "STOCK_INDEX_REMOTE_UPDATE_ENABLED=false",
+        ],
+        "docs": [
+            {
+                "label": "Tushare 股票列表指南",
+                "href": "https://github.com/ZhuLinsen/daily_stock_analysis/blob/main/docs/TUSHARE_STOCK_LIST_GUIDE.md",
+            },
+        ],
+        "warning_codes": [],
+    },
     "REALTIME_SOURCE_PRIORITY": {
         "title": "Realtime Source Priority",
         "description": "Comma-separated priority for realtime quote providers.",

--- a/src/data/stock_index_loader.py
+++ b/src/data/stock_index_loader.py
@@ -5,15 +5,20 @@ import json
 import logging
 from pathlib import Path
 from threading import RLock
-from typing import Dict, Iterable
+from typing import Dict, Iterable, Optional
 
 from src.data.stock_mapping import is_meaningful_stock_name
-from src.services.stock_index_remote_service import get_remote_stock_index_cache_path
+from src.services.stock_index_remote_service import (
+    get_remote_stock_index_cache_path,
+    is_valid_remote_stock_index_file,
+    validate_stock_index_payload,
+)
 
 logger = logging.getLogger(__name__)
 
 _STOCK_INDEX_FILENAME = "stocks.index.json"
 _STOCK_INDEX_CACHE: Dict[str, str] | None = None
+_REMOTE_INDEX_VALIDITY_CACHE: tuple[Path, float, int, bool] | None = None
 _STOCK_INDEX_CACHE_LOCK = RLock()
 
 
@@ -25,6 +30,10 @@ def get_stock_index_candidate_paths() -> tuple[Path, ...]:
         repo_root / "apps" / "dsa-web" / "public" / _STOCK_INDEX_FILENAME,
         repo_root / "static" / _STOCK_INDEX_FILENAME,
     )
+
+
+def _same_path(left: Path, right: Path) -> bool:
+    return left == right or left.resolve() == right.resolve()
 
 
 def _add_lookup_key(keys: set[str], value: str) -> None:
@@ -63,7 +72,7 @@ def _build_lookup_keys(canonical_code: str, display_code: str) -> Iterable[str]:
     return keys
 
 
-def _load_stock_index_file(index_path: Path) -> Dict[str, str]:
+def _load_stock_index_payload(index_path: Path) -> list:
     with index_path.open("r", encoding="utf-8") as fh:
         raw_items = json.load(fh)
 
@@ -71,7 +80,10 @@ def _load_stock_index_file(index_path: Path) -> Dict[str, str]:
         raise ValueError(
             f"Unexpected {_STOCK_INDEX_FILENAME} payload type: {type(raw_items).__name__}"
         )
+    return raw_items
 
+
+def _build_stock_name_map(raw_items: list) -> Dict[str, str]:
     stock_name_map: Dict[str, str] = {}
     for item in raw_items:
         if not isinstance(item, list) or len(item) < 3:
@@ -87,6 +99,87 @@ def _load_stock_index_file(index_path: Path) -> Dict[str, str]:
     return stock_name_map
 
 
+def _load_stock_index_file(index_path: Path) -> Dict[str, str]:
+    return _build_stock_name_map(_load_stock_index_payload(index_path))
+
+
+def _load_remote_stock_index_file(index_path: Path) -> Dict[str, str]:
+    raw_items = _load_stock_index_payload(index_path)
+    validate_stock_index_payload(raw_items)
+    return _build_stock_name_map(raw_items)
+
+
+def _get_stock_index_signature(index_path: Path) -> tuple[float, int] | None:
+    try:
+        stat_result = index_path.stat()
+    except OSError as exc:
+        logger.debug("[股票名称] 读取股票索引元数据失败 %s: %s", index_path, exc)
+        return None
+    if not index_path.is_file():
+        return None
+    return stat_result.st_mtime, stat_result.st_size
+
+
+def _get_fresh_stock_index_candidates(
+    candidate_paths: Iterable[Path],
+    remote_cache_path: Path,
+) -> tuple[Path, ...]:
+    paths = tuple(candidate_paths)
+    candidates: list[tuple[tuple[float, int], Path]] = []
+
+    for position, candidate_path in enumerate(paths):
+        signature = _get_stock_index_signature(candidate_path)
+        if signature is None:
+            continue
+
+        mtime, _size = signature
+        tie_breaker = 0 if _same_path(candidate_path, remote_cache_path) else len(paths) - position
+        candidates.append(((mtime, tie_breaker), candidate_path))
+
+    return tuple(path for _sort_key, path in sorted(candidates, reverse=True))
+
+
+def _is_remote_stock_index_cache_usable(
+    index_path: Path,
+    remote_cache_path: Path,
+    signature: tuple[float, int],
+) -> bool:
+    global _REMOTE_INDEX_VALIDITY_CACHE
+
+    if not _same_path(index_path, remote_cache_path):
+        return True
+
+    mtime, size = signature
+    cached = _REMOTE_INDEX_VALIDITY_CACHE
+    if cached is not None and cached[:3] == (index_path, mtime, size):
+        return cached[3]
+
+    is_valid = is_valid_remote_stock_index_file(index_path)
+    _REMOTE_INDEX_VALIDITY_CACHE = (index_path, mtime, size, is_valid)
+    return is_valid
+
+
+def find_existing_stock_index_path(
+    candidate_paths: Optional[Iterable[Path]] = None,
+    *,
+    remote_cache_path: Optional[Path] = None,
+) -> Path | None:
+    """Return the newest usable stock index across remote and bundled candidates."""
+    paths = tuple(candidate_paths) if candidate_paths is not None else get_stock_index_candidate_paths()
+    remote_path = remote_cache_path or get_remote_stock_index_cache_path()
+
+    for candidate_path in _get_fresh_stock_index_candidates(paths, remote_path):
+        signature = _get_stock_index_signature(candidate_path)
+        if signature is None:
+            continue
+        if not _is_remote_stock_index_cache_usable(candidate_path, remote_path, signature):
+            continue
+
+        return candidate_path
+
+    return None
+
+
 def get_stock_name_index_map() -> Dict[str, str]:
     """Lazily load and cache the generated stock-name index."""
     global _STOCK_INDEX_CACHE
@@ -98,20 +191,21 @@ def get_stock_name_index_map() -> Dict[str, str]:
         if _STOCK_INDEX_CACHE is not None:
             return _STOCK_INDEX_CACHE
 
-        for candidate_path in get_stock_index_candidate_paths():
-            if not candidate_path.is_file():
-                continue
-
+        remote_path = get_remote_stock_index_cache_path()
+        for index_path in _get_fresh_stock_index_candidates(get_stock_index_candidate_paths(), remote_path):
             try:
-                _STOCK_INDEX_CACHE = _load_stock_index_file(candidate_path)
+                if _same_path(index_path, remote_path):
+                    _STOCK_INDEX_CACHE = _load_remote_stock_index_file(index_path)
+                else:
+                    _STOCK_INDEX_CACHE = _load_stock_index_file(index_path)
                 logger.debug(
                     "[股票名称] 已加载前端股票索引映射: %s (%d 条)",
-                    candidate_path,
+                    index_path,
                     len(_STOCK_INDEX_CACHE),
                 )
                 return _STOCK_INDEX_CACHE
             except (OSError, TypeError, ValueError) as exc:
-                logger.debug("[股票名称] 读取股票索引失败 %s: %s", candidate_path, exc)
+                logger.debug("[股票名称] 读取股票索引失败 %s: %s", index_path, exc)
 
         _STOCK_INDEX_CACHE = {}
         return _STOCK_INDEX_CACHE
@@ -134,9 +228,10 @@ def get_index_stock_name(stock_code: str) -> str | None:
 
 def clear_stock_index_cache() -> None:
     """Clear the in-process stock index lookup cache."""
-    global _STOCK_INDEX_CACHE
+    global _REMOTE_INDEX_VALIDITY_CACHE, _STOCK_INDEX_CACHE
     with _STOCK_INDEX_CACHE_LOCK:
         _STOCK_INDEX_CACHE = None
+        _REMOTE_INDEX_VALIDITY_CACHE = None
 
 
 def _clear_stock_index_cache_for_tests() -> None:

--- a/src/data/stock_index_loader.py
+++ b/src/data/stock_index_loader.py
@@ -8,6 +8,7 @@ from threading import RLock
 from typing import Dict, Iterable
 
 from src.data.stock_mapping import is_meaningful_stock_name
+from src.services.stock_index_remote_service import get_remote_stock_index_cache_path
 
 logger = logging.getLogger(__name__)
 
@@ -20,6 +21,7 @@ def get_stock_index_candidate_paths() -> tuple[Path, ...]:
     """Return the supported locations for the generated stock index."""
     repo_root = Path(__file__).resolve().parents[2]
     return (
+        get_remote_stock_index_cache_path(),
         repo_root / "apps" / "dsa-web" / "public" / _STOCK_INDEX_FILENAME,
         repo_root / "static" / _STOCK_INDEX_FILENAME,
     )
@@ -130,7 +132,12 @@ def get_index_stock_name(stock_code: str) -> str | None:
     return None
 
 
-def _clear_stock_index_cache_for_tests() -> None:
+def clear_stock_index_cache() -> None:
+    """Clear the in-process stock index lookup cache."""
     global _STOCK_INDEX_CACHE
     with _STOCK_INDEX_CACHE_LOCK:
         _STOCK_INDEX_CACHE = None
+
+
+def _clear_stock_index_cache_for_tests() -> None:
+    clear_stock_index_cache()

--- a/src/services/stock_index_remote_service.py
+++ b/src/services/stock_index_remote_service.py
@@ -1,0 +1,247 @@
+# -*- coding: utf-8 -*-
+"""Best-effort remote cache for the generated stock autocomplete index."""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from threading import Lock
+from typing import Any, Optional
+
+import requests
+
+logger = logging.getLogger(__name__)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_STOCK_INDEX_REMOTE_URL = (
+    "https://raw.githubusercontent.com/ZhuLinsen/daily_stock_analysis/"
+    "main/apps/dsa-web/public/stocks.index.json"
+)
+DEFAULT_STOCK_INDEX_CACHE_PATH = REPO_ROOT / "data" / "cache" / "stocks.index.json"
+DEFAULT_STOCK_INDEX_REMOTE_TTL_HOURS = 48
+DEFAULT_STOCK_INDEX_REMOTE_TIMEOUT_SECONDS = 10
+DEFAULT_STOCK_INDEX_REMOTE_MAX_FAILURES = 3
+SUPPORTED_STOCK_INDEX_MARKETS = {"CN", "HK", "US", "BSE"}
+
+_REMOTE_REFRESH_LOCK = Lock()
+_REMOTE_FAILURE_LOCK = Lock()
+_REMOTE_CONSECUTIVE_FAILURES = 0
+_REMOTE_SUPPRESS_UNTIL = 0.0
+
+
+@dataclass(frozen=True)
+class RemoteStockIndexSettings:
+    """Runtime settings for remote stock-index refresh."""
+
+    enabled: bool = True
+    url: str = DEFAULT_STOCK_INDEX_REMOTE_URL
+    ttl_hours: int = DEFAULT_STOCK_INDEX_REMOTE_TTL_HOURS
+    timeout_seconds: int = DEFAULT_STOCK_INDEX_REMOTE_TIMEOUT_SECONDS
+    cache_path: Path = DEFAULT_STOCK_INDEX_CACHE_PATH
+
+
+@dataclass(frozen=True)
+class RemoteStockIndexResult:
+    """Outcome of a best-effort refresh attempt."""
+
+    cache_path: Optional[Path]
+    refreshed: bool = False
+    skipped: bool = False
+    error: Optional[str] = None
+
+
+def settings_from_config(config: Any) -> RemoteStockIndexSettings:
+    """Build remote stock-index settings from the application config object."""
+    return RemoteStockIndexSettings(
+        enabled=bool(getattr(config, "stock_index_remote_update_enabled", True)),
+        url=DEFAULT_STOCK_INDEX_REMOTE_URL,
+        ttl_hours=DEFAULT_STOCK_INDEX_REMOTE_TTL_HOURS,
+        timeout_seconds=DEFAULT_STOCK_INDEX_REMOTE_TIMEOUT_SECONDS,
+    )
+
+
+def get_remote_stock_index_cache_path() -> Path:
+    """Return the canonical on-disk cache path for remote stock index data."""
+    return DEFAULT_STOCK_INDEX_CACHE_PATH
+
+
+def is_remote_stock_index_cache_fresh(
+    cache_path: Path = DEFAULT_STOCK_INDEX_CACHE_PATH,
+    *,
+    ttl_hours: int = DEFAULT_STOCK_INDEX_REMOTE_TTL_HOURS,
+    now: Optional[float] = None,
+) -> bool:
+    """Return whether the remote cache exists and is still inside its TTL."""
+    if ttl_hours <= 0 or not cache_path.is_file():
+        return False
+
+    current_time = time.time() if now is None else now
+    try:
+        age_seconds = current_time - cache_path.stat().st_mtime
+    except OSError:
+        return False
+    return age_seconds < ttl_hours * 3600
+
+
+def validate_stock_index_payload(
+    payload: Any,
+    *,
+    min_items: int = 100,
+) -> list[list[Any]]:
+    """Validate the compressed ``stocks.index.json`` wire format."""
+    if not isinstance(payload, list):
+        raise ValueError("stock index payload must be a list")
+    if len(payload) < min_items:
+        raise ValueError(f"stock index payload is unexpectedly small: {len(payload)}")
+
+    for index, item in enumerate(payload):
+        if not isinstance(item, list) or len(item) < 10:
+            raise ValueError(f"stock index item {index} is not a compressed tuple")
+
+        canonical_code, display_code, name, _pinyin, _abbr, aliases, market, asset_type, active = item[:9]
+        if not all(isinstance(value, str) and value.strip() for value in (canonical_code, display_code, name)):
+            raise ValueError(f"stock index item {index} is missing code or name")
+        if not isinstance(aliases, list):
+            raise ValueError(f"stock index item {index} aliases must be a list")
+        if market not in SUPPORTED_STOCK_INDEX_MARKETS:
+            raise ValueError(f"stock index item {index} has unsupported market: {market!r}")
+        if asset_type not in {"stock", "index", "etf"}:
+            raise ValueError(f"stock index item {index} has unsupported asset type: {asset_type!r}")
+        if not isinstance(active, bool):
+            raise ValueError(f"stock index item {index} active flag must be boolean")
+
+    return payload
+
+
+def is_valid_remote_stock_index_file(cache_path: Path = DEFAULT_STOCK_INDEX_CACHE_PATH) -> bool:
+    """Return whether a cached remote stock-index file is still usable."""
+    try:
+        payload = json.loads(cache_path.read_text(encoding="utf-8"))
+        validate_stock_index_payload(payload)
+        return True
+    except FileNotFoundError:
+        return False
+    except (OSError, json.JSONDecodeError, ValueError, TypeError) as exc:
+        logger.warning("[stock-index] cached remote index is invalid: %s", exc)
+        return False
+
+
+def _download_remote_stock_index(settings: RemoteStockIndexSettings) -> bytes:
+    response = requests.get(settings.url, timeout=settings.timeout_seconds)
+    response.raise_for_status()
+
+    content = response.content
+    payload = json.loads(content.decode(response.encoding or "utf-8"))
+    validate_stock_index_payload(payload)
+    return content
+
+
+def _atomic_write(cache_path: Path, content: bytes) -> None:
+    cache_path.parent.mkdir(parents=True, exist_ok=True)
+    temp_path = cache_path.with_name(f".{cache_path.name}.{os.getpid()}.tmp")
+    try:
+        temp_path.write_bytes(content)
+        os.replace(temp_path, cache_path)
+    finally:
+        try:
+            temp_path.unlink()
+        except FileNotFoundError:
+            pass
+
+
+def _clear_backend_stock_index_cache() -> None:
+    try:
+        from src.data.stock_index_loader import clear_stock_index_cache
+
+        clear_stock_index_cache()
+    except Exception as exc:  # noqa: BLE001 - cache clearing must not break refresh.
+        logger.warning("[stock-index] remote index refreshed but backend cache clear failed: %s", exc)
+
+
+def _reset_remote_failure_state() -> None:
+    global _REMOTE_CONSECUTIVE_FAILURES, _REMOTE_SUPPRESS_UNTIL
+    with _REMOTE_FAILURE_LOCK:
+        _REMOTE_CONSECUTIVE_FAILURES = 0
+        _REMOTE_SUPPRESS_UNTIL = 0.0
+
+
+def _remote_refresh_suppressed(now: float) -> bool:
+    global _REMOTE_CONSECUTIVE_FAILURES, _REMOTE_SUPPRESS_UNTIL
+    with _REMOTE_FAILURE_LOCK:
+        if _REMOTE_CONSECUTIVE_FAILURES < DEFAULT_STOCK_INDEX_REMOTE_MAX_FAILURES:
+            return False
+        if now < _REMOTE_SUPPRESS_UNTIL:
+            return True
+        _REMOTE_CONSECUTIVE_FAILURES = 0
+        _REMOTE_SUPPRESS_UNTIL = 0.0
+        return False
+
+
+def _record_remote_failure(now: float, ttl_hours: int) -> int:
+    global _REMOTE_CONSECUTIVE_FAILURES, _REMOTE_SUPPRESS_UNTIL
+    with _REMOTE_FAILURE_LOCK:
+        _REMOTE_CONSECUTIVE_FAILURES += 1
+        if _REMOTE_CONSECUTIVE_FAILURES >= DEFAULT_STOCK_INDEX_REMOTE_MAX_FAILURES:
+            _REMOTE_SUPPRESS_UNTIL = now + max(ttl_hours, 1) * 3600
+        return _REMOTE_CONSECUTIVE_FAILURES
+
+
+def refresh_remote_stock_index_cache(settings: RemoteStockIndexSettings) -> RemoteStockIndexResult:
+    """Refresh the remote stock index cache without breaking callers on failure."""
+    cache_path = settings.cache_path
+    if not settings.enabled:
+        return RemoteStockIndexResult(cache_path=cache_path if cache_path.is_file() else None, skipped=True)
+
+    current_time = time.time()
+    if is_remote_stock_index_cache_fresh(cache_path, ttl_hours=settings.ttl_hours, now=current_time):
+        if is_valid_remote_stock_index_file(cache_path):
+            _reset_remote_failure_state()
+            return RemoteStockIndexResult(cache_path=cache_path, skipped=True)
+
+    if _remote_refresh_suppressed(current_time):
+        return RemoteStockIndexResult(
+            cache_path=cache_path if is_valid_remote_stock_index_file(cache_path) else None,
+            skipped=True,
+            error="remote update temporarily suppressed after repeated failures",
+        )
+
+    if not _REMOTE_REFRESH_LOCK.acquire(blocking=False):
+        return RemoteStockIndexResult(
+            cache_path=cache_path if is_valid_remote_stock_index_file(cache_path) else None,
+            skipped=True,
+        )
+
+    try:
+        if is_remote_stock_index_cache_fresh(cache_path, ttl_hours=settings.ttl_hours):
+            if is_valid_remote_stock_index_file(cache_path):
+                _reset_remote_failure_state()
+                return RemoteStockIndexResult(cache_path=cache_path, skipped=True)
+
+        content = _download_remote_stock_index(settings)
+        _atomic_write(cache_path, content)
+        _clear_backend_stock_index_cache()
+        _reset_remote_failure_state()
+        logger.info("[stock-index] remote index refreshed: %s", cache_path)
+        return RemoteStockIndexResult(cache_path=cache_path, refreshed=True)
+    except Exception as exc:  # noqa: BLE001 - remote refresh is best-effort by design.
+        message = str(exc)
+        failures = _record_remote_failure(current_time, settings.ttl_hours)
+        logger.warning(
+            "[stock-index] remote update failed (%d/%d), using local fallback: %s",
+            failures,
+            DEFAULT_STOCK_INDEX_REMOTE_MAX_FAILURES,
+            message,
+        )
+        if is_valid_remote_stock_index_file(cache_path):
+            return RemoteStockIndexResult(cache_path=cache_path, error=message)
+        return RemoteStockIndexResult(cache_path=None, error=message)
+    finally:
+        _REMOTE_REFRESH_LOCK.release()
+
+
+def _reset_remote_stock_index_state_for_tests() -> None:
+    _reset_remote_failure_state()

--- a/src/services/stock_index_remote_service.py
+++ b/src/services/stock_index_remote_service.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import json
 import logging
+import math
 import os
 import time
 from dataclasses import dataclass
@@ -102,7 +103,18 @@ def validate_stock_index_payload(
         if not isinstance(item, list) or len(item) < 10:
             raise ValueError(f"stock index item {index} is not a compressed tuple")
 
-        canonical_code, display_code, name, _pinyin, _abbr, aliases, market, asset_type, active = item[:9]
+        (
+            canonical_code,
+            display_code,
+            name,
+            _pinyin,
+            _abbr,
+            aliases,
+            market,
+            asset_type,
+            active,
+            popularity,
+        ) = item[:10]
         if not all(isinstance(value, str) and value.strip() for value in (canonical_code, display_code, name)):
             raise ValueError(f"stock index item {index} is missing code or name")
         if not isinstance(aliases, list):
@@ -113,6 +125,12 @@ def validate_stock_index_payload(
             raise ValueError(f"stock index item {index} has unsupported asset type: {asset_type!r}")
         if not isinstance(active, bool):
             raise ValueError(f"stock index item {index} active flag must be boolean")
+        if (
+            isinstance(popularity, bool)
+            or not isinstance(popularity, (int, float))
+            or not math.isfinite(float(popularity))
+        ):
+            raise ValueError(f"stock index item {index} popularity must be a finite number")
 
     return payload
 
@@ -135,7 +153,7 @@ def _download_remote_stock_index(settings: RemoteStockIndexSettings) -> bytes:
     response.raise_for_status()
 
     content = response.content
-    payload = json.loads(content.decode(response.encoding or "utf-8"))
+    payload = json.loads(content.decode("utf-8"))
     validate_stock_index_payload(payload)
     return content
 

--- a/tests/test_main_schedule_mode.py
+++ b/tests/test_main_schedule_mode.py
@@ -482,16 +482,27 @@ class MainScheduleModeTestCase(unittest.TestCase):
         )
         pipeline = MagicMock()
         pipeline.run.return_value = []
+        events = []
+
+        def refresh_index(config_arg):
+            events.append("refresh")
+
+        def build_pipeline(*args, **kwargs):
+            events.append("pipeline")
+            return pipeline
 
         lock_token = try_acquire_market_review_lock(config)
         self.assertIsNotNone(lock_token)
         try:
-            with patch("src.core.pipeline.StockAnalysisPipeline", return_value=pipeline), \
+            with patch.object(main, "_refresh_stock_index_cache_for_analysis", side_effect=refresh_index) as refresh, \
+                 patch("src.core.pipeline.StockAnalysisPipeline", side_effect=build_pipeline), \
                  patch("src.core.market_review.run_market_review") as run_market_review:
                 main.run_full_analysis(config, args, [])
         finally:
             release_market_review_lock(lock_token)
 
+        refresh.assert_called_once_with(config)
+        self.assertEqual(events[:2], ["refresh", "pipeline"])
         pipeline.run.assert_called_once()
         run_market_review.assert_not_called()
 

--- a/tests/test_static_assets_consistency.py
+++ b/tests/test_static_assets_consistency.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 import importlib
 import json
 import logging
+import os
 import sys
 from pathlib import Path
 from unittest.mock import ANY, patch
@@ -289,7 +290,7 @@ def _write_stock_index(path: Path, name: str = "平安银行", size: int = 1) ->
     )
 
 
-def test_stock_index_route_serves_remote_cache_first(tmp_path: Path) -> None:
+def test_stock_index_route_serves_newer_remote_cache(tmp_path: Path) -> None:
     from api import app as app_module
     from api.app import create_app
 
@@ -299,6 +300,9 @@ def test_stock_index_route_serves_remote_cache_first(tmp_path: Path) -> None:
     _write_stock_index(static_dir / "stocks.index.json", "内置静态")
     _write_stock_index(cache_path, "远程缓存", size=100)
     _write_stock_index(bundled_path, "源码内置")
+    os.utime(static_dir / "stocks.index.json", (1_000, 1_000))
+    os.utime(cache_path, (2_000, 2_000))
+    os.utime(bundled_path, (1_000, 1_000))
 
     client = TestClient(create_app(static_dir=static_dir))
 
@@ -312,6 +316,31 @@ def test_stock_index_route_serves_remote_cache_first(tmp_path: Path) -> None:
     assert response.headers["cache-control"] == "no-cache"
     assert response.json()[0][2] == "远程缓存"
     schedule.assert_called_once()
+
+
+def test_stock_index_route_prefers_newer_static_index_over_older_remote_cache(tmp_path: Path) -> None:
+    from api import app as app_module
+    from api.app import create_app
+
+    static_dir = tmp_path / "static"
+    cache_path = tmp_path / "cache" / "stocks.index.json"
+    bundled_path = tmp_path / "bundled" / "stocks.index.json"
+    _write_stock_index(static_dir / "stocks.index.json", "新内置静态")
+    _write_stock_index(cache_path, "旧远程缓存", size=100)
+    _write_stock_index(bundled_path, "源码内置")
+    os.utime(static_dir / "stocks.index.json", (2_000, 2_000))
+    os.utime(cache_path, (1_000, 1_000))
+    os.utime(bundled_path, (1_000, 1_000))
+
+    client = TestClient(create_app(static_dir=static_dir))
+
+    with patch.object(app_module, "get_remote_stock_index_cache_path", return_value=cache_path), \
+         patch.object(app_module, "_bundled_stock_index_path", return_value=bundled_path), \
+         patch.object(app_module, "_schedule_stock_index_background_refresh"):
+        response = client.get("/stocks.index.json")
+
+    assert response.status_code == 200
+    assert response.json()[0][2] == "新内置静态"
 
 
 def test_stock_index_route_falls_back_to_static_index(tmp_path: Path) -> None:
@@ -335,6 +364,31 @@ def test_stock_index_route_falls_back_to_static_index(tmp_path: Path) -> None:
     assert response.json()[0][2] == "内置静态"
 
 
+def test_stock_index_route_does_not_parse_bundled_candidates_on_hot_path(tmp_path: Path) -> None:
+    from api import app as app_module
+    from api.app import create_app
+    from src.data import stock_index_loader
+
+    static_dir = tmp_path / "static"
+    cache_path = tmp_path / "cache" / "missing.json"
+    bundled_path = tmp_path / "bundled" / "stocks.index.json"
+    _write_stock_index(static_dir / "stocks.index.json", "内置静态")
+    _write_stock_index(bundled_path, "源码内置")
+    os.utime(static_dir / "stocks.index.json", (2_000, 2_000))
+    os.utime(bundled_path, (1_000, 1_000))
+
+    client = TestClient(create_app(static_dir=static_dir))
+
+    with patch.object(app_module, "get_remote_stock_index_cache_path", return_value=cache_path), \
+         patch.object(app_module, "_bundled_stock_index_path", return_value=bundled_path), \
+         patch.object(app_module, "_schedule_stock_index_background_refresh"), \
+         patch.object(stock_index_loader, "_load_stock_index_file", side_effect=AssertionError("unexpected parse")):
+        response = client.get("/stocks.index.json")
+
+    assert response.status_code == 200
+    assert response.json()[0][2] == "内置静态"
+
+
 def test_stock_index_route_skips_invalid_remote_cache(tmp_path: Path) -> None:
     from api import app as app_module
     from api.app import create_app
@@ -346,6 +400,9 @@ def test_stock_index_route_skips_invalid_remote_cache(tmp_path: Path) -> None:
     cache_path.write_text("not-json", encoding="utf-8")
     _write_stock_index(static_dir / "stocks.index.json", "内置静态")
     _write_stock_index(bundled_path, "源码内置")
+    os.utime(cache_path, (3_000, 3_000))
+    os.utime(static_dir / "stocks.index.json", (2_000, 2_000))
+    os.utime(bundled_path, (1_000, 1_000))
 
     client = TestClient(create_app(static_dir=static_dir))
 

--- a/tests/test_static_assets_consistency.py
+++ b/tests/test_static_assets_consistency.py
@@ -352,6 +352,8 @@ def test_stock_index_route_falls_back_to_static_index(tmp_path: Path) -> None:
     bundled_path = tmp_path / "bundled" / "stocks.index.json"
     _write_stock_index(static_dir / "stocks.index.json", "内置静态")
     _write_stock_index(bundled_path, "源码内置")
+    os.utime(static_dir / "stocks.index.json", (1_000, 1_000))
+    os.utime(bundled_path, (2_000, 2_000))
 
     client = TestClient(create_app(static_dir=static_dir))
 

--- a/tests/test_static_assets_consistency.py
+++ b/tests/test_static_assets_consistency.py
@@ -12,9 +12,11 @@ referenced by ``index.html`` does not exist on disk.
 from __future__ import annotations
 
 import importlib
+import json
 import logging
 import sys
 from pathlib import Path
+from unittest.mock import ANY, patch
 
 import pytest
 from fastapi.testclient import TestClient
@@ -260,6 +262,132 @@ def test_frontend_index_responses_are_not_cacheable(tmp_path: Path) -> None:
         )
         assert response.headers["pragma"] == "no-cache"
         assert response.headers["expires"] == "0"
+
+
+def _write_stock_index(path: Path, name: str = "平安银行", size: int = 1) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(
+            [
+                [
+                    f"{index:06d}.SZ",
+                    f"{index:06d}",
+                    name,
+                    "pinganyinhang",
+                    "payh",
+                    [],
+                    "CN",
+                    "stock",
+                    True,
+                    100,
+                ]
+                for index in range(size)
+            ],
+            ensure_ascii=False,
+        ),
+        encoding="utf-8",
+    )
+
+
+def test_stock_index_route_serves_remote_cache_first(tmp_path: Path) -> None:
+    from api import app as app_module
+    from api.app import create_app
+
+    static_dir = tmp_path / "static"
+    cache_path = tmp_path / "cache" / "stocks.index.json"
+    bundled_path = tmp_path / "bundled" / "stocks.index.json"
+    _write_stock_index(static_dir / "stocks.index.json", "内置静态")
+    _write_stock_index(cache_path, "远程缓存", size=100)
+    _write_stock_index(bundled_path, "源码内置")
+
+    client = TestClient(create_app(static_dir=static_dir))
+
+    with patch.object(app_module, "get_remote_stock_index_cache_path", return_value=cache_path), \
+         patch.object(app_module, "_bundled_stock_index_path", return_value=bundled_path), \
+         patch.object(app_module, "_schedule_stock_index_background_refresh") as schedule:
+        response = client.get("/stocks.index.json")
+
+    assert response.status_code == 200
+    assert response.headers["content-type"].startswith("application/json")
+    assert response.headers["cache-control"] == "no-cache"
+    assert response.json()[0][2] == "远程缓存"
+    schedule.assert_called_once()
+
+
+def test_stock_index_route_falls_back_to_static_index(tmp_path: Path) -> None:
+    from api import app as app_module
+    from api.app import create_app
+
+    static_dir = tmp_path / "static"
+    cache_path = tmp_path / "cache" / "missing.json"
+    bundled_path = tmp_path / "bundled" / "stocks.index.json"
+    _write_stock_index(static_dir / "stocks.index.json", "内置静态")
+    _write_stock_index(bundled_path, "源码内置")
+
+    client = TestClient(create_app(static_dir=static_dir))
+
+    with patch.object(app_module, "get_remote_stock_index_cache_path", return_value=cache_path), \
+         patch.object(app_module, "_bundled_stock_index_path", return_value=bundled_path), \
+         patch.object(app_module, "_schedule_stock_index_background_refresh"):
+        response = client.get("/stocks.index.json")
+
+    assert response.status_code == 200
+    assert response.json()[0][2] == "内置静态"
+
+
+def test_stock_index_route_skips_invalid_remote_cache(tmp_path: Path) -> None:
+    from api import app as app_module
+    from api.app import create_app
+
+    static_dir = tmp_path / "static"
+    cache_path = tmp_path / "cache" / "stocks.index.json"
+    bundled_path = tmp_path / "bundled" / "stocks.index.json"
+    cache_path.parent.mkdir(parents=True, exist_ok=True)
+    cache_path.write_text("not-json", encoding="utf-8")
+    _write_stock_index(static_dir / "stocks.index.json", "内置静态")
+    _write_stock_index(bundled_path, "源码内置")
+
+    client = TestClient(create_app(static_dir=static_dir))
+
+    with patch.object(app_module, "get_remote_stock_index_cache_path", return_value=cache_path), \
+         patch.object(app_module, "_bundled_stock_index_path", return_value=bundled_path), \
+         patch.object(app_module, "_schedule_stock_index_background_refresh"):
+        response = client.get("/stocks.index.json")
+
+    assert response.status_code == 200
+    assert response.json()[0][2] == "内置静态"
+
+
+def test_stock_index_route_returns_404_when_all_candidates_missing(tmp_path: Path) -> None:
+    from api import app as app_module
+    from api.app import create_app
+
+    static_dir = tmp_path / "static"
+    cache_path = tmp_path / "cache" / "missing.json"
+    bundled_path = tmp_path / "bundled" / "missing.json"
+
+    client = TestClient(create_app(static_dir=static_dir))
+
+    with patch.object(app_module, "get_remote_stock_index_cache_path", return_value=cache_path), \
+         patch.object(app_module, "_bundled_stock_index_path", return_value=bundled_path), \
+         patch.object(app_module, "_schedule_stock_index_background_refresh"):
+        response = client.get("/stocks.index.json")
+
+    assert response.status_code == 404
+    assert response.text == "stock index not found"
+
+
+def test_app_startup_schedules_stock_index_background_refresh(tmp_path: Path) -> None:
+    from api import app as app_module
+    from api.app import create_app
+
+    static_dir = tmp_path / "static"
+
+    with patch.object(app_module, "_schedule_stock_index_background_refresh") as schedule:
+        with TestClient(create_app(static_dir=static_dir)):
+            pass
+
+    schedule.assert_called_once_with(ANY, "startup")
 
 
 @pytest.mark.parametrize(

--- a/tests/test_stock_index_loader.py
+++ b/tests/test_stock_index_loader.py
@@ -38,6 +38,20 @@ class TestStockIndexLoader(unittest.TestCase):
                 self.assertEqual(stock_index_loader.get_index_stock_name("700.HK"), "腾讯控股")
                 self.assertEqual(stock_index_loader.get_index_stock_name("aapl"), "苹果")
 
+    def test_default_candidate_paths_prefer_remote_cache(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            remote_cache = Path(temp_dir) / "data" / "cache" / "stocks.index.json"
+            with patch.object(
+                stock_index_loader,
+                "get_remote_stock_index_cache_path",
+                return_value=remote_cache,
+            ):
+                paths = stock_index_loader.get_stock_index_candidate_paths()
+
+            self.assertEqual(paths[0], remote_cache)
+            self.assertTrue(str(paths[1]).endswith("apps/dsa-web/public/stocks.index.json"))
+            self.assertTrue(str(paths[2]).endswith("static/stocks.index.json"))
+
     def test_get_stock_name_index_map_is_cached_after_first_load(self):
         with tempfile.TemporaryDirectory() as temp_dir:
             index_path = Path(temp_dir) / "stocks.index.json"

--- a/tests/test_stock_index_loader.py
+++ b/tests/test_stock_index_loader.py
@@ -1,11 +1,37 @@
 # -*- coding: utf-8 -*-
 import json
+import os
 import tempfile
 import unittest
 from pathlib import Path
 from unittest.mock import patch
 
 from src.data import stock_index_loader
+
+
+def _write_stock_index(path: Path, name: str, size: int = 1) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(
+            [
+                [
+                    f"{index + 1:06d}.SZ",
+                    f"{index + 1:06d}",
+                    name,
+                    "pinganyinhang",
+                    "payh",
+                    [],
+                    "CN",
+                    "stock",
+                    True,
+                    100,
+                ]
+                for index in range(size)
+            ],
+            ensure_ascii=False,
+        ),
+        encoding="utf-8",
+    )
 
 
 class TestStockIndexLoader(unittest.TestCase):
@@ -114,6 +140,61 @@ class TestStockIndexLoader(unittest.TestCase):
                 return_value=(malformed_path, valid_path),
             ):
                 self.assertEqual(stock_index_loader.get_index_stock_name("000001"), "平安银行")
+
+    def test_newer_bundled_index_wins_over_older_remote_cache(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            remote_cache = Path(temp_dir) / "cache" / "stocks.index.json"
+            bundled_path = Path(temp_dir) / "apps" / "stocks.index.json"
+            _write_stock_index(remote_cache, "旧远程缓存", size=100)
+            _write_stock_index(bundled_path, "新内置索引")
+            os.utime(remote_cache, (1_000, 1_000))
+            os.utime(bundled_path, (2_000, 2_000))
+
+            with patch.object(stock_index_loader, "get_remote_stock_index_cache_path", return_value=remote_cache), \
+                 patch.object(
+                     stock_index_loader,
+                     "get_stock_index_candidate_paths",
+                     return_value=(remote_cache, bundled_path),
+                 ):
+                self.assertEqual(stock_index_loader.find_existing_stock_index_path(), bundled_path)
+                self.assertEqual(stock_index_loader.get_index_stock_name("000001"), "新内置索引")
+
+    def test_newer_remote_cache_wins_when_valid(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            remote_cache = Path(temp_dir) / "cache" / "stocks.index.json"
+            bundled_path = Path(temp_dir) / "apps" / "stocks.index.json"
+            _write_stock_index(remote_cache, "新远程缓存", size=100)
+            _write_stock_index(bundled_path, "旧内置索引")
+            os.utime(remote_cache, (2_000, 2_000))
+            os.utime(bundled_path, (1_000, 1_000))
+
+            with patch.object(stock_index_loader, "get_remote_stock_index_cache_path", return_value=remote_cache), \
+                 patch.object(
+                     stock_index_loader,
+                     "get_stock_index_candidate_paths",
+                     return_value=(remote_cache, bundled_path),
+                 ):
+                self.assertEqual(stock_index_loader.find_existing_stock_index_path(), remote_cache)
+                self.assertEqual(stock_index_loader.get_index_stock_name("000001"), "新远程缓存")
+
+    def test_invalid_remote_cache_is_skipped_even_when_newer(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            remote_cache = Path(temp_dir) / "cache" / "stocks.index.json"
+            bundled_path = Path(temp_dir) / "apps" / "stocks.index.json"
+            remote_cache.parent.mkdir(parents=True, exist_ok=True)
+            remote_cache.write_text("not-json", encoding="utf-8")
+            _write_stock_index(bundled_path, "内置索引")
+            os.utime(remote_cache, (2_000, 2_000))
+            os.utime(bundled_path, (1_000, 1_000))
+
+            with patch.object(stock_index_loader, "get_remote_stock_index_cache_path", return_value=remote_cache), \
+                 patch.object(
+                     stock_index_loader,
+                     "get_stock_index_candidate_paths",
+                     return_value=(remote_cache, bundled_path),
+                 ):
+                self.assertEqual(stock_index_loader.find_existing_stock_index_path(), bundled_path)
+                self.assertEqual(stock_index_loader.get_index_stock_name("000001"), "内置索引")
 
 
 if __name__ == "__main__":

--- a/tests/test_stock_index_remote_service.py
+++ b/tests/test_stock_index_remote_service.py
@@ -1,0 +1,195 @@
+# -*- coding: utf-8 -*-
+"""Tests for best-effort remote stock-index caching."""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import time
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
+
+import pytest
+
+from src.services import stock_index_remote_service as service
+
+
+@pytest.fixture(autouse=True)
+def reset_remote_stock_index_state() -> None:
+    service._reset_remote_stock_index_state_for_tests()
+    yield
+    service._reset_remote_stock_index_state_for_tests()
+
+
+def _stock_index_payload(size: int = 100, *, name: str = "平安银行") -> list[list[object]]:
+    return [
+        [
+            f"{index:06d}.SZ",
+            f"{index:06d}",
+            name,
+            "pinganyinhang",
+            "payh",
+            [],
+            "CN",
+            "stock",
+            True,
+            100,
+        ]
+        for index in range(size)
+    ]
+
+
+def _bse_stock_index_payload(size: int = 100) -> list[list[object]]:
+    payload = _stock_index_payload(size=size)
+    payload[0][0] = "920964.BJ"
+    payload[0][1] = "920964"
+    payload[0][2] = "润农节水"
+    payload[0][6] = "BSE"
+    return payload
+
+
+def _response(payload: object) -> Mock:
+    response = Mock()
+    response.content = json.dumps(payload, ensure_ascii=False).encode("utf-8")
+    response.encoding = "utf-8"
+    response.raise_for_status.return_value = None
+    return response
+
+
+def test_refresh_remote_stock_index_cache_writes_valid_payload(tmp_path: Path) -> None:
+    cache_path = tmp_path / "stocks.index.json"
+    settings = service.RemoteStockIndexSettings(cache_path=cache_path)
+
+    with patch.object(service.requests, "get", return_value=_response(_stock_index_payload())) as get:
+        result = service.refresh_remote_stock_index_cache(settings)
+
+    assert result.refreshed is True
+    assert result.cache_path == cache_path
+    assert json.loads(cache_path.read_text(encoding="utf-8"))[0][2] == "平安银行"
+    get.assert_called_once_with(service.DEFAULT_STOCK_INDEX_REMOTE_URL, timeout=10)
+
+
+def test_refresh_remote_stock_index_cache_clears_backend_loader_cache(tmp_path: Path) -> None:
+    cache_path = tmp_path / "stocks.index.json"
+    settings = service.RemoteStockIndexSettings(cache_path=cache_path)
+
+    with patch.object(service.requests, "get", return_value=_response(_stock_index_payload())), \
+         patch("src.data.stock_index_loader.clear_stock_index_cache") as clear_cache:
+        result = service.refresh_remote_stock_index_cache(settings)
+
+    assert result.refreshed is True
+    clear_cache.assert_called_once_with()
+
+
+def test_refresh_remote_stock_index_cache_skips_fresh_cache(tmp_path: Path) -> None:
+    cache_path = tmp_path / "stocks.index.json"
+    cache_path.write_text(json.dumps(_stock_index_payload(), ensure_ascii=False), encoding="utf-8")
+    settings = service.RemoteStockIndexSettings(cache_path=cache_path, ttl_hours=48)
+
+    with patch.object(service.requests, "get") as get:
+        result = service.refresh_remote_stock_index_cache(settings)
+
+    assert result.skipped is True
+    assert result.cache_path == cache_path
+    get.assert_not_called()
+
+
+def test_refresh_remote_stock_index_cache_keeps_old_cache_on_download_failure(tmp_path: Path) -> None:
+    cache_path = tmp_path / "stocks.index.json"
+    cache_path.write_text(json.dumps(_stock_index_payload(name="旧缓存"), ensure_ascii=False), encoding="utf-8")
+    old_mtime = time.time() - 100 * 3600
+    os.utime(cache_path, (old_mtime, old_mtime))
+    settings = service.RemoteStockIndexSettings(cache_path=cache_path, ttl_hours=48)
+
+    with patch.object(service.requests, "get", side_effect=TimeoutError("timeout")):
+        result = service.refresh_remote_stock_index_cache(settings)
+
+    assert result.cache_path == cache_path
+    assert result.error == "timeout"
+    assert json.loads(cache_path.read_text(encoding="utf-8"))[0][2] == "旧缓存"
+
+
+def test_refresh_remote_stock_index_cache_suppresses_after_repeated_failures(tmp_path: Path) -> None:
+    cache_path = tmp_path / "stocks.index.json"
+    settings = service.RemoteStockIndexSettings(cache_path=cache_path, ttl_hours=48)
+
+    with patch.object(service.requests, "get", side_effect=TimeoutError("timeout")) as get:
+        results = [service.refresh_remote_stock_index_cache(settings) for _ in range(6)]
+
+    assert get.call_count == service.DEFAULT_STOCK_INDEX_REMOTE_MAX_FAILURES
+    assert results[-1].skipped is True
+    assert results[-1].error == "remote update temporarily suppressed after repeated failures"
+
+
+def test_refresh_remote_stock_index_cache_retries_after_failure_window(tmp_path: Path) -> None:
+    cache_path = tmp_path / "stocks.index.json"
+    settings = service.RemoteStockIndexSettings(cache_path=cache_path, ttl_hours=1)
+
+    with patch.object(service.time, "time", return_value=1_000.0), \
+         patch.object(service.requests, "get", side_effect=TimeoutError("timeout")):
+        for _ in range(service.DEFAULT_STOCK_INDEX_REMOTE_MAX_FAILURES):
+            service.refresh_remote_stock_index_cache(settings)
+
+    with patch.object(service.time, "time", return_value=4_601.0), \
+         patch.object(service.requests, "get", return_value=_response(_stock_index_payload())) as get:
+        result = service.refresh_remote_stock_index_cache(settings)
+
+    assert result.refreshed is True
+    get.assert_called_once()
+
+
+def test_refresh_remote_stock_index_cache_rejects_invalid_remote_payload(tmp_path: Path) -> None:
+    cache_path = tmp_path / "stocks.index.json"
+    cache_path.write_text(json.dumps(_stock_index_payload(name="旧缓存"), ensure_ascii=False), encoding="utf-8")
+    settings = service.RemoteStockIndexSettings(cache_path=cache_path, ttl_hours=0)
+
+    with patch.object(service.requests, "get", return_value=_response([["000001.SZ"]])):
+        result = service.refresh_remote_stock_index_cache(settings)
+
+    assert result.cache_path == cache_path
+    assert result.error
+    assert json.loads(cache_path.read_text(encoding="utf-8"))[0][2] == "旧缓存"
+
+
+def test_validate_stock_index_payload_accepts_bse_market() -> None:
+    payload = _bse_stock_index_payload()
+
+    assert service.validate_stock_index_payload(payload) is payload
+
+
+def test_missing_remote_stock_index_cache_is_silent(tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
+    cache_path = tmp_path / "missing" / "stocks.index.json"
+
+    with caplog.at_level(logging.WARNING, logger="src.services.stock_index_remote_service"):
+        assert service.is_valid_remote_stock_index_file(cache_path) is False
+
+    assert not any("cached remote index is invalid" in record.getMessage() for record in caplog.records)
+
+
+def test_settings_from_config_uses_internal_remote_url_only() -> None:
+    config = SimpleNamespace(
+        stock_index_remote_update_enabled=False,
+        stock_index_remote_url="https://example.invalid/override.json",
+    )
+
+    settings = service.settings_from_config(config)
+
+    assert settings.enabled is False
+    assert settings.url == service.DEFAULT_STOCK_INDEX_REMOTE_URL
+    assert settings.ttl_hours == service.DEFAULT_STOCK_INDEX_REMOTE_TTL_HOURS
+    assert settings.timeout_seconds == service.DEFAULT_STOCK_INDEX_REMOTE_TIMEOUT_SECONDS
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {},
+        [["000001.SZ"]],
+        _stock_index_payload(size=99),
+    ],
+)
+def test_validate_stock_index_payload_rejects_bad_payloads(payload: object) -> None:
+    with pytest.raises(ValueError):
+        service.validate_stock_index_payload(payload)

--- a/tests/test_stock_index_remote_service.py
+++ b/tests/test_stock_index_remote_service.py
@@ -71,6 +71,19 @@ def test_refresh_remote_stock_index_cache_writes_valid_payload(tmp_path: Path) -
     get.assert_called_once_with(service.DEFAULT_STOCK_INDEX_REMOTE_URL, timeout=10)
 
 
+def test_refresh_remote_stock_index_cache_decodes_remote_payload_as_utf8(tmp_path: Path) -> None:
+    cache_path = tmp_path / "stocks.index.json"
+    settings = service.RemoteStockIndexSettings(cache_path=cache_path)
+    response = _response(_stock_index_payload())
+    response.encoding = "ascii"
+
+    with patch.object(service.requests, "get", return_value=response):
+        result = service.refresh_remote_stock_index_cache(settings)
+
+    assert result.refreshed is True
+    assert json.loads(cache_path.read_text(encoding="utf-8"))[0][2] == "平安银行"
+
+
 def test_refresh_remote_stock_index_cache_clears_backend_loader_cache(tmp_path: Path) -> None:
     cache_path = tmp_path / "stocks.index.json"
     settings = service.RemoteStockIndexSettings(cache_path=cache_path)
@@ -157,6 +170,23 @@ def test_validate_stock_index_payload_accepts_bse_market() -> None:
     payload = _bse_stock_index_payload()
 
     assert service.validate_stock_index_payload(payload) is payload
+
+
+@pytest.mark.parametrize("popularity", [None, "100", True, float("nan"), float("inf")])
+def test_validate_stock_index_payload_rejects_invalid_popularity(popularity: object) -> None:
+    payload = _stock_index_payload()
+    payload[0][9] = popularity
+
+    with pytest.raises(ValueError, match="popularity"):
+        service.validate_stock_index_payload(payload)
+
+
+def test_validate_stock_index_payload_rejects_missing_popularity() -> None:
+    payload = _stock_index_payload()
+    payload[0] = payload[0][:9]
+
+    with pytest.raises(ValueError):
+        service.validate_stock_index_payload(payload)
 
 
 def test_missing_remote_stock_index_cache_is_silent(tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:


### PR DESCRIPTION
  ## PR Type

  - [x] fix
  - [x] feat
  - [ ] refactor
  - [x] docs
  - [ ] chore
  - [x] test

  ## Background And Problem

  Issue #1446 暴露了股票基础索引更新不及时的问题。以 `001270.SZ` 为例，该股票自 `2026-05-20` 起撤销退市风险警示，证券简称从 `*ST铖昌` 变更为 `铖昌科技`，但旧的本地股票自动补全索引和后端股票名称解析仍可能携带过期简称，进而污染 Web 检索和分析上下文。

  PR #1462 已完成第一阶段紧急修复：刷新仓库内置静态索引。该修复已经合入，但仍依赖后续发版或用户更新本地文件。
  
  本 PR 补齐后续机制：运行时默认从 upstream `main` 获取最新股票自动补全索引，缓存到本地，并让 Web/CLI 分析链路在失败时自动降级到已有缓存或内置索引。

  ## Scope Of Change

  - 新增 `src/services/stock_index_remote_service.py`
    - 从 upstream GitHub `main` 下载 `apps/dsa-web/public/stocks.index.json`
    - 默认缓存到 `data/cache/stocks.index.json`
    - 默认 TTL 为 48 小时，超时为 10 秒
    - 校验远程 payload 格式、市场、资产类型、active 标识和 popularity 字段
    - 使用原子写入，刷新成功后清理后端股票索引进程缓存
    - 连续失败达到阈值后在当前进程内暂停重试，避免反复阻塞

  - 更新 `src/data/stock_index_loader.py`
    - 将远程缓存纳入股票索引候选路径
    - 在远程缓存比内置索引更新且合法时优先使用远程缓存
    - 远程缓存非法、缺失或解析失败时继续降级到内置索引
    - 新增公开的 `clear_stock_index_cache()` 供远程刷新后清理内存缓存

  - 更新 Web/API 服务入口
    - `/stocks.index.json` 改为由后端返回当前可用的最新索引
    - API 启动和访问 `/stocks.index.json` 时触发后台 best-effort 刷新
    - 保持前端仍访问本地 `/stocks.index.json`，不直接跨域访问 GitHub
    - 本地 fallback 在 `static/` 构建产物和源码内置索引之间保持确定性优先级

  - 更新 CLI/定时分析入口
    - `run_full_analysis()` 在进入分析前 best-effort 刷新股票索引缓存
    -  远程刷新失败不会阻断 WebUI、API 或分析流程；但首次分析、API 启动或首次访问 `/stocks.index.json` 可能触发一次 针对本项目仓库的 GitHub raw 请求，最坏受内置 10 秒  timeout 影响；

  - 新增配置项
    - `.env.example` 新增 `STOCK_INDEX_REMOTE_UPDATE_ENABLED=true`
    - `src/config.py` 读取该配置，默认开启
    - `src/core/config_registry.py` 暴露 Web 设置项
    - Web 设置帮助补充中英双语说明

  - 更新文档与变更记录
    - `docs/TUSHARE_STOCK_LIST_GUIDE.md` 补充本地客户端自动获取最新索引说明
    - `docs/settings-help.md` 补充设置帮助覆盖范围
    - `docs/CHANGELOG.md` 在 `[Unreleased]` 扁平格式中补充本次用户可见变更

  - 补充测试
    - 覆盖远程缓存刷新、payload 校验、失败降级、连续失败抑制
    - 覆盖 loader 对远程缓存、内置索引、非法远程缓存的选择逻辑
    - 覆盖 `/stocks.index.json` 路由返回远程缓存、本地静态索引、非法缓存降级和 404 场景
    - 覆盖分析入口会在 pipeline 创建前触发索引刷新

  ## Issue Link

  Close #1446

  ## Verification Commands And Results

  ```bash
  source .venv/bin/activate
  python -m py_compile api/app.py main.py src/config.py src/core/config_registry.py src/data/stock_index_loader.py src/services/stock_index_remote_service.py tests/
  test_main_schedule_mode.py tests/test_static_assets_consistency.py tests/test_stock_index_loader.py tests/test_stock_index_remote_service.py
```
  关键输出/结论：

  通过，无语法错误。
```
  source .venv/bin/activate
  python -m flake8 api/app.py main.py src/config.py src/core/config_registry.py src/data/stock_index_loader.py src/services/stock_index_remote_service.py tests/
  test_main_schedule_mode.py tests/test_static_assets_consistency.py tests/test_stock_index_loader.py tests/test_stock_index_remote_service.py --select=E9,F63,F7,F82
  --format="%(path)s:%(row)d: %(code)s %(text)s"
```
  关键输出/结论：

  通过，无严重 flake8 问题。
```
  source .venv/bin/activate
  python -m pytest tests/test_static_assets_consistency.py::test_stock_index_route_falls_back_to_static_index tests/
  test_static_assets_consistency.py::test_stock_index_route_serves_newer_remote_cache tests/
  test_static_assets_consistency.py::test_stock_index_route_prefers_newer_static_index_over_older_remote_cache tests/
  test_static_assets_consistency.py::test_stock_index_route_skips_invalid_remote_cache
```
  关键输出/结论：

  4 passed in 13.77s
```
  source .venv/bin/activate
  ./scripts/ci_gate.sh
```
  关键输出/结论：

  2420 passed, 3 deselected, 8 warnings, 215 subtests passed in 294.47s
  backend-gate: all checks passed
  
```
  cd apps/dsa-web
  npm ci
  npm run lint
  npm run build
```
  关键输出/结论：

  - npm ci 安装成功，审计提示当前依赖树存在 10 vulnerabilities (4 moderate, 6 high)，本 PR 未调整依赖版本。
  - npm run lint 通过。
  - npm run build 通过，vite 成功构建前端产物。

  ## Compatibility And Risk

  - 默认新增 STOCK_INDEX_REMOTE_UPDATE_ENABLED=true，未配置时启用远程索引刷新；用户可设置为 false 恢复只使用本地内置索引。
  - 远程 URL、TTL、timeout 为内置值，不新增用户可配置 URL，避免引入任意远程索引来源风险。
  - 远程刷新是 best-effort：GitHub raw 不可访问、超时、返回非法 JSON 或 payload 校验失败时，不阻断 WebUI、API 或分析流程。
  - CLI/定时分析入口会在分析前同步尝试刷新，网络不可达时最多受内置 timeout 影响；连续失败后会在进程内暂停重试，降低重复等待。
  - 已有用户 .env 不会被自动改写、清空或迁移；仅 .env.example、配置读取和 Web 设置元数据新增该配置项。
  - 本 PR 不修改股票分析 prompt、EXTRACT_PROMPT、数据库 schema、认证、Docker、Desktop 打包或 GitHub Actions 行为。

  本 PR 触及 `.env.example`、`src/config.py`、`src/core/config_registry.py` 和 Web 设置帮助文案，因此结构化检查可能命中“外部模型/API 兼容风险”与“运行时配置迁移风险”类别。 具体影响说明：
    - 未修改 LiteLLM/OpenAI/Gemini/DeepSeek 等模型名、provider、Base URL、请求参数或 fallback 逻辑。
    - 未修改 LLM Channels、模型配置保存、保存前清理、迁移、回填或旧配置重写逻辑。
    - 新增配置仅为 `STOCK_INDEX_REMOTE_UPDATE_ENABLED`，类型为 boolean，默认开启，用于控制股票自动补全索引远程刷新。
    - 已有用户 `.env` 不会被自动改写、清空或迁移；关闭该能力只需设置 `STOCK_INDEX_REMOTE_UPDATE_ENABLED=false`。
    - 本 PR 的外部请求是 当前项目 GitHub raw 上的静态 `stocks.index.json`，不属于第三方模型/API provider 兼容语义变更；请求失败时会自动降级到已有远程缓存或随应用打包的内置索引。
    - 首次分析、API 启动或首次访问 `/stocks.index.json` 可能触发一次 GitHub raw 请求，受内置 10 秒 timeout 影响；无法访问 GitHub raw 的部署环境建议显式设置 `STOCK_INDEX_REMOTE_UPDATE_ENABLED=false`
  
  ## Rollback Plan

  最小回滚方式：revert this PR，即可恢复只使用随应用打包的本地股票索引、移除远程刷新服务、配置项、文档和测试变更。

  如只需临时关闭新能力，可设置：

  STOCK_INDEX_REMOTE_UPDATE_ENABLED=false

  如需清理已下载缓存，可删除：

  data/cache/stocks.index.json

  无需数据库迁移或额外数据回滚。

  ## EXTRACT_PROMPT Change (if applicable)

  不适用。本 PR 未修改 src/services/image_stock_extractor.py 或 EXTRACT_PROMPT。
  <details>
  <summary>展开 / Expand: Full EXTRACT_PROMPT</summary>
  </details>

## Checklist

- [X] 本 PR 有明确动机和业务价值 / This PR has a clear motivation and value
- [X] 已提供可复现的验证命令与结果 / Reproducible verification commands and results are included
- [X] 已评估兼容性与风险 / Compatibility and risk have been assessed
- [X] 已提供回滚方案 / A rollback plan is provided
- [X] 若涉及用户可见变更，已同步更新相关文档与 `docs/CHANGELOG.md`；`README.md` 仅在首页级信息变化时更新，细节优先写入 `docs/*.md` / If user-visible changes are included, relevant docs and `docs/CHANGELOG.md` are updated; `README.md` is updated only for homepage-level changes, with details kept in `docs/*.md`
