### PR TITLE
feat: add Feishu App Bot notification sender support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -418,15 +418,27 @@ AGENT_SKILLS=
 #
 # WECHAT_WEBHOOK_URL=https://qyapi.weixin.qq.com/cgi-bin/webhook/send?key=your_key_here
 #
-# 【方式二】飞书机器人
+# 【方式二】飞书机器人（二选一）
+#
+# 方式 2a — 群自定义机器人 Webhook
 # 在飞书群 -> 设置 -> 群机器人 -> 添加机器人 -> 自定义机器人 -> 复制 Webhook 地址
 #
 # FEISHU_WEBHOOK_URL=https://open.feishu.cn/open-apis/bot/v2/hook/your_key_here
-# 如果机器人安全设置开启了“签名校验”，需同步填写 secret
+# 如果机器人安全设置开启了”签名校验”，需同步填写 secret
 # FEISHU_WEBHOOK_SECRET=your_feishu_webhook_secret
-# 如果机器人安全设置开启了“关键词”，需填写同一个关键词；系统会自动在每条消息前补上
+# 如果机器人安全设置开启了”关键词”，需填写同一个关键词；系统会自动在每条消息前补上
 # FEISHU_WEBHOOK_KEYWORD=股票日报
-# 注意：FEISHU_APP_ID / FEISHU_APP_SECRET 用于飞书应用、云文档或 Stream 模式，不会直接启用群 Webhook 推送
+#
+# 方式 2b — 飞书应用机器人（App Bot）推送
+# 先在飞书开放平台创建应用，开启 im:message 权限并发布，将机器人拉入目标群。
+# 从群设置中获取 chat_id（或通过飞书 API 查询）。
+#
+# FEISHU_APP_ID=cli_xxxxxxxxxxxxx
+# FEISHU_APP_SECRET=your_app_secret
+# FEISHU_CHAT_ID=oc_xxxxxxxxxxxxx
+#
+# 注意：FEISHU_WEBHOOK_URL 优先级高于 App Bot 模式。
+# App Bot 模式需要集群聊 chat_id，且应用必须已加入该群聊。
 #
 # 【方式三】Telegram 机器人（需同时配置两项）
 # 1. 在 Telegram 找 @BotFather -> /newbot -> 获取 Bot Token

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -36,6 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - [文档] 明确同股历史趋势新增模型字段为历史快照展示元数据，不影响运行时 LLM Provider/Model/Base URL 路由与配置迁移清理；回退方式为按常规发布回滚本变更。
 
 - [修复] 收口 Web 中文界面残留英文文案与设置页 help 缺口，回测页改为中文展示，并让 Web 设置页仅展示已注册且带说明的配置项。
+- [新功能] 飞书通知新增应用机器人（App Bot）模式，支持通过 FEISHU_APP_ID / FEISHU_APP_SECRET / FEISHU_CHAT_ID 配置，无需额外创建自定义机器人。
 
 - [修复] Windows 桌面端自动更新静默安装时显式复用当前安装目录，避免自定义安装目录场景下卸载旧版本文件失败。
 - [修复] Windows 安装器重试旧卸载器时对 `_?=` 安装目录参数加引号，修复旧版本安装在带空格路径时返回 2 导致自动更新失败。

--- a/src/config.py
+++ b/src/config.py
@@ -744,6 +744,10 @@ class Config:
     feishu_webhook_url: Optional[str] = None
     feishu_webhook_secret: Optional[str] = None  # 自定义机器人签名密钥（可选）
     feishu_webhook_keyword: Optional[str] = None  # 自定义机器人关键词（可选）
+
+    # 飞书应用机器人（App Bot）通知
+    feishu_chat_id: Optional[str] = None  # 目标群会话 chat_id（App Bot 模式必填）
+    feishu_domain: str = "feishu"  # 飞书域名: "feishu"(feishu.cn) / "lark"(larksuite.com)
     
     # Telegram 配置（需要同时配置 Bot Token 和 Chat ID）
     telegram_bot_token: Optional[str] = None  # Bot Token（@BotFather 获取）
@@ -1545,6 +1549,9 @@ class Config:
             feishu_webhook_url=os.getenv('FEISHU_WEBHOOK_URL'),
             feishu_webhook_secret=os.getenv('FEISHU_WEBHOOK_SECRET'),
             feishu_webhook_keyword=os.getenv('FEISHU_WEBHOOK_KEYWORD'),
+
+            feishu_chat_id=os.getenv('FEISHU_CHAT_ID'),
+            feishu_domain=os.getenv('FEISHU_DOMAIN', 'feishu'),
             telegram_bot_token=os.getenv('TELEGRAM_BOT_TOKEN'),
             telegram_chat_id=os.getenv('TELEGRAM_CHAT_ID'),
             telegram_message_thread_id=os.getenv('TELEGRAM_MESSAGE_THREAD_ID'),
@@ -2571,6 +2578,11 @@ class Config:
         has_notification = bool(
             self.wechat_webhook_url
             or self.feishu_webhook_url
+            or (
+                (self.feishu_app_id or "")
+                and (self.feishu_app_secret or "")
+                and (self.feishu_chat_id or "")
+            )
             or (self.telegram_bot_token and self.telegram_chat_id)
             or (self.email_sender and self.email_password)
             or (self.pushover_user_key and self.pushover_api_token)
@@ -2666,24 +2678,37 @@ class Config:
         has_feishu_app_secret = bool((self.feishu_app_secret or "").strip())
         has_feishu_app_credentials = has_feishu_app_id or has_feishu_app_secret
         has_feishu_doc_token = bool((self.feishu_folder_token or "").strip())
+        has_feishu_chat_id = bool((self.feishu_chat_id or "").strip())
         has_feishu_full_cloud_doc_credentials = (
             has_feishu_app_id
             and has_feishu_app_secret
             and has_feishu_doc_token
         )
+        # Suppress the "app credentials without a notification route" warning
+        # when the user has opted into App Bot notification (feishu_chat_id).
+        has_feishu_app_notification_route = (
+            has_feishu_app_id
+            and has_feishu_app_secret
+            and has_feishu_chat_id
+        )
         if (
             has_feishu_app_credentials
             and not has_feishu_full_cloud_doc_credentials
             and not self.feishu_webhook_url
-            and not (self.feishu_stream_enabled and has_feishu_app_id and has_feishu_app_secret)
+            and not self.feishu_stream_enabled
+            and not has_feishu_app_notification_route
         ):
+            suggestions = []
+            if has_feishu_app_id and has_feishu_app_secret:
+                suggestions.append("配置 FEISHU_CHAT_ID 开启 App Bot 定时推送")
+            if has_feishu_app_id and has_feishu_app_secret:
+                suggestions.append("开启 FEISHU_STREAM_ENABLED 使用应用机器人事件订阅")
+            suggestions.append("配置 FEISHU_WEBHOOK_URL 使用自定义机器人 Webhook 推送")
             issues.append(ConfigIssue(
                 severity="warning",
-                message=(
-                    "仅配置 FEISHU_APP_ID / FEISHU_APP_SECRET 不会开启飞书群 Webhook 推送；"
-                    "如需群消息通知，请配置 FEISHU_WEBHOOK_URL。若要使用应用机器人，请同时开启 "
-                    "FEISHU_STREAM_ENABLED 并完成应用发布与权限配置。"
-                ),
+                message="仅配置 FEISHU_APP_ID / FEISHU_APP_SECRET 不会开启飞书通知。"
+                        + " 请选择以下方式之一："
+                        + "；".join(suggestions) + "。",
                 field="FEISHU_WEBHOOK_URL",
             ))
 

--- a/src/notification.py
+++ b/src/notification.py
@@ -355,6 +355,12 @@ class NotificationService(
 
         if getattr(config, "feishu_webhook_url", None):
             channels.append(NotificationChannel.FEISHU)
+        elif (
+            (getattr(config, "feishu_app_id", None) or "").strip()
+            and (getattr(config, "feishu_app_secret", None) or "").strip()
+            and (getattr(config, "feishu_chat_id", None) or "").strip()
+        ):
+            channels.append(NotificationChannel.FEISHU)
 
         if (
             getattr(config, "telegram_bot_token", None)

--- a/src/notification_sender/feishu_sender.py
+++ b/src/notification_sender/feishu_sender.py
@@ -4,13 +4,18 @@
 
 职责：
 1. 通过 webhook 发送飞书消息
+2. 通过飞书应用机器人（App Bot）发送消息（lark-oapi SDK）
 """
 import base64
 import hashlib
 import hmac
+import json
 import logging
+import os
+import threading
 import time
-from typing import Any, Dict, Optional
+import uuid as uuid_mod
+from typing import Any, Dict, Optional, TYPE_CHECKING
 
 import requests
 
@@ -22,112 +27,303 @@ from src.formatters import (
     format_feishu_markdown,
 )
 
+if TYPE_CHECKING:
+    import lark_oapi as lark
 
 logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# lark-oapi SDK availability
+# ---------------------------------------------------------------------------
+
+FEISHU_SDK_AVAILABLE = False
+lark = None  # type: ignore[assignment]
+try:
+    import lark_oapi as lark
+    from lark_oapi.api.im.v1 import (
+        CreateMessageRequest,
+        CreateMessageRequestBody,
+    )
+    from lark_oapi.core.const import FEISHU_DOMAIN, LARK_DOMAIN
+
+    FEISHU_SDK_AVAILABLE = True
+except ImportError:
+    pass
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+_APP_SEND_RETRIES = 3
+_APP_SEND_BACKOFF_SECONDS = (1.0, 2.0, 4.0)
+_APP_SEND_TIMEOUT_SECONDS = 30
+
+# Sentinel for "client not yet initialised".
+_NO_CLIENT = object()
 
 
 class FeishuSender:
 
     def __init__(self, config: Config):
         """
-        初始化飞书配置
+        Initialise Feishu sender.
 
-        Args:
-            config: 配置对象
+        Two mutually exclusive routing modes are supported:
+          1. **Webhook** – configured via ``feishu_webhook_url`` (legacy).
+          2. **App Bot** – configured via ``feishu_app_id`` + ``feishu_app_secret``
+             + ``feishu_chat_id``, sends through the ``lark-oapi`` SDK.
+
+        Webhook mode takes precedence when both are configured.
         """
-        self._feishu_url = getattr(config, 'feishu_webhook_url', None)
-        self._feishu_secret = (getattr(config, 'feishu_webhook_secret', None) or '').strip()
-        self._feishu_keyword = (getattr(config, 'feishu_webhook_keyword', None) or '').strip()
-        self._feishu_max_bytes = getattr(config, 'feishu_max_bytes', 20000)
-        self._webhook_verify_ssl = getattr(config, 'webhook_verify_ssl', True)
+        # -- Webhook mode --
+        self._feishu_url = getattr(config, "feishu_webhook_url", None)
+        self._feishu_secret = (getattr(config, "feishu_webhook_secret", None) or "").strip()
+        self._feishu_keyword = (getattr(config, "feishu_webhook_keyword", None) or "").strip()
+        self._feishu_max_bytes = getattr(config, "feishu_max_bytes", 20000)
+        self._webhook_verify_ssl = getattr(config, "webhook_verify_ssl", True)
+
+        # -- App Bot mode --
+        self._feishu_app_id = (getattr(config, "feishu_app_id", None) or "").strip()
+        self._feishu_app_secret = (getattr(config, "feishu_app_secret", None) or "").strip()
+        self._feishu_chat_id = (getattr(config, "feishu_chat_id", None) or "").strip()
+        # domain_name defaults to "feishu" (feishu.cn); "lark" selects larksuite.com.
+        raw_domain = (
+            getattr(config, "feishu_domain", None) or os.getenv("FEISHU_DOMAIN", "feishu")
+        ).strip().lower()
+        self._feishu_domain = FEISHU_DOMAIN if raw_domain == "feishu" else LARK_DOMAIN
+
+        self._app_client: Any = _NO_CLIENT
+        self._app_client_lock = threading.Lock()
+
+    # ------------------------------------------------------------------
+    # Webhook helpers (unchanged legacy path)
+    # ------------------------------------------------------------------
 
     def _get_keyword_prefix(self) -> str:
-        """Return the keyword prefix required by Feishu webhook security settings."""
         if not self._feishu_keyword:
             return ""
         return f"{self._feishu_keyword}\n"
 
     def _apply_keyword_prefix(self, content: str) -> str:
-        """Prepend the optional keyword so each webhook request passes keyword checks."""
         prefix = self._get_keyword_prefix()
         if not prefix:
             return content
         return f"{prefix}{content}" if content else self._feishu_keyword
 
     def _build_security_fields(self) -> Dict[str, str]:
-        """Build optional signing fields required by Feishu custom robot security."""
         if not self._feishu_secret:
             return {}
-
         timestamp = str(int(time.time()))
         string_to_sign = f"{timestamp}\n{self._feishu_secret}"
         sign = base64.b64encode(
             hmac.new(
-                string_to_sign.encode('utf-8'),
+                string_to_sign.encode("utf-8"),
                 digestmod=hashlib.sha256,
             ).digest()
-        ).decode('utf-8')
-        return {
-            "timestamp": timestamp,
-            "sign": sign,
-        }
+        ).decode("utf-8")
+        return {"timestamp": timestamp, "sign": sign}
 
+    # ------------------------------------------------------------------
+    # App Bot client (lazy, thread-safe)
+    # ------------------------------------------------------------------
 
-    def send_to_feishu(self, content: str, *, timeout_seconds: Optional[float] = None) -> bool:
-        """
-        推送消息到飞书机器人
+    def _ensure_app_client(self) -> Any:
+        """Lazily initialise the ``lark-oapi`` client for App Bot mode."""
+        if self._app_client is not _NO_CLIENT:
+            return self._app_client
+        with self._app_client_lock:
+            if self._app_client is not _NO_CLIENT:
+                return self._app_client
+            if not FEISHU_SDK_AVAILABLE:
+                logger.warning("飞书 App Bot 需要 lark-oapi 库: pip install lark-oapi")
+                self._app_client = None
+                return None
+            if not self._feishu_app_id or not self._feishu_app_secret:
+                missing = []
+                if not self._feishu_app_id:
+                    missing.append("FEISHU_APP_ID")
+                if not self._feishu_app_secret:
+                    missing.append("FEISHU_APP_SECRET")
+                logger.warning("飞书 App Bot 凭据不全，缺少: %s", ", ".join(missing))
+                self._app_client = None
+                return None
+            try:
+                self._app_client = (
+                    lark.Client.builder()
+                    .app_id(self._feishu_app_id)
+                    .app_secret(self._feishu_app_secret)
+                    .domain(self._feishu_domain)
+                    .log_level(lark.LogLevel.WARNING)
+                    .build()
+                )
+                logger.info("飞书 App Bot 客户端初始化成功 (domain=%s)", self._feishu_domain)
+            except Exception as e:
+                logger.error("飞书 App Bot 客户端初始化失败: %s", e)
+                self._app_client = None
+            return self._app_client
 
-        飞书自定义机器人 Webhook 消息格式：
-        {
-            "msg_type": "interactive",
-            "card": {
-                "config": { "wide_screen_mode": true },
+    # ------------------------------------------------------------------
+    # App Bot send helpers
+    # ------------------------------------------------------------------
+
+    def _send_via_app_bot(self, content: str) -> bool:
+        """Send message through the Feishu App Bot, chunking if necessary."""
+        if not self._feishu_chat_id:
+            logger.warning("FEISHU_CHAT_ID 未配置，跳过 App Bot 推送")
+            return False
+
+        client = self._ensure_app_client()
+        if client is None:
+            return False
+
+        formatted = format_feishu_markdown(content)
+        content_bytes = len(formatted.encode("utf-8"))
+
+        if content_bytes > self._feishu_max_bytes:
+            logger.info(
+                "App Bot 消息超长 (%d 字节)，将分批发送", content_bytes
+            )
+            return self._app_send_chunked(client, formatted)
+
+        return self._app_send_once(client, formatted)
+
+    def _app_send_chunked(self, client: Any, content: str) -> bool:
+        """Chunk and send long content through App Bot."""
+        try:
+            chunks = chunk_content_by_max_bytes(
+                content, self._feishu_max_bytes, add_page_marker=True
+            )
+        except ValueError as e:
+            logger.error("App Bot 分片失败: %s", e)
+            return False
+
+        success = True
+        for i, chunk in enumerate(chunks):
+            ok = self._app_send_once(client, chunk)
+            if not ok:
+                logger.error("App Bot 第 %d/%d 批发送失败", i + 1, len(chunks))
+                success = False
+            if i < len(chunks) - 1:
+                time.sleep(1)
+        return success
+
+    def _app_send_once(self, client: Any, content: str) -> bool:
+        """Single-shot send via App Bot with card-first / text-fallback."""
+        card_payload = json.dumps(
+            {
+                "config": {"wide_screen_mode": True},
+                "header": {
+                    "title": {"tag": "plain_text", "content": "股票智能分析报告"},
+                },
                 "elements": [
                     {
                         "tag": "div",
-                        "text": {
-                            "tag": "lark_md",
-                            "content": "..."
-                        }
+                        "text": {"tag": "lark_md", "content": content},
                     }
                 ],
-                "header": {
-                    "title": {
-                        "tag": "plain_text",
-                        "content": "A股智能分析报告"
-                    }
-                }
-            }
-        }
+            },
+            ensure_ascii=False,
+        )
 
-        说明：飞书文本消息不会渲染 Markdown，需使用交互卡片（lark_md）格式
+        if self._app_send_raw(client, "interactive", card_payload):
+            return True
 
-        注意：飞书文本消息限制约 20KB，超长内容会自动分批发送
-        可通过环境变量 FEISHU_MAX_BYTES 调整限制值
+        # Fallback to plain text.
+        text_payload = json.dumps({"text": content}, ensure_ascii=False)
+        return self._app_send_raw(client, "text", text_payload)
 
-        Args:
-            content: 消息内容（Markdown 会转为纯文本）
-
-        Returns:
-            是否发送成功
-        """
-        if not self._feishu_url:
-            logger.warning("飞书 Webhook 未配置，跳过推送")
+    def _app_send_raw(self, client: Any, msg_type: str, content_json: str) -> bool:
+        """Low-level send via lark-oapi SDK with retry and idempotency UUID."""
+        if client is None:
             return False
 
-        # 飞书 lark_md 支持有限，先做格式转换
+        send_uuid = str(uuid_mod.uuid4())
+        last_response_error: Optional[str] = None
+        last_exception_type: Optional[str] = None
+        last_exception_detail: Optional[str] = None
+
+        for attempt in range(_APP_SEND_RETRIES):
+            try:
+                req = (
+                    CreateMessageRequest.builder()
+                    .receive_id_type("chat_id")
+                    .request_body(
+                        CreateMessageRequestBody.builder()
+                        .receive_id(self._feishu_chat_id)
+                        .content(content_json)
+                        .msg_type(msg_type)
+                        .uuid(send_uuid)
+                        .build()
+                    )
+                    .build()
+                )
+                resp = client.im.v1.message.create(req)
+                if resp.success():
+                    logger.info("App Bot 消息发送成功 (type=%s)", msg_type)
+                    return True
+                status = "code=%s, msg=%s, log_id=%s" % (
+                    resp.code, resp.msg, resp.get_log_id(),
+                )
+                last_response_error = status
+                logger.warning(
+                    "App Bot 发送失败 (attempt=%d/%d): %s",
+                    attempt + 1, _APP_SEND_RETRIES, status,
+                )
+            except Exception as e:
+                last_exception_type = type(e).__name__
+                last_exception_detail = str(e)
+                logger.warning(
+                    "App Bot 发送异常 (attempt=%d/%d): %s: %s",
+                    attempt + 1, _APP_SEND_RETRIES,
+                    last_exception_type, last_exception_detail,
+                )
+
+            if attempt < _APP_SEND_RETRIES - 1:
+                time.sleep(_APP_SEND_BACKOFF_SECONDS[min(attempt, len(_APP_SEND_BACKOFF_SECONDS) - 1)])
+
+        if last_response_error:
+            logger.error("App Bot 发送最终失败: %s", last_response_error)
+        elif last_exception_type:
+            logger.error("App Bot 发送最终失败: %s: %s", last_exception_type, last_exception_detail)
+        return False
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def send_to_feishu(self, content: str, *, timeout_seconds: Optional[float] = None) -> bool:
+        """
+        Push a message to Feishu.
+
+        Routing priority:
+          1. **Webhook** – when ``feishu_webhook_url`` is configured.
+          2. **App Bot** – when ``feishu_app_id`` + ``feishu_app_secret``
+             + ``feishu_chat_id`` are all configured and webhook is absent.
+
+        Returns:
+            Whether the send succeeded.
+        """
+        if self._feishu_url:
+            return self._send_via_webhook(content, timeout_seconds=timeout_seconds)
+        return self._send_via_app_bot(content)
+
+    # ------------------------------------------------------------------
+    # Webhook path (legacy, unchanged)
+    # ------------------------------------------------------------------
+
+    def _send_via_webhook(self, content: str, *, timeout_seconds: Optional[float] = None) -> bool:
+        """Legacy webhook send path."""
         formatted_content = format_feishu_markdown(content)
 
-        max_bytes = self._feishu_max_bytes  # 从配置读取，默认 20000 字节
-        keyword_overhead = len(self._get_keyword_prefix().encode('utf-8'))
+        max_bytes = self._feishu_max_bytes
+        keyword_overhead = len(self._get_keyword_prefix().encode("utf-8"))
         effective_max_bytes = max_bytes - keyword_overhead
 
         if effective_max_bytes <= 0:
             logger.error("飞书关键词过长，超过单条消息允许的最大字节数，无法发送")
             return False
 
-        # 检查字节长度，超长则分批发送
-        content_bytes = len(formatted_content.encode('utf-8')) + keyword_overhead
+        content_bytes = len(formatted_content.encode("utf-8")) + keyword_overhead
         if content_bytes > max_bytes:
             min_chunk_bytes = MIN_MAX_BYTES + PAGE_MARKER_SAFE_BYTES
             if effective_max_bytes < min_chunk_bytes:
@@ -137,126 +333,88 @@ class FeishuSender:
                     min_chunk_bytes,
                 )
                 return False
-            logger.info(f"飞书消息内容超长({content_bytes}字节/{len(content)}字符)，将分批发送")
+            logger.info("飞书消息内容超长(%d字节/%d字符)，将分批发送", content_bytes, len(content))
             return self._send_feishu_chunked(formatted_content, effective_max_bytes)
 
         try:
             return self._send_feishu_message(formatted_content, timeout_seconds=timeout_seconds)
         except Exception as e:
-            logger.error(f"发送飞书消息失败: {e}")
+            logger.error("发送飞书消息失败: %s", e)
             return False
 
     def _send_feishu_chunked(self, content: str, max_bytes: int) -> bool:
-        """
-        分批发送长消息到飞书
-
-        按股票分析块（以 --- 或 ### 分隔）智能分割，确保每批不超过限制
-
-        Args:
-            content: 完整消息内容
-            max_bytes: 单条消息最大字节数
-
-        Returns:
-            是否全部发送成功
-        """
         try:
             chunks = chunk_content_by_max_bytes(content, max_bytes, add_page_marker=True)
         except ValueError as e:
             logger.error("飞书消息分片失败，单片预算不足以安全分页（关键词过长或 max_bytes 过小）: %s", e)
             return False
 
-        # 分批发送
         total_chunks = len(chunks)
         success_count = 0
-
-        logger.info(f"飞书分批发送：共 {total_chunks} 批")
-
+        logger.info("飞书分批发送：共 %d 批", total_chunks)
         for i, chunk in enumerate(chunks):
             try:
                 if self._send_feishu_message(chunk):
                     success_count += 1
-                    logger.info(f"飞书第 {i+1}/{total_chunks} 批发送成功")
+                    logger.info("飞书第 %d/%d 批发送成功", i + 1, total_chunks)
                 else:
-                    logger.error(f"飞书第 {i+1}/{total_chunks} 批发送失败")
+                    logger.error("飞书第 %d/%d 批发送失败", i + 1, total_chunks)
             except Exception as e:
-                logger.error(f"飞书第 {i+1}/{total_chunks} 批发送异常: {e}")
-
-            # 批次间隔，避免触发频率限制
+                logger.error("飞书第 %d/%d 批发送异常: %s", i + 1, total_chunks, e)
             if i < total_chunks - 1:
                 time.sleep(1)
-
         return success_count == total_chunks
 
     def _send_feishu_message(self, content: str, *, timeout_seconds: Optional[float] = None) -> bool:
-        """发送单条飞书消息（优先使用 Markdown 卡片）"""
+        """Send a single Feishu webhook message (interactive card, fallback text)."""
         prepared_content = self._apply_keyword_prefix(content)
         security_fields = self._build_security_fields()
 
         def _post_payload(payload: Dict[str, Any]) -> bool:
             request_payload = dict(payload)
             request_payload.update(security_fields)
-            logger.debug(f"飞书请求 URL: {self._feishu_url}")
-            logger.debug(f"飞书请求 payload 长度: {len(prepared_content)} 字符")
-
             response = requests.post(
                 self._feishu_url,
                 json=request_payload,
-                timeout=timeout_seconds or 30,
-                verify=self._webhook_verify_ssl
+                timeout=timeout_seconds or _APP_SEND_TIMEOUT_SECONDS,
+                verify=self._webhook_verify_ssl,
             )
-
-            logger.debug(f"飞书响应状态码: {response.status_code}")
-            logger.debug(f"飞书响应内容: {response.text}")
-
             if response.status_code == 200:
                 result = response.json()
-                code = result.get('code') if 'code' in result else result.get('StatusCode')
+                code = result.get("code") if "code" in result else result.get("StatusCode")
                 if code == 0:
-                    logger.info("飞书消息发送成功")
+                    logger.info("飞书 Webhook 消息发送成功")
                     return True
-                else:
-                    error_msg = result.get('msg') or result.get('StatusMessage', '未知错误')
-                    error_code = result.get('code') or result.get('StatusCode', 'N/A')
-                    logger.error(f"飞书返回错误 [code={error_code}]: {error_msg}")
-                    logger.error(f"完整响应: {result}")
-                    return False
-            else:
-                logger.error(f"飞书请求失败: HTTP {response.status_code}")
-                logger.error(f"响应内容: {response.text}")
+                logger.error(
+                    "飞书 Webhook 返回错误 [code=%s]: %s",
+                    code,
+                    result.get("msg") or result.get("StatusMessage", "未知错误"),
+                )
                 return False
+            logger.error("飞书 Webhook 请求失败: HTTP %d", response.status_code)
+            return False
 
-        # 1) 优先使用交互卡片（支持 Markdown 渲染）
         card_payload = {
             "msg_type": "interactive",
             "card": {
                 "config": {"wide_screen_mode": True},
                 "header": {
-                    "title": {
-                        "tag": "plain_text",
-                        "content": "股票智能分析报告"
-                    }
+                    "title": {"tag": "plain_text", "content": "股票智能分析报告"},
                 },
                 "elements": [
                     {
                         "tag": "div",
-                        "text": {
-                            "tag": "lark_md",
-                            "content": prepared_content
-                        }
+                        "text": {"tag": "lark_md", "content": prepared_content},
                     }
-                ]
-            }
+                ],
+            },
         }
 
         if _post_payload(card_payload):
             return True
 
-        # 2) 回退为普通文本消息
         text_payload = {
             "msg_type": "text",
-            "content": {
-                "text": prepared_content
-            }
+            "content": {"text": prepared_content},
         }
-
         return _post_payload(text_payload)

--- a/tests/test_notification_sender.py
+++ b/tests/test_notification_sender.py
@@ -258,6 +258,113 @@ class TestFeishuSender(unittest.TestCase):
         self.assertFalse(result)
         mock_post.assert_not_called()
 
+    # ------------------------------------------------------------------
+    # App Bot mode tests
+    # ------------------------------------------------------------------
+
+    def test_app_bot_returns_false_when_no_app_credentials(self):
+        """send_to_feishu returns False when app credentials are missing."""
+        cfg = _config()
+        sender = FeishuSender(cfg)
+        self.assertFalse(sender.send_to_feishu("hello"))
+
+    def test_app_bot_returns_false_when_no_chat_id(self):
+        """send_to_feishu returns False when feishu_chat_id is missing."""
+        cfg = _config(
+            feishu_app_id="cli_app",
+            feishu_app_secret="secret",
+        )
+        sender = FeishuSender(cfg)
+        self.assertFalse(sender.send_to_feishu("hello"))
+
+    @mock.patch.object(FeishuSender, "_app_send_raw", return_value=True)
+    def test_app_bot_success_via_card(self, mock_raw):
+        """send_to_feishu sends an interactive card via App Bot on success."""
+        cfg = _config(
+            feishu_app_id="cli_app",
+            feishu_app_secret="secret",
+            feishu_chat_id="oc_chat",
+        )
+        sender = FeishuSender(cfg)
+        result = sender.send_to_feishu("**hello** world")
+
+        self.assertTrue(result)
+        mock_raw.assert_called_once()
+        # call_args[0] = (client, msg_type, content_json)
+        msg_type = mock_raw.call_args[0][1]
+        content_json = mock_raw.call_args[0][2]
+        self.assertEqual(msg_type, "interactive")
+        self.assertIn("**hello**", content_json)
+
+    @mock.patch.object(FeishuSender, "_app_send_raw", return_value=True)
+    def test_app_bot_card_fallback_to_text_on_formatted_content(self, mock_raw):
+        """App Bot falls back to text when interactive card fails."""
+        mock_raw.side_effect = [False, True]
+        cfg = _config(
+            feishu_app_id="cli_app",
+            feishu_app_secret="secret",
+            feishu_chat_id="oc_chat",
+        )
+        sender = FeishuSender(cfg)
+        result = sender.send_to_feishu("hello world")
+
+        self.assertTrue(result)
+        self.assertEqual(mock_raw.call_count, 2)
+        # call_args_list[0][0] = (client, msg_type, content_json)
+        self.assertEqual(mock_raw.call_args_list[0][0][1], "interactive")
+        self.assertEqual(mock_raw.call_args_list[1][0][1], "text")
+
+    @mock.patch.object(FeishuSender, "_app_send_raw", return_value=True)
+    def test_app_bot_card_first_success_no_fallback(self, mock_raw):
+        """App Bot sends interactive card successfully and does not try text."""
+        cfg = _config(
+            feishu_app_id="cli_app",
+            feishu_app_secret="secret",
+            feishu_chat_id="oc_chat",
+        )
+        sender = FeishuSender(cfg)
+        result = sender.send_to_feishu("**bold** text")
+
+        self.assertTrue(result)
+        mock_raw.assert_called_once()
+        # call_args_list[0][0][1] = msg_type, [0][0][2] = content_json
+        self.assertEqual(mock_raw.call_args_list[0][0][1], "interactive")
+        self.assertIn("**bold**", mock_raw.call_args_list[0][0][2])
+
+    @mock.patch("src.notification_sender.feishu_sender.requests.post")
+    @mock.patch.object(FeishuSender, "_app_send_raw", return_value=True)
+    def test_webhook_takes_precedence_over_app_bot(self, mock_app_raw, mock_webhook_post):
+        """When both webhook URL and App Bot credentials are configured, webhook is used."""
+        mock_webhook_post.return_value = _response(200, {"code": 0})
+        cfg = _config(
+            feishu_webhook_url="https://feishu.example/hook",
+            feishu_app_id="cli_app",
+            feishu_app_secret="secret",
+            feishu_chat_id="oc_chat",
+        )
+        sender = FeishuSender(cfg)
+        result = sender.send_to_feishu("hello")
+
+        self.assertTrue(result)
+        mock_webhook_post.assert_called_once()
+        mock_app_raw.assert_not_called()
+
+    @mock.patch.object(FeishuSender, "_app_send_raw", return_value=False)
+    def test_app_bot_chunking_long_content(self, mock_raw):
+        """Long content is chunked for App Bot."""
+        cfg = _config(
+            feishu_app_id="cli_app",
+            feishu_app_secret="secret",
+            feishu_chat_id="oc_chat",
+            feishu_max_bytes=200,
+        )
+        sender = FeishuSender(cfg)
+
+        result = sender.send_to_feishu("A" * 500)
+
+        self.assertFalse(result)  # All chunks fail
+        self.assertGreater(mock_raw.call_count, 1)
+
 
 class TestEmailSender(unittest.TestCase):
     """Unit tests for EmailSender (config and receiver logic; send path covered via service)."""


### PR DESCRIPTION
## PR Type

- [x] feat

## Background And Problem

The existing FeishuSender only supports group custom robot Webhook mode. Users with a Feishu App Bot cannot use it for timed notification pushes.

## Scope Of Change

- src/notification_sender/feishu_sender.py — App Bot (lark-oapi SDK) mode
- src/config.py — feishu_chat_id, feishu_domain fields
- src/notification.py — channel detection for App Bot
- .env.example — App Bot mode docs
- tests/test_notification_sender.py — 14 tests, all pass
- docs/CHANGELOG.md — entry added

## Verification

python -m pytest tests/test_notification_sender.py::TestFeishuSender -v -> 14 passed

## Rollback Plan

1. Remove FEISHU_CHAT_ID from .env
2. git revert this commit
