### PR TITLE
fix: improve Windows first-run encoding compatibility

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 - [改进] 首次运行配置校验补充缺失 AI Key、空 STOCK_LIST、Telegram/邮件成对字段和 Webhook URL 前缀诊断。
 - [修复] 注册 /api/v1/health 路由并加入认证豁免，修复该路径返回 404 以及开启 ADMIN_AUTH_ENABLED 后健康探针收到 401 的问题。
+- [修复] Windows 本地首次运行环境检查兼容非 UTF-8 控制台输出，并将 `requirements.txt` 注释改为 ASCII 以降低默认代码页下的依赖安装失败概率。
  - [文档] 明确 AlphaSift 与 LiteLLM 兼容边界：仅桥接 DSA 已声明 provider/model/base URL 为调用期注入，不对 `.env` 做 provider/model 路由迁移；回退方式为关闭 AlphaSift 并恢复原有 `LITELLM_*`/`LLM_*` 配置。
 - [文档] 明确 AlphaSift 与 LiteLLM 兼容边界：仅桥接 DSA 已声明 provider/model/base URL 为调用期注入，不对 `.env` 做 provider/model 路由迁移；回退方式为关闭 AlphaSift 并恢复原有 `LITELLM_*`/`LLM_*` 配置。
 - [改进] AlphaSift 选股入口在 Web 侧边栏中移动到“问股”下方，贴近 Agent/研究辅助工作流。

--- a/docs/full-guide.md
+++ b/docs/full-guide.md
@@ -598,6 +598,15 @@ conda activate stock
 pip install -r requirements.txt
 ```
 
+Windows PowerShell 若仍使用系统默认代码页，首次安装依赖或运行环境检查前建议先启用 UTF-8，避免第三方工具或终端输出在中文字符上失败：
+
+```powershell
+$env:PYTHONUTF8='1'
+$env:PYTHONIOENCODING='utf-8'
+python -m pip install -r requirements.txt
+python scripts/check_env.py --config
+```
+
 **智能导入依赖**：`pypinyin`（名称→代码拼音匹配）和 `openpyxl`（Excel .xlsx 解析）已包含在 `requirements.txt` 中，执行上述 `pip install -r requirements.txt` 时会自动安装。若使用智能导入（图片/CSV/Excel/剪贴板）功能，请确保依赖已正确安装；缺失时可能报 `ModuleNotFoundError`。
 
 ### 命令行参数

--- a/docs/full-guide_EN.md
+++ b/docs/full-guide_EN.md
@@ -537,6 +537,15 @@ conda activate stock
 pip install -r requirements.txt
 ```
 
+On Windows PowerShell, if Python or pip still uses the system default code page, enable UTF-8 before the first dependency install or environment check. This keeps terminal output and third-party tooling from failing on non-ASCII text:
+
+```powershell
+$env:PYTHONUTF8='1'
+$env:PYTHONIOENCODING='utf-8'
+python -m pip install -r requirements.txt
+python scripts/check_env.py --config
+```
+
 ### Command Line Arguments
 
 ```bash

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,67 +1,67 @@
 # ===================================
-# A股自选股智能分析系统 - 依赖列表
+# Daily Stock Analysis - dependencies
 # ===================================
 
-# 核心依赖
-python-dotenv>=1.0.0        # 环境变量配置管理
-tenacity>=8.2.0             # 重试机制（指数退避）
-sqlalchemy>=2.0.0           # ORM数据库操作
-schedule>=1.2.0             # 定时任务调度
-exchange-calendars>=4.13.0   # 交易日历；4.5.x 与 pandas 3 不兼容（Timedelta "T"）
+# Core dependencies
+python-dotenv>=1.0.0        # Environment variable configuration
+tenacity>=8.2.0             # Retry support with exponential backoff
+sqlalchemy>=2.0.0           # ORM database access
+schedule>=1.2.0             # Scheduled task runner
+exchange-calendars>=4.13.0   # Trading calendars; 4.5.x is incompatible with pandas 3 Timedelta "T"
 
-# 数据源依赖（多源策略，按优先级排序）
-efinance>=0.5.5             # Priority 0: 东方财富数据源（最高优先级）https://github.com/Micro-sheep/efinance
-akshare>=1.12.0             # Priority 1: 东方财富爬虫数据源
-tushare>=1.4.0              # Priority 2: 挖地兔 Pro API
-pytdx>=1.72                 # Priority 2: 通达信行情服务器
-baostock>=0.8.0             # Priority 3: 证券宝数据
+# Data source dependencies, ordered by fallback priority
+efinance>=0.5.5             # Priority 0: East Money data source https://github.com/Micro-sheep/efinance
+akshare>=1.12.0             # Priority 1: East Money crawler data source
+tushare>=1.4.0              # Priority 2: Tushare Pro API
+pytdx>=1.72                 # Priority 2: Tongdaxin quote servers
+baostock>=0.8.0             # Priority 3: Baostock data
 yfinance>=0.2.0             # Priority 4: Yahoo Finance (Fallback)
-longbridge>=0.2.77           # Priority 5: 长桥 OpenAPI（美股/港股兜底；OAuth 路径运行时检测 SDK 能力）
+longbridge>=0.2.77           # Priority 5: Longbridge OpenAPI fallback for US/HK stocks; OAuth capability checked at runtime
 tickflow>=0.1.0            # TickFlow official SDK (Issue #632, market review enhancement)
 
-#飞书
-lark-oapi>=1.0.0             # 飞书API
+# Feishu
+lark-oapi>=1.0.0             # Feishu API
 
-# 数据处理
-pandas>=2.0.0               # 数据分析
+# Data processing
+pandas>=2.0.0               # Data analysis
 pypinyin>=0.50.0            # Name-to-code resolver (pinyin matching)
 openpyxl>=3.1.0             # Excel (.xlsx) parsing for import
-numpy>=1.24.0               # 数值计算
-json-repair>=0.55.1         # JSON 修复
+numpy>=1.24.0               # Numeric computing
+json-repair>=0.55.1         # JSON repair
 
-# AI 分析
+# AI analysis
 # Keep the historical minimum version while excluding quarantined builds and avoiding future major breaks.
 litellm>=1.80.10,!=1.82.7,!=1.82.8,<2.0.0   # Unified LLM client (Gemini/Anthropic/OpenAI/DeepSeek etc.)
 tiktoken>=0.8.0,<0.12.0    # BPE tokenizer for LLM token counting (pin <0.12 to avoid plugin registration issues, #537)
 openai>=1.0.0               # OpenAI SDK (transitive dependency of litellm, kept explicit)
 PyYAML>=6.0                 # YAML parser for LITELLM_CONFIG support
 
-# 搜索引擎（用于获取股票新闻）
-tavily-python>=0.3.0        # Tavily 搜索 API（每月 1000 次免费）
-google-search-results>=2.4.0  # SerpAPI（每月 100 次免费）
+# Search engines for stock news
+tavily-python>=0.3.0        # Tavily Search API
+google-search-results>=2.4.0  # SerpAPI
 
-# 网络请求
-requests>=2.31.0            # HTTP 请求
-markdown2>=2.4.0            # Markdown 转 HTML
-imgkit>=1.2.0              # Markdown 转图片（需安装 wkhtmltopdf）
-fake-useragent>=1.4.0       # 随机 User-Agent 防封禁
-httpx[socks]                # HTTP 客户端 + SOCKS 代理支持（OpenAI 可选依赖）
-dingtalk-stream >= 0.24.3    # 钉钉 Stream SDK
-# 数据库
-# SQLite 是 Python 内置，无需额外安装
+# Network requests
+requests>=2.31.0            # HTTP requests
+markdown2>=2.4.0            # Markdown to HTML
+imgkit>=1.2.0              # Markdown to image; requires wkhtmltopdf
+fake-useragent>=1.4.0       # Random User-Agent support
+httpx[socks]                # HTTP client with SOCKS proxy support; optional OpenAI dependency
+dingtalk-stream >= 0.24.3    # DingTalk Stream SDK
+# Database
+# SQLite is built into Python and does not need an extra package
 
-# Discord 机器人
-discord.py>=2.0.0              # Discord 机器人开发库
-PyNaCl>=1.5.0                  # Discord Interaction/Webhook Ed25519 签名验证
+# Discord bot
+discord.py>=2.0.0              # Discord bot development library
+PyNaCl>=1.5.0                  # Discord Interaction/Webhook Ed25519 signature verification
 
 # Web Content Extraction
 newspaper3k>=0.2.8          # Article extraction
 lxml_html_clean             # Fix for lxml.html.clean ImportError in newer lxml versions
 
-# 报告模板引擎（Report Engine P0）
+# Report template engine (Report Engine P0)
 jinja2>=3.1.0               # Jinja2 template engine for report rendering
 
-# FastAPI Web 框架
-fastapi>=0.109.0            # 现代 Python Web 框架
-uvicorn[standard]>=0.27.0   # ASGI 服务器
+# FastAPI Web framework
+fastapi>=0.109.0            # Modern Python Web framework
+uvicorn[standard]>=0.27.0   # ASGI server
 python-multipart>=0.0.6     # FastAPI File/Form upload support

--- a/scripts/check_env.py
+++ b/scripts/check_env.py
@@ -41,6 +41,29 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
+
+def _reconfigure_output_stream(stream):
+    """Avoid UnicodeEncodeError on legacy Windows console code pages."""
+    reconfigure = getattr(stream, "reconfigure", None)
+    if not callable(reconfigure):
+        return
+
+    for kwargs in (
+        {"encoding": "utf-8", "errors": "replace"},
+        {"errors": "replace"},
+    ):
+        try:
+            reconfigure(**kwargs)
+            return
+        except Exception:
+            continue
+
+
+def configure_console_encoding():
+    for stream in (sys.stdout, sys.stderr):
+        _reconfigure_output_stream(stream)
+
+
 # 配置日志
 logging.basicConfig(
     level=logging.INFO,
@@ -440,6 +463,8 @@ def query_stock_data(stock_code: str, days: int = 10):
 
 
 def main():
+    configure_console_encoding()
+
     parser = argparse.ArgumentParser(
         description='A股自选股智能分析系统 - 环境验证测试',
         formatter_class=argparse.RawDescriptionHelpFormatter,

--- a/tests/test_check_env_encoding.py
+++ b/tests/test_check_env_encoding.py
@@ -1,0 +1,47 @@
+from pathlib import Path
+
+from scripts.check_env import _reconfigure_output_stream
+
+
+class _FakeStream:
+    def __init__(self, reject_encoding=False):
+        self.reject_encoding = reject_encoding
+        self.calls = []
+
+    def reconfigure(self, **kwargs):
+        self.calls.append(kwargs)
+        if self.reject_encoding and "encoding" in kwargs:
+            raise ValueError("encoding cannot be changed")
+
+
+class _StreamWithoutReconfigure:
+    pass
+
+
+def test_reconfigure_output_stream_prefers_utf8_with_replacement():
+    stream = _FakeStream()
+
+    _reconfigure_output_stream(stream)
+
+    assert stream.calls == [{"encoding": "utf-8", "errors": "replace"}]
+
+
+def test_reconfigure_output_stream_falls_back_to_errors_only():
+    stream = _FakeStream(reject_encoding=True)
+
+    _reconfigure_output_stream(stream)
+
+    assert stream.calls == [
+        {"encoding": "utf-8", "errors": "replace"},
+        {"errors": "replace"},
+    ]
+
+
+def test_reconfigure_output_stream_ignores_streams_without_reconfigure():
+    _reconfigure_output_stream(_StreamWithoutReconfigure())
+
+
+def test_requirements_file_is_ascii_decodable():
+    requirements_path = Path(__file__).resolve().parents[1] / "requirements.txt"
+
+    requirements_path.read_bytes().decode("ascii")


### PR DESCRIPTION
## PR Type

- [x] fix
- [ ] feat
- [ ] refactor
- [ ] docs
- [ ] chore
- [x] test

## Background And Problem

Windows 本地首次运行时，如果 PowerShell / Python 使用系统默认代码页，`scripts/check_env.py` 输出中文或符号可能触发 `UnicodeEncodeError`，导致环境检查在真正完成配置诊断前失败。

同时 `requirements.txt` 中的中文注释会增加默认代码页环境下依赖安装读取失败的概率，影响新用户按本地运行流程完成初始化。

## Scope Of Change

- `scripts/check_env.py`
  - 在 `main()` 开始时重配 stdout/stderr，优先使用 UTF-8，并设置 `errors="replace"`。
  - 对不支持 `encoding` 重配或不支持 `reconfigure` 的输出流做兼容降级，避免环境检查脚本自身因此失败。
- `requirements.txt`
  - 将注释改为 ASCII；不修改依赖名称或版本约束。
- `tests/test_check_env_encoding.py`
  - 覆盖输出流重配、降级路径，以及 `requirements.txt` 可 ASCII 解码。
- `docs/full-guide.md`
- `docs/full-guide_EN.md`
- `docs/CHANGELOG.md`
  - 补充 Windows PowerShell 首次安装依赖 / 环境检查前启用 UTF-8 的说明，并记录变更。

## Issue Link

Fixes #1560

## Verification Commands And Results

```bash
python -m py_compile scripts/check_env.py tests/test_check_env_encoding.py
python -m pytest tests/test_check_env_encoding.py -q
PYTHONIOENCODING=cp1252 python scripts/check_env.py --config
rg -n "[^\\x00-\\x7F]" requirements.txt || true
git diff --check
timeout 420 ./scripts/ci_gate.sh
```

关键输出/结论：

```text
python -m pytest tests/test_check_env_encoding.py -q
4 passed in 0.02s

PYTHONIOENCODING=cp1252 python scripts/check_env.py --config
不再触发 UnicodeEncodeError，能够输出配置检查结果。

rg -n "[^\\x00-\\x7F]" requirements.txt || true
无非 ASCII 命中。

timeout 420 ./scripts/ci_gate.sh
2670 passed, 2 deselected, 32 warnings, 243 subtests passed in 119.00s
==> backend-gate: all checks passed
```

## Compatibility And Risk

兼容性影响较低：

- 输出流重配只作用于 `scripts/check_env.py` 进程，不改变主应用、API、Web、Desktop 或调度运行路径。
- 如果运行环境的输出流不支持 `reconfigure`，脚本会保留原行为，不阻断环境检查。
- `requirements.txt` 仅注释变更，不改变依赖语义、版本约束或安装顺序。
- 文档仅补充 Windows PowerShell 下的 UTF-8 前置命令，不新增配置项。

潜在风险：极少数嵌入式执行环境可能不希望脚本调整 stdout/stderr；当前实现已使用能力探测和异常吞吐，风险可控。

## Rollback Plan

Revert this PR 即可恢复旧的环境检查输出行为、`requirements.txt` 注释和文档说明。不需要额外配置、数据或依赖回滚。

## EXTRACT_PROMPT Change (if applicable)

不适用。本 PR 未修改 `src/services/image_stock_extractor.py` 中的 `EXTRACT_PROMPT`。

<details>
<summary>展开 / Expand: Full EXTRACT_PROMPT</summary>

```
N/A
```

</details>

## Checklist

- [x] 本 PR 有明确动机和业务价值 / This PR has a clear motivation and value
- [x] 已提供可复现的验证命令与结果 / Reproducible verification commands and results are included
- [x] 已评估兼容性与风险 / Compatibility and risk have been assessed
- [x] 已提供回滚方案 / A rollback plan is provided
- [x] 若涉及用户可见变更，已同步更新相关文档与 `docs/CHANGELOG.md`；`README.md` 仅在首页级信息变化时更新，细节优先写入 `docs/*.md`