### PR TITLE
代码健康修复：稳定测试、健康检查、错误响应与 schema 版本记录

### DIFF
--- a/api/app.py
+++ b/api/app.py
@@ -122,10 +122,21 @@ def _missing_asset_media_type(asset_path: str) -> str:
         return content_type
     return "text/plain"
 
+
+def _warn_if_open_cors_without_auth() -> None:
+    if is_auth_enabled():
+        return
+    logger.warning(
+        "CORS_ALLOW_ALL=true is enabled while ADMIN_AUTH_ENABLED is false. "
+        "The API will accept browser requests from any origin; only use this "
+        "on trusted local networks or enable admin authentication."
+    )
+
 from api.v1 import api_v1_router
 from api.middlewares.auth import add_auth_middleware
 from api.middlewares.error_handler import add_error_handlers
 from api.v1.schemas.common import HealthResponse
+from src.auth import is_auth_enabled
 from src.data.stock_index_loader import find_existing_stock_index_path
 from src.services.system_config_service import SystemConfigService
 from src.services.stock_index_remote_service import (
@@ -236,6 +247,7 @@ def create_app(static_dir: Optional[Path] = None) -> FastAPI:
     allow_all_origins = os.environ.get("CORS_ALLOW_ALL", "").lower() == "true"
     allow_credentials = not allow_all_origins
     if allow_all_origins:
+        _warn_if_open_cors_without_auth()
         allowed_origins = ["*"]
     
     app.add_middleware(

--- a/api/app.py
+++ b/api/app.py
@@ -305,6 +305,13 @@ def create_app(static_dir: Optional[Path] = None) -> FastAPI:
             return HTMLResponse(content=_FRONTEND_NOT_BUILT_HTML)
     
     @app.get(
+        "/health",
+        response_model=HealthResponse,
+        tags=["Health"],
+        summary="健康检查",
+        description="用于负载均衡器或监控系统检查服务状态"
+    )
+    @app.get(
         "/api/health",
         response_model=HealthResponse,
         tags=["Health"],

--- a/api/v1/endpoints/analysis.py
+++ b/api/v1/endpoints/analysis.py
@@ -29,6 +29,7 @@ from fastapi import APIRouter, HTTPException, Depends, Query, Body
 from fastapi.responses import JSONResponse, StreamingResponse
 
 from api.deps import get_config_dep
+from api.v1.errors import api_error
 from api.v1.schemas.analysis import (
     AnalyzeRequest,
     AnalysisResultResponse,
@@ -166,13 +167,7 @@ def _run_market_review_background(
 
 
 def _invalid_analysis_input_error() -> HTTPException:
-    return HTTPException(
-        status_code=400,
-        detail={
-            "error": "validation_error",
-            "message": "请输入有效的股票代码或股票名称",
-        },
-    )
+    return api_error(400, "validation_error", "请输入有效的股票代码或股票名称")
 
 
 def _is_obviously_invalid_analysis_input(text: str) -> bool:
@@ -268,13 +263,7 @@ def trigger_analysis(
         stock_codes.extend(request.stock_codes)
 
     if not stock_codes:
-        raise HTTPException(
-            status_code=400,
-            detail={
-                "error": "validation_error",
-                "message": "必须提供 stock_code 或 stock_codes 参数"
-            }
-        )
+        raise api_error(400, "validation_error", "必须提供 stock_code 或 stock_codes 参数")
 
     # Normalize and de-duplicate inputs while preserving compatibility.
     resolved = [_resolve_and_normalize_input(c) for c in stock_codes]
@@ -295,32 +284,18 @@ def trigger_analysis(
     # Limit the number of stocks in a single request to prevent DoS
     MAX_BATCH_SIZE = 50
     if len(stock_codes) > MAX_BATCH_SIZE:
-        raise HTTPException(
-            status_code=400,
-            detail={
-                "error": "validation_error",
-                "message": f"单次分析请求最多支持 {MAX_BATCH_SIZE} 只股票"
-            }
-        )
+        raise api_error(400, "validation_error", f"单次分析请求最多支持 {MAX_BATCH_SIZE} 只股票")
 
     if not stock_codes:
-        raise HTTPException(
-            status_code=400,
-            detail={
-                "error": "validation_error",
-                "message": "股票代码不能为空或仅包含空白字符"
-            }
-        )
+        raise api_error(400, "validation_error", "股票代码不能为空或仅包含空白字符")
 
     # Sync mode only supports single-stock analysis.
     if not request.async_mode:
         if len(stock_codes) > 1:
-            raise HTTPException(
-                status_code=400,
-                detail={
-                    "error": "validation_error",
-                    "message": "同步模式仅支持单只股票分析，请使用 async_mode=true 进行批量分析"
-                }
+            raise api_error(
+                400,
+                "validation_error",
+                "同步模式仅支持单只股票分析，请使用 async_mode=true 进行批量分析",
             )
         return _handle_sync_analysis(stock_codes[0], request)
 
@@ -453,13 +428,7 @@ def _handle_sync_analysis(
 
         if result is None:
             error_message = service.last_error or f"分析股票 {stock_code} 失败"
-            raise HTTPException(
-                status_code=500,
-                detail={
-                    "error": "analysis_failed",
-                    "message": error_message,
-                }
-            )
+            raise api_error(500, "analysis_failed", error_message)
 
         # 构建报告结构
         report_data = result.get("report", {})
@@ -490,13 +459,7 @@ def _handle_sync_analysis(
         raise
     except Exception as e:
         logger.error(f"分析失败: {e}", exc_info=True)
-        raise HTTPException(
-            status_code=500,
-            detail={
-                "error": "internal_error",
-                "message": f"分析过程发生错误: {str(e)}"
-            }
-        )
+        raise api_error(500, "internal_error", f"分析过程发生错误: {str(e)}")
 
 
 # ============================================================
@@ -533,13 +496,7 @@ def trigger_market_review(
 
     lock_token = _try_acquire_market_review_lock(config)
     if lock_token is None:
-        raise HTTPException(
-            status_code=409,
-            detail={
-                "error": "duplicate_market_review",
-                "message": "大盘复盘正在执行中，请稍后再试",
-            },
-        )
+        raise api_error(409, "duplicate_market_review", "大盘复盘正在执行中，请稍后再试")
 
     try:
         task_id = uuid.uuid4().hex
@@ -1028,22 +985,10 @@ def get_analysis_status(task_id: str) -> TaskStatus:
 
     except Exception as e:
         logger.error(f"查询任务状态失败: {e}", exc_info=True)
-        raise HTTPException(
-            status_code=500,
-            detail={
-                "error": "internal_error",
-                "message": f"查询任务状态失败: {str(e)}"
-            }
-        )
+        raise api_error(500, "internal_error", f"查询任务状态失败: {str(e)}")
 
     # 3. 任务不存在
-    raise HTTPException(
-        status_code=404,
-        detail={
-            "error": "not_found",
-            "message": f"任务 {task_id} 不存在或已过期"
-        }
-    )
+    raise api_error(404, "not_found", f"任务 {task_id} 不存在或已过期")
 
 
 # ============================================================

--- a/api/v1/endpoints/portfolio.py
+++ b/api/v1/endpoints/portfolio.py
@@ -10,6 +10,7 @@ from typing import Optional
 from fastapi import APIRouter, File, Form, HTTPException, Query, UploadFile
 from fastapi.responses import JSONResponse
 
+from api.v1.errors import api_error
 from api.v1.schemas.analysis import DuplicateTaskErrorResponse, TaskAccepted
 from api.v1.schemas.common import ErrorResponse
 from api.v1.schemas.portfolio import (
@@ -50,25 +51,16 @@ router = APIRouter()
 
 
 def _bad_request(exc: Exception) -> HTTPException:
-    return HTTPException(
-        status_code=400,
-        detail={"error": "validation_error", "message": str(exc)},
-    )
+    return api_error(400, "validation_error", str(exc))
 
 
 def _internal_error(message: str, exc: Exception) -> HTTPException:
     logger.error(f"{message}: {exc}", exc_info=True)
-    return HTTPException(
-        status_code=500,
-        detail={"error": "internal_error", "message": f"{message}: {str(exc)}"},
-    )
+    return api_error(500, "internal_error", f"{message}: {str(exc)}")
 
 
 def _conflict_error(*, error: str, message: str) -> HTTPException:
-    return HTTPException(
-        status_code=409,
-        detail={"error": error, "message": message},
-    )
+    return api_error(409, error, message)
 
 
 def _serialize_import_record(item: dict) -> PortfolioImportTradeItem:
@@ -140,10 +132,7 @@ def update_account(account_id: int, request: PortfolioAccountUpdateRequest) -> P
             is_active=request.is_active,
         )
         if updated is None:
-            raise HTTPException(
-                status_code=404,
-                detail={"error": "not_found", "message": f"Account not found: {account_id}"},
-            )
+            raise api_error(404, "not_found", f"Account not found: {account_id}")
         return PortfolioAccountItem(**updated)
     except HTTPException:
         raise
@@ -163,10 +152,7 @@ def delete_account(account_id: int):
     try:
         ok = service.deactivate_account(account_id)
         if not ok:
-            raise HTTPException(
-                status_code=404,
-                detail={"error": "not_found", "message": f"Account not found: {account_id}"},
-            )
+            raise api_error(404, "not_found", f"Account not found: {account_id}")
         return {"deleted": 1}
     except HTTPException:
         raise
@@ -254,10 +240,7 @@ def delete_trade(trade_id: int) -> PortfolioDeleteResponse:
     try:
         ok = service.delete_trade_event(trade_id)
         if not ok:
-            raise HTTPException(
-                status_code=404,
-                detail={"error": "not_found", "message": f"Trade not found: {trade_id}"},
-            )
+            raise api_error(404, "not_found", f"Trade not found: {trade_id}")
         return PortfolioDeleteResponse(deleted=1)
     except PortfolioBusyError as exc:
         raise _conflict_error(error="portfolio_busy", message=str(exc))
@@ -335,10 +318,7 @@ def delete_cash_ledger(entry_id: int) -> PortfolioDeleteResponse:
     try:
         ok = service.delete_cash_ledger_event(entry_id)
         if not ok:
-            raise HTTPException(
-                status_code=404,
-                detail={"error": "not_found", "message": f"Cash ledger entry not found: {entry_id}"},
-            )
+            raise api_error(404, "not_found", f"Cash ledger entry not found: {entry_id}")
         return PortfolioDeleteResponse(deleted=1)
     except PortfolioBusyError as exc:
         raise _conflict_error(error="portfolio_busy", message=str(exc))
@@ -421,10 +401,7 @@ def delete_corporate_action(action_id: int) -> PortfolioDeleteResponse:
     try:
         ok = service.delete_corporate_action_event(action_id)
         if not ok:
-            raise HTTPException(
-                status_code=404,
-                detail={"error": "not_found", "message": f"Corporate action not found: {action_id}"},
-            )
+            raise api_error(404, "not_found", f"Corporate action not found: {action_id}")
         return PortfolioDeleteResponse(deleted=1)
     except PortfolioBusyError as exc:
         raise _conflict_error(error="portfolio_busy", message=str(exc))
@@ -538,10 +515,7 @@ def _resolve_position_analysis_context(
             matches.append((account, position, position_symbol))
 
     if not matches:
-        raise HTTPException(
-            status_code=404,
-            detail={"error": "not_found", "message": f"No non-zero portfolio position for {target}"},
-        )
+        raise api_error(404, "not_found", f"No non-zero portfolio position for {target}")
     if account_id is None:
         account_ids = {
             int(account.get("account_id"))
@@ -549,12 +523,10 @@ def _resolve_position_analysis_context(
             if account.get("account_id") is not None
         }
         if len(account_ids) > 1:
-            raise HTTPException(
-                status_code=400,
-                detail={
-                    "error": "ambiguous_position_account",
-                    "message": f"{target} is held in multiple accounts; pass account_id",
-                },
+            raise api_error(
+                400,
+                "ambiguous_position_account",
+                f"{target} is held in multiple accounts; pass account_id",
             )
 
     account, position, position_symbol = matches[0]

--- a/api/v1/errors.py
+++ b/api/v1/errors.py
@@ -1,0 +1,33 @@
+# -*- coding: utf-8 -*-
+"""Shared helpers for API error responses."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import HTTPException
+from fastapi.responses import JSONResponse
+
+
+def error_body(error: str, message: str, *, detail: Any = None) -> dict[str, Any]:
+    body: dict[str, Any] = {
+        "error": error,
+        "message": message,
+    }
+    if detail is not None:
+        body["detail"] = detail
+    return body
+
+
+def api_error(status_code: int, error: str, message: str, *, detail: Any = None) -> HTTPException:
+    return HTTPException(
+        status_code=status_code,
+        detail=error_body(error, message, detail=detail),
+    )
+
+
+def error_json_response(status_code: int, error: str, message: str, *, detail: Any = None) -> JSONResponse:
+    return JSONResponse(
+        status_code=status_code,
+        content=error_body(error, message, detail=detail),
+    )

--- a/apps/dsa-web/package-lock.json
+++ b/apps/dsa-web/package-lock.json
@@ -7,6 +7,10 @@
     "": {
       "name": "dsa-web",
       "version": "0.0.0",
+      "engines": {
+        "node": ">=20.19.0 <27",
+        "npm": ">=10"
+      },
       "dependencies": {
         "@remixicon/react": "^4.9.0",
         "axios": "^1.13.4",

--- a/apps/dsa-web/package.json
+++ b/apps/dsa-web/package.json
@@ -3,6 +3,10 @@
   "private": true,
   "version": "0.0.0",
   "type": "module",
+  "engines": {
+    "node": ">=20.19.0 <27",
+    "npm": ">=10"
+  },
   "scripts": {
     "dev": "vite",
     "build": "tsc -b && vite build",

--- a/apps/dsa-web/src/components/report/__tests__/ReportMarkdownDrawer.test.tsx
+++ b/apps/dsa-web/src/components/report/__tests__/ReportMarkdownDrawer.test.tsx
@@ -109,6 +109,8 @@ describe('ReportMarkdownDrawer', () => {
 
     await renderDrawer();
 
-    expect(await screen.findByRole('heading', { name: 'Lazy loaded report' })).toBeInTheDocument();
+    expect(
+      await screen.findByRole('heading', { name: 'Lazy loaded report' }, { timeout: 5000 }),
+    ).toBeInTheDocument();
   });
 });

--- a/apps/dsa-web/src/pages/PortfolioPage.tsx
+++ b/apps/dsa-web/src/pages/PortfolioPage.tsx
@@ -5,7 +5,25 @@ import { portfolioApi } from '../api/portfolio';
 import type { ParsedApiError } from '../api/error';
 import { getParsedApiError } from '../api/error';
 import { ApiErrorAlert, Card, Badge, ConfirmDialog, EmptyState, InlineAlert } from '../components/common';
-import { toDateInputValue } from '../utils/format';
+import type { FxRefreshFeedback } from '../utils/portfolioFormat';
+import {
+  buildFxRefreshFeedback,
+  formatBrokerLabel,
+  formatCashDirectionLabel,
+  formatCorporateActionLabel,
+  formatMoney,
+  formatPct,
+  formatPositionMoney,
+  formatPositionPrice,
+  formatSideLabel,
+  formatSignedPct,
+  getCsvCommitVariant,
+  getCsvParseVariant,
+  getFxRefreshFeedbackVariant,
+  getPositionPriceLabel,
+  getTodayIso,
+  hasPositionPrice,
+} from '../utils/portfolioFormat';
 import type {
   PortfolioAccountItem,
   PortfolioCashDirection,
@@ -13,7 +31,6 @@ import type {
   PortfolioCorporateActionListItem,
   PortfolioCorporateActionType,
   PortfolioCostMethod,
-  PortfolioFxRefreshResponse,
   PortfolioImportBrokerItem,
   PortfolioImportCommitResponse,
   PortfolioImportParseResponse,
@@ -45,142 +62,16 @@ type PendingDelete =
   | { eventType: 'cash'; id: number; message: string }
   | { eventType: 'corporate'; id: number; message: string };
 
-type FxRefreshFeedback = {
-  tone: 'neutral' | 'success' | 'warning';
-  text: string;
-};
-
 type FxRefreshContext = {
   viewKey: string;
   requestId: number;
 };
-
-type PortfolioAlertVariant = 'info' | 'success' | 'warning' | 'danger';
 
 const PORTFOLIO_INPUT_CLASS =
   'input-surface input-focus-glow h-11 w-full rounded-xl border bg-transparent px-4 text-sm transition-all focus:outline-none disabled:cursor-not-allowed disabled:opacity-60';
 const PORTFOLIO_SELECT_CLASS = `${PORTFOLIO_INPUT_CLASS} appearance-none pr-10`;
 const PORTFOLIO_FILE_PICKER_CLASS =
   'input-surface input-focus-glow flex h-11 w-full cursor-pointer items-center justify-center rounded-xl border bg-transparent px-4 text-sm transition-all focus:outline-none disabled:cursor-not-allowed disabled:opacity-60';
-
-function getTodayIso(): string {
-  return toDateInputValue(new Date());
-}
-
-function formatMoney(value: number | undefined | null, currency = 'CNY'): string {
-  if (value == null || Number.isNaN(value)) return '--';
-  return `${currency} ${Number(value).toLocaleString('zh-CN', {
-    minimumFractionDigits: 2,
-    maximumFractionDigits: 2,
-  })}`;
-}
-
-function formatPct(value: number | undefined | null): string {
-  if (value == null || Number.isNaN(value)) return '--';
-  return `${value.toFixed(2)}%`;
-}
-
-function formatSignedPct(value: number | undefined | null): string {
-  if (value == null || Number.isNaN(value)) return '--';
-  const sign = value > 0 ? '+' : '';
-  return `${sign}${value.toFixed(2)}%`;
-}
-
-function hasPositionPrice(row: PortfolioPositionItem): boolean {
-  return row.priceAvailable !== false && row.priceSource !== 'missing';
-}
-
-function formatPositionPrice(row: PortfolioPositionItem): string {
-  if (!hasPositionPrice(row)) return '--';
-  return row.lastPrice.toFixed(4);
-}
-
-function formatPositionMoney(value: number, row: PortfolioPositionItem): string {
-  if (!hasPositionPrice(row)) return '--';
-  return formatMoney(value, row.valuationCurrency);
-}
-
-function getPositionPriceLabel(row: PortfolioPositionItem): string {
-  if (!hasPositionPrice(row)) return '缺价';
-  if (row.priceSource === 'realtime_quote') {
-    return row.priceProvider ? `实时价 · ${row.priceProvider}` : '实时价';
-  }
-  if (row.priceSource === 'history_close') {
-    return row.priceStale && row.priceDate ? `收盘价 · ${row.priceDate}` : '收盘价';
-  }
-  return row.priceSource || '未知来源';
-}
-
-function formatSideLabel(value: PortfolioSide): string {
-  return value === 'buy' ? '买入' : '卖出';
-}
-
-function formatCashDirectionLabel(value: PortfolioCashDirection): string {
-  return value === 'in' ? '流入' : '流出';
-}
-
-function formatCorporateActionLabel(value: PortfolioCorporateActionType): string {
-  return value === 'cash_dividend' ? '现金分红' : '拆并股调整';
-}
-
-function formatBrokerLabel(value: string, displayName?: string): string {
-  if (displayName && displayName.trim()) return `${value}（${displayName.trim()}）`;
-  if (value === 'huatai') return 'huatai（华泰）';
-  if (value === 'citic') return 'citic（中信）';
-  if (value === 'cmb') return 'cmb（招商）';
-  return value;
-}
-
-function buildFxRefreshFeedback(data: PortfolioFxRefreshResponse): FxRefreshFeedback {
-  if (data.refreshEnabled === false) {
-    return {
-      tone: 'neutral',
-      text: '汇率在线刷新已被禁用。',
-    };
-  }
-
-  if (data.pairCount === 0) {
-    return {
-      tone: 'neutral',
-      text: '当前范围无可刷新的汇率对。',
-    };
-  }
-
-  if (data.updatedCount > 0 && data.staleCount === 0 && data.errorCount === 0) {
-    return {
-      tone: 'success',
-      text: `汇率已刷新，共更新 ${data.updatedCount} 对。`,
-    };
-  }
-
-  const summary = `更新 ${data.updatedCount} 对，仍过期 ${data.staleCount} 对，失败 ${data.errorCount} 对。`;
-  if (data.staleCount > 0) {
-    return {
-      tone: 'warning',
-      text: `已尝试刷新，但仍有部分货币对使用 stale/fallback 汇率。${summary}`,
-    };
-  }
-
-  return {
-    tone: 'warning',
-    text: `在线刷新未完全成功。${summary}`,
-  };
-}
-
-function getFxRefreshFeedbackVariant(tone: FxRefreshFeedback['tone']): PortfolioAlertVariant {
-  if (tone === 'success') return 'success';
-  if (tone === 'warning') return 'warning';
-  return 'info';
-}
-
-function getCsvParseVariant(result: PortfolioImportParseResponse): PortfolioAlertVariant {
-  return result.errorCount > 0 || result.skippedCount > 0 ? 'warning' : 'info';
-}
-
-function getCsvCommitVariant(result: PortfolioImportCommitResponse, isDryRun: boolean): PortfolioAlertVariant {
-  if (isDryRun) return 'info';
-  return result.failedCount > 0 || result.duplicateCount > 0 ? 'warning' : 'success';
-}
 
 const PortfolioPage: React.FC = () => {
   // Set page title

--- a/apps/dsa-web/src/setupTests.ts
+++ b/apps/dsa-web/src/setupTests.ts
@@ -1,5 +1,33 @@
 import '@testing-library/jest-dom';
 
+class MemoryStorageMock implements Storage {
+  private readonly values = new Map<string, string>();
+
+  get length() {
+    return this.values.size;
+  }
+
+  clear() {
+    this.values.clear();
+  }
+
+  getItem(key: string) {
+    return this.values.get(key) ?? null;
+  }
+
+  key(index: number) {
+    return Array.from(this.values.keys())[index] ?? null;
+  }
+
+  removeItem(key: string) {
+    this.values.delete(key);
+  }
+
+  setItem(key: string, value: string) {
+    this.values.set(key, String(value));
+  }
+}
+
 class IntersectionObserverMock implements IntersectionObserver {
   readonly root = null;
   readonly rootMargin = '';
@@ -20,3 +48,18 @@ Object.defineProperty(globalThis, 'IntersectionObserver', {
   writable: true,
   value: IntersectionObserverMock,
 });
+
+const hasLocalStorage = (() => {
+  try {
+    return typeof globalThis.localStorage !== 'undefined';
+  } catch {
+    return false;
+  }
+})();
+
+if (!hasLocalStorage) {
+  Object.defineProperty(globalThis, 'localStorage', {
+    configurable: true,
+    value: new MemoryStorageMock(),
+  });
+}

--- a/apps/dsa-web/src/utils/__tests__/portfolioFormat.test.ts
+++ b/apps/dsa-web/src/utils/__tests__/portfolioFormat.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildFxRefreshFeedback,
+  formatBrokerLabel,
+  formatMoney,
+  formatPositionMoney,
+  formatPositionPrice,
+  formatSignedPct,
+  getCsvCommitVariant,
+  getCsvParseVariant,
+  getPositionPriceLabel,
+} from '../portfolioFormat';
+import type { PortfolioPositionItem } from '../../types/portfolio';
+
+const pricedPosition: PortfolioPositionItem = {
+  symbol: 'HK00700',
+  market: 'hk',
+  currency: 'HKD',
+  quantity: 100,
+  avgCost: 300,
+  totalCost: 30000,
+  lastPrice: 321.12345,
+  marketValueBase: 32112.345,
+  unrealizedPnlBase: 2112.345,
+  unrealizedPnlPct: 7.04,
+  valuationCurrency: 'CNY',
+  priceSource: 'realtime_quote',
+  priceProvider: 'longbridge',
+  priceAvailable: true,
+};
+
+describe('portfolioFormat', () => {
+  it('formats money and signed percentages consistently', () => {
+    expect(formatMoney(1234.5, 'USD')).toBe('USD 1,234.50');
+    expect(formatMoney(null)).toBe('--');
+    expect(formatSignedPct(3.456)).toBe('+3.46%');
+    expect(formatSignedPct(-1.2)).toBe('-1.20%');
+  });
+
+  it('formats position price fields based on price availability', () => {
+    expect(formatPositionPrice(pricedPosition)).toBe('321.1234');
+    expect(formatPositionMoney(123, pricedPosition)).toBe('CNY 123.00');
+    expect(getPositionPriceLabel(pricedPosition)).toBe('实时价 · longbridge');
+
+    const missingPosition = { ...pricedPosition, priceAvailable: false, priceSource: 'missing' };
+    expect(formatPositionPrice(missingPosition)).toBe('--');
+    expect(formatPositionMoney(123, missingPosition)).toBe('--');
+    expect(getPositionPriceLabel(missingPosition)).toBe('缺价');
+  });
+
+  it('formats broker labels and CSV result variants', () => {
+    expect(formatBrokerLabel('huatai')).toBe('huatai（华泰）');
+    expect(formatBrokerLabel('custom', ' 自定义 ')).toBe('custom（自定义）');
+    expect(getCsvParseVariant({ broker: 'huatai', recordCount: 1, skippedCount: 1, errorCount: 0, records: [], errors: [] })).toBe('warning');
+    expect(getCsvCommitVariant({ accountId: 1, recordCount: 1, insertedCount: 1, duplicateCount: 0, failedCount: 0, dryRun: false, errors: [] }, false)).toBe('success');
+  });
+
+  it('builds FX refresh feedback from refresh outcomes', () => {
+    expect(buildFxRefreshFeedback({
+      asOf: '2026-03-19',
+      accountCount: 1,
+      refreshEnabled: false,
+      disabledReason: 'disabled',
+      pairCount: 1,
+      updatedCount: 0,
+      staleCount: 0,
+      errorCount: 0,
+    })).toMatchObject({ tone: 'neutral' });
+
+    expect(buildFxRefreshFeedback({
+      asOf: '2026-03-19',
+      accountCount: 1,
+      refreshEnabled: true,
+      disabledReason: null,
+      pairCount: 1,
+      updatedCount: 1,
+      staleCount: 0,
+      errorCount: 0,
+    })).toMatchObject({ tone: 'success' });
+  });
+});

--- a/apps/dsa-web/src/utils/portfolioFormat.ts
+++ b/apps/dsa-web/src/utils/portfolioFormat.ts
@@ -1,0 +1,136 @@
+import type {
+  PortfolioCashDirection,
+  PortfolioCorporateActionType,
+  PortfolioFxRefreshResponse,
+  PortfolioImportCommitResponse,
+  PortfolioImportParseResponse,
+  PortfolioPositionItem,
+  PortfolioSide,
+} from '../types/portfolio';
+import { toDateInputValue } from './format';
+
+export type FxRefreshFeedback = {
+  tone: 'neutral' | 'success' | 'warning';
+  text: string;
+};
+
+export type PortfolioAlertVariant = 'info' | 'success' | 'warning' | 'danger';
+
+export function getTodayIso(): string {
+  return toDateInputValue(new Date());
+}
+
+export function formatMoney(value: number | undefined | null, currency = 'CNY'): string {
+  if (value == null || Number.isNaN(value)) return '--';
+  return `${currency} ${Number(value).toLocaleString('zh-CN', {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  })}`;
+}
+
+export function formatPct(value: number | undefined | null): string {
+  if (value == null || Number.isNaN(value)) return '--';
+  return `${value.toFixed(2)}%`;
+}
+
+export function formatSignedPct(value: number | undefined | null): string {
+  if (value == null || Number.isNaN(value)) return '--';
+  const sign = value > 0 ? '+' : '';
+  return `${sign}${value.toFixed(2)}%`;
+}
+
+export function hasPositionPrice(row: PortfolioPositionItem): boolean {
+  return row.priceAvailable !== false && row.priceSource !== 'missing';
+}
+
+export function formatPositionPrice(row: PortfolioPositionItem): string {
+  if (!hasPositionPrice(row)) return '--';
+  return row.lastPrice.toFixed(4);
+}
+
+export function formatPositionMoney(value: number, row: PortfolioPositionItem): string {
+  if (!hasPositionPrice(row)) return '--';
+  return formatMoney(value, row.valuationCurrency);
+}
+
+export function getPositionPriceLabel(row: PortfolioPositionItem): string {
+  if (!hasPositionPrice(row)) return '缺价';
+  if (row.priceSource === 'realtime_quote') {
+    return row.priceProvider ? `实时价 · ${row.priceProvider}` : '实时价';
+  }
+  if (row.priceSource === 'history_close') {
+    return row.priceStale && row.priceDate ? `收盘价 · ${row.priceDate}` : '收盘价';
+  }
+  return row.priceSource || '未知来源';
+}
+
+export function formatSideLabel(value: PortfolioSide): string {
+  return value === 'buy' ? '买入' : '卖出';
+}
+
+export function formatCashDirectionLabel(value: PortfolioCashDirection): string {
+  return value === 'in' ? '流入' : '流出';
+}
+
+export function formatCorporateActionLabel(value: PortfolioCorporateActionType): string {
+  return value === 'cash_dividend' ? '现金分红' : '拆并股调整';
+}
+
+export function formatBrokerLabel(value: string, displayName?: string): string {
+  if (displayName && displayName.trim()) return `${value}（${displayName.trim()}）`;
+  if (value === 'huatai') return 'huatai（华泰）';
+  if (value === 'citic') return 'citic（中信）';
+  if (value === 'cmb') return 'cmb（招商）';
+  return value;
+}
+
+export function buildFxRefreshFeedback(data: PortfolioFxRefreshResponse): FxRefreshFeedback {
+  if (data.refreshEnabled === false) {
+    return {
+      tone: 'neutral',
+      text: '汇率在线刷新已被禁用。',
+    };
+  }
+
+  if (data.pairCount === 0) {
+    return {
+      tone: 'neutral',
+      text: '当前范围无可刷新的汇率对。',
+    };
+  }
+
+  if (data.updatedCount > 0 && data.staleCount === 0 && data.errorCount === 0) {
+    return {
+      tone: 'success',
+      text: `汇率已刷新，共更新 ${data.updatedCount} 对。`,
+    };
+  }
+
+  const summary = `更新 ${data.updatedCount} 对，仍过期 ${data.staleCount} 对，失败 ${data.errorCount} 对。`;
+  if (data.staleCount > 0) {
+    return {
+      tone: 'warning',
+      text: `已尝试刷新，但仍有部分货币对使用 stale/fallback 汇率。${summary}`,
+    };
+  }
+
+  return {
+    tone: 'warning',
+    text: `在线刷新未完全成功。${summary}`,
+  };
+}
+
+export function getFxRefreshFeedbackVariant(tone: FxRefreshFeedback['tone']): PortfolioAlertVariant {
+  if (tone === 'success') return 'success';
+  if (tone === 'warning') return 'warning';
+  return 'info';
+}
+
+export function getCsvParseVariant(result: PortfolioImportParseResponse): PortfolioAlertVariant {
+  return result.errorCount > 0 || result.skippedCount > 0 ? 'warning' : 'info';
+}
+
+export function getCsvCommitVariant(result: PortfolioImportCommitResponse, isDryRun: boolean): PortfolioAlertVariant {
+  if (isDryRun) return 'info';
+  return result.failedCount > 0 || result.duplicateCount > 0 ? 'warning' : 'success';
+}

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -26,6 +26,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - [文档] 补充说明：LLM / LiteLLM 兼容键的回退仅用于 Settings 界面展示与校验上下文拼装，不改写、不迁移、不清理用户现有的 provider/model/base URL 持久化配置；未发生 provider / model / base URL 语义迁移，仅保留同名启动注入的展示级兜底。兼容边界依据 `requirements.txt`（`litellm>=1.80.10,!=1.82.7,!=1.82.8,<2.0.0`、`openai>=1.0.0`）；官方语义来源：[LiteLLM OpenAI-compatible](https://docs.litellm.ai/docs/providers/openai_compatible)、[OpenAI Chat Completion API](https://platform.openai.com/docs/api-reference/chat/create)。回退/恢复路径为：重启/更新后清理同名 `env_file` / `--env-file` / `environment` 覆盖后使用持久化保存值，或通过桌面端导入/导出 `.env` 片段恢复；仅在 WebUI 未改写同名启动注入值时才会按该片段接管。验证回归点见 `tests/test_system_config_service.py::test_get_config_uses_runtime_env_as_display_fallback`、`tests/test_system_config_service.py::test_get_config_runtime_env_fallback_does_not_persist_llm_fields_on_save`、`tests/test_system_config_service.py::test_runtime_env_fallback_does_not_override_saved_provider_and_base_url_settings`、以及 `tests/test_system_config_api.py` 的 `/api/v1/system/config` 获取/保存链路回归。
 <!-- 新条目格式：- [类型] 描述（类型取值：新功能/改进/修复/文档/测试/chore）-->
 <!-- 每条独立一行追加到本段末尾，无需分类标题，合并时冲突最小 -->
+- [修复] `/health` 根路径健康检查现在始终返回 JSON，避免静态 Web fallback 吞掉健康探针；`/api/health` 与 `/api/v1/health` 继续保持兼容。
+- [改进] API 错误响应构造收敛到共享 helper，保持既有错误 envelope 形状并降低 endpoint 重复代码。
+- [改进] WebUI 绑定公网地址或 CORS 全开放且未启用管理员认证时新增运行时 warning；仅增加可观测性，不阻断启动、不改写配置。
+- [改进] 数据库初始化新增 `schema_migrations` baseline 标记表与幂等记录，用于后续 schema 演进追踪；不迁移、不清理、不改写既有业务表数据。
+- [测试] Web 测试运行时声明 Node `>=20.19.0 <27` 与 npm `>=10`，并补 localStorage 测试兜底以稳定 Vitest。
 - [改进] #1386 P6 复用市场阶段与 AnalysisContextPack 公开摘要联动告警、持仓手动分析、历史、回测和通知展示，不新增数据库迁移。
 
 - [新功能] 飞书通知新增应用机器人（App Bot）模式，支持通过 FEISHU_APP_ID / FEISHU_APP_SECRET / FEISHU_CHAT_ID 配置，无需额外创建自定义机器人。

--- a/docs/architecture/api_spec.json
+++ b/docs/architecture/api_spec.json
@@ -55,6 +55,28 @@
         }
       }
     },
+    "/health": {
+      "get": {
+        "tags": [
+          "Health"
+        ],
+        "summary": "根路径健康检查",
+        "description": "用于负载均衡器或监控系统检查服务状态；即使静态 Web 前端已构建，也返回 JSON 而不是 SPA HTML fallback。",
+        "operationId": "rootHealthCheck",
+        "responses": {
+          "200": {
+            "description": "服务健康",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HealthResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/health": {
       "get": {
         "tags": [
@@ -63,6 +85,28 @@
         "summary": "健康检查",
         "description": "用于负载均衡器或监控系统检查服务状态",
         "operationId": "healthCheck",
+        "responses": {
+          "200": {
+            "description": "服务健康",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HealthResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/health": {
+      "get": {
+        "tags": [
+          "Health"
+        ],
+        "summary": "v1 健康检查",
+        "description": "API v1 前缀下的健康检查接口，用于监控系统和客户端探测服务状态。",
+        "operationId": "v1HealthCheck",
         "responses": {
           "200": {
             "description": "服务健康",

--- a/main.py
+++ b/main.py
@@ -59,6 +59,7 @@ from src.logging_config import setup_logging
 
 logger = logging.getLogger(__name__)
 _RUNTIME_ENV_FILE_KEYS = set()
+_PUBLIC_BIND_HOSTS = frozenset({"0.0.0.0", "::", "[::]", "*"})
 
 
 def _get_active_env_path() -> Path:
@@ -66,6 +67,26 @@ def _get_active_env_path() -> Path:
     if env_file:
         return Path(env_file)
     return Path(__file__).resolve().parent / ".env"
+
+
+def _is_public_bind_host(host: str) -> bool:
+    return (host or "").strip().lower() in _PUBLIC_BIND_HOSTS
+
+
+def _warn_if_public_webui_without_auth(host: str) -> None:
+    if not _is_public_bind_host(host):
+        return
+
+    from src.auth import is_auth_enabled
+
+    if is_auth_enabled():
+        return
+    logger.warning(
+        "WEBUI_HOST=%s binds the Web UI to a public interface while "
+        "ADMIN_AUTH_ENABLED=false. Keep this service behind a trusted network "
+        "boundary or enable admin authentication before exposing it.",
+        host,
+    )
 
 
 def _read_active_env_values() -> Optional[Dict[str, str]]:
@@ -853,6 +874,7 @@ def main() -> int:
             args.host = os.getenv('WEBUI_HOST')
         if args.port == 8000 and os.getenv('WEBUI_PORT'):
             args.port = int(os.getenv('WEBUI_PORT'))
+        _warn_if_public_webui_without_auth(args.host)
 
     bot_clients_started = False
     if start_serve:

--- a/src/storage.py
+++ b/src/storage.py
@@ -875,13 +875,24 @@ class DatabaseManager(metaclass=_DatabaseManagerMeta):
 
     def _ensure_schema_migration_record(self) -> None:
         session = self._SessionLocal()
+        values = {
+            "version": CURRENT_SCHEMA_VERSION,
+            "description": "Baseline schema created through SQLAlchemy metadata.create_all",
+        }
         try:
-            if session.get(DatabaseSchemaMigration, CURRENT_SCHEMA_VERSION) is None:
-                session.add(DatabaseSchemaMigration(
-                    version=CURRENT_SCHEMA_VERSION,
-                    description="Baseline schema created through SQLAlchemy metadata.create_all",
-                ))
+            if self._is_sqlite_engine:
+                statement = sqlite_insert(DatabaseSchemaMigration).values(**values)
+                statement = statement.on_conflict_do_nothing(index_elements=["version"])
+                session.execute(statement)
+            else:
+                session.execute(DatabaseSchemaMigration.__table__.insert().values(**values))
             session.commit()
+        except IntegrityError:
+            session.rollback()
+            with self._SessionLocal() as verify_session:
+                existing = verify_session.get(DatabaseSchemaMigration, CURRENT_SCHEMA_VERSION)
+            if existing is None:
+                raise
         except Exception:
             session.rollback()
             raise

--- a/src/storage.py
+++ b/src/storage.py
@@ -57,6 +57,7 @@ from src.config import get_config
 
 logger = logging.getLogger(__name__)
 T = TypeVar("T")
+CURRENT_SCHEMA_VERSION = "2026-06-05-create-all-baseline"
 
 # SQLAlchemy ORM 基类
 Base = declarative_base()
@@ -66,6 +67,16 @@ if TYPE_CHECKING:
 
 
 # === 数据模型定义 ===
+
+class DatabaseSchemaMigration(Base):
+    """Applied database schema version marker."""
+
+    __tablename__ = 'schema_migrations'
+
+    version = Column(String(64), primary_key=True)
+    description = Column(String(255), nullable=False)
+    applied_at = Column(DateTime, default=datetime.now, nullable=False, index=True)
+
 
 class StockDaily(Base):
     """
@@ -843,6 +854,7 @@ class DatabaseManager(metaclass=_DatabaseManagerMeta):
 
             # 创建所有表
             Base.metadata.create_all(self._engine)
+            self._ensure_schema_migration_record()
 
             self._initialized = True
             logger.info(f"数据库初始化完成: {db_url}")
@@ -860,6 +872,21 @@ class DatabaseManager(metaclass=_DatabaseManagerMeta):
             self._SessionLocal = None
             self.__class__._instance = None
             raise
+
+    def _ensure_schema_migration_record(self) -> None:
+        session = self._SessionLocal()
+        try:
+            if session.get(DatabaseSchemaMigration, CURRENT_SCHEMA_VERSION) is None:
+                session.add(DatabaseSchemaMigration(
+                    version=CURRENT_SCHEMA_VERSION,
+                    description="Baseline schema created through SQLAlchemy metadata.create_all",
+                ))
+            session.commit()
+        except Exception:
+            session.rollback()
+            raise
+        finally:
+            session.close()
 
     @classmethod
     def get_instance(cls) -> 'DatabaseManager':

--- a/tests/test_api_app_cors.py
+++ b/tests/test_api_app_cors.py
@@ -28,6 +28,24 @@ class AppCorsConfigTestCase(unittest.TestCase):
         self.assertEqual(cors.kwargs["allow_origins"], ["*"])
         self.assertFalse(cors.kwargs["allow_credentials"])
 
+    def test_allow_all_warns_when_auth_is_disabled(self):
+        with patch.dict(os.environ, {"CORS_ALLOW_ALL": "true"}, clear=False), \
+             patch("api.app.is_auth_enabled", return_value=False), \
+             patch("api.app.logger.warning") as warning:
+            self._build_app()
+
+        warning.assert_called_once()
+        self.assertIn("CORS_ALLOW_ALL=true", warning.call_args.args[0])
+        self.assertIn("ADMIN_AUTH_ENABLED is false", warning.call_args.args[0])
+
+    def test_allow_all_does_not_warn_when_auth_is_enabled(self):
+        with patch.dict(os.environ, {"CORS_ALLOW_ALL": "true"}, clear=False), \
+             patch("api.app.is_auth_enabled", return_value=True), \
+             patch("api.app.logger.warning") as warning:
+            self._build_app()
+
+        warning.assert_not_called()
+
     def test_explicit_origin_list_keeps_credentials_enabled(self):
         with patch.dict(os.environ, {"CORS_ALLOW_ALL": "false"}, clear=False):
             app = self._build_app()

--- a/tests/test_api_error_helpers.py
+++ b/tests/test_api_error_helpers.py
@@ -1,0 +1,32 @@
+# -*- coding: utf-8 -*-
+"""Tests for shared API error helpers."""
+
+from fastapi import HTTPException
+
+from api.v1.errors import api_error, error_body, error_json_response
+
+
+def test_error_body_omits_empty_detail() -> None:
+    assert error_body("validation_error", "bad input") == {
+        "error": "validation_error",
+        "message": "bad input",
+    }
+
+
+def test_api_error_uses_standard_detail_shape() -> None:
+    exc = api_error(404, "not_found", "missing", detail={"id": 1})
+
+    assert isinstance(exc, HTTPException)
+    assert exc.status_code == 404
+    assert exc.detail == {
+        "error": "not_found",
+        "message": "missing",
+        "detail": {"id": 1},
+    }
+
+
+def test_error_json_response_uses_standard_content() -> None:
+    response = error_json_response(409, "conflict", "already exists")
+
+    assert response.status_code == 409
+    assert response.body == b'{"error":"conflict","message":"already exists"}'

--- a/tests/test_api_health.py
+++ b/tests/test_api_health.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-"""Tests for health check endpoints: /api/health and /api/v1/health."""
+"""Tests for health check endpoints: /health, /api/health and /api/v1/health."""
 
 import tempfile
 import unittest
@@ -17,7 +17,7 @@ def _make_client():
 
 
 class HealthEndpointTestCase(unittest.TestCase):
-    """Both /api/health and /api/v1/health should return 200 with valid payload."""
+    """Health endpoints should return 200 with valid payload."""
 
     @classmethod
     def setUpClass(cls):
@@ -34,12 +34,32 @@ class HealthEndpointTestCase(unittest.TestCase):
         self.assertEqual(body["status"], "ok")
         self.assertIn("timestamp", body)
 
+    def test_root_health_returns_200(self):
+        resp = self.client.get("/health")
+        self.assertEqual(resp.status_code, 200)
+        body = resp.json()
+        self.assertEqual(body["status"], "ok")
+        self.assertIn("timestamp", body)
+
     def test_api_v1_health_returns_200(self):
         resp = self.client.get("/api/v1/health")
         self.assertEqual(resp.status_code, 200)
         body = resp.json()
         self.assertEqual(body["status"], "ok")
         self.assertIn("timestamp", body)
+
+    def test_root_health_is_not_handled_by_spa_fallback(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            static_dir = Path(temp_dir)
+            (static_dir / "assets").mkdir()
+            (static_dir / "index.html").write_text("<!doctype html><div id=\"root\"></div>", encoding="utf-8")
+
+            client = TestClient(create_app(static_dir=static_dir))
+            resp = client.get("/health")
+
+        self.assertEqual(resp.status_code, 200)
+        self.assertIn("application/json", resp.headers["content-type"])
+        self.assertEqual(resp.json()["status"], "ok")
 
 
 class HealthEndpointAuthEnabledTestCase(unittest.TestCase):
@@ -58,6 +78,11 @@ class HealthEndpointAuthEnabledTestCase(unittest.TestCase):
 
     def test_api_health_returns_200_when_auth_enabled(self):
         resp = self.client.get("/api/health")
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.json()["status"], "ok")
+
+    def test_root_health_returns_200_when_auth_enabled(self):
+        resp = self.client.get("/health")
         self.assertEqual(resp.status_code, 200)
         self.assertEqual(resp.json()["status"], "ok")
 

--- a/tests/test_main_schedule_mode.py
+++ b/tests/test_main_schedule_mode.py
@@ -96,6 +96,22 @@ class MainScheduleModeTestCase(unittest.TestCase):
         defaults.update(overrides)
         return _DummyConfig(**defaults)
 
+    def test_public_webui_bind_warns_when_auth_is_disabled(self) -> None:
+        with patch("src.auth.is_auth_enabled", return_value=False), \
+             patch("main.logger.warning") as warning_log:
+            main._warn_if_public_webui_without_auth("0.0.0.0")
+
+        warning_log.assert_called_once()
+        self.assertIn("WEBUI_HOST=%s", warning_log.call_args.args[0])
+        self.assertEqual(warning_log.call_args.args[1], "0.0.0.0")
+
+    def test_loopback_webui_bind_does_not_warn_when_auth_is_disabled(self) -> None:
+        with patch("src.auth.is_auth_enabled", return_value=False), \
+             patch("main.logger.warning") as warning_log:
+            main._warn_if_public_webui_without_auth("127.0.0.1")
+
+        warning_log.assert_not_called()
+
     def test_schedule_mode_ignores_cli_stock_snapshot(self) -> None:
         args = self._make_args(schedule=True, stocks="600519,000001")
         config = self._make_config(schedule_enabled=False)

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -31,6 +31,61 @@ class TestStorage(unittest.TestCase):
         self.assertIn("metadata.create_all", row.description)
 
         DatabaseManager.reset_instance()
+
+    def test_schema_migration_record_is_idempotent(self):
+        DatabaseManager.reset_instance()
+        db = DatabaseManager(db_url="sqlite:///:memory:")
+
+        db._ensure_schema_migration_record()
+        db._ensure_schema_migration_record()
+
+        with db.get_session() as session:
+            count = session.execute(
+                select(func.count()).select_from(DatabaseSchemaMigration)
+            ).scalar_one()
+
+        self.assertEqual(count, 1)
+
+        DatabaseManager.reset_instance()
+
+    def test_schema_migration_record_handles_concurrent_initialization(self):
+        DatabaseManager.reset_instance()
+        temp_dir = tempfile.TemporaryDirectory()
+        db_path = os.path.join(temp_dir.name, "schema_migration_race.db")
+        db = DatabaseManager(db_url=f"sqlite:///{db_path}")
+        worker_count = 8
+        barrier = threading.Barrier(worker_count)
+        errors = []
+        state_lock = threading.Lock()
+
+        with db.get_session() as session:
+            session.query(DatabaseSchemaMigration).delete()
+            session.commit()
+
+        def ensure_record() -> None:
+            try:
+                barrier.wait(timeout=5)
+                db._ensure_schema_migration_record()
+            except Exception as exc:
+                with state_lock:
+                    errors.append(exc)
+
+        threads = [threading.Thread(target=ensure_record) for _ in range(worker_count)]
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join(timeout=5)
+
+        with db.get_session() as session:
+            rows = session.execute(select(DatabaseSchemaMigration)).scalars().all()
+
+        self.assertFalse(any(thread.is_alive() for thread in threads))
+        self.assertEqual(errors, [])
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(rows[0].version, CURRENT_SCHEMA_VERSION)
+
+        DatabaseManager.reset_instance()
+        temp_dir.cleanup()
     
     def test_parse_sniper_value(self):
         """测试解析狙击点位数值"""

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -15,9 +15,22 @@ from sqlalchemy.sql import func
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 
 from src.config import Config
-from src.storage import Base, DatabaseManager, StockDaily
+from src.storage import Base, CURRENT_SCHEMA_VERSION, DatabaseManager, DatabaseSchemaMigration, StockDaily
 
 class TestStorage(unittest.TestCase):
+
+    def test_database_initialization_records_schema_version(self):
+        DatabaseManager.reset_instance()
+        db = DatabaseManager(db_url="sqlite:///:memory:")
+
+        with db.get_session() as session:
+            row = session.get(DatabaseSchemaMigration, CURRENT_SCHEMA_VERSION)
+
+        self.assertIsNotNone(row)
+        self.assertEqual(row.version, CURRENT_SCHEMA_VERSION)
+        self.assertIn("metadata.create_all", row.description)
+
+        DatabaseManager.reset_instance()
     
     def test_parse_sniper_value(self):
         """测试解析狙击点位数值"""


### PR DESCRIPTION
## PR Type

- [x] fix
- [ ] feat
- [x] refactor
- [x] docs
- [ ] chore
- [x] test

## Background And Problem

本 PR 来自代码健康度审查后的低风险修复集合，目标是不改变业务逻辑前提下收敛稳定性、可维护性和部署可观测性问题：

- `/health` 根路径在静态 Web 资源存在时可能被 SPA fallback 吞掉并返回 HTML，不适合作为标准健康探针。
- Web Vitest 在新版 Node 运行时下需要稳定的 `localStorage` 测试兜底和明确 engines 窗口。
- CORS 全开放或 WebUI 绑定公网地址且未启用管理员认证时，运行时缺少明显 warning。
- analysis / portfolio endpoint 存在重复错误响应构造。
- 数据库 schema 演进缺少 baseline 记录；补充后需要保证多实例初始化时幂等。
- `PortfolioPage.tsx` 内聚合了大量纯格式化 helper，页面组件偏大。

## Scope Of Change

- Backend/API: `api/app.py`, `api/v1/errors.py`, `api/v1/endpoints/analysis.py`, `api/v1/endpoints/portfolio.py`, `main.py`
- DB: `src/storage.py`, `tests/test_storage.py`
- Web: `apps/dsa-web/package.json`, `apps/dsa-web/package-lock.json`, `apps/dsa-web/src/setupTests.ts`, `apps/dsa-web/src/pages/PortfolioPage.tsx`, `apps/dsa-web/src/utils/portfolioFormat.ts`, related tests
- Docs/API spec: `docs/CHANGELOG.md`, `docs/architecture/api_spec.json`
- Tests: backend API/storage tests, Web unit tests, Desktop tests

## Issue Link

无 Issue。原因：这是代码健康度审查后的维护性/稳定性修复集合，不对应单个用户报障。

验收标准：

- `/health`, `/api/health`, `/api/v1/health` 均返回 `200 application/json`。
- `schema_migrations` baseline 初始化可重复、可并发执行，不因重复主键导致 `DatabaseManager` 初始化失败。
- API 错误响应 envelope 保持兼容。
- Web/Backend/Desktop 现有测试与仓库 backend gate 通过。
- 用户可见变更写入 `docs/CHANGELOG.md`，新增健康检查路径写入 `docs/architecture/api_spec.json`。

## Verification Commands And Results

```bash
# backend gate; local run used a temporary PATH so python/python3 resolve to Python 3.11
./scripts/ci_gate.sh

python -m pytest \
  tests/test_storage.py::TestStorage::test_database_initialization_records_schema_version \
  tests/test_storage.py::TestStorage::test_schema_migration_record_is_idempotent \
  tests/test_storage.py::TestStorage::test_schema_migration_record_handles_concurrent_initialization \
  tests/test_api_health.py -q

python -m json.tool docs/architecture/api_spec.json >/dev/null
git diff --check

# structured detector evidence for LLM/provider/base_url false-positive review
# added/removed lines contain no LLM, LiteLLM, base_url, runtime config, or config migration changes
git diff --unified=0 main...HEAD | rg -n "^(\\+|-)" | rg -i "litellm|llm|provider|base_url|model|credential|runtime config|配置迁移|运行时配置"

# previously run for this PR before the latest docs/db-idempotency follow-up
npm run test      # apps/dsa-web
npm run lint      # apps/dsa-web
npm run build     # apps/dsa-web
npm test          # apps/dsa-desktop
```

关键输出/结论：

- `./scripts/ci_gate.sh`: passed; `2767 passed, 2 deselected, 27 warnings, 258 subtests passed`; `backend-gate: all checks passed`.
- 聚焦 pytest: `10 passed`，覆盖 schema baseline 重复/并发初始化和 health routes。
- `docs/architecture/api_spec.json`: JSON validation passed.
- `git diff --check`: passed.
- 结构化检测复核：新增/删除行没有 `LLM`、`LiteLLM`、`base_url`、运行时配置迁移或旧配置清理/保存逻辑改动。命中来源是 `docs/CHANGELOG.md` diff 上下文中 PR 之前已存在的 LLM/LiteLLM 条目，以及 `response_model=HealthResponse`、`priceProvider` 这类非 AI provider/config 字段。
- Web tests: `63 test files passed; 574 passed, 2 skipped`.
- Web lint/build: passed.
- Desktop tests: `24 passed`.
- API smoke: `/health`, `/api/health`, `/api/v1/health` -> `200 application/json ok`.
- Secret scan: no new real secrets found; only existing placeholder test keys for redaction assertions.

## Compatibility And Risk

- Overall risk: medium, because this PR touches health check routing, DB initialization metadata, runtime warnings, API error helper extraction, and Web runtime test setup.
- Health check compatibility: `/api/health` and `/api/v1/health` remain available; `/health` is added as JSON health check and no longer falls through to SPA HTML. Existing API clients are not required to migrate.
- DB compatibility: existing databases get only a new `schema_migrations` marker table and one baseline row. No business tables are migrated, rewritten, cleaned, or backfilled. Baseline insertion is idempotent and uses SQLite `ON CONFLICT DO NOTHING`; non-SQLite duplicate primary key races are treated as success when the baseline row exists.
- Runtime warning compatibility: public WebUI bind / open CORS warnings only add logs. They do not block startup, change auth state, rewrite `.env`, or alter network binding behavior.
- Web runtime compatibility: `apps/dsa-web` now declares Node `>=20.19.0 <27` and npm `>=10`; this documents the tested Vitest/build window and does not change production runtime code.
- API error helper compatibility: endpoint error bodies keep the existing `{error, message, detail?}` shape while removing duplicate construction code.
- Structured compatibility detector note: this PR does not change any third-party model/API compatibility semantics, LLM/LiteLLM provider fallback, model defaults, base URL routing, credentials, runtime config save/cleanup/migration/backfill logic, or user `.env` values. No official model/provider source citation is required because those semantics are not modified.

## Rollback Plan

- Minimal rollback: revert this PR as a whole.
- Targeted rollback is possible because commits are split by concern:
  - `/health` behavior: revert `fix(api): return json from root health endpoint`.
  - Web test/runtime setup: revert `test(web): stabilize vitest runtime setup`.
  - Public exposure warnings: revert `chore(security): warn on public web exposure without auth`.
  - API error helper extraction: revert `refactor(api): centralize error response helpers`.
  - DB schema marker: revert `chore(db): record baseline schema version` and `fix(db): make schema baseline initialization idempotent`.
  - Portfolio formatter extraction: revert `refactor(web): extract portfolio formatting helpers`.
  - Docs/API spec: revert `docs: document health check and schema baseline changes`.
- DB rollback note: if a deployed SQLite/DB instance already created only `schema_migrations` and no later migration depends on it, the table can be left in place harmlessly. Drop it only after confirming no later schema records depend on it.
- No destructive data migration is included.

## EXTRACT_PROMPT Change (if applicable)

Not applicable.

## Checklist

- [x] 本 PR 有明确动机和业务价值 / This PR has a clear motivation and value
- [x] 已提供可复现的验证命令与结果 / Reproducible verification commands and results are included
- [x] 已评估兼容性与风险 / Compatibility and risk have been assessed
- [x] 已提供回滚方案 / A rollback plan is provided
- [x] 若涉及用户可见变更，已同步更新相关文档与 `docs/CHANGELOG.md`；`README.md` 仅在首页级信息变化时更新，细节优先写入 `docs/*.md` / If user-visible changes are included, relevant docs and `docs/CHANGELOG.md` are updated; `README.md` is updated only for homepage-level changes, with details kept in `docs/*.md`
