### PR TITLE
fix: Web 大盘复盘报告未按 Markdown 正常格式化展示 (#1555)

### DIFF
--- a/apps/dsa-web/src/components/report/ReportMarkdownContent.tsx
+++ b/apps/dsa-web/src/components/report/ReportMarkdownContent.tsx
@@ -1,0 +1,40 @@
+import type React from 'react';
+import Markdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
+
+interface ReportMarkdownContentProps {
+  content: string;
+  className?: string;
+  testId?: string;
+}
+
+const baseMarkdownClassName = `home-markdown-prose prose prose-invert prose-sm max-w-none
+  prose-headings:text-foreground prose-headings:font-semibold prose-headings:mt-4 prose-headings:mb-2
+  prose-h1:text-xl
+  prose-h2:text-lg
+  prose-h3:text-base
+  prose-p:leading-relaxed prose-p:mb-3 prose-p:last:mb-0
+  prose-strong:text-foreground prose-strong:font-semibold
+  prose-ul:my-2 prose-ol:my-2 prose-li:my-1
+  prose-code:px-1.5 prose-code:py-0.5 prose-code:rounded prose-code:before:content-none prose-code:after:content-none
+  prose-pre:border
+  prose-table:border-collapse
+  prose-hr:my-4
+  prose-a:no-underline hover:prose-a:underline
+  prose-blockquote:text-secondary-text
+  whitespace-pre-line break-words`;
+
+export const ReportMarkdownContent: React.FC<ReportMarkdownContentProps> = ({
+  content,
+  className,
+  testId,
+}) => (
+  <div
+    data-testid={testId}
+    className={[baseMarkdownClassName, className].filter(Boolean).join(' ')}
+  >
+    <Markdown remarkPlugins={[remarkGfm]}>
+      {content}
+    </Markdown>
+  </div>
+);

--- a/apps/dsa-web/src/components/report/ReportMarkdownPanel.tsx
+++ b/apps/dsa-web/src/components/report/ReportMarkdownPanel.tsx
@@ -1,12 +1,11 @@
 import type React from 'react';
 import { useCallback, useEffect, useState } from 'react';
-import Markdown from 'react-markdown';
-import remarkGfm from 'remark-gfm';
 import { historyApi } from '../../api/history';
 import type { ReportLanguage } from '../../types/analysis';
 import { markdownToPlainText } from '../../utils/markdown';
 import { getReportText, normalizeReportLanguage } from '../../utils/reportLanguage';
 import { Tooltip } from '../common/Tooltip';
+import { ReportMarkdownContent } from './ReportMarkdownContent';
 
 export interface ReportMarkdownPanelProps {
   recordId: number;
@@ -166,28 +165,7 @@ export const ReportMarkdownPanel: React.FC<ReportMarkdownPanelProps> = ({
           </button>
         </div>
       ) : (
-        <div
-          className="home-markdown-prose prose prose-invert prose-sm max-w-none
-            prose-headings:text-foreground prose-headings:font-semibold prose-headings:mt-4 prose-headings:mb-2
-            prose-h1:text-xl
-            prose-h2:text-lg
-            prose-h3:text-base
-            prose-p:leading-relaxed prose-p:mb-3 prose-p:last:mb-0
-            prose-strong:text-foreground prose-strong:font-semibold
-            prose-ul:my-2 prose-ol:my-2 prose-li:my-1
-            prose-code:px-1.5 prose-code:py-0.5 prose-code:rounded prose-code:before:content-none prose-code:after:content-none
-            prose-pre:border
-            prose-table:border-collapse
-            prose-hr:my-4
-            prose-a:no-underline hover:prose-a:underline
-            prose-blockquote:text-secondary-text
-            whitespace-pre-line break-words
-          "
-        >
-          <Markdown remarkPlugins={[remarkGfm]}>
-            {content}
-          </Markdown>
-        </div>
+        <ReportMarkdownContent content={content} />
       )}
 
       <div className="home-divider mt-6 flex justify-end border-t pt-4">

--- a/apps/dsa-web/src/components/report/ReportOverview.tsx
+++ b/apps/dsa-web/src/components/report/ReportOverview.tsx
@@ -7,6 +7,7 @@ import type {
 import { Badge, Card, ScoreGauge } from '../common';
 import { formatDateTime } from '../../utils/format';
 import { getReportText, normalizeReportLanguage } from '../../utils/reportLanguage';
+import { ReportMarkdownContent } from './ReportMarkdownContent';
 
 interface ReportOverviewProps {
   meta: ReportMeta;
@@ -83,6 +84,7 @@ export const ReportOverview: React.FC<ReportOverviewProps> = ({
   const relatedBoards = (Array.isArray(details?.belongBoards) ? details.belongBoards : [])
     .filter((board) => normalizeBoardName(board?.name).length > 0);
   const boardSignals = buildBoardSignalMap(details);
+  const isMarketReview = meta.reportType === 'market_review';
 
   const getPriceChangeStyle = (changePct: number | undefined): React.CSSProperties | undefined => {
     if (changePct === undefined || changePct === null) {
@@ -163,9 +165,17 @@ export const ReportOverview: React.FC<ReportOverviewProps> = ({
             {/* 关键结论 */}
             <div className="home-divider border-t pt-5">
               <span className="label-uppercase">{text.keyInsights}</span>
-              <p className="mt-2 max-w-[62ch] whitespace-pre-wrap text-left text-[15px] leading-7 text-foreground">
-                {summary.analysisSummary || text.noAnalysisSummary}
-              </p>
+              {isMarketReview ? (
+                <ReportMarkdownContent
+                  content={summary.analysisSummary || text.noAnalysisSummary}
+                  className="mt-2 text-left"
+                  testId="market-review-history-markdown"
+                />
+              ) : (
+                <p className="mt-2 max-w-[62ch] whitespace-pre-wrap text-left text-[15px] leading-7 text-foreground">
+                  {summary.analysisSummary || text.noAnalysisSummary}
+                </p>
+              )}
             </div>
           </Card>
 

--- a/apps/dsa-web/src/index.css
+++ b/apps/dsa-web/src/index.css
@@ -1892,6 +1892,10 @@ textarea {
   padding-bottom: 0.5rem;
 }
 
+.home-markdown-prose {
+  min-width: 0;
+}
+
 .home-markdown-prose :where(h2) {
   color: hsl(var(--color-purple));
 }
@@ -1906,6 +1910,16 @@ textarea {
 .home-markdown-prose :where(pre) {
   border: 1px solid var(--home-prose-border);
   background: hsl(var(--elevated) / 0.92);
+  overflow-x: auto;
+}
+
+.home-markdown-prose :where(table) {
+  display: block;
+  width: max-content;
+  max-width: 100%;
+  overflow-x: auto;
+  border-collapse: collapse;
+  -webkit-overflow-scrolling: touch;
 }
 
 .home-markdown-prose :where(th, td) {

--- a/apps/dsa-web/src/pages/HomePage.tsx
+++ b/apps/dsa-web/src/pages/HomePage.tsx
@@ -11,6 +11,7 @@ import { DashboardStateBlock } from '../components/dashboard';
 import { StockAutocomplete } from '../components/StockAutocomplete';
 import { HistoryList, StockHistoryTrendDrawer } from '../components/history';
 import { ReportMarkdownDrawer } from '../components/report/ReportMarkdownDrawer';
+import { ReportMarkdownContent } from '../components/report/ReportMarkdownContent';
 import { ReportSummary } from '../components/report/ReportSummary';
 import { TaskPanel } from '../components/tasks';
 import { useDashboardLifecycle, useHomeDashboardState } from '../hooks';
@@ -791,12 +792,11 @@ const HomePage: React.FC = () => {
                     {marketReviewReportCopied ? '已复制' : '复制'}
                   </button>
                 </div>
-                <pre
-                  data-testid="market-review-report"
-                  className="overflow-x-auto whitespace-pre-wrap break-words rounded-lg bg-background px-3 py-2 leading-relaxed"
-                >
-                  {marketReviewReport}
-                </pre>
+                <ReportMarkdownContent
+                  content={marketReviewReport}
+                  testId="market-review-report"
+                  className="rounded-lg bg-background px-3 py-2"
+                />
               </div>
             ) : null}
 

--- a/apps/dsa-web/src/pages/__tests__/HomePage.test.tsx
+++ b/apps/dsa-web/src/pages/__tests__/HomePage.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { analysisApi, DuplicateTaskError } from '../../api/analysis';
@@ -289,6 +289,98 @@ describe('HomePage', () => {
     expect(analysisApi.getStatus).toHaveBeenCalledWith('task-1');
   });
 
+  it('renders completed market review report as markdown in the dashboard', async () => {
+    vi.mocked(historyApi.getList).mockResolvedValue({
+      total: 0,
+      page: 1,
+      limit: 20,
+      items: [],
+    });
+    vi.mocked(analysisApi.triggerMarketReview).mockResolvedValue({
+      status: 'accepted',
+      sendNotification: true,
+      message: '大盘复盘任务已提交',
+      taskId: 'task-1',
+    });
+    vi.mocked(analysisApi.getStatus).mockResolvedValue({
+      taskId: 'task-1',
+      status: 'completed',
+      marketReviewReport: [
+        '# 大盘复盘',
+        '',
+        '> 市场今日呈现震荡修复',
+        '',
+        '**盘面信号**',
+        '',
+        '- 成交额放大',
+        '',
+        '| 指标 | 数值 |',
+        '| --- | --- |',
+        '| 上证指数 | +1.2% |',
+      ].join('\n'),
+    });
+
+    render(
+      <MemoryRouter>
+        <HomePage />
+      </MemoryRouter>,
+    );
+
+    fireEvent.click(await screen.findByRole('button', { name: '大盘复盘' }));
+
+    const report = await screen.findByTestId('market-review-report');
+    expect(within(report).getByRole('heading', { name: '大盘复盘', level: 1 })).toBeInTheDocument();
+    expect(within(report).getByText('市场今日呈现震荡修复').closest('blockquote')).toBeTruthy();
+    expect(within(report).getByText('盘面信号').tagName).toBe('STRONG');
+    expect(within(report).getByText('成交额放大').closest('li')).toBeTruthy();
+    expect(within(report).getByText('+1.2%').closest('table')).toBeTruthy();
+    expect(within(report).queryByText('**盘面信号**')).not.toBeInTheDocument();
+  });
+
+  it('renders market review history detail body as markdown', async () => {
+    vi.mocked(historyApi.getList).mockResolvedValue({
+      total: 1,
+      page: 1,
+      limit: 20,
+      items: [marketReviewHistoryItem],
+    });
+    vi.mocked(historyApi.getDetail).mockResolvedValue({
+      ...marketReviewHistoryReport,
+      summary: {
+        ...marketReviewHistoryReport.summary,
+        analysisSummary: [
+          '# 大盘复盘',
+          '',
+          '## 今日大盘',
+          '',
+          '> 情绪修复',
+          '',
+          '**信号依据**',
+          '',
+          '- 放量',
+          '',
+          '| 指标 | 数值 |',
+          '| --- | --- |',
+          '| 上证指数 | +0.8% |',
+        ].join('\n'),
+      },
+    });
+
+    render(
+      <MemoryRouter>
+        <HomePage />
+      </MemoryRouter>,
+    );
+
+    const report = await screen.findByTestId('market-review-history-markdown');
+    expect(within(report).getByRole('heading', { name: '今日大盘', level: 2 })).toBeInTheDocument();
+    expect(within(report).getByText('情绪修复').closest('blockquote')).toBeTruthy();
+    expect(within(report).getByText('信号依据').tagName).toBe('STRONG');
+    expect(within(report).getByText('放量').closest('li')).toBeTruthy();
+    expect(within(report).getByText('+0.8%').closest('table')).toBeTruthy();
+    expect(within(report).queryByText('**信号依据**')).not.toBeInTheDocument();
+  });
+
   it('scrolls the dashboard to market review feedback after toolbar clicks', async () => {
     vi.mocked(historyApi.getList).mockResolvedValue({
       total: 1,
@@ -551,8 +643,8 @@ describe('HomePage', () => {
     await waitFor(() => {
       expect(screen.queryByText('暂无更多同股历史分析')).not.toBeInTheDocument();
     });
-    expect(screen.getByRole('button', { name: /继续观察买点/ })).toBeInTheDocument();
-    expect(screen.getByText(/共 1 次分析/)).toBeInTheDocument();
+    expect(screen.getByRole('row', { name: /继续观察买点/ })).toBeInTheDocument();
+    expect(screen.getByText(/已加载 1 \/ 1 条/)).toBeInTheDocument();
 
     const historyCalls = vi.mocked(historyApi.getList).mock.calls.filter((call) => call[0]?.stockCode === '600519');
     expect(historyCalls).toHaveLength(3);

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+- [修复] Web 大盘复盘即时结果和历史详情复用统一 Markdown 渲染，恢复标题、引用、加粗、列表与表格展示。
 - [改进] AlphaSift 选股入口在 Web 侧边栏中移动到“问股”下方，贴近 Agent/研究辅助工作流。
 - [改进] Docker 镜像构建阶段预置默认 AlphaSift 适配层，与桌面发布包一样避免运行期额外安装。
 - [新功能] 新增默认关闭的 AlphaSift 选股页签，通过 `ALPHASIFT_ENABLED` 开启后经由稳定适配层读取策略并执行选股。


### PR DESCRIPTION
## PR Type
- [x] fix
- [ ] feat
- [ ] refactor
- [ ] docs
- [ ] chore
- [ ] test

## Background And Problem
- 当前问题：让 Web 大盘复盘报告正文复用统一 Markdown 渲染能力，并保持桌面端与移动端展示可读。
- 影响范围：本次改动涉及 7 个文件，Diff 为 `+171 / -36`。
- 触发来源：Issue 自动执行（Issue #1555）。

## Scope Of Change
- `apps/dsa-web/src/components/report/ReportMarkdownContent.tsx`
- `apps/dsa-web/src/components/report/ReportMarkdownPanel.tsx`
- `apps/dsa-web/src/components/report/ReportOverview.tsx`
- `apps/dsa-web/src/index.css`
- `apps/dsa-web/src/pages/HomePage.tsx`
- `apps/dsa-web/src/pages/__tests__/HomePage.test.tsx`
- `docs/CHANGELOG.md`

## Documentation And Changelog
- 已同步更新文档/变更记录：`docs/CHANGELOG.md`。
- 当前补丁尚未包含 `README.md` 或专题文档；如用户可见行为发生变化，请补充文档落点。

## Issue Link
Closes #1555

## Verification Commands And Results
```bash
./scripts/ci_gate.sh flake8
./scripts/ci_gate.sh offline-tests
```

关键输出/结论 / Key output & conclusion:
- lint:PASS, test:PASS

## Compatibility And Risk
- **Medium**：涉及 `apps/dsa-web/src/components/report/ReportMarkdownContent.tsx`, `apps/dsa-web/src/components/report/ReportMarkdownPanel.tsx`, `apps/dsa-web/src/components/report/ReportOverview.tsx`, `apps/dsa-web/src/index.css`, `apps/dsa-web/src/pages/HomePage.tsx`, `apps/dsa-web/src/pages/__tests__/HomePage.test.tsx`，建议按文件范围复核。
- 前提假设：
  - 普通分析报告或其他报告详情页中已有可复用的 Markdown 渲染组件或渲染逻辑。
  - 大盘复盘报告可能使用了不同的数据字段或详情页分支，当前分支把 Markdown 当纯文本展示。
  - 优先只改 Web 前端展示逻辑，不调整后端报告生成、API 字段、workflow、secrets 或部署配置。
  - 该 Web 产物可能被桌面端复用，因此需要评估 Desktop 兼容性，但预计不需要修改 Electron 代码。

## Rollback Plan
- `git revert <merge-commit>` 回滚本 PR 提交，重点确认 `apps/dsa-web/src/components/report/ReportMarkdownContent.tsx`, `apps/dsa-web/src/components/report/ReportMarkdownPanel.tsx`, `apps/dsa-web/src/components/report/ReportOverview.tsx`, `apps/dsa-web/src/index.css` 恢复正常。

## Acceptance Criteria
- 打开大盘复盘报告时，标题、引用、加粗、列表按 Markdown 格式渲染。
- Markdown 表格在桌面端和移动端保持可读，不出现明显溢出或重叠。
- 大盘复盘报告与普通报告详情页使用一致或等价的 Markdown 渲染组件。
- 普通分析报告详情页的现有 Markdown 展示不回归。

## Checklist
- [x] 本 PR 有明确动机和业务价值 / This PR has a clear motivation and value
- [x] 已提供可复现的验证命令与结果 / Reproducible verification commands and results are included
- [x] 已评估兼容性与风险 / Compatibility and risk have been assessed
- [x] 已提供回滚方案 / A rollback plan is provided
- [ ] 文档与 `docs/CHANGELOG.md` 同步仍需确认；如涉及用户可见变更，请在合并前补充原因与文档落点 / Documentation and `docs/CHANGELOG.md` sync still needs confirmation before merge when user-visible behavior changes