### PR TITLE
fix: 问股自由文本金融缩写不再误识别为股票代码 P1

### DIFF
--- a/apps/dsa-web/src/pages/__tests__/ChatPage.test.tsx
+++ b/apps/dsa-web/src/pages/__tests__/ChatPage.test.tsx
@@ -961,6 +961,20 @@ describe('extractStockCodeFromMessage', () => {
     expect(extractStockCodeFromMessage('TSLA')).toBe('TSLA');
   });
 
+  it('does NOT return finance abbreviations as tickers', () => {
+    expect(extractStockCodeFromMessage('如果不考虑 TTM 呢')).toBeNull();
+    expect(extractStockCodeFromMessage('市盈率 TTM 怎么看')).toBeNull();
+    expect(extractStockCodeFromMessage('PE 怎么看')).toBeNull();
+    expect(extractStockCodeFromMessage('MACD 还没金叉吗')).toBeNull();
+    expect(extractStockCodeFromMessage('RSI 怎么看')).toBeNull();
+  });
+
+  it('skips finance abbreviations before a real ticker', () => {
+    expect(extractStockCodeFromMessage('PE AAPL 怎么看')).toBe('AAPL');
+    expect(extractStockCodeFromMessage('TTM AAPL 怎么看')).toBe('AAPL');
+    expect(extractStockCodeFromMessage('MACD AAPL 怎么看')).toBe('AAPL');
+  });
+
   it('does NOT return exchange prefixes as tickers', () => {
     expect(extractStockCodeFromMessage('分析 SH 走势')).toBeNull();
     expect(extractStockCodeFromMessage('看看 BJ')).toBeNull();

--- a/apps/dsa-web/src/pages/__tests__/ChatPage.test.tsx
+++ b/apps/dsa-web/src/pages/__tests__/ChatPage.test.tsx
@@ -967,12 +967,16 @@ describe('extractStockCodeFromMessage', () => {
     expect(extractStockCodeFromMessage('PE 怎么看')).toBeNull();
     expect(extractStockCodeFromMessage('MACD 还没金叉吗')).toBeNull();
     expect(extractStockCodeFromMessage('RSI 怎么看')).toBeNull();
+    expect(extractStockCodeFromMessage('WHAT IS PE')).toBeNull();
+    expect(extractStockCodeFromMessage('PE IS HIGH')).toBeNull();
+    expect(extractStockCodeFromMessage('WHAT IS TTM')).toBeNull();
   });
 
   it('skips finance abbreviations before a real ticker', () => {
     expect(extractStockCodeFromMessage('PE AAPL 怎么看')).toBe('AAPL');
     expect(extractStockCodeFromMessage('TTM AAPL 怎么看')).toBe('AAPL');
     expect(extractStockCodeFromMessage('MACD AAPL 怎么看')).toBe('AAPL');
+    expect(extractStockCodeFromMessage('WHAT IS PE AAPL')).toBe('AAPL');
   });
 
   it('does NOT return exchange prefixes as tickers', () => {

--- a/apps/dsa-web/src/utils/chatStockCode.ts
+++ b/apps/dsa-web/src/utils/chatStockCode.ts
@@ -3,6 +3,25 @@ import { normalizeStockCode } from './stockCode';
 
 const EXCHANGE_PREFIXES = new Set(['SH', 'SZ', 'BJ', 'HK', 'US', 'SS']);
 
+// Mirrors backend finance/analysis ticker-deny terms for #1596 free-text extraction.
+// Backend _COMMON_WORDS also includes broader English filler words that are intentionally not mirrored here.
+const FINANCE_TICKER_DENYLIST = new Set([
+  'BUY', 'SELL', 'HOLD', 'LONG', 'PUT', 'CALL',
+  'ETF', 'IPO', 'RSI', 'EPS', 'PEG', 'ROE', 'ROA',
+  'USA', 'USD', 'CNY', 'HKD', 'EUR', 'GBP',
+  'STOCK', 'TRADE', 'PRICE', 'INDEX', 'FUND',
+  'HIGH', 'LOW', 'OPEN', 'CLOSE', 'STOP', 'LOSS',
+  'TREND', 'BULL', 'BEAR', 'RISK', 'CASH', 'BOND',
+  'MACD', 'VWAP', 'BOLL',
+  'TTM', 'LTM', 'NTM', 'FWD', 'YOY', 'QOQ', 'YTD',
+  'EBIT', 'EBITDA', 'DCF', 'CAGR', 'FCF', 'NAV', 'AUM',
+  'PE', 'PB',
+]);
+
+function isDeniedTickerCandidate(value: string): boolean {
+  return FINANCE_TICKER_DENYLIST.has(value.trim().toUpperCase());
+}
+
 export function extractStockCodeFromMessage(message: string): string | null {
   // More specific patterns first to avoid greedy \d{6} capturing inside .SH/.SZ codes
   const patterns = [
@@ -23,6 +42,9 @@ export function extractStockCodeFromMessage(message: string): string | null {
     if (matches) {
       for (const m of matches) {
         if (EXCHANGE_PREFIXES.has(m.toUpperCase())) {
+          continue;
+        }
+        if (isDeniedTickerCandidate(m)) {
           continue;
         }
         const { valid, normalized } = validateStockCode(m);

--- a/apps/dsa-web/src/utils/chatStockCode.ts
+++ b/apps/dsa-web/src/utils/chatStockCode.ts
@@ -3,9 +3,23 @@ import { normalizeStockCode } from './stockCode';
 
 const EXCHANGE_PREFIXES = new Set(['SH', 'SZ', 'BJ', 'HK', 'US', 'SS']);
 
-// Mirrors backend finance/analysis ticker-deny terms for #1596 free-text extraction.
-// Backend _COMMON_WORDS also includes broader English filler words that are intentionally not mirrored here.
-const FINANCE_TICKER_DENYLIST = new Set([
+// Mirrors backend _COMMON_WORDS for #1596 free-text extraction only.
+// Explicit validation via validateStockCode() intentionally keeps its original contract.
+const FREE_TEXT_TICKER_DENYLIST = new Set([
+  'AM', 'AS', 'AT', 'BE', 'BY', 'DO', 'GO', 'HE', 'IF', 'IN',
+  'IS', 'IT', 'ME', 'MY', 'NO', 'OF', 'ON', 'OR', 'SO', 'TO',
+  'UP', 'US', 'WE',
+  'THE', 'AND', 'FOR', 'ARE', 'BUT', 'NOT', 'YOU', 'ALL',
+  'CAN', 'HAD', 'HER', 'WAS', 'ONE', 'OUR', 'OUT', 'HAS',
+  'HIS', 'HOW', 'ITS', 'LET', 'MAY', 'NEW', 'NOW', 'OLD',
+  'SEE', 'WAY', 'WHO', 'DID', 'GET', 'HIM', 'USE', 'SAY',
+  'SHE', 'TOO', 'ANY', 'WITH', 'FROM', 'THAT', 'THAN',
+  'THIS', 'WHAT', 'WHEN', 'WILL', 'JUST', 'ALSO',
+  'BEEN', 'EACH', 'HAVE', 'MUCH', 'ONLY', 'OVER',
+  'SOME', 'SUCH', 'THEM', 'THEN', 'THEY', 'VERY',
+  'WERE', 'YOUR', 'ABOUT', 'AFTER', 'COULD', 'EVERY',
+  'OTHER', 'THEIR', 'THERE', 'THESE', 'THOSE', 'WHICH',
+  'WOULD', 'BEING', 'STILL', 'WHERE',
   'BUY', 'SELL', 'HOLD', 'LONG', 'PUT', 'CALL',
   'ETF', 'IPO', 'RSI', 'EPS', 'PEG', 'ROE', 'ROA',
   'USA', 'USD', 'CNY', 'HKD', 'EUR', 'GBP',
@@ -16,10 +30,13 @@ const FINANCE_TICKER_DENYLIST = new Set([
   'TTM', 'LTM', 'NTM', 'FWD', 'YOY', 'QOQ', 'YTD',
   'EBIT', 'EBITDA', 'DCF', 'CAGR', 'FCF', 'NAV', 'AUM',
   'PE', 'PB',
+  'HELLO', 'PLEASE', 'THANKS', 'CHECK', 'LOOK', 'THINK',
+  'MAYBE', 'GUESS', 'TELL', 'SHOW', 'WHATS',
+  'WHY', 'HOWDY', 'HEY', 'HI',
 ]);
 
 function isDeniedTickerCandidate(value: string): boolean {
-  return FINANCE_TICKER_DENYLIST.has(value.trim().toUpperCase());
+  return FREE_TEXT_TICKER_DENYLIST.has(value.trim().toUpperCase());
 }
 
 export function extractStockCodeFromMessage(message: string): string | null {

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+- [修复] 问股自由文本追问不再将 TTM、PE、YOY 等金融缩写误识别为新股票代码。
 - [修复] GitHub Actions 每日分析工作流读取 SearXNG 自建实例地址时支持 Variables 优先、Secrets 回退，修复仅配置 Variables 时 URL 不生效的问题。
 - [修复] Web/桌面端左侧导航选中态改用 border 实现，避免蓝色竖条指示器溢出侧栏边界；侧栏展开宽度 116px → 136px，新增 rail 紧凑模式。
 - [修复] Windows 桌面端自动更新安装目录不再预先加引号，避免带空格路径在自动安装时触发“缺少快捷方式 / 找不到 Daily Stock Analysis.exe”的系统弹窗。

--- a/src/agent/orchestrator.py
+++ b/src/agent/orchestrator.py
@@ -1387,6 +1387,9 @@ _COMMON_WORDS: set[str] = {
     "HIGH", "LOW", "OPEN", "CLOSE", "STOP", "LOSS",
     "TREND", "BULL", "BEAR", "RISK", "CASH", "BOND",
     "MACD", "VWAP", "BOLL",
+    "TTM", "LTM", "NTM", "FWD", "YOY", "QOQ", "YTD",
+    "EBIT", "EBITDA", "DCF", "CAGR", "FCF", "NAV", "AUM",
+    "PE", "PB",
     # Greetings / filler words that often appear in chat messages
     "HELLO", "PLEASE", "THANKS", "CHECK", "LOOK", "THINK",
     "MAYBE", "GUESS", "TELL", "SHOW", "WHAT", "WHATS",
@@ -1396,6 +1399,11 @@ _COMMON_WORDS: set[str] = {
 _LOWERCASE_TICKER_HINTS = re.compile(
     r"分析|看看|查一?下|研究|诊断|走势|趋势|股价|股票|个股",
 )
+
+
+def _is_denied_ticker_candidate(candidate: str) -> bool:
+    """Return whether a text token should not be auto-treated as a ticker."""
+    return (candidate or "").strip().upper() in _COMMON_WORDS
 
 
 def _extract_stock_code(text: str) -> str:
@@ -1410,17 +1418,16 @@ def _extract_stock_code(text: str) -> str:
     if m:
         return m.group(1).upper()
     # US ticker — require 2+ uppercase letters bounded by non-alpha chars.
-    m = re.search(r'(?<![a-zA-Z])([A-Z]{2,5}(?:\.[A-Z]{1,2})?)(?![a-zA-Z])', text)
-    if m:
-        candidate = m.group(1)
-        if candidate not in _COMMON_WORDS:
+    for match in re.finditer(r'(?<![a-zA-Z])([A-Z]{2,5}(?:\.[A-Z]{1,2})?)(?![a-zA-Z])', text):
+        candidate = match.group(1)
+        if not _is_denied_ticker_candidate(candidate):
             return candidate
 
     stripped = (text or "").strip()
     bare_match = re.fullmatch(r'([A-Za-z]{2,5}(?:\.[A-Za-z]{1,2})?)', stripped)
     if bare_match:
         candidate = bare_match.group(1).upper()
-        if candidate not in _COMMON_WORDS:
+        if not _is_denied_ticker_candidate(candidate):
             return candidate
 
     if not _LOWERCASE_TICKER_HINTS.search(stripped):
@@ -1429,7 +1436,7 @@ def _extract_stock_code(text: str) -> str:
     for match in re.finditer(r'(?<![a-zA-Z])([A-Za-z]{2,5}(?:\.[A-Za-z]{1,2})?)(?![a-zA-Z])', text):
         raw_candidate = match.group(1)
         candidate = raw_candidate.upper()
-        if candidate in _COMMON_WORDS:
+        if _is_denied_ticker_candidate(candidate):
             continue
         return candidate
     return ""

--- a/src/agent/orchestrator.py
+++ b/src/agent/orchestrator.py
@@ -1368,6 +1368,9 @@ class AgentOrchestrator:
 # be kept at module level to avoid re-creating it on every call.
 _COMMON_WORDS: set[str] = {
     # Pronouns / articles / prepositions / conjunctions
+    "AM", "AS", "AT", "BE", "BY", "DO", "GO", "HE", "IF", "IN",
+    "IS", "IT", "ME", "MY", "NO", "OF", "ON", "OR", "SO", "TO",
+    "UP", "US", "WE",
     "THE", "AND", "FOR", "ARE", "BUT", "NOT", "YOU", "ALL",
     "CAN", "HAD", "HER", "WAS", "ONE", "OUR", "OUT", "HAS",
     "HIS", "HOW", "ITS", "LET", "MAY", "NEW", "NOW", "OLD",

--- a/tests/test_multi_agent.py
+++ b/tests/test_multi_agent.py
@@ -140,6 +140,25 @@ class TestExtractStockCode(unittest.TestCase):
     def test_common_word_trend(self):
         self.assertEqual(_extract_stock_code("the TREND is up"), "")
 
+    def test_finance_abbrev_excluded(self):
+        for text in [
+            "TTM",
+            "市盈率 TTM 怎么看",
+            "PE 怎么看",
+            "PE TTM",
+            "YOY",
+            "QOQ",
+            "EBITDA",
+            "DCF",
+            "CAGR",
+        ]:
+            with self.subTest(text=text):
+                self.assertEqual(_extract_stock_code(text), "")
+
+    def test_finance_abbrev_before_real_ticker(self):
+        self.assertEqual(_extract_stock_code("PE AAPL 怎么看"), "AAPL")
+        self.assertEqual(_extract_stock_code("TTM AAPL 怎么看"), "AAPL")
+
     # --- Priority: A-share > HK > US ---
 
     def test_a_share_takes_priority_over_us(self):
@@ -164,7 +183,10 @@ class TestExtractStockCode(unittest.TestCase):
 
     def test_common_words_set_completeness(self):
         """Ensure critical finance terms are in _COMMON_WORDS."""
-        expected_in_set = {"BUY", "SELL", "HOLD", "ETF", "IPO", "RSI", "MACD", "STOCK", "TREND"}
+        expected_in_set = {
+            "BUY", "SELL", "HOLD", "ETF", "IPO", "RSI", "MACD", "STOCK", "TREND",
+            "TTM", "PE", "YOY", "QOQ", "EBITDA", "DCF", "CAGR",
+        }
         self.assertTrue(expected_in_set.issubset(_COMMON_WORDS))
 
 

--- a/tests/test_multi_agent.py
+++ b/tests/test_multi_agent.py
@@ -146,6 +146,9 @@ class TestExtractStockCode(unittest.TestCase):
             "市盈率 TTM 怎么看",
             "PE 怎么看",
             "PE TTM",
+            "WHAT IS PE",
+            "PE IS HIGH",
+            "WHAT IS TTM",
             "YOY",
             "QOQ",
             "EBITDA",
@@ -158,6 +161,7 @@ class TestExtractStockCode(unittest.TestCase):
     def test_finance_abbrev_before_real_ticker(self):
         self.assertEqual(_extract_stock_code("PE AAPL 怎么看"), "AAPL")
         self.assertEqual(_extract_stock_code("TTM AAPL 怎么看"), "AAPL")
+        self.assertEqual(_extract_stock_code("WHAT IS PE AAPL"), "AAPL")
 
     # --- Priority: A-share > HK > US ---
 
@@ -186,6 +190,7 @@ class TestExtractStockCode(unittest.TestCase):
         expected_in_set = {
             "BUY", "SELL", "HOLD", "ETF", "IPO", "RSI", "MACD", "STOCK", "TREND",
             "TTM", "PE", "YOY", "QOQ", "EBITDA", "DCF", "CAGR",
+            "IS", "WHAT", "HIGH",
         }
         self.assertTrue(expected_in_set.issubset(_COMMON_WORDS))
 


### PR DESCRIPTION
## PR Type

- [x] fix
- [ ] feat
- [ ] refactor
- [ ] docs
- [ ] chore
- [x] test

## Background And Problem

Refs #1596。

问股 Agent 在多轮追问中会把 `TTM`、`PE`、`MACD`、`RSI` 等金融/技术缩写误识别为新的美股 ticker，导致前端 `activeStockCode` 或后端 multi-agent/bot 预解析从当前股票上下文跑偏。

本 PR 只处理 #1596 Phase 1：自由文本股票代码抽取里的金融缩写消歧止血。

## Scope Of Change

- 后端 `src/agent/orchestrator.py`
  - 扩展 `_COMMON_WORDS` 的金融/分析术语集合，加入 `TTM`、`LTM`、`NTM`、`FWD`、`YOY`、`QOQ`、`YTD`、`EBITDA`、`DCF`、`CAGR`、`PE`、`PB` 等。
  - 美股 uppercase 抽取从单次首命中改为 `finditer` 遍历，跳过 denylist 后继续寻找真实 ticker，避免 `PE AAPL` / `TTM AAPL` 被首个缩写挡住。
  - 补齐 `IS`、`IN`、`ON` 等短英文 filler，避免 `WHAT IS PE`、`PE IS HIGH` 这类英文大写追问在跳过金融缩写后误返回 filler token。
- 前端 `apps/dsa-web/src/utils/chatStockCode.ts`
  - 在聊天自由文本抽取中加入与后端 `_COMMON_WORDS` 对齐的 free-text ticker denylist。
  - 不修改 `validateStockCode()` / `looksLikeStockCode()` 的显式股票代码校验语义。
- 测试
  - 覆盖 `市盈率 TTM 怎么看`、`如果不考虑 TTM 呢`、`PE 怎么看`、`MACD 还没金叉吗`、`RSI 怎么看` 不再返回 ticker。
  - 覆盖 `WHAT IS PE`、`PE IS HIGH`、`WHAT IS TTM` 不再返回英文 filler ticker。
  - 覆盖 `PE AAPL`、`TTM AAPL`、`MACD AAPL`、`WHAT IS PE AAPL` 仍能抽取真实 ticker。
- 文档
  - 更新 `docs/CHANGELOG.md` 的 `[Unreleased]` 修复条目。

## Issue Link

- `Refs #1596`

## Verification Commands And Results

```bash
PATH=".venv/bin:$PATH" ./scripts/ci_gate.sh
PATH=".venv/bin:$PATH" python -m pytest tests/test_multi_agent.py::TestExtractStockCode -q
cd apps/dsa-web && npm test -- src/pages/__tests__/ChatPage.test.tsx -t extractStockCodeFromMessage
cd apps/dsa-web && npm run lint
PATH=".venv/bin:$PATH" python -m py_compile src/agent/orchestrator.py
cd apps/dsa-web && npm run build
git diff --check
```

关键输出/结论：

- `PATH=".venv/bin:$PATH" ./scripts/ci_gate.sh`：`2715 passed, 2 deselected, 27 warnings, 255 subtests passed`，`backend-gate: all checks passed`
- `tests/test_multi_agent.py::TestExtractStockCode`：35 passed
- `ChatPage.test.tsx -t extractStockCodeFromMessage`：11 passed
- `npm run lint`：通过
- `python -m py_compile src/agent/orchestrator.py`：通过
- `npm run build`：通过
- `git diff --check`：通过

## Compatibility And Risk

兼容性影响：

- 显式股票代码校验未改，`validateStockCode("PB")`、`validateStockCode("AAPL")` 等显式输入仍保持原语义。
- 自由文本抽取路径会更保守：`TTM`、`PB`、`IS` 等如果作为裸词出现在普通追问中，不再自动当作新 ticker。用户如果确实要分析同名 ticker，需要在后续 Phase 2 中通过明确切换/澄清契约处理。

风险与边界：

- 本 PR 不包含 sticky `context.stock_code`，从历史报告进入问股后的后续轮次上下文持续传递仍属于 Phase 2。
- 本 PR 不包含 tool-call guard，single-agent 模型如果直接在 tool call 中填入错误 `stock_code=TTM`，仍需 Phase 2 处理。
- 前后端 denylist 仍为双份维护；本 PR 通过注释和对称回归测试约束两侧自由文本抽取行为。

## Rollback Plan

如发现自由文本股票代码抽取行为有不可接受的回归，直接 revert 本 PR 即可恢复原逻辑；不涉及配置、数据库迁移或用户数据回滚。

## EXTRACT_PROMPT Change (if applicable)

不适用。本 PR 未修改 `src/services/image_stock_extractor.py` 或 `EXTRACT_PROMPT`。

## Checklist

- [x] 本 PR 有明确动机和业务价值 / This PR has a clear motivation and value
- [x] 已提供可复现的验证命令与结果 / Reproducible verification commands and results are included
- [x] 已评估兼容性与风险 / Compatibility and risk have been assessed
- [x] 已提供回滚方案 / A rollback plan is provided
- [x] 若涉及用户可见变更，已同步更新相关文档与 `docs/CHANGELOG.md`；`README.md` 仅在首页级信息变化时更新，细节优先写入 `docs/*.md` / If user-visible changes are included, relevant docs and `docs/CHANGELOG.md` are updated; `README.md` is updated only for homepage-level changes, with details kept in `docs/*.md`