### PR TITLE
feat: support Actions SCHEDULE_TIME gate

### DIFF
--- a/.github/workflows/00-daily-analysis.yml
+++ b/.github/workflows/00-daily-analysis.yml
@@ -1,9 +1,12 @@
 name: 每日股票分析
 
 on:
-  # 定时触发 - 每天北京时间 18:00 (UTC 10:00)
+  # 定时触发 - 工作日北京时间每 5 分钟轻量检查一次，实际分析时间由 SCHEDULE_TIME 控制
   schedule:
-    - cron: '0 10 * * 1-5'     # 周一到周五，UTC 10:00 = 北京时间 18:00
+    # 北京时间 08:00-23:55，对应 UTC 周一至周五 00:00-15:55
+    - cron: '*/5 0-15 * * 1-5'
+    # 北京时间 00:00-07:55，对应 UTC 前一天 16:00-23:55
+    - cron: '*/5 16-23 * * 0-5'
   
   # 手动触发
   workflow_dispatch:
@@ -35,28 +38,88 @@ jobs:
     timeout-minutes: ${{ fromJSON(vars.ANALYSIS_TIMEOUT_MINUTES || '30') }}
     
     steps:
+      - name: 检查定时触发窗口
+        id: schedule_gate
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          SCHEDULE_TIME: ${{ vars.SCHEDULE_TIME || '18:00' }}
+        run: |
+          set -euo pipefail
+
+          if [ "$EVENT_NAME" != "schedule" ]; then
+            echo "should_run=true" >> "$GITHUB_OUTPUT"
+            echo "reason=manual trigger" >> "$GITHUB_OUTPUT"
+            echo "手动触发，跳过 SCHEDULE_TIME 窗口检查"
+            exit 0
+          fi
+
+          schedule_time="${SCHEDULE_TIME:-18:00}"
+          if ! [[ "$schedule_time" =~ ^([01][0-9]|2[0-3]):[0-5][0-9]$ ]]; then
+            echo "::error::SCHEDULE_TIME 必须使用 HH:MM 格式，当前值: '$schedule_time'"
+            exit 1
+          fi
+
+          current_time="$(TZ='Asia/Shanghai' date '+%H:%M')"
+          current_minutes=$((10#${current_time%:*} * 60 + 10#${current_time#*:}))
+          target_minutes=$((10#${schedule_time%:*} * 60 + 10#${schedule_time#*:}))
+          delta_minutes=$((current_minutes - target_minutes))
+          target_weekday="$(TZ='Asia/Shanghai' date '+%u')"
+
+          if [ "$delta_minutes" -lt 0 ]; then
+            delta_minutes=$((delta_minutes + 1440))
+            target_weekday="$(TZ='Asia/Shanghai' date -d 'yesterday' '+%u')"
+          fi
+
+          if [ "$target_weekday" -gt 5 ]; then
+            echo "should_run=false" >> "$GITHUB_OUTPUT"
+            echo "reason=not a Beijing weekday" >> "$GITHUB_OUTPUT"
+            echo "北京时间目标日期为周末，跳过定时分析"
+            exit 0
+          fi
+
+          if [ "$delta_minutes" -lt 5 ]; then
+            echo "should_run=true" >> "$GITHUB_OUTPUT"
+            echo "reason=matched $schedule_time Beijing time window" >> "$GITHUB_OUTPUT"
+            echo "命中 SCHEDULE_TIME=$schedule_time，北京当前时间 $current_time，继续执行分析"
+          else
+            echo "should_run=false" >> "$GITHUB_OUTPUT"
+            echo "reason=current Beijing time $current_time does not match $schedule_time" >> "$GITHUB_OUTPUT"
+            echo "未命中 SCHEDULE_TIME=$schedule_time，北京当前时间 $current_time，跳过本次定时分析"
+          fi
+
+      - name: 跳过未命中定时窗口
+        if: steps.schedule_gate.outputs.should_run != 'true'
+        run: |
+          echo "本次不执行分析：${{ steps.schedule_gate.outputs.reason }}"
+
       - name: 随机延迟（避免固定时间访问）
+        if: steps.schedule_gate.outputs.should_run == 'true'
         run: sleep $((RANDOM % 60))  # 随机延迟0-60秒启动
       
       - name: 检出代码
+        if: steps.schedule_gate.outputs.should_run == 'true'
         uses: actions/checkout@v5
       
       - name: 设置 Python 环境
+        if: steps.schedule_gate.outputs.should_run == 'true'
         uses: actions/setup-python@v6
         with:
           python-version: '3.11'
           cache: 'pip'
       
       - name: 安装依赖
+        if: steps.schedule_gate.outputs.should_run == 'true'
         run: |
           pip install --upgrade pip
           pip install -r requirements.txt
       
       - name: 创建必要目录
+        if: steps.schedule_gate.outputs.should_run == 'true'
         run: |
           mkdir -p data logs reports
       
       - name: 执行股票分析
+        if: steps.schedule_gate.outputs.should_run == 'true'
         env:
           # ==========================================
           # AI 配置
@@ -358,6 +421,7 @@ jobs:
           MARKET_REVIEW_ENABLED: ${{ vars.MARKET_REVIEW_ENABLED || secrets.MARKET_REVIEW_ENABLED || 'true' }}
           ANALYSIS_DELAY: ${{ vars.ANALYSIS_DELAY || secrets.ANALYSIS_DELAY || '0' }}
           TRADING_DAY_CHECK_ENABLED: ${{ vars.TRADING_DAY_CHECK_ENABLED || secrets.TRADING_DAY_CHECK_ENABLED || 'true' }}
+          SCHEDULE_TIME: ${{ vars.SCHEDULE_TIME || '18:00' }}
           
           # ==========================================
           # 系统配置
@@ -392,6 +456,7 @@ jobs:
           echo "🎯 运行模式: $MODE"
           echo "📊 自选股: $STOCK_LIST"
           echo "📝 报告类型: $REPORT_TYPE"
+          echo "⏱️ 定时配置: SCHEDULE_TIME=${SCHEDULE_TIME:-18:00}"
           echo ""
           echo "=========================================="
           echo "📋 配置检查"
@@ -469,7 +534,7 @@ jobs:
       
       - name: 上传分析报告
         uses: actions/upload-artifact@v6
-        if: always()
+        if: always() && steps.schedule_gate.outputs.should_run == 'true'
         with:
           name: analysis-reports-${{ github.run_number }}
           path: |
@@ -478,7 +543,7 @@ jobs:
           retention-days: 30
       
       - name: 显示运行结果
-        if: always()
+        if: always() && steps.schedule_gate.outputs.should_run == 'true'
         run: |
           echo ""
           echo "=========================================="

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - [新功能] AnalysisContextPack P4 低敏 overview 接入历史详情、同步分析响应、completed 任务状态和 Web 报告页，展示数据块状态、来源、缺失原因与降级摘要。
 
 - [修复] 收口 Web 中文界面残留英文文案与设置页 help 缺口，回测页改为中文展示，并让 Web 设置页仅展示已注册且带说明的配置项。
+- [新功能] GitHub Actions 每日分析支持通过仓库变量 `SCHEDULE_TIME` 配置北京时间执行窗口，未命中时在安装依赖前跳过分析步骤。
 
 ## [3.19.0] - 2026-05-29
 

--- a/docs/full-guide.md
+++ b/docs/full-guide.md
@@ -621,23 +621,33 @@ python main.py --workers 5            # 指定并发数
 
 ### GitHub Actions 定时
 
-编辑 `.github/workflows/00-daily-analysis.yml`:
+默认 workflow 会在工作日北京时间每 5 分钟进行一次轻量检查，并读取仓库
+`Settings → Secrets and variables → Actions → Variables` 中的 `SCHEDULE_TIME`
+决定是否继续执行分析。未配置时默认 `18:00`。
+
+```text
+SCHEDULE_TIME=18:00
+```
+
+`SCHEDULE_TIME` 使用 `HH:MM` 格式和北京时间。命中配置时间后的 5 分钟窗口内会继续执行；
+未命中时会在安装依赖前直接跳过。手动触发 `workflow_dispatch` 不受该窗口限制。
+
+> GitHub Actions 的 `on.schedule.cron` 仍然是 workflow 文件里的固定配置，不能直接读取
+> Repository Variables、Secrets 或 `.env` 动态替换。这里的实现是“固定低成本轮询 +
+> 运行前门控”，不是动态改写 cron。
+
+当前 workflow 的轮询 cron 覆盖工作日北京时间全天：
 
 ```yaml
 schedule:
-  # UTC 时间，北京时间 = UTC + 8
-  - cron: '0 10 * * 1-5'   # 周一到周五 18:00（北京时间）
+  # 北京时间 08:00-23:55，对应 UTC 周一至周五 00:00-15:55
+  - cron: '*/5 0-15 * * 1-5'
+  # 北京时间 00:00-07:55，对应 UTC 前一天 16:00-23:55
+  - cron: '*/5 16-23 * * 0-5'
 ```
 
-常用时间对照：
-
-| 北京时间 | UTC cron 表达式 |
-|---------|----------------|
-| 09:30 | `'30 1 * * 1-5'` |
-| 12:00 | `'0 4 * * 1-5'` |
-| 15:00 | `'0 7 * * 1-5'` |
-| 18:00 | `'0 10 * * 1-5'` |
-| 21:00 | `'0 13 * * 1-5'` |
+如需完全减少 workflow 触发次数，而不是仅跳过分析步骤，请自行把
+`.github/workflows/00-daily-analysis.yml` 改回单点 cron，并按 UTC 时间换算。
 
 #### GitHub Actions 非交易日手动运行（Issue #461 / #466）
 

--- a/docs/full-guide_EN.md
+++ b/docs/full-guide_EN.md
@@ -557,23 +557,37 @@ python main.py --workers 5            # Specify concurrency
 
 ### GitHub Actions Schedule
 
-Edit `.github/workflows/00-daily-analysis.yml`:
+The default workflow now performs a lightweight check every 5 minutes during
+Beijing workdays, then reads the repository variable `SCHEDULE_TIME` from
+`Settings -> Secrets and variables -> Actions -> Variables` to decide whether to
+continue with the analysis. When unset, it defaults to `18:00`.
+
+```text
+SCHEDULE_TIME=18:00
+```
+
+`SCHEDULE_TIME` uses `HH:MM` in Beijing time. Scheduled runs continue only within
+the 5-minute window after the configured time; non-matching runs stop before
+dependency installation. Manual `workflow_dispatch` runs bypass this gate.
+
+> GitHub Actions still parses `on.schedule.cron` from the workflow file; the cron
+> expression cannot directly read Repository Variables, Secrets, or `.env`
+> values. This workflow uses fixed low-cost polling plus a pre-run gate instead
+> of dynamically rewriting cron.
+
+The current polling cron covers the full Beijing workday:
 
 ```yaml
 schedule:
-  # UTC time, Beijing time = UTC + 8
-  - cron: '0 10 * * 1-5'   # Monday to Friday 18:00 (Beijing Time)
+  # Beijing 08:00-23:55, mapped to Monday-Friday 00:00-15:55 UTC
+  - cron: '*/5 0-15 * * 1-5'
+  # Beijing 00:00-07:55, mapped to the previous UTC day 16:00-23:55
+  - cron: '*/5 16-23 * * 0-5'
 ```
 
-Common time reference:
-
-| Beijing Time | UTC cron expression |
-|---------|----------------|
-| 09:30 | `'30 1 * * 1-5'` |
-| 12:00 | `'0 4 * * 1-5'` |
-| 15:00 | `'0 7 * * 1-5'` |
-| 18:00 | `'0 10 * * 1-5'` |
-| 21:00 | `'0 13 * * 1-5'` |
+If you need to reduce the number of workflow triggers instead of only skipping
+the analysis steps, edit `.github/workflows/00-daily-analysis.yml` back to a
+single cron point and convert the desired time to UTC manually.
 
 ### Local Scheduled Tasks
 


### PR DESCRIPTION
## PR Type
- [ ] fix
- [x] feat
- [ ] refactor
- [ ] docs
- [ ] chore
- [ ] test

## Background And Problem
Issue #1497 asks for the bundled GitHub Actions daily analysis workflow to let users configure the actual execution time through the existing `SCHEDULE_TIME` setting. `on.schedule.cron` itself cannot be dynamically replaced by repository variables, so a plain env mapping would not affect the trigger. The smallest runtime implementation is a fixed lightweight polling schedule plus a pre-run gate that reads `vars.SCHEDULE_TIME`.

## Scope Of Change
- `.github/workflows/00-daily-analysis.yml`
  - changes the scheduled trigger from a single 18:00 Beijing cron to Beijing-workday 5-minute lightweight checks
  - adds a `schedule_gate` step that validates `SCHEDULE_TIME` as `HH:MM`, skips weekends, and only continues inside the configured Beijing-time window
  - keeps `workflow_dispatch` manual runs outside the gate
  - maps `SCHEDULE_TIME` into the analysis step for visibility / config consistency
- `docs/full-guide.md`
- `docs/full-guide_EN.md`
- `docs/CHANGELOG.md`

## Acceptance Criteria
- Unset `SCHEDULE_TIME` keeps the default Beijing 18:00 execution window.
- Valid `HH:MM` repository variable values are honored by the workflow pre-run gate.
- Non-matching scheduled runs skip before checkout, setup-python, dependency install, and analysis.
- Invalid `SCHEDULE_TIME` fails with a readable workflow error.
- Manual workflow dispatch remains runnable immediately.

## Issue Link
Closes #1497

## Verification Commands And Results
```bash
git diff --check
python - <<'PY'
from pathlib import Path
import yaml
with Path('.github/workflows/00-daily-analysis.yml').open(encoding='utf-8') as fh:
    yaml.safe_load(fh)
print('workflow yaml parsed')
PY
bash -euo pipefail <<'BASH'
# Validates representative schedule gate cases: exact match, in-window, out-of-window,
# cross-midnight, weekend skip, invalid HH:MM.
...
BASH
./scripts/ci_gate.sh
```

Key results:
- `git diff --check`: PASS
- workflow YAML parse: PASS
- schedule gate shell cases: PASS
- `./scripts/ci_gate.sh`: PASS, `2492 passed, 2 deselected, 16 warnings, 215 subtests passed`
- `actionlint` was not installed locally, so dedicated Actions lint was not run.

## Compatibility And Risk
- GitHub Actions: scheduled workflow runs more often, but non-matching runs stop before checkout / setup / dependency install / analysis. This reduces expensive work while allowing repository-variable time selection.
- GitHub scheduler limitation: repository variables still do not mutate `on.schedule.cron`; the implementation is fixed polling plus runtime gating.
- Manual runs: `workflow_dispatch` bypasses the schedule gate and keeps current behavior.
- API / Web / Desktop: no runtime surface change.
- Docs: Chinese and English full guides were updated together; README was not changed to avoid homepage-level bloat.

## Rollback Plan
Revert this PR to restore the previous single-cron GitHub Actions schedule and remove the related guide / changelog entries.