### PR TITLE
feat: improve first-run configuration validation

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+- [改进] 首次运行配置校验补充缺失 AI Key、空 STOCK_LIST、Telegram/邮件成对字段和 Webhook URL 前缀诊断。
 - [改进] AlphaSift 选股入口在 Web 侧边栏中移动到“问股”下方，贴近 Agent/研究辅助工作流。
 - [改进] Docker 镜像构建阶段预置默认 AlphaSift 适配层，与桌面发布包一样避免运行期额外安装。
 - [新功能] 新增默认关闭的 AlphaSift 选股页签，通过 `ALPHASIFT_ENABLED` 开启后经由稳定适配层读取策略并执行选股。

--- a/docs/full-guide.md
+++ b/docs/full-guide.md
@@ -65,7 +65,7 @@ daily_stock_analysis/
 | `OPENAI_BASE_URL` | OpenAI 兼容 API 地址（如 `https://api.deepseek.com`） | 可选 |
 | `OPENAI_MODEL` | 模型名称（如 `gemini-3.1-pro-preview`、`deepseek-v4-flash`、`gpt-5.5`） | 可选 |
 
-> *注：以上模型 Key / 渠道至少配置一个；推荐优先从 Anspire 或 AIHubMix 这类一 Key 多模型服务开始。
+> *注：以上模型 Key / 渠道至少配置一个；推荐优先从 Anspire 或 AIHubMix 这类一 Key 多模型服务开始。启动时配置校验会在缺少可用 AI 模型 Key 或模型渠道时给出明确错误提示。
 
 #### 通知渠道配置（可同时配置多个，全部推送）
 
@@ -104,7 +104,7 @@ daily_stock_analysis/
 | `CUSTOM_WEBHOOK_BODY_TEMPLATE` | 自定义 Webhook JSON body 模板，适配 AstrBot、NapCat、自建服务等特殊 payload | 可选 |
 | `WEBHOOK_VERIFY_SSL` | 读取该配置的 webhook-style HTTPS 通知请求证书校验（默认 true）。设为 false 可支持自签名证书。警告：关闭有严重安全风险（MITM），仅限可信内网 | 可选 |
 
-> *注：至少配置一个渠道，配置多个则同时推送
+> *注：至少配置一个渠道，配置多个则同时推送。启动时配置校验会提示 Telegram / 邮件成对字段缺失，以及常见 Webhook URL 未以 `http://` 或 `https://` 开头的问题。
 >
 > 当前默认 `00-daily-analysis.yml` 只显式映射固定 Secret / Variable 名称，不会自动把 `STOCK_GROUP_1`、`EMAIL_GROUP_1` 这类任意编号变量导入运行环境。所以分组邮箱功能目前不适用于仓库自带默认 GitHub Actions workflow；它适用于本地 `.env`、Docker，或你自行显式扩展过 `env:` 映射的运行环境。Actions 已显式映射 `CUSTOM_WEBHOOK_BODY_TEMPLATE`、`WEBHOOK_VERIFY_SSL`、`FEISHU_WEBHOOK_SECRET`、`FEISHU_WEBHOOK_KEYWORD`、`PUSHPLUS_TOPIC`、`NTFY_URL`、`NTFY_TOKEN`、`GOTIFY_URL`、`GOTIFY_TOKEN`、P3 通知路由键以及 P4 通知降噪键；`MARKDOWN_TO_IMAGE_CHANNELS` 和 `MERGE_EMAIL_NOTIFICATION` 仍作为行为开关不在默认 workflow 中自动映射。
 

--- a/docs/full-guide_EN.md
+++ b/docs/full-guide_EN.md
@@ -65,7 +65,7 @@ Go to your forked repo → `Settings` → `Secrets and variables` → `Actions` 
 | `OPENAI_BASE_URL` | OpenAI-compatible API endpoint (e.g., `https://api.deepseek.com`) | Optional |
 | `OPENAI_MODEL` | Model name (e.g., `deepseek-v4-flash`) | Optional |
 
-> *Note: Configure at least one model key or channel. Anspire or AIHubMix is the simplest starting point for one-key multi-model access.
+> *Note: Configure at least one model key or channel. Anspire or AIHubMix is the simplest starting point for one-key multi-model access. Startup validation reports a clear error when no usable AI model key or model channel is configured.
 
 #### Notification Channels (Multiple can be configured, all will receive notifications)
 
@@ -105,7 +105,7 @@ Go to your forked repo → `Settings` → `Secrets and variables` → `Actions` 
 | `CUSTOM_WEBHOOK_BODY_TEMPLATE` | Custom Webhook JSON body template for AstrBot, NapCat, or self-hosted services with special payloads | Optional |
 | `WEBHOOK_VERIFY_SSL` | HTTPS certificate verification for webhook-style notification requests that read this setting (default true). Set to false for self-signed certs. WARNING: Disabling has serious security risk (MITM), use only on trusted internal networks | Optional |
 
-> *Note: Configure at least one channel; multiple channels will all receive notifications
+> *Note: Configure at least one channel; multiple channels will all receive notifications. Startup validation reports missing paired Telegram / email fields and common Webhook URLs that do not start with `http://` or `https://`.
 >
 > The default `00-daily-analysis.yml` in this repository only exports fixed Secret / Variable names. Arbitrary numbered env vars such as `STOCK_GROUP_1` and `EMAIL_GROUP_1` are not auto-injected into the job, so grouped email routing is not available in the stock workflow unless you explicitly extend the workflow's `env:` mapping in your own fork. Actions now maps `CUSTOM_WEBHOOK_BODY_TEMPLATE`, `WEBHOOK_VERIFY_SSL`, `FEISHU_WEBHOOK_SECRET`, `FEISHU_WEBHOOK_KEYWORD`, `PUSHPLUS_TOPIC`, `NTFY_URL`, `NTFY_TOKEN`, `GOTIFY_URL`, `GOTIFY_TOKEN`, the P3 notification route keys, and the P4 notification noise-control keys; `MARKDOWN_TO_IMAGE_CHANNELS` and `MERGE_EMAIL_NOTIFICATION` remain behavior toggles outside the default workflow mapping.
 

--- a/src/config.py
+++ b/src/config.py
@@ -1122,10 +1122,6 @@ class Config:
             if (c or "").strip()
         ]
         
-        # 如果没有配置，使用默认的示例股票
-        if not stock_list:
-            stock_list = ['600519', '000001', '300750']
-        
         # === LiteLLM multi-key parsing ===
         # GEMINI_API_KEYS (comma-separated) > GEMINI_API_KEY (single)
         _gemini_keys_raw = os.getenv('GEMINI_API_KEYS', '')
@@ -2376,9 +2372,6 @@ class Config:
             if (c or "").strip()
         ]
 
-        if not stock_list:
-            stock_list = ['000001']
-
         self.stock_list = stock_list
     
     def validate_structured(self) -> List[ConfigIssue]:
@@ -2400,7 +2393,7 @@ class Config:
         if not self.stock_list:
             issues.append(ConfigIssue(
                 severity="error",
-                message="未配置自选股列表 (STOCK_LIST)",
+                message="未配置 STOCK_LIST。请设置至少一个股票代码，例如：600519,hk00700,AAPL。",
                 field="STOCK_LIST",
             ))
         elif self.stock_email_groups:
@@ -2452,10 +2445,12 @@ class Config:
             issues.append(ConfigIssue(
                 severity="error",
                 message=(
-                    "未配置任何可用的 AI 模型接入（高级模型路由配置 / 渠道 / API Key），"
-                    "AI 分析功能将不可用"
+                    "未配置任何 AI 模型 API Key。请至少配置 ANSPIRE_API_KEYS、"
+                    "AIHUBMIX_KEY、GEMINI_API_KEY、ANTHROPIC_API_KEY、"
+                    "OPENAI_API_KEY 或 DEEPSEEK_API_KEY 中的一个，或配置 "
+                    "LITELLM_CONFIG / LLM_CHANNELS 可用模型渠道。"
                 ),
-                field="LITELLM_CONFIG",
+                field="ANSPIRE_API_KEYS",
             ))
         elif not self.litellm_model:
             issues.append(ConfigIssue(
@@ -2596,6 +2591,49 @@ class Config:
                 message="未配置通知渠道，将不发送推送通知",
                 field="WECHAT_WEBHOOK_URL",
             ))
+
+        has_telegram_token = bool((self.telegram_bot_token or "").strip())
+        has_telegram_chat_id = bool((self.telegram_chat_id or "").strip())
+        if has_telegram_token != has_telegram_chat_id:
+            issues.append(ConfigIssue(
+                severity="error",
+                message="Telegram 通知配置不完整：TELEGRAM_BOT_TOKEN 和 TELEGRAM_CHAT_ID 必须同时配置。",
+                field="TELEGRAM_CHAT_ID" if has_telegram_token else "TELEGRAM_BOT_TOKEN",
+            ))
+
+        has_email_sender = bool((self.email_sender or "").strip())
+        has_email_password = bool((self.email_password or "").strip())
+        if has_email_sender != has_email_password:
+            issues.append(ConfigIssue(
+                severity="error",
+                message="邮件通知配置不完整：EMAIL_SENDER 和 EMAIL_PASSWORD 必须同时配置。",
+                field="EMAIL_PASSWORD" if has_email_sender else "EMAIL_SENDER",
+            ))
+
+        def _warn_if_webhook_url_invalid(field: str, value: Optional[str]) -> None:
+            raw_url = (value or "").strip()
+            if not raw_url:
+                return
+            parsed = urlparse(raw_url)
+            if parsed.scheme.lower() in {"http", "https"} and parsed.netloc:
+                return
+            issues.append(ConfigIssue(
+                severity="warning",
+                message=f"{field} 看起来不是有效 URL，请确认是否以 http:// 或 https:// 开头。",
+                field=field,
+            ))
+
+        for field, value in (
+            ("WECHAT_WEBHOOK_URL", self.wechat_webhook_url),
+            ("FEISHU_WEBHOOK_URL", self.feishu_webhook_url),
+            ("DISCORD_WEBHOOK_URL", self.discord_webhook_url),
+            ("SLACK_WEBHOOK_URL", self.slack_webhook_url),
+            ("ASTRBOT_URL", self.astrbot_url),
+        ):
+            _warn_if_webhook_url_invalid(field, value)
+
+        for custom_url in self.custom_webhook_urls:
+            _warn_if_webhook_url_invalid("CUSTOM_WEBHOOK_URLS", custom_url)
 
         if self.ntfy_url and not _has_ntfy_topic_endpoint(self.ntfy_url):
             issues.append(ConfigIssue(

--- a/src/config.py
+++ b/src/config.py
@@ -651,6 +651,9 @@ class Config:
     llm_models_source: str = "legacy_env"
     # LLM_CHANNELS: list of channel dicts, each with name/base_url/api_keys/models
     llm_channels: List[Dict[str, Any]] = field(default_factory=list)
+    # Raw channel names requested through LLM_CHANNELS, including channels that
+    # were skipped during parsing because required channel fields were missing.
+    llm_channel_names: List[str] = field(default_factory=list)
     # Pre-built LiteLLM Router model_list (populated from channels, YAML, or legacy keys)
     llm_model_list: List[Dict[str, Any]] = field(default_factory=list)
 
@@ -1231,6 +1234,7 @@ class Config:
         litellm_config_path = os.getenv('LITELLM_CONFIG', '').strip() or None
         llm_models_source = "legacy_env"
         llm_channels: List[Dict[str, Any]] = []
+        llm_channel_names: List[str] = []
         llm_model_list: List[Dict[str, Any]] = []
 
         # Priority 1: LITELLM_CONFIG (standard LiteLLM YAML config file)
@@ -1243,6 +1247,11 @@ class Config:
         if not llm_model_list:
             _channels_str = os.getenv('LLM_CHANNELS', '').strip()
             if _channels_str:
+                llm_channel_names = [
+                    ch.strip().lower()
+                    for ch in _channels_str.split(',')
+                    if ch.strip()
+                ]
                 llm_channels = cls._parse_llm_channels(_channels_str)
                 llm_model_list = cls._channels_to_model_list(llm_channels)
                 if llm_model_list:
@@ -1431,6 +1440,7 @@ class Config:
             litellm_config_path=litellm_config_path,
             llm_models_source=llm_models_source,
             llm_channels=llm_channels,
+            llm_channel_names=llm_channel_names,
             llm_model_list=llm_model_list,
             gemini_api_keys=gemini_api_keys,
             anthropic_api_keys=anthropic_api_keys,
@@ -2442,16 +2452,36 @@ class Config:
         # direct litellm env path and therefore do not populate llm_model_list.
         has_direct_env_model = bool(self.litellm_model) and _uses_direct_env_provider(self.litellm_model)
         if not self.llm_model_list and not has_direct_env_model:
-            issues.append(ConfigIssue(
-                severity="error",
-                message=(
-                    "未配置任何 AI 模型 API Key。请至少配置 ANSPIRE_API_KEYS、"
-                    "AIHUBMIX_KEY、GEMINI_API_KEY、ANTHROPIC_API_KEY、"
-                    "OPENAI_API_KEY 或 DEEPSEEK_API_KEY 中的一个，或配置 "
-                    "LITELLM_CONFIG / LLM_CHANNELS 可用模型渠道。"
-                ),
-                field="ANSPIRE_API_KEYS",
-            ))
+            if self.litellm_config_path:
+                issues.append(ConfigIssue(
+                    severity="error",
+                    message=(
+                        "已配置 LITELLM_CONFIG，但未解析出可用模型。"
+                        "请检查 YAML 中的 model_list、litellm_params 和环境变量引用。"
+                    ),
+                    field="LITELLM_CONFIG",
+                ))
+            elif self.llm_channel_names:
+                issues.append(ConfigIssue(
+                    severity="error",
+                    message=(
+                        "已配置 LLM_CHANNELS，但未解析出可用模型渠道。"
+                        "请检查对应 LLM_<CHANNEL>_API_KEY(S)、"
+                        "LLM_<CHANNEL>_MODELS、LLM_<CHANNEL>_PROTOCOL 或 Base URL。"
+                    ),
+                    field="LLM_CHANNELS",
+                ))
+            else:
+                issues.append(ConfigIssue(
+                    severity="error",
+                    message=(
+                        "未配置任何可用的 AI 模型接入。请至少配置 ANSPIRE_API_KEYS、"
+                        "AIHUBMIX_KEY、GEMINI_API_KEY、ANTHROPIC_API_KEY、"
+                        "OPENAI_API_KEY 或 DEEPSEEK_API_KEY 中的一个，或配置 "
+                        "LITELLM_CONFIG / LLM_CHANNELS 可用模型渠道。"
+                    ),
+                    field="LITELLM_CONFIG",
+                ))
         elif not self.litellm_model:
             issues.append(ConfigIssue(
                 severity="info",

--- a/tests/test_config_env_compat.py
+++ b/tests/test_config_env_compat.py
@@ -431,6 +431,21 @@ class ConfigEnvCompatibilityTestCase(unittest.TestCase):
 
         self.assertEqual(config.stock_list, ["600519", "000001"])
 
+    def test_refresh_stock_list_preserves_empty_required_config(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            env_path = Path(temp_dir) / ".env"
+            env_path.write_text("STOCK_LIST=\n", encoding="utf-8")
+
+            config = Config(stock_list=["600519"])
+            with patch.dict(os.environ, {"ENV_FILE": str(env_path)}, clear=True):
+                config.refresh_stock_list()
+
+        self.assertEqual(config.stock_list, [])
+        issues = config.validate_structured()
+        self.assertTrue(
+            any(issue.severity == "error" and issue.field == "STOCK_LIST" for issue in issues)
+        )
+
     def test_parse_report_language_accepts_known_alias_without_warning(self) -> None:
         with self.assertNoLogs("src.config", level="WARNING"):
             parsed = Config._parse_report_language("zh-cn")

--- a/tests/test_config_validate_structured.py
+++ b/tests/test_config_validate_structured.py
@@ -118,7 +118,10 @@ class TestValidateStructuredStockList:
         cfg = _make_config(stock_list=[])
         issues = cfg.validate_structured()
         errors = [i for i in issues if i.severity == "error"]
-        assert any("STOCK_LIST" in i.field for i in errors)
+        stock_errors = [i for i in errors if i.field == "STOCK_LIST"]
+        assert stock_errors
+        assert "未配置 STOCK_LIST" in stock_errors[0].message
+        assert "600519,hk00700,AAPL" in stock_errors[0].message
 
     def test_configured_stock_list_no_stock_error(self):
         cfg = _make_config(stock_list=["600519", "000001"])
@@ -187,6 +190,24 @@ class TestValidateStructuredLLM:
         cfg = _make_config(llm_model_list=[])
         issues = cfg.validate_structured()
         assert any(i.severity == "error" and "AI 模型" in i.message for i in issues)
+
+    def test_validate_missing_all_llm_keys_reports_error(self):
+        cfg = _make_config(
+            llm_model_list=[],
+            litellm_model="",
+            gemini_api_keys=[],
+            anthropic_api_keys=[],
+            openai_api_keys=[],
+            deepseek_api_keys=[],
+            anspire_api_keys=[],
+        )
+
+        issues = cfg.validate_structured()
+
+        error = next(i for i in issues if i.severity == "error" and i.field == "ANSPIRE_API_KEYS")
+        assert "未配置任何 AI 模型 API Key" in error.message
+        assert "ANSPIRE_API_KEYS" in error.message
+        assert "DEEPSEEK_API_KEY" in error.message
 
     def test_llm_channels_only_no_error(self):
         """LLM_CHANNELS populated via llm_model_list must NOT trigger an error.
@@ -336,6 +357,61 @@ class TestValidateStructuredNotification:
         cfg = _make_config(wechat_webhook_url="https://example.com/wh")
         issues = cfg.validate_structured()
         assert not any(i.severity == "warning" and "通知渠道" in i.message for i in issues)
+
+    @pytest.mark.parametrize(
+        ("kwargs", "missing_field"),
+        [
+            ({"telegram_bot_token": "bot-token", "telegram_chat_id": None}, "TELEGRAM_CHAT_ID"),
+            ({"telegram_bot_token": None, "telegram_chat_id": "123456"}, "TELEGRAM_BOT_TOKEN"),
+        ],
+    )
+    def test_validate_incomplete_telegram_config_reports_error(self, kwargs, missing_field):
+        cfg = _make_config(**kwargs)
+        issues = cfg.validate_structured()
+
+        assert any(
+            i.severity == "error"
+            and i.field == missing_field
+            and "Telegram 通知配置不完整" in i.message
+            for i in issues
+        )
+
+    @pytest.mark.parametrize(
+        ("kwargs", "missing_field"),
+        [
+            ({"email_sender": "sender@example.com", "email_password": None}, "EMAIL_PASSWORD"),
+            ({"email_sender": None, "email_password": "app-password"}, "EMAIL_SENDER"),
+        ],
+    )
+    def test_validate_incomplete_email_config_reports_error(self, kwargs, missing_field):
+        cfg = _make_config(**kwargs)
+        issues = cfg.validate_structured()
+
+        assert any(
+            i.severity == "error"
+            and i.field == missing_field
+            and "邮件通知配置不完整" in i.message
+            for i in issues
+        )
+
+    @pytest.mark.parametrize(
+        ("field", "kwargs"),
+        [
+            ("WECHAT_WEBHOOK_URL", {"wechat_webhook_url": "abc"}),
+            ("FEISHU_WEBHOOK_URL", {"feishu_webhook_url": "xxx"}),
+            ("DISCORD_WEBHOOK_URL", {"discord_webhook_url": "test"}),
+        ],
+    )
+    def test_validate_invalid_webhook_url_reports_warning(self, field, kwargs):
+        cfg = _make_config(**kwargs)
+        issues = cfg.validate_structured()
+
+        assert any(
+            i.severity == "warning"
+            and i.field == field
+            and "http:// 或 https://" in i.message
+            for i in issues
+        )
 
     def test_astrbot_url_counts_as_notification_channel(self):
         cfg = _make_config(

--- a/tests/test_config_validate_structured.py
+++ b/tests/test_config_validate_structured.py
@@ -204,10 +204,34 @@ class TestValidateStructuredLLM:
 
         issues = cfg.validate_structured()
 
-        error = next(i for i in issues if i.severity == "error" and i.field == "ANSPIRE_API_KEYS")
-        assert "未配置任何 AI 模型 API Key" in error.message
+        error = next(i for i in issues if i.severity == "error" and i.field == "LITELLM_CONFIG")
+        assert "未配置任何可用的 AI 模型接入" in error.message
         assert "ANSPIRE_API_KEYS" in error.message
         assert "DEEPSEEK_API_KEY" in error.message
+
+    @patch("src.config.setup_env")
+    @patch.object(Config, "_parse_litellm_yaml", return_value=[])
+    def test_declared_llm_channels_without_models_reports_channel_error(
+        self,
+        _mock_parse_yaml,
+        _mock_setup_env,
+    ):
+        with patch.dict(
+            "os.environ",
+            {
+                "LLM_CHANNELS": "primary",
+                "LLM_PRIMARY_API_KEY": "sk-primary-test-value",
+            },
+            clear=True,
+        ):
+            cfg = Config._load_from_env()
+
+        issues = cfg.validate_structured()
+
+        error = next(i for i in issues if i.severity == "error" and i.field == "LLM_CHANNELS")
+        assert "已配置 LLM_CHANNELS" in error.message
+        assert "LLM_<CHANNEL>_MODELS" in error.message
+        assert not any(i.severity == "error" and i.field == "ANSPIRE_API_KEYS" for i in issues)
 
     def test_llm_channels_only_no_error(self):
         """LLM_CHANNELS populated via llm_model_list must NOT trigger an error.


### PR DESCRIPTION
## PR Type

- [ ] fix
- [x] feat
- [ ] refactor
- [ ] docs
- [ ] chore
- [ ] test

## Background And Problem

首次运行时，用户容易遗漏必要配置，例如未配置自选股、未配置任何可用 LLM 接入、通知渠道字段只填了一半，或 Webhook URL 明显不是 HTTP(S) URL。

这些问题原本可能在后续分析流程中才暴露，排查方向不够明确。本 PR 在配置校验层提前给出结构化诊断，帮助新用户更快定位首次运行配置问题。

## Scope Of Change

本 PR 修改范围：

- `src/config.py`
  - 增强 `Config.validate_structured()` 的首次运行配置诊断
  - 空 `STOCK_LIST` 改为结构化 error，不再自动回填示例股票
  - 区分 LLM 配置缺失与 `LLM_CHANNELS` 已声明但未解析出可用模型渠道的场景
  - 增加 Telegram / Email 成对字段完整性校验
  - 对明显非法的 Webhook URL 给出 warning
- `tests/test_config_validate_structured.py`
  - 增加 STOCK_LIST、LLM、Telegram、Email、Webhook URL 相关结构化校验测试
  - 增加 `LLM_CHANNELS` 已声明但缺少 `LLM_<CHANNEL>_MODELS` 时的回归测试，避免误归因到 `ANSPIRE_API_KEYS`
- `tests/test_config_env_compat.py`
  - 覆盖空 `STOCK_LIST` 不再被环境加载逻辑自动回填的兼容性行为
- `docs/full-guide.md`
- `docs/full-guide_EN.md`
- `docs/CHANGELOG.md`

## Issue Link

无关联 issue。

动机：补齐首次运行配置校验中的常见缺口，减少新用户因缺少必要配置而进入后续分析流程后才失败的情况。

验收标准：

- 未配置任何可用 LLM 接入时，结构化校验给出明确 error
- `LLM_CHANNELS` 已声明但缺少模型/API/protocol 等字段导致无法解析出可用模型时，error 归因到 `LLM_CHANNELS`，不误导用户去检查 `ANSPIRE_API_KEYS`
- `STOCK_LIST` 为空时给出明确 error
- Telegram / Email 成对字段不完整时给出明确 error
- Webhook URL 不是 `http://` 或 `https://` 开头时给出 warning
- 新增行为有单元测试覆盖
- 中英文文档和 changelog 已同步

## Verification Commands And Results

实际执行过的本地验证命令：

```bash
python -m pytest tests/test_config_validate_structured.py tests/test_config_env_compat.py tests/test_llm_channel_config.py
python -m py_compile src/config.py tests/test_config_validate_structured.py
git diff --check -- src/config.py tests/test_config_validate_structured.py
./scripts/ci_gate.sh
```

关键输出/结论：

```text
python -m pytest tests/test_config_validate_structured.py tests/test_config_env_compat.py tests/test_llm_channel_config.py
124 passed, 25 subtests passed in 1.03s

./scripts/ci_gate.sh
2618 passed, 2 deselected, 27 warnings, 243 subtests passed in 102.80s
==> backend-gate: all checks passed
```

GitHub Actions 当前检查也已通过。

## Compatibility And Risk

本 PR 不改变第三方模型/API 的兼容语义、请求参数、provider 路由前缀、Base URL 默认值、SDK 默认值或 provider fallback 行为；因此没有需要引用的外部模型/API 官方变更来源。

本 PR 涉及的是配置诊断语义增强：

- `LITELLM_CONFIG` 路径：若 YAML 已解析出 `llm_model_list`，不新增错误；若配置了 `LITELLM_CONFIG` 但未解析出可用模型，诊断归因到 `LITELLM_CONFIG`
- `LLM_CHANNELS` 路径：若 channel 已解析出 `llm_model_list`，不新增错误；若声明了 `LLM_CHANNELS` 但缺少 `LLM_<CHANNEL>_API_KEY(S)`、`LLM_<CHANNEL>_MODELS`、`LLM_<CHANNEL>_PROTOCOL` 或 Base URL 等字段导致无可用模型，诊断归因到 `LLM_CHANNELS`
- legacy env key 路径：保留 `ANSPIRE_API_KEYS`、`AIHUBMIX_KEY`、`GEMINI_API_KEY`、`ANTHROPIC_API_KEY`、`OPENAI_API_KEY`、`DEEPSEEK_API_KEY` 等既有配置链路；有可用 legacy key 时不新增 LLM 缺失错误

已覆盖路径：

- `test_yaml_config_only_no_error` 覆盖 `LITELLM_CONFIG` YAML 路径
- `test_llm_channels_only_no_error` 覆盖 `LLM_CHANNELS` 正常可用路径
- `test_declared_llm_channels_without_models_reports_channel_error` 覆盖 `LLM_CHANNELS` 已声明但缺少模型字段的错误归因
- `test_legacy_gemini_key_no_error` / `test_deepseek_only_no_error` 覆盖 legacy env key 路径
- `tests/test_llm_channel_config.py` 覆盖 LLM channel 解析、protocol/model 前缀、Base URL 相关既有行为

运行时配置兼容性：

- 本 PR 不会自动改写、清空或迁移用户已有配置
- `STOCK_LIST` 为空时不再自动回填示例股票，而是保留为空并通过结构化校验报 error
- 用户恢复方式：显式配置至少一个股票代码，例如 `STOCK_LIST=600519,hk00700,AAPL`
- 通知配置不完整时只增加诊断，不改变实际发送逻辑
- Webhook URL 非 HTTP(S) 时只增加 warning，不改变发送逻辑

潜在风险：

- 对依赖“空 `STOCK_LIST` 自动回填示例股票”的用户，首次运行会看到新的配置错误；恢复方式是显式配置 `STOCK_LIST`
- `validate()` 仍会把结构化 issue 转为字符串列表，严重级别消费方式保持现状，本 PR 不改变主流程日志/阻断策略

## Rollback Plan

如需回滚，直接 revert 本 PR 即可恢复旧的配置校验行为。

不需要额外回滚配置或数据迁移。本 PR 不写入用户配置、不迁移数据、不清空已有环境变量。

## EXTRACT_PROMPT Change (if applicable)

不适用。本 PR 未修改 `src/services/image_stock_extractor.py` 中的 `EXTRACT_PROMPT`。

## Checklist

- [x] 本 PR 有明确动机和业务价值 / This PR has a clear motivation and value
- [x] 已提供可复现的验证命令与结果 / Reproducible verification commands and results are included
- [x] 已评估兼容性与风险 / Compatibility and risk have been assessed
- [x] 已提供回滚方案 / A rollback plan is provided
- [x] 若涉及用户可见变更，已同步更新相关文档与 `docs/CHANGELOG.md`；`README.md` 仅在首页级信息变化时更新，细节优先写入 `docs/*.md`
