### PR TITLE
fix: support Longbridge OAuth token cache

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -36,6 +36,7 @@ TUSHARE_TOKEN=
 # Longbridge OpenAPI（可选，美股/港股量比、换手率、PE 等字段兜底）
 # 从 https://open.longbridge.com/ 获取
 # OAuth 2.0（推荐）：先运行 scripts/generate_longbridge_oauth_token.py 生成本机 SDK token 缓存
+# client_id 优先取 LONGBRIDGE_OAUTH_CLIENT_ID；留空且没有 Legacy Access Token 时兼容使用 LONGBRIDGE_APP_KEY
 # GitHub Actions / Docker 可把 token 缓存文件 base64 后填入 LONGBRIDGE_OAUTH_TOKEN_CACHE_B64
 # LONGBRIDGE_OAUTH_CLIENT_ID=
 # LONGBRIDGE_OAUTH_TOKEN_CACHE_B64=

--- a/.env.example
+++ b/.env.example
@@ -35,6 +35,11 @@ TUSHARE_TOKEN=
 
 # Longbridge OpenAPI（可选，美股/港股量比、换手率、PE 等字段兜底）
 # 从 https://open.longbridge.com/ 获取
+# OAuth 2.0（推荐）：先运行 scripts/generate_longbridge_oauth_token.py 生成本机 SDK token 缓存
+# GitHub Actions / Docker 可把 token 缓存文件 base64 后填入 LONGBRIDGE_OAUTH_TOKEN_CACHE_B64
+# LONGBRIDGE_OAUTH_CLIENT_ID=
+# LONGBRIDGE_OAUTH_TOKEN_CACHE_B64=
+# Legacy API Key（兼容旧账号；Access Token 不是 OAuth access token）
 # LONGBRIDGE_APP_KEY=
 # LONGBRIDGE_APP_SECRET=
 # LONGBRIDGE_ACCESS_TOKEN=

--- a/.github/workflows/00-daily-analysis.yml
+++ b/.github/workflows/00-daily-analysis.yml
@@ -233,6 +233,8 @@ jobs:
           # ==========================================
           TUSHARE_TOKEN: ${{ secrets.TUSHARE_TOKEN }}
           # Longbridge OpenAPI（美股/港股实时行情字段补充；不设则仅 YFinance/AkShare，无 [Longbridge] 调用）
+          LONGBRIDGE_OAUTH_CLIENT_ID: ${{ vars.LONGBRIDGE_OAUTH_CLIENT_ID || secrets.LONGBRIDGE_OAUTH_CLIENT_ID }}
+          LONGBRIDGE_OAUTH_TOKEN_CACHE_B64: ${{ secrets.LONGBRIDGE_OAUTH_TOKEN_CACHE_B64 }}
           LONGBRIDGE_APP_KEY: ${{ secrets.LONGBRIDGE_APP_KEY }}
           LONGBRIDGE_APP_SECRET: ${{ secrets.LONGBRIDGE_APP_SECRET }}
           LONGBRIDGE_ACCESS_TOKEN: ${{ secrets.LONGBRIDGE_ACCESS_TOKEN }}
@@ -409,7 +411,13 @@ jobs:
           echo ""
           echo "【数据源】"
           echo "  Tushare Token: $([ -n "$TUSHARE_TOKEN" ] && echo '✅ 已配置' || echo '⚪ 未配置')"
-          echo "  Longbridge: $([ -n "$LONGBRIDGE_APP_KEY" ] && [ -n "$LONGBRIDGE_APP_SECRET" ] && [ -n "$LONGBRIDGE_ACCESS_TOKEN" ] && echo '✅ 已配置（美股/港股行情补充）' || echo '⚪ 未配置（仅 YFinance 等，无长桥调用）')"
+          if [ -n "$LONGBRIDGE_APP_KEY" ] && [ -n "$LONGBRIDGE_APP_SECRET" ] && [ -n "$LONGBRIDGE_ACCESS_TOKEN" ]; then
+            echo "  Longbridge: ✅ 已配置（Legacy API Key）"
+          elif [ -n "$LONGBRIDGE_OAUTH_CLIENT_ID" ] || { [ -n "$LONGBRIDGE_APP_KEY" ] && [ -z "$LONGBRIDGE_ACCESS_TOKEN" ]; }; then
+            echo "  Longbridge: $([ -n "$LONGBRIDGE_OAUTH_TOKEN_CACHE_B64" ] && echo '✅ 已配置（OAuth token cache）' || echo '🟡 已配置 OAuth client，缺少 token cache')"
+          else
+            echo "  Longbridge: ⚪ 未配置（仅 YFinance 等，无长桥调用）"
+          fi
           echo ""
           echo "【搜索引擎】"
           echo "  Bocha API Keys: $([ -n "$BOCHA_API_KEYS" ] && echo '✅ 已配置' || echo '⚪ 未配置')"

--- a/data_provider/base.py
+++ b/data_provider/base.py
@@ -1041,7 +1041,7 @@ class DataFetcherManager:
 
         优先级动态调整逻辑：
         - 如果配置了 TUSHARE_TOKEN：实例化 TushareFetcher，并按其内部逻辑提升优先级
-        - 如果配置了 Longbridge 凭据：实例化 LongbridgeFetcher 作为美股/港股兜底
+        - 如果配置了 Longbridge OAuth 或 Legacy 凭据：实例化 LongbridgeFetcher 作为美股/港股兜底
         - 未配置的可选数据源不实例化，避免在批量拉取时反复探测无效源
         - 默认优先级：
           0. EfinanceFetcher (Priority 0) - 最高优先级
@@ -1073,12 +1073,7 @@ class DataFetcherManager:
         else:
             logger.debug("[数据源初始化] 跳过未配置的 TushareFetcher")
 
-        has_longbridge_creds = bool(
-            (getattr(config, "longbridge_app_key", None) or "").strip()
-            and (getattr(config, "longbridge_app_secret", None) or "").strip()
-            and (getattr(config, "longbridge_access_token", None) or "").strip()
-        )
-        if has_longbridge_creds:
+        if LongbridgeFetcher.has_configured_credentials(config):
             optional_fetchers.append(LongbridgeFetcher())  # 长桥（美股/港股兜底，懒加载）
         else:
             logger.debug("[数据源初始化] 跳过未配置的 LongbridgeFetcher")

--- a/data_provider/longbridge_fetcher.py
+++ b/data_provider/longbridge_fetcher.py
@@ -233,16 +233,11 @@ def _restore_oauth_token_cache_from_env(client_id: str) -> bool:
     The Longbridge SDK expects its OAuth token cache at
     ``~/.longbridge/openapi/tokens/<client_id>``.  In headless environments the
     file can be provided as base64 through ``LONGBRIDGE_OAUTH_TOKEN_CACHE_B64``.
-    If an existing cache exists, this helper only overwrites it when invalid
-    (empty/truncated/format-broken), keeping valid cache unchanged.
+    If an env cache is supplied and differs from the existing file, treat the
+    env value as the operator-provided recovery source for headless runs.
     """
     raw = os.getenv("LONGBRIDGE_OAUTH_TOKEN_CACHE_B64")
     if not raw:
-        return False
-
-    token_cache = _oauth_token_cache_path(client_id)
-    if token_cache.exists() and _is_valid_oauth_cache_file(token_cache):
-        logger.debug("[Longbridge] OAuth token 缓存存在且有效，跳过恢复: %s", token_cache)
         return False
 
     try:
@@ -254,6 +249,15 @@ def _restore_oauth_token_cache_from_env(client_id: str) -> bool:
     if not payload:
         logger.warning("[Longbridge] OAuth token cache base64 为空，跳过恢复")
         return False
+
+    token_cache = _oauth_token_cache_path(client_id)
+    if token_cache.exists():
+        try:
+            if token_cache.read_bytes() == payload:
+                logger.debug("[Longbridge] OAuth token 缓存已与 env secret 一致，跳过恢复: %s", token_cache)
+                return False
+        except OSError as exc:
+            logger.warning("[Longbridge] 读取现有 OAuth token 缓存失败，将尝试用 env secret 覆盖: %s", exc)
 
     try:
         token_cache.parent.mkdir(parents=True, exist_ok=True)

--- a/data_provider/longbridge_fetcher.py
+++ b/data_provider/longbridge_fetcher.py
@@ -22,6 +22,7 @@ Legacy API Key 三件套（`LONGBRIDGE_APP_KEY` / `LONGBRIDGE_APP_SECRET` / `LON
 
 import base64
 import binascii
+import json
 import logging
 import os
 import time
@@ -262,6 +263,51 @@ def _restore_oauth_token_cache_from_env(client_id: str) -> bool:
         return False
 
 
+def _is_valid_oauth_cache_file(token_cache: Path) -> bool:
+    """Basic health check for SDK token cache content.
+
+    We avoid attempting interactive OAuth flows when the cache is missing or
+    malformed, so headless jobs fail explicitly instead of hanging for manual
+    re-authorization.
+    """
+    if not token_cache.exists():
+        return False
+
+    try:
+        raw = token_cache.read_bytes()
+    except OSError as exc:
+        logger.warning("[Longbridge] 读取 OAuth token 缓存失败: %s", exc)
+        return False
+
+    if not raw.strip():
+        logger.warning("[Longbridge] OAuth token 缓存为空文件: %s", token_cache)
+        return False
+
+    try:
+        payload = raw.decode("utf-8").strip()
+    except UnicodeDecodeError as exc:
+        logger.warning("[Longbridge] OAuth token 缓存不是 UTF-8 文本: %s", exc)
+        return False
+
+    try:
+        data = json.loads(payload)
+    except json.JSONDecodeError as exc:
+        logger.warning("[Longbridge] OAuth token 缓存不是合法 JSON: %s", exc)
+        return False
+
+    if not isinstance(data, dict) or not data:
+        logger.warning("[Longbridge] OAuth token 缓存内容为空或格式不符合预期: %s", token_cache)
+        return False
+
+    return True
+
+
+def _oauth_reauth_not_supported(url: str) -> None:
+    raise RuntimeError(
+        f"OAuth token 缓存已失效或缺失，当前为无头运行不支持打开授权页面，请重建 LONGBRIDGE_OAUTH_TOKEN_CACHE_B64: {url}"
+    )
+
+
 def _longbridge_credentials(config: Any = None) -> Dict[str, Optional[str]]:
     """Collect Longbridge auth inputs from Config/env without exposing secrets."""
     app_key = _clean_optional(getattr(config, "longbridge_app_key", None))
@@ -475,21 +521,24 @@ class LongbridgeFetcher(BaseFetcher):
                     if not token_cache.exists():
                         _restore_oauth_token_cache_from_env(oauth_client_id)
 
-                    if token_cache.exists():
+                    if _is_valid_oauth_cache_file(token_cache):
                         try:
                             from longbridge.openapi import OAuthBuilder
 
                             oauth = OAuthBuilder(oauth_client_id).build(
-                                lambda url: logger.warning(
-                                    "[Longbridge] OAuth token 需要重新授权，请在交互环境打开: %s",
-                                    url,
-                                )
+                                _oauth_reauth_not_supported,
                             )
                             lb_config = Config.from_oauth(oauth)
                             logger.info("[Longbridge] Config.from_oauth() 创建成功")
                         except Exception as exc:
                             oauth_error = exc
                             logger.warning("[Longbridge] OAuth 初始化失败: %s", exc)
+                    elif token_cache.exists():
+                        logger.warning(
+                            "[Longbridge] OAuth token 缓存内容异常，已拒绝交互式续期: %s。"
+                            "请先执行 scripts/generate_longbridge_oauth_token.py 重建缓存。",
+                            token_cache,
+                        )
                     else:
                         logger.warning(
                             "[Longbridge] OAuth client 已配置，但 token 缓存不存在: %s。"

--- a/data_provider/longbridge_fetcher.py
+++ b/data_provider/longbridge_fetcher.py
@@ -233,13 +233,16 @@ def _restore_oauth_token_cache_from_env(client_id: str) -> bool:
     The Longbridge SDK expects its OAuth token cache at
     ``~/.longbridge/openapi/tokens/<client_id>``.  In headless environments the
     file can be provided as base64 through ``LONGBRIDGE_OAUTH_TOKEN_CACHE_B64``.
+    If an existing cache exists, this helper only overwrites it when invalid
+    (empty/truncated/format-broken), keeping valid cache unchanged.
     """
     raw = os.getenv("LONGBRIDGE_OAUTH_TOKEN_CACHE_B64")
     if not raw:
         return False
 
     token_cache = _oauth_token_cache_path(client_id)
-    if token_cache.exists():
+    if token_cache.exists() and _is_valid_oauth_cache_file(token_cache):
+        logger.debug("[Longbridge] OAuth token 缓存存在且有效，跳过恢复: %s", token_cache)
         return False
 
     try:
@@ -518,8 +521,7 @@ class LongbridgeFetcher(BaseFetcher):
 
                 if oauth_client_id:
                     token_cache = _oauth_token_cache_path(oauth_client_id)
-                    if not token_cache.exists():
-                        _restore_oauth_token_cache_from_env(oauth_client_id)
+                    _restore_oauth_token_cache_from_env(oauth_client_id)
 
                     if _is_valid_oauth_cache_file(token_cache):
                         try:

--- a/data_provider/longbridge_fetcher.py
+++ b/data_provider/longbridge_fetcher.py
@@ -14,11 +14,14 @@ LongbridgeFetcher - 长桥兜底数据源 (Priority 5)
 3. 懒加载 QuoteContext，首次调用时才建立连接
 4. static_info 进程内短缓存，减少重复请求（默认 24h，可调；见 LONGBRIDGE_STATIC_INFO_TTL_SECONDS）
 
-凭证：`LONGBRIDGE_APP_KEY` / `LONGBRIDGE_APP_SECRET` / `LONGBRIDGE_ACCESS_TOKEN`。
+凭证：优先使用 `LONGBRIDGE_OAUTH_CLIENT_ID` + SDK token 缓存（OAuth 2.0）；
+Legacy API Key 三件套（`LONGBRIDGE_APP_KEY` / `LONGBRIDGE_APP_SECRET` / `LONGBRIDGE_ACCESS_TOKEN`）仍兼容。
 可选：`LONGBRIDGE_STATIC_INFO_TTL_SECONDS`；SDK `language` 取自 `REPORT_LANGUAGE`，`log_path` 为 `{LOG_DIR}/longbridge_sdk.log`；
 `LONGBRIDGE_HTTP_URL` / `LONGBRIDGE_QUOTE_WS_URL` / `LONGBRIDGE_TRADE_WS_URL` / `LONGBRIDGE_REGION` （见官方文档默认值）。
 """
 
+import base64
+import binascii
 import logging
 import os
 import time
@@ -212,6 +215,86 @@ def _longbridge_config_kwargs() -> Dict[str, Any]:
     return kw
 
 
+def _clean_optional(value: Any) -> Optional[str]:
+    if value is None:
+        return None
+    cleaned = str(value).strip()
+    return cleaned or None
+
+
+def _oauth_token_cache_path(client_id: str) -> Path:
+    return Path.home() / ".longbridge" / "openapi" / "tokens" / client_id
+
+
+def _restore_oauth_token_cache_from_env(client_id: str) -> bool:
+    """Restore the SDK OAuth token cache from a GitHub Actions/Docker secret.
+
+    The Longbridge SDK expects its OAuth token cache at
+    ``~/.longbridge/openapi/tokens/<client_id>``.  In headless environments the
+    file can be provided as base64 through ``LONGBRIDGE_OAUTH_TOKEN_CACHE_B64``.
+    """
+    raw = os.getenv("LONGBRIDGE_OAUTH_TOKEN_CACHE_B64")
+    if not raw:
+        return False
+
+    token_cache = _oauth_token_cache_path(client_id)
+    if token_cache.exists():
+        return False
+
+    try:
+        payload = base64.b64decode("".join(raw.split()), validate=True)
+    except (binascii.Error, ValueError) as exc:
+        logger.warning("[Longbridge] OAuth token cache base64 解码失败: %s", exc)
+        return False
+
+    if not payload:
+        logger.warning("[Longbridge] OAuth token cache base64 为空，跳过恢复")
+        return False
+
+    try:
+        token_cache.parent.mkdir(parents=True, exist_ok=True)
+        token_cache.write_bytes(payload)
+        token_cache.chmod(0o600)
+        logger.info("[Longbridge] 已从 LONGBRIDGE_OAUTH_TOKEN_CACHE_B64 恢复 OAuth token 缓存")
+        return True
+    except Exception as exc:
+        logger.warning("[Longbridge] 写入 OAuth token 缓存失败: %s", exc)
+        return False
+
+
+def _longbridge_credentials(config: Any = None) -> Dict[str, Optional[str]]:
+    """Collect Longbridge auth inputs from Config/env without exposing secrets."""
+    app_key = _clean_optional(getattr(config, "longbridge_app_key", None))
+    app_secret = _clean_optional(getattr(config, "longbridge_app_secret", None))
+    access_token = _clean_optional(getattr(config, "longbridge_access_token", None))
+    oauth_client_id = _clean_optional(getattr(config, "longbridge_oauth_client_id", None))
+
+    app_key = app_key or _clean_optional(os.getenv("LONGBRIDGE_APP_KEY"))
+    app_secret = app_secret or _clean_optional(os.getenv("LONGBRIDGE_APP_SECRET"))
+    access_token = access_token or _clean_optional(os.getenv("LONGBRIDGE_ACCESS_TOKEN"))
+    oauth_client_id = oauth_client_id or _clean_optional(os.getenv("LONGBRIDGE_OAUTH_CLIENT_ID"))
+
+    # Some Longbridge pages label the OAuth public client id as "App Key".
+    # Use it as a compatibility alias only when no Legacy access token exists.
+    if not oauth_client_id and app_key and not access_token:
+        oauth_client_id = app_key
+
+    return {
+        "app_key": app_key,
+        "app_secret": app_secret,
+        "access_token": access_token,
+        "oauth_client_id": oauth_client_id,
+    }
+
+
+def _has_legacy_credentials(creds: Dict[str, Optional[str]]) -> bool:
+    return bool(creds.get("app_key") and creds.get("app_secret") and creds.get("access_token"))
+
+
+def _has_oauth_credentials(creds: Dict[str, Optional[str]]) -> bool:
+    return bool(creds.get("oauth_client_id"))
+
+
 def _is_us_code(stock_code: str) -> bool:
     normalized = stock_code.strip().upper()
     return is_us_stock_code(normalized) or is_us_index_code(normalized)
@@ -326,25 +409,22 @@ class LongbridgeFetcher(BaseFetcher):
         return True
 
     def _is_available(self) -> bool:
-        """Check if Longbridge credentials are configured."""
+        """Check if Longbridge credentials are configured (OAuth or Legacy)."""
         if self._available is not None:
             return self._available
         try:
             from src.config import get_config
-            config = get_config()
-            has_creds = bool(
-                config.longbridge_app_key
-                and config.longbridge_app_secret
-                and config.longbridge_access_token
-            )
+            creds = _longbridge_credentials(get_config())
         except Exception:
-            has_creds = bool(
-                os.getenv("LONGBRIDGE_APP_KEY")
-                and os.getenv("LONGBRIDGE_APP_SECRET")
-                and os.getenv("LONGBRIDGE_ACCESS_TOKEN")
-            )
-        self._available = has_creds
-        return has_creds
+            creds = _longbridge_credentials()
+        self._available = _has_legacy_credentials(creds) or _has_oauth_credentials(creds)
+        return self._available
+
+    @staticmethod
+    def has_configured_credentials(config: Any = None) -> bool:
+        """Return True when runtime config can attempt Longbridge auth."""
+        creds = _longbridge_credentials(config)
+        return _has_legacy_credentials(creds) or _has_oauth_credentials(creds)
 
     def _get_ctx(self):
         """Lazy-init the QuoteContext (thread-safe)."""
@@ -361,17 +441,19 @@ class LongbridgeFetcher(BaseFetcher):
                 # ── 1. Clean up empty URL env vars & apply REGION mapping ──
                 _sanitize_longbridge_env()
 
-                # ── 2. Ensure credentials are available in env ──
+                # ── 2. Collect credentials and mirror Legacy values to env ──
                 try:
                     from src.config import get_config
                     app_config = get_config()
-                    app_key = app_config.longbridge_app_key
-                    app_secret = app_config.longbridge_app_secret
-                    access_token = app_config.longbridge_access_token
                 except Exception:
-                    app_key = os.getenv("LONGBRIDGE_APP_KEY")
-                    app_secret = os.getenv("LONGBRIDGE_APP_SECRET")
-                    access_token = os.getenv("LONGBRIDGE_ACCESS_TOKEN")
+                    app_config = None
+
+                creds = _longbridge_credentials(app_config)
+                app_key = creds["app_key"]
+                app_secret = creds["app_secret"]
+                access_token = creds["access_token"]
+                oauth_client_id = creds["oauth_client_id"]
+                has_legacy = _has_legacy_credentials(creds)
 
                 for k, v in {
                     "LONGBRIDGE_APP_KEY": app_key,
@@ -380,29 +462,60 @@ class LongbridgeFetcher(BaseFetcher):
                 }.items():
                     if v and not os.environ.get(k):
                         os.environ[k] = v
+                if oauth_client_id and not os.environ.get("LONGBRIDGE_OAUTH_CLIENT_ID"):
+                    os.environ["LONGBRIDGE_OAUTH_CLIENT_ID"] = oauth_client_id
 
                 # ── 3. Build Config ──
                 extra_kw = _longbridge_config_kwargs()
                 lb_config = None
+                oauth_error: Optional[Exception] = None
 
-                # Prefer from_apikey_env() — reads all LONGBRIDGE_* env vars
-                # (credentials + URLs + options) including .env files.
-                # Available in longbridge >= 4.x.  from_env() only exists on
-                # the unreleased master branch.
-                for factory_name in ("from_apikey_env", "from_env"):
-                    factory = getattr(Config, factory_name, None)
-                    if factory is None:
-                        continue
-                    try:
-                        lb_config = factory()
-                        logger.info("[Longbridge] Config.%s() 成功", factory_name)
-                        break
-                    except Exception as e:
-                        logger.debug(
-                            "[Longbridge] Config.%s() 失败: %s", factory_name, e
+                if oauth_client_id:
+                    token_cache = _oauth_token_cache_path(oauth_client_id)
+                    if not token_cache.exists():
+                        _restore_oauth_token_cache_from_env(oauth_client_id)
+
+                    if token_cache.exists():
+                        try:
+                            from longbridge.openapi import OAuthBuilder
+
+                            oauth = OAuthBuilder(oauth_client_id).build(
+                                lambda url: logger.warning(
+                                    "[Longbridge] OAuth token 需要重新授权，请在交互环境打开: %s",
+                                    url,
+                                )
+                            )
+                            lb_config = Config.from_oauth(oauth)
+                            logger.info("[Longbridge] Config.from_oauth() 创建成功")
+                        except Exception as exc:
+                            oauth_error = exc
+                            logger.warning("[Longbridge] OAuth 初始化失败: %s", exc)
+                    else:
+                        logger.warning(
+                            "[Longbridge] OAuth client 已配置，但 token 缓存不存在: %s。"
+                            "请先执行 scripts/generate_longbridge_oauth_token.py 生成缓存；"
+                            "GitHub Actions/Docker 可提供 LONGBRIDGE_OAUTH_TOKEN_CACHE_B64。",
+                            token_cache,
                         )
 
-                if lb_config is None:
+                if lb_config is None and has_legacy:
+                    # Legacy fallback is allowed only when the full non-empty
+                    # three-piece credential exists; this keeps OAuth-only
+                    # failures from being rewritten as API-key failures.
+                    for factory_name in ("from_apikey_env", "from_env"):
+                        factory = getattr(Config, factory_name, None)
+                        if factory is None:
+                            continue
+                        try:
+                            lb_config = factory()
+                            logger.info("[Longbridge] Config.%s() 成功", factory_name)
+                            break
+                        except Exception as e:
+                            logger.debug(
+                                "[Longbridge] Config.%s() 失败: %s", factory_name, e
+                            )
+
+                if lb_config is None and has_legacy:
                     lb_config = Config.from_apikey(
                         app_key,
                         app_secret,
@@ -410,6 +523,15 @@ class LongbridgeFetcher(BaseFetcher):
                         **extra_kw,
                     )
                     logger.info("[Longbridge] Config.from_apikey() 创建成功")
+                elif lb_config is None:
+                    reason = (
+                        f"OAuth 初始化失败: {oauth_error}"
+                        if oauth_error
+                        else "未找到可用 OAuth token 缓存且未配置完整 Legacy 三件套"
+                    )
+                    logger.warning("[Longbridge] 未建立认证配置: %s", reason)
+                    self._available = False
+                    return None
 
                 # Diagnostic logging
                 region = os.getenv("LONGBRIDGE_REGION") or os.getenv("LONGPORT_REGION") or "(auto)"

--- a/data_provider/longbridge_fetcher.py
+++ b/data_provider/longbridge_fetcher.py
@@ -315,6 +315,13 @@ def _oauth_reauth_not_supported(url: str) -> None:
     )
 
 
+def _oauth_sdk_unavailable_error() -> RuntimeError:
+    return RuntimeError(
+        "当前安装的 longbridge SDK 不支持 OAuth 2.0（缺少 OAuthBuilder/Config.from_oauth）。"
+        "请在支持该 SDK 版本的平台安装 longbridge>=4.0.0，或继续使用 Legacy 三件套。"
+    )
+
+
 def _longbridge_credentials(config: Any = None) -> Dict[str, Optional[str]]:
     """Collect Longbridge auth inputs from Config/env without exposing secrets."""
     app_key = _clean_optional(getattr(config, "longbridge_app_key", None))
@@ -534,8 +541,14 @@ class LongbridgeFetcher(BaseFetcher):
                             oauth = OAuthBuilder(oauth_client_id).build(
                                 _oauth_reauth_not_supported,
                             )
-                            lb_config = Config.from_oauth(oauth)
+                            from_oauth = getattr(Config, "from_oauth", None)
+                            if from_oauth is None:
+                                raise AttributeError("Config.from_oauth")
+                            lb_config = from_oauth(oauth)
                             logger.info("[Longbridge] Config.from_oauth() 创建成功")
+                        except (ImportError, AttributeError):
+                            oauth_error = _oauth_sdk_unavailable_error()
+                            logger.warning("[Longbridge] OAuth SDK 不可用: %s", oauth_error)
                         except Exception as exc:
                             oauth_error = exc
                             logger.warning("[Longbridge] OAuth 初始化失败: %s", exc)

--- a/data_provider/yfinance_fetcher.py
+++ b/data_provider/yfinance_fetcher.py
@@ -230,6 +230,8 @@ class YfinanceFetcher(BaseFetcher):
         # 列名映射（yfinance 使用首字母大写）
         column_mapping = {
             'Date': 'date',
+            'Datetime': 'date',
+            'datetime': 'date',
             'Open': 'open',
             'High': 'high',
             'Low': 'low',
@@ -238,6 +240,17 @@ class YfinanceFetcher(BaseFetcher):
         }
 
         df = df.rename(columns=column_mapping)
+        if 'date' not in df.columns:
+            index_col = df.columns[0] if len(df.columns) else None
+            if index_col is not None:
+                candidate = df[index_col]
+                if pd.api.types.is_datetime64_any_dtype(candidate):
+                    df = df.rename(columns={index_col: 'date'})
+                elif not pd.api.types.is_numeric_dtype(candidate):
+                    parsed_dates = pd.to_datetime(candidate, errors='coerce')
+                    if parsed_dates.notna().any():
+                        df = df.rename(columns={index_col: 'date'})
+                        df['date'] = parsed_dates
 
         # 计算涨跌幅（因为 yfinance 不直接提供）
         if 'close' in df.columns:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -26,6 +26,9 @@ x-common: &common
     - ../logs:/app/logs
     - ../reports:/app/reports
     - ../strategies:/app/strategies:ro
+    # Longbridge OAuth token cache persistence; entrypoint repairs container-side ownership for dsa user.
+    # Create ../longbridge_tokens on the host before copying an authorized token cache into it.
+    - ../longbridge_tokens:/home/dsa/.longbridge
     # 如需覆盖前端静态资源，可挂载本地 static 目录
     # - ../static:/app/static:ro
 

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -5,7 +5,7 @@ APP_USER="dsa"
 APP_GROUP="dsa"
 APP_UID="1000"
 APP_GID="1000"
-WRITABLE_DIRS="/app/data /app/logs /app/reports"
+WRITABLE_DIRS="/app/data /app/logs /app/reports /home/dsa/.longbridge"
 DATABASE_FILE="${DATABASE_PATH:-/app/data/stock_analysis.db}"
 
 warn() {

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -84,6 +84,8 @@ if [ "$(id -u)" = "0" ]; then
         fi
     done
 
+    HOME="/home/dsa"
+    export HOME
     exec gosu "$APP_USER:$APP_GROUP" "$@"
 fi
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -51,6 +51,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - [新功能] 普通分析与 Agent 运行时 Prompt 接入 AnalysisContextPack 低敏摘要，保持 history/API/Web 输出兼容。
 - [修复] 交互式命令（钉钉会话、飞书会话、Telegram）触发的分析结果只回到来源会话，不再同时广播到静态通知渠道。
 - [修复] 适配 Longbridge OAuth 2.0 认证与 token 缓存恢复，避免新后台无 Legacy Access Token 时长桥数据源被误判为未配置。
+- [修复] 将 `longbridge` 依赖下限提升到 `4.0.0`，确保 OAuth token 缓存路径可使用 SDK 的 `OAuthBuilder` 与 `Config.from_oauth`。
 - [修复] 兼容 YFinance 日线返回未命名日期索引的场景，避免标准化后缺少 `date` 列导致美股日线 fallback 中断。
 
 ## [3.18.0] - 2026-05-21

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -50,6 +50,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - [测试] 执行 `python -c "import exchange_calendars as xcals; xcals.get_calendar('XSHG'); print('ok')"` 通过验证，以覆盖导入与交易日历初始化兼容性。
 - [新功能] 普通分析与 Agent 运行时 Prompt 接入 AnalysisContextPack 低敏摘要，保持 history/API/Web 输出兼容。
 - [修复] 交互式命令（钉钉会话、飞书会话、Telegram）触发的分析结果只回到来源会话，不再同时广播到静态通知渠道。
+- [修复] 适配 Longbridge OAuth 2.0 认证与 token 缓存恢复，避免新后台无 Legacy Access Token 时长桥数据源被误判为未配置。
+- [修复] 兼容 YFinance 日线返回未命名日期索引的场景，避免标准化后缺少 `date` 列导致美股日线 fallback 中断。
 
 ## [3.18.0] - 2026-05-21
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -51,7 +51,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - [新功能] 普通分析与 Agent 运行时 Prompt 接入 AnalysisContextPack 低敏摘要，保持 history/API/Web 输出兼容。
 - [修复] 交互式命令（钉钉会话、飞书会话、Telegram）触发的分析结果只回到来源会话，不再同时广播到静态通知渠道。
 - [修复] 适配 Longbridge OAuth 2.0 认证与 token 缓存恢复，避免新后台无 Legacy Access Token 时长桥数据源被误判为未配置。
-- [修复] 将 `longbridge` 依赖下限提升到 `4.0.0`，确保 OAuth token 缓存路径可使用 SDK 的 `OAuthBuilder` 与 `Config.from_oauth`。
+- [修复] Longbridge OAuth 路径在当前 SDK 不支持 `OAuthBuilder` / `Config.from_oauth` 时明确日志降级，避免 Linux/Docker 仅可安装旧 SDK 时构建失败。
 - [修复] 兼容 YFinance 日线返回未命名日期索引的场景，避免标准化后缺少 `date` 列导致美股日线 fallback 中断。
 
 ## [3.18.0] - 2026-05-21

--- a/docs/full-guide.md
+++ b/docs/full-guide.md
@@ -1034,6 +1034,7 @@ PUSHOVER_API_TOKEN=your_api_token
 - 美股/港股数据兜底，补充 YFinance 缺失的量比、换手率、PE 等字段
 - 新接入推荐使用 Longbridge 官方 OAuth 2.0：client_id 优先使用 `LONGBRIDGE_OAUTH_CLIENT_ID`，留空且没有 Legacy Access Token 时兼容使用 `LONGBRIDGE_APP_KEY`；先在可交互环境执行 `python scripts/generate_longbridge_oauth_token.py --client-id <client_id>` 生成 SDK token 缓存
 - GitHub Actions / Docker 等 headless 环境不能在分析任务里等待浏览器授权；可将本机 `~/.longbridge/openapi/tokens/<client_id>` 文件 base64 后配置为 `LONGBRIDGE_OAUTH_TOKEN_CACHE_B64`
+- OAuth 运行时依赖 SDK 提供 `OAuthBuilder` / `Config.from_oauth`；若当前 Linux/Docker 环境只能安装旧版 SDK，日志会明确提示并自动跳过 Longbridge，不影响 YFinance / AkShare 兜底
 - Legacy API Key 仍兼容：设置 `LONGBRIDGE_APP_KEY`、`LONGBRIDGE_APP_SECRET`、`LONGBRIDGE_ACCESS_TOKEN`；其中 Access Token 是旧版 API Key 凭证，不是 OAuth access token
 - 可选设置 `LONGBRIDGE_CONNECTION_COOLDOWN_SECONDS` 控制连接关闭类异常后的冷却秒数（默认 15）
 - 接入点可配 `LONGBRIDGE_HTTP_URL`、`LONGBRIDGE_QUOTE_WS_URL`、`LONGBRIDGE_TRADE_WS_URL`、`LONGBRIDGE_REGION`

--- a/docs/full-guide.md
+++ b/docs/full-guide.md
@@ -154,9 +154,11 @@ daily_stock_analysis/
 | `SEARXNG_BASE_URLS` | SearXNG 自建实例（无配额兜底，需在 settings.yml 启用 format: json）；留空时默认自动发现公共实例 | 可选 |
 | `SEARXNG_PUBLIC_INSTANCES_ENABLED` | 是否在 `SEARXNG_BASE_URLS` 为空时自动从 `searx.space` 获取公共实例（默认 `true`） | 可选 |
 | `TUSHARE_TOKEN` | [Tushare Pro](https://tushare.pro/weborder/#/login?reg=834638 ) Token | 可选 |
-| `LONGBRIDGE_APP_KEY` | [Longbridge OpenAPI](https://open.longbridge.com/) App Key（美股/港股量比、换手率、PE 兜底） | 可选 |
+| `LONGBRIDGE_OAUTH_CLIENT_ID` | [Longbridge OpenAPI](https://open.longbridge.com/) OAuth client_id；新接入推荐 OAuth 2.0 | 可选 |
+| `LONGBRIDGE_OAUTH_TOKEN_CACHE_B64` | OAuth token 缓存文件的 base64 内容，供 GitHub Actions / Docker 等 headless 环境恢复 SDK token 缓存 | 可选 |
+| `LONGBRIDGE_APP_KEY` | Longbridge Legacy App Key；无 `LONGBRIDGE_ACCESS_TOKEN` 时也可作为 OAuth client_id 兼容别名 | 可选 |
 | `LONGBRIDGE_APP_SECRET` | Longbridge App Secret | 可选 |
-| `LONGBRIDGE_ACCESS_TOKEN` | Longbridge Access Token | 可选 |
+| `LONGBRIDGE_ACCESS_TOKEN` | Longbridge Legacy Access Token（不是 OAuth access token） | 可选 |
 | `LONGBRIDGE_STATIC_INFO_TTL_SECONDS` | 长桥 `static_info` 进程内缓存秒数（默认 86400，0=不缓存） | 可选 |
 | `LONGBRIDGE_CONNECTION_COOLDOWN_SECONDS` | 长桥连接关闭类异常后的冷却秒数（默认 15；冷却期内临时跳过 Longbridge，避免频繁重连） | 可选 |
 | `LONGBRIDGE_HTTP_URL` | HTTP 接口地址（默认 `https://openapi.longbridge.com`） | 可选 |
@@ -168,7 +170,7 @@ daily_stock_analysis/
 | `LONGBRIDGE_PRINT_QUOTE_PACKAGES` | 连接时是否打印行情包（未设置时默认 `false`；设为 `1`/`true`/`yes` 开启） | 可选 |
 | `ENABLE_CHIP_DISTRIBUTION` | 启用筹码分布（Actions 默认 false；需筹码数据时在 Variables 中设为 true，接口可能不稳定） | 可选 |
 
-> **GitHub Actions：** 仓库自带 `00-daily-analysis.yml` 已把上表中的 `LONGBRIDGE_*` 映射到任务环境。若未在 **Settings → Secrets and variables → Actions** 中配置 `LONGBRIDGE_APP_KEY`、`LONGBRIDGE_APP_SECRET`、`LONGBRIDGE_ACCESS_TOKEN`，CI 内不会调用长桥（日志中一般看不到 `[Longbridge]` 相关行情行）。可选接入点变量（如 `LONGBRIDGE_REGION`）可放在 **Variables** 或 **Secrets**。
+> **GitHub Actions：** 仓库自带 `00-daily-analysis.yml` 已把上表中的 `LONGBRIDGE_*` 映射到任务环境。OAuth 方式需要配置 `LONGBRIDGE_OAUTH_CLIENT_ID`，并把本机 `~/.longbridge/openapi/tokens/<client_id>` 文件 base64 后保存为 Secret `LONGBRIDGE_OAUTH_TOKEN_CACHE_B64`；Legacy 方式仍可配置 `LONGBRIDGE_APP_KEY`、`LONGBRIDGE_APP_SECRET`、`LONGBRIDGE_ACCESS_TOKEN`。可选接入点变量（如 `LONGBRIDGE_REGION`）可放在 **Variables** 或 **Secrets**。
 
 > **Longbridge 运行时行为：** 未配置凭据时不会实例化 Longbridge 这个可选 fetcher；若运行时遇到 `client is closed`、`context closed`、`connection closed` 等连接关闭类异常，会进入冷却期（默认 15 秒，可用 `LONGBRIDGE_CONNECTION_COOLDOWN_SECONDS` 调整），冷却期内美股/港股的实时与日线请求会自动跳过 Longbridge，退回 YFinance / AkShare 等兜底链路。
 
@@ -354,9 +356,11 @@ daily_stock_analysis/
 |--------|------|--------|:----:|
 | `TUSHARE_TOKEN` | Tushare Pro Token | - | 可选 |
 | `TICKFLOW_API_KEY` | TickFlow API Key；配置后 A 股大盘复盘指数优先尝试 TickFlow，若套餐支持标的池查询则市场统计也会优先尝试 TickFlow | - | 可选 |
-| `LONGBRIDGE_APP_KEY` | [Longbridge OpenAPI](https://open.longbridge.com/) App Key；配置后美股/港股的量比、换手率、PE 等 YFinance 缺失字段会自动从长桥补充 | - | 可选 |
+| `LONGBRIDGE_OAUTH_CLIENT_ID` | Longbridge OAuth client_id；新接入推荐使用 OAuth 2.0 | - | 可选 |
+| `LONGBRIDGE_OAUTH_TOKEN_CACHE_B64` | OAuth token 缓存文件的 base64 内容，供 GitHub Actions / Docker 等 headless 环境使用 | - | 可选 |
+| `LONGBRIDGE_APP_KEY` | Longbridge Legacy App Key；无 `LONGBRIDGE_ACCESS_TOKEN` 时也可作为 OAuth client_id 兼容别名 | - | 可选 |
 | `LONGBRIDGE_APP_SECRET` | Longbridge App Secret | - | 可选 |
-| `LONGBRIDGE_ACCESS_TOKEN` | Longbridge Access Token | - | 可选 |
+| `LONGBRIDGE_ACCESS_TOKEN` | Longbridge Legacy Access Token（不是 OAuth access token） | - | 可选 |
 | `LONGBRIDGE_*`（可选） | 见官方 [环境变量](https://open.longbridge.com/zh-CN/docs/getting-started#环境变量)；另有 `LONGBRIDGE_STATIC_INFO_TTL_SECONDS` 与 `LONGBRIDGE_CONNECTION_COOLDOWN_SECONDS` | - | 可选 |
 | `ENABLE_REALTIME_QUOTE` | 启用实时行情（关闭后使用历史收盘价分析） | `true` | 可选 |
 | `ENABLE_REALTIME_TECHNICAL_INDICATORS` | 盘中实时技术面：启用时用实时价计算 MA5/MA10/MA20 与多头排列（Issue #234）；关闭则用昨日收盘 | `true` | 可选 |
@@ -1028,8 +1032,9 @@ PUSHOVER_API_TOKEN=your_api_token
 
 ### Longbridge（长桥）
 - 美股/港股数据兜底，补充 YFinance 缺失的量比、换手率、PE 等字段
-- 需从 [open.longbridge.com](https://open.longbridge.com/) 注册并获取 App Key / App Secret / Access Token
-- 设置 `LONGBRIDGE_APP_KEY`、`LONGBRIDGE_APP_SECRET`、`LONGBRIDGE_ACCESS_TOKEN`
+- 新接入推荐使用 Longbridge 官方 OAuth 2.0：设置 `LONGBRIDGE_OAUTH_CLIENT_ID`，并先在可交互环境执行 `python scripts/generate_longbridge_oauth_token.py --client-id <client_id>` 生成 SDK token 缓存
+- GitHub Actions / Docker 等 headless 环境不能在分析任务里等待浏览器授权；可将本机 `~/.longbridge/openapi/tokens/<client_id>` 文件 base64 后配置为 `LONGBRIDGE_OAUTH_TOKEN_CACHE_B64`
+- Legacy API Key 仍兼容：设置 `LONGBRIDGE_APP_KEY`、`LONGBRIDGE_APP_SECRET`、`LONGBRIDGE_ACCESS_TOKEN`；其中 Access Token 是旧版 API Key 凭证，不是 OAuth access token
 - 可选设置 `LONGBRIDGE_CONNECTION_COOLDOWN_SECONDS` 控制连接关闭类异常后的冷却秒数（默认 15）
 - 接入点可配 `LONGBRIDGE_HTTP_URL`、`LONGBRIDGE_QUOTE_WS_URL`、`LONGBRIDGE_TRADE_WS_URL`、`LONGBRIDGE_REGION`
 - 其余可选参数见官方 [环境变量说明](https://open.longbridge.com/zh-CN/docs/getting-started#环境变量)

--- a/docs/full-guide.md
+++ b/docs/full-guide.md
@@ -154,7 +154,7 @@ daily_stock_analysis/
 | `SEARXNG_BASE_URLS` | SearXNG 自建实例（无配额兜底，需在 settings.yml 启用 format: json）；留空时默认自动发现公共实例 | 可选 |
 | `SEARXNG_PUBLIC_INSTANCES_ENABLED` | 是否在 `SEARXNG_BASE_URLS` 为空时自动从 `searx.space` 获取公共实例（默认 `true`） | 可选 |
 | `TUSHARE_TOKEN` | [Tushare Pro](https://tushare.pro/weborder/#/login?reg=834638 ) Token | 可选 |
-| `LONGBRIDGE_OAUTH_CLIENT_ID` | [Longbridge OpenAPI](https://open.longbridge.com/) OAuth client_id；新接入推荐 OAuth 2.0 | 可选 |
+| `LONGBRIDGE_OAUTH_CLIENT_ID` | [Longbridge OpenAPI](https://open.longbridge.com/) OAuth client_id；留空且无 Legacy Access Token 时会兼容使用 `LONGBRIDGE_APP_KEY` | 可选 |
 | `LONGBRIDGE_OAUTH_TOKEN_CACHE_B64` | OAuth token 缓存文件的 base64 内容，供 GitHub Actions / Docker 等 headless 环境恢复 SDK token 缓存 | 可选 |
 | `LONGBRIDGE_APP_KEY` | Longbridge Legacy App Key；无 `LONGBRIDGE_ACCESS_TOKEN` 时也可作为 OAuth client_id 兼容别名 | 可选 |
 | `LONGBRIDGE_APP_SECRET` | Longbridge App Secret | 可选 |
@@ -170,7 +170,7 @@ daily_stock_analysis/
 | `LONGBRIDGE_PRINT_QUOTE_PACKAGES` | 连接时是否打印行情包（未设置时默认 `false`；设为 `1`/`true`/`yes` 开启） | 可选 |
 | `ENABLE_CHIP_DISTRIBUTION` | 启用筹码分布（Actions 默认 false；需筹码数据时在 Variables 中设为 true，接口可能不稳定） | 可选 |
 
-> **GitHub Actions：** 仓库自带 `00-daily-analysis.yml` 已把上表中的 `LONGBRIDGE_*` 映射到任务环境。OAuth 方式需要配置 `LONGBRIDGE_OAUTH_CLIENT_ID`，并把本机 `~/.longbridge/openapi/tokens/<client_id>` 文件 base64 后保存为 Secret `LONGBRIDGE_OAUTH_TOKEN_CACHE_B64`；Legacy 方式仍可配置 `LONGBRIDGE_APP_KEY`、`LONGBRIDGE_APP_SECRET`、`LONGBRIDGE_ACCESS_TOKEN`。可选接入点变量（如 `LONGBRIDGE_REGION`）可放在 **Variables** 或 **Secrets**。
+> **GitHub Actions：** 仓库自带 `00-daily-analysis.yml` 已把上表中的 `LONGBRIDGE_*` 映射到任务环境。OAuth 方式需要一个 client_id（优先 `LONGBRIDGE_OAUTH_CLIENT_ID`；留空且无 Legacy Access Token 时使用 `LONGBRIDGE_APP_KEY` 兼容），并把本机 `~/.longbridge/openapi/tokens/<client_id>` 文件 base64 后保存为 Secret `LONGBRIDGE_OAUTH_TOKEN_CACHE_B64`；Legacy 方式仍可配置 `LONGBRIDGE_APP_KEY`、`LONGBRIDGE_APP_SECRET`、`LONGBRIDGE_ACCESS_TOKEN`。可选接入点变量（如 `LONGBRIDGE_REGION`）可放在 **Variables** 或 **Secrets**。
 
 > **Longbridge 运行时行为：** 未配置凭据时不会实例化 Longbridge 这个可选 fetcher；若运行时遇到 `client is closed`、`context closed`、`connection closed` 等连接关闭类异常，会进入冷却期（默认 15 秒，可用 `LONGBRIDGE_CONNECTION_COOLDOWN_SECONDS` 调整），冷却期内美股/港股的实时与日线请求会自动跳过 Longbridge，退回 YFinance / AkShare 等兜底链路。
 
@@ -356,7 +356,7 @@ daily_stock_analysis/
 |--------|------|--------|:----:|
 | `TUSHARE_TOKEN` | Tushare Pro Token | - | 可选 |
 | `TICKFLOW_API_KEY` | TickFlow API Key；配置后 A 股大盘复盘指数优先尝试 TickFlow，若套餐支持标的池查询则市场统计也会优先尝试 TickFlow | - | 可选 |
-| `LONGBRIDGE_OAUTH_CLIENT_ID` | Longbridge OAuth client_id；新接入推荐使用 OAuth 2.0 | - | 可选 |
+| `LONGBRIDGE_OAUTH_CLIENT_ID` | Longbridge OAuth client_id；留空且无 Legacy Access Token 时会兼容使用 `LONGBRIDGE_APP_KEY` | - | 可选 |
 | `LONGBRIDGE_OAUTH_TOKEN_CACHE_B64` | OAuth token 缓存文件的 base64 内容，供 GitHub Actions / Docker 等 headless 环境使用 | - | 可选 |
 | `LONGBRIDGE_APP_KEY` | Longbridge Legacy App Key；无 `LONGBRIDGE_ACCESS_TOKEN` 时也可作为 OAuth client_id 兼容别名 | - | 可选 |
 | `LONGBRIDGE_APP_SECRET` | Longbridge App Secret | - | 可选 |
@@ -1032,7 +1032,7 @@ PUSHOVER_API_TOKEN=your_api_token
 
 ### Longbridge（长桥）
 - 美股/港股数据兜底，补充 YFinance 缺失的量比、换手率、PE 等字段
-- 新接入推荐使用 Longbridge 官方 OAuth 2.0：设置 `LONGBRIDGE_OAUTH_CLIENT_ID`，并先在可交互环境执行 `python scripts/generate_longbridge_oauth_token.py --client-id <client_id>` 生成 SDK token 缓存
+- 新接入推荐使用 Longbridge 官方 OAuth 2.0：client_id 优先使用 `LONGBRIDGE_OAUTH_CLIENT_ID`，留空且没有 Legacy Access Token 时兼容使用 `LONGBRIDGE_APP_KEY`；先在可交互环境执行 `python scripts/generate_longbridge_oauth_token.py --client-id <client_id>` 生成 SDK token 缓存
 - GitHub Actions / Docker 等 headless 环境不能在分析任务里等待浏览器授权；可将本机 `~/.longbridge/openapi/tokens/<client_id>` 文件 base64 后配置为 `LONGBRIDGE_OAUTH_TOKEN_CACHE_B64`
 - Legacy API Key 仍兼容：设置 `LONGBRIDGE_APP_KEY`、`LONGBRIDGE_APP_SECRET`、`LONGBRIDGE_ACCESS_TOKEN`；其中 Access Token 是旧版 API Key 凭证，不是 OAuth access token
 - 可选设置 `LONGBRIDGE_CONNECTION_COOLDOWN_SECONDS` 控制连接关闭类异常后的冷却秒数（默认 15）

--- a/docs/full-guide_EN.md
+++ b/docs/full-guide_EN.md
@@ -900,7 +900,9 @@ System defaults to AkShare (free), also supports other data sources:
 
 ### Longbridge
 - Optional fallback for US/HK stocks, mainly used to supplement fields that YFinance may miss
-- Configure `LONGBRIDGE_APP_KEY`, `LONGBRIDGE_APP_SECRET`, and `LONGBRIDGE_ACCESS_TOKEN`
+- New integrations should use Longbridge OAuth 2.0: set `LONGBRIDGE_OAUTH_CLIENT_ID`, then run `python scripts/generate_longbridge_oauth_token.py --client-id <client_id>` once on an interactive machine to generate the SDK token cache
+- For GitHub Actions / Docker headless runs, base64 the local `~/.longbridge/openapi/tokens/<client_id>` file and store it as `LONGBRIDGE_OAUTH_TOKEN_CACHE_B64`
+- Legacy API Key remains supported with `LONGBRIDGE_APP_KEY`, `LONGBRIDGE_APP_SECRET`, and `LONGBRIDGE_ACCESS_TOKEN`; this Access Token is the legacy API-key credential, not an OAuth access token
 - Optional knobs: `LONGBRIDGE_STATIC_INFO_TTL_SECONDS` (default `86400`) and `LONGBRIDGE_CONNECTION_COOLDOWN_SECONDS` (default `15`)
 - If credentials are absent, the optional Longbridge fetcher is not instantiated
 - When runtime errors such as `client is closed`, `context closed`, or `connection closed` occur, Longbridge enters a short cooldown window and US/HK daily or realtime requests automatically fall back to YFinance / AkShare instead of reconnecting on every request

--- a/docs/full-guide_EN.md
+++ b/docs/full-guide_EN.md
@@ -902,6 +902,7 @@ System defaults to AkShare (free), also supports other data sources:
 - Optional fallback for US/HK stocks, mainly used to supplement fields that YFinance may miss
 - New integrations should use Longbridge OAuth 2.0: the client id is read from `LONGBRIDGE_OAUTH_CLIENT_ID`, or from `LONGBRIDGE_APP_KEY` when no Legacy Access Token is configured; run `python scripts/generate_longbridge_oauth_token.py --client-id <client_id>` once on an interactive machine to generate the SDK token cache
 - For GitHub Actions / Docker headless runs, base64 the local `~/.longbridge/openapi/tokens/<client_id>` file and store it as `LONGBRIDGE_OAUTH_TOKEN_CACHE_B64`
+- OAuth runtime support requires SDK APIs `OAuthBuilder` and `Config.from_oauth`; if a Linux/Docker environment can only install the older SDK, the app logs a clear warning and skips Longbridge while keeping YFinance / AkShare fallback available
 - Legacy API Key remains supported with `LONGBRIDGE_APP_KEY`, `LONGBRIDGE_APP_SECRET`, and `LONGBRIDGE_ACCESS_TOKEN`; this Access Token is the legacy API-key credential, not an OAuth access token
 - Optional knobs: `LONGBRIDGE_STATIC_INFO_TTL_SECONDS` (default `86400`) and `LONGBRIDGE_CONNECTION_COOLDOWN_SECONDS` (default `15`)
 - If credentials are absent, the optional Longbridge fetcher is not instantiated

--- a/docs/full-guide_EN.md
+++ b/docs/full-guide_EN.md
@@ -900,7 +900,7 @@ System defaults to AkShare (free), also supports other data sources:
 
 ### Longbridge
 - Optional fallback for US/HK stocks, mainly used to supplement fields that YFinance may miss
-- New integrations should use Longbridge OAuth 2.0: set `LONGBRIDGE_OAUTH_CLIENT_ID`, then run `python scripts/generate_longbridge_oauth_token.py --client-id <client_id>` once on an interactive machine to generate the SDK token cache
+- New integrations should use Longbridge OAuth 2.0: the client id is read from `LONGBRIDGE_OAUTH_CLIENT_ID`, or from `LONGBRIDGE_APP_KEY` when no Legacy Access Token is configured; run `python scripts/generate_longbridge_oauth_token.py --client-id <client_id>` once on an interactive machine to generate the SDK token cache
 - For GitHub Actions / Docker headless runs, base64 the local `~/.longbridge/openapi/tokens/<client_id>` file and store it as `LONGBRIDGE_OAUTH_TOKEN_CACHE_B64`
 - Legacy API Key remains supported with `LONGBRIDGE_APP_KEY`, `LONGBRIDGE_APP_SECRET`, and `LONGBRIDGE_ACCESS_TOKEN`; this Access Token is the legacy API-key credential, not an OAuth access token
 - Optional knobs: `LONGBRIDGE_STATIC_INFO_TTL_SECONDS` (default `86400`) and `LONGBRIDGE_CONNECTION_COOLDOWN_SECONDS` (default `15`)

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,7 @@ tushare>=1.4.0              # Priority 2: 挖地兔 Pro API
 pytdx>=1.72                 # Priority 2: 通达信行情服务器
 baostock>=0.8.0             # Priority 3: 证券宝数据
 yfinance>=0.2.0             # Priority 4: Yahoo Finance (Fallback)
-longbridge>=4.0.0           # Priority 5: 长桥 OpenAPI（美股/港股兜底；OAuth requires 4.x SDK）
+longbridge>=0.2.77           # Priority 5: 长桥 OpenAPI（美股/港股兜底）
 tickflow>=0.1.0            # TickFlow official SDK (Issue #632, market review enhancement)
 
 #飞书

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,7 @@ tushare>=1.4.0              # Priority 2: 挖地兔 Pro API
 pytdx>=1.72                 # Priority 2: 通达信行情服务器
 baostock>=0.8.0             # Priority 3: 证券宝数据
 yfinance>=0.2.0             # Priority 4: Yahoo Finance (Fallback)
-longbridge>=0.2.0           # Priority 5: 长桥 OpenAPI（美股/港股兜底）
+longbridge>=4.0.0           # Priority 5: 长桥 OpenAPI（美股/港股兜底；OAuth requires 4.x SDK）
 tickflow>=0.1.0            # TickFlow official SDK (Issue #632, market review enhancement)
 
 #飞书

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,7 @@ tushare>=1.4.0              # Priority 2: 挖地兔 Pro API
 pytdx>=1.72                 # Priority 2: 通达信行情服务器
 baostock>=0.8.0             # Priority 3: 证券宝数据
 yfinance>=0.2.0             # Priority 4: Yahoo Finance (Fallback)
-longbridge>=0.2.77           # Priority 5: 长桥 OpenAPI（美股/港股兜底）
+longbridge>=4.0.0            # Priority 5: 长桥 OpenAPI（美股/港股兜底，OAuth 2.0）
 tickflow>=0.1.0            # TickFlow official SDK (Issue #632, market review enhancement)
 
 #飞书

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,7 @@ tushare>=1.4.0              # Priority 2: 挖地兔 Pro API
 pytdx>=1.72                 # Priority 2: 通达信行情服务器
 baostock>=0.8.0             # Priority 3: 证券宝数据
 yfinance>=0.2.0             # Priority 4: Yahoo Finance (Fallback)
-longbridge>=4.0.0            # Priority 5: 长桥 OpenAPI（美股/港股兜底，OAuth 2.0）
+longbridge>=0.2.77           # Priority 5: 长桥 OpenAPI（美股/港股兜底；OAuth 路径运行时检测 SDK 能力）
 tickflow>=0.1.0            # TickFlow official SDK (Issue #632, market review enhancement)
 
 #飞书

--- a/scripts/generate_longbridge_oauth_token.py
+++ b/scripts/generate_longbridge_oauth_token.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+"""Generate the Longbridge SDK OAuth token cache for headless runtimes."""
+
+from __future__ import annotations
+
+import argparse
+import os
+from pathlib import Path
+
+
+def _default_client_id() -> str:
+    return (
+        os.getenv("LONGBRIDGE_OAUTH_CLIENT_ID")
+        or os.getenv("LONGBRIDGE_APP_KEY")
+        or ""
+    ).strip()
+
+
+def _token_cache_path(client_id: str) -> Path:
+    return Path.home() / ".longbridge" / "openapi" / "tokens" / client_id
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Run Longbridge OAuth authorization and persist the SDK token cache. "
+            "Use this once on an interactive machine before schedule/Docker/GitHub Actions runs."
+        )
+    )
+    parser.add_argument(
+        "--client-id",
+        default=_default_client_id(),
+        help="OAuth client_id. Defaults to LONGBRIDGE_OAUTH_CLIENT_ID, then LONGBRIDGE_APP_KEY.",
+    )
+    parser.add_argument(
+        "--verify-symbol",
+        default="",
+        help="Optional Longbridge symbol such as AAPL.US or 700.HK to verify QuoteContext after auth.",
+    )
+    args = parser.parse_args()
+
+    client_id = (args.client_id or "").strip()
+    if not client_id:
+        parser.error("missing --client-id or LONGBRIDGE_OAUTH_CLIENT_ID")
+
+    try:
+        from longbridge.openapi import Config, OAuthBuilder, QuoteContext
+    except Exception as exc:
+        raise SystemExit(
+            "longbridge SDK is not installed. Run `pip install -r requirements.txt` first."
+        ) from exc
+
+    def show_url(url: str) -> None:
+        print(f"Open this URL to authorize Longbridge OAuth:\n{url}\n")
+
+    oauth = OAuthBuilder(client_id).build(show_url)
+    config = Config.from_oauth(oauth)
+
+    if args.verify_symbol:
+        ctx = QuoteContext(config)
+        quote = ctx.quote([args.verify_symbol])[0]
+        print(f"Verified {args.verify_symbol}: {getattr(quote, 'last_done', None)}")
+
+    token_cache = _token_cache_path(client_id)
+    print(f"OAuth token cache: {token_cache}")
+    print(
+        "For GitHub Actions, store the base64 of this file as "
+        "`LONGBRIDGE_OAUTH_TOKEN_CACHE_B64`."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/config.py
+++ b/src/config.py
@@ -625,6 +625,7 @@ class Config:
     longbridge_app_key: Optional[str] = None
     longbridge_app_secret: Optional[str] = None
     longbridge_access_token: Optional[str] = None
+    longbridge_oauth_client_id: Optional[str] = None
     stock_index_remote_update_enabled: bool = True
 
     # === AI 分析配置 ===
@@ -1415,6 +1416,7 @@ class Config:
             longbridge_app_key=os.getenv('LONGBRIDGE_APP_KEY') or None,
             longbridge_app_secret=os.getenv('LONGBRIDGE_APP_SECRET') or None,
             longbridge_access_token=os.getenv('LONGBRIDGE_ACCESS_TOKEN') or None,
+            longbridge_oauth_client_id=os.getenv('LONGBRIDGE_OAUTH_CLIENT_ID') or None,
             stock_index_remote_update_enabled=parse_env_bool(
                 os.getenv('STOCK_INDEX_REMOTE_UPDATE_ENABLED'),
                 default=True,

--- a/tests/test_docker_entrypoint.py
+++ b/tests/test_docker_entrypoint.py
@@ -32,6 +32,8 @@ def test_docker_entrypoint_repairs_ownership_and_user_permissions() -> None:
     assert "can_write_dir_as_app_user" in entrypoint
     assert "DATABASE_FILE" in entrypoint
     assert "/home/dsa/.longbridge" in entrypoint
+    assert 'HOME="/home/dsa"' in entrypoint
+    assert re.search(r"export\s+HOME\s+exec\s+gosu", entrypoint, re.DOTALL)
     assert re.search(r"\bchown\s+-R\b", entrypoint)
     assert re.search(r"\bchmod\s+-R\s+u\+rwX\b", entrypoint)
     assert re.search(r"gosu\s+\"\$APP_USER:\$APP_GROUP\"\s+test\s+-w", entrypoint)

--- a/tests/test_docker_entrypoint.py
+++ b/tests/test_docker_entrypoint.py
@@ -31,6 +31,7 @@ def test_docker_entrypoint_repairs_ownership_and_user_permissions() -> None:
     assert "has_unwritable_mount_path" in entrypoint
     assert "can_write_dir_as_app_user" in entrypoint
     assert "DATABASE_FILE" in entrypoint
+    assert "/home/dsa/.longbridge" in entrypoint
     assert re.search(r"\bchown\s+-R\b", entrypoint)
     assert re.search(r"\bchmod\s+-R\s+u\+rwX\b", entrypoint)
     assert re.search(r"gosu\s+\"\$APP_USER:\$APP_GROUP\"\s+test\s+-w", entrypoint)
@@ -44,6 +45,7 @@ def test_docker_compose_injects_env_without_single_file_env_mount() -> None:
     assert "../.env" in common["env_file"]
     assert "../.env:/app/.env" not in common["volumes"]
     assert not any(str(volume).startswith("../.env:") for volume in common["volumes"])
+    assert "../longbridge_tokens:/home/dsa/.longbridge" in common["volumes"]
 
 
 def test_docker_guides_do_not_recommend_single_file_env_bind_mount() -> None:

--- a/tests/test_fetcher_source_optimization.py
+++ b/tests/test_fetcher_source_optimization.py
@@ -65,9 +65,18 @@ class TestFetcherSourceOptimization(unittest.TestCase):
             longbridge_app_key="",
             longbridge_app_secret="",
             longbridge_access_token="",
+            longbridge_oauth_client_id="",
         )
 
-        with patch("data_provider.efinance_fetcher.EfinanceFetcher", return_value=_StubFetcher("EfinanceFetcher", 0)), patch(
+        with patch.dict(
+            "os.environ",
+            {
+                "LONGBRIDGE_OAUTH_CLIENT_ID": "",
+                "LONGBRIDGE_APP_KEY": "",
+                "LONGBRIDGE_APP_SECRET": "",
+                "LONGBRIDGE_ACCESS_TOKEN": "",
+            },
+        ), patch("data_provider.efinance_fetcher.EfinanceFetcher", return_value=_StubFetcher("EfinanceFetcher", 0)), patch(
             "data_provider.akshare_fetcher.AkshareFetcher",
             return_value=_StubFetcher("AkshareFetcher", 1),
         ), patch(
@@ -86,6 +95,7 @@ class TestFetcherSourceOptimization(unittest.TestCase):
             "data_provider.longbridge_fetcher.LongbridgeFetcher",
             return_value=_StubFetcher("LongbridgeFetcher", 5),
         ) as mock_longbridge:
+            mock_longbridge.has_configured_credentials.return_value = False
             manager = DataFetcherManager()
 
         self.assertEqual(
@@ -100,6 +110,41 @@ class TestFetcherSourceOptimization(unittest.TestCase):
         )
         mock_tushare.assert_not_called()
         mock_longbridge.assert_not_called()
+
+    @patch("src.config.get_config")
+    def test_manager_enables_longbridge_with_oauth_client_id(self, mock_get_config):
+        mock_get_config.return_value = SimpleNamespace(
+            tushare_token="",
+            longbridge_app_key="",
+            longbridge_app_secret="",
+            longbridge_access_token="",
+            longbridge_oauth_client_id="client-1",
+        )
+
+        with patch("data_provider.efinance_fetcher.EfinanceFetcher", return_value=_StubFetcher("EfinanceFetcher", 0)), patch(
+            "data_provider.akshare_fetcher.AkshareFetcher",
+            return_value=_StubFetcher("AkshareFetcher", 1),
+        ), patch(
+            "data_provider.pytdx_fetcher.PytdxFetcher",
+            return_value=_StubFetcher("PytdxFetcher", 2),
+        ), patch(
+            "data_provider.baostock_fetcher.BaostockFetcher",
+            return_value=_StubFetcher("BaostockFetcher", 3),
+        ), patch(
+            "data_provider.yfinance_fetcher.YfinanceFetcher",
+            return_value=_StubFetcher("YfinanceFetcher", 4),
+        ), patch(
+            "data_provider.tushare_fetcher.TushareFetcher",
+            return_value=_StubFetcher("TushareFetcher", -1),
+        ), patch(
+            "data_provider.longbridge_fetcher.LongbridgeFetcher",
+            return_value=_StubFetcher("LongbridgeFetcher", 5),
+        ) as mock_longbridge:
+            mock_longbridge.has_configured_credentials.return_value = True
+            manager = DataFetcherManager()
+
+        self.assertIn("LongbridgeFetcher", manager.available_fetchers)
+        mock_longbridge.assert_called_once()
 
     @patch("src.config.get_config")
     def test_us_realtime_route_skips_temporarily_unavailable_longbridge(self, mock_get_config):

--- a/tests/test_longbridge_fetcher.py
+++ b/tests/test_longbridge_fetcher.py
@@ -282,6 +282,40 @@ class TestLongbridgeAuthSelection(unittest.TestCase):
         mock_config.from_apikey.assert_not_called()
 
     @patch("src.config.get_config")
+    def test_oauth_replaces_existing_cache_when_base64_secret_differs(self, mock_get_config):
+        mock_get_config.return_value = self._config(oauth_client_id="client-1")
+        modules = self._install_mock_longbridge()
+        mock_lb_module, mock_lb_openapi, mock_config, _, mock_oauth_builder = modules
+        mock_oauth_builder.return_value.build.return_value = "oauth-token"
+        mock_config.from_oauth.return_value = "oauth-config"
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            token_cache = Path(tmpdir) / "client-1"
+            token_cache.write_text('{"refresh_token":"old-but-json-valid"}', encoding="utf-8")
+            encoded_cache = base64.b64encode(b'{"refresh_token":"fresh"}').decode("ascii")
+            with patch.dict("sys.modules", {"longbridge": mock_lb_module, "longbridge.openapi": mock_lb_openapi}), patch.dict(
+                os.environ,
+                {
+                    "LONGBRIDGE_OAUTH_CLIENT_ID": "client-1",
+                    "LONGBRIDGE_OAUTH_TOKEN_CACHE_B64": encoded_cache,
+                    "LONGBRIDGE_APP_KEY": "",
+                    "LONGBRIDGE_APP_SECRET": "",
+                    "LONGBRIDGE_ACCESS_TOKEN": "",
+                },
+            ), patch("data_provider.longbridge_fetcher._longbridge_config_kwargs", return_value={}), patch(
+                "data_provider.longbridge_fetcher._oauth_token_cache_path",
+                return_value=token_cache,
+            ):
+                fetcher = LongbridgeFetcher()
+                ctx = fetcher._get_ctx()
+                self.assertEqual(token_cache.read_bytes(), b'{"refresh_token":"fresh"}')
+
+        self.assertEqual(ctx, "quote-context")
+        mock_config.from_oauth.assert_called_once_with("oauth-token")
+        mock_config.from_apikey_env.assert_not_called()
+        mock_config.from_apikey.assert_not_called()
+
+    @patch("src.config.get_config")
     def test_oauth_callback_reauth_request_fails_closed_in_headless(self, mock_get_config):
         mock_get_config.return_value = self._config(oauth_client_id="client-1")
         modules = self._install_mock_longbridge()

--- a/tests/test_longbridge_fetcher.py
+++ b/tests/test_longbridge_fetcher.py
@@ -134,7 +134,7 @@ class TestLongbridgeAuthSelection(unittest.TestCase):
 
         with tempfile.TemporaryDirectory() as tmpdir:
             token_cache = Path(tmpdir) / "client-1"
-            token_cache.write_text("{}", encoding="utf-8")
+            token_cache.write_text('{"refresh_token":"valid-token"}', encoding="utf-8")
             with patch.dict("sys.modules", {"longbridge": mock_lb_module, "longbridge.openapi": mock_lb_openapi}), patch.dict(
                 os.environ,
                 {
@@ -181,6 +181,69 @@ class TestLongbridgeAuthSelection(unittest.TestCase):
 
         self.assertIsNone(ctx)
         mock_oauth_builder.assert_not_called()
+        mock_config.from_apikey_env.assert_not_called()
+        mock_config.from_apikey.assert_not_called()
+
+    @patch("src.config.get_config")
+    def test_oauth_invalid_cache_content_skips_oauth_reauth_and_fails_closed(self, mock_get_config):
+        mock_get_config.return_value = self._config(oauth_client_id="client-1")
+        modules = self._install_mock_longbridge()
+        mock_lb_module, mock_lb_openapi, mock_config, _, mock_oauth_builder = modules
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            invalid_cache = Path(tmpdir) / "client-1"
+            invalid_cache.write_text("invalid-json", encoding="utf-8")
+            with patch.dict("sys.modules", {"longbridge": mock_lb_module, "longbridge.openapi": mock_lb_openapi}), patch.dict(
+                os.environ,
+                {
+                    "LONGBRIDGE_OAUTH_CLIENT_ID": "client-1",
+                    "LONGBRIDGE_APP_KEY": "",
+                    "LONGBRIDGE_APP_SECRET": "",
+                    "LONGBRIDGE_ACCESS_TOKEN": "",
+                },
+            ), patch("data_provider.longbridge_fetcher._longbridge_config_kwargs", return_value={}), patch(
+                "data_provider.longbridge_fetcher._oauth_token_cache_path",
+                return_value=invalid_cache,
+            ):
+                fetcher = LongbridgeFetcher()
+                ctx = fetcher._get_ctx()
+
+        self.assertIsNone(ctx)
+        mock_oauth_builder.assert_not_called()
+        mock_config.from_apikey_env.assert_not_called()
+        mock_config.from_apikey.assert_not_called()
+
+    @patch("src.config.get_config")
+    def test_oauth_callback_reauth_request_fails_closed_in_headless(self, mock_get_config):
+        mock_get_config.return_value = self._config(oauth_client_id="client-1")
+        modules = self._install_mock_longbridge()
+        mock_lb_module, mock_lb_openapi, mock_config, _, mock_oauth_builder = modules
+
+        def _require_oauth_reauth_request(show_url):
+            show_url("https://longbridge.oauth/login")
+            raise RuntimeError("re-auth requested")
+        mock_oauth_builder.return_value.build.side_effect = _require_oauth_reauth_request
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            token_cache = Path(tmpdir) / "client-1"
+            token_cache.write_text('{"refresh_token":"expired-token"}', encoding="utf-8")
+            with patch.dict("sys.modules", {"longbridge": mock_lb_module, "longbridge.openapi": mock_lb_openapi}), patch.dict(
+                os.environ,
+                {
+                    "LONGBRIDGE_OAUTH_CLIENT_ID": "client-1",
+                    "LONGBRIDGE_APP_KEY": "",
+                    "LONGBRIDGE_APP_SECRET": "",
+                    "LONGBRIDGE_ACCESS_TOKEN": "",
+                },
+            ), patch("data_provider.longbridge_fetcher._longbridge_config_kwargs", return_value={}), patch(
+                "data_provider.longbridge_fetcher._oauth_token_cache_path",
+                return_value=token_cache,
+            ):
+                fetcher = LongbridgeFetcher()
+                ctx = fetcher._get_ctx()
+
+        self.assertIsNone(ctx)
+        mock_oauth_builder.assert_called_once_with("client-1")
         mock_config.from_apikey_env.assert_not_called()
         mock_config.from_apikey.assert_not_called()
 

--- a/tests/test_longbridge_fetcher.py
+++ b/tests/test_longbridge_fetcher.py
@@ -157,6 +157,39 @@ class TestLongbridgeAuthSelection(unittest.TestCase):
         mock_quote_context.assert_called_once_with("oauth-config")
 
     @patch("src.config.get_config")
+    def test_oauth_uses_app_key_as_client_id_when_access_token_missing(self, mock_get_config):
+        mock_get_config.return_value = self._config(app_key="app-key", app_secret="app-secret")
+        modules = self._install_mock_longbridge()
+        mock_lb_module, mock_lb_openapi, mock_config, mock_quote_context, mock_oauth_builder = modules
+        mock_oauth_builder.return_value.build.return_value = "oauth-token"
+        mock_config.from_oauth.return_value = "oauth-config"
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            token_cache = Path(tmpdir) / "app-key"
+            token_cache.write_text('{"refresh_token":"valid-token"}', encoding="utf-8")
+            with patch.dict("sys.modules", {"longbridge": mock_lb_module, "longbridge.openapi": mock_lb_openapi}), patch.dict(
+                os.environ,
+                {
+                    "LONGBRIDGE_OAUTH_CLIENT_ID": "",
+                    "LONGBRIDGE_APP_KEY": "app-key",
+                    "LONGBRIDGE_APP_SECRET": "app-secret",
+                    "LONGBRIDGE_ACCESS_TOKEN": "",
+                },
+            ), patch("data_provider.longbridge_fetcher._longbridge_config_kwargs", return_value={}), patch(
+                "data_provider.longbridge_fetcher._oauth_token_cache_path",
+                return_value=token_cache,
+            ):
+                fetcher = LongbridgeFetcher()
+                ctx = fetcher._get_ctx()
+
+        self.assertEqual(ctx, "quote-context")
+        mock_oauth_builder.assert_called_once_with("app-key")
+        mock_config.from_oauth.assert_called_once_with("oauth-token")
+        mock_config.from_apikey_env.assert_not_called()
+        mock_config.from_apikey.assert_not_called()
+        mock_quote_context.assert_called_once_with("oauth-config")
+
+    @patch("src.config.get_config")
     def test_oauth_without_cache_does_not_call_legacy_when_legacy_incomplete(self, mock_get_config):
         mock_get_config.return_value = self._config(oauth_client_id="client-1")
         modules = self._install_mock_longbridge()

--- a/tests/test_longbridge_fetcher.py
+++ b/tests/test_longbridge_fetcher.py
@@ -218,6 +218,38 @@ class TestLongbridgeAuthSelection(unittest.TestCase):
         mock_config.from_apikey.assert_not_called()
 
     @patch("src.config.get_config")
+    def test_oauth_sdk_without_oauth_api_fails_closed_with_clear_log(self, mock_get_config):
+        mock_get_config.return_value = self._config(oauth_client_id="client-1")
+        mock_lb_module = types.ModuleType("longbridge")
+        mock_lb_openapi = types.ModuleType("longbridge.openapi")
+        mock_config = MagicMock()
+        mock_quote_context = MagicMock(return_value="quote-context")
+        mock_lb_openapi.Config = mock_config
+        mock_lb_openapi.QuoteContext = mock_quote_context
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            token_cache = Path(tmpdir) / "client-1"
+            token_cache.write_text('{"refresh_token":"valid-token"}', encoding="utf-8")
+            with patch.dict("sys.modules", {"longbridge": mock_lb_module, "longbridge.openapi": mock_lb_openapi}), patch.dict(
+                os.environ,
+                {
+                    "LONGBRIDGE_OAUTH_CLIENT_ID": "client-1",
+                    "LONGBRIDGE_APP_KEY": "",
+                    "LONGBRIDGE_APP_SECRET": "",
+                    "LONGBRIDGE_ACCESS_TOKEN": "",
+                },
+            ), patch("data_provider.longbridge_fetcher._longbridge_config_kwargs", return_value={}), patch(
+                "data_provider.longbridge_fetcher._oauth_token_cache_path",
+                return_value=token_cache,
+            ), self.assertLogs("data_provider.longbridge_fetcher", level="WARNING") as logs:
+                fetcher = LongbridgeFetcher()
+                ctx = fetcher._get_ctx()
+
+        self.assertIsNone(ctx)
+        self.assertIn("不支持 OAuth 2.0", "\n".join(logs.output))
+        mock_quote_context.assert_not_called()
+
+    @patch("src.config.get_config")
     def test_oauth_invalid_cache_content_skips_oauth_reauth_and_fails_closed(self, mock_get_config):
         mock_get_config.return_value = self._config(oauth_client_id="client-1")
         modules = self._install_mock_longbridge()

--- a/tests/test_longbridge_fetcher.py
+++ b/tests/test_longbridge_fetcher.py
@@ -12,9 +12,14 @@ Verifies:
 """
 
 import os
+import base64
 import sys
+import tempfile
 import time
+import types
 import unittest
+from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import patch, MagicMock, PropertyMock
 from dataclasses import dataclass
 
@@ -79,6 +84,171 @@ class TestLongbridgeFetcherNoCredentials(unittest.TestCase):
 
     def test_is_available_false(self):
         self.assertFalse(self.fetcher._is_available())
+
+
+class TestLongbridgeAuthSelection(unittest.TestCase):
+    """Verify OAuth and Legacy auth selection without real SDK calls."""
+
+    def _install_mock_longbridge(self):
+        mock_lb_module = types.ModuleType("longbridge")
+        mock_lb_openapi = types.ModuleType("longbridge.openapi")
+        mock_config = MagicMock()
+        mock_quote_context = MagicMock(return_value="quote-context")
+        mock_oauth_builder = MagicMock()
+
+        mock_lb_openapi.Config = mock_config
+        mock_lb_openapi.QuoteContext = mock_quote_context
+        mock_lb_openapi.OAuthBuilder = mock_oauth_builder
+        return mock_lb_module, mock_lb_openapi, mock_config, mock_quote_context, mock_oauth_builder
+
+    def _config(
+        self,
+        *,
+        app_key="",
+        app_secret="",
+        access_token="",
+        oauth_client_id="",
+    ):
+        return SimpleNamespace(
+            longbridge_app_key=app_key,
+            longbridge_app_secret=app_secret,
+            longbridge_access_token=access_token,
+            longbridge_oauth_client_id=oauth_client_id,
+        )
+
+    @patch("src.config.get_config")
+    def test_is_available_with_oauth_client_id(self, mock_get_config):
+        mock_get_config.return_value = self._config(oauth_client_id="client-1")
+
+        fetcher = LongbridgeFetcher()
+
+        self.assertTrue(fetcher._is_available())
+
+    @patch("src.config.get_config")
+    def test_oauth_uses_token_cache_without_legacy_fallback(self, mock_get_config):
+        mock_get_config.return_value = self._config(oauth_client_id="client-1")
+        modules = self._install_mock_longbridge()
+        mock_lb_module, mock_lb_openapi, mock_config, mock_quote_context, mock_oauth_builder = modules
+        mock_oauth_builder.return_value.build.return_value = "oauth-token"
+        mock_config.from_oauth.return_value = "oauth-config"
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            token_cache = Path(tmpdir) / "client-1"
+            token_cache.write_text("{}", encoding="utf-8")
+            with patch.dict("sys.modules", {"longbridge": mock_lb_module, "longbridge.openapi": mock_lb_openapi}), patch.dict(
+                os.environ,
+                {
+                    "LONGBRIDGE_OAUTH_CLIENT_ID": "client-1",
+                    "LONGBRIDGE_APP_KEY": "",
+                    "LONGBRIDGE_APP_SECRET": "",
+                    "LONGBRIDGE_ACCESS_TOKEN": "",
+                },
+            ), patch("data_provider.longbridge_fetcher._longbridge_config_kwargs", return_value={}), patch(
+                "data_provider.longbridge_fetcher._oauth_token_cache_path",
+                return_value=token_cache,
+            ):
+                fetcher = LongbridgeFetcher()
+                ctx = fetcher._get_ctx()
+
+        self.assertEqual(ctx, "quote-context")
+        mock_oauth_builder.assert_called_once_with("client-1")
+        mock_config.from_oauth.assert_called_once_with("oauth-token")
+        mock_config.from_apikey_env.assert_not_called()
+        mock_quote_context.assert_called_once_with("oauth-config")
+
+    @patch("src.config.get_config")
+    def test_oauth_without_cache_does_not_call_legacy_when_legacy_incomplete(self, mock_get_config):
+        mock_get_config.return_value = self._config(oauth_client_id="client-1")
+        modules = self._install_mock_longbridge()
+        mock_lb_module, mock_lb_openapi, mock_config, _, mock_oauth_builder = modules
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            missing_cache = Path(tmpdir) / "client-1"
+            with patch.dict("sys.modules", {"longbridge": mock_lb_module, "longbridge.openapi": mock_lb_openapi}), patch.dict(
+                os.environ,
+                {
+                    "LONGBRIDGE_OAUTH_CLIENT_ID": "client-1",
+                    "LONGBRIDGE_APP_KEY": "",
+                    "LONGBRIDGE_APP_SECRET": "",
+                    "LONGBRIDGE_ACCESS_TOKEN": "",
+                },
+            ), patch("data_provider.longbridge_fetcher._longbridge_config_kwargs", return_value={}), patch(
+                "data_provider.longbridge_fetcher._oauth_token_cache_path",
+                return_value=missing_cache,
+            ):
+                fetcher = LongbridgeFetcher()
+                ctx = fetcher._get_ctx()
+
+        self.assertIsNone(ctx)
+        mock_oauth_builder.assert_not_called()
+        mock_config.from_apikey_env.assert_not_called()
+        mock_config.from_apikey.assert_not_called()
+
+    @patch("src.config.get_config")
+    def test_oauth_restores_token_cache_from_base64_secret(self, mock_get_config):
+        mock_get_config.return_value = self._config(oauth_client_id="client-1")
+        modules = self._install_mock_longbridge()
+        mock_lb_module, mock_lb_openapi, mock_config, _, mock_oauth_builder = modules
+        mock_oauth_builder.return_value.build.return_value = "oauth-token"
+        mock_config.from_oauth.return_value = "oauth-config"
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            token_cache = Path(tmpdir) / "client-1"
+            encoded_cache = base64.b64encode(b'{"refresh_token":"test"}').decode("ascii")
+            with patch.dict("sys.modules", {"longbridge": mock_lb_module, "longbridge.openapi": mock_lb_openapi}), patch.dict(
+                os.environ,
+                {
+                    "LONGBRIDGE_OAUTH_CLIENT_ID": "client-1",
+                    "LONGBRIDGE_OAUTH_TOKEN_CACHE_B64": encoded_cache,
+                    "LONGBRIDGE_APP_KEY": "",
+                    "LONGBRIDGE_APP_SECRET": "",
+                    "LONGBRIDGE_ACCESS_TOKEN": "",
+                },
+            ), patch("data_provider.longbridge_fetcher._longbridge_config_kwargs", return_value={}), patch(
+                "data_provider.longbridge_fetcher._oauth_token_cache_path",
+                return_value=token_cache,
+            ):
+                fetcher = LongbridgeFetcher()
+                ctx = fetcher._get_ctx()
+                self.assertEqual(token_cache.read_bytes(), b'{"refresh_token":"test"}')
+
+        self.assertEqual(ctx, "quote-context")
+        mock_config.from_oauth.assert_called_once_with("oauth-token")
+
+    @patch("src.config.get_config")
+    def test_oauth_failure_can_fallback_to_complete_legacy_credentials(self, mock_get_config):
+        mock_get_config.return_value = self._config(
+            app_key="app-key",
+            app_secret="app-secret",
+            access_token="access-token",
+            oauth_client_id="client-1",
+        )
+        modules = self._install_mock_longbridge()
+        mock_lb_module, mock_lb_openapi, mock_config, mock_quote_context, mock_oauth_builder = modules
+        mock_oauth_builder.return_value.build.side_effect = RuntimeError("bad cache")
+        mock_config.from_apikey_env.return_value = "legacy-config"
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            token_cache = Path(tmpdir) / "client-1"
+            token_cache.write_text("{}", encoding="utf-8")
+            with patch.dict("sys.modules", {"longbridge": mock_lb_module, "longbridge.openapi": mock_lb_openapi}), patch.dict(
+                os.environ,
+                {
+                    "LONGBRIDGE_OAUTH_CLIENT_ID": "client-1",
+                    "LONGBRIDGE_APP_KEY": "app-key",
+                    "LONGBRIDGE_APP_SECRET": "app-secret",
+                    "LONGBRIDGE_ACCESS_TOKEN": "access-token",
+                },
+            ), patch("data_provider.longbridge_fetcher._longbridge_config_kwargs", return_value={}), patch(
+                "data_provider.longbridge_fetcher._oauth_token_cache_path",
+                return_value=token_cache,
+            ):
+                fetcher = LongbridgeFetcher()
+                ctx = fetcher._get_ctx()
+
+        self.assertEqual(ctx, "quote-context")
+        mock_config.from_apikey_env.assert_called_once()
+        mock_quote_context.assert_called_once_with("legacy-config")
 
 
 class TestLongbridgeFetcherMocked(unittest.TestCase):

--- a/tests/test_longbridge_fetcher.py
+++ b/tests/test_longbridge_fetcher.py
@@ -214,6 +214,41 @@ class TestLongbridgeAuthSelection(unittest.TestCase):
         mock_config.from_apikey.assert_not_called()
 
     @patch("src.config.get_config")
+    def test_oauth_overwrites_invalid_cache_from_base64_secret(self, mock_get_config):
+        mock_get_config.return_value = self._config(oauth_client_id="client-1")
+        modules = self._install_mock_longbridge()
+        mock_lb_module, mock_lb_openapi, mock_config, _, mock_oauth_builder = modules
+        mock_oauth_builder.return_value.build.return_value = "oauth-token"
+        mock_config.from_oauth.return_value = "oauth-config"
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            invalid_cache = Path(tmpdir) / "client-1"
+            invalid_cache.write_text("invalid-json", encoding="utf-8")
+            encoded_cache = base64.b64encode(b'{"refresh_token":"refreshed"}').decode("ascii")
+            with patch.dict("sys.modules", {"longbridge": mock_lb_module, "longbridge.openapi": mock_lb_openapi}), patch.dict(
+                os.environ,
+                {
+                    "LONGBRIDGE_OAUTH_CLIENT_ID": "client-1",
+                    "LONGBRIDGE_OAUTH_TOKEN_CACHE_B64": encoded_cache,
+                    "LONGBRIDGE_APP_KEY": "",
+                    "LONGBRIDGE_APP_SECRET": "",
+                    "LONGBRIDGE_ACCESS_TOKEN": "",
+                },
+            ), patch("data_provider.longbridge_fetcher._longbridge_config_kwargs", return_value={}), patch(
+                "data_provider.longbridge_fetcher._oauth_token_cache_path",
+                return_value=invalid_cache,
+            ):
+                fetcher = LongbridgeFetcher()
+                ctx = fetcher._get_ctx()
+                self.assertEqual(invalid_cache.read_bytes(), b'{"refresh_token":"refreshed"}')
+
+        self.assertEqual(ctx, "quote-context")
+        mock_oauth_builder.assert_called_once_with("client-1")
+        mock_config.from_oauth.assert_called_once_with("oauth-token")
+        mock_config.from_apikey_env.assert_not_called()
+        mock_config.from_apikey.assert_not_called()
+
+    @patch("src.config.get_config")
     def test_oauth_callback_reauth_request_fails_closed_in_headless(self, mock_get_config):
         mock_get_config.return_value = self._config(oauth_client_id="client-1")
         modules = self._install_mock_longbridge()

--- a/tests/test_yfinance_normalize.py
+++ b/tests/test_yfinance_normalize.py
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+"""Regression tests for YfinanceFetcher daily data normalization."""
+
+import pandas as pd
+
+from data_provider.yfinance_fetcher import YfinanceFetcher
+
+
+def test_normalize_daily_data_recovers_unnamed_datetime_index_date_column() -> None:
+    fetcher = YfinanceFetcher()
+    raw = pd.DataFrame(
+        {
+            "Open": [10.0, 10.5],
+            "High": [11.0, 11.2],
+            "Low": [9.8, 10.1],
+            "Close": [10.8, 11.0],
+            "Volume": [1000, 1200],
+        },
+        index=pd.DatetimeIndex(["2026-05-25", "2026-05-26"]),
+    )
+
+    normalized = fetcher._normalize_data(raw, "DRAM")
+    cleaned = fetcher._clean_data(normalized)
+
+    assert "date" in normalized.columns
+    assert cleaned["date"].dt.strftime("%Y-%m-%d").tolist() == ["2026-05-25", "2026-05-26"]


### PR DESCRIPTION
## PR Type

- [x] fix
- [ ] feat
- [ ] refactor
- [x] docs
- [ ] chore
- [x] test

## Background And Problem

Fixes #1481.

Longbridge now exposes new OpenAPI credentials without the old Legacy Access Token for some users. The current main branch only treats Longbridge as configured when `LONGBRIDGE_APP_KEY` / `LONGBRIDGE_APP_SECRET` / `LONGBRIDGE_ACCESS_TOKEN` are all present, so GitHub Actions reports `Longbridge: ⚪ 未配置` even when the user has the new dashboard credentials.

This also makes the reported YFinance `KeyError: 'date'` more painful because the Longbridge US/HK fallback is never instantiated.

A related PR already existed: #1319 (`feat: add OAuth 2.0 support for Longbridge data source`), but it was closed unmerged. This PR keeps the same direction while addressing the previously risky parts: OAuth-only does not fall through to incomplete Legacy auth, Actions/Docker have a headless token cache path, and docs/tests are updated together.

## Scope Of Change

- Longbridge auth selection now supports OAuth 2.0 via explicit `LONGBRIDGE_OAUTH_CLIENT_ID` or the existing `LONGBRIDGE_APP_KEY` compatibility alias when no Legacy Access Token is configured, while preserving Legacy API Key credentials.
- Added `LONGBRIDGE_OAUTH_TOKEN_CACHE_B64` restore support for GitHub Actions / Docker headless runs, including replacement of malformed or stale persisted token cache files when the env secret differs.
- Added `scripts/generate_longbridge_oauth_token.py` for interactive token-cache generation.
- Updated daily analysis workflow status output and env mapping.
- Persisted `/home/dsa/.longbridge` in Docker compose and repaired ownership in the entrypoint.
- Kept the Linux/Docker-compatible `longbridge>=0.2.77` lower bound and added runtime SDK capability detection with a clear fallback when OAuth APIs are unavailable.
- Updated `.env.example`, `docs/full-guide.md`, `docs/full-guide_EN.md`, and `docs/CHANGELOG.md`.
- Fixed YFinance normalization when an unnamed DatetimeIndex becomes a non-`date` column after `reset_index()`.
- Added regression tests for Longbridge OAuth/Legacy behavior, App Key-as-client-id compatibility, stale/invalid token cache replacement, OAuth SDK capability fallback, Docker token cache mount, manager initialization, and YFinance date normalization.

## Issue Link

Fixes #1481

## Verification Commands And Results

```bash
python -m py_compile data_provider/longbridge_fetcher.py data_provider/base.py data_provider/yfinance_fetcher.py src/config.py scripts/generate_longbridge_oauth_token.py
python -m pytest tests/test_longbridge_fetcher.py tests/test_fetcher_source_optimization.py tests/test_yfinance_normalize.py tests/test_docker_entrypoint.py -q
git diff --check
./scripts/ci_gate.sh
```

关键输出/结论 / Key output & conclusion:

- Targeted pytest: `37 passed`
- Full backend gate: `2447 passed, 2 deselected, 16 warnings, 215 subtests passed`
- `./scripts/ci_gate.sh`: all checks passed
- After rebasing onto latest `origin/main` (`5afe11c`), reran `py_compile`, targeted pytest, and `git diff --check origin/main...HEAD`: all passed

Follow-up verification after commits `a13726eb` / `dd416d91` / `23e2481a`:

- `python -m py_compile data_provider/longbridge_fetcher.py data_provider/base.py data_provider/yfinance_fetcher.py src/config.py scripts/generate_longbridge_oauth_token.py`: passed
- `git diff --check`: passed
- `PYTHONUTF8=1 python -m pytest tests/test_longbridge_fetcher.py tests/test_fetcher_source_optimization.py tests/test_yfinance_normalize.py -q`: `35 passed`
- `PYTHONUTF8=1; PATH="C:\Program Files\Git\bin;$PATH"; python -m pytest tests/test_docker_entrypoint.py -q -k "not repairs_nested_mount_ownership and not skips_owner_chmod_when_chown_fails"`: `6 passed, 2 deselected`
- Full Docker entrypoint fake-tool tests are Linux-oriented; the two fake ownership tests are left to GitHub Linux CI.

Note: the first local `./scripts/ci_gate.sh` run failed only because this Python environment lacked `pypinyin`, which is already declared in `requirements.txt`. After installing `pypinyin>=0.50.0`, the full gate passed.

## Compatibility And Risk

- Legacy Longbridge API Key config remains supported with `LONGBRIDGE_APP_KEY`, `LONGBRIDGE_APP_SECRET`, and `LONGBRIDGE_ACCESS_TOKEN`.
- OAuth mode can reuse `LONGBRIDGE_APP_KEY` as the client id compatibility alias only when `LONGBRIDGE_OAUTH_CLIENT_ID` and Legacy Access Token are both absent.
- OAuth mode requires an SDK token cache generated once in an interactive environment. Headless Actions/Docker runs restore that cache from `LONGBRIDGE_OAUTH_TOKEN_CACHE_B64`; when the supplied cache differs from an existing persisted file, the env-provided cache is treated as the recovery source.
- OAuth runtime also requires SDK APIs `OAuthBuilder` and `Config.from_oauth`. If the current environment can only install an older SDK without those APIs, Longbridge logs a clear warning and is skipped, preserving YFinance/AkShare fallback behavior instead of breaking install/build.
- Existing runtime config is not rewritten or migrated automatically.
- Official source: Longbridge documents OAuth 2.0 and the SDK token cache location under `~/.longbridge/openapi/tokens/<client_id>` in the Getting Started guide: https://open.longbridge.com/docs/getting-started#authentication-methods

Risk: if a user's cached OAuth token is expired or copied incorrectly and no fresh `LONGBRIDGE_OAUTH_TOKEN_CACHE_B64` is supplied, Longbridge will still be unavailable until they regenerate the token cache. The failure is logged clearly and does not remove YFinance/AkShare fallback behavior.

## Rollback Plan

Revert this PR. If OAuth variables or Docker token-cache volumes were added during deployment, remove `LONGBRIDGE_OAUTH_CLIENT_ID`, `LONGBRIDGE_OAUTH_TOKEN_CACHE_B64`, and the optional `../longbridge_tokens` volume to restore the previous Legacy-only behavior.

## EXTRACT_PROMPT Change (if applicable)

Not applicable; this PR does not change `src/services/image_stock_extractor.py` or `EXTRACT_PROMPT`.

## Checklist

- [x] 本 PR 有明确动机和业务价值 / This PR has a clear motivation and value
- [x] 已提供可复现的验证命令与结果 / Reproducible verification commands and results are included
- [x] 已评估兼容性与风险 / Compatibility and risk have been assessed
- [x] 已提供回滚方案 / A rollback plan is provided
- [x] 若涉及用户可见变更，已同步更新相关文档与 `docs/CHANGELOG.md`；`README.md` 仅在首页级信息变化时更新，细节优先写入 `docs/*.md` / If user-visible changes are included, relevant docs and `docs/CHANGELOG.md` are updated; `README.md` is updated only for homepage-level changes, with details kept in `docs/*.md`
