### PR TITLE
fix: 收敛多股通知摘要的市场状态展示

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+- [改进] 多股通知报告将市场阶段收敛为总览下方单行 `市场状态`，不再在每只股票摘要下重复展示数据质量和限制详情。
 - [修复] Web 个股栏和历史卡片在窄布局下不再让市场阶段标签遮挡股票名称。
 - [修复] 问股自由文本追问不再将 TTM、PE、YOY 等金融缩写误识别为新股票代码。
 - [修复] GitHub Actions 每日分析工作流读取 SearXNG 自建实例地址时支持 Variables 优先、Secrets 回退，修复仅配置 Variables 时 URL 不生效的问题。

--- a/src/market_phase_summary.py
+++ b/src/market_phase_summary.py
@@ -45,6 +45,38 @@ _PUBLIC_SOURCE_LABELS_EN = {
     "evaluator_snapshot": "evaluator snapshot",
     "legacy_text": "legacy text",
 }
+_MARKET_STATUS_PREFIX = {
+    "zh": "市场状态",
+    "en": "Market status",
+}
+_MARKET_LABELS_ZH = {
+    "cn": "A股",
+    "hk": "港股",
+    "us": "美股",
+}
+_MARKET_LABELS_EN = {
+    "cn": "A-shares",
+    "hk": "Hong Kong",
+    "us": "US",
+}
+_PHASE_LABELS_ZH = {
+    "premarket": "盘前",
+    "intraday": "盘中",
+    "lunch_break": "午间休市",
+    "closing_auction": "临近收盘",
+    "postmarket": "盘后",
+    "non_trading": "非交易日",
+    "unknown": "阶段未知",
+}
+_PHASE_LABELS_EN = {
+    "premarket": "Pre-market",
+    "intraday": "Intraday",
+    "lunch_break": "Lunch break",
+    "closing_auction": "Near close",
+    "postmarket": "Post-market",
+    "non_trading": "Non-trading",
+    "unknown": "Unknown phase",
+}
 
 
 def render_market_phase_summary(phase_context: Any) -> Optional[Dict[str, Any]]:
@@ -144,6 +176,34 @@ def format_public_phase_pack_excerpt(
             lines.append(f"- {'limitation' if lang == 'en' else '限制'}: {item}")
 
     return "\n".join(lines)
+
+
+def format_public_market_status_line(
+    market_phase_summary: Any,
+    *,
+    report_language: str = "zh",
+) -> str:
+    """Format one compact market/phase line for aggregate reports."""
+    phase_summary = _as_mapping(market_phase_summary)
+    if not phase_summary:
+        return ""
+    phase = _safe_phase(phase_summary.get("phase"))
+    if phase is None:
+        return ""
+
+    lang = "en" if str(report_language or "").lower().startswith("en") else "zh"
+    phase_labels = _PHASE_LABELS_EN if lang == "en" else _PHASE_LABELS_ZH
+    market_labels = _MARKET_LABELS_EN if lang == "en" else _MARKET_LABELS_ZH
+    phase_label = phase_labels.get(phase, phase)
+    market = _safe_text(phase_summary.get("market"))
+    market_key = market.lower()
+    if market_key:
+        market_label = market_labels.get(market_key, market.upper() if lang == "en" else market)
+        value = f"{market_label} · {phase_label}"
+    else:
+        value = phase_label
+    separator = ": " if lang == "en" else "："
+    return f"{_MARKET_STATUS_PREFIX[lang]}{separator}{value}"
 
 
 def _as_mapping(value: Any) -> Optional[Mapping[str, Any]]:

--- a/src/notification.py
+++ b/src/notification.py
@@ -25,7 +25,7 @@ from enum import Enum
 
 from src.config import Config, get_config
 from src.enums import ReportType
-from src.market_phase_summary import format_public_phase_pack_excerpt
+from src.market_phase_summary import format_public_market_status_line, format_public_phase_pack_excerpt
 from src.notification_routing import (
     get_notification_route_config,
     split_notification_route_channels,
@@ -345,6 +345,28 @@ class NotificationService(
             source=getattr(result, "analysis_visibility_source", None) or "evaluator_snapshot",
             report_language=report_language,
         )
+
+    def _public_market_status_line(self, results: List[AnalysisResult], report_language: str) -> str:
+        for result in results or []:
+            line = format_public_market_status_line(
+                getattr(result, "market_phase_summary", None),
+                report_language=report_language,
+            )
+            if line:
+                return line
+        return ""
+
+    def _append_market_status_line(
+        self,
+        lines: List[str],
+        results: List[AnalysisResult],
+        report_language: str,
+    ) -> None:
+        status_line = self._public_market_status_line(results, report_language)
+        if status_line:
+            lines.extend([status_line, ""])
+        elif lines and lines[-1] != "":
+            lines.append("")
 
     def _should_show_llm_model(self) -> bool:
         return bool(getattr(self._config, "report_show_llm_model", self._report_show_llm_model))
@@ -779,10 +801,9 @@ class NotificationService(
             "",
             f"> {labels['analyzed_prefix']} **{len(results)}** {labels['stock_unit']} | "
             f"{labels['generated_at_label']}：{datetime.now().strftime('%H:%M:%S')}",
-            "",
-            "---",
-            "",
         ]
+        self._append_market_status_line(report_lines, results, report_language)
+        report_lines.extend(["---", ""])
         
         # 按评分排序（高分在前）
         sorted_results = sorted(
@@ -822,9 +843,6 @@ class NotificationService(
                     f"{labels['score_label']} {r.sentiment_score} | "
                     f"{localize_trend_prediction(r.trend_prediction, report_language)}"
                 )
-                excerpt = self._public_phase_pack_excerpt(r, report_language)
-                if excerpt:
-                    report_lines.append(excerpt)
         else:
             report_lines.extend([f"## 📈 {labels['report_title']}", ""])
             # 逐个股票的详细分析
@@ -841,10 +859,6 @@ class NotificationService(
                     f"**Confidence：{confidence_stars}**",
                     "",
                 ])
-                excerpt = self._public_phase_pack_excerpt(result, report_language)
-                if excerpt:
-                    report_lines.extend([excerpt, ""])
-
                 self._append_market_snapshot(report_lines, result)
                 
                 # 核心看点
@@ -1060,8 +1074,8 @@ class NotificationService(
             "",
             f"> {labels['analyzed_prefix']} **{len(results)}** {labels['stock_unit']} | "
             f"🟢{labels['buy_label']}:{buy_count} 🟡{labels['watch_label']}:{hold_count} 🔴{labels['sell_label']}:{sell_count}",
-            "",
         ]
+        self._append_market_status_line(report_lines, results, report_language)
 
         # === 新增：分析结果摘要 (Issue #112) ===
         if results:
@@ -1078,9 +1092,6 @@ class NotificationService(
                     f"{labels['score_label']} {r.sentiment_score} | "
                     f"{localize_trend_prediction(r.trend_prediction, report_language)}"
                 )
-                excerpt = self._public_phase_pack_excerpt(r, report_language)
-                if excerpt:
-                    report_lines.append(excerpt)
             report_lines.extend([
                 "",
                 "---",
@@ -1367,8 +1378,8 @@ class NotificationService(
             "",
             f"> {len(results)} {labels['stock_unit']} | "
             f"🟢{labels['buy_label']}:{buy_count} 🟡{labels['watch_label']}:{hold_count} 🔴{labels['sell_label']}:{sell_count}",
-            "",
         ]
+        self._append_market_status_line(lines, results, report_language)
         
         # Issue #262: summary_only 时仅输出摘要列表
         if self._report_summary_only:
@@ -1519,8 +1530,8 @@ class NotificationService(
             f"> {labels['analyzed_prefix']} **{len(results)}** {labels['stock_unit_compact']} | "
             f"🟢{labels['buy_label']}:{buy_count} 🟡{labels['watch_label']}:{hold_count} 🔴{labels['sell_label']}:{sell_count} | "
             f"{labels['avg_score_label']}:{avg_score:.0f}",
-            "",
         ]
+        self._append_market_status_line(lines, results, report_language)
         
         # 每只股票精简信息（控制长度）
         for result in sorted_results:
@@ -1607,8 +1618,8 @@ class NotificationService(
             f"# {report_date} {labels['brief_title']}",
             "",
             f"> {len(results)} {labels['stock_unit_compact']} | 🟢{buy_count} 🟡{hold_count} 🔴{sell_count}",
-            "",
         ]
+        self._append_market_status_line(lines, results, report_language)
         for r in sorted_results:
             _, emoji, _ = self._get_signal_level(r)
             name = self._get_display_name(r, report_language)
@@ -1620,9 +1631,6 @@ class NotificationService(
                 f"{localize_operation_advice(r.operation_advice, report_language)} | "
                 f"{labels['score_label']} {r.sentiment_score} | {one}"
             )
-            excerpt = self._public_phase_pack_excerpt(r, report_language)
-            if excerpt:
-                lines.append(excerpt)
         lines.append("")
         lines.append(f"*{datetime.now().strftime('%Y-%m-%d %H:%M:%S')}*")
         models = self._collect_models_used(results)

--- a/src/services/report_renderer.py
+++ b/src/services/report_renderer.py
@@ -158,13 +158,14 @@ def render(
         )
 
     def market_status_line() -> str:
-        for result in sorted_results:
-            line = format_public_market_status_line(
-                getattr(result, "market_phase_summary", None),
-                report_language=report_language,
-            )
-            if line:
-                return line
+        for source_results in (results or [], sorted_results):
+            for result in source_results:
+                line = format_public_market_status_line(
+                    getattr(result, "market_phase_summary", None),
+                    report_language=report_language,
+                )
+                if line:
+                    return line
         return ""
 
     context: Dict[str, Any] = {

--- a/src/services/report_renderer.py
+++ b/src/services/report_renderer.py
@@ -15,7 +15,7 @@ from typing import Any, Dict, List, Optional
 
 from src.analyzer import AnalysisResult
 from src.config import get_config
-from src.market_phase_summary import format_public_phase_pack_excerpt
+from src.market_phase_summary import format_public_market_status_line, format_public_phase_pack_excerpt
 from src.report_language import (
     get_localized_stock_name,
     get_report_labels,
@@ -157,6 +157,16 @@ def render(
             report_language=report_language,
         )
 
+    def market_status_line() -> str:
+        for result in sorted_results:
+            line = format_public_market_status_line(
+                getattr(result, "market_phase_summary", None),
+                report_language=report_language,
+            )
+            if line:
+                return line
+        return ""
+
     context: Dict[str, Any] = {
         "report_date": report_date,
         "report_timestamp": report_timestamp,
@@ -170,6 +180,7 @@ def render(
         "report_language": report_language,
         "models_used": models_used,
         "show_llm_model": show_llm_model,
+        "market_status_line": market_status_line(),
         "escape_md": _escape_md,
         "clean_sniper": _clean_sniper_value,
         "failed_checks": failed_checks,

--- a/templates/report_brief.j2
+++ b/templates/report_brief.j2
@@ -1,16 +1,15 @@
 # 🎯 {{ report_date }} {{ labels.brief_title }}
 
 > {{ results|length }} {{ labels.stock_unit_compact }} | 🟢{{ buy_count }} 🟡{{ hold_count }} 🔴{{ sell_count }}
+{% if market_status_line %}
+{{ market_status_line }}
+{% endif %}
 
 {% for e in enriched %}
 {% set dash = e.result.dashboard or {} %}
 {% set core = (dash.get('core_conclusion') or {}) if dash else {} %}
 {% set one = (core.get('one_sentence') or e.result.analysis_summary or '')[:60] %}
 **{{ e.stock_name }}({{ e.result.code }})** {{ e.signal_emoji }} {{ e.localized_operation_advice }} | {{ labels.score_label }} {{ e.result.sentiment_score }} | {{ one }}
-{% set phase_excerpt = phase_pack_excerpt(e.result) %}
-{% if phase_excerpt %}
-{{ phase_excerpt }}
-{% endif %}
 {% endfor %}
 
 *{{ report_timestamp }}*

--- a/templates/report_markdown.j2
+++ b/templates/report_markdown.j2
@@ -2,15 +2,14 @@
 # 🎯 {{ report_date }} {{ labels.dashboard_title }}
 
 > {{ labels.analyzed_prefix }} **{{ results|length }}** {{ labels.stock_unit }} | 🟢{{ labels.buy_label }}:{{ buy_count }} 🟡{{ labels.watch_label }}:{{ hold_count }} 🔴{{ labels.sell_label }}:{{ sell_count }}
+{% if market_status_line %}
+{{ market_status_line }}
+{% endif %}
 
 ## 📊 {{ labels.summary_heading }}
 
 {% for e in enriched %}
 {{ e.signal_emoji }} **{{ e.stock_name }}({{ e.result.code }})**: {{ e.localized_operation_advice }} | {{ labels.score_label }} {{ e.result.sentiment_score }} | {{ e.localized_trend_prediction }}
-{% set phase_excerpt = phase_pack_excerpt(e.result) %}
-{% if phase_excerpt %}
-{{ phase_excerpt }}
-{% endif %}
 {% endfor %}
 
 ---

--- a/templates/report_wechat.j2
+++ b/templates/report_wechat.j2
@@ -1,15 +1,14 @@
 ## 🎯 {{ report_date }} {{ labels.dashboard_title }}
 
 > {{ results|length }} {{ labels.stock_unit }} | 🟢{{ labels.buy_label }}:{{ buy_count }} 🟡{{ labels.watch_label }}:{{ hold_count }} 🔴{{ labels.sell_label }}:{{ sell_count }}
+{% if market_status_line %}
+{{ market_status_line }}
+{% endif %}
 
 {% if summary_only %}
 **📊 {{ labels.summary_heading }}**
 {% for e in enriched %}
 {{ e.signal_emoji }} **{{ e.stock_name }}({{ e.result.code }})**: {{ e.localized_operation_advice }} | {{ labels.score_label }} {{ e.result.sentiment_score }} | {{ e.localized_trend_prediction }}
-{% set phase_excerpt = phase_pack_excerpt(e.result) %}
-{% if phase_excerpt %}
-{{ phase_excerpt }}
-{% endif %}
 {% endfor %}
 {% else %}
 {% for e in enriched %}
@@ -20,10 +19,6 @@
 {% set intel = dashboard.get('intelligence') or {} %}
 
 ### {{ e.signal_emoji }} **{{ e.signal_text }}** | {{ e.stock_name }}({{ result.code }})
-{% set phase_excerpt = phase_pack_excerpt(result) %}
-{% if phase_excerpt %}
-{{ phase_excerpt }}
-{% endif %}
 
 {% set one_sentence = core.get('one_sentence', result.analysis_summary) if core else result.analysis_summary %}
 {% if one_sentence %}

--- a/tests/test_market_phase_summary.py
+++ b/tests/test_market_phase_summary.py
@@ -6,6 +6,7 @@ import json
 from src.market_phase_summary import (
     MARKET_PHASE_SUMMARY_KEY,
     extract_market_phase_summary,
+    format_public_market_status_line,
     format_public_phase_pack_excerpt,
     normalize_analysis_phase_bucket,
     render_market_phase_summary,
@@ -159,3 +160,32 @@ def test_format_public_phase_pack_excerpt_limits_and_redacts_public_fields() -> 
 
 def test_format_public_phase_pack_excerpt_returns_empty_without_summary_or_pack() -> None:
     assert format_public_phase_pack_excerpt(None, None, source="evaluator_snapshot") == ""
+
+
+def test_format_public_market_status_line_localizes_compact_summary() -> None:
+    assert (
+        format_public_market_status_line(
+            {"market": "cn", "phase": "postmarket"},
+            report_language="zh",
+        )
+        == "市场状态：A股 · 盘后"
+    )
+    assert (
+        format_public_market_status_line(
+            {"market": "us", "phase": "premarket"},
+            report_language="en",
+        )
+        == "Market status: US · Pre-market"
+    )
+
+
+def test_format_public_market_status_line_returns_empty_without_valid_phase() -> None:
+    assert format_public_market_status_line(None, report_language="zh") == ""
+    assert format_public_market_status_line({"market": "cn"}, report_language="zh") == ""
+    assert (
+        format_public_market_status_line(
+            {"market": "cn", "phase": "bad_phase"},
+            report_language="zh",
+        )
+        == ""
+    )

--- a/tests/test_notification.py
+++ b/tests/test_notification.py
@@ -630,7 +630,7 @@ class TestNotificationServiceReportGeneration(unittest.TestCase):
         self.assertIn("*分析模型：gemini/gemini-2.5-flash*", out)
 
     @mock.patch("src.notification.get_config")
-    def test_generated_reports_include_public_phase_pack_excerpt_only(self, mock_get_config: mock.MagicMock):
+    def test_aggregate_reports_show_compact_market_status_only(self, mock_get_config: mock.MagicMock):
         mock_get_config.return_value = _make_config(report_renderer_enabled=False)
         service = NotificationService()
         result = AnalysisResult(
@@ -657,15 +657,49 @@ class TestNotificationServiceReportGeneration(unittest.TestCase):
 
         out = service.generate_brief_report([result], report_date="2026-02-01")
 
-        self.assertIn("阶段：intraday", out)
-        self.assertIn("触发来源：portfolio", out)
-        self.assertIn("盘中数据提示", out)
-        self.assertIn("数据质量: limited", out)
-        self.assertIn("限制: quote: stale", out)
-        self.assertIn("限制: news: missing", out)
+        self.assertIn("市场状态：A股 · 盘中", out)
+        self.assertNotIn("阶段：intraday", out)
+        self.assertNotIn("触发来源：portfolio", out)
+        self.assertNotIn("盘中数据提示", out)
+        self.assertNotIn("数据质量: limited", out)
+        self.assertNotIn("限制: quote: stale", out)
+        self.assertNotIn("限制: news: missing", out)
         self.assertNotIn("portfolio_context: hidden", out)
         self.assertNotIn("raw context pack", out)
         self.assertNotIn("prompt", out.lower())
+
+    @mock.patch("src.notification.get_config")
+    def test_template_dashboard_report_uses_single_market_status_line(self, mock_get_config: mock.MagicMock):
+        mock_get_config.return_value = _make_config(report_renderer_enabled=True)
+        service = NotificationService()
+        result = AnalysisResult(
+            code="600519",
+            name="贵州茅台",
+            sentiment_score=72,
+            trend_prediction="看多",
+            operation_advice="持有",
+            analysis_summary="稳健",
+        )
+        result.market_phase_summary = {
+            "phase": "postmarket",
+            "market": "cn",
+            "trigger_source": "cli",
+        }
+        result.analysis_context_pack_overview = {
+            "data_quality": {
+                "level": "good",
+                "limitations": ["technical: partial"],
+            }
+        }
+
+        out = service.generate_dashboard_report([result], report_date="2026-02-01")
+
+        self.assertIn("市场状态：A股 · 盘后", out)
+        self.assertEqual(out.count("市场状态："), 1)
+        self.assertNotIn("阶段：postmarket", out)
+        self.assertNotIn("触发来源：cli", out)
+        self.assertNotIn("数据质量: good", out)
+        self.assertNotIn("technical: partial", out)
 
     @mock.patch("src.notification.get_config")
     def test_generated_reports_skip_phase_pack_excerpt_when_summary_missing(self, mock_get_config: mock.MagicMock):

--- a/tests/test_report_renderer.py
+++ b/tests/test_report_renderer.py
@@ -159,7 +159,7 @@ class TestReportRenderer(unittest.TestCase):
         self.assertNotIn("分析模型", hidden)
         self.assertNotIn("gemini/gemini-2.5-flash", hidden)
 
-    def test_render_templates_include_public_phase_pack_excerpt(self) -> None:
+    def test_render_templates_show_compact_market_status_only(self) -> None:
         r = _make_result()
         r.market_phase_summary = {
             "phase": "intraday",
@@ -178,11 +178,12 @@ class TestReportRenderer(unittest.TestCase):
         out = render("brief", [r])
 
         self.assertIsNotNone(out)
-        self.assertIn("阶段：intraday", out)
-        self.assertIn("盘中数据提示", out)
-        self.assertIn("数据质量: limited", out)
-        self.assertIn("限制: quote: stale", out)
-        self.assertIn("限制: news: missing", out)
+        self.assertIn("市场状态：A股 · 盘中", out)
+        self.assertNotIn("阶段：intraday", out)
+        self.assertNotIn("盘中数据提示", out)
+        self.assertNotIn("数据质量: limited", out)
+        self.assertNotIn("限制: quote: stale", out)
+        self.assertNotIn("限制: news: missing", out)
         self.assertNotIn("technical: fallback", out)
         self.assertNotIn("raw context pack", out)
 
@@ -194,6 +195,26 @@ class TestReportRenderer(unittest.TestCase):
         self.assertIsNotNone(out)
         self.assertNotIn("摘要来源", out)
         self.assertNotIn("evaluator snapshot", out)
+
+    def test_render_market_status_preserves_input_order(self) -> None:
+        cn = _make_result(
+            code="600519",
+            name="贵州茅台",
+            sentiment_score=60,
+        )
+        cn.market_phase_summary = {"market": "cn", "phase": "postmarket"}
+        us = _make_result(
+            code="AAPL",
+            name="Apple",
+            sentiment_score=90,
+        )
+        us.market_phase_summary = {"market": "us", "phase": "premarket"}
+
+        out = render("markdown", [cn, us], summary_only=True)
+
+        self.assertIsNotNone(out)
+        self.assertIn("市场状态：A股 · 盘后", out)
+        self.assertNotIn("市场状态：美股 · 盘前", out)
 
     def test_render_markdown_footer_uses_consistent_separator(self) -> None:
         r = _make_result(model_used="gemini/gemini-2.5-flash")


### PR DESCRIPTION
## PR Type

- [x] fix
- [ ] feat
- [ ] refactor
- [ ] docs
- [ ] chore
- [x] test

## Background And Problem

Fixes #1609

多股通知报告在 P6 接入市场阶段和 AnalysisContextPack 数据质量摘要后，会在每只股票摘要下重复输出 `阶段 / 触发来源 / 摘要来源 / 数据质量 / 限制` 等诊断信息。用户在 GitHub Actions 邮件里看到 10-20 只股票时，这些重复元数据很像“乱码”或异常内容，削弱摘要区的可读性。

本 PR 将聚合报告的阶段信息收敛为总览下方的一行 `市场状态`，例如：

```text
共分析 5 只股票 | 🟢买入:0 🟡观望:4 🔴卖出:1
市场状态：A股 · 盘后
```

## Review Follow-up

- 已检查 PR 评审反馈：当前只有一条旧 inline review thread，且已因 `a9147b3e` 变为 outdated；该问题对应 renderer 输入顺序，已修复并补测试。
- 自动审查曾提到“模板文件未修改”，但本 PR 已修改并纳入 diff 的模板文件包括：
  - `templates/report_markdown.j2`
  - `templates/report_brief.j2`
  - `templates/report_wechat.j2`
- 已补充 renderer 输入顺序回归：聚合报告的 `market_status_line` 优先按原始输入顺序选择第一条可用市场状态，避免排序后选错市场。
- 已在最新 head 执行本地 `ci_gate`：`PATH=/tmp/dsa-pr1612-venv/bin:$PATH ./scripts/ci_gate.sh` 完整通过，输出 `==> backend-gate: all checks passed`。
- 对 OpenReview 结构化风险检测的说明：本 PR diff 中出现的 `gemini/gemini-2.5-flash`、`models_used`、`show_llm_model` 均来自既有报告展示/测试上下文，触发来源是 `src/notification.py` 与 `tests/test_report_renderer.py` 附近的模型展示测试 hunk；本 PR 未新增或修改 provider、Base URL、LiteLLM 路由、模型名解析、运行时配置迁移、保存前模型清理或外部 API 兼容逻辑。

## Scope Of Change

- `src/market_phase_summary.py`
  - 新增 `format_public_market_status_line()`，将公开 `market_phase_summary` 格式化为单行市场/阶段状态。
- `src/notification.py`
  - 聚合日报、决策仪表盘、微信报告、精简/brief 报告在总览下方展示单行 `市场状态`。
  - 移除多股摘要/详情里逐股重复的 phase/pack excerpt 输出。
  - 单股报告仍保留既有 phase/pack excerpt，不改变单股诊断展示。
- `src/services/report_renderer.py`
  - Jinja renderer 注入 `market_status_line`，保证 renderer enabled/disabled 两条路径一致。
  - `market_status_line` 按原始输入顺序取第一条可用市场状态，避免结果排序影响展示语义。
- Jinja 模板文件
  - `templates/report_markdown.j2`：聚合报告总览下方展示 `market_status_line`，移除逐股复杂诊断块。
  - `templates/report_brief.j2`：brief 聚合报告展示 `market_status_line`，移除逐股复杂诊断块。
  - `templates/report_wechat.j2`：微信聚合报告展示 `market_status_line`，移除逐股复杂诊断块。
- `tests/test_market_phase_summary.py`、`tests/test_notification.py`、`tests/test_report_renderer.py`
  - 覆盖中文/英文市场状态格式化。
  - 覆盖 fallback 与 Jinja 聚合报告不再输出逐股复杂诊断字段。
  - 覆盖 renderer 选择市场状态时保留输入顺序。
- `docs/CHANGELOG.md`
  - 增加用户可见改进说明。

## Issue Link

Fixes #1609

## Verification Commands And Results

```bash
PATH=/tmp/dsa-pr1612-venv/bin:$PATH python -m pytest tests/test_market_phase_summary.py tests/test_notification.py tests/test_report_renderer.py -k "market_status or phase_pack_excerpt" -q
PATH=/tmp/dsa-pr1612-venv/bin:$PATH python -m pytest tests/test_market_phase_summary.py tests/test_notification.py tests/test_report_renderer.py -q
PATH=/tmp/dsa-pr1612-venv/bin:$PATH python -m py_compile src/market_phase_summary.py src/notification.py src/services/report_renderer.py
git diff --check origin/main...HEAD
PATH=/tmp/dsa-pr1612-venv/bin:$PATH ./scripts/ci_gate.sh
```

关键输出/结论：

- targeted pytest: `10 passed, 82 deselected, 11 warnings`
- related full pytest files: `92 passed, 11 warnings`
- `py_compile`: passed
- `git diff --check origin/main...HEAD`: passed
- local backend gate on latest head: `2771 passed, 2 deselected, 32 warnings, 258 subtests passed`，并输出 `==> backend-gate: all checks passed`

说明：本机系统 Python 缺少 `tiktoken` 且处于 externally-managed 环境；按 `requirements.txt` 约束在临时 venv `/tmp/dsa-pr1612-venv` 中安装 `tiktoken>=0.8.0,<0.12.0` 后执行验证。该 venv 未写入仓库。

本地预览聚合报告顶部已变为：

```text
# 🎯 2026-06-05 决策仪表盘

> 共分析 **2** 只股票 | 🟢买入:0 🟡观望:2 🔴卖出:0
市场状态：A股 · 盘后

## 📊 分析结果摘要
```

## Compatibility And Risk

- API / Web / Desktop：不修改 API schema、Web/桌面端字段契约或历史数据结构。
- 配置 / Docker / GitHub Actions：不新增配置项，不改变 `REPORT_TYPE`、`REPORT_SUMMARY_ONLY`、通知渠道或 Actions 触发逻辑。
- 模型 / Provider / Base URL / LiteLLM：不修改任何 provider、模型路由、Base URL、LiteLLM 参数、官方 API 兼容或运行时配置迁移语义；diff 中的模型字符串仅为既有报告展示测试上下文。
- fallback / 通知 / 报告结构：只调整多股通知报告的展示层，把逐股重复诊断收敛为总览单行；单股报告保留既有诊断 excerpt。
- 第三方依赖 / 官方约束来源：不涉及第三方模型、数据源或 provider fallback 语义。
- 旧配置迁移或静默改写风险：无配置迁移、无数据迁移、无静默改写。

风险点：

- 多股聚合通知不再逐股显示 `数据质量` 和前两条 `limitations`，若用户依赖这些字段排查单只股票，需要查看单股报告、Web 详情或运行日志。
- 聚合报告的 `市场状态` 取第一条可用 `market_phase_summary`。常规同市场批量分析下符合预期；跨市场混合股票时该行表示首个可用市场阶段。

## Rollback Plan

最小回滚方式是 revert this PR。无数据库迁移、配置项或外部依赖需要额外回滚。

## EXTRACT_PROMPT Change (if applicable)

未修改 `src/services/image_stock_extractor.py` 中的 `EXTRACT_PROMPT`。

<details>
<summary>展开 / Expand: Full EXTRACT_PROMPT</summary>

```text
N/A
```

</details>

## Checklist

- [x] 本 PR 有明确动机和业务价值 / This PR has a clear motivation and value
- [x] 已提供可复现的验证命令与结果 / Reproducible verification commands and results are included
- [x] 已评估兼容性与风险 / Compatibility and risk have been assessed
- [x] 已提供回滚方案 / A rollback plan is provided
- [x] 若涉及用户可见变更，已同步更新相关文档与 `docs/CHANGELOG.md`；`README.md` 仅在首页级信息变化时更新，细节优先写入 `docs/*.md` / If user-visible changes are included, relevant docs and `docs/CHANGELOG.md` are updated; `README.md` is updated only for homepage-level changes, with details kept in `docs/*.md`
