### PR TITLE
fix: 修复股票卡片市场阶段标签遮挡

### DIFF
--- a/apps/dsa-web/src/components/history/HistoryListItem.tsx
+++ b/apps/dsa-web/src/components/history/HistoryListItem.tsx
@@ -4,7 +4,7 @@ import type { HistoryItem } from '../../types/analysis';
 import { getSentimentColor } from '../../types/analysis';
 import { formatDateTime } from '../../utils/format';
 import { getMarketPhaseSummaryLabel } from '../../utils/marketPhase';
-import { truncateStockName, isStockNameTruncated } from '../../utils/stockName';
+import { truncateStockName } from '../../utils/stockName';
 
 interface HistoryListItemProps {
   item: HistoryItem;
@@ -45,7 +45,6 @@ export const HistoryListItem: React.FC<HistoryListItemProps> = ({
 }) => {
   const sentimentColor = item.sentimentScore !== undefined ? getSentimentColor(item.sentimentScore) : null;
   const stockName = item.stockName || item.stockCode;
-  const isTruncated = isStockNameTruncated(stockName);
   const phaseLabel = getMarketPhaseSummaryLabel(item.marketPhaseSummary, 'zh')?.replace('市场阶段: ', '').replace('市场阶段：', '');
 
   return (
@@ -62,11 +61,12 @@ export const HistoryListItem: React.FC<HistoryListItemProps> = ({
       <button
         type="button"
         onClick={() => onClick(item.id)}
-        className={`home-history-item flex-1 text-left p-2.5 group/item ${
+        aria-label={`${stockName} ${item.stockCode} 历史记录`}
+        className={`home-history-item w-full min-w-0 flex-1 text-left p-2.5 group/item ${
           isViewing ? 'home-history-item-selected' : ''
         }`}
       >
-        <div className={`flex items-center gap-2.5 relative z-10${isTruncated ? ' group-hover/item:z-20' : ''}`}>
+        <div className="relative z-10 flex items-center gap-2.5">
           {sentimentColor && (
             <div
               className="w-1 h-8 rounded-full flex-shrink-0"
@@ -79,26 +79,16 @@ export const HistoryListItem: React.FC<HistoryListItemProps> = ({
           <div className="flex-1 min-w-0">
             <div className="flex items-start justify-between gap-2">
               <div className="min-w-0 flex-1">
-                <span className="truncate text-sm font-semibold text-foreground tracking-tight">
-                  <span className="group-hover/item:hidden">
-                    {truncateStockName(stockName)}
-                  </span>
-                  <span className="hidden group-hover/item:inline">
-                    {stockName}
-                  </span>
+                <span className="block w-full truncate text-sm font-semibold text-foreground tracking-tight">
+                  {truncateStockName(stockName)}
                 </span>
               </div>
-              <div className="flex shrink-0 items-center gap-1">
-                {phaseLabel ? (
-                  <Badge variant="default" size="sm" className="shadow-none text-[10px] leading-none">
-                    {phaseLabel}
-                  </Badge>
-                ) : null}
+              <div className="flex shrink-0 items-center gap-1" data-testid="history-card-actions">
                 {sentimentColor && (
                   <Badge
                     variant="default"
                     size="sm"
-                    className={`home-history-sentiment-badge shrink-0 shadow-none text-[11px] font-semibold leading-none transition-opacity duration-200${isTruncated ? ' group-hover/item:opacity-80' : ''}`}
+                    className="home-history-sentiment-badge shrink-0 shadow-none text-[11px] font-semibold leading-none transition-opacity duration-200"
                     style={{
                       color: sentimentColor,
                       borderColor: `${sentimentColor}30`,
@@ -110,7 +100,7 @@ export const HistoryListItem: React.FC<HistoryListItemProps> = ({
                 )}
               </div>
             </div>
-            <div className="flex items-center gap-2 mt-1">
+            <div className="mt-1 flex flex-wrap items-center gap-2" data-testid="history-card-meta">
               <span className="text-[11px] text-secondary-text font-mono">
                 {item.stockCode}
               </span>
@@ -118,6 +108,14 @@ export const HistoryListItem: React.FC<HistoryListItemProps> = ({
               <span className="text-[11px] text-muted-text">
                 {formatDateTime(item.createdAt)}
               </span>
+              {phaseLabel ? (
+                <>
+                  <span className="w-1 h-1 rounded-full bg-subtle-hover" />
+                  <Badge variant="default" size="sm" className="shrink-0 shadow-none text-[10px] leading-none">
+                    {phaseLabel}
+                  </Badge>
+                </>
+              ) : null}
             </div>
           </div>
         </div>

--- a/apps/dsa-web/src/components/history/StockBarItem.tsx
+++ b/apps/dsa-web/src/components/history/StockBarItem.tsx
@@ -4,7 +4,7 @@ import type { StockBarItem as StockBarItemType } from '../../types/analysis';
 import { getSentimentColor } from '../../types/analysis';
 import { formatDateTime } from '../../utils/format';
 import { getMarketPhaseSummaryLabel } from '../../utils/marketPhase';
-import { truncateStockName, isStockNameTruncated } from '../../utils/stockName';
+import { truncateStockName } from '../../utils/stockName';
 
 interface StockBarItemProps {
   item: StockBarItemType;
@@ -35,7 +35,6 @@ export const StockBarItemComponent: React.FC<StockBarItemProps> = ({
 }) => {
   const sentimentColor = item.sentimentScore !== undefined ? getSentimentColor(item.sentimentScore) : null;
   const stockName = item.stockName || item.stockCode;
-  const isTruncated = isStockNameTruncated(stockName);
   const operationLabel = getOperationBadgeLabel(item.operationAdvice);
   const phaseLabel = getMarketPhaseSummaryLabel(item.marketPhaseSummary, 'zh')?.replace('市场阶段: ', '').replace('市场阶段：', '');
 
@@ -43,11 +42,12 @@ export const StockBarItemComponent: React.FC<StockBarItemProps> = ({
     <button
       type="button"
       onClick={() => onClick(item.id)}
-      className={`home-history-item w-full text-left p-2.5 group/item ${
+      aria-label={`${stockName} ${item.stockCode} 历史记录`}
+      className={`home-history-item w-full min-w-0 flex-1 text-left p-2.5 group/item ${
         isViewing ? 'home-history-item-selected' : ''
       }`}
     >
-      <div className={`flex items-center gap-2.5 relative z-10${isTruncated ? ' group-hover/item:z-20' : ''}`}>
+      <div className="relative z-10 flex items-center gap-2.5">
         {isMarketReview ? (
           <div className="w-1 h-8 rounded-full flex-shrink-0 bg-amber-400" style={{ boxShadow: '0 0 10px rgba(251,191,36,0.4)' }} />
         ) : sentimentColor ? (
@@ -64,21 +64,11 @@ export const StockBarItemComponent: React.FC<StockBarItemProps> = ({
         <div className="flex-1 min-w-0">
           <div className="flex items-start justify-between gap-2">
             <div className="min-w-0 flex-1">
-              <span className="truncate text-sm font-semibold text-foreground tracking-tight">
-                <span className="group-hover/item:hidden">
-                  {truncateStockName(stockName)}
-                </span>
-                <span className="hidden group-hover/item:inline">
-                  {stockName}
-                </span>
+              <span className="block w-full truncate text-sm font-semibold text-foreground tracking-tight">
+                {truncateStockName(stockName)}
               </span>
             </div>
-            <div className="flex items-center gap-1 shrink-0">
-              {phaseLabel ? (
-                <Badge variant="default" size="sm" className="shrink-0 shadow-none text-[10px] leading-none">
-                  {phaseLabel}
-                </Badge>
-              ) : null}
+            <div className="flex items-center gap-1 shrink-0" data-testid="history-card-actions">
               {isMarketReview ? (
                 <Badge
                   variant="default"
@@ -125,7 +115,7 @@ export const StockBarItemComponent: React.FC<StockBarItemProps> = ({
               )}
             </div>
           </div>
-          <div className="flex items-center gap-2 mt-1">
+          <div className="mt-1 flex flex-wrap items-center gap-2" data-testid="history-card-meta">
             <span className="text-[11px] text-secondary-text font-mono">
               {item.stockCode}
             </span>
@@ -145,6 +135,14 @@ export const StockBarItemComponent: React.FC<StockBarItemProps> = ({
                 </span>
               </>
             )}
+            {phaseLabel ? (
+              <>
+                <span className="w-1 h-1 rounded-full bg-subtle-hover" />
+                <Badge variant="default" size="sm" className="shrink-0 shadow-none text-[10px] leading-none">
+                  {phaseLabel}
+                </Badge>
+              </>
+            ) : null}
           </div>
         </div>
       </div>

--- a/apps/dsa-web/src/components/history/__tests__/HistoryList.test.tsx
+++ b/apps/dsa-web/src/components/history/__tests__/HistoryList.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, within } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 import { HistoryList } from '../HistoryList';
 import type { HistoryItem } from '../../../types/analysis';
@@ -35,6 +35,11 @@ const longChineseNameItem: HistoryItem = {
   sentimentScore: 75,
   operationAdvice: '持有',
   createdAt: '2026-03-16T08:00:00Z',
+  marketPhaseSummary: {
+    market: 'CN',
+    phase: 'non_trading',
+    warnings: [],
+  },
 };
 
 describe('HistoryList', () => {
@@ -103,11 +108,18 @@ describe('HistoryList', () => {
     );
 
     // '贵州茅台股票股份有限公司' (12 Chinese chars) should be truncated to '贵州茅台股票股份.' (8 chars + dot)
-    // The full name exists in a hidden span, visible on hover
     expect(screen.getByText('贵州茅台股票股份.')).toBeInTheDocument();
-    const fullNameHidden = screen.queryByText('贵州茅台股票股份有限公司');
-    expect(fullNameHidden).toBeInTheDocument();
-    expect(fullNameHidden).toHaveClass('hidden');
+    expect(screen.queryByText('贵州茅台股票股份有限公司')).not.toBeInTheDocument();
+    expect(
+      screen.getByRole('button', {
+        name: /^贵州茅台股票股份有限公司 600519 历史记录$/,
+      }),
+    ).toBeInTheDocument();
+
+    const actions = screen.getByTestId('history-card-actions');
+    const meta = screen.getByTestId('history-card-meta');
+    expect(within(actions).queryByText('CN · 非交易日')).not.toBeInTheDocument();
+    expect(within(meta).getByText('CN · 非交易日')).toBeVisible();
   });
 
   it('generates unique select-all ids across multiple instances', () => {

--- a/apps/dsa-web/src/components/history/__tests__/StockBarItem.test.tsx
+++ b/apps/dsa-web/src/components/history/__tests__/StockBarItem.test.tsx
@@ -1,0 +1,47 @@
+import { render, screen, within } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { StockBarItemComponent } from '../StockBarItem';
+import type { StockBarItem } from '../../../types/analysis';
+
+const issue1600Item: StockBarItem = {
+  id: 1,
+  stockCode: '600519',
+  stockName: '贵州茅台股票股份有限公司',
+  sentimentScore: 62,
+  operationAdvice: '观望',
+  analysisCount: 2,
+  lastAnalysisTime: '2026-05-31T04:52:00Z',
+  marketPhaseSummary: {
+    market: 'CN',
+    phase: 'non_trading',
+    warnings: [],
+  },
+};
+
+describe('StockBarItemComponent', () => {
+  it('keeps market phase in the meta row instead of the action row', () => {
+    render(
+      <StockBarItemComponent
+        item={issue1600Item}
+        isViewing={false}
+        onClick={vi.fn()}
+        onDelete={vi.fn()}
+      />,
+    );
+
+    const actions = screen.getByTestId('history-card-actions');
+    const meta = screen.getByTestId('history-card-meta');
+
+    expect(within(actions).getByText('观望 62')).toBeInTheDocument();
+    expect(within(actions).getByRole('button', { name: /删除 贵州茅台股票股份有限公司 历史记录/ })).toBeInTheDocument();
+    expect(within(actions).queryByText('CN · 非交易日')).not.toBeInTheDocument();
+    expect(within(meta).getByText('CN · 非交易日')).toBeVisible();
+
+    expect(screen.getByText('贵州茅台股票股份.')).toBeVisible();
+    expect(
+      screen.getByRole('button', {
+        name: /^贵州茅台股票股份有限公司 600519 历史记录$/,
+      }),
+    ).toBeInTheDocument();
+  });
+});

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+- [修复] Web 个股栏和历史卡片在窄布局下不再让市场阶段标签遮挡股票名称。
 - [修复] GitHub Actions 每日分析工作流读取 SearXNG 自建实例地址时支持 Variables 优先、Secrets 回退，修复仅配置 Variables 时 URL 不生效的问题。
 - [新功能] Web 大盘复盘历史新增独立集合入口，支持按 `MARKET` / `market_review` 聚合查看与单条记录删除，并避免混入普通个股栏。
 - [修复] Web/桌面端左侧导航选中态改用 border 实现，避免蓝色竖条指示器溢出侧栏边界；侧栏展开宽度 116px → 136px，新增 rail 紧凑模式。


### PR DESCRIPTION
## PR Type

- [x] fix
- [ ] feat
- [ ] refactor
- [ ] docs
- [ ] chore
- [ ] test

## Background And Problem

Fixes #1600

Issue #1600 来自用户截图反馈：在 Web 前端较窄或紧凑卡片布局下，股票卡片主行同时承载股票名称、`CN · 非交易日` 市场阶段标签、`观望 58/62` 情绪/操作标签和删除按钮，长中文股票名称会被状态标签挤压，影响可读性。

本 PR 的用户可见主路径是首页个股栏：

`HomePage -> StockBar -> StockBarItem`

`HistoryListItem` 当前不是 #1600 截图主路径，本次同步调整是为了让同构历史卡片保持一致布局，避免后续启用或复用时保留同类遮挡风险。

## Scope Of Change

- `apps/dsa-web/src/components/history/StockBarItem.tsx`
  - 将市场阶段标签从主行右侧 actions 区移动到次级 meta 行。
  - 移除 hover 展开完整股票名的双 span 结构，股票名固定截断显示。
  - 按钮 `aria-label` 保留完整股票名称和股票代码，避免截断后丢失无障碍信息。
  - 增加 `history-card-actions` / `history-card-meta` 测试标识，用于稳定验证阶段标签所在区域。
- `apps/dsa-web/src/components/history/HistoryListItem.tsx`
  - 按同样规则同步主行/meta 行结构，阶段标签只出现在 meta 行。
- `apps/dsa-web/src/components/history/__tests__/StockBarItem.test.tsx`
  - 新增 #1600 回归测试，覆盖长中文股票名、`观望 62`、`CN · 非交易日` 和删除按钮同卡片场景。
- `apps/dsa-web/src/components/history/__tests__/HistoryList.test.tsx`
  - 扩展长中文股票名 fixture，补充 `marketPhaseSummary`，验证阶段标签位于 meta 行且完整名称保留在 accessible name 中。
- `docs/CHANGELOG.md`
  - 在 `[Unreleased]` 按扁平格式追加用户可见修复说明。
- <img width="492" height="260" alt="Issue 1600 card screenshot" src="https://github.com/user-attachments/assets/815a42f4-8759-4aca-99b0-a44645dc8642" />


本 PR 不修改后端 API、schema、配置项、数据源、桌面端逻辑、报告结构或持久化数据。

## Issue Link

Fixes #1600

## Verification Commands And Results

```bash
cd apps/dsa-web
npm run test -- src/components/history/__tests__/StockBarItem.test.tsx src/components/history/__tests__/HistoryList.test.tsx
npm run lint
npm run build
git diff --check
```

关键输出/结论：

- `vitest`: 2 个测试文件通过，7 个测试通过。
- `eslint`: 通过。
- `tsc -b && vite build`: 通过，Vite production build 完成。
- `git diff --check`: 通过。

补充视觉验证：

- 在当前 PR 分支上使用本地 mock API + Chrome/Playwright 以 `390x844` 视口打开首页并点击移动端“历史记录”入口。
- 复现数据：长中文股票名 `贵州茅台股票股份有限公司`、`operationAdvice: 观望`、`sentimentScore: 62`、`marketPhaseSummary: { market: CN, phase: non_trading }`。
- 几何断言结果：
  - `phaseInActions=false`
  - `phaseInMeta=true`
  - 股票名不与 `观望 62` 重叠
  - 股票名不与 `CN · 非交易日` 重叠

验证边界：

- 视觉验证路径仍会出现既有的 nested `<button>` 控制台警告，因为卡片外层按钮内包含删除按钮；该问题不是本 PR 新增，也不是 #1600 遮挡修复范围。
- 本 PR 未引入新依赖；在临时 worktree 执行 `npm ci` 仅用于安装现有前端依赖后运行验证。

## Compatibility And Risk

- API / schema / 配置 / 数据源：无变化。
- Web 用户可见行为：市场阶段标签从卡片主行右侧移动到次级信息行；股票名称不再 hover 展开完整文本，完整名称通过按钮 accessible name 保留。
- 兼容风险：低。改动限制在 Web 历史/个股栏卡片布局和对应测试。
- 剩余风险：既有 nested `<button>` 结构仍会产生 React 控制台警告，建议后续单独拆分为卡片容器 + 独立操作按钮处理，避免把可访问性结构重构混入本次布局修复。

## Rollback Plan

如需回滚，直接 revert 本 PR 即可；不需要额外配置、数据迁移或后端回滚。

## EXTRACT_PROMPT Change (if applicable)

不适用。本 PR 未修改 `src/services/image_stock_extractor.py` 或 `EXTRACT_PROMPT`。

## Checklist

- [x] 本 PR 有明确动机和业务价值 / This PR has a clear motivation and value
- [x] 已提供可复现的验证命令与结果 / Reproducible verification commands and results are included
- [x] 已评估兼容性与风险 / Compatibility and risk have been assessed
- [x] 已提供回滚方案 / A rollback plan is provided
- [x] 若涉及用户可见变更，已同步更新相关文档与 `docs/CHANGELOG.md`；`README.md` 仅在首页级信息变化时更新，细节优先写入 `docs/*.md` / If user-visible changes are included, relevant docs and `docs/CHANGELOG.md` are updated; `README.md` is updated only for homepage-level changes, with details kept in `docs/*.md`
