### PR TITLE
refactor: 抽取 AnalysisContextPack artifacts 构造… (#1493)

### DIFF
--- a/src/core/pipeline.py
+++ b/src/core/pipeline.py
@@ -46,6 +46,10 @@ from src.report_language import (
 )
 from src.search_service import SearchService
 from src.services.social_sentiment_service import SocialSentimentService
+from src.services.analysis_context_builder import (
+    AnalysisContextBuilder,
+    PipelineAnalysisArtifacts,
+)
 from src.services.run_diagnostics import (
     activate_run_diagnostic_context,
     current_diagnostic_snapshot,
@@ -507,6 +511,28 @@ class StockAnalysisPipeline:
                 fundamental_context,
             )
             enhanced_context["market_phase_context"] = market_phase_context_dict
+
+            legacy_artifacts = self._build_legacy_analysis_artifacts(
+                code=code,
+                stock_name=stock_name,
+                market=market,
+                market_phase_context=market_phase_context_dict,
+                base_context=context,
+                enhanced_context=enhanced_context,
+                realtime_quote=realtime_quote,
+                trend_result=trend_result,
+                chip_data=chip_data,
+                fundamental_context=fundamental_context,
+                news_context=news_context,
+                news_result_count=news_result_count,
+                query_id=query_id,
+            )
+            analyzer_context = dict(enhanced_context)
+            pack_summary = self._build_analysis_context_pack_summary(
+                legacy_artifacts,
+            )
+            if pack_summary is not None:
+                analyzer_context["analysis_context_pack_summary"] = pack_summary
             
             # Step 7: 调用 AI 分析（传入增强的上下文和新闻）
             llm_progress_state = {"last_progress": 64}
@@ -525,7 +551,7 @@ class StockAnalysisPipeline:
             llm_started_at = time.monotonic()
             try:
                 result = self.analyzer.analyze(
-                    enhanced_context,
+                    analyzer_context,
                     news_context=news_context,
                     progress_callback=self._emit_progress,
                     stream_progress_callback=_on_llm_stream,
@@ -889,6 +915,7 @@ class StockAnalysisPipeline:
         try:
             from src.agent.factory import build_agent_executor
             report_language = normalize_report_language(getattr(self.config, "report_language", "zh"))
+            market = get_market_for_stock(normalize_stock_code(code))
 
             requested_skills = (
                 self.analysis_skills
@@ -934,6 +961,19 @@ class StockAnalysisPipeline:
                 except Exception as e:
                     logger.warning(f"[{code}] Agent mode: social sentiment fetch failed: {e}")
 
+            agent_artifacts = self._build_agent_analysis_artifacts(
+                code=code,
+                stock_name=stock_name,
+                market=market,
+                market_phase_context=market_phase_context,
+                query_id=query_id,
+                initial_context=initial_context,
+            )
+            agent_context = dict(initial_context)
+            pack_summary = self._build_analysis_context_pack_summary(agent_artifacts)
+            if pack_summary is not None:
+                agent_context["analysis_context_pack_summary"] = pack_summary
+
             # Issue #1066: ensure deep history is in DB before agent tools run
             self._ensure_agent_history(code)
 
@@ -944,7 +984,7 @@ class StockAnalysisPipeline:
                 message = f"请分析股票 {code} ({stock_name})，并生成决策仪表盘报告。"
             llm_started_at = time.monotonic()
             try:
-                agent_result = executor.run(message, context=initial_context)
+                agent_result = executor.run(message, context=agent_context)
             except Exception as exc:
                 record_llm_run(
                     success=False,
@@ -1773,6 +1813,101 @@ class StockAnalysisPipeline:
                 )
             except Exception as exc:
                 logger.warning("回写通知诊断快照失败（fail-open）: %s", exc)
+
+    def _build_legacy_analysis_artifacts(
+        self,
+        *,
+        code: str,
+        stock_name: str,
+        market: str,
+        market_phase_context: Optional[Dict[str, Any]],
+        base_context: Dict[str, Any],
+        enhanced_context: Dict[str, Any],
+        realtime_quote: Optional[Any],
+        trend_result: Optional[TrendAnalysisResult],
+        chip_data: Optional[ChipDistribution],
+        fundamental_context: Optional[Dict[str, Any]],
+        news_context: Optional[str],
+        news_result_count: Optional[int],
+        query_id: Optional[str] = None,
+    ) -> PipelineAnalysisArtifacts:
+        return PipelineAnalysisArtifacts(
+            code=code,
+            stock_name=stock_name,
+            market=market,
+            phase=market_phase_context,
+            base_context=dict(base_context),
+            enhanced_context=dict(enhanced_context),
+            realtime_quote=realtime_quote,
+            trend_result=trend_result,
+            chip_data=chip_data,
+            fundamental_context=fundamental_context,
+            news_context=news_context,
+            news_result_count=news_result_count,
+            metadata={
+                "query_id": query_id,
+                "query_source": self.query_source,
+                "analysis_path": "legacy",
+            },
+        )
+
+    def _build_agent_analysis_artifacts(
+        self,
+        *,
+        code: str,
+        stock_name: str,
+        market: str,
+        market_phase_context: Optional[Dict[str, Any]],
+        query_id: Optional[str],
+        initial_context: Dict[str, Any],
+    ) -> PipelineAnalysisArtifacts:
+        market_session_date = (
+            market_phase_context.get("session_date")
+            if isinstance(market_phase_context, dict)
+            else None
+        )
+        session_date = market_session_date or get_market_now(market).date().isoformat()
+        return PipelineAnalysisArtifacts(
+            code=code,
+            stock_name=stock_name,
+            market=market,
+            phase=market_phase_context,
+            base_context={
+                "code": code,
+                "stock_name": stock_name,
+                "date": session_date,
+                "data_missing": True,
+                "today": {},
+                "yesterday": {},
+            },
+            enhanced_context={},
+            realtime_quote=initial_context.get("realtime_quote"),
+            trend_result=initial_context.get("trend_result"),
+            chip_data=initial_context.get("chip_distribution"),
+            fundamental_context=initial_context.get("fundamental_context"),
+            news_context=initial_context.get("news_context"),
+            news_result_count=None,
+            metadata={
+                "query_id": query_id,
+                "query_source": self.query_source,
+                "analysis_path": "agent",
+                "agent_zero_fetch": True,
+            },
+        )
+
+    def _build_analysis_context_pack_summary(
+        self,
+        artifacts: PipelineAnalysisArtifacts,
+    ) -> Optional[Dict[str, Any]]:
+        try:
+            return AnalysisContextBuilder.build(artifacts).to_safe_dict()
+        except Exception as exc:
+            logger.warning(
+                "构建 analysis_context_pack_summary 失败: code=%s, error=%s",
+                artifacts.code,
+                exc,
+            )
+            return None
 
     @staticmethod
     def _without_market_phase_context(context: Dict[str, Any]) -> Dict[str, Any]:

--- a/tests/test_pipeline_market_phase_context.py
+++ b/tests/test_pipeline_market_phase_context.py
@@ -157,6 +157,7 @@ class PipelineMarketPhaseContextTestCase(unittest.TestCase):
         self.assertTrue(save_kwargs["save_snapshot"])
         snapshot = save_kwargs["context_snapshot"]
         self.assertNotIn("market_phase_context", snapshot["enhanced_context"])
+        self.assertNotIn("analysis_context_pack_summary", snapshot["enhanced_context"])
 
     def test_agent_legacy_context_gets_runtime_key_but_history_snapshot_strips_it(self):
         pipeline = _make_pipeline(agent_mode=True, save_context_snapshot=True)
@@ -201,7 +202,80 @@ class PipelineMarketPhaseContextTestCase(unittest.TestCase):
         self.assertTrue(save_kwargs["save_snapshot"])
         self.assertNotIn("market_phase_context", save_kwargs["context_snapshot"])
         enhanced_context = save_kwargs["context_snapshot"]["enhanced_context"]
+        self.assertNotIn("analysis_context_pack_summary", enhanced_context)
         self.assertEqual(enhanced_context["stock_name"], "贵州茅台")
+
+    def test_legacy_artifacts_keep_full_payload_mappings(self):
+        pipeline = _make_pipeline(agent_mode=False, save_context_snapshot=False)
+        base_context = {
+            "code": "600519",
+            "stock_name": "贵州茅台",
+            "date": "2026-03-27",
+            "today": {"close": 10.2},
+            "yesterday": {"close": 9.8},
+        }
+        enhanced_context = {
+            "today": {"close": 10.2, "data_source": "realtime:ak"},
+            "market_phase_context": {"phase": "intraday"},
+            "fundamental_context": {"status": "ok"},
+        }
+
+        artifacts = pipeline._build_legacy_analysis_artifacts(
+            code="600519",
+            stock_name="贵州茅台",
+            market="cn",
+            market_phase_context={"phase": "intraday"},
+            base_context=base_context,
+            enhanced_context=enhanced_context,
+            realtime_quote={"price": 10.2},
+            trend_result={"trend_status": "up"},
+            chip_data={"profit_ratio": 0.45},
+            fundamental_context={"status": "ok"},
+            news_context="news summary",
+            news_result_count=3,
+            query_id="q-legacy",
+        )
+        self.assertEqual(artifacts.code, "600519")
+        self.assertEqual(artifacts.stock_name, "贵州茅台")
+        self.assertEqual(artifacts.market, "cn")
+        self.assertEqual(artifacts.base_context, base_context)
+        self.assertEqual(artifacts.enhanced_context, enhanced_context)
+        self.assertEqual(artifacts.news_context, "news summary")
+        self.assertEqual(artifacts.news_result_count, 3)
+        self.assertEqual(artifacts.phase, {"phase": "intraday"})
+        self.assertEqual(artifacts.metadata["analysis_path"], "legacy")
+
+    def test_agent_artifacts_keep_zero_fetch_contract(self):
+        pipeline = _make_pipeline(agent_mode=True, save_context_snapshot=False)
+        initial_context = {
+            "stock_code": "600519",
+            "stock_name": "贵州茅台",
+            "report_type": "SIMPLE",
+            "report_language": "zh",
+            "fundamental_context": {"status": "ok"},
+            "realtime_quote": {"price": 10.2},
+            "chip_distribution": {"profit_ratio": 0.45},
+            "trend_result": {"trend_status": "up"},
+            "news_context": "agent news",
+        }
+        artifacts = pipeline._build_agent_analysis_artifacts(
+            code="600519",
+            stock_name="贵州茅台",
+            market="cn",
+            market_phase_context={"session_date": "2026-03-27"},
+            query_id="q-agent",
+            initial_context=initial_context,
+        )
+        self.assertEqual(artifacts.code, "600519")
+        self.assertEqual(artifacts.stock_name, "贵州茅台")
+        self.assertEqual(artifacts.market, "cn")
+        self.assertEqual(artifacts.base_context["code"], "600519")
+        self.assertEqual(artifacts.base_context["date"], "2026-03-27")
+        self.assertEqual(artifacts.enhanced_context, {})
+        self.assertIsNone(artifacts.news_result_count)
+        self.assertEqual(artifacts.news_context, "agent news")
+        self.assertEqual(artifacts.metadata["analysis_path"], "agent")
+        self.assertTrue(artifacts.metadata["agent_zero_fetch"])
 
     def test_agent_history_snapshot_contains_diagnostics_context_when_active(self):
         pipeline = _make_pipeline(agent_mode=True, save_context_snapshot=True)


### PR DESCRIPTION
## PR Type
- [ ] fix
- [ ] feat
- [x] refactor
- [ ] docs
- [ ] chore
- [ ] test

## Background And Problem
- 当前问题：在 `src/core/pipeline.py` 内抽取普通分析与 Agent 路径各自专用的 AnalysisContextPack artifacts 构造 helper，减少重复字段映射且保持现有语义不变。
- 影响范围：本次改动涉及 2 个文件，Diff 为 `+211 / -2`。
- 触发来源：Issue 自动执行（Issue #1493）。

## Scope Of Change
- `src/core/pipeline.py`
- `tests/test_pipeline_market_phase_context.py`

## Documentation And Changelog
- 当前补丁未包含 `README.md`、`docs/` 或 `docs/CHANGELOG.md` 更新；如果本次变更涉及 CLI、API、配置、日志语义或其他用户可见行为，请在合并前补充原因与文档落点。

## Issue Link
Closes #1493

## Verification Commands And Results
```bash
./scripts/ci_gate.sh flake8
./scripts/ci_gate.sh offline-tests
```

关键输出/结论 / Key output & conclusion:
- lint:PASS, test:PASS

## Compatibility And Risk
- **Medium**：涉及 `src/core/pipeline.py`, `tests/test_pipeline_market_phase_context.py`，建议按文件范围复核。
- 前提假设：
  - #1491 已合并，当前代码中普通分析路径和 Agent 路径分别存在 `PipelineAnalysisArtifacts(...)` 构造逻辑。
  - 维护者讨论已明确采用“双 helper、纯字段映射”方向，范围控制在 `src/core/pipeline.py`。
  - 本任务是内部重构，不新增 API/Web/history/task/report schema 字段，也不需要修改 secrets、workflow、deploy 或 migration。
  - Agent helper 只能使用 `initial_context` 中已有 artifact，保持 zero-fetch 边界，不引入 DB/fetcher/search/tool 调用。

## Rollback Plan
- `git revert <merge-commit>` 回滚本 PR 提交，重点确认 `src/core/pipeline.py`, `tests/test_pipeline_market_phase_context.py` 恢复正常。

## Acceptance Criteria
- 新增或抽取 `_build_legacy_analysis_artifacts(...)`，仅服务普通分析路径，并保留完整 `context`、`enhanced_context`、`news_context`、`news_result_count` 映射。
- 新增或抽取 `_build_agent_analysis_artifacts(...)`，仅服务 Agent 路径，并保持 `base_context` 最小结构、`enhanced_context={}`、`news_result_count=None`。
- 普通分析和 Agent 路径仍只由 pipeline 生产 `analysis_context_pack_summary`。
- `analysis_context_pack_summary` 仍不进入 `context_snapshot` 或 diagnostic snapshot。
- 不实现 Agent tool-level pack cache reuse，不改变 `AnalysisContextBuilder` zero-fetch 契约。

## Checklist
- [x] 本 PR 有明确动机和业务价值 / This PR has a clear motivation and value
- [x] 已提供可复现的验证命令与结果 / Reproducible verification commands and results are included
- [x] 已评估兼容性与风险 / Compatibility and risk have been assessed
- [x] 已提供回滚方案 / A rollback plan is provided
- [ ] 文档与 `docs/CHANGELOG.md` 同步仍需确认；如涉及用户可见变更，请在合并前补充原因与文档落点 / Documentation and `docs/CHANGELOG.md` sync still needs confirmation before merge when user-visible behavior changes