### PR TITLE
feat: 新增个股栏与自选队列操作

### DIFF
--- a/api/v1/endpoints/history.py
+++ b/api/v1/endpoints/history.py
@@ -223,10 +223,13 @@ def get_stock_bar(
         start = date_type.fromisoformat(start_date) if start_date else None
         end = date_type.fromisoformat(end_date) if end_date else None
 
+        # Fetch more than limit to compensate for normalization dedup shrinkage
+        # (e.g. 002460 + 002460.SZ both initially counted but merged to one)
+        fetch_limit = min(limit * 3, 500)
         records = db_manager.get_distinct_stocks_from_history(
             start_date=start,
             end_date=end,
-            limit=limit,
+            limit=fetch_limit,
         )
 
         # Deduplicate by normalized code, keeping the record with highest id

--- a/api/v1/endpoints/history.py
+++ b/api/v1/endpoints/history.py
@@ -156,6 +156,37 @@ def get_history_list(
 
 
 @router.delete(
+    "/by-code/{stock_code}",
+    response_model=DeleteHistoryResponse,
+    responses={
+        200: {"description": "删除成功"},
+        404: {"description": "未找到记录", "model": ErrorResponse},
+        500: {"description": "服务器错误", "model": ErrorResponse},
+    },
+    summary="按股票代码删除历史分析记录",
+    description="删除指定股票代码的所有分析历史记录（支持代码变体归一化匹配）",
+)
+def delete_history_by_code(
+    stock_code: str,
+    db_manager: DatabaseManager = Depends(get_database_manager),
+) -> DeleteHistoryResponse:
+    try:
+        candidates = HistoryService._history_code_filter_candidates(stock_code)
+        records, _ = db_manager.get_analysis_history_paginated(code=candidates, limit=10000)
+        record_ids = [r.id for r in records if r.id is not None]
+        if not record_ids:
+            return DeleteHistoryResponse(deleted=0)
+        deleted = db_manager.delete_analysis_history_records(record_ids)
+        return DeleteHistoryResponse(deleted=deleted)
+    except Exception as e:
+        logger.error(f"按股票代码删除历史记录失败: {e}", exc_info=True)
+        raise HTTPException(
+            status_code=500,
+            detail={"error": "internal_error", "message": f"删除失败: {str(e)}"},
+        )
+
+
+@router.delete(
     "",
     response_model=DeleteHistoryResponse,
     responses={
@@ -267,6 +298,7 @@ def get_stock_bar(
                 )
             )
 
+        items = items[:limit]
         return StockBarResponse(total=len(items), items=items)
 
     except Exception as e:

--- a/api/v1/endpoints/history.py
+++ b/api/v1/endpoints/history.py
@@ -62,18 +62,11 @@ router = APIRouter()
 def _normalize_code_for_grouping(code: str) -> str:
     """Normalize stock code for deduplication grouping.
 
-    Strips A-share suffixes (.SZ/.SH/.SS) and normalizes HK prefix case
-    so that 002460 and 002460.SZ are treated as the same stock.
+    Delegates to data_provider.base.normalize_stock_code which handles
+    SH600519, 600519.SH, HK00700, 00700.HK, BJ920748, etc.
     """
-    if not code:
-        return code
-    upper = code.upper()
-    for suffix in ('.SZ', '.SH', '.SS'):
-        if upper.endswith(suffix):
-            return code[:-len(suffix)]
-    if code.lower().startswith('hk'):
-        return code.lower()
-    return code
+    from data_provider.base import normalize_stock_code
+    return normalize_stock_code(code or "")
 
 
 @router.get(

--- a/api/v1/endpoints/history.py
+++ b/api/v1/endpoints/history.py
@@ -29,6 +29,8 @@ from api.v1.schemas.history import (
     ReportDetails,
     MarkdownReportResponse,
     RunDiagnosticSummaryResponse,
+    StockBarItem,
+    StockBarResponse,
 )
 from api.v1.schemas.common import ErrorResponse
 from src.storage import DatabaseManager
@@ -55,6 +57,23 @@ from src.market_phase_summary import extract_market_phase_summary
 logger = logging.getLogger(__name__)
 
 router = APIRouter()
+
+
+def _normalize_code_for_grouping(code: str) -> str:
+    """Normalize stock code for deduplication grouping.
+
+    Strips A-share suffixes (.SZ/.SH/.SS) and normalizes HK prefix case
+    so that 002460 and 002460.SZ are treated as the same stock.
+    """
+    if not code:
+        return code
+    upper = code.upper()
+    for suffix in ('.SZ', '.SH', '.SS'):
+        if upper.endswith(suffix):
+            return code[:-len(suffix)]
+    if code.lower().startswith('hk'):
+        return code.lower()
+    return code
 
 
 @router.get(
@@ -185,6 +204,83 @@ def delete_history_records(
                 "error": "internal_error",
                 "message": f"删除历史记录失败: {str(e)}"
             }
+        )
+
+
+@router.get(
+    "/stocks",
+    response_model=StockBarResponse,
+    responses={
+        200: {"description": "不重复个股列表"},
+        500: {"description": "服务器错误", "model": ErrorResponse},
+    },
+    summary="获取不重复个股列表",
+    description="返回历史记录中每只股票的最新一条分析摘要，大盘复盘（code=MARKET）始终置顶。",
+)
+def get_stock_bar(
+    start_date: Optional[str] = Query(None, description="开始日期 (YYYY-MM-DD)"),
+    end_date: Optional[str] = Query(None, description="结束日期 (YYYY-MM-DD)"),
+    limit: int = Query(200, ge=1, le=500, description="最大返回数量"),
+    db_manager: DatabaseManager = Depends(get_database_manager),
+) -> StockBarResponse:
+    try:
+        from datetime import date as date_type
+        from src.utils.data_processing import parse_json_field
+
+        start = date_type.fromisoformat(start_date) if start_date else None
+        end = date_type.fromisoformat(end_date) if end_date else None
+
+        records = db_manager.get_distinct_stocks_from_history(
+            start_date=start,
+            end_date=end,
+            limit=limit,
+        )
+
+        # Deduplicate by normalized code, keeping the record with highest id
+        seen: dict = {}
+        for record in records:
+            norm_code = _normalize_code_for_grouping(record.code or "")
+            if norm_code not in seen or record.id > seen[norm_code].id:
+                seen[norm_code] = record
+
+        items = []
+        for norm_code in seen:
+            record = seen[norm_code]
+            raw_result = parse_json_field(getattr(record, "raw_result", None))
+            model_used = raw_result.get("model_used") if isinstance(raw_result, dict) else None
+
+            analysis_count = db_manager.get_analysis_history_paginated(
+                code=HistoryService._history_code_filter_candidates(
+                    record.code or "",
+                ),
+                limit=1,
+            )[1]
+            items.append(
+                StockBarItem(
+                    id=record.id,
+                    stock_code=record.code or "",
+                    stock_name=record.name,
+                    report_type=record.report_type,
+                    sentiment_score=record.sentiment_score,
+                    operation_advice=record.operation_advice,
+                    analysis_count=analysis_count,
+                    last_analysis_time=(
+                        record.created_at.isoformat() if record.created_at else None
+                    ),
+                    model_used=normalize_model_used(model_used),
+                )
+            )
+
+        return StockBarResponse(total=len(items), items=items)
+
+    except Exception as e:
+        logger.error(f"查询个股栏失败: {e}", exc_info=True)
+        raise HTTPException(
+            status_code=500,
+            detail={
+                "error": "internal_error",
+                "message": f"查询个股栏失败: {str(e)}",
+            },
         )
 
 

--- a/api/v1/endpoints/stocks.py
+++ b/api/v1/endpoints/stocks.py
@@ -51,38 +51,23 @@ ALLOWED_MIME_STR = ", ".join(ALLOWED_MIME)
 
 
 def _read_watchlist_codes(service: SystemConfigService) -> list:
-    """Read and normalize STOCK_LIST codes, deduplicating by canonical form."""
+    """Read STOCK_LIST codes as-is (no normalization)."""
     config_data = service.get_config(include_schema=False)
     stock_list_str = ""
     for item in config_data.get("items", []):
         if item.get("key") == "STOCK_LIST":
             stock_list_str = str(item.get("value", ""))
             break
-    raw = [c.strip() for c in stock_list_str.split(",") if c.strip()]
-    seen = set()
-    normalized = []
-    for code in raw:
-        canonical = normalize_stock_code(code)
-        if canonical and canonical not in seen:
-            seen.add(canonical)
-            normalized.append(canonical)
-    return normalized
+    return [c.strip() for c in stock_list_str.split(",") if c.strip()]
 
 
 def _write_watchlist_codes(service: SystemConfigService, codes: list) -> None:
-    """Persist deduplicated stock codes to STOCK_LIST."""
+    """Persist stock codes to STOCK_LIST as-is (no normalization)."""
     config_data = service.get_config(include_schema=False)
     config_version = config_data.get("config_version", "")
-    seen = set()
-    deduped = []
-    for code in codes:
-        canonical = normalize_stock_code(code)
-        if canonical and canonical not in seen:
-            seen.add(canonical)
-            deduped.append(canonical)
     service.update(
         config_version=config_version,
-        items=[{"key": "STOCK_LIST", "value": ",".join(deduped)}],
+        items=[{"key": "STOCK_LIST", "value": ",".join(codes)}],
         mask_token="******",
         reload_now=True,
     )
@@ -359,12 +344,13 @@ def add_to_watchlist(
     service: SystemConfigService = Depends(get_system_config_service),
 ) -> WatchlistResponse:
     try:
-        normalized = _validate_and_normalize_stock_code(request.stock_code)
+        validated = _validate_and_normalize_stock_code(request.stock_code)
         codes = _read_watchlist_codes(service)
-        if normalized not in codes:
-            codes.append(normalized)
+        normalized_existing = [normalize_stock_code(c) for c in codes]
+        if validated not in normalized_existing:
+            codes.append(request.stock_code.strip())
             _write_watchlist_codes(service, codes)
-        return WatchlistResponse(stock_codes=codes, message=f"已加入 {normalized}")
+        return WatchlistResponse(stock_codes=codes, message=f"已加入 {request.stock_code.strip()}")
     except HTTPException:
         raise
     except Exception as e:
@@ -391,12 +377,14 @@ def remove_from_watchlist(
     service: SystemConfigService = Depends(get_system_config_service),
 ) -> WatchlistResponse:
     try:
-        normalized = _validate_and_normalize_stock_code(request.stock_code)
+        validated = _validate_and_normalize_stock_code(request.stock_code)
         codes = _read_watchlist_codes(service)
-        if normalized in codes:
-            codes.remove(normalized)
+        normalized_existing = [normalize_stock_code(c) for c in codes]
+        if validated in normalized_existing:
+            idx = normalized_existing.index(validated)
+            removed = codes.pop(idx)
             _write_watchlist_codes(service, codes)
-        return WatchlistResponse(stock_codes=codes, message=f"已移除 {normalized}")
+        return WatchlistResponse(stock_codes=codes, message=f"已移除 {request.stock_code.strip()}")
     except HTTPException:
         raise
     except Exception as e:

--- a/api/v1/endpoints/stocks.py
+++ b/api/v1/endpoints/stocks.py
@@ -95,6 +95,7 @@ _STOCK_CODE_RE = re.compile(
     r"|\d{6}\.(?:SH|SZ|SS|BJ)"                # exchange-suffixed A-share
     r"|\d{1,5}\.HK"                           # HK suffix format
     r"|HK\d{1,5}"                             # HK prefix format
+    r"|\d{5}"                                 # bare 5-digit HK code
     r"|[A-Z]{1,5}(?:\.(?:US|[A-Z]))?"         # US ticker
     r")$",
     re.IGNORECASE,

--- a/api/v1/endpoints/stocks.py
+++ b/api/v1/endpoints/stocks.py
@@ -13,6 +13,7 @@
 
 import logging
 from typing import Optional
+import re
 
 from fastapi import APIRouter, File, HTTPException, Query, Request, UploadFile, Depends
 
@@ -50,33 +51,60 @@ ALLOWED_MIME_STR = ", ".join(ALLOWED_MIME)
 
 
 def _read_watchlist_codes(service: SystemConfigService) -> list:
-    """Read current STOCK_LIST codes, preserving original order."""
+    """Read and normalize STOCK_LIST codes, deduplicating by canonical form."""
     config_data = service.get_config(include_schema=False)
     stock_list_str = ""
     for item in config_data.get("items", []):
         if item.get("key") == "STOCK_LIST":
             stock_list_str = str(item.get("value", ""))
             break
-    return [c.strip() for c in stock_list_str.split(",") if c.strip()]
+    raw = [c.strip() for c in stock_list_str.split(",") if c.strip()]
+    seen = set()
+    normalized = []
+    for code in raw:
+        canonical = normalize_stock_code(code)
+        if canonical and canonical not in seen:
+            seen.add(canonical)
+            normalized.append(canonical)
+    return normalized
 
 
 def _write_watchlist_codes(service: SystemConfigService, codes: list) -> None:
-    """Persist normalized stock codes to STOCK_LIST."""
+    """Persist deduplicated stock codes to STOCK_LIST."""
     config_data = service.get_config(include_schema=False)
     config_version = config_data.get("config_version", "")
-    new_value = ",".join(codes)
+    seen = set()
+    deduped = []
+    for code in codes:
+        canonical = normalize_stock_code(code)
+        if canonical and canonical not in seen:
+            seen.add(canonical)
+            deduped.append(canonical)
     service.update(
         config_version=config_version,
-        items=[{"key": "STOCK_LIST", "value": new_value}],
+        items=[{"key": "STOCK_LIST", "value": ",".join(deduped)}],
         mask_token="******",
         reload_now=True,
     )
 
 
-def _validate_and_normalize_stock_code(code: str) -> str:
-    """Validate stock code format and return normalized form.
+# Stock code validation patterns (aligned with frontend validateStockCode)
+_STOCK_CODE_RE = re.compile(
+    r"^(?:\d{6}"                              # A-share 6-digit
+    r"|(?:SH|SZ|BJ)\d{6}"                     # exchange-prefixed A-share
+    r"|\d{6}\.(?:SH|SZ|SS|BJ)"                # exchange-suffixed A-share
+    r"|\d{1,5}\.HK"                           # HK suffix format
+    r"|HK\d{1,5}"                             # HK prefix format
+    r"|[A-Z]{1,5}(?:\.(?:US|[A-Z]))?"         # US ticker
+    r")$",
+    re.IGNORECASE,
+)
 
-    Raises HTTPException(400) if the code does not look like a valid stock code.
+
+def _validate_and_normalize_stock_code(code: str) -> str:
+    """Validate stock code format and return canonical form.
+
+    Raises HTTPException(400) if the code does not match supported formats.
     """
     stripped = code.strip()
     if not stripped:
@@ -84,8 +112,7 @@ def _validate_and_normalize_stock_code(code: str) -> str:
             status_code=400,
             detail={"error": "invalid_stock_code", "message": "股票代码不能为空"},
         )
-    normalized = normalize_stock_code(stripped)
-    if not normalized or len(normalized) < 2:
+    if not _STOCK_CODE_RE.match(stripped):
         raise HTTPException(
             status_code=400,
             detail={
@@ -93,7 +120,7 @@ def _validate_and_normalize_stock_code(code: str) -> str:
                 "message": f"'{stripped}' 不是合法的股票代码格式",
             },
         )
-    return normalized
+    return normalize_stock_code(stripped)
 
 
 @router.post(

--- a/api/v1/endpoints/stocks.py
+++ b/api/v1/endpoints/stocks.py
@@ -14,7 +14,9 @@
 import logging
 from typing import Optional
 
-from fastapi import APIRouter, File, HTTPException, Query, Request, UploadFile
+from fastapi import APIRouter, File, HTTPException, Query, Request, UploadFile, Depends
+
+from api.deps import get_system_config_service
 
 from api.v1.schemas.stocks import (
     ExtractFromImageResponse,
@@ -23,6 +25,7 @@ from api.v1.schemas.stocks import (
     StockHistoryResponse,
     StockQuote,
 )
+from api.v1.schemas.history import WatchlistRequest, WatchlistResponse
 from api.v1.schemas.common import ErrorResponse
 from src.services.image_stock_extractor import (
     ALLOWED_MIME,
@@ -35,6 +38,7 @@ from src.services.import_parser import (
     parse_import_from_text,
 )
 from src.services.stock_service import StockService
+from src.services.system_config_service import SystemConfigService
 
 logger = logging.getLogger(__name__)
 
@@ -237,6 +241,124 @@ async def parse_import(request: Request) -> ExtractFromImageResponse:
     ]
     codes = list(dict.fromkeys(i.code for i in extract_items if i.code))
     return ExtractFromImageResponse(codes=codes, items=extract_items, raw_text=None)
+
+
+@router.get(
+    "/watchlist",
+    response_model=WatchlistResponse,
+    responses={
+        200: {"description": "当前自选队列"},
+        500: {"description": "服务器错误", "model": ErrorResponse},
+    },
+    summary="获取自选队列",
+    description="返回当前 STOCK_LIST 配置中的所有股票代码。",
+)
+def get_watchlist(
+    service: SystemConfigService = Depends(get_system_config_service),
+) -> WatchlistResponse:
+    try:
+        config_data = service.get_config(include_schema=False)
+        stock_list_str = ""
+        for item in config_data.get("items", []):
+            if item.get("key") == "STOCK_LIST":
+                stock_list_str = str(item.get("value", ""))
+                break
+        codes = [c.strip() for c in stock_list_str.split(",") if c.strip()]
+        return WatchlistResponse(stock_codes=codes, message=f"当前自选 {len(codes)} 只股票")
+    except Exception as e:
+        logger.error(f"获取自选队列失败: {e}", exc_info=True)
+        raise HTTPException(
+            status_code=500,
+            detail={"error": "internal_error", "message": f"获取自选队列失败: {str(e)}"},
+        )
+
+
+@router.post(
+    "/watchlist/add",
+    response_model=WatchlistResponse,
+    responses={
+        200: {"description": "已加入自选"},
+        400: {"description": "参数错误", "model": ErrorResponse},
+        500: {"description": "服务器错误", "model": ErrorResponse},
+    },
+    summary="加入自选队列",
+    description="将指定股票代码加入 STOCK_LIST。",
+)
+def add_to_watchlist(
+    request: WatchlistRequest,
+    service: SystemConfigService = Depends(get_system_config_service),
+) -> WatchlistResponse:
+    try:
+        config_data = service.get_config(include_schema=False)
+        config_version = config_data.get("config_version", "")
+        stock_list_str = ""
+        for item in config_data.get("items", []):
+            if item.get("key") == "STOCK_LIST":
+                stock_list_str = str(item.get("value", ""))
+                break
+        codes = [c.strip() for c in stock_list_str.split(",") if c.strip()]
+        if request.stock_code not in codes:
+            codes.append(request.stock_code)
+            new_value = ",".join(codes)
+            service.update(
+                config_version=config_version,
+                items=[{"key": "STOCK_LIST", "value": new_value}],
+                mask_token="******",
+                reload_now=True,
+            )
+        return WatchlistResponse(stock_codes=codes, message=f"已加入 {request.stock_code}")
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"加入自选失败: {e}", exc_info=True)
+        raise HTTPException(
+            status_code=500,
+            detail={"error": "internal_error", "message": f"加入自选失败: {str(e)}"},
+        )
+
+
+@router.post(
+    "/watchlist/remove",
+    response_model=WatchlistResponse,
+    responses={
+        200: {"description": "已从自选删除"},
+        400: {"description": "参数错误", "model": ErrorResponse},
+        500: {"description": "服务器错误", "model": ErrorResponse},
+    },
+    summary="从自选队列删除",
+    description="从 STOCK_LIST 中移除指定股票代码。",
+)
+def remove_from_watchlist(
+    request: WatchlistRequest,
+    service: SystemConfigService = Depends(get_system_config_service),
+) -> WatchlistResponse:
+    try:
+        config_data = service.get_config(include_schema=False)
+        config_version = config_data.get("config_version", "")
+        stock_list_str = ""
+        for item in config_data.get("items", []):
+            if item.get("key") == "STOCK_LIST":
+                stock_list_str = str(item.get("value", ""))
+                break
+        codes = [c.strip() for c in stock_list_str.split(",") if c.strip()]
+        if request.stock_code in codes:
+            codes.remove(request.stock_code)
+            new_value = ",".join(codes)
+            service.update(
+                config_version=config_version,
+                items=[{"key": "STOCK_LIST", "value": new_value}],
+                mask_token="******",
+                reload_now=True,
+            )
+        return WatchlistResponse(stock_codes=codes, message=f"已移除 {request.stock_code}")
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"从自选删除失败: {e}", exc_info=True)
+        raise HTTPException(
+            status_code=500,
+            detail={"error": "internal_error", "message": f"从自选删除失败: {str(e)}"},
+        )
 
 
 @router.get(

--- a/api/v1/endpoints/stocks.py
+++ b/api/v1/endpoints/stocks.py
@@ -39,6 +39,7 @@ from src.services.import_parser import (
 )
 from src.services.stock_service import StockService
 from src.services.system_config_service import SystemConfigService
+from data_provider.base import normalize_stock_code
 
 logger = logging.getLogger(__name__)
 
@@ -46,6 +47,53 @@ router = APIRouter()
 
 # 须在 /{stock_code} 路由之前定义
 ALLOWED_MIME_STR = ", ".join(ALLOWED_MIME)
+
+
+def _read_watchlist_codes(service: SystemConfigService) -> list:
+    """Read current STOCK_LIST codes, preserving original order."""
+    config_data = service.get_config(include_schema=False)
+    stock_list_str = ""
+    for item in config_data.get("items", []):
+        if item.get("key") == "STOCK_LIST":
+            stock_list_str = str(item.get("value", ""))
+            break
+    return [c.strip() for c in stock_list_str.split(",") if c.strip()]
+
+
+def _write_watchlist_codes(service: SystemConfigService, codes: list) -> None:
+    """Persist normalized stock codes to STOCK_LIST."""
+    config_data = service.get_config(include_schema=False)
+    config_version = config_data.get("config_version", "")
+    new_value = ",".join(codes)
+    service.update(
+        config_version=config_version,
+        items=[{"key": "STOCK_LIST", "value": new_value}],
+        mask_token="******",
+        reload_now=True,
+    )
+
+
+def _validate_and_normalize_stock_code(code: str) -> str:
+    """Validate stock code format and return normalized form.
+
+    Raises HTTPException(400) if the code does not look like a valid stock code.
+    """
+    stripped = code.strip()
+    if not stripped:
+        raise HTTPException(
+            status_code=400,
+            detail={"error": "invalid_stock_code", "message": "股票代码不能为空"},
+        )
+    normalized = normalize_stock_code(stripped)
+    if not normalized or len(normalized) < 2:
+        raise HTTPException(
+            status_code=400,
+            detail={
+                "error": "invalid_stock_code",
+                "message": f"'{stripped}' 不是合法的股票代码格式",
+            },
+        )
+    return normalized
 
 
 @router.post(
@@ -257,13 +305,7 @@ def get_watchlist(
     service: SystemConfigService = Depends(get_system_config_service),
 ) -> WatchlistResponse:
     try:
-        config_data = service.get_config(include_schema=False)
-        stock_list_str = ""
-        for item in config_data.get("items", []):
-            if item.get("key") == "STOCK_LIST":
-                stock_list_str = str(item.get("value", ""))
-                break
-        codes = [c.strip() for c in stock_list_str.split(",") if c.strip()]
+        codes = _read_watchlist_codes(service)
         return WatchlistResponse(stock_codes=codes, message=f"当前自选 {len(codes)} 只股票")
     except Exception as e:
         logger.error(f"获取自选队列失败: {e}", exc_info=True)
@@ -289,24 +331,12 @@ def add_to_watchlist(
     service: SystemConfigService = Depends(get_system_config_service),
 ) -> WatchlistResponse:
     try:
-        config_data = service.get_config(include_schema=False)
-        config_version = config_data.get("config_version", "")
-        stock_list_str = ""
-        for item in config_data.get("items", []):
-            if item.get("key") == "STOCK_LIST":
-                stock_list_str = str(item.get("value", ""))
-                break
-        codes = [c.strip() for c in stock_list_str.split(",") if c.strip()]
-        if request.stock_code not in codes:
-            codes.append(request.stock_code)
-            new_value = ",".join(codes)
-            service.update(
-                config_version=config_version,
-                items=[{"key": "STOCK_LIST", "value": new_value}],
-                mask_token="******",
-                reload_now=True,
-            )
-        return WatchlistResponse(stock_codes=codes, message=f"已加入 {request.stock_code}")
+        normalized = _validate_and_normalize_stock_code(request.stock_code)
+        codes = _read_watchlist_codes(service)
+        if normalized not in codes:
+            codes.append(normalized)
+            _write_watchlist_codes(service, codes)
+        return WatchlistResponse(stock_codes=codes, message=f"已加入 {normalized}")
     except HTTPException:
         raise
     except Exception as e:
@@ -333,24 +363,12 @@ def remove_from_watchlist(
     service: SystemConfigService = Depends(get_system_config_service),
 ) -> WatchlistResponse:
     try:
-        config_data = service.get_config(include_schema=False)
-        config_version = config_data.get("config_version", "")
-        stock_list_str = ""
-        for item in config_data.get("items", []):
-            if item.get("key") == "STOCK_LIST":
-                stock_list_str = str(item.get("value", ""))
-                break
-        codes = [c.strip() for c in stock_list_str.split(",") if c.strip()]
-        if request.stock_code in codes:
-            codes.remove(request.stock_code)
-            new_value = ",".join(codes)
-            service.update(
-                config_version=config_version,
-                items=[{"key": "STOCK_LIST", "value": new_value}],
-                mask_token="******",
-                reload_now=True,
-            )
-        return WatchlistResponse(stock_codes=codes, message=f"已移除 {request.stock_code}")
+        normalized = _validate_and_normalize_stock_code(request.stock_code)
+        codes = _read_watchlist_codes(service)
+        if normalized in codes:
+            codes.remove(normalized)
+            _write_watchlist_codes(service, codes)
+        return WatchlistResponse(stock_codes=codes, message=f"已移除 {normalized}")
     except HTTPException:
         raise
     except Exception as e:

--- a/api/v1/schemas/history.py
+++ b/api/v1/schemas/history.py
@@ -301,6 +301,59 @@ class MarkdownReportResponse(BaseModel):
     })
 
 
+class StockBarItem(BaseModel):
+    """个股栏条目（去重后的股票维度摘要）"""
+
+    id: int = Field(..., description="该股最新一次分析的历史记录主键 ID")
+    stock_code: str = Field(..., description="股票代码")
+    stock_name: Optional[str] = Field(None, description="股票名称")
+    report_type: Optional[str] = Field(None, description="报告类型")
+    sentiment_score: Optional[int] = Field(
+        None,
+        description="最新情绪评分",
+    )
+    operation_advice: Optional[str] = Field(None, description="最新操作建议")
+    analysis_count: int = Field(..., description="该股票的历史分析总次数")
+    last_analysis_time: Optional[str] = Field(None, description="最近一次分析时间")
+    model_used: Optional[str] = Field(
+        None,
+        description="最新分析使用的模型快照",
+    )
+    model_config = ConfigDict(json_schema_extra={
+        "example": {
+            "id": 1234,
+            "stock_code": "600519",
+            "stock_name": "贵州茅台",
+            "report_type": "detailed",
+            "sentiment_score": 75,
+            "operation_advice": "持有",
+            "analysis_count": 18,
+            "last_analysis_time": "2024-01-01T12:00:00",
+            "model_used": "Gemini 2.5 Pro",
+        }
+    })
+
+
+class StockBarResponse(BaseModel):
+    """个股栏列表响应"""
+
+    total: int = Field(..., description="不重复个股数")
+    items: List[StockBarItem] = Field(default_factory=list, description="个股列表")
+
+
+class WatchlistRequest(BaseModel):
+    """自选队列操作请求"""
+
+    stock_code: str = Field(..., description="股票代码", min_length=1)
+
+
+class WatchlistResponse(BaseModel):
+    """自选队列响应"""
+
+    stock_codes: List[str] = Field(default_factory=list, description="当前自选队列股票代码列表")
+    message: str = Field(..., description="操作结果描述")
+
+
 class RunDiagnosticComponent(BaseModel):
     """单个运行诊断组件摘要。"""
 

--- a/apps/dsa-web/src/api/history.ts
+++ b/apps/dsa-web/src/api/history.ts
@@ -8,6 +8,7 @@ import type {
   NewsIntelResponse,
   NewsIntelItem,
   RunDiagnosticSummary,
+  StockBarResponse,
 } from '../types/analysis';
 
 // ============ API 接口 ============
@@ -98,5 +99,29 @@ export const historyApi = {
     });
 
     return toCamelCase<{ deleted: number }>(response.data);
+  },
+
+  /**
+   * 获取个股栏列表（不重复个股，大盘复盘置顶）
+   */
+  getStockBarList: async (params: {
+    startDate?: string;
+    endDate?: string;
+    limit?: number;
+  } = {}): Promise<StockBarResponse> => {
+    const queryParams: Record<string, string | number> = {};
+    if (params.startDate) queryParams.start_date = params.startDate;
+    if (params.endDate) queryParams.end_date = params.endDate;
+    if (params.limit) queryParams.limit = params.limit;
+
+    const response = await apiClient.get<Record<string, unknown>>('/api/v1/history/stocks', {
+      params: queryParams,
+    });
+
+    const data = toCamelCase<{ total: number; items: unknown[] }>(response.data);
+    return {
+      total: data.total,
+      items: data.items.map(item => toCamelCase<Record<string, unknown>>(item) as unknown as typeof data.items[0]),
+    } as StockBarResponse;
   },
 };

--- a/apps/dsa-web/src/api/history.ts
+++ b/apps/dsa-web/src/api/history.ts
@@ -102,6 +102,15 @@ export const historyApi = {
   },
 
   /**
+   * 按股票代码删除所有历史记录
+   * @param stockCode 股票代码
+   */
+  deleteByCode: async (stockCode: string): Promise<{ deleted: number }> => {
+    const response = await apiClient.delete<Record<string, unknown>>(`/api/v1/history/by-code/${encodeURIComponent(stockCode)}`);
+    return toCamelCase<{ deleted: number }>(response.data);
+  },
+
+  /**
    * 获取个股栏列表（不重复个股，大盘复盘置顶）
    */
   getStockBarList: async (params: {

--- a/apps/dsa-web/src/api/systemConfig.ts
+++ b/apps/dsa-web/src/api/systemConfig.ts
@@ -235,4 +235,35 @@ export const systemConfigApi = {
       throw error;
     }
   },
+
+  /**
+   * 获取自选队列股票代码列表
+   */
+  getWatchlist: async (): Promise<string[]> => {
+    const response = await apiClient.get<Record<string, unknown>>('/api/v1/stocks/watchlist');
+    const data = toCamelCase<{ stockCodes: string[] }>(response.data);
+    return data.stockCodes || [];
+  },
+
+  /**
+   * 添加股票到自选队列
+   */
+  addToWatchlist: async (stockCode: string): Promise<string[]> => {
+    const response = await apiClient.post<Record<string, unknown>>('/api/v1/stocks/watchlist/add', {
+      stock_code: stockCode,
+    });
+    const data = toCamelCase<{ stockCodes: string[] }>(response.data);
+    return data.stockCodes || [];
+  },
+
+  /**
+   * 从自选队列移除股票
+   */
+  removeFromWatchlist: async (stockCode: string): Promise<string[]> => {
+    const response = await apiClient.post<Record<string, unknown>>('/api/v1/stocks/watchlist/remove', {
+      stock_code: stockCode,
+    });
+    const data = toCamelCase<{ stockCodes: string[] }>(response.data);
+    return data.stockCodes || [];
+  },
 };

--- a/apps/dsa-web/src/components/history/StockBar.tsx
+++ b/apps/dsa-web/src/components/history/StockBar.tsx
@@ -1,5 +1,6 @@
 import type React from 'react';
-import { ScrollArea } from '../common';
+import { useState, useCallback, useRef, useEffect, useId } from 'react';
+import { Badge, Button, ScrollArea } from '../common';
 import { DashboardPanelHeader, DashboardStateBlock } from '../dashboard';
 import { StockBarItemComponent } from './StockBarItem';
 import type { StockBarItem as StockBarItemType } from '../../types/analysis';
@@ -10,12 +11,14 @@ interface StockBarProps {
   selectedStockCode?: string;
   selectedRecordId?: number;
   onItemClick: (recordId: number) => void;
+  onDeleteStock?: (stockCode: string) => Promise<void> | void;
+  isDeleting?: boolean;
   className?: string;
 }
 
 /**
  * 个股栏组件：以股票维度展示历史分析记录，每只股票只显示一条，
- * 大盘复盘置顶，其余按最新分析时间排列。
+ * 大盘复盘置顶，其余按最新分析时间排列。支持全选、批量删除。
  */
 export const StockBar: React.FC<StockBarProps> = ({
   items,
@@ -23,9 +26,50 @@ export const StockBar: React.FC<StockBarProps> = ({
   selectedStockCode,
   selectedRecordId,
   onItemClick,
+  onDeleteStock,
+  isDeleting = false,
   className = '',
 }) => {
   const isMarketReview = (code: string) => code === 'MARKET';
+  const [selectedCodes, setSelectedCodes] = useState<Set<string>>(new Set());
+  const selectAllRef = useRef<HTMLInputElement>(null);
+  const selectAllId = useId();
+
+  const deletableItems = items.filter((item) => !isMarketReview(item.stockCode));
+  const selectedCount = [...selectedCodes].filter((code) => deletableItems.some((item) => item.stockCode === code)).length;
+  const allVisibleSelected = deletableItems.length > 0 && selectedCount === deletableItems.length;
+  const someVisibleSelected = selectedCount > 0 && !allVisibleSelected;
+
+  useEffect(() => {
+    if (selectAllRef.current) {
+      selectAllRef.current.indeterminate = someVisibleSelected;
+    }
+  }, [someVisibleSelected]);
+
+  const toggleCode = useCallback((code: string) => {
+    setSelectedCodes((prev) => {
+      const next = new Set(prev);
+      if (next.has(code)) next.delete(code);
+      else next.add(code);
+      return next;
+    });
+  }, []);
+
+  const toggleSelectAll = useCallback(() => {
+    setSelectedCodes((prev) => {
+      if (prev.size === deletableItems.length) return new Set();
+      return new Set(deletableItems.map((item) => item.stockCode));
+    });
+  }, [deletableItems]);
+
+  const handleDeleteSelected = useCallback(async () => {
+    if (!onDeleteStock || selectedCodes.size === 0) return;
+    const codesToDelete = [...selectedCodes];
+    for (const code of codesToDelete) {
+      await onDeleteStock(code);
+    }
+    setSelectedCodes(new Set());
+  }, [onDeleteStock, selectedCodes]);
 
   return (
     <aside className={`glass-card overflow-hidden flex flex-col ${className}`}>
@@ -45,11 +89,46 @@ export const StockBar: React.FC<StockBarProps> = ({
             )}
             headingClassName="items-center"
             actions={
-              items.length > 0 ? (
+              selectedCount > 0 ? (
+                <Badge variant="info" size="sm" className="animate-in fade-in zoom-in duration-200">
+                  已选 {selectedCount}
+                </Badge>
+              ) : items.length > 0 ? (
                 <span className="text-[11px] text-muted-text">{items.length}只</span>
               ) : undefined
             }
           />
+
+          {items.length > 0 && onDeleteStock && (
+            <div className="flex items-center gap-2">
+              <label
+                className="flex flex-1 cursor-pointer items-center gap-2 rounded-lg px-2 py-1"
+                htmlFor={selectAllId}
+              >
+                <input
+                  id={selectAllId}
+                  ref={selectAllRef}
+                  type="checkbox"
+                  checked={allVisibleSelected}
+                  onChange={toggleSelectAll}
+                  disabled={isDeleting}
+                  aria-label="全选当前个股"
+                  className="h-3.5 w-3.5 cursor-pointer bg-transparent accent-primary focus:ring-primary/30 disabled:opacity-50"
+                />
+                <span className="text-[11px] text-muted-text select-none">全选当前</span>
+              </label>
+              <Button
+                variant="danger-subtle"
+                size="xsm"
+                onClick={() => void handleDeleteSelected()}
+                disabled={selectedCount === 0 || isDeleting}
+                isLoading={isDeleting}
+                className="disabled:!border-transparent disabled:!bg-transparent"
+              >
+                {isDeleting ? '删除中' : '删除'}
+              </Button>
+            </div>
+          )}
         </div>
 
         {isLoading ? (
@@ -74,15 +153,30 @@ export const StockBar: React.FC<StockBarProps> = ({
               const code = item.stockCode || '';
               const isMarket = isMarketReview(code);
               const isSelected = selectedRecordId === item.id || selectedStockCode === code;
+              const isChecked = selectedCodes.has(code);
 
               return (
-                <StockBarItemComponent
-                  key={`${code}-${item.id}`}
-                  item={item}
-                  isViewing={isSelected}
-                  onClick={onItemClick}
-                  isMarketReview={isMarket}
-                />
+                <div key={`${code}-${item.id}`} className="flex items-start gap-2 group">
+                  {!isMarket && onDeleteStock && (
+                    <div className="pt-5">
+                      <input
+                        type="checkbox"
+                        checked={isChecked}
+                        onChange={() => toggleCode(code)}
+                        disabled={isDeleting}
+                        className="h-3.5 w-3.5 cursor-pointer rounded border-subtle-hover bg-transparent accent-primary focus:ring-primary/30 disabled:opacity-50"
+                      />
+                    </div>
+                  )}
+                  <StockBarItemComponent
+                    item={item}
+                    isViewing={isSelected}
+                    onClick={onItemClick}
+                    onDelete={isMarket ? undefined : onDeleteStock}
+                    isDeleting={isDeleting}
+                    isMarketReview={isMarket}
+                  />
+                </div>
               );
             })}
           </div>

--- a/apps/dsa-web/src/components/history/StockBar.tsx
+++ b/apps/dsa-web/src/components/history/StockBar.tsx
@@ -1,0 +1,93 @@
+import type React from 'react';
+import { ScrollArea } from '../common';
+import { DashboardPanelHeader, DashboardStateBlock } from '../dashboard';
+import { StockBarItemComponent } from './StockBarItem';
+import type { StockBarItem as StockBarItemType } from '../../types/analysis';
+
+interface StockBarProps {
+  items: StockBarItemType[];
+  isLoading: boolean;
+  selectedStockCode?: string;
+  selectedRecordId?: number;
+  onItemClick: (recordId: number) => void;
+  className?: string;
+}
+
+/**
+ * 个股栏组件：以股票维度展示历史分析记录，每只股票只显示一条，
+ * 大盘复盘置顶，其余按最新分析时间排列。
+ */
+export const StockBar: React.FC<StockBarProps> = ({
+  items,
+  isLoading,
+  selectedStockCode,
+  selectedRecordId,
+  onItemClick,
+  className = '',
+}) => {
+  const isMarketReview = (code: string) => code === 'MARKET';
+
+  return (
+    <aside className={`glass-card overflow-hidden flex flex-col ${className}`}>
+      <ScrollArea
+        viewportClassName="p-4"
+        testId="home-stock-bar-scroll"
+      >
+        <div className="mb-4 space-y-3">
+          <DashboardPanelHeader
+            className="mb-1"
+            title="个股栏"
+            titleClassName="text-sm font-medium"
+            leading={(
+              <svg className="h-4 w-4 text-primary" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3 7v10a2 2 0 002 2h14a2 2 0 002-2V9a2 2 0 00-2-2h-6l-2-2H5a2 2 0 00-2 2z" />
+              </svg>
+            )}
+            headingClassName="items-center"
+            actions={
+              items.length > 0 ? (
+                <span className="text-[11px] text-muted-text">{items.length}只</span>
+              ) : undefined
+            }
+          />
+        </div>
+
+        {isLoading ? (
+          <DashboardStateBlock
+            loading
+            compact
+            title="加载个股中..."
+          />
+        ) : items.length === 0 ? (
+          <DashboardStateBlock
+            title="暂无个股记录"
+            description="完成首次分析后，这里将按股票展示最新分析结果。"
+            icon={(
+              <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" />
+              </svg>
+            )}
+          />
+        ) : (
+          <div className="space-y-1.5">
+            {items.map((item) => {
+              const code = item.stockCode || '';
+              const isMarket = isMarketReview(code);
+              const isSelected = selectedRecordId === item.id || selectedStockCode === code;
+
+              return (
+                <StockBarItemComponent
+                  key={`${code}-${item.id}`}
+                  item={item}
+                  isViewing={isSelected}
+                  onClick={onItemClick}
+                  isMarketReview={isMarket}
+                />
+              );
+            })}
+          </div>
+        )}
+      </ScrollArea>
+    </aside>
+  );
+};

--- a/apps/dsa-web/src/components/history/StockBarItem.tsx
+++ b/apps/dsa-web/src/components/history/StockBarItem.tsx
@@ -1,0 +1,125 @@
+import type React from 'react';
+import { Badge } from '../common';
+import type { StockBarItem as StockBarItemType } from '../../types/analysis';
+import { getSentimentColor } from '../../types/analysis';
+import { formatDateTime } from '../../utils/format';
+import { truncateStockName, isStockNameTruncated } from '../../utils/stockName';
+
+interface StockBarItemProps {
+  item: StockBarItemType;
+  isViewing: boolean;
+  onClick: (recordId: number) => void;
+  isMarketReview?: boolean;
+}
+
+const getOperationBadgeLabel = (advice?: string) => {
+  const normalized = advice?.trim();
+  if (!normalized) return null;
+  if (normalized.includes('减仓')) return '减仓';
+  if (normalized.includes('卖')) return '卖出';
+  if (normalized.includes('观望') || normalized.includes('等待')) return '观望';
+  if (normalized.includes('买') || normalized.includes('布局')) return '买入';
+  return normalized.split(/[，。；、\s]/)[0] || '建议';
+};
+
+export const StockBarItemComponent: React.FC<StockBarItemProps> = ({
+  item,
+  isViewing,
+  onClick,
+  isMarketReview = false,
+}) => {
+  const sentimentColor = item.sentimentScore !== undefined ? getSentimentColor(item.sentimentScore) : null;
+  const stockName = item.stockName || item.stockCode;
+  const isTruncated = isStockNameTruncated(stockName);
+  const operationLabel = getOperationBadgeLabel(item.operationAdvice);
+
+  return (
+    <button
+      type="button"
+      onClick={() => onClick(item.id)}
+      className={`home-history-item w-full text-left p-2.5 group/item ${
+        isViewing ? 'home-history-item-selected' : ''
+      }`}
+    >
+      <div className={`flex items-center gap-2.5 relative z-10${isTruncated ? ' group-hover/item:z-20' : ''}`}>
+        {isMarketReview ? (
+          <div className="w-1 h-8 rounded-full flex-shrink-0 bg-amber-400" style={{ boxShadow: '0 0 10px rgba(251,191,36,0.4)' }} />
+        ) : sentimentColor ? (
+          <div
+            className="w-1 h-8 rounded-full flex-shrink-0"
+            style={{
+              backgroundColor: sentimentColor,
+              boxShadow: `0 0 10px ${sentimentColor}40`,
+            }}
+          />
+        ) : (
+          <div className="w-1 h-8 rounded-full flex-shrink-0 bg-subtle" />
+        )}
+        <div className="flex-1 min-w-0">
+          <div className="flex items-start justify-between gap-2">
+            <div className="min-w-0 flex-1">
+              <span className="truncate text-sm font-semibold text-foreground tracking-tight">
+                <span className="group-hover/item:hidden">
+                  {truncateStockName(stockName)}
+                </span>
+                <span className="hidden group-hover/item:inline">
+                  {stockName}
+                </span>
+              </span>
+            </div>
+            <div className="flex items-center gap-1 shrink-0">
+              {isMarketReview ? (
+                <Badge
+                  variant="default"
+                  size="sm"
+                  className="shrink-0 shadow-none text-[10px] font-semibold leading-none"
+                  style={{
+                    color: '#f59e0b',
+                    borderColor: 'rgba(245,158,11,0.3)',
+                    backgroundColor: 'rgba(245,158,11,0.1)',
+                  }}
+                >
+                  大盘
+                </Badge>
+              ) : operationLabel && sentimentColor ? (
+                <Badge
+                  variant="default"
+                  size="sm"
+                  className="home-history-sentiment-badge shrink-0 shadow-none text-[11px] font-semibold leading-none transition-opacity duration-200"
+                  style={{
+                    color: sentimentColor,
+                    borderColor: `${sentimentColor}30`,
+                    backgroundColor: `${sentimentColor}10`,
+                  }}
+                >
+                  {operationLabel} {item.sentimentScore}
+                </Badge>
+              ) : null}
+            </div>
+          </div>
+          <div className="flex items-center gap-2 mt-1">
+            <span className="text-[11px] text-secondary-text font-mono">
+              {item.stockCode}
+            </span>
+            {item.lastAnalysisTime && (
+              <>
+                <span className="w-1 h-1 rounded-full bg-subtle-hover" />
+                <span className="text-[11px] text-muted-text">
+                  {formatDateTime(item.lastAnalysisTime)}
+                </span>
+              </>
+            )}
+            {item.analysisCount > 1 && !isMarketReview && (
+              <>
+                <span className="w-1 h-1 rounded-full bg-subtle-hover" />
+                <span className="text-[10px] text-muted-text">
+                  {item.analysisCount}次
+                </span>
+              </>
+            )}
+          </div>
+        </div>
+      </div>
+    </button>
+  );
+};

--- a/apps/dsa-web/src/components/history/StockBarItem.tsx
+++ b/apps/dsa-web/src/components/history/StockBarItem.tsx
@@ -1,5 +1,5 @@
 import type React from 'react';
-import { Badge } from '../common';
+import { Badge, Button } from '../common';
 import type { StockBarItem as StockBarItemType } from '../../types/analysis';
 import { getSentimentColor } from '../../types/analysis';
 import { formatDateTime } from '../../utils/format';
@@ -9,6 +9,8 @@ interface StockBarItemProps {
   item: StockBarItemType;
   isViewing: boolean;
   onClick: (recordId: number) => void;
+  onDelete?: (stockCode: string) => void;
+  isDeleting?: boolean;
   isMarketReview?: boolean;
 }
 
@@ -26,6 +28,8 @@ export const StockBarItemComponent: React.FC<StockBarItemProps> = ({
   item,
   isViewing,
   onClick,
+  onDelete,
+  isDeleting = false,
   isMarketReview = false,
 }) => {
   const sentimentColor = item.sentimentScore !== undefined ? getSentimentColor(item.sentimentScore) : null;
@@ -95,6 +99,23 @@ export const StockBarItemComponent: React.FC<StockBarItemProps> = ({
                   {operationLabel} {item.sentimentScore}
                 </Badge>
               ) : null}
+              {onDelete && !isMarketReview && (
+                <Button
+                  variant="ghost"
+                  size="xsm"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    onDelete(item.stockCode);
+                  }}
+                  disabled={isDeleting}
+                  className="opacity-0 group-hover/item:opacity-100 transition-opacity h-6 w-6 p-0 flex items-center justify-center"
+                  aria-label={`删除 ${item.stockName || item.stockCode} 历史记录`}
+                >
+                  <svg className="h-3.5 w-3.5 text-danger" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
+                  </svg>
+                </Button>
+              )}
             </div>
           </div>
           <div className="flex items-center gap-2 mt-1">

--- a/apps/dsa-web/src/components/history/index.ts
+++ b/apps/dsa-web/src/components/history/index.ts
@@ -1,3 +1,5 @@
 export { HistoryList } from './HistoryList';
 export { HistoryListItem } from './HistoryListItem';
+export { StockBar } from './StockBar';
+export { StockBarItemComponent } from './StockBarItem';
 export { StockHistoryTrendDrawer } from './StockHistoryTrendDrawer';

--- a/apps/dsa-web/src/components/report/ReportOverview.tsx
+++ b/apps/dsa-web/src/components/report/ReportOverview.tsx
@@ -4,7 +4,7 @@ import type {
   ReportMeta,
   ReportSummary as ReportSummaryType,
 } from '../../types/analysis';
-import { Badge, Card, ScoreGauge } from '../common';
+import { Badge, Button, Card, ScoreGauge } from '../common';
 import { formatDateTime } from '../../utils/format';
 import { getReportText, normalizeReportLanguage } from '../../utils/reportLanguage';
 
@@ -13,6 +13,12 @@ interface ReportOverviewProps {
   summary: ReportSummaryType;
   details?: ReportDetailsType;
   isHistory?: boolean;
+  watchlist?: {
+    isInWatchlist: (code: string) => boolean;
+    onToggle: (code: string) => void;
+    isActioning: boolean;
+    actionMessage: string | null;
+  };
 }
 
 type BoardStatus = 'leading' | 'lagging';
@@ -77,6 +83,7 @@ export const ReportOverview: React.FC<ReportOverviewProps> = ({
   meta,
   summary,
   details,
+  watchlist,
 }) => {
   const reportLanguage = normalizeReportLanguage(meta.reportLanguage);
   const text = getReportText(reportLanguage);
@@ -269,8 +276,28 @@ export const ReportOverview: React.FC<ReportOverviewProps> = ({
           </div>
         </div>
 
-        {/* 右侧：情绪指标 / 关联详情 */}
-        <div className="flex flex-col">
+        {/* 右侧：情绪指标 / 自选操作 */}
+        <div className="flex flex-col space-y-4">
+          {watchlist && meta.reportType !== 'market_review' && (
+            <Card variant="bordered" padding="sm" className="home-panel-card">
+              <div className="text-center space-y-3">
+                <span className="label-uppercase">自选</span>
+                <div className="text-xs text-muted-text font-mono">{meta.stockCode}</div>
+                <Button
+                  variant={watchlist.isInWatchlist(meta.stockCode) ? 'danger-subtle' : 'secondary'}
+                  size="sm"
+                  isLoading={watchlist.isActioning}
+                  onClick={() => watchlist.onToggle(meta.stockCode)}
+                  className="w-full text-xs"
+                >
+                  {watchlist.isInWatchlist(meta.stockCode) ? '从自选删除' : '加入自选'}
+                </Button>
+                {watchlist.actionMessage && (
+                  <p className="text-[11px] text-secondary-text animate-in fade-in">{watchlist.actionMessage}</p>
+                )}
+              </div>
+            </Card>
+          )}
           <Card variant="bordered" padding="md" className="home-panel-card home-rail-card !overflow-visible">
             <div className="text-center">
               <h3 className="mb-5 text-sm font-medium tracking-wide text-foreground">{text.marketSentiment}</h3>

--- a/apps/dsa-web/src/components/report/ReportSummary.tsx
+++ b/apps/dsa-web/src/components/report/ReportSummary.tsx
@@ -11,6 +11,13 @@ import { getReportText, normalizeReportLanguage } from '../../utils/reportLangua
 interface ReportSummaryProps {
   data: AnalysisResult | AnalysisReport;
   isHistory?: boolean;
+  /** 自选相关 */
+  watchlist?: {
+    isInWatchlist: (code: string) => boolean;
+    onToggle: (code: string) => void;
+    isActioning: boolean;
+    actionMessage: string | null;
+  };
 }
 
 /**
@@ -20,6 +27,7 @@ interface ReportSummaryProps {
 export const ReportSummary: React.FC<ReportSummaryProps> = ({
   data,
   isHistory = false,
+  watchlist,
 }) => {
   // 兼容 AnalysisResult 和 AnalysisReport 两种数据格式
   const report: AnalysisReport = 'report' in data ? data.report : data;
@@ -43,6 +51,7 @@ export const ReportSummary: React.FC<ReportSummaryProps> = ({
         summary={summary}
         details={details}
         isHistory={isHistory}
+        watchlist={watchlist}
       />
 
       {/* 策略点位区 */}

--- a/apps/dsa-web/src/hooks/__tests__/useDashboardLifecycle.test.tsx
+++ b/apps/dsa-web/src/hooks/__tests__/useDashboardLifecycle.test.tsx
@@ -17,6 +17,11 @@ const createTask = () => ({
   createdAt: '2026-03-18T08:00:00Z',
 });
 
+const defaultMocks = {
+  loadStockBar: vi.fn().mockResolvedValue(undefined),
+  refreshStockBar: vi.fn().mockResolvedValue(undefined),
+};
+
 describe('useDashboardLifecycle', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -41,6 +46,7 @@ describe('useDashboardLifecycle', () => {
         syncTaskUpdated: vi.fn(),
         syncTaskFailed: vi.fn(),
         removeTask: vi.fn(),
+        ...defaultMocks,
       }),
     );
 
@@ -77,6 +83,7 @@ describe('useDashboardLifecycle', () => {
         syncTaskUpdated: vi.fn(),
         syncTaskFailed: vi.fn(),
         removeTask,
+        ...defaultMocks,
       }),
     );
 
@@ -110,6 +117,7 @@ describe('useDashboardLifecycle', () => {
         syncTaskUpdated,
         syncTaskFailed: vi.fn(),
         removeTask,
+        ...defaultMocks,
       }),
     );
 
@@ -142,6 +150,7 @@ describe('useDashboardLifecycle', () => {
         syncTaskUpdated,
         syncTaskFailed: vi.fn(),
         removeTask: vi.fn(),
+        ...defaultMocks,
       }),
     );
 
@@ -173,6 +182,7 @@ describe('useDashboardLifecycle', () => {
         syncTaskUpdated: vi.fn(),
         syncTaskFailed,
         removeTask,
+        ...defaultMocks,
       }),
     );
 
@@ -208,6 +218,7 @@ describe('useDashboardLifecycle', () => {
         syncTaskUpdated: vi.fn(),
         syncTaskFailed: vi.fn(),
         removeTask: vi.fn(),
+        ...defaultMocks,
       }),
     );
 

--- a/apps/dsa-web/src/hooks/useDashboardLifecycle.ts
+++ b/apps/dsa-web/src/hooks/useDashboardLifecycle.ts
@@ -6,6 +6,8 @@ type UseDashboardLifecycleOptions = {
   loadInitialHistory: () => Promise<void>;
   refreshHistory: (silent?: boolean) => Promise<void>;
   refreshActiveTasks: () => Promise<void>;
+  loadStockBar: () => Promise<void>;
+  refreshStockBar: () => Promise<void>;
   syncTaskCreated: (task: TaskInfo) => void;
   syncTaskUpdated: (task: TaskInfo) => void;
   syncTaskFailed: (task: TaskInfo) => void;
@@ -17,6 +19,8 @@ export function useDashboardLifecycle({
   loadInitialHistory,
   refreshHistory,
   refreshActiveTasks,
+  loadStockBar,
+  refreshStockBar,
   syncTaskCreated,
   syncTaskUpdated,
   syncTaskFailed,
@@ -31,8 +35,9 @@ export function useDashboardLifecycle({
     }
 
     void loadInitialHistory();
+    void loadStockBar();
     void refreshActiveTasks();
-  }, [enabled, loadInitialHistory, refreshActiveTasks]);
+  }, [enabled, loadInitialHistory, loadStockBar, refreshActiveTasks]);
 
   useEffect(() => {
     if (!enabled) {
@@ -41,11 +46,12 @@ export function useDashboardLifecycle({
 
     const intervalId = window.setInterval(() => {
       void refreshHistory(true);
+      void refreshStockBar();
       void refreshActiveTasks();
     }, 30_000);
 
     return () => window.clearInterval(intervalId);
-  }, [enabled, refreshHistory, refreshActiveTasks]);
+  }, [enabled, refreshHistory, refreshStockBar, refreshActiveTasks]);
 
   useEffect(() => {
     if (!enabled) {
@@ -55,13 +61,14 @@ export function useDashboardLifecycle({
     const handleVisibilityChange = () => {
       if (document.visibilityState === 'visible') {
         void refreshHistory(true);
+        void refreshStockBar();
         void refreshActiveTasks();
       }
     };
 
     document.addEventListener('visibilitychange', handleVisibilityChange);
     return () => document.removeEventListener('visibilitychange', handleVisibilityChange);
-  }, [enabled, refreshHistory, refreshActiveTasks]);
+  }, [enabled, refreshHistory, refreshStockBar, refreshActiveTasks]);
 
   useEffect(() => {
     return () => {
@@ -89,6 +96,7 @@ export function useDashboardLifecycle({
     onTaskCompleted: (task) => {
       syncTaskUpdated(task);
       void refreshHistory(true);
+      void refreshStockBar();
       scheduleTaskRemoval(task.taskId, 2_000);
     },
     onTaskFailed: (task) => {

--- a/apps/dsa-web/src/hooks/useHomeDashboardState.ts
+++ b/apps/dsa-web/src/hooks/useHomeDashboardState.ts
@@ -55,6 +55,10 @@ export function useHomeDashboardState() {
       closeHistoryTrend: state.closeHistoryTrend,
       setStockHistoryRange: state.setStockHistoryRange,
       loadMoreStockHistory: state.loadMoreStockHistory,
+      stockBarItems: state.stockBarItems,
+      isLoadingStockBar: state.isLoadingStockBar,
+      loadStockBar: state.loadStockBar,
+      refreshStockBar: state.refreshStockBar,
     })),
   );
 

--- a/apps/dsa-web/src/hooks/useWatchlist.ts
+++ b/apps/dsa-web/src/hooks/useWatchlist.ts
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { systemConfigApi } from '../api/systemConfig';
+import { normalizeStockCode } from '../utils/stockCode';
 
 export interface UseWatchlistReturn {
   watchlistCodes: string[];
@@ -64,7 +65,7 @@ export function useWatchlist(): UseWatchlistReturn {
   }, []);
 
   const isInWatchlist = useCallback(
-    (stockCode: string) => codes.includes(stockCode),
+    (stockCode: string) => codes.includes(normalizeStockCode(stockCode)),
     [codes],
   );
 

--- a/apps/dsa-web/src/hooks/useWatchlist.ts
+++ b/apps/dsa-web/src/hooks/useWatchlist.ts
@@ -1,0 +1,122 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { systemConfigApi } from '../api/systemConfig';
+
+export interface UseWatchlistReturn {
+  watchlistCodes: string[];
+  isLoading: boolean;
+  isActioning: boolean;
+  actionMessage: string | null;
+  isInWatchlist: (stockCode: string) => boolean;
+  addToWatchlist: (stockCode: string) => Promise<void>;
+  removeFromWatchlist: (stockCode: string) => Promise<void>;
+  toggleWatchlist: (stockCode: string) => Promise<void>;
+  refresh: () => Promise<void>;
+}
+
+export function useWatchlist(): UseWatchlistReturn {
+  const [codes, setCodes] = useState<string[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [isActioning, setIsActioning] = useState(false);
+  const [actionMessage, setActionMessage] = useState<string | null>(null);
+  const messageTimerRef = useRef<number | null>(null);
+  const mountedRef = useRef(true);
+
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+      if (messageTimerRef.current !== null) {
+        window.clearTimeout(messageTimerRef.current);
+      }
+    };
+  }, []);
+
+  const refresh = useCallback(async () => {
+    try {
+      const result = await systemConfigApi.getWatchlist();
+      if (mountedRef.current) {
+        setCodes(result);
+      }
+    } catch {
+      // keep existing codes
+    }
+  }, []);
+
+  useEffect(() => {
+    setIsLoading(true);
+    void refresh().finally(() => {
+      if (mountedRef.current) {
+        setIsLoading(false);
+      }
+    });
+  }, [refresh]);
+
+  const showMessage = useCallback((msg: string) => {
+    if (messageTimerRef.current !== null) {
+      window.clearTimeout(messageTimerRef.current);
+    }
+    setActionMessage(msg);
+    messageTimerRef.current = window.setTimeout(() => {
+      if (mountedRef.current) {
+        setActionMessage(null);
+      }
+    }, 3000);
+  }, []);
+
+  const isInWatchlist = useCallback(
+    (stockCode: string) => codes.includes(stockCode),
+    [codes],
+  );
+
+  const addToWatchlist = useCallback(async (stockCode: string) => {
+    if (!stockCode || isActioning) return;
+    setIsActioning(true);
+    try {
+      const result = await systemConfigApi.addToWatchlist(stockCode);
+      if (mountedRef.current) {
+        setCodes(result);
+        showMessage(`已加入自选 ${stockCode}`);
+      }
+    } catch {
+      if (mountedRef.current) showMessage('操作失败');
+    } finally {
+      if (mountedRef.current) setIsActioning(false);
+    }
+  }, [isActioning, showMessage]);
+
+  const removeFromWatchlist = useCallback(async (stockCode: string) => {
+    if (!stockCode || isActioning) return;
+    setIsActioning(true);
+    try {
+      const result = await systemConfigApi.removeFromWatchlist(stockCode);
+      if (mountedRef.current) {
+        setCodes(result);
+        showMessage(`已从自选移除 ${stockCode}`);
+      }
+    } catch {
+      if (mountedRef.current) showMessage('操作失败');
+    } finally {
+      if (mountedRef.current) setIsActioning(false);
+    }
+  }, [isActioning, showMessage]);
+
+  const toggleWatchlist = useCallback(async (stockCode: string) => {
+    if (isInWatchlist(stockCode)) {
+      await removeFromWatchlist(stockCode);
+    } else {
+      await addToWatchlist(stockCode);
+    }
+  }, [isInWatchlist, removeFromWatchlist, addToWatchlist]);
+
+  return {
+    watchlistCodes: codes,
+    isLoading,
+    isActioning,
+    actionMessage,
+    isInWatchlist,
+    addToWatchlist,
+    removeFromWatchlist,
+    toggleWatchlist,
+    refresh,
+  };
+}

--- a/apps/dsa-web/src/pages/ChatPage.tsx
+++ b/apps/dsa-web/src/pages/ChatPage.tsx
@@ -25,7 +25,7 @@ import {
 } from '../utils/chatFollowUp';
 import { isNearBottom } from '../utils/chatScroll';
 import { getReportText } from '../utils/reportLanguage';
-import { validateStockCode } from '../utils/validation';
+import { extractStockCodeFromMessage } from '../utils/chatStockCode';
 
 // Quick question examples shown on empty state
 const QUICK_QUESTIONS = [
@@ -49,26 +49,6 @@ const getMessageSkillNames = (msg: Message): string[] => {
 };
 
 const getMessageSkillLabel = (msg: Message): string => getMessageSkillNames(msg).join('、');
-
-function extractStockCodeFromMessage(message: string): string | null {
-  const patterns = [
-    /\b(\d{6})\b/g,
-    /\b(hk\d{4,5})\b/gi,
-    /\b(00\d{4}\.SZ)\b/gi,
-    /\b(60\d{4}\.SH)\b/gi,
-    /\b([A-Z]{1,5})\b/g,
-  ];
-  for (const pattern of patterns) {
-    const matches = message.match(pattern);
-    if (matches) {
-      for (const m of matches) {
-        const { valid, normalized } = validateStockCode(m);
-        if (valid) return normalized;
-      }
-    }
-  }
-  return null;
-}
 
 const ChatPage: React.FC = () => {
   const [searchParams, setSearchParams] = useSearchParams();

--- a/apps/dsa-web/src/pages/ChatPage.tsx
+++ b/apps/dsa-web/src/pages/ChatPage.tsx
@@ -25,6 +25,7 @@ import {
 } from '../utils/chatFollowUp';
 import { isNearBottom } from '../utils/chatScroll';
 import { getReportText } from '../utils/reportLanguage';
+import { validateStockCode } from '../utils/validation';
 
 // Quick question examples shown on empty state
 const QUICK_QUESTIONS = [
@@ -49,6 +50,26 @@ const getMessageSkillNames = (msg: Message): string[] => {
 
 const getMessageSkillLabel = (msg: Message): string => getMessageSkillNames(msg).join('、');
 
+function extractStockCodeFromMessage(message: string): string | null {
+  const patterns = [
+    /\b(\d{6})\b/g,
+    /\b(hk\d{4,5})\b/gi,
+    /\b(00\d{4}\.SZ)\b/gi,
+    /\b(60\d{4}\.SH)\b/gi,
+    /\b([A-Z]{1,5})\b/g,
+  ];
+  for (const pattern of patterns) {
+    const matches = message.match(pattern);
+    if (matches) {
+      for (const m of matches) {
+        const { valid, normalized } = validateStockCode(m);
+        if (valid) return normalized;
+      }
+    }
+  }
+  return null;
+}
+
 const ChatPage: React.FC = () => {
   const [searchParams, setSearchParams] = useSearchParams();
   const [input, setInput] = useState('');
@@ -72,6 +93,11 @@ const ChatPage: React.FC = () => {
   const [contextCompressionError, setContextCompressionError] = useState<string | null>(null);
   const [copiedMessages, setCopiedMessages] = useState<Set<string>>(new Set());
   const [showJumpToBottom, setShowJumpToBottom] = useState(false);
+  const [watchlistCodes, setWatchlistCodes] = useState<string[]>([]);
+  const [isWatchlistActioning, setIsWatchlistActioning] = useState(false);
+  const [watchlistMessage, setWatchlistMessage] = useState<string | null>(null);
+  const [activeStockCode, setActiveStockCode] = useState<string | null>(null);
+  const watchlistMessageTimerRef = useRef<number | null>(null);
   const copyResetTimerRef = useRef<Partial<Record<string, number>>>({});
   const messagesViewportRef = useRef<HTMLDivElement>(null);
   const messagesEndRef = useRef<HTMLDivElement>(null);
@@ -108,6 +134,66 @@ const ChatPage: React.FC = () => {
   useEffect(() => () => {
     isMountedRef.current = false;
   }, []);
+
+  const loadWatchlist = useCallback(async () => {
+    try {
+      const codes = await systemConfigApi.getWatchlist();
+      if (isMountedRef.current) {
+        setWatchlistCodes(codes);
+      }
+    } catch {
+      // ignore error silently
+    }
+  }, []);
+
+  useEffect(() => {
+    void loadWatchlist();
+  }, [loadWatchlist]);
+
+  const stockInWatchlist = useCallback(
+    (stockCode: string) => watchlistCodes.includes(stockCode),
+    [watchlistCodes],
+  );
+
+  const handleToggleWatchlist = useCallback(
+    async (stockCode: string) => {
+      if (!stockCode || isWatchlistActioning) return;
+      setIsWatchlistActioning(true);
+      setWatchlistMessage(null);
+      try {
+        if (stockInWatchlist(stockCode)) {
+          const codes = await systemConfigApi.removeFromWatchlist(stockCode);
+          if (isMountedRef.current) {
+            setWatchlistCodes(codes);
+            setWatchlistMessage(`已从自选中移除 ${stockCode}`);
+          }
+        } else {
+          const codes = await systemConfigApi.addToWatchlist(stockCode);
+          if (isMountedRef.current) {
+            setWatchlistCodes(codes);
+            setWatchlistMessage(`已加入自选 ${stockCode}`);
+          }
+        }
+      } catch {
+        if (isMountedRef.current) {
+          setWatchlistMessage('操作失败，请重试');
+        }
+      } finally {
+        if (isMountedRef.current) {
+          setIsWatchlistActioning(false);
+          if (watchlistMessageTimerRef.current !== null) {
+            window.clearTimeout(watchlistMessageTimerRef.current);
+          }
+          watchlistMessageTimerRef.current = window.setTimeout(() => {
+            if (isMountedRef.current) {
+              setWatchlistMessage(null);
+            }
+          }, 3000);
+        }
+      }
+    },
+    [isWatchlistActioning, stockInWatchlist],
+  );
 
   const {
     messages,
@@ -346,6 +432,7 @@ const ChatPage: React.FC = () => {
 
     const hydrationToken = ++followUpHydrationTokenRef.current;
     setInput(buildFollowUpPrompt(stock, name));
+    setActiveStockCode(stock);
     followUpContextRef.current = {
       stock_code: stock,
       stock_name: name,
@@ -376,6 +463,11 @@ const ChatPage: React.FC = () => {
       if (!msgText || loading) return;
       const usedSkillIds = normalizeSelectedSkillIds(overrideSkillIds ?? selectedSkillIds);
       const usedSkillNames = usedSkillIds.length > 0 ? getSkillNames(usedSkillIds) : ['通用'];
+
+      const stockCode = extractStockCodeFromMessage(msgText);
+      if (stockCode) {
+        setActiveStockCode(stockCode);
+      }
 
       const payload = {
         message: msgText,
@@ -1126,6 +1218,24 @@ const ChatPage: React.FC = () => {
                     </label>
                   );
                 })}
+              </div>
+            )}
+
+            {activeStockCode && (
+              <div className="flex items-center gap-2">
+                <span className="text-xs text-muted-text font-mono">{activeStockCode}</span>
+                <Button
+                  variant="secondary"
+                  size="xsm"
+                  isLoading={isWatchlistActioning}
+                  onClick={() => void handleToggleWatchlist(activeStockCode)}
+                  className="text-[11px]"
+                >
+                  {stockInWatchlist(activeStockCode) ? '从自选删除' : '加入自选'}
+                </Button>
+                {watchlistMessage && (
+                  <span className="text-[11px] text-secondary-text animate-in fade-in">{watchlistMessage}</span>
+                )}
               </div>
             )}
 

--- a/apps/dsa-web/src/pages/ChatPage.tsx
+++ b/apps/dsa-web/src/pages/ChatPage.tsx
@@ -26,6 +26,7 @@ import {
 import { isNearBottom } from '../utils/chatScroll';
 import { getReportText } from '../utils/reportLanguage';
 import { extractStockCodeFromMessage } from '../utils/chatStockCode';
+import { normalizeStockCode } from '../utils/stockCode';
 
 // Quick question examples shown on empty state
 const QUICK_QUESTIONS = [
@@ -131,7 +132,7 @@ const ChatPage: React.FC = () => {
   }, [loadWatchlist]);
 
   const stockInWatchlist = useCallback(
-    (stockCode: string) => watchlistCodes.includes(stockCode),
+    (stockCode: string) => watchlistCodes.includes(normalizeStockCode(stockCode)),
     [watchlistCodes],
   );
 

--- a/apps/dsa-web/src/pages/HomePage.tsx
+++ b/apps/dsa-web/src/pages/HomePage.tsx
@@ -4,6 +4,7 @@ import { BarChart3, Check, SlidersHorizontal } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
 import { getParsedApiError, type ParsedApiError } from '../api/error';
 import { analysisApi } from '../api/analysis';
+import { historyApi } from '../api/history';
 import { agentApi, type SkillInfo } from '../api/agent';
 import { systemConfigApi } from '../api/systemConfig';
 import { ApiErrorAlert, Button, EmptyState, InlineAlert } from '../components/common';
@@ -320,6 +321,21 @@ const HomePage: React.FC = () => {
     setSidebarOpen(false);
   }, [selectHistoryItem]);
 
+  const [isDeletingStock, setIsDeletingStock] = useState(false);
+  const handleDeleteStock = useCallback(async (stockCode: string) => {
+    if (isDeletingStock) return;
+    setIsDeletingStock(true);
+    try {
+      await historyApi.deleteByCode(stockCode);
+      await refreshStockBar();
+      await refreshHistory(true);
+    } catch {
+      // error silently ignored
+    } finally {
+      setIsDeletingStock(false);
+    }
+  }, [isDeletingStock, refreshStockBar, refreshHistory]);
+
   const handleSubmitAnalysis = useCallback(
     (
       stockCode?: string,
@@ -527,6 +543,8 @@ const HomePage: React.FC = () => {
           selectedStockCode={selectedReport?.meta.stockCode}
           selectedRecordId={selectedReport?.meta.id}
           onItemClick={handleHistoryItemClick}
+          onDeleteStock={handleDeleteStock}
+          isDeleting={isDeletingStock}
           className="flex-1 overflow-hidden"
         />
       </div>
@@ -536,6 +554,8 @@ const HomePage: React.FC = () => {
       stockBarItems,
       isLoadingStockBar,
       handleHistoryItemClick,
+      handleDeleteStock,
+      isDeletingStock,
       selectedReport?.meta.stockCode,
       selectedReport?.meta.id,
     ],

--- a/apps/dsa-web/src/pages/HomePage.tsx
+++ b/apps/dsa-web/src/pages/HomePage.tsx
@@ -6,14 +6,15 @@ import { getParsedApiError, type ParsedApiError } from '../api/error';
 import { analysisApi } from '../api/analysis';
 import { agentApi, type SkillInfo } from '../api/agent';
 import { systemConfigApi } from '../api/systemConfig';
-import { ApiErrorAlert, ConfirmDialog, Button, EmptyState, InlineAlert } from '../components/common';
+import { ApiErrorAlert, Button, EmptyState, InlineAlert } from '../components/common';
 import { DashboardStateBlock } from '../components/dashboard';
 import { StockAutocomplete } from '../components/StockAutocomplete';
-import { HistoryList, StockHistoryTrendDrawer } from '../components/history';
+import { StockHistoryTrendDrawer, StockBar } from '../components/history';
 import { ReportMarkdownDrawer } from '../components/report/ReportMarkdownDrawer';
 import { ReportSummary } from '../components/report/ReportSummary';
 import { TaskPanel } from '../components/tasks';
 import { useDashboardLifecycle, useHomeDashboardState } from '../hooks';
+import { useWatchlist } from '../hooks/useWatchlist';
 import type { SetupStatusResponse } from '../types/systemConfig';
 import { getReportText, normalizeReportLanguage } from '../utils/reportLanguage';
 
@@ -26,7 +27,6 @@ type MarketReviewNotice = {
 const HomePage: React.FC = () => {
   const navigate = useNavigate();
   const [sidebarOpen, setSidebarOpen] = useState(false);
-  const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
   const [isSubmittingMarketReview, setIsSubmittingMarketReview] = useState(false);
   const [marketReviewNotice, setMarketReviewNotice] = useState<MarketReviewNotice>(null);
   const [marketReviewError, setMarketReviewError] = useState<ParsedApiError | null>(null);
@@ -72,12 +72,6 @@ const HomePage: React.FC = () => {
     duplicateError,
     error,
     isAnalyzing,
-    historyItems,
-    selectedHistoryIds,
-    isDeletingHistory,
-    isLoadingHistory,
-    isLoadingMore,
-    hasMore,
     selectedReport,
     isLoadingReport,
     isHistoryTrendOpen,
@@ -94,11 +88,7 @@ const HomePage: React.FC = () => {
     clearError,
     loadInitialHistory,
     refreshHistory,
-    loadMoreHistory,
     selectHistoryItem,
-    toggleHistorySelection,
-    toggleSelectAllVisible,
-    deleteSelectedHistory,
     submitAnalysis,
     notify,
     setNotify,
@@ -113,7 +103,10 @@ const HomePage: React.FC = () => {
     closeHistoryTrend,
     setStockHistoryRange,
     loadMoreStockHistory,
-    selectedIds,
+    stockBarItems,
+    isLoadingStockBar,
+    loadStockBar,
+    refreshStockBar,
   } = useHomeDashboardState();
 
   useEffect(() => {
@@ -311,12 +304,16 @@ const HomePage: React.FC = () => {
   useDashboardLifecycle({
     loadInitialHistory,
     refreshHistory,
+    loadStockBar,
+    refreshStockBar,
     syncTaskCreated,
     syncTaskUpdated,
     syncTaskFailed,
     refreshActiveTasks,
     removeTask,
   });
+
+  const watchlistState = useWatchlist();
 
   const handleHistoryItemClick = useCallback((recordId: number) => {
     void selectHistoryItem(recordId);
@@ -520,45 +517,27 @@ const HomePage: React.FC = () => {
     );
   }, [marketReviewReport]);
 
-  const handleDeleteSelectedHistory = useCallback(() => {
-    void deleteSelectedHistory();
-    setShowDeleteConfirm(false);
-  }, [deleteSelectedHistory]);
-
   const sidebarContent = useMemo(
     () => (
       <div className="flex min-h-0 h-full flex-col gap-3 overflow-hidden">
         <TaskPanel tasks={activeTasks} />
-        <HistoryList
-          items={historyItems}
-          isLoading={isLoadingHistory}
-          isLoadingMore={isLoadingMore}
-          hasMore={hasMore}
-          selectedId={selectedReport?.meta.id}
-          selectedIds={selectedIds}
-          isDeleting={isDeletingHistory}
+        <StockBar
+          items={stockBarItems}
+          isLoading={isLoadingStockBar}
+          selectedStockCode={selectedReport?.meta.stockCode}
+          selectedRecordId={selectedReport?.meta.id}
           onItemClick={handleHistoryItemClick}
-          onLoadMore={() => void loadMoreHistory()}
-          onToggleItemSelection={toggleHistorySelection}
-          onToggleSelectAll={toggleSelectAllVisible}
-          onDeleteSelected={() => setShowDeleteConfirm(true)}
           className="flex-1 overflow-hidden"
         />
       </div>
     ),
     [
       activeTasks,
-      hasMore,
-      historyItems,
-      isDeletingHistory,
-      isLoadingHistory,
-      isLoadingMore,
+      stockBarItems,
+      isLoadingStockBar,
       handleHistoryItemClick,
-      loadMoreHistory,
-      selectedIds,
+      selectedReport?.meta.stockCode,
       selectedReport?.meta.id,
-      toggleHistorySelection,
-      toggleSelectAllVisible,
     ],
   );
 
@@ -882,7 +861,16 @@ const HomePage: React.FC = () => {
                     onRetry={() => void openHistoryTrend()}
                   />
                 ) : (
-                  <ReportSummary data={selectedReport} isHistory />
+                  <ReportSummary
+                    data={selectedReport}
+                    isHistory
+                    watchlist={{
+                      isInWatchlist: watchlistState.isInWatchlist,
+                      onToggle: watchlistState.toggleWatchlist,
+                      isActioning: watchlistState.isActioning,
+                      actionMessage: watchlistState.actionMessage,
+                    }}
+                  />
                 )}
               </div>
             ) : (
@@ -914,20 +902,6 @@ const HomePage: React.FC = () => {
         />
       ) : null}
 
-      <ConfirmDialog
-        isOpen={showDeleteConfirm}
-        title="删除历史记录"
-        message={
-          selectedHistoryIds.length === 1
-            ? '确认删除这条历史记录吗？删除后将不可恢复。'
-            : `确认删除选中的 ${selectedHistoryIds.length} 条历史记录吗？删除后将不可恢复。`
-        }
-        confirmText={isDeletingHistory ? '删除中...' : '确认删除'}
-        cancelText="取消"
-        isDanger={true}
-        onConfirm={handleDeleteSelectedHistory}
-        onCancel={() => setShowDeleteConfirm(false)}
-      />
     </div>
   );
 };

--- a/apps/dsa-web/src/pages/__tests__/ChatPage.test.tsx
+++ b/apps/dsa-web/src/pages/__tests__/ChatPage.test.tsx
@@ -23,6 +23,9 @@ const {
   mockSendChat,
   mockGetSystemConfig,
   mockUpdateSystemConfig,
+  mockGetWatchlist,
+  mockAddToWatchlist,
+  mockRemoveFromWatchlist,
   mockDownloadSession,
   mockFormatSessionAsMarkdown,
 } = vi.hoisted(() => ({
@@ -31,6 +34,9 @@ const {
   mockSendChat: vi.fn(),
   mockGetSystemConfig: vi.fn(),
   mockUpdateSystemConfig: vi.fn(),
+  mockGetWatchlist: vi.fn(),
+  mockAddToWatchlist: vi.fn(),
+  mockRemoveFromWatchlist: vi.fn(),
   mockDownloadSession: vi.fn(),
   mockFormatSessionAsMarkdown: vi.fn(),
 }));
@@ -77,6 +83,9 @@ vi.mock('../../api/systemConfig', () => ({
   systemConfigApi: {
     getConfig: mockGetSystemConfig,
     update: mockUpdateSystemConfig,
+    getWatchlist: mockGetWatchlist,
+    addToWatchlist: mockAddToWatchlist,
+    removeFromWatchlist: mockRemoveFromWatchlist,
   },
 }));
 
@@ -159,6 +168,7 @@ beforeEach(() => {
   });
   mockDeleteChatSession.mockResolvedValue(undefined);
   mockSendChat.mockResolvedValue({ success: true });
+  mockGetWatchlist.mockResolvedValue([]);
   mockGetSystemConfig.mockResolvedValue({
     configVersion: 'cfg-v1',
     maskToken: 'mask-token',
@@ -932,13 +942,18 @@ describe('extractStockCodeFromMessage', () => {
     expect(extractStockCodeFromMessage('002460')).toBe('002460');
   });
 
-  it('returns HK prefixed code', () => {
+  it('returns HK prefixed code (normalized)', () => {
     expect(extractStockCodeFromMessage('分析 hk00700')).toBe('HK00700');
   });
 
-  it('returns code with .SH/.SZ suffix', () => {
-    expect(extractStockCodeFromMessage('看 600519.SH')).toBe('600519.SH');
-    expect(extractStockCodeFromMessage('000001.SZ')).toBe('000001.SZ');
+  it('returns .HK suffix code (normalized to canonical)', () => {
+    expect(extractStockCodeFromMessage('00700.HK')).toBe('HK00700');
+    expect(extractStockCodeFromMessage('1810.HK')).toBe('HK01810');
+  });
+
+  it('returns code with .SH/.SZ suffix (normalized)', () => {
+    expect(extractStockCodeFromMessage('看 600519.SH')).toBe('600519');
+    expect(extractStockCodeFromMessage('000001.SZ')).toBe('000001');
   });
 
   it('returns US ticker like AAPL', () => {
@@ -960,11 +975,45 @@ describe('extractStockCodeFromMessage', () => {
     expect(extractStockCodeFromMessage('大盘走势如何')).toBeNull();
   });
 
-  it('matches prefixed code like SH600519', () => {
-    expect(extractStockCodeFromMessage('分析 SH600519')).toBe('SH600519');
+  it('matches prefixed code like SH600519 (normalized)', () => {
+    expect(extractStockCodeFromMessage('分析 SH600519')).toBe('600519');
   });
 
-  it('returns SZ-prefixed code when standalone', () => {
-    expect(extractStockCodeFromMessage('SZ000001')).toBe('SZ000001');
+  it('returns SZ-prefixed code when standalone (normalized)', () => {
+    expect(extractStockCodeFromMessage('SZ000001')).toBe('000001');
+  });
+});
+
+describe('watchlist button with code variants', () => {
+  it('shows "从自选删除" when canonical code is in watchlist and user inputs variant', async () => {
+    mockGetWatchlist.mockResolvedValue(['600519', 'HK01810']);
+
+    render(
+      <MemoryRouter>
+        <ChatPage />
+      </MemoryRouter>,
+    );
+
+    const textarea = await screen.findByPlaceholderText(/例如/);
+    fireEvent.change(textarea, { target: { value: '分析 600519.SH' } });
+    fireEvent.keyDown(textarea, { key: 'Enter' });
+
+    expect(await screen.findByText('从自选删除')).toBeInTheDocument();
+  });
+
+  it('shows "从自选删除" for HK variant codes', async () => {
+    mockGetWatchlist.mockResolvedValue(['HK01810']);
+
+    render(
+      <MemoryRouter>
+        <ChatPage />
+      </MemoryRouter>,
+    );
+
+    const textarea = await screen.findByPlaceholderText(/例如/);
+    fireEvent.change(textarea, { target: { value: '分析 1810.HK' } });
+    fireEvent.keyDown(textarea, { key: 'Enter' });
+
+    expect(await screen.findByText('从自选删除')).toBeInTheDocument();
   });
 });

--- a/apps/dsa-web/src/pages/__tests__/ChatPage.test.tsx
+++ b/apps/dsa-web/src/pages/__tests__/ChatPage.test.tsx
@@ -5,6 +5,7 @@ import { createParsedApiError } from '../../api/error';
 import { historyApi } from '../../api/history';
 import type { Message } from '../../stores/agentChatStore';
 import ChatPage from '../ChatPage';
+import { extractStockCodeFromMessage } from '../../utils/chatStockCode';
 
 function createDeferred<T>() {
   let resolve!: (value: T) => void;
@@ -922,5 +923,48 @@ describe('ChatPage', () => {
     fireEvent.click(jumpButton);
 
     expect(HTMLElement.prototype.scrollIntoView).toHaveBeenCalled();
+  });
+});
+
+describe('extractStockCodeFromMessage', () => {
+  it('returns 6-digit A-share code', () => {
+    expect(extractStockCodeFromMessage('分析 600519 趋势')).toBe('600519');
+    expect(extractStockCodeFromMessage('002460')).toBe('002460');
+  });
+
+  it('returns HK prefixed code', () => {
+    expect(extractStockCodeFromMessage('分析 hk00700')).toBe('HK00700');
+  });
+
+  it('returns code with .SH/.SZ suffix', () => {
+    expect(extractStockCodeFromMessage('看 600519.SH')).toBe('600519.SH');
+    expect(extractStockCodeFromMessage('000001.SZ')).toBe('000001.SZ');
+  });
+
+  it('returns US ticker like AAPL', () => {
+    expect(extractStockCodeFromMessage('分析 AAPL 走势')).toBe('AAPL');
+    expect(extractStockCodeFromMessage('TSLA')).toBe('TSLA');
+  });
+
+  it('does NOT return exchange prefixes as tickers', () => {
+    expect(extractStockCodeFromMessage('分析 SH 走势')).toBeNull();
+    expect(extractStockCodeFromMessage('看看 BJ')).toBeNull();
+    expect(extractStockCodeFromMessage('HK')).toBeNull();
+    expect(extractStockCodeFromMessage('买入 SZ')).toBeNull();
+    expect(extractStockCodeFromMessage('US 市场')).toBeNull();
+    expect(extractStockCodeFromMessage('SS')).toBeNull();
+  });
+
+  it('returns null for messages without stock codes', () => {
+    expect(extractStockCodeFromMessage('茅台现在适合买入吗')).toBeNull();
+    expect(extractStockCodeFromMessage('大盘走势如何')).toBeNull();
+  });
+
+  it('matches prefixed code like SH600519', () => {
+    expect(extractStockCodeFromMessage('分析 SH600519')).toBe('SH600519');
+  });
+
+  it('returns SZ-prefixed code when standalone', () => {
+    expect(extractStockCodeFromMessage('SZ000001')).toBe('SZ000001');
   });
 });

--- a/apps/dsa-web/src/pages/__tests__/HomePage.test.tsx
+++ b/apps/dsa-web/src/pages/__tests__/HomePage.test.tsx
@@ -23,10 +23,10 @@ vi.mock('../../api/history', () => ({
   historyApi: {
     getList: vi.fn(),
     getDetail: vi.fn(),
-    deleteRecords: vi.fn(),
     getNews: vi.fn().mockResolvedValue({ total: 0, items: [] }),
     getMarkdown: vi.fn().mockResolvedValue('# report'),
     getDiagnostics: vi.fn(),
+    getStockBarList: vi.fn().mockResolvedValue({ total: 0, items: [] }),
   },
 }));
 
@@ -46,6 +46,7 @@ vi.mock('../../api/analysis', async () => {
 vi.mock('../../api/systemConfig', () => ({
   systemConfigApi: {
     getSetupStatus: vi.fn(),
+    getWatchlist: vi.fn().mockResolvedValue([]),
   },
 }));
 
@@ -224,7 +225,7 @@ describe('HomePage', () => {
     expect(await screen.findByText('开始分析')).toBeInTheDocument();
     expect(screen.getByRole('heading', { name: '开始分析', level: 3 })).toBeInTheDocument();
     expect(screen.getByText('输入股票代码进行分析，或从左侧选择历史报告查看。')).toBeInTheDocument();
-    expect(screen.getByText('暂无历史分析记录')).toBeInTheDocument();
+    expect(screen.getByText('暂无个股记录')).toBeInTheDocument();
   });
 
   it('surfaces duplicate task warnings from dashboard submission', async () => {
@@ -439,41 +440,6 @@ describe('HomePage', () => {
     );
   });
 
-  it('confirms and deletes selected history from the dashboard state flow', async () => {
-    vi.mocked(historyApi.getList).mockResolvedValue({
-      total: 1,
-      page: 1,
-      limit: 20,
-      items: [historyItem],
-    });
-    vi.mocked(historyApi.getDetail).mockResolvedValue(historyReport);
-    vi.mocked(historyApi.deleteRecords).mockResolvedValue({ deleted: 1 });
-
-    useStockPoolStore.setState({
-      historyItems: [historyItem],
-      selectedHistoryIds: [1],
-      selectedReport: historyReport,
-    });
-
-    render(
-      <MemoryRouter>
-        <HomePage />
-      </MemoryRouter>,
-    );
-
-    fireEvent.click(await screen.findByRole('button', { name: '删除' }));
-
-    expect(
-      await screen.findByText('确认删除这条历史记录吗？删除后将不可恢复。'),
-    ).toBeInTheDocument();
-
-    fireEvent.click(screen.getByRole('button', { name: '确认删除' }));
-
-    await waitFor(() => {
-      expect(historyApi.deleteRecords).toHaveBeenCalledWith([1]);
-    });
-  });
-
   it('opens and closes the mobile history drawer without changing dashboard styles', async () => {
     vi.mocked(historyApi.getList).mockResolvedValue({
       total: 0,
@@ -509,6 +475,22 @@ describe('HomePage', () => {
         createdAt: '2020-01-01T08:00:00Z',
       },
     };
+
+    vi.mocked(historyApi.getStockBarList).mockResolvedValue({
+      total: 1,
+      items: [
+        {
+          id: 1,
+          stockCode: '600519',
+          stockName: '贵州茅台',
+          reportType: 'detailed',
+          sentimentScore: 58,
+          operationAdvice: '继续观察买点',
+          analysisCount: 2,
+          lastAnalysisTime: '2026-03-21T08:00:00Z',
+        },
+      ],
+    });
 
     vi.mocked(historyApi.getList).mockImplementation((params: { stockCode?: string; startDate?: string } = {}) => {
       if (!Object.prototype.hasOwnProperty.call(params, 'stockCode')) {
@@ -551,8 +533,8 @@ describe('HomePage', () => {
     await waitFor(() => {
       expect(screen.queryByText('暂无更多同股历史分析')).not.toBeInTheDocument();
     });
-    expect(screen.getByRole('button', { name: /继续观察买点/ })).toBeInTheDocument();
-    expect(screen.getByText(/共 1 次分析/)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /贵州茅台/ })).toBeInTheDocument();
+    expect(screen.getByText(/2次/)).toBeInTheDocument();
 
     const historyCalls = vi.mocked(historyApi.getList).mock.calls.filter((call) => call[0]?.stockCode === '600519');
     expect(historyCalls).toHaveLength(3);

--- a/apps/dsa-web/src/pages/__tests__/HomePage.test.tsx
+++ b/apps/dsa-web/src/pages/__tests__/HomePage.test.tsx
@@ -533,7 +533,7 @@ describe('HomePage', () => {
     await waitFor(() => {
       expect(screen.queryByText('暂无更多同股历史分析')).not.toBeInTheDocument();
     });
-    expect(screen.getByRole('button', { name: /贵州茅台/ })).toBeInTheDocument();
+    expect(screen.getAllByRole('button', { name: /贵州茅台/ }).length).toBeGreaterThanOrEqual(1);
     expect(screen.getByText(/2次/)).toBeInTheDocument();
 
     const historyCalls = vi.mocked(historyApi.getList).mock.calls.filter((call) => call[0]?.stockCode === '600519');

--- a/apps/dsa-web/src/stores/stockPoolStore.ts
+++ b/apps/dsa-web/src/stores/stockPoolStore.ts
@@ -3,7 +3,7 @@ import { analysisApi, DuplicateTaskError } from '../api/analysis';
 import type { ParsedApiError } from '../api/error';
 import { getParsedApiError } from '../api/error';
 import { historyApi } from '../api/history';
-import type { AnalysisReport, HistoryItem, HistoryListResponse, StockHistoryFilters, StockHistoryRange, TaskInfo } from '../types/analysis';
+import type { AnalysisReport, HistoryItem, HistoryListResponse, StockBarItem, StockHistoryFilters, StockHistoryRange, TaskInfo } from '../types/analysis';
 import { getRecentStartDate, getTodayInShanghai } from '../utils/format';
 import { isObviouslyInvalidStockQuery, looksLikeStockCode, validateStockCode } from '../utils/validation';
 
@@ -64,6 +64,8 @@ export interface StockPoolState {
   stockHistoryFilters: StockHistoryFilters;
   activeTasks: TaskInfo[];
   markdownDrawerOpen: boolean;
+  stockBarItems: StockBarItem[];
+  isLoadingStockBar: boolean;
   setQuery: (query: string) => void;
   clearError: () => void;
   clearInlineMessages: () => void;
@@ -88,6 +90,8 @@ export interface StockPoolState {
   refreshActiveTasks: () => Promise<void>;
   removeTask: (taskId: string) => void;
   resetDashboardState: () => void;
+  loadStockBar: () => Promise<void>;
+  refreshStockBar: () => Promise<void>;
 }
 
 const initialState = {
@@ -122,6 +126,8 @@ const initialState = {
   },
   activeTasks: [] as TaskInfo[],
   markdownDrawerOpen: false,
+  stockBarItems: [] as StockBarItem[],
+  isLoadingStockBar: false,
 };
 
 function buildHistoryParams(page: number) {
@@ -712,5 +718,34 @@ export const useStockPoolStore = create<StockPoolState>((set, get) => ({
     activeTaskLocalRevision += 1;
     dismissedTaskIds.clear();
     set({ ...initialState });
+  },
+
+  loadStockBar: async () => {
+    const state = get();
+    if (state.isLoadingStockBar) return;
+    set({ isLoadingStockBar: true });
+    try {
+      const response = await historyApi.getStockBarList({
+        startDate: getRecentStartDate(90),
+        endDate: getTodayInShanghai(),
+      });
+      set({ stockBarItems: response.items });
+    } catch {
+      // keep existing items on error
+    } finally {
+      set({ isLoadingStockBar: false });
+    }
+  },
+
+  refreshStockBar: async () => {
+    try {
+      const response = await historyApi.getStockBarList({
+        startDate: getRecentStartDate(90),
+        endDate: getTodayInShanghai(),
+      });
+      set({ stockBarItems: response.items });
+    } catch {
+      // keep existing items on error
+    }
   },
 }));

--- a/apps/dsa-web/src/types/analysis.ts
+++ b/apps/dsa-web/src/types/analysis.ts
@@ -392,6 +392,25 @@ export interface HistoryPagination {
   limit: number;
 }
 
+// ============ Stock Bar Types ============
+
+export interface StockBarItem {
+  id: number;
+  stockCode: string;
+  stockName?: string;
+  reportType?: string;
+  sentimentScore?: number;
+  operationAdvice?: string;
+  analysisCount: number;
+  lastAnalysisTime?: string;
+  modelUsed?: string;
+}
+
+export interface StockBarResponse {
+  total: number;
+  items: StockBarItem[];
+}
+
 // ============ Error Types ============
 
 export interface ApiError {

--- a/apps/dsa-web/src/utils/__tests__/stockCode.test.ts
+++ b/apps/dsa-web/src/utils/__tests__/stockCode.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest';
+import { normalizeStockCode } from '../stockCode';
+
+describe('normalizeStockCode', () => {
+  it('keeps clean A-share codes as-is', () => {
+    expect(normalizeStockCode('600519')).toBe('600519');
+    expect(normalizeStockCode('000001')).toBe('000001');
+    expect(normalizeStockCode('920748')).toBe('920748');
+  });
+
+  it('strips SH/SZ prefix', () => {
+    expect(normalizeStockCode('SH600519')).toBe('600519');
+    expect(normalizeStockCode('SZ000001')).toBe('000001');
+    expect(normalizeStockCode('BJ920748')).toBe('920748');
+  });
+
+  it('strips dotted SH/SZ/BJ prefix', () => {
+    expect(normalizeStockCode('SH.600519')).toBe('600519');
+    expect(normalizeStockCode('SZ.000001')).toBe('000001');
+    expect(normalizeStockCode('BJ.920748')).toBe('920748');
+  });
+
+  it('strips .SH/.SZ/.BJ suffix', () => {
+    expect(normalizeStockCode('600519.SH')).toBe('600519');
+    expect(normalizeStockCode('000001.SZ')).toBe('000001');
+    expect(normalizeStockCode('920748.BJ')).toBe('920748');
+  });
+
+  it('normalizes HK prefix to 5-digit form', () => {
+    expect(normalizeStockCode('HK00700')).toBe('HK00700');
+    expect(normalizeStockCode('HK1810')).toBe('HK01810');
+    expect(normalizeStockCode('HK700')).toBe('HK00700');
+    expect(normalizeStockCode('hk00700')).toBe('HK00700');
+    expect(normalizeStockCode('hk1810')).toBe('HK01810');
+  });
+
+  it('normalizes HK suffix to canonical prefix form', () => {
+    expect(normalizeStockCode('00700.HK')).toBe('HK00700');
+    expect(normalizeStockCode('1810.HK')).toBe('HK01810');
+    expect(normalizeStockCode('700.HK')).toBe('HK00700');
+  });
+
+  it('keeps US tickers as-is', () => {
+    expect(normalizeStockCode('AAPL')).toBe('AAPL');
+    expect(normalizeStockCode('TSLA')).toBe('TSLA');
+    expect(normalizeStockCode('GOOGL')).toBe('GOOGL');
+  });
+
+  it('is case-insensitive for prefixes', () => {
+    expect(normalizeStockCode('sh600519')).toBe('600519');
+    expect(normalizeStockCode('sz000001')).toBe('000001');
+  });
+
+  it('handles same-stock variants as equivalent', () => {
+    const codes = ['600519', 'SH600519', '600519.SH', 'SH.600519'];
+    const normalized = codes.map(normalizeStockCode);
+    expect(new Set(normalized).size).toBe(1);
+    expect(normalized[0]).toBe('600519');
+  });
+
+  it('handles HK variants as equivalent', () => {
+    const codes = ['HK00700', '00700.HK', 'hk00700'];
+    const normalized = codes.map(normalizeStockCode);
+    expect(new Set(normalized).size).toBe(1);
+    expect(normalized[0]).toBe('HK00700');
+  });
+});

--- a/apps/dsa-web/src/utils/chatStockCode.ts
+++ b/apps/dsa-web/src/utils/chatStockCode.ts
@@ -1,0 +1,32 @@
+import { validateStockCode } from './validation';
+
+const EXCHANGE_PREFIXES = new Set(['SH', 'SZ', 'BJ', 'HK', 'US', 'SS']);
+
+export function extractStockCodeFromMessage(message: string): string | null {
+  // More specific patterns first to avoid greedy \d{6} capturing inside .SH/.SZ codes
+  const patterns = [
+    /\b(30\d{4}\.SZ)\b/gi,
+    /\b(68\d{4}\.SH)\b/gi,
+    /\b(00\d{4}\.SZ)\b/gi,
+    /\b(60\d{4}\.SH)\b/gi,
+    /\b(SH\d{6})\b/gi,
+    /\b(SZ\d{6})\b/gi,
+    /\b(BJ\d{6})\b/gi,
+    /\b(hk\d{4,5})\b/gi,
+    /\b(\d{5,6})\b/g,
+    /\b([A-Z]{2,5})\b/g,
+  ];
+  for (const pattern of patterns) {
+    const matches = message.match(pattern);
+    if (matches) {
+      for (const m of matches) {
+        if (EXCHANGE_PREFIXES.has(m.toUpperCase())) {
+          continue;
+        }
+        const { valid, normalized } = validateStockCode(m);
+        if (valid) return normalized;
+      }
+    }
+  }
+  return null;
+}

--- a/apps/dsa-web/src/utils/chatStockCode.ts
+++ b/apps/dsa-web/src/utils/chatStockCode.ts
@@ -1,4 +1,5 @@
 import { validateStockCode } from './validation';
+import { normalizeStockCode } from './stockCode';
 
 const EXCHANGE_PREFIXES = new Set(['SH', 'SZ', 'BJ', 'HK', 'US', 'SS']);
 
@@ -13,6 +14,7 @@ export function extractStockCodeFromMessage(message: string): string | null {
     /\b(SZ\d{6})\b/gi,
     /\b(BJ\d{6})\b/gi,
     /\b(hk\d{4,5})\b/gi,
+    /\b(\d{1,5}\.HK)\b/gi,
     /\b(\d{5,6})\b/g,
     /\b([A-Z]{2,5})\b/g,
   ];
@@ -24,7 +26,7 @@ export function extractStockCodeFromMessage(message: string): string | null {
           continue;
         }
         const { valid, normalized } = validateStockCode(m);
-        if (valid) return normalized;
+        if (valid) return normalizeStockCode(normalized);
       }
     }
   }

--- a/apps/dsa-web/src/utils/stockCode.ts
+++ b/apps/dsa-web/src/utils/stockCode.ts
@@ -1,0 +1,76 @@
+/**
+ * Normalize stock code by stripping exchange prefixes/suffixes.
+ *
+ * Mirrors the behavior of data_provider.base.normalize_stock_code in the backend.
+ *
+ *   600519      → 600519     SH600519    → 600519
+ *   600519.SH   → 600519     SH.600519   → 600519
+ *   SZ000001    → 000001     000001.SZ   → 000001
+ *   BJ920748    → 920748     920748.BJ   → 920748
+ *   HK00700     → HK00700    00700.HK    → HK00700
+ *   hk1810      → HK01810    1810.HK     → HK01810
+ *   AAPL        → AAPL       TSLA        → TSLA
+ */
+export function normalizeStockCode(stockCode: string): string {
+  const code = stockCode.trim();
+  const upper = code.toUpperCase();
+
+  // Normalize HK prefix to a canonical 5-digit form (e.g. hk1810 → HK01810)
+  if (upper.startsWith('HK') && !upper.startsWith('HK.')) {
+    const candidate = upper.slice(2);
+    if (/^\d{1,5}$/.test(candidate) && candidate.length >= 1 && candidate.length <= 5) {
+      return `HK${candidate.padStart(5, '0')}`;
+    }
+  }
+
+  // Strip SH/SZ prefix (e.g. SH600519 → 600519)
+  if ((upper.startsWith('SH') || upper.startsWith('SZ')) && !upper.startsWith('SH.') && !upper.startsWith('SZ.')) {
+    const candidate = code.slice(2);
+    if (/^\d{5,6}$/.test(candidate)) {
+      return candidate;
+    }
+  }
+
+  // Strip dotted SH/SZ prefix (e.g. SH.600519 → 600519)
+  if (upper.startsWith('SH.') || upper.startsWith('SZ.')) {
+    const candidate = code.slice(3);
+    if (/^\d{5,6}$/.test(candidate)) {
+      return candidate;
+    }
+  }
+
+  // Strip BJ prefix (e.g. BJ920748 → 920748)
+  if (upper.startsWith('BJ') && !upper.startsWith('BJ.')) {
+    const candidate = code.slice(2);
+    if (/^\d{6}$/.test(candidate)) {
+      return candidate;
+    }
+  }
+
+  // Strip dotted BJ prefix (e.g. BJ.920748 → 920748)
+  if (upper.startsWith('BJ.')) {
+    const candidate = code.slice(3);
+    if (/^\d{6}$/.test(candidate)) {
+      return candidate;
+    }
+  }
+
+  // Strip .SH/.SZ/.BJ suffix and .HK suffix with HK-prefix canonicalization
+  if (code.includes('.')) {
+    const dotIndex = code.lastIndexOf('.');
+    const base = code.slice(0, dotIndex);
+    const suffix = code.slice(dotIndex + 1).toUpperCase();
+
+    // 00700.HK → HK00700
+    if (suffix === 'HK' && /^\d{1,5}$/.test(base)) {
+      return `HK${base.padStart(5, '0')}`;
+    }
+
+    // 600519.SH → 600519
+    if ((suffix === 'SH' || suffix === 'SS' || suffix === 'SZ' || suffix === 'BJ') && /^\d+$/.test(base)) {
+      return base;
+    }
+  }
+
+  return code;
+}

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -31,10 +31,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 <!-- 新条目格式：- [类型] 描述（类型取值：新功能/改进/修复/文档/测试/chore）-->
 <!-- 每条独立一行追加到本段末尾，无需分类标题，合并时冲突最小 -->
-- [新功能] Web 首页左侧栏改为个股栏，按股票去重展示，大盘复盘置顶，点击个股加载最新报告，支持按代码变体（.SZ/.SH/.SS）归一化去重合并。
+- [新功能] Web 首页左侧栏改为个股栏，按股票去重展示，大盘复盘置顶，点击个股加载最新报告，支持按代码变体（.SZ/.SH/.SS）归一化去重合并。保留全选、批量删除和删除确认入口；新增按股票代码批量删除 API `DELETE /api/v1/history/by-code/{stock_code}`。
 - [新功能] 报告详情右侧栏新增自选操作入口，支持查看当前股票是否在自选队列、一键加入或移除；大盘复盘报告不显示该操作。
 - [新功能] 问股页面输入区上方新增自选操作按钮，用户发送包含股票代码的消息后自动显示加入自选/从自选删除入口。
-- [改进] 新增 GET /api/v1/history/stocks 端点按 code 分组返回不重复个股列表；新增 GET /api/v1/stocks/watchlist、POST /api/v1/stocks/watchlist/add、POST /api/v1/stocks/watchlist/remove 端点支持自选队列增删查，全链路 unified normalize_stock_code 归一化。
+- [改进] 新增 GET /api/v1/history/stocks 端点按 code 分组返回不重复个股列表；新增 GET /api/v1/stocks/watchlist、POST /api/v1/stocks/watchlist/add、POST /api/v1/stocks/watchlist/remove 端点支持自选队列增删查。STOCK_LIST 读写保持原样，不做自动归一化；add/remove 时归一化比较判断等价代码变体。
 - [改进] 新增 useWatchlist hook 统一管理自选队列前端状态，复用 SystemConfigService 的 STOCK_LIST 配置项实现持久化。
 - [新功能] Web 报告页新增同股历史趋势抽屉入口，历史列表摘要补充趋势、摘要、模型和分析时行情字段，支持按当前股票查看历史分析并加载更多。
 - [新功能] AnalysisContextPack P4 低敏 overview 接入历史详情、同步分析响应、completed 任务状态和 Web 报告页，展示数据块状态、来源、缺失原因与降级摘要。

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -31,7 +31,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 <!-- 新条目格式：- [类型] 描述（类型取值：新功能/改进/修复/文档/测试/chore）-->
 <!-- 每条独立一行追加到本段末尾，无需分类标题，合并时冲突最小 -->
-- [新功能] Web 报告页新增同股历史趋势抽屉入口，历史列表摘要补充趋势、摘要、模型和分析时行情字段，支持按当前股票查看历史分析并加载更多。
+- [新功能] Web 首页左侧栏改为个股栏，按股票去重展示，大盘复盘置顶，点击个股加载最新报告，支持按代码变体（.SZ/.SH/.SS）归一化去重合并。
+- [新功能] 报告详情右侧栏新增自选操作入口，支持查看当前股票是否在自选队列、一键加入或移除；大盘复盘报告不显示该操作。
+- [新功能] 问股页面输入区上方新增自选操作按钮，用户发送包含股票代码的消息后自动显示加入自选/从自选删除入口。
+- [改进] 新增 GET /api/v1/history/stocks 端点按 code 分组返回不重复个股列表；新增 GET/POST /api/v1/stocks/watchlist 端点支持自选队列增删改查。
+- [改进] 新增 useWatchlist hook 统一管理自选队列前端状态，复用 SystemConfigService 的 STOCK_LIST 配置项实现持久化。
 - [新功能] AnalysisContextPack P4 低敏 overview 接入历史详情、同步分析响应、completed 任务状态和 Web 报告页，展示数据块状态、来源、缺失原因与降级摘要。
 - [改进] AnalysisContextPack P5 增加数据质量评分、`fetch_failed` 状态、Prompt 数据限制区块和 Web 低敏质量展示。
 - [改进] #1386 P2-full 在 AnalysisContextPack Prompt 数据限制中追加市场阶段与降级数据的交叉约束，并修正中文分析 Prompt 的阶段化行情标签。

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -34,8 +34,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - [新功能] Web 首页左侧栏改为个股栏，按股票去重展示，大盘复盘置顶，点击个股加载最新报告，支持按代码变体（.SZ/.SH/.SS）归一化去重合并。
 - [新功能] 报告详情右侧栏新增自选操作入口，支持查看当前股票是否在自选队列、一键加入或移除；大盘复盘报告不显示该操作。
 - [新功能] 问股页面输入区上方新增自选操作按钮，用户发送包含股票代码的消息后自动显示加入自选/从自选删除入口。
-- [改进] 新增 GET /api/v1/history/stocks 端点按 code 分组返回不重复个股列表；新增 GET/POST /api/v1/stocks/watchlist 端点支持自选队列增删改查。
+- [改进] 新增 GET /api/v1/history/stocks 端点按 code 分组返回不重复个股列表；新增 GET /api/v1/stocks/watchlist、POST /api/v1/stocks/watchlist/add、POST /api/v1/stocks/watchlist/remove 端点支持自选队列增删查，全链路 unified normalize_stock_code 归一化。
 - [改进] 新增 useWatchlist hook 统一管理自选队列前端状态，复用 SystemConfigService 的 STOCK_LIST 配置项实现持久化。
+- [新功能] Web 报告页新增同股历史趋势抽屉入口，历史列表摘要补充趋势、摘要、模型和分析时行情字段，支持按当前股票查看历史分析并加载更多。
 - [新功能] AnalysisContextPack P4 低敏 overview 接入历史详情、同步分析响应、completed 任务状态和 Web 报告页，展示数据块状态、来源、缺失原因与降级摘要。
 - [改进] AnalysisContextPack P5 增加数据质量评分、`fetch_failed` 状态、Prompt 数据限制区块和 Web 低敏质量展示。
 - [改进] #1386 P2-full 在 AnalysisContextPack Prompt 数据限制中追加市场阶段与降级数据的交叉约束，并修正中文分析 Prompt 的阶段化行情标签。

--- a/src/storage.py
+++ b/src/storage.py
@@ -36,6 +36,7 @@ from sqlalchemy import (
     Index,
     UniqueConstraint,
     Text,
+    case,
     select,
     and_,
     or_,
@@ -1611,6 +1612,61 @@ class DatabaseManager(metaclass=_DatabaseManagerMeta):
                 delete(AnalysisHistory).where(AnalysisHistory.id.in_(ids))
             )
             return result.rowcount or 0
+
+    def get_distinct_stocks_from_history(
+        self,
+        start_date: Optional[date] = None,
+        end_date: Optional[date] = None,
+        limit: int = 200,
+    ) -> List[AnalysisHistory]:
+        """
+        获取历史记录中的不重复股票列表，每只股票取最新一条记录。
+
+        使用子查询按 code 分组取 MAX(id)，再 JOIN 回查完整记录。
+        大盘复盘（code="MARKET"）始终排在最前。
+
+        Args:
+            start_date: 开始日期
+            end_date: 结束日期
+            limit: 最大返回数量
+
+        Returns:
+            每条股票最新一条 AnalysisHistory 记录列表
+        """
+        with self.get_session() as session:
+            subq = (
+                select(
+                    AnalysisHistory.code,
+                    func.max(AnalysisHistory.id).label("max_id"),
+                )
+            )
+            if start_date:
+                subq = subq.where(
+                    AnalysisHistory.created_at >= datetime.combine(start_date, datetime.min.time())
+                )
+            if end_date:
+                subq = subq.where(
+                    AnalysisHistory.created_at < datetime.combine(end_date + timedelta(days=1), datetime.min.time())
+                )
+            subq = subq.group_by(AnalysisHistory.code).subquery()
+
+            results = (
+                session.execute(
+                    select(AnalysisHistory)
+                    .join(subq, AnalysisHistory.id == subq.c.max_id)
+                    .order_by(
+                        case(
+                            (AnalysisHistory.code == "MARKET", 0),
+                            else_=1,
+                        ),
+                        desc(AnalysisHistory.created_at),
+                    )
+                    .limit(limit)
+                )
+                .scalars()
+                .all()
+            )
+            return list(results)
 
     def get_latest_analysis_by_query_id(self, query_id: str) -> Optional[AnalysisHistory]:
         """


### PR DESCRIPTION
## PR Type

- [x] feat

## Background And Problem

Issue #1530 提出两项改进：
1. 左侧历史报告栏应为个股维度去重展示，大盘复盘置顶，按分析顺序排列
2. 问股页面缺少对自选队列的操作能力（加入自选/从自选删除）

## Scope Of Change

| 模块 | 文件 | 说明 |
|------|------|------|
| 后端 API | `api/v1/endpoints/history.py` | 新增 `GET /history/stocks` 去重个股栏端点；新增 `DELETE /history/by-code/{stock_code}` 按股票代码批量删除端点 |
| 后端 API | `api/v1/endpoints/stocks.py` | 新增 `GET /watchlist`、`POST /watchlist/add`、`POST /watchlist/remove` 自选端点，含 regex 校验；STOCK_LIST 读写原样，add/remove 时归一化比较 |
| 后端 Schema | `api/v1/schemas/history.py` | 新增 `StockBarItem/Response`、`WatchlistRequest/Response` |
| 后端存储 | `src/storage.py` | 新增 `get_distinct_stocks_from_history` 去重查询 |
| 前端组件 | `StockBar.tsx`, `StockBarItem.tsx` | 个股栏替换原 HistoryList，保留全选/批量删除入口，每项新增 hover 删除按钮 |
| 前端 Hook | `useWatchlist.ts` | 自选队列状态管理，`isInWatchlist` 使用 `normalizeStockCode` 归一化判断 |
| 前端页面 | `HomePage.tsx`, `ChatPage.tsx` | 集成个股栏（含删除）与自选按钮 |
| 前端报告 | `ReportOverview.tsx`, `ReportSummary.tsx` | 右边栏新增自选卡片（market_review 不显示） |
| 前端工具 | `utils/chatStockCode.ts` / `utils/stockCode.ts` | 消息中提取股票代码 + `normalizeStockCode` 归一化工具 |
| 文档 | `docs/CHANGELOG.md` | 追加 [Unreleased] 扁平条目 |

## Issue Link

Refs #1530

## Verification Commands And Results

```bash
./scripts/ci_gate.sh
# 2612 passed, 2 deselected, 24 warnings, 243 subtests passed

cd apps/dsa-web && npm run lint && npm run build
# lint: 0 errors, 0 warnings

python scripts/check_ai_assets.py
# [ai-assets] OK

cd apps/dsa-web && npx vitest run src/pages/__tests__/ChatPage.test.tsx src/pages/__tests__/HomePage.test.tsx src/utils/__tests__/stockCode.test.ts src/hooks/__tests__/useDashboardLifecycle.test.tsx
# 4 passed, 67 tests
```

## Compatibility And Risk

- 新增 API 端点均为追加，不修改现有端点签名，向后兼容
- **批量删除**：StockBar 保留全选/批量删除入口，新增 `DELETE /api/v1/history/by-code/{stock_code}` 端点支持按股票代码删除全部历史记录
- **STOCK_LIST 不做自动归一化**：读写均保持原样，不修改用户已有配置。add/remove 时仅归一化比较判断等价代码变体
- **前端归一化**：`stockInWatchlist` 和 `extractStockCodeFromMessage` 使用 `normalizeStockCode` 归一化后比较
- **输入校验**：watchlist API 入口 regex 校验覆盖全部格式，非法输入返回 400
- 桌面端未验证，但改动仅涉及 Web 组件和 API

## Rollback Plan

`git revert` 本 PR 即可完全回退；STOCK_LIST 不做任何自动迁移，回滚无副作用。