### PR TITLE
fix: 兼容每日分析工作流读取 SearXNG Variables

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -300,6 +300,7 @@ SERPAPI_API_KEYS=
 # 获取: https://brave.com/search/api/
 BRAVE_API_KEYS=
 # SearXNG 实例地址（逗号分隔，私有部署无配额，需在 settings.yml 启用 format: json）
+# GitHub Actions 每日分析工作流支持同名 Variables 优先、Secrets 回退；公网地址可配置为 Variable。
 # 留空时默认自动从 searx.space 拉取公共实例；若不希望访问公共实例，可将下方开关设为 false
 SEARXNG_BASE_URLS=
 SEARXNG_PUBLIC_INSTANCES_ENABLED=true

--- a/.github/workflows/00-daily-analysis.yml
+++ b/.github/workflows/00-daily-analysis.yml
@@ -259,7 +259,7 @@ jobs:
           SERPAPI_API_KEYS: ${{ secrets.SERPAPI_API_KEYS }}
           MINIMAX_API_KEYS: ${{ secrets.MINIMAX_API_KEYS }}
           BRAVE_API_KEYS: ${{ secrets.BRAVE_API_KEYS }}
-          SEARXNG_BASE_URLS: ${{ secrets.SEARXNG_BASE_URLS }}
+          SEARXNG_BASE_URLS: ${{ vars.SEARXNG_BASE_URLS || secrets.SEARXNG_BASE_URLS }}
           SEARXNG_PUBLIC_INSTANCES_ENABLED: ${{ vars.SEARXNG_PUBLIC_INSTANCES_ENABLED || secrets.SEARXNG_PUBLIC_INSTANCES_ENABLED }}
           
           # ==========================================

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+- [修复] GitHub Actions 每日分析工作流读取 SearXNG 自建实例地址时支持 Variables 优先、Secrets 回退，修复仅配置 Variables 时 URL 不生效的问题。
 - [修复] Web/桌面端左侧导航选中态改用 border 实现，避免蓝色竖条指示器溢出侧栏边界；侧栏展开宽度 116px → 136px，新增 rail 紧凑模式。
 - [修复] Windows 桌面端自动更新安装目录不再预先加引号，避免带空格路径在自动安装时触发“缺少快捷方式 / 找不到 Daily Stock Analysis.exe”的系统弹窗。
 - [修复] Agent 分析路径生成 AnalysisContextPack overview 前复用已落库日线分析上下文，避免日线已抓取成功仍显示 `daily_bars_missing`。

--- a/tests/test_searxng_env_docs.py
+++ b/tests/test_searxng_env_docs.py
@@ -1,0 +1,38 @@
+from pathlib import Path
+
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+
+
+def test_env_example_documents_searxng_actions_variable_mapping() -> None:
+    env_example = (ROOT_DIR / ".env.example").read_text(encoding="utf-8")
+
+    start = env_example.index("# SearXNG 实例地址")
+    end = env_example.index("SEARXNG_PUBLIC_INSTANCES_ENABLED=true", start)
+    searxng_block = env_example[start:end]
+
+    assert "GitHub Actions" in searxng_block
+    assert "Variables 优先" in searxng_block
+    assert "Secrets" in searxng_block
+    assert "需配置为 Secret" not in searxng_block
+
+
+def test_daily_analysis_workflow_matches_documented_searxng_variable_mapping() -> None:
+    workflow = (
+        ROOT_DIR / ".github" / "workflows" / "00-daily-analysis.yml"
+    ).read_text(encoding="utf-8")
+
+    assert (
+        "SEARXNG_BASE_URLS: ${{ vars.SEARXNG_BASE_URLS || secrets.SEARXNG_BASE_URLS }}"
+        in workflow
+    )
+    assert "SEARXNG_BASE_URLS: ${{ secrets.SEARXNG_BASE_URLS }}" not in workflow
+
+
+def test_changelog_mentions_searxng_actions_variable_mapping() -> None:
+    changelog = (ROOT_DIR / "docs" / "CHANGELOG.md").read_text(encoding="utf-8")
+
+    assert (
+        "- [修复] GitHub Actions 每日分析工作流读取 SearXNG 自建实例地址时"
+        "支持 Variables 优先、Secrets 回退，修复仅配置 Variables 时 URL 不生效的问题。"
+    ) in changelog


### PR DESCRIPTION
## PR Type
- [x] fix
- [ ] feat
- [ ] refactor
- [ ] docs
- [ ] chore
- [x] test

## Background And Problem
Issue #1565 反馈：`.github/workflows/00-daily-analysis.yml` 只读取 `secrets.SEARXNG_BASE_URLS`，当用户把自建 SearXNG 公网地址配置到 GitHub Actions Variables 时，daily workflow 运行日志仍显示 `SearXNG Base URLs: ⚪ 未配置`，最终会回退到公共实例或表现为搜索未启用。

这个地址通常不是敏感信息，适合放在 Variables；同一 workflow 中 `SEARXNG_PUBLIC_INSTANCES_ENABLED` 也已经采用 `vars || secrets` 兼容写法。因此本 PR 将 `SEARXNG_BASE_URLS` 对齐为 Variables 优先、Secrets 回退。

## Scope Of Change
- `.github/workflows/00-daily-analysis.yml`
  - 将 `SEARXNG_BASE_URLS` 从仅读取 Secrets 改为 `${{ vars.SEARXNG_BASE_URLS || secrets.SEARXNG_BASE_URLS }}`。
- `.env.example`
  - 说明 GitHub Actions 每日分析工作流支持同名 Variables 优先、Secrets 回退。
- `tests/test_searxng_env_docs.py`
  - 新增/修正回归测试，验证 workflow、`.env.example` 和 changelog 都指向新的兼容语义。
- `docs/CHANGELOG.md`
  - 按 `[Unreleased]` 扁平格式补充修复记录。

## Issue Link
Closes #1565

## Verification Commands And Results
```bash
git diff --check
$env:PYTHONUTF8='1'; python -m pytest tests/test_searxng_env_docs.py
```

结果：
- `git diff --check`：PASS
- `tests/test_searxng_env_docs.py`：3 passed

说明：本地 Windows/Anaconda 环境直接运行 `python -m pytest ...` 会在读取 `setup.cfg` 时因 GBK/UTF-8 编码差异失败，尚未进入测试收集；设置 `PYTHONUTF8=1` 后通过。

## Compatibility And Risk
- 影响范围仅限 GitHub Actions daily workflow 的环境变量映射、说明文档和回归测试。
- 仅配置 Secrets 的用户保持兼容。
- 同时配置 Variables 和 Secrets 时，Variables 优先；这与 `SEARXNG_PUBLIC_INSTANCES_ENABLED` 的现有模式一致。
- 未改动 SearchService、pipeline、API、Web 或 Desktop 运行时代码。
- 主要风险是 GitHub Actions 表达式语义依赖 `vars || secrets`，但同 workflow 已有相同用法作为参考。

## Review Feedback Addressed
- 补齐原评审指出缺失的核心 workflow 修改。
- 测试不再反向固定 `secrets.SEARXNG_BASE_URLS` 旧行为，改为验证 Variables 优先、Secrets 回退。
- `.env.example` 和 changelog 不再提示必须配置同名 Secret，而是说明新的兼容语义。

## Rollback Plan
- Revert this PR. 回滚后 daily workflow 将恢复为仅读取 `secrets.SEARXNG_BASE_URLS`。