### PR TITLE
chore: 抽取 AnalysisContextPack artifacts 构造 helper

### DIFF
--- a/src/core/pipeline.py
+++ b/src/core/pipeline.py
@@ -516,12 +516,12 @@ class StockAnalysisPipeline:
             # Step 7: 调用 AI 分析（传入增强的上下文和新闻）
             report_language = normalize_report_language(getattr(self.config, "report_language", "zh"))
             analysis_context_pack_summary = self._build_analysis_context_pack_summary(
-                PipelineAnalysisArtifacts(
+                self._build_legacy_analysis_artifacts(
                     code=code,
                     stock_name=stock_name,
                     market=market,
                     phase=market_phase_context_dict,
-                    base_context=context,
+                    context=context,
                     enhanced_context=enhanced_context,
                     realtime_quote=realtime_quote,
                     trend_result=trend_result,
@@ -529,10 +529,7 @@ class StockAnalysisPipeline:
                     fundamental_context=fundamental_context,
                     news_context=news_context,
                     news_result_count=news_result_count,
-                    metadata={
-                        "query_id": query_id,
-                        "trigger_source": self.query_source,
-                    },
+                    query_id=query_id,
                 ),
                 report_language=report_language,
                 code=code,
@@ -969,29 +966,14 @@ class StockAnalysisPipeline:
 
             market = get_market_for_stock(normalize_stock_code(code))
             analysis_context_pack_summary = self._build_analysis_context_pack_summary(
-                PipelineAnalysisArtifacts(
+                self._build_agent_analysis_artifacts(
                     code=code,
                     stock_name=stock_name,
                     market=market,
                     phase=market_phase_context,
-                    base_context={
-                        "code": code,
-                        "stock_name": stock_name,
-                        "data_missing": True,
-                        "today": {},
-                        "yesterday": {},
-                    },
-                    enhanced_context={},
-                    realtime_quote=initial_context.get("realtime_quote"),
-                    trend_result=initial_context.get("trend_result"),
-                    chip_data=initial_context.get("chip_distribution"),
+                    initial_context=initial_context,
                     fundamental_context=fundamental_context,
-                    news_context=initial_context.get("news_context"),
-                    news_result_count=None,
-                    metadata={
-                        "query_id": query_id,
-                        "trigger_source": self.query_source,
-                    },
+                    query_id=query_id,
                 ),
                 report_language=report_language,
                 code=code,
@@ -1836,6 +1818,78 @@ class StockAnalysisPipeline:
                 )
             except Exception as exc:
                 logger.warning("回写通知诊断快照失败（fail-open）: %s", exc)
+
+    def _build_legacy_analysis_artifacts(
+        self,
+        *,
+        code: str,
+        stock_name: str,
+        market: str,
+        phase: Optional[Dict[str, Any]],
+        context: Dict[str, Any],
+        enhanced_context: Dict[str, Any],
+        realtime_quote: Any,
+        trend_result: Optional[TrendAnalysisResult],
+        chip_data: Optional[ChipDistribution],
+        fundamental_context: Optional[Dict[str, Any]],
+        news_context: Optional[str],
+        news_result_count: Optional[int],
+        query_id: str,
+    ) -> PipelineAnalysisArtifacts:
+        return PipelineAnalysisArtifacts(
+            code=code,
+            stock_name=stock_name,
+            market=market,
+            phase=phase,
+            base_context=context,
+            enhanced_context=enhanced_context,
+            realtime_quote=realtime_quote,
+            trend_result=trend_result,
+            chip_data=chip_data,
+            fundamental_context=fundamental_context,
+            news_context=news_context,
+            news_result_count=news_result_count,
+            metadata={
+                "query_id": query_id,
+                "trigger_source": self.query_source,
+            },
+        )
+
+    def _build_agent_analysis_artifacts(
+        self,
+        *,
+        code: str,
+        stock_name: str,
+        market: str,
+        phase: Optional[Dict[str, Any]],
+        initial_context: Dict[str, Any],
+        fundamental_context: Optional[Dict[str, Any]],
+        query_id: str,
+    ) -> PipelineAnalysisArtifacts:
+        return PipelineAnalysisArtifacts(
+            code=code,
+            stock_name=stock_name,
+            market=market,
+            phase=phase,
+            base_context={
+                "code": code,
+                "stock_name": stock_name,
+                "data_missing": True,
+                "today": {},
+                "yesterday": {},
+            },
+            enhanced_context={},
+            realtime_quote=initial_context.get("realtime_quote"),
+            trend_result=initial_context.get("trend_result"),
+            chip_data=initial_context.get("chip_distribution"),
+            fundamental_context=fundamental_context,
+            news_context=initial_context.get("news_context"),
+            news_result_count=None,
+            metadata={
+                "query_id": query_id,
+                "trigger_source": self.query_source,
+            },
+        )
 
     def _build_analysis_context_pack_summary(
         self,

--- a/tests/test_pipeline_market_phase_context.py
+++ b/tests/test_pipeline_market_phase_context.py
@@ -135,6 +135,114 @@ class PipelineMarketPhaseContextTestCase(unittest.TestCase):
             current_time=frozen_time,
         )
 
+    def test_legacy_analysis_artifacts_helper_maps_full_pipeline_fields(self):
+        pipeline = _make_pipeline(agent_mode=False, save_context_snapshot=True)
+        pipeline.query_source = "api"
+        phase = _phase_payload()
+        context = {"code": "600519", "today": {"close": 1800.0}, "yesterday": {}}
+        enhanced_context = {"realtime": {"price": 1888.0}, "stock_name": "贵州茅台"}
+        realtime_quote = {"price": 1888.0, "source": "test"}
+        trend_result = {"ma_trend": "up"}
+        chip_data = {"concentration": "medium"}
+        fundamental_context = {"market": "cn", "pe": 28}
+        news_context = "news summary"
+
+        artifacts = pipeline._build_legacy_analysis_artifacts(
+            code="600519",
+            stock_name="贵州茅台",
+            market="cn",
+            phase=phase,
+            context=context,
+            enhanced_context=enhanced_context,
+            realtime_quote=realtime_quote,
+            trend_result=trend_result,
+            chip_data=chip_data,
+            fundamental_context=fundamental_context,
+            news_context=news_context,
+            news_result_count=3,
+            query_id="q-legacy",
+        )
+
+        self.assertEqual(artifacts.code, "600519")
+        self.assertEqual(artifacts.stock_name, "贵州茅台")
+        self.assertEqual(artifacts.market, "cn")
+        self.assertIs(artifacts.phase, phase)
+        self.assertIs(artifacts.base_context, context)
+        self.assertIs(artifacts.enhanced_context, enhanced_context)
+        self.assertIs(artifacts.realtime_quote, realtime_quote)
+        self.assertIs(artifacts.trend_result, trend_result)
+        self.assertIs(artifacts.chip_data, chip_data)
+        self.assertIs(artifacts.fundamental_context, fundamental_context)
+        self.assertEqual(artifacts.news_context, news_context)
+        self.assertEqual(artifacts.news_result_count, 3)
+        self.assertEqual(
+            artifacts.metadata,
+            {"query_id": "q-legacy", "trigger_source": "api"},
+        )
+
+    def test_agent_analysis_artifacts_helper_maps_initial_context_zero_fetch(self):
+        pipeline = _make_pipeline(agent_mode=True, save_context_snapshot=True)
+        pipeline.query_source = "system"
+        phase = _phase_payload()
+        realtime_quote = {"price": 1888.0, "source": "test"}
+        trend_result = {"ma_trend": "up"}
+        chip_distribution = {"concentration": "medium"}
+        fundamental_context = {"market": "cn", "pe": 28}
+        initial_context = {
+            "realtime_quote": realtime_quote,
+            "trend_result": trend_result,
+            "chip_distribution": chip_distribution,
+            "news_context": "prefetched news",
+        }
+
+        artifacts = pipeline._build_agent_analysis_artifacts(
+            code="600519",
+            stock_name="贵州茅台",
+            market="cn",
+            phase=phase,
+            initial_context=initial_context,
+            fundamental_context=fundamental_context,
+            query_id="q-agent",
+        )
+
+        self.assertEqual(artifacts.code, "600519")
+        self.assertEqual(artifacts.stock_name, "贵州茅台")
+        self.assertEqual(artifacts.market, "cn")
+        self.assertIs(artifacts.phase, phase)
+        self.assertEqual(
+            artifacts.base_context,
+            {
+                "code": "600519",
+                "stock_name": "贵州茅台",
+                "data_missing": True,
+                "today": {},
+                "yesterday": {},
+            },
+        )
+        self.assertNotIn("date", artifacts.base_context)
+        self.assertEqual(artifacts.enhanced_context, {})
+        self.assertIs(artifacts.realtime_quote, realtime_quote)
+        self.assertIs(artifacts.trend_result, trend_result)
+        self.assertIs(artifacts.chip_data, chip_distribution)
+        self.assertIs(artifacts.fundamental_context, fundamental_context)
+        self.assertEqual(artifacts.news_context, "prefetched news")
+        self.assertIsNone(artifacts.news_result_count)
+        self.assertEqual(
+            artifacts.metadata,
+            {"query_id": "q-agent", "trigger_source": "system"},
+        )
+
+        artifacts_without_chip = pipeline._build_agent_analysis_artifacts(
+            code="600519",
+            stock_name="贵州茅台",
+            market="cn",
+            phase=phase,
+            initial_context={},
+            fundamental_context=fundamental_context,
+            query_id="q-agent-no-chip",
+        )
+        self.assertIsNone(artifacts_without_chip.chip_data)
+
     def test_legacy_pipeline_passes_market_phase_context_to_analyzer_only(self):
         pipeline = _make_pipeline(agent_mode=False, save_context_snapshot=True)
         phase_payload = _phase_payload()


### PR DESCRIPTION
## PR Type

- [ ] fix
- [ ] feat
- [ ] refactor
- [ ] docs
- [x] chore
- [ ] test

## Background And Problem

Issue #1493 记录了 #1491 合入后的一处内部 cleanup：`StockAnalysisPipeline` 中普通分析路径和 Agent 路径各自 inline 构造 `PipelineAnalysisArtifacts(...)`，字段结构重复，但两条路径的契约不同。

本 PR 只抽取两个显式 helper，降低后续字段漂移风险，同时保留普通分析和 Agent zero-fetch 的不同边界。

## Scope Of Change

- `src/core/pipeline.py`
  - 新增 `_build_legacy_analysis_artifacts(...)`，保留普通分析路径完整 artifacts 映射。
  - 新增 `_build_agent_analysis_artifacts(...)`，只从 `initial_context` 已有内容组装 Agent artifacts，保持 `enhanced_context={}`、`news_result_count=None` 和最小 `base_context`。
  - 调用点只替换重复构造逻辑，`analysis_context_pack_summary` 注入位置保持不变。
- `tests/test_pipeline_market_phase_context.py`
  - 新增 helper 级映射测试，覆盖 legacy 全字段映射、Agent zero-fetch 字段、`chip_distribution` 缺失分支和 metadata。

## Issue Link

Refs #1493

## Verification Commands And Results

```bash
git diff --check
python -m py_compile src/core/pipeline.py
python -m pytest tests/test_pipeline_market_phase_context.py tests/test_analysis_context_pack_prompt.py tests/test_analyzer_news_prompt.py tests/test_agent_executor.py tests/test_multi_agent.py
```

关键输出/结论：

- `git diff --check`：通过，无 whitespace error。
- `python -m py_compile src/core/pipeline.py`：通过。
- pytest：`199 passed, 2 warnings in 1.61s`。
- 2 个 warning 来自 protobuf / Python 3.14 deprecation，与本 PR 改动无关。

## Compatibility And Risk

None. 本 PR 是内部 helper 抽取，不新增 API/Web/history/task/report schema 字段，不改变 `AnalysisContextBuilder` 契约，不新增 DB/fetcher/search/tool 调用。

主要风险是字段映射漂移；已通过新增 helper 单测和既有 P3 行为回归覆盖：

- 普通路径仍使用完整 `context` / `enhanced_context` / `news_context` / `news_result_count`。
- Agent 路径仍保持 zero-fetch：只从 `initial_context` 已有字段取值，`base_context` 仍为最小结构且不含 `date`。
- `analysis_context_pack_summary` 仍不写入 `context_snapshot` / diagnostic snapshot。

## Rollback Plan

Revert this PR 即可恢复原 inline 构造逻辑；无需配置回滚、数据迁移或历史记录修复。

## EXTRACT_PROMPT Change (if applicable)

不适用，本 PR 未修改 `src/services/image_stock_extractor.py` 中的 `EXTRACT_PROMPT`。

<details>
<summary>展开 / Expand: Full EXTRACT_PROMPT</summary>

```
N/A
```

</details>

## Checklist

- [x] 本 PR 有明确动机和业务价值 / This PR has a clear motivation and value
- [x] 已提供可复现的验证命令与结果 / Reproducible verification commands and results are included
- [x] 已评估兼容性与风险 / Compatibility and risk have been assessed
- [x] 已提供回滚方案 / A rollback plan is provided
- [x] 若涉及用户可见变更，已同步更新相关文档与 `docs/CHANGELOG.md`；`README.md` 仅在首页级信息变化时更新，细节优先写入 `docs/*.md` / If user-visible changes are included, relevant docs and `docs/CHANGELOG.md` are updated; `README.md` is updated only for homepage-level changes, with details kept in `docs/*.md`

说明：本 PR 不涉及用户可见变更，因此不更新 docs/CHANGELOG。