### PR TITLE
fix: 交互式消息只回对应渠道而非全局广播 (#1501)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -49,7 +49,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - [修复] 将 `exchange-calendars` 依赖下限提升到 `4.13.0`，避免 pandas 3 环境导入交易日历时因 Timedelta 单位 `T` 失效导致分析失败。
 - [测试] 执行 `python -c "import exchange_calendars as xcals; xcals.get_calendar('XSHG'); print('ok')"` 通过验证，以覆盖导入与交易日历初始化兼容性。
 - [新功能] 普通分析与 Agent 运行时 Prompt 接入 AnalysisContextPack 低敏摘要，保持 history/API/Web 输出兼容。
-- [修复] 飞书 Stream 命令触发的分析结果只回到来源飞书会话，不再同时广播到 `FEISHU_WEBHOOK_URL` 静态机器人。
+- [修复] 交互式命令（钉钉会话、飞书会话、Telegram）触发的分析结果只回到来源会话，不再同时广播到静态通知渠道。
 
 ## [3.18.0] - 2026-05-21
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -49,6 +49,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - [修复] 将 `exchange-calendars` 依赖下限提升到 `4.13.0`，避免 pandas 3 环境导入交易日历时因 Timedelta 单位 `T` 失效导致分析失败。
 - [测试] 执行 `python -c "import exchange_calendars as xcals; xcals.get_calendar('XSHG'); print('ok')"` 通过验证，以覆盖导入与交易日历初始化兼容性。
 - [新功能] 普通分析与 Agent 运行时 Prompt 接入 AnalysisContextPack 低敏摘要，保持 history/API/Web 输出兼容。
+- [修复] 飞书 Stream 命令触发的分析结果只回到来源飞书会话，不再同时广播到 `FEISHU_WEBHOOK_URL` 静态机器人。
 
 ## [3.18.0] - 2026-05-21
 

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -21,7 +21,8 @@
 | AstrBot | 静态配置 | `ASTRBOT_URL` | `ASTRBOT_TOKEN`, `WEBHOOK_VERIFY_SSL` | `ASTRBOT_TOKEN` 可选 |
 | `UNKNOWN` | 兜底枚举 | - | - | 仅为未知渠道兜底，不由静态环境变量启用 |
 | 钉钉会话 | 运行时上下文 | - | - | 从来源消息上下文提取，无法仅由 `.env` 静态判断 |
-| 飞书会话 | 运行时上下文 | - | - | 从来源消息上下文提取，飞书 Stream 命令结果只回到来源会话 |
+| 飞书会话 | 运行时上下文 | - | - | 从来源消息上下文提取，交互式命令结果仅回到来源会话 |
+| Telegram 会话 | 运行时上下文 | - | - | 从来源消息上下文提取，交互式命令结果仅回到来源会话 |
 
 ## Minimal / Advanced 分层
 
@@ -189,7 +190,7 @@ P3 新增三类通知路由配置：
 - 留空或未配置：保持旧行为，发送到所有已配置静态渠道。
 - 非空：只发送到路由列表与已配置渠道的交集；交集为空时不会 fallback 到全渠道。
 - `send_to_context()` 不受路由限制，机器人会话上下文仍会收到触发任务的回复。
-- 飞书 Stream 命令带有来源会话时，会跳过 `FEISHU_WEBHOOK_URL` 等静态通知渠道；`SCHEDULE`、CLI、API 或无来源上下文的任务仍按 report 路由发送。
+- 交互式命令（钉钉会话、飞书会话、Telegram）带有来源上下文时，会跳过 `FEISHU_WEBHOOK_URL` 等静态通知渠道；`SCHEDULE`、CLI、API 或无来源上下文的任务仍按 report 路由发送。
 - 路由过滤发生在 Markdown 转图片前，`MARKDOWN_TO_IMAGE_CHANNELS` 只对路由后的渠道子集生效。
 - `MERGE_EMAIL_NOTIFICATION` 不需要额外配置；只要 `email` 仍在 report 路由后的渠道中，现有合并邮件行为保持不变。
 - `--check-notify` 会把未知渠道值报为 error，把合法但未启用的路由目标报为 warning。

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -21,7 +21,7 @@
 | AstrBot | 静态配置 | `ASTRBOT_URL` | `ASTRBOT_TOKEN`, `WEBHOOK_VERIFY_SSL` | `ASTRBOT_TOKEN` 可选 |
 | `UNKNOWN` | 兜底枚举 | - | - | 仅为未知渠道兜底，不由静态环境变量启用 |
 | 钉钉会话 | 运行时上下文 | - | - | 从来源消息上下文提取，无法仅由 `.env` 静态判断 |
-| 飞书会话 | 运行时上下文 | - | - | 从来源消息上下文提取，无法仅由 `.env` 静态判断 |
+| 飞书会话 | 运行时上下文 | - | - | 从来源消息上下文提取，飞书 Stream 命令结果只回到来源会话 |
 
 ## Minimal / Advanced 分层
 
@@ -189,6 +189,7 @@ P3 新增三类通知路由配置：
 - 留空或未配置：保持旧行为，发送到所有已配置静态渠道。
 - 非空：只发送到路由列表与已配置渠道的交集；交集为空时不会 fallback 到全渠道。
 - `send_to_context()` 不受路由限制，机器人会话上下文仍会收到触发任务的回复。
+- 飞书 Stream 命令带有来源会话时，会跳过 `FEISHU_WEBHOOK_URL` 等静态通知渠道；`SCHEDULE`、CLI、API 或无来源上下文的任务仍按 report 路由发送。
 - 路由过滤发生在 Markdown 转图片前，`MARKDOWN_TO_IMAGE_CHANNELS` 只对路由后的渠道子集生效。
 - `MERGE_EMAIL_NOTIFICATION` 不需要额外配置；只要 `email` 仍在 report 路由后的渠道中，现有合并邮件行为保持不变。
 - `--check-notify` 会把未知渠道值报为 error，把合法但未启用的路由目标报为 warning。

--- a/src/core/pipeline.py
+++ b/src/core/pipeline.py
@@ -2426,7 +2426,7 @@ class StockAnalysisPipeline:
                         logger.info("决策仪表盘推送成功")
                     else:
                         logger.warning("决策仪表盘推送失败")
-                    logger.info("飞书消息上下文回复模式：已跳过静态通知渠道")
+                    logger.info("交互式消息上下文回复模式：已跳过静态通知渠道")
                     return
 
                 if channels and hasattr(self.notifier, "evaluate_noise_control"):

--- a/src/core/pipeline.py
+++ b/src/core/pipeline.py
@@ -2411,6 +2411,24 @@ class StockAnalysisPipeline:
                 if send_context:
                     _record_channel_result("__context__", True)
 
+                should_broadcast_static = True
+                should_broadcast_static_func = getattr(
+                    self.notifier,
+                    "should_broadcast_static_channels",
+                    None,
+                )
+                if callable(should_broadcast_static_func):
+                    should_broadcast_static = bool(should_broadcast_static_func())
+                if not should_broadcast_static:
+                    if not send_context:
+                        _record_channel_result("__context__", False)
+                    if send_context:
+                        logger.info("决策仪表盘推送成功")
+                    else:
+                        logger.warning("决策仪表盘推送失败")
+                    logger.info("飞书消息上下文回复模式：已跳过静态通知渠道")
+                    return
+
                 if channels and hasattr(self.notifier, "evaluate_noise_control"):
                     report_type_key = report_type.value if isinstance(report_type, ReportType) else str(report_type)
                     codes_key = ",".join(

--- a/src/notification.py
+++ b/src/notification.py
@@ -506,6 +506,7 @@ class NotificationService(
         return (
             self._extract_dingtalk_session_webhook() is not None
             or self._extract_feishu_reply_info() is not None
+            or self._extract_telegram_context_chat_id() is not None
         )
 
     def _source_platform(self) -> str:
@@ -515,17 +516,29 @@ class NotificationService(
             platform = platform.value
         return str(platform or "").lower()
 
-    def _is_feishu_context_reply_only(self) -> bool:
-        """Feishu Stream command responses should not fan out to static webhooks."""
-        return (
-            isinstance(self._source_message, BotMessage)
-            and self._source_platform() == "feishu"
-            and self._extract_feishu_reply_info() is not None
-        )
+    def _extract_telegram_context_chat_id(self) -> Optional[str]:
+        """从来源消息中提取 Telegram 上下文 chat_id（用于异步回复）。"""
+        if not isinstance(self._source_message, BotMessage):
+            return None
+        if self._source_platform() != "telegram":
+            return None
+        raw_data = getattr(self._source_message, "raw_data", {}) or {}
+        for candidate in (
+            getattr(self._source_message, "chat_id", ""),
+            raw_data.get("chat_id"),
+            raw_data.get("message", {}).get("chat", {}).get("id") if isinstance(raw_data.get("message"), dict) else None,
+        ):
+            if isinstance(candidate, str) and candidate.strip():
+                return candidate.strip()
+            if candidate is not None and not isinstance(candidate, str):
+                candidate_text = str(candidate).strip()
+                if candidate_text:
+                    return candidate_text
+        return None
 
     def should_broadcast_static_channels(self) -> bool:
         """Whether static notification channels should receive this dispatch."""
-        return not self._is_feishu_context_reply_only()
+        return not self._has_context_channel()
 
     def _extract_dingtalk_session_webhook(self) -> Optional[str]:
         """从来源消息中提取钉钉会话 Webhook（用于 Stream 模式回复）"""
@@ -600,6 +613,18 @@ class NotificationService(
                     logger.error("飞书会话（Stream）推送失败")
             except Exception as e:
                 logger.error(f"飞书会话（Stream）推送异常: {e}")
+
+        # 尝试 Telegram 会话上下文（按来源 chat_id 回执）
+        telegram_chat_id = self._extract_telegram_context_chat_id()
+        if telegram_chat_id:
+            try:
+                if self.send_to_telegram(content, chat_id=telegram_chat_id):
+                    logger.info("已通过 Telegram 上下文会话推送报告")
+                    success = True
+                else:
+                    logger.error("Telegram 上下文会话推送失败")
+            except Exception as e:
+                logger.error(f"Telegram 上下文会话推送异常: {e}")
 
         return success
 
@@ -2130,14 +2155,14 @@ class NotificationService(
         context_success = self.send_to_context(content)
         if not self.should_broadcast_static_channels():
             if context_success:
-                logger.info("已通过飞书消息上下文完成推送，跳过静态通知渠道")
+                logger.info("已通过上下文会话完成推送，跳过静态通知渠道")
                 return NotificationDispatchResult(
                     dispatched=True,
                     success=True,
                     status="sent",
                     channel_results=[ChannelAttemptResult(channel="__context__", success=True)],
                 )
-            logger.warning("飞书消息上下文推送失败，已跳过静态通知渠道")
+            logger.warning("交互式上下文推送失败，已跳过静态通知渠道")
             return NotificationDispatchResult(
                 dispatched=True,
                 success=False,
@@ -2150,7 +2175,7 @@ class NotificationService(
                         retryable=True,
                     )
                 ],
-                message="feishu context delivery failed; static channels skipped",
+                message="interactive context delivery failed; static channels skipped",
             )
 
         if not self._available_channels:

--- a/src/notification.py
+++ b/src/notification.py
@@ -238,8 +238,10 @@ class NotificationService(
 
         # 检测所有已配置的渠道
         self._available_channels = self._detect_all_channels()
-        if self._has_context_channel():
+        if self._extract_dingtalk_session_webhook() is not None:
             self._context_channels.append("钉钉会话")
+        if self._extract_feishu_reply_info() is not None:
+            self._context_channels.append("飞书会话")
 
         if not self._available_channels and not self._context_channels:
             logger.warning("未配置有效的通知渠道，将不发送推送通知")
@@ -505,6 +507,25 @@ class NotificationService(
             self._extract_dingtalk_session_webhook() is not None
             or self._extract_feishu_reply_info() is not None
         )
+
+    def _source_platform(self) -> str:
+        """Return normalized platform from the source bot message."""
+        platform = getattr(self._source_message, "platform", "")
+        if hasattr(platform, "value"):
+            platform = platform.value
+        return str(platform or "").lower()
+
+    def _is_feishu_context_reply_only(self) -> bool:
+        """Feishu Stream command responses should not fan out to static webhooks."""
+        return (
+            isinstance(self._source_message, BotMessage)
+            and self._source_platform() == "feishu"
+            and self._extract_feishu_reply_info() is not None
+        )
+
+    def should_broadcast_static_channels(self) -> bool:
+        """Whether static notification channels should receive this dispatch."""
+        return not self._is_feishu_context_reply_only()
 
     def _extract_dingtalk_session_webhook(self) -> Optional[str]:
         """从来源消息中提取钉钉会话 Webhook（用于 Stream 模式回复）"""
@@ -2107,6 +2128,30 @@ class NotificationService(
             Structured dispatch diagnostics.
         """
         context_success = self.send_to_context(content)
+        if not self.should_broadcast_static_channels():
+            if context_success:
+                logger.info("已通过飞书消息上下文完成推送，跳过静态通知渠道")
+                return NotificationDispatchResult(
+                    dispatched=True,
+                    success=True,
+                    status="sent",
+                    channel_results=[ChannelAttemptResult(channel="__context__", success=True)],
+                )
+            logger.warning("飞书消息上下文推送失败，已跳过静态通知渠道")
+            return NotificationDispatchResult(
+                dispatched=True,
+                success=False,
+                status="all_failed",
+                channel_results=[
+                    ChannelAttemptResult(
+                        channel="__context__",
+                        success=False,
+                        error_code="send_failed",
+                        retryable=True,
+                    )
+                ],
+                message="feishu context delivery failed; static channels skipped",
+            )
 
         if not self._available_channels:
             if context_success:

--- a/src/notification_sender/telegram_sender.py
+++ b/src/notification_sender/telegram_sender.py
@@ -37,7 +37,14 @@ class TelegramSender:
         """检查 Telegram 配置是否完整"""
         return bool(self._telegram_config['bot_token'] and self._telegram_config['chat_id'])
    
-    def send_to_telegram(self, content: str, *, timeout_seconds: Optional[float] = None) -> bool:
+    def send_to_telegram(
+        self,
+        content: str,
+        *,
+        chat_id: Optional[str] = None,
+        message_thread_id: Optional[str] = None,
+        timeout_seconds: Optional[float] = None,
+    ) -> bool:
         """
         推送消息到 Telegram 机器人
         
@@ -55,13 +62,20 @@ class TelegramSender:
         Returns:
             是否发送成功
         """
-        if not self._is_telegram_configured():
+        target_chat_id = chat_id if chat_id is not None else self._telegram_config.get("chat_id")
+        target_message_thread_id = (
+            message_thread_id
+            if message_thread_id is not None
+            else self._telegram_config.get("message_thread_id")
+        )
+
+        if not (self._telegram_config["bot_token"] and target_chat_id):
             logger.warning("Telegram 配置不完整，跳过推送")
             return False
-        
+
         bot_token = self._telegram_config['bot_token']
-        chat_id = self._telegram_config['chat_id']
-        message_thread_id = self._telegram_config.get('message_thread_id')
+        chat_id = target_chat_id
+        message_thread_id = target_message_thread_id
         
         try:
             # Telegram API 端点

--- a/tests/test_notification.py
+++ b/tests/test_notification.py
@@ -62,6 +62,34 @@ def _make_feishu_message() -> BotMessage:
     )
 
 
+def _make_dingtalk_message() -> BotMessage:
+    return BotMessage(
+        platform="dingtalk",
+        message_id="msg-2",
+        user_id="user-2",
+        user_name="tester",
+        chat_id="dingtalk-chat",
+        chat_type=ChatType.GROUP,
+        content="/a 600519",
+        raw_data={
+            "sessionWebhook": "https://oapi.dingtalk.com/robot/sendBySession?session=abc123",
+        },
+    )
+
+
+def _make_telegram_message() -> BotMessage:
+    return BotMessage(
+        platform="telegram",
+        message_id="msg-3",
+        user_id="user-3",
+        user_name="tester",
+        chat_id="100200300",
+        chat_type=ChatType.PRIVATE,
+        content="/a 600519",
+        raw_data={"chat_id": "100200300"},
+    )
+
+
 class TestNotificationServiceSendToMethods(unittest.TestCase):
     """测试通知发送服务
 
@@ -328,6 +356,47 @@ class TestNotificationServiceSendToMethods(unittest.TestCase):
         self.assertEqual(result.status, "all_failed")
         self.assertEqual([item.channel for item in result.channel_results], ["__context__"])
         mock_webhook.assert_not_called()
+
+    @mock.patch("src.notification.get_config")
+    def test_dingtalk_context_response_skips_static_webhook(self, mock_get_config: mock.MagicMock):
+        cfg = _make_config(
+            feishu_webhook_url="https://open.feishu.cn/open-apis/bot/v2/hook/test-token",
+            dingtalk_app_key="dingtalk-key",
+            dingtalk_app_secret="dingtalk-secret",
+            wechat_webhook_url="https://wechat.example/hook",
+        )
+        mock_get_config.return_value = cfg
+        service = NotificationService(source_message=_make_dingtalk_message())
+
+        with mock.patch.object(service, "_send_dingtalk_chunked", return_value=True) as mock_dingtalk, \
+             mock.patch.object(service, "send_to_wechat", return_value=True) as mock_wechat:
+            result = service.send_with_results("content", route_type="report")
+
+        self.assertTrue(result.dispatched)
+        self.assertTrue(result.success)
+        self.assertEqual([item.channel for item in result.channel_results], ["__context__"])
+        mock_dingtalk.assert_called_once_with("https://oapi.dingtalk.com/robot/sendBySession?session=abc123", "content", max_bytes=20000)
+        mock_wechat.assert_not_called()
+
+    @mock.patch("src.notification.get_config")
+    def test_telegram_context_response_skips_static_webhook(self, mock_get_config: mock.MagicMock):
+        cfg = _make_config(
+            telegram_bot_token="TOKEN",
+            telegram_chat_id="123456",
+            wechat_webhook_url="https://wechat.example/hook",
+        )
+        mock_get_config.return_value = cfg
+        service = NotificationService(source_message=_make_telegram_message())
+
+        with mock.patch.object(service, "send_to_telegram", return_value=True) as mock_telegram, \
+             mock.patch.object(service, "send_to_wechat", return_value=True) as mock_wechat:
+            result = service.send_with_results("content", route_type="report")
+
+        self.assertTrue(result.dispatched)
+        self.assertTrue(result.success)
+        self.assertEqual([item.channel for item in result.channel_results], ["__context__"])
+        mock_telegram.assert_called_once_with("content", chat_id="100200300")
+        mock_wechat.assert_not_called()
 
     @mock.patch("src.notification.get_config")
     def test_feishu_webhook_still_sends_without_source_context(self, mock_get_config: mock.MagicMock):

--- a/tests/test_notification.py
+++ b/tests/test_notification.py
@@ -33,6 +33,7 @@ from src.config import Config
 from src.notification import NotificationService, NotificationChannel
 from src.notification_noise import reset_notification_noise_state
 from src.analyzer import AnalysisResult
+from bot.models import BotMessage, ChatType
 import requests
 
 
@@ -47,6 +48,18 @@ def _make_response(status_code: int, json: Optional[dict] = None) -> requests.Re
     if json:
         response.json = lambda: json
     return response
+
+
+def _make_feishu_message() -> BotMessage:
+    return BotMessage(
+        platform="feishu",
+        message_id="msg-1",
+        user_id="user-1",
+        user_name="tester",
+        chat_id="chat-1",
+        chat_type=ChatType.GROUP,
+        content="/a 600519",
+    )
 
 
 class TestNotificationServiceSendToMethods(unittest.TestCase):
@@ -274,6 +287,65 @@ class TestNotificationServiceSendToMethods(unittest.TestCase):
         self.assertTrue(ok)
         mock_context.assert_called_once_with("content")
         mock_custom.assert_not_called()
+
+    @mock.patch("src.notification.get_config")
+    def test_feishu_context_response_skips_static_webhook(self, mock_get_config: mock.MagicMock):
+        cfg = _make_config(
+            feishu_webhook_url="https://open.feishu.cn/open-apis/bot/v2/hook/test-token",
+            feishu_app_id="cli_test",
+            feishu_app_secret="app-secret",
+        )
+        mock_get_config.return_value = cfg
+        service = NotificationService(source_message=_make_feishu_message())
+
+        with mock.patch.object(service, "_send_feishu_stream_reply", return_value=True) as mock_reply, \
+             mock.patch.object(service, "send_to_feishu", return_value=True) as mock_webhook:
+            result = service.send_with_results("content", route_type="report")
+
+        self.assertTrue(result.dispatched)
+        self.assertTrue(result.success)
+        self.assertEqual(result.status, "sent")
+        self.assertEqual([item.channel for item in result.channel_results], ["__context__"])
+        mock_reply.assert_called_once_with("chat-1", "content")
+        mock_webhook.assert_not_called()
+
+    @mock.patch("src.notification.get_config")
+    def test_feishu_context_failure_does_not_fallback_to_static_webhook(self, mock_get_config: mock.MagicMock):
+        cfg = _make_config(
+            feishu_webhook_url="https://open.feishu.cn/open-apis/bot/v2/hook/test-token",
+            feishu_app_id="cli_test",
+            feishu_app_secret="app-secret",
+        )
+        mock_get_config.return_value = cfg
+        service = NotificationService(source_message=_make_feishu_message())
+
+        with mock.patch.object(service, "_send_feishu_stream_reply", return_value=False), \
+             mock.patch.object(service, "send_to_feishu", return_value=True) as mock_webhook:
+            result = service.send_with_results("content", route_type="report")
+
+        self.assertTrue(result.dispatched)
+        self.assertFalse(result.success)
+        self.assertEqual(result.status, "all_failed")
+        self.assertEqual([item.channel for item in result.channel_results], ["__context__"])
+        mock_webhook.assert_not_called()
+
+    @mock.patch("src.notification.get_config")
+    def test_feishu_webhook_still_sends_without_source_context(self, mock_get_config: mock.MagicMock):
+        cfg = _make_config(
+            feishu_webhook_url="https://open.feishu.cn/open-apis/bot/v2/hook/test-token",
+            feishu_app_id="cli_test",
+            feishu_app_secret="app-secret",
+        )
+        mock_get_config.return_value = cfg
+        service = NotificationService()
+
+        with mock.patch.object(service, "send_to_feishu", return_value=True) as mock_webhook:
+            result = service.send_with_results("content", route_type="report")
+
+        self.assertTrue(result.dispatched)
+        self.assertTrue(result.success)
+        self.assertEqual([item.channel for item in result.channel_results], ["feishu"])
+        mock_webhook.assert_called_once_with("content")
 
     @mock.patch("src.notification.get_config")
     def test_send_dedup_suppresses_static_channels_after_success(self, mock_get_config: mock.MagicMock):

--- a/tests/test_pipeline_notification_image_routing.py
+++ b/tests/test_pipeline_notification_image_routing.py
@@ -426,6 +426,38 @@ class TestPipelineReportRouteFiltering(unittest.TestCase):
         pipeline.notifier.record_noise_control.assert_not_called()
         pipeline.notifier.release_noise_control.assert_not_called()
 
+    def test_dingtalk_context_only_delivery_skips_static_channels_in_aggregate_path(self):
+        pipeline = StockAnalysisPipeline.__new__(StockAnalysisPipeline)
+        pipeline.notifier = _FakeRoutedNotifier([NotificationChannel.TELEGRAM])
+        pipeline.notifier.send_to_context.return_value = True
+        pipeline.notifier.should_broadcast_static_channels = MagicMock(return_value=False)
+        pipeline.config = SimpleNamespace(stock_email_groups=[])
+        results = [SimpleNamespace(code="000001")]
+
+        pipeline._send_notifications(results, ReportType.SIMPLE)
+
+        pipeline.notifier.should_broadcast_static_channels.assert_called_once_with()
+        pipeline.notifier.send_to_telegram.assert_not_called()
+        pipeline.notifier.evaluate_noise_control.assert_not_called()
+        pipeline.notifier.record_noise_control.assert_not_called()
+        pipeline.notifier.release_noise_control.assert_not_called()
+
+    def test_telegram_context_only_delivery_skips_static_channels_in_aggregate_path(self):
+        pipeline = StockAnalysisPipeline.__new__(StockAnalysisPipeline)
+        pipeline.notifier = _FakeRoutedNotifier([NotificationChannel.TELEGRAM])
+        pipeline.notifier.send_to_context.return_value = True
+        pipeline.notifier.should_broadcast_static_channels = MagicMock(return_value=False)
+        pipeline.config = SimpleNamespace(stock_email_groups=[])
+        results = [SimpleNamespace(code="000001")]
+
+        pipeline._send_notifications(results, ReportType.SIMPLE)
+
+        pipeline.notifier.should_broadcast_static_channels.assert_called_once_with()
+        pipeline.notifier.send_to_telegram.assert_not_called()
+        pipeline.notifier.evaluate_noise_control.assert_not_called()
+        pipeline.notifier.record_noise_control.assert_not_called()
+        pipeline.notifier.release_noise_control.assert_not_called()
+
     def test_send_notifications_records_each_channel_run_rather_than_aggregating(self):
         token = activate_run_diagnostic_context(trace_id="trace-notify")
         try:

--- a/tests/test_pipeline_notification_image_routing.py
+++ b/tests/test_pipeline_notification_image_routing.py
@@ -410,6 +410,22 @@ class TestPipelineReportRouteFiltering(unittest.TestCase):
         persisted_runs = final_update.kwargs["diagnostics"]["notification_runs"]
         self.assertEqual([run.get("channel") for run in persisted_runs], ["__context__", "telegram"])
 
+    def test_context_only_delivery_skips_static_channels_in_aggregate_path(self):
+        pipeline = StockAnalysisPipeline.__new__(StockAnalysisPipeline)
+        pipeline.notifier = _FakeRoutedNotifier([NotificationChannel.TELEGRAM])
+        pipeline.notifier.send_to_context.return_value = True
+        pipeline.notifier.should_broadcast_static_channels = MagicMock(return_value=False)
+        pipeline.config = SimpleNamespace(stock_email_groups=[])
+        results = [SimpleNamespace(code="000001")]
+
+        pipeline._send_notifications(results, ReportType.SIMPLE)
+
+        pipeline.notifier.should_broadcast_static_channels.assert_called_once_with()
+        pipeline.notifier.send_to_telegram.assert_not_called()
+        pipeline.notifier.evaluate_noise_control.assert_not_called()
+        pipeline.notifier.record_noise_control.assert_not_called()
+        pipeline.notifier.release_noise_control.assert_not_called()
+
     def test_send_notifications_records_each_channel_run_rather_than_aggregating(self):
         token = activate_run_diagnostic_context(trace_id="trace-notify")
         try:


### PR DESCRIPTION
## PR Type
- [x] fix
- [ ] feat
- [ ] refactor
- [ ] docs
- [ ] chore
- [ ] test

## Background And Problem
- 当前问题：让飞书应用内命令分析结果只回到触发命令的飞书应用上下文，定时任务仍按已配置的 webhook 目标推送。
- 影响范围：本次改动涉及 7 个文件，Diff 为 `+301 / -7`。
- 触发来源：Issue 自动执行（Issue #1501）。

## Scope Of Change
- `docs/CHANGELOG.md`
- `docs/notifications.md`
- `src/core/pipeline.py`
- `src/notification.py`
- `src/notification_sender/telegram_sender.py`
- `tests/test_notification.py`
- `tests/test_pipeline_notification_image_routing.py`

## Documentation And Changelog
- 已同步更新文档/变更记录：`docs/CHANGELOG.md`, `docs/notifications.md`。

## Issue Link
Closes #1501

## Verification Commands And Results
```bash
./scripts/ci_gate.sh flake8
./scripts/ci_gate.sh offline-tests
```

关键输出/结论 / Key output & conclusion:
- lint:PASS, test:PASS

## Compatibility And Risk
- **Medium**：涉及 `docs/CHANGELOG.md`, `docs/notifications.md`, `src/core/pipeline.py`, `src/notification.py`, `src/notification_sender/telegram_sender.py`, `tests/test_notification.py`，建议按文件范围复核。
- 前提假设：
  - 当前重复推送来自 notification.py 的 send_with_results 先 send_to_context 再遍历 target_channels。
  - 飞书应用命令调用链能够向通知发送逻辑传入上下文或参数，用于区分交互式命令响应与 SCHEDULE 定时通知。
  - 优先采用新增可选参数或复用现有上下文字段控制是否继续广播 target_channels，避免改变默认定时任务行为。
  - 不修改 secrets、workflow、部署流程或飞书配置键本身。

## Rollback Plan
- `git revert <merge-commit>` 回滚本 PR 提交，重点确认 `docs/CHANGELOG.md`, `docs/notifications.md`, `src/core/pipeline.py`, `src/notification.py` 恢复正常。

## Acceptance Criteria
- 同时配置 FEISHU_WEBHOOK_URL、FEISHU_APP_ID、FEISHU_APP_SECRET 时，飞书应用命令触发的分析结果只发送到命令来源上下文。
- SCHEDULE 或无命令上下文的常规分析仍会发送到配置的飞书 webhook 目标。
- 其他通知渠道的默认行为不被破坏，单一通知渠道失败仍不拖垮主分析流程。
- 新增或调整的测试覆盖命令上下文发送后不再重复广播 target_channels 的场景。

## Checklist
- [x] 本 PR 有明确动机和业务价值 / This PR has a clear motivation and value
- [x] 已提供可复现的验证命令与结果 / Reproducible verification commands and results are included
- [x] 已评估兼容性与风险 / Compatibility and risk have been assessed
- [x] 已提供回滚方案 / A rollback plan is provided
- [x] 已同步更新相关文档与 `docs/CHANGELOG.md`，并在 PR 描述中说明文档落点 / Relevant docs and `docs/CHANGELOG.md` are updated, and the documentation location is stated in this PR