### PR TITLE
fix: register health router in v1 API so /api/v1/health returns 200

### DIFF
--- a/api/middlewares/auth.py
+++ b/api/middlewares/auth.py
@@ -20,6 +20,7 @@ EXEMPT_PATHS = frozenset({
     "/api/v1/auth/login",
     "/api/v1/auth/status",
     "/api/health",
+    "/api/v1/health",
     "/health",
     "/docs",
     "/redoc",

--- a/api/v1/router.py
+++ b/api/v1/router.py
@@ -11,7 +11,7 @@ API v1 路由聚合
 
 from fastapi import APIRouter
 
-from api.v1.endpoints import alerts, analysis, auth, history, stocks, backtest, system_config, agent, usage, portfolio, alphasift
+from api.v1.endpoints import alerts, analysis, auth, history, stocks, backtest, system_config, agent, usage, portfolio, alphasift, health
 
 # 创建 v1 版本主路由
 router = APIRouter(prefix="/api/v1")
@@ -80,4 +80,9 @@ router.include_router(
     alphasift.router,
     prefix="/alphasift",
     tags=["AlphaSift"]
+)
+
+router.include_router(
+    health.router,
+    tags=["Health"]
 )

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 ## [Unreleased]
 
 - [改进] 首次运行配置校验补充缺失 AI Key、空 STOCK_LIST、Telegram/邮件成对字段和 Webhook URL 前缀诊断。
+- [修复] 注册 /api/v1/health 路由并加入认证豁免，修复该路径返回 404 以及开启 ADMIN_AUTH_ENABLED 后健康探针收到 401 的问题。
 - [改进] AlphaSift 选股入口在 Web 侧边栏中移动到“问股”下方，贴近 Agent/研究辅助工作流。
 - [改进] Docker 镜像构建阶段预置默认 AlphaSift 适配层，与桌面发布包一样避免运行期额外安装。
 - [新功能] 新增默认关闭的 AlphaSift 选股页签，通过 `ALPHASIFT_ENABLED` 开启后经由稳定适配层读取策略并执行选股。

--- a/tests/test_api_health.py
+++ b/tests/test_api_health.py
@@ -1,0 +1,38 @@
+# -*- coding: utf-8 -*-
+"""Tests for health check endpoints: /api/health and /api/v1/health."""
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+from api.app import create_app
+
+
+class HealthEndpointTestCase(unittest.TestCase):
+    """Both /api/health and /api/v1/health should return 200 with valid payload."""
+
+    @classmethod
+    def setUpClass(cls):
+        temp_dir = tempfile.TemporaryDirectory()
+        cls.addClassCleanup(temp_dir.cleanup)
+        cls.client = TestClient(create_app(static_dir=Path(temp_dir.name)))
+
+    def test_api_health_returns_200(self):
+        resp = self.client.get("/api/health")
+        self.assertEqual(resp.status_code, 200)
+        body = resp.json()
+        self.assertEqual(body["status"], "ok")
+        self.assertIn("timestamp", body)
+
+    def test_api_v1_health_returns_200(self):
+        resp = self.client.get("/api/v1/health")
+        self.assertEqual(resp.status_code, 200)
+        body = resp.json()
+        self.assertEqual(body["status"], "ok")
+        self.assertIn("timestamp", body)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_api_health.py
+++ b/tests/test_api_health.py
@@ -48,7 +48,7 @@ class HealthEndpointAuthEnabledTestCase(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        cls._patcher = patch("src.auth.is_auth_enabled", return_value=True)
+        cls._patcher = patch("api.middlewares.auth.is_auth_enabled", return_value=True)
         cls._patcher.start()
         cls._temp_dir, cls.client = _make_client()
 

--- a/tests/test_api_health.py
+++ b/tests/test_api_health.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 """Tests for health check endpoints: /api/health and /api/v1/health."""
 
-import os
 import tempfile
 import unittest
 from pathlib import Path

--- a/tests/test_api_health.py
+++ b/tests/test_api_health.py
@@ -1,13 +1,20 @@
 # -*- coding: utf-8 -*-
 """Tests for health check endpoints: /api/health and /api/v1/health."""
 
+import os
 import tempfile
 import unittest
 from pathlib import Path
+from unittest.mock import patch
 
 from fastapi.testclient import TestClient
 
 from api.app import create_app
+
+
+def _make_client():
+    temp_dir = tempfile.TemporaryDirectory()
+    return temp_dir, TestClient(create_app(static_dir=Path(temp_dir.name)))
 
 
 class HealthEndpointTestCase(unittest.TestCase):
@@ -15,9 +22,11 @@ class HealthEndpointTestCase(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        temp_dir = tempfile.TemporaryDirectory()
-        cls.addClassCleanup(temp_dir.cleanup)
-        cls.client = TestClient(create_app(static_dir=Path(temp_dir.name)))
+        cls._temp_dir, cls.client = _make_client()
+
+    @classmethod
+    def tearDownClass(cls):
+        cls._temp_dir.cleanup()
 
     def test_api_health_returns_200(self):
         resp = self.client.get("/api/health")
@@ -32,6 +41,31 @@ class HealthEndpointTestCase(unittest.TestCase):
         body = resp.json()
         self.assertEqual(body["status"], "ok")
         self.assertIn("timestamp", body)
+
+
+class HealthEndpointAuthEnabledTestCase(unittest.TestCase):
+    """Health endpoints must remain accessible when admin auth is enabled."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls._patcher = patch("src.auth.is_auth_enabled", return_value=True)
+        cls._patcher.start()
+        cls._temp_dir, cls.client = _make_client()
+
+    @classmethod
+    def tearDownClass(cls):
+        cls._temp_dir.cleanup()
+        cls._patcher.stop()
+
+    def test_api_health_returns_200_when_auth_enabled(self):
+        resp = self.client.get("/api/health")
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.json()["status"], "ok")
+
+    def test_api_v1_health_returns_200_when_auth_enabled(self):
+        resp = self.client.get("/api/v1/health")
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.json()["status"], "ok")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## PR Type

- [x] fix

## Background And Problem

`api/v1/endpoints/health.py` 定义了 `/health` 路由，但从未在 `api/v1/router.py` 中注册，导致 `/api/v1/health` 返回 404，而 `/api/health` 正常工作。同时 `api/middlewares/auth.py` 的 `EXEMPT_PATHS` 缺少 `/api/v1/health`，开启 `ADMIN_AUTH_ENABLED` 后健康探针会收到 401。

## Scope Of Change

- `api/v1/router.py`：导入 `health` 模块并 `include_router(health.router, tags=["Health"])`
- `api/middlewares/auth.py`：将 `/api/v1/health` 加入 `EXEMPT_PATHS`
- `docs/CHANGELOG.md`：在 `[Unreleased]` 补充变更记录
- `tests/test_api_health.py`：覆盖认证关闭和开启两种场景

## Issue Link

Fixes #1561

## Verification Commands And Results

```bash
python -m pytest tests/test_api_health.py -v
```

```
tests/test_api_health.py::HealthEndpointTestCase::test_api_health_returns_200 PASSED
tests/test_api_health.py::HealthEndpointTestCase::test_api_v1_health_returns_200 PASSED
tests/test_api_health.py::HealthEndpointAuthEnabledTestCase::test_api_health_returns_200_when_auth_enabled PASSED
tests/test_api_health.py::HealthEndpointAuthEnabledTestCase::test_api_v1_health_returns_200_when_auth_enabled PASSED
4 passed
```

```bash
python -m py_compile api/v1/router.py api/middlewares/auth.py tests/test_api_health.py
# OK
```

本地未跑完整 `./scripts/ci_gate.sh`，以 PR 的 backend-gate / docker-build CI 通过作为替代证据。

## Compatibility And Risk

- 纯追加变更，不修改、不删除已有 `/api/health` 路径，已有监控配置无需调整。
- `/api/v1/health` 从 404 变为 200，属于修复而非破坏。
- `EXEMPT_PATHS` 新增条目仅影响认证豁免范围，不影响其他路由的认证行为。
- 不涉及第三方模型 / API 兼容语义、运行时配置保存/迁移、或依赖版本窗口。

## Rollback Plan

Revert this PR 即可。不需要额外回滚配置或数据迁移。

## Checklist

- [x] 本 PR 有明确动机和业务价值 / This PR has a clear motivation and value
- [x] 已提供可复现的验证命令与结果 / Reproducible verification commands and results are included
- [x] 已评估兼容性与风险 / Compatibility and risk have been assessed
- [x] 已提供回滚方案 / A rollback plan is provided
- [x] 若涉及用户可见变更，已同步更新相关文档与 `docs/CHANGELOG.md`；`README.md` 仅在首页级信息变化时更新，细节优先写入 `docs/*.md`