### PR TITLE
fix: bundle AlphaSift in macOS desktop backend

### DIFF
--- a/api/v1/endpoints/alphasift.py
+++ b/api/v1/endpoints/alphasift.py
@@ -104,6 +104,17 @@ def _install_alphasift(config: Config) -> Dict[str, Any]:
             )
 
         install_spec = _validate_install_spec(config.alphasift_install_spec)
+        if _is_packaged_runtime():
+            raise HTTPException(
+                status_code=424,
+                detail={
+                    "error": "alphasift_install_packaged_runtime_unsupported",
+                    "message": (
+                        "打包后的桌面端不支持运行期自动 pip 安装 AlphaSift。"
+                        "请升级到已内置 AlphaSift 的桌面包，或使用源码部署并在当前 Python 环境中手动安装。"
+                    ),
+                },
+            )
 
         try:
             _purge_alphasift_modules()
@@ -148,7 +159,6 @@ def _install_alphasift(config: Config) -> Dict[str, Any]:
             install_spec_is_default=_is_default_alphasift_install_spec(install_spec),
         )
 
-
 def _validate_install_spec(raw_install_spec: str) -> str:
     install_spec = (raw_install_spec or "").strip()
     if not install_spec or install_spec.lower() == "alphasift":
@@ -173,6 +183,10 @@ def _validate_install_spec(raw_install_spec: str) -> str:
         )
 
     return install_spec
+
+
+def _is_packaged_runtime() -> bool:
+    return bool(getattr(sys, "frozen", False) or getattr(sys, "_MEIPASS", None))
 
 
 @router.post("/screen")

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 ## [Unreleased]
 
 - [修复] Web/桌面端左侧导航选中态改用 border 实现，避免蓝色竖条指示器溢出侧栏边界；侧栏展开宽度 116px → 136px，新增 rail 紧凑模式。
+- [修复] macOS 桌面端打包阶段预置并收集 AlphaSift 适配层，避免发布包开启选股后缺少 `alphasift.dsa_adapter`。
+- [修复] AlphaSift 自动安装接口在打包桌面端返回明确的不支持运行期 pip 安装错误，避免误执行 `stock_analysis -m pip`。
 
 <!-- 新条目格式：- [类型] 描述（类型取值：新功能/改进/修复/文档/测试/chore）-->
 <!-- 每条独立一行追加到本段末尾，无需分类标题，合并时冲突最小 -->

--- a/docs/alphasift-integration.md
+++ b/docs/alphasift-integration.md
@@ -62,7 +62,7 @@ AlphaSift 侧已在 `ZhuLinsen/alphasift@b2ca66dd47001b9a09890cfe21c2b18c7219ccf
 ## DSA 后端行为
 
 - `/api/v1/alphasift/status`：返回开关、可用性、默认安装来源标识和适配层元信息；不会暴露完整安装来源。
-- `/api/v1/alphasift/install`：开启流程在适配层缺失时会调用它；桌面模式（`DSA_DESKTOP_MODE=true`）不要求管理员会话，非桌面部署必须启用 `ADMIN_AUTH_ENABLED=true` 并携带有效管理员会话，否则返回 `401/403`。接口只允许默认受信任安装来源，并会强制重装锁定 commit，避免旧版 `alphasift` 包残留。
+- `/api/v1/alphasift/install`：开启流程在适配层缺失时会调用它；桌面模式（`DSA_DESKTOP_MODE=true`）不要求管理员会话，非桌面部署必须启用 `ADMIN_AUTH_ENABLED=true` 并携带有效管理员会话，否则返回 `401/403`。接口只允许默认受信任安装来源，并会强制重装锁定 commit，避免旧版 `alphasift` 包残留。打包桌面端不支持运行期 pip 安装，如果依赖缺失会返回明确错误，用户应升级到已内置 AlphaSift 的桌面包或改用源码部署。
 - `/api/v1/alphasift/strategies`：读取 AlphaSift 策略列表；如果 `ALPHASIFT_ENABLED=true` 且 `diagnostics.reason=missing_module`，会先按 `/install` 的同一鉴权要求自动安装后再读取；若适配层状态异常，会返回 `424 + diagnostics`，不触发自动安装。
 - `/api/v1/alphasift/screen`：调用适配层 `screen(..., use_llm=True)`，并在调用期间临时注入 DSA 已解析的 LLM 运行环境，同时向支持 `context` 的适配层传入结构化 LLM 配置；如果已开启但 `diagnostics.reason=missing_module`，会先按 `/install` 的同一鉴权要求自动安装后再运行；运行时异常则返回 `424 + diagnostics` 并保留原始错误边界。
 
@@ -86,6 +86,7 @@ AlphaSift 侧已在 `ZhuLinsen/alphasift@b2ca66dd47001b9a09890cfe21c2b18c7219ccf
 
 - 未开启返回 `403 alphasift_disabled`。
 - 受控安装接口来源不受信任返回 `403 alphasift_install_spec_not_allowed`。
+- 打包桌面端尝试运行期自动安装返回 `424 alphasift_install_packaged_runtime_unsupported`。
 - AlphaSift 未安装、缺少适配层或适配层不可调用返回 `424`。
 - 市场或策略被适配层拒绝时返回 `400/422`。
 - 运行失败返回 `424 alphasift_screen_failed`。
@@ -104,7 +105,7 @@ AlphaSift 侧已在 `ZhuLinsen/alphasift@b2ca66dd47001b9a09890cfe21c2b18c7219ccf
 
 源码运行的桌面端复用同一个 Python 后端环境，并设置 `DSA_DESKTOP_MODE=true`；通过设置页开启时如缺少适配层，会直接尝试自动安装默认受信任来源。
 
-打包后的桌面端通常不依赖运行期 `pip install`：`scripts/build-backend.ps1` 会在构建阶段安装默认 `ALPHASIFT_INSTALL_SPEC` 并把 `alphasift.dsa_adapter` 收集进 PyInstaller 产物。发布包默认仍关闭；用户在 Web 设置页开启后会先检查适配层，若打包产物异常缺失，再尝试受控自动安装。
+打包后的桌面端不依赖运行期 `pip install`：`scripts/build-backend.ps1` 和 `scripts/build-backend-macos.sh` 会在构建阶段安装默认 `ALPHASIFT_INSTALL_SPEC` 并把 `alphasift.dsa_adapter` 收集进 PyInstaller 产物。发布包默认仍关闭；用户在 Web 设置页开启后会先检查适配层，若打包产物异常缺失，会返回明确错误并提示升级桌面包或使用源码部署。
 
 ## Docker 说明
 

--- a/scripts/build-backend-macos.sh
+++ b/scripts/build-backend-macos.sh
@@ -41,8 +41,19 @@ fi
 log "Installing backend dependencies..."
 "${PYTHON_BIN}" -m pip install -r "${ROOT_DIR}/requirements.txt"
 
+log "Bundling AlphaSift desktop dependency..."
+alpha_sift_install_spec="$("${PYTHON_BIN}" -c "from src.config import DEFAULT_ALPHASIFT_INSTALL_SPEC; print(DEFAULT_ALPHASIFT_INSTALL_SPEC)")"
+if [[ -z "${alpha_sift_install_spec}" ]]; then
+  echo "ERROR: DEFAULT_ALPHASIFT_INSTALL_SPEC is empty; cannot bundle AlphaSift for desktop."
+  exit 1
+fi
+"${PYTHON_BIN}" -m pip install "${alpha_sift_install_spec}"
+
 log "Checking python-multipart availability..."
 "${PYTHON_BIN}" -c "import multipart, multipart.multipart"
+
+log "Checking AlphaSift adapter availability..."
+"${PYTHON_BIN}" -c "import alphasift.dsa_adapter"
 
 if [[ -d "${ROOT_DIR}/dist/backend" ]]; then
   rm -rf "${ROOT_DIR}/dist/backend"
@@ -74,6 +85,9 @@ hidden_imports=(
   "api.v1.endpoints.history"
   "api.v1.endpoints.stocks"
   "api.v1.endpoints.health"
+  "api.v1.endpoints.alphasift"
+  "alphasift"
+  "alphasift.dsa_adapter"
   "api.v1.schemas"
   "api.v1.schemas.analysis"
   "api.v1.schemas.history"
@@ -103,7 +117,7 @@ for module in "${hidden_imports[@]}"; do
 done
 
 pushd "${ROOT_DIR}" >/dev/null
-cmd=("${PYTHON_BIN}" -m PyInstaller --name stock_analysis --onedir --noconfirm --noconsole --add-data "static:static" --add-data "strategies:strategies" --collect-data litellm --collect-data tiktoken)
+cmd=("${PYTHON_BIN}" -m PyInstaller --name stock_analysis --onedir --noconfirm --noconsole --add-data "static:static" --add-data "strategies:strategies" --collect-data litellm --collect-data tiktoken --collect-all alphasift)
 cmd+=("${hidden_import_args[@]}" "main.py")
 
 echo "Running: ${cmd[*]}"
@@ -136,6 +150,13 @@ fi
 packaged_strategy_count="$(find "${packaged_strategies}" -maxdepth 1 -type f -name '*.yaml' | wc -l | tr -d '[:space:]')"
 if [[ "${packaged_strategy_count}" != "${source_strategy_count}" ]]; then
   echo "ERROR: packaged strategies count mismatch: expected ${source_strategy_count}, got ${packaged_strategy_count}."
+  exit 1
+fi
+
+log "Verifying packaged AlphaSift adapter files..."
+packaged_alphasift_count="$(find "${ROOT_DIR}/dist/backend/stock_analysis" -path '*alphasift*' | wc -l | tr -d '[:space:]')"
+if [[ "${packaged_alphasift_count}" == "0" ]]; then
+  echo "ERROR: packaged AlphaSift adapter files not found under dist/backend/stock_analysis."
   exit 1
 fi
 

--- a/tests/test_alphasift_api.py
+++ b/tests/test_alphasift_api.py
@@ -439,6 +439,26 @@ class AlphaSiftOpportunitiesApiTestCase(unittest.TestCase):
         self.assertIn("--force-reinstall", install_command)
         self.assertIn(DEFAULT_ALPHASIFT_TEST_SPEC, install_command)
 
+    def test_install_rejects_packaged_runtime_without_subprocess(self) -> None:
+        config = self._config(enabled=True)
+
+        with (
+            patch.dict(os.environ, {"DSA_DESKTOP_MODE": "true"}, clear=False),
+            patch("api.v1.endpoints.alphasift._is_alphasift_available", return_value=False),
+            patch.object(alphasift_endpoint.sys, "frozen", True, create=True),
+            patch("api.v1.endpoints.alphasift.subprocess.run") as run_mock,
+        ):
+            with self.assertRaises(HTTPException) as caught:
+                alphasift_endpoint.alphasift_install(request=self._request(), config=config)
+
+        self.assertEqual(caught.exception.status_code, 424)
+        self.assertEqual(
+            caught.exception.detail["error"],
+            "alphasift_install_packaged_runtime_unsupported",
+        )
+        self.assertIn("打包后的桌面端不支持", caught.exception.detail["message"])
+        run_mock.assert_not_called()
+
     def test_install_rejects_when_alphasift_adapter_reports_unavailable(self) -> None:
         config = self._config(enabled=True)
         completed = SimpleNamespace(returncode=0, stdout="installed", stderr="")

--- a/tests/test_desktop_build_scripts.py
+++ b/tests/test_desktop_build_scripts.py
@@ -1,0 +1,17 @@
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_macos_backend_build_bundles_default_alphasift_adapter() -> None:
+    script = (REPO_ROOT / "scripts" / "build-backend-macos.sh").read_text(encoding="utf-8")
+
+    assert "DEFAULT_ALPHASIFT_INSTALL_SPEC" in script
+    assert '"${PYTHON_BIN}" -m pip install "${alpha_sift_install_spec}"' in script
+    assert "import alphasift.dsa_adapter" in script
+    assert '"api.v1.endpoints.alphasift"' in script
+    assert '"alphasift"' in script
+    assert '"alphasift.dsa_adapter"' in script
+    assert "--collect-all alphasift" in script
+    assert "packaged AlphaSift adapter files not found" in script


### PR DESCRIPTION
## PR Type

- [x] fix
- [ ] feat
- [ ] refactor
- [x] docs
- [ ] chore
- [x] test

## Background And Problem

macOS 桌面端开启 AlphaSift 自动选股后，后端包内缺少 `alphasift.dsa_adapter`，状态接口会显示 AlphaSift 不可用。

进一步复现发现，打包后的 PyInstaller 运行时如果触发 `/api/v1/alphasift/install`，`sys.executable` 指向的是打包后的 `stock_analysis` 可执行文件，而不是 Python 解释器，因此会误执行：

```bash
stock_analysis -m pip install --upgrade --force-reinstall ...
```

实际报错为：

```text
stock_analysis: error: unrecognized arguments: -m pip install --upgrade --force-reinstall ...
```

根因是 Windows 桌面后端构建脚本已经在构建阶段安装、校验并收集 AlphaSift，而 macOS 构建脚本缺少同等逻辑；同时运行期自动安装接口没有识别 PyInstaller 打包环境。

## Scope Of Change

- `scripts/build-backend-macos.sh`
  - 构建阶段安装默认 `DEFAULT_ALPHASIFT_INSTALL_SPEC`
  - 校验 `import alphasift.dsa_adapter`
  - 增加 AlphaSift 相关 hidden imports
  - PyInstaller 增加 `--collect-all alphasift`
  - 构建后检查打包产物中是否包含 AlphaSift 文件
- `api/v1/endpoints/alphasift.py`
  - 在 PyInstaller 打包运行时拒绝运行期 pip 自动安装，并返回明确的 `424 alphasift_install_packaged_runtime_unsupported`
- `tests/test_alphasift_api.py`
  - 覆盖打包运行时不调用 subprocess 安装的行为
- `tests/test_desktop_build_scripts.py`
  - 覆盖 macOS 后端构建脚本必须包含 AlphaSift 打包关键步骤
- `docs/alphasift-integration.md`
  - 更新源码部署、打包桌面端、错误码说明
- `docs/CHANGELOG.md`
  - 记录用户可见修复

## Issue Link

无 Issue：来自用户本地复现的桌面端 AlphaSift 自动安装失败问题。

验收标准：

- macOS 桌面端打包产物内置 `alphasift.dsa_adapter`
- 打包后开启 AlphaSift 时状态接口返回可用
- 打包运行时不再尝试执行 `stock_analysis -m pip install ...`
- 源码部署场景仍保留受控安装接口

## Verification Commands And Results

```bash
bash -n scripts/build-backend-macos.sh
```

关键输出/结论：脚本语法检查通过。

```bash
/opt/homebrew/Caskroom/miniforge/base/envs/stock/bin/python -m py_compile \
  api/v1/endpoints/alphasift.py \
  tests/test_alphasift_api.py \
  tests/test_desktop_build_scripts.py
```

关键输出/结论：Python 编译检查通过。

```bash
/opt/homebrew/Caskroom/miniforge/base/envs/stock/bin/python -m pytest \
  tests/test_alphasift_api.py tests/test_desktop_build_scripts.py -q
```

关键输出/结论：`34 passed, 1 warning`。

```bash
/opt/homebrew/Caskroom/miniforge/base/envs/stock/bin/python -m pytest \
  tests/test_docker_entrypoint.py::test_dockerfile_bundles_default_alphasift_adapter -q
```

关键输出/结论：`1 passed, 1 warning`。

```bash
env PYTHON_BIN=/opt/homebrew/Caskroom/miniforge/base/envs/stock/bin/python \
  bash scripts/build-backend-macos.sh
```

关键输出/结论：macOS 后端构建通过，输出包含 `Verifying packaged AlphaSift adapter files...` 和 `Backend build completed.`；打包产物包含 `_internal/alphasift` 与 `_internal/alphasift-0.2.0.dist-info`。

```bash
env ALPHASIFT_ENABLED=true ADMIN_AUTH_ENABLED=false STOCK_INDEX_REMOTE_UPDATE_ENABLED=false USE_PROXY=false \
  dist/backend/stock_analysis/stock_analysis --serve-only --host 127.0.0.1 --port 23129
curl -sS http://127.0.0.1:23129/api/v1/alphasift/status
```

关键输出/结论：打包后状态接口返回 `available: true`、`version: "0.2.0"`、`strategy_count: 8`。

```bash
bash scripts/build-desktop-macos.sh
```

关键输出/结论：完整 macOS 桌面端构建通过，生成 `apps/dsa-desktop/dist/Daily Stock Analysis-3.20.0-arm64.dmg`。构建过程中 npm audit 报告 7 个 high vulnerabilities，属于既有依赖审计问题，本 PR 未修改。

```bash
PATH=/opt/homebrew/Caskroom/miniforge/base/envs/stock/bin:$PATH ./scripts/ci_gate.sh
```

关键输出/结论：`backend-gate: all checks passed`；离线 pytest 结果为 `2697 passed, 2 deselected, 26 warnings, 243 subtests passed`。

## Compatibility And Risk

- 源码部署兼容性：保留 `/api/v1/alphasift/install` 受控安装能力。
- 打包桌面端兼容性：打包运行时不再支持运行期 pip 自动安装，改为构建阶段内置 AlphaSift；如果旧打包产物缺依赖，会返回明确 424 错误并提示升级桌面包或使用源码部署。
- 构建影响：macOS 桌面后端构建会额外安装并收集 AlphaSift，包体大小和构建时间可能小幅增加。
- 第三方 API 兼容语义：None。本 PR 不修改第三方模型/API 请求参数、路由前缀或 provider fallback。
- 运行时配置保存/迁移：None。本 PR 不改写、清空或迁移用户配置。

## Rollback Plan

最小回滚方式：revert this PR。无需额外数据迁移；如需临时规避，可设置 `ALPHASIFT_ENABLED=false` 关闭 AlphaSift 入口，或继续使用源码环境手动安装 AlphaSift。

## EXTRACT_PROMPT Change (if applicable)

不适用。本 PR 未修改 `src/services/image_stock_extractor.py` 中的 `EXTRACT_PROMPT`。

<details>
<summary>展开 / Expand: Full EXTRACT_PROMPT</summary>

```
(not changed)
```

</details>

## Checklist

- [x] 本 PR 有明确动机和业务价值 / This PR has a clear motivation and value
- [x] 已提供可复现的验证命令与结果 / Reproducible verification commands and results are included
- [x] 已评估兼容性与风险 / Compatibility and risk have been assessed
- [x] 已提供回滚方案 / A rollback plan is provided
- [x] 若涉及用户可见变更，已同步更新相关文档与 `docs/CHANGELOG.md`；`README.md` 仅在首页级信息变化时更新，细节优先写入 `docs/*.md` / If user-visible changes are included, relevant docs and `docs/CHANGELOG.md` are updated; `README.md` is updated only for homepage-level changes, with details kept in `docs/*.md`
