### PR TITLE
test: mock market light alert notifier

### DIFF
--- a/tests/test_alert_worker.py
+++ b/tests/test_alert_worker.py
@@ -1020,7 +1020,8 @@ class AlertWorkerTestCase(unittest.TestCase):
             },
             "data_quality": "ok",
         }
-        worker = AlertWorker(config_provider=lambda: self._config(), service=self.service)
+        notifier = self._notifier()
+        worker = AlertWorker(config_provider=lambda: self._config(), service=self.service, notifier=notifier)
 
         with patch("src.services.market_light_alerts.build_current_snapshot", return_value=snapshot):
             first = worker.run_once()
@@ -1030,6 +1031,8 @@ class AlertWorkerTestCase(unittest.TestCase):
         self.assertEqual(first["recorded"], 1)
         self.assertEqual(second["triggered"], 1)
         self.assertEqual(second["recorded"], 0)
+        notifier.send_with_results.assert_called_once()
+        self.assertEqual(notifier.send_with_results.call_args.kwargs["route_type"], "alert")
         triggers = self._triggers(rule_id=rule["id"], status="triggered")
         self.assertEqual(len(triggers), 1)
         self.assertEqual(triggers[0]["target"], "cn")


### PR DESCRIPTION
## PR Type
- [ ] fix
- [ ] feat
- [ ] refactor
- [ ] docs
- [ ] chore
- [x] test

## Background And Problem
`AlertWorkerTestCase::test_market_light_rule_triggers_with_market_payload_and_deduplicates_trade_date` created an `AlertWorker` without injecting the test notifier. When a developer has real notification environment variables configured locally, the test can instantiate `NotificationService()` and send an actual alert such as `Event Alert | A股大盘`.

## Scope Of Change
- `tests/test_alert_worker.py`
  - injects the existing mock notifier into the market-light trigger test
  - asserts that the alert route is still exercised through the mock notifier

## Issue Link
No issue. This is a test isolation fix found during local validation.

## Verification Commands And Results
```bash
git diff --check
python -m pytest tests/test_alert_worker.py::AlertWorkerTestCase::test_market_light_rule_triggers_with_market_payload_and_deduplicates_trade_date
python -m pytest tests/test_alert_worker.py
```

Key results:
- `git diff --check`: PASS
- target test: PASS
- `tests/test_alert_worker.py`: PASS, `51 passed, 5 subtests passed`

## Compatibility And Risk
- Runtime behavior: no production code changes.
- Tests: the market-light alert test now uses the same mock-notifier pattern as nearby notification-triggering tests, preventing accidental real webhook delivery while preserving route assertions.
- Docs / changelog: not updated because this is tests-only and does not change user-visible behavior.

## Rollback Plan
Revert this PR to restore the previous test behavior.