### PR TITLE
fix: 锁定问股追问的当前标的上下文 P2

### DIFF
--- a/apps/dsa-web/src/pages/ChatPage.tsx
+++ b/apps/dsa-web/src/pages/ChatPage.tsx
@@ -25,7 +25,7 @@ import {
 } from '../utils/chatFollowUp';
 import { isNearBottom } from '../utils/chatScroll';
 import { getReportText } from '../utils/reportLanguage';
-import { extractStockCodeFromMessage } from '../utils/chatStockCode';
+import { extractStockCodesFromMessage } from '../utils/chatStockCode';
 import { normalizeStockCode } from '../utils/stockCode';
 
 // Quick question examples shown on empty state
@@ -40,6 +40,17 @@ const QUICK_QUESTIONS = [
 
 const MAX_SELECTED_SKILLS = 3;
 const CONTEXT_COMPRESSION_CONFIG_KEY = 'AGENT_CONTEXT_COMPRESSION_ENABLED';
+const STRONG_COMPARE_STOCK_MESSAGE_RE = /比较|对比|\bvs\b|和[^，。,.!?！？]{0,40}比/i;
+const WEAK_COMPARE_STOCK_MESSAGE_RE = /差异(?!化)|区别|不同|相比|对照|比一比/;
+const CHOICE_COMPARE_STOCK_MESSAGE_RE = /哪个|哪只|哪一个|谁更|更值得|更适合|怎么选|选哪|二选一/;
+const LINKED_COMPARE_STOCK_MESSAGE_RE = /(?:和|与|跟|同)[^，。,.!?！？]{0,40}(?:差异(?!化)|区别|不同|相比|对照|比一比)/;
+const SWITCH_STOCK_MESSAGE_RE = /换成|改看|分析|看看|研究|诊断/;
+
+type ActiveStockContext = Pick<ChatFollowUpContext, 'stock_code' | 'stock_name'>;
+type ActiveStockResolution = {
+  context: ActiveStockContext;
+  useForCurrentSend: boolean;
+};
 
 const getMessageSkillNames = (msg: Message): string[] => {
   if (msg.skillNames?.length) return msg.skillNames;
@@ -50,6 +61,89 @@ const getMessageSkillNames = (msg: Message): string[] => {
 };
 
 const getMessageSkillLabel = (msg: Message): string => getMessageSkillNames(msg).join('、');
+
+const isCompareStockMessage = (
+  message: string,
+  stockCodes: string[],
+  currentStockCode?: string | null,
+): boolean => {
+  if (STRONG_COMPARE_STOCK_MESSAGE_RE.test(message)) {
+    return true;
+  }
+  const current = currentStockCode ? normalizeStockCode(currentStockCode) : null;
+  const newStockCodes = current
+    ? stockCodes.filter((code) => code !== current)
+    : stockCodes;
+  if (newStockCodes.length >= 2) {
+    return true;
+  }
+  if (CHOICE_COMPARE_STOCK_MESSAGE_RE.test(message) && stockCodes.length >= 2) {
+    return true;
+  }
+  if (!WEAK_COMPARE_STOCK_MESSAGE_RE.test(message)) {
+    return false;
+  }
+  if (stockCodes.length >= 2) {
+    return true;
+  }
+  if (!currentStockCode) {
+    return false;
+  }
+  const hasNewStock = stockCodes.some((code) => code !== current);
+  return hasNewStock && LINKED_COMPARE_STOCK_MESSAGE_RE.test(message);
+};
+
+const resolveActiveStockContextFromMessage = (
+  message: string,
+  currentContext: ActiveStockContext | null,
+): ActiveStockResolution | null => {
+  const stockCodes = extractStockCodesFromMessage(message);
+  const stockCode = stockCodes[0] ?? null;
+  if (!stockCode) {
+    return null;
+  }
+
+  const isCompare = isCompareStockMessage(message, stockCodes, currentContext?.stock_code);
+  const isSwitch = SWITCH_STOCK_MESSAGE_RE.test(message);
+  const currentStockCode = currentContext?.stock_code
+    ? normalizeStockCode(currentContext.stock_code)
+    : null;
+  const newStockCodes = currentStockCode
+    ? stockCodes.filter((code) => code !== currentStockCode)
+    : stockCodes;
+  const targetStockCode = isSwitch && newStockCodes.length === 1
+    ? newStockCodes[0]
+    : stockCode;
+  const isDifferentStock = currentStockCode !== targetStockCode;
+
+  if (isCompare || (currentContext && !isSwitch)) {
+    return null;
+  }
+
+  return {
+    context: {
+      stock_code: targetStockCode,
+      stock_name: currentContext && !isDifferentStock
+        ? currentContext.stock_name
+        : null,
+    },
+    useForCurrentSend: isSwitch && isDifferentStock,
+  };
+};
+
+const restoreActiveStockContextFromMessages = (messages: Message[]): ActiveStockContext | null => {
+  let restoredContext: ActiveStockContext | null = null;
+  for (const message of messages) {
+    if (message.role !== 'user') {
+      continue;
+    }
+    const resolution = resolveActiveStockContextFromMessage(message.content, restoredContext);
+    if (resolution) {
+      restoredContext = resolution.context;
+    }
+  }
+  return restoredContext;
+};
 
 const ChatPage: React.FC = () => {
   const [searchParams, setSearchParams] = useSearchParams();
@@ -78,6 +172,7 @@ const ChatPage: React.FC = () => {
   const [isWatchlistActioning, setIsWatchlistActioning] = useState(false);
   const [watchlistMessage, setWatchlistMessage] = useState<string | null>(null);
   const [activeStockCode, setActiveStockCode] = useState<string | null>(null);
+  const [activeStockContext, setActiveStockContext] = useState<ActiveStockContext | null>(null);
   const watchlistMessageTimerRef = useRef<number | null>(null);
   const copyResetTimerRef = useRef<Partial<Record<string, number>>>({});
   const messagesViewportRef = useRef<HTMLDivElement>(null);
@@ -190,6 +285,18 @@ const ChatPage: React.FC = () => {
     startStream,
     clearCompletionBadge,
   } = useAgentChatStore();
+
+  useEffect(() => {
+    if (activeStockContext || messages.length === 0) {
+      return;
+    }
+    const restoredContext = restoreActiveStockContextFromMessages(messages);
+    if (!restoredContext) {
+      return;
+    }
+    setActiveStockContext(restoredContext);
+    setActiveStockCode(restoredContext.stock_code);
+  }, [activeStockContext, messages, sessionId]);
 
   const syncScrollState = useCallback(() => {
     const viewport = messagesViewportRef.current;
@@ -374,16 +481,25 @@ const ChatPage: React.FC = () => {
 
   const handleStartNewChat = useCallback(() => {
     followUpContextRef.current = null;
+    setActiveStockContext(null);
+    setActiveStockCode(null);
     requestScrollToBottom('auto');
     useAgentChatStore.getState().startNewChat();
     setSidebarOpen(false);
   }, [requestScrollToBottom]);
 
   const handleSwitchSession = useCallback((targetSessionId: string) => {
+    if (targetSessionId === sessionId) {
+      setSidebarOpen(false);
+      return;
+    }
+    followUpContextRef.current = null;
+    setActiveStockContext(null);
+    setActiveStockCode(null);
     requestScrollToBottom('auto');
     switchSession(targetSessionId);
     setSidebarOpen(false);
-  }, [requestScrollToBottom, switchSession]);
+  }, [requestScrollToBottom, sessionId, switchSession]);
 
   const confirmDelete = useCallback(() => {
     if (!deleteConfirmId) return;
@@ -414,6 +530,10 @@ const ChatPage: React.FC = () => {
     const hydrationToken = ++followUpHydrationTokenRef.current;
     setInput(buildFollowUpPrompt(stock, name));
     setActiveStockCode(stock);
+    setActiveStockContext({
+      stock_code: stock,
+      stock_name: name,
+    });
     followUpContextRef.current = {
       stock_code: stock,
       stock_name: name,
@@ -445,16 +565,24 @@ const ChatPage: React.FC = () => {
       const usedSkillIds = normalizeSelectedSkillIds(overrideSkillIds ?? selectedSkillIds);
       const usedSkillNames = usedSkillIds.length > 0 ? getSkillNames(usedSkillIds) : ['通用'];
 
-      const stockCode = extractStockCodeFromMessage(msgText);
-      if (stockCode) {
-        setActiveStockCode(stockCode);
+      let nextActiveStockContext = activeStockContext;
+      let useActiveContextForThisSend = false;
+      const stockResolution = resolveActiveStockContextFromMessage(msgText, activeStockContext);
+      if (stockResolution) {
+        nextActiveStockContext = stockResolution.context;
+        useActiveContextForThisSend = stockResolution.useForCurrentSend;
+        setActiveStockContext(nextActiveStockContext);
+        setActiveStockCode(nextActiveStockContext.stock_code);
       }
+      const contextForSend = useActiveContextForThisSend
+        ? nextActiveStockContext
+        : followUpContextRef.current ?? nextActiveStockContext ?? undefined;
 
       const payload = {
         message: msgText,
         session_id: sessionId,
         ...(usedSkillIds.length > 0 ? { skills: usedSkillIds } : {}),
-        context: followUpContextRef.current ?? undefined,
+        context: contextForSend ?? undefined,
       };
       followUpHydrationTokenRef.current += 1;
       followUpContextRef.current = null;
@@ -467,7 +595,7 @@ const ChatPage: React.FC = () => {
         skillName: usedSkillNames.join('、'),
       });
     },
-    [getSkillNames, input, loading, normalizeSelectedSkillIds, requestScrollToBottom, selectedSkillIds, sessionId, startStream],
+    [activeStockContext, getSkillNames, input, loading, normalizeSelectedSkillIds, requestScrollToBottom, selectedSkillIds, sessionId, startStream],
   );
 
   const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {

--- a/apps/dsa-web/src/pages/__tests__/ChatPage.test.tsx
+++ b/apps/dsa-web/src/pages/__tests__/ChatPage.test.tsx
@@ -5,7 +5,7 @@ import { createParsedApiError } from '../../api/error';
 import { historyApi } from '../../api/history';
 import type { Message } from '../../stores/agentChatStore';
 import ChatPage from '../ChatPage';
-import { extractStockCodeFromMessage } from '../../utils/chatStockCode';
+import { extractStockCodeFromMessage, extractStockCodesFromMessage } from '../../utils/chatStockCode';
 
 function createDeferred<T>() {
   let resolve!: (value: T) => void;
@@ -294,7 +294,7 @@ describe('ChatPage', () => {
     expect(screen.getByText('配置服务不可用')).toBeInTheDocument();
   });
 
-  it('switches session when clicking anywhere on the session card', async () => {
+  it('does not switch when clicking the current session card', async () => {
     render(
       <MemoryRouter initialEntries={['/chat']}>
         <ChatPage />
@@ -306,7 +306,7 @@ describe('ChatPage', () => {
     });
 
     fireEvent.click(sessionCard);
-    expect(mockSwitchSession).toHaveBeenCalledWith('session-1');
+    expect(mockSwitchSession).not.toHaveBeenCalled();
     expect(sessionCard).toHaveAttribute('aria-current', 'page');
   });
 
@@ -695,7 +695,30 @@ describe('ChatPage', () => {
       expect(mockStartStream).toHaveBeenLastCalledWith(
         expect.objectContaining({
           message: '继续分析成交量',
-          context: undefined,
+          context: expect.objectContaining({
+            stock_code: '600519',
+            stock_name: '贵州茅台',
+          }),
+        }),
+        expect.objectContaining({
+          skillName: '趋势分析',
+        }),
+      );
+    });
+
+    fireEvent.change(screen.getByPlaceholderText(/分析 600519/), {
+      target: { value: '如果不考虑 TTM 呢' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: '发送' }));
+
+    await waitFor(() => {
+      expect(mockStartStream).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          message: '如果不考虑 TTM 呢',
+          context: expect.objectContaining({
+            stock_code: '600519',
+            stock_name: '贵州茅台',
+          }),
         }),
         expect.objectContaining({
           skillName: '趋势分析',
@@ -788,6 +811,459 @@ describe('ChatPage', () => {
       );
     });
     expect(historyApi.getDetail).not.toHaveBeenCalled();
+
+    fireEvent.change(screen.getByPlaceholderText(/分析 600519/), {
+      target: { value: '继续看估值' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: '发送' }));
+
+    await waitFor(() => {
+      expect(mockStartStream).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          message: '继续看估值',
+          context: {
+            stock_code: 'AAPL',
+            stock_name: null,
+          },
+        }),
+        expect.objectContaining({
+          skillName: '趋势分析',
+        }),
+      );
+    });
+  });
+
+  it('switches active stock context for explicit switch messages', async () => {
+    render(
+      <MemoryRouter initialEntries={['/chat?stock=600519&name=%E8%B4%B5%E5%B7%9E%E8%8C%85%E5%8F%B0']}>
+        <ChatPage />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByDisplayValue('请深入分析 贵州茅台(600519)')).toBeInTheDocument();
+
+    fireEvent.change(screen.getByPlaceholderText(/分析 600519/), {
+      target: { value: '换成 AAPL 看看' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: '发送' }));
+
+    await waitFor(() => {
+      expect(mockStartStream).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          message: '换成 AAPL 看看',
+          context: {
+            stock_code: 'AAPL',
+            stock_name: null,
+          },
+        }),
+        expect.objectContaining({
+          skillName: '趋势分析',
+        }),
+      );
+    });
+  });
+
+  it('switches to the single new stock when the current stock appears first', async () => {
+    render(
+      <MemoryRouter initialEntries={['/chat?stock=600519&name=%E8%B4%B5%E5%B7%9E%E8%8C%85%E5%8F%B0']}>
+        <ChatPage />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByDisplayValue('请深入分析 贵州茅台(600519)')).toBeInTheDocument();
+
+    fireEvent.change(screen.getByPlaceholderText(/分析 600519/), {
+      target: { value: '先不看 600519，换成 AAPL 看看' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: '发送' }));
+
+    await waitFor(() => {
+      expect(mockStartStream).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          message: '先不看 600519，换成 AAPL 看看',
+          context: {
+            stock_code: 'AAPL',
+            stock_name: null,
+          },
+        }),
+        expect.objectContaining({
+          skillName: '趋势分析',
+        }),
+      );
+    });
+
+    fireEvent.change(screen.getByPlaceholderText(/分析 600519/), {
+      target: { value: '继续看支撑位' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: '发送' }));
+
+    await waitFor(() => {
+      expect(mockStartStream).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          message: '继续看支撑位',
+          context: {
+            stock_code: 'AAPL',
+            stock_name: null,
+          },
+        }),
+        expect.objectContaining({
+          skillName: '趋势分析',
+        }),
+      );
+    });
+  });
+
+  it('keeps active stock context for compare messages', async () => {
+    render(
+      <MemoryRouter initialEntries={['/chat?stock=600519&name=%E8%B4%B5%E5%B7%9E%E8%8C%85%E5%8F%B0']}>
+        <ChatPage />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByDisplayValue('请深入分析 贵州茅台(600519)')).toBeInTheDocument();
+
+    fireEvent.change(screen.getByPlaceholderText(/分析 600519/), {
+      target: { value: '比较 600519 和 AAPL' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: '发送' }));
+
+    await waitFor(() => {
+      expect(mockStartStream).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          message: '比较 600519 和 AAPL',
+          context: {
+            stock_code: '600519',
+            stock_name: '贵州茅台',
+          },
+        }),
+        expect.objectContaining({
+          skillName: '趋势分析',
+        }),
+      );
+    });
+  });
+
+  it('keeps active stock context for difference-style compare messages', async () => {
+    render(
+      <MemoryRouter initialEntries={['/chat?stock=600519&name=%E8%B4%B5%E5%B7%9E%E8%8C%85%E5%8F%B0']}>
+        <ChatPage />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByDisplayValue('请深入分析 贵州茅台(600519)')).toBeInTheDocument();
+
+    fireEvent.change(screen.getByPlaceholderText(/分析 600519/), {
+      target: { value: '分析 600519 和 AAPL 的差异' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: '发送' }));
+
+    await waitFor(() => {
+      expect(mockStartStream).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          message: '分析 600519 和 AAPL 的差异',
+          context: {
+            stock_code: '600519',
+            stock_name: '贵州茅台',
+          },
+        }),
+        expect.objectContaining({
+          skillName: '趋势分析',
+        }),
+      );
+    });
+  });
+
+  it('keeps active stock context when the compared stock appears first', async () => {
+    render(
+      <MemoryRouter initialEntries={['/chat?stock=600519&name=%E8%B4%B5%E5%B7%9E%E8%8C%85%E5%8F%B0']}>
+        <ChatPage />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByDisplayValue('请深入分析 贵州茅台(600519)')).toBeInTheDocument();
+
+    fireEvent.change(screen.getByPlaceholderText(/分析 600519/), {
+      target: { value: '分析 AAPL 和 600519 的差异' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: '发送' }));
+
+    await waitFor(() => {
+      expect(mockStartStream).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          message: '分析 AAPL 和 600519 的差异',
+          context: {
+            stock_code: '600519',
+            stock_name: '贵州茅台',
+          },
+        }),
+        expect.objectContaining({
+          skillName: '趋势分析',
+        }),
+      );
+    });
+  });
+
+  it('keeps active stock context for choice-style multi-stock messages', async () => {
+    render(
+      <MemoryRouter initialEntries={['/chat?stock=600519&name=%E8%B4%B5%E5%B7%9E%E8%8C%85%E5%8F%B0']}>
+        <ChatPage />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByDisplayValue('请深入分析 贵州茅台(600519)')).toBeInTheDocument();
+
+    fireEvent.change(screen.getByPlaceholderText(/分析 600519/), {
+      target: { value: 'AAPL 和 TSLA 哪个更值得买' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: '发送' }));
+
+    await waitFor(() => {
+      expect(mockStartStream).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          message: 'AAPL 和 TSLA 哪个更值得买',
+          context: {
+            stock_code: '600519',
+            stock_name: '贵州茅台',
+          },
+        }),
+        expect.objectContaining({
+          skillName: '趋势分析',
+        }),
+      );
+    });
+  });
+
+  it('switches active stock context for single-stock difference phrasing', async () => {
+    render(
+      <MemoryRouter initialEntries={['/chat?stock=600519&name=%E8%B4%B5%E5%B7%9E%E8%8C%85%E5%8F%B0']}>
+        <ChatPage />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByDisplayValue('请深入分析 贵州茅台(600519)')).toBeInTheDocument();
+
+    fireEvent.change(screen.getByPlaceholderText(/分析 600519/), {
+      target: { value: '分析 AAPL 的差异化优势' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: '发送' }));
+
+    await waitFor(() => {
+      expect(mockStartStream).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          message: '分析 AAPL 的差异化优势',
+          context: {
+            stock_code: 'AAPL',
+            stock_name: null,
+          },
+        }),
+        expect.objectContaining({
+          skillName: '趋势分析',
+        }),
+      );
+    });
+  });
+
+  it('switches active stock context for lowercase US ticker switch messages', async () => {
+    render(
+      <MemoryRouter initialEntries={['/chat?stock=600519&name=%E8%B4%B5%E5%B7%9E%E8%8C%85%E5%8F%B0']}>
+        <ChatPage />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByDisplayValue('请深入分析 贵州茅台(600519)')).toBeInTheDocument();
+
+    fireEvent.change(screen.getByPlaceholderText(/分析 600519/), {
+      target: { value: '分析tsla' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: '发送' }));
+
+    await waitFor(() => {
+      expect(mockStartStream).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          message: '分析tsla',
+          context: {
+            stock_code: 'TSLA',
+            stock_name: null,
+          },
+        }),
+        expect.objectContaining({
+          skillName: '趋势分析',
+        }),
+      );
+    });
+  });
+
+  it('keeps active stock context when clicking the current session', async () => {
+    render(
+      <MemoryRouter initialEntries={['/chat?stock=600519&name=%E8%B4%B5%E5%B7%9E%E8%8C%85%E5%8F%B0']}>
+        <ChatPage />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByDisplayValue('请深入分析 贵州茅台(600519)')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: '切换到对话 请简要分析 600519' }));
+    expect(mockSwitchSession).not.toHaveBeenCalled();
+
+    fireEvent.change(screen.getByPlaceholderText(/分析 600519/), {
+      target: { value: '继续看成交量' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: '发送' }));
+
+    await waitFor(() => {
+      expect(mockStartStream).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          message: '继续看成交量',
+          context: {
+            stock_code: '600519',
+            stock_name: '贵州茅台',
+          },
+        }),
+        expect.objectContaining({
+          skillName: '趋势分析',
+        }),
+      );
+    });
+  });
+
+  it('restores active stock context from loaded session messages', async () => {
+    mockStoreState.messages = [
+      { id: 'm-1', role: 'user', content: '请分析 600519' },
+      { id: 'm-2', role: 'assistant', content: '600519 分析结果' },
+      { id: 'm-3', role: 'user', content: '先不看 600519，换成 AAPL 看看' },
+      { id: 'm-4', role: 'assistant', content: 'AAPL 分析结果' },
+    ];
+
+    render(
+      <MemoryRouter initialEntries={['/chat']}>
+        <ChatPage />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByTestId('chat-workspace')).toBeInTheDocument();
+
+    fireEvent.change(screen.getByPlaceholderText(/分析 600519/), {
+      target: { value: '继续看支撑位' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: '发送' }));
+
+    await waitFor(() => {
+      expect(mockStartStream).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          message: '继续看支撑位',
+          context: {
+            stock_code: 'AAPL',
+            stock_name: null,
+          },
+        }),
+        expect.objectContaining({
+          skillName: '趋势分析',
+        }),
+      );
+    });
+  });
+
+  it('clears active stock context when starting a new chat or switching sessions', async () => {
+    mockStoreState.sessions = [
+      ...mockStoreState.sessions,
+      {
+        session_id: 'session-2',
+        title: '旧会话',
+        message_count: 1,
+        created_at: '2026-03-16T09:00:00Z',
+        last_active: '2026-03-16T09:05:00Z',
+      },
+    ];
+
+    const { unmount } = render(
+      <MemoryRouter initialEntries={['/chat?stock=600519&name=%E8%B4%B5%E5%B7%9E%E8%8C%85%E5%8F%B0']}>
+        <ChatPage />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByDisplayValue('请深入分析 贵州茅台(600519)')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: '开启新对话' }));
+    expect(mockStartNewChat).toHaveBeenCalled();
+
+    fireEvent.change(screen.getByPlaceholderText(/分析 600519/), {
+      target: { value: '继续看成交量' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: '发送' }));
+
+    await waitFor(() => {
+      expect(mockStartStream).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          message: '继续看成交量',
+          context: undefined,
+        }),
+        expect.objectContaining({
+          skillName: '趋势分析',
+        }),
+      );
+    });
+
+    unmount();
+    mockStartStream.mockClear();
+
+    render(
+      <MemoryRouter initialEntries={['/chat?stock=600519&name=%E8%B4%B5%E5%B7%9E%E8%8C%85%E5%8F%B0']}>
+        <ChatPage />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByDisplayValue('请深入分析 贵州茅台(600519)')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: '切换到对话 旧会话' }));
+    expect(mockSwitchSession).toHaveBeenCalledWith('session-2');
+
+    fireEvent.change(screen.getByPlaceholderText(/分析 600519/), {
+      target: { value: '继续看成交量' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: '发送' }));
+
+    await waitFor(() => {
+      expect(mockStartStream).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          message: '继续看成交量',
+          context: undefined,
+        }),
+        expect.objectContaining({
+          skillName: '趋势分析',
+        }),
+      );
+    });
+  });
+
+  it('clears active stock context when deleting the current session', async () => {
+    render(
+      <MemoryRouter initialEntries={['/chat?stock=600519&name=%E8%B4%B5%E5%B7%9E%E8%8C%85%E5%8F%B0']}>
+        <ChatPage />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByDisplayValue('请深入分析 贵州茅台(600519)')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: '删除对话 请简要分析 600519' }));
+    fireEvent.click(screen.getByRole('button', { name: '删除' }));
+
+    await waitFor(() => {
+      expect(mockDeleteChatSession).toHaveBeenCalledWith('session-1');
+    });
+    expect(mockStartNewChat).toHaveBeenCalled();
+
+    fireEvent.change(screen.getByPlaceholderText(/分析 600519/), {
+      target: { value: '继续看成交量' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: '发送' }));
+
+    await waitFor(() => {
+      expect(mockStartStream).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          message: '继续看成交量',
+          context: undefined,
+        }),
+        expect.objectContaining({
+          skillName: '趋势分析',
+        }),
+      );
+    });
   });
 
   it('ignores malformed follow-up query params', async () => {
@@ -999,6 +1475,35 @@ describe('extractStockCodeFromMessage', () => {
 
   it('returns SZ-prefixed code when standalone (normalized)', () => {
     expect(extractStockCodeFromMessage('SZ000001')).toBe('000001');
+  });
+
+  it('returns all stock codes in message order', () => {
+    expect(extractStockCodesFromMessage('分析 600519 和 AAPL 的差异')).toEqual(['600519', 'AAPL']);
+    expect(extractStockCodesFromMessage('分析 AAPL 和 600519 的差异')).toEqual(['AAPL', '600519']);
+    expect(extractStockCodesFromMessage('AAPL 和 TSLA 哪个更值得买')).toEqual(['AAPL', 'TSLA']);
+  });
+
+  it('extracts lowercase tickers only with explicit stock intent hints', () => {
+    expect(extractStockCodesFromMessage('分析tsla')).toEqual(['TSLA']);
+    expect(extractStockCodesFromMessage('看看 tsla')).toEqual(['TSLA']);
+    expect(extractStockCodesFromMessage('aapl 和 tsla 哪个更值得买')).toEqual(['AAPL', 'TSLA']);
+    expect(extractStockCodesFromMessage('hello tsla')).toEqual([]);
+  });
+
+  it('returns all HK and A-share variants without exchange affix tokens', () => {
+    expect(extractStockCodesFromMessage('比较 01810 和 AAPL')).toEqual(['HK01810', 'AAPL']);
+    expect(extractStockCodesFromMessage('比较 1810.HK 和 AAPL')).toEqual(['HK01810', 'AAPL']);
+    expect(extractStockCodesFromMessage('比较 600519.SH 和 AAPL')).toEqual(['600519', 'AAPL']);
+    expect(extractStockCodesFromMessage('比较 000001.SZ 和 SS')).toEqual(['000001']);
+    expect(extractStockCodesFromMessage('比较 SH600519 和 AAPL')).toEqual(['600519', 'AAPL']);
+    expect(extractStockCodesFromMessage('比较 SZ000001 和 AAPL')).toEqual(['000001', 'AAPL']);
+    expect(extractStockCodesFromMessage('比较 BJ920748 和 AAPL')).toEqual(['920748', 'AAPL']);
+    expect(extractStockCodesFromMessage('比较 HK01810 和 AAPL')).toEqual(['HK01810', 'AAPL']);
+  });
+
+  it('does not return denied abbreviations in multi-code extraction', () => {
+    expect(extractStockCodesFromMessage('如果不考虑 TTM 和 PE')).toEqual([]);
+    expect(extractStockCodesFromMessage('MACD AAPL 和 RSI')).toEqual(['AAPL']);
   });
 });
 

--- a/apps/dsa-web/src/utils/__tests__/stockCode.test.ts
+++ b/apps/dsa-web/src/utils/__tests__/stockCode.test.ts
@@ -34,6 +34,11 @@ describe('normalizeStockCode', () => {
     expect(normalizeStockCode('hk1810')).toBe('HK01810');
   });
 
+  it('normalizes pure 5-digit HK codes to canonical prefix form', () => {
+    expect(normalizeStockCode('00700')).toBe('HK00700');
+    expect(normalizeStockCode('01810')).toBe('HK01810');
+  });
+
   it('normalizes HK suffix to canonical prefix form', () => {
     expect(normalizeStockCode('00700.HK')).toBe('HK00700');
     expect(normalizeStockCode('1810.HK')).toBe('HK01810');
@@ -59,7 +64,7 @@ describe('normalizeStockCode', () => {
   });
 
   it('handles HK variants as equivalent', () => {
-    const codes = ['HK00700', '00700.HK', 'hk00700'];
+    const codes = ['00700', 'HK00700', '00700.HK', 'hk00700'];
     const normalized = codes.map(normalizeStockCode);
     expect(new Set(normalized).size).toBe(1);
     expect(normalized[0]).toBe('HK00700');

--- a/apps/dsa-web/src/utils/chatStockCode.ts
+++ b/apps/dsa-web/src/utils/chatStockCode.ts
@@ -2,6 +2,7 @@ import { validateStockCode } from './validation';
 import { normalizeStockCode } from './stockCode';
 
 const EXCHANGE_PREFIXES = new Set(['SH', 'SZ', 'BJ', 'HK', 'US', 'SS']);
+const LOWERCASE_TICKER_CONTEXT_RE = /换成|改看|分析|看看|研究|诊断|比较|对比|\bvs\b|和[^，。,.!?！？]{0,40}比|差异(?!化)|区别|不同|相比|对照|比一比|哪个|哪只|哪一个|谁更|更值得|更适合|怎么选|选哪|二选一/i;
 
 // Mirrors backend _COMMON_WORDS for #1596 free-text extraction only.
 // Explicit validation via validateStockCode() intentionally keeps its original contract.
@@ -40,6 +41,10 @@ function isDeniedTickerCandidate(value: string): boolean {
 }
 
 export function extractStockCodeFromMessage(message: string): string | null {
+  return extractStockCodesFromMessage(message)[0] ?? null;
+}
+
+export function extractStockCodesFromMessage(message: string): string[] {
   // More specific patterns first to avoid greedy \d{6} capturing inside .SH/.SZ codes
   const patterns = [
     /\b(30\d{4}\.SZ)\b/gi,
@@ -54,20 +59,43 @@ export function extractStockCodeFromMessage(message: string): string | null {
     /\b(\d{5,6})\b/g,
     /\b([A-Z]{2,5})\b/g,
   ];
-  for (const pattern of patterns) {
-    const matches = message.match(pattern);
-    if (matches) {
-      for (const m of matches) {
-        if (EXCHANGE_PREFIXES.has(m.toUpperCase())) {
-          continue;
-        }
-        if (isDeniedTickerCandidate(m)) {
-          continue;
-        }
-        const { valid, normalized } = validateStockCode(m);
-        if (valid) return normalizeStockCode(normalized);
-      }
+  if (LOWERCASE_TICKER_CONTEXT_RE.test(message)) {
+    patterns.push(/\b([a-z]{2,5}(?:\.[a-z]{1,2})?)\b/g);
+  }
+
+  const matches: Array<{ value: string; index: number; priority: number }> = [];
+  patterns.forEach((pattern, priority) => {
+    pattern.lastIndex = 0;
+    for (const match of message.matchAll(pattern)) {
+      const value = match[1] ?? match[0];
+      matches.push({
+        value,
+        index: match.index ?? 0,
+        priority,
+      });
+    }
+  });
+
+  matches.sort((a, b) => a.index - b.index || a.priority - b.priority);
+
+  const stockCodes: string[] = [];
+  const seen = new Set<string>();
+  for (const match of matches) {
+    if (EXCHANGE_PREFIXES.has(match.value.toUpperCase())) {
+      continue;
+    }
+    if (isDeniedTickerCandidate(match.value)) {
+      continue;
+    }
+    const { valid, normalized } = validateStockCode(match.value);
+    if (!valid) {
+      continue;
+    }
+    const stockCode = normalizeStockCode(normalized);
+    if (!seen.has(stockCode)) {
+      seen.add(stockCode);
+      stockCodes.push(stockCode);
     }
   }
-  return null;
+  return stockCodes;
 }

--- a/apps/dsa-web/src/utils/stockCode.ts
+++ b/apps/dsa-web/src/utils/stockCode.ts
@@ -7,7 +7,8 @@
  *   600519.SH   → 600519     SH.600519   → 600519
  *   SZ000001    → 000001     000001.SZ   → 000001
  *   BJ920748    → 920748     920748.BJ   → 920748
- *   HK00700     → HK00700    00700.HK    → HK00700
+ *   HK00700     → HK00700    00700       → HK00700
+ *   00700.HK    → HK00700
  *   hk1810      → HK01810    1810.HK     → HK01810
  *   AAPL        → AAPL       TSLA        → TSLA
  */
@@ -21,6 +22,11 @@ export function normalizeStockCode(stockCode: string): string {
     if (/^\d{1,5}$/.test(candidate) && candidate.length >= 1 && candidate.length <= 5) {
       return `HK${candidate.padStart(5, '0')}`;
     }
+  }
+
+  // Pure 5-digit codes are HK stocks by validateStockCode() contract.
+  if (/^\d{5}$/.test(upper)) {
+    return `HK${upper}`;
   }
 
   // Strip SH/SZ prefix (e.g. SH600519 → 600519)

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 ## [Unreleased]
 
 - [改进] 多股通知报告将市场阶段收敛为总览下方单行 `市场状态`，不再在每只股票摘要下重复展示数据质量和限制详情。
+- [修复] 问股从历史报告进入后的追问会持续携带当前标的，切回或重载已有会话时可从历史消息恢复基础当前标的，并由后端阻断未明确切换时的错误股票工具调用。
 - [修复] Web 个股栏和历史卡片在窄布局下不再让市场阶段标签遮挡股票名称。
 - [修复] 问股自由文本追问不再将 TTM、PE、YOY 等金融缩写误识别为新股票代码。
 - [修复] GitHub Actions 每日分析工作流读取 SearXNG 自建实例地址时支持 Variables 优先、Secrets 回退，修复仅配置 Variables 时 URL 不生效的问题。

--- a/docs/full-guide.md
+++ b/docs/full-guide.md
@@ -1348,6 +1348,7 @@ FastAPI 提供 RESTful API 服务，支持配置管理和触发分析。
 - 🗂️ **市场复盘历史独立入口** - 大盘复盘历史通过专用入口与普通个股历史隔离；建议通过 `stock_code=MARKET` + `report_type=market_review` 直接查询与回放大盘复盘记录
 - 🧾 **市场复盘历史可复用** - 大盘复盘任务会持久化到分析历史，`report_type` 为 `market_review`，可直接通过历史列表/详情打开对应 Markdown 或详情页，不会重新触发分析重算
 - 🧩 **输入数据块可见** - 普通分析报告会在历史详情、同步响应和 completed 任务状态中返回低敏 `AnalysisContextPack` overview，Web 报告页在策略点位和资讯之后默认折叠展示数据块状态、来源、缺失原因和降级摘要
+- 💬 **问股追问上下文** - 从历史报告进入问股后，后续追问会持续携带当前 `stock_code/stock_name`；切回或重载已有问股会话时，会从已加载的历史用户消息恢复基础当前标的；只有用户明确切换标的时才切换上下文，含比较/对比/vs/差异/相比等明确比较意图或多个非当前明确股票代码的问题不会污染当前标的
 - 📈 **回测验证** - 评估历史分析准确率，查询方向胜率与模拟收益
 - 🔗 **API 文档** - 访问 `/docs` 查看 Swagger UI
 
@@ -1387,6 +1388,7 @@ FastAPI 提供 RESTful API 服务，支持配置管理和触发分析。
 > 说明：`GET /api/v1/history` 的列表摘要可按 `stock_code` 分页查询同一股票历史，并返回趋势判断、分析摘要、模型名与分析时价格/涨跌幅等可选字段；旧记录缺少快照字段时返回空值。Web 报告页的“历史趋势”抽屉复用该接口加载同股历史。
 > 说明（Issue #1520）：列表中的模型名展示字段仅来源于历史快照中的 `model_used`，仅用于历史回溯展示，不影响运行时模型模型路由（`litellm_model`、`llm_model_list`）、Provider、Base URL 与配置迁移/清理语义。回退方式为回退本次提交，现网历史查询/抽屉/接口链路兼容性保持不变。
 > 说明：历史详情、同步分析响应和 completed 任务状态会在 `report.details.analysis_context_pack_overview` 返回低敏输入数据块 overview；其中同步分析响应依赖本次已持久化的 `analysis_history.context_snapshot`，`SAVE_CONTEXT_SNAPSHOT=false` 时新记录不保证返回 overview。`details.context_snapshot` 会剥离该顶层字段，不返回完整 `AnalysisContextPack` 或 Prompt summary。
+> 说明：`POST /api/v1/agent/chat` 与 `POST /api/v1/agent/chat/stream` 会把前端传入的 `context.stock_code` 作为问股当前标的基线。前端从历史报告进入问股后会持续发送 active stock context；切回或重载已有会话时，会根据已加载的历史用户消息恢复基础 `{stock_code, stock_name: null}`。服务端会在每轮消息中重新判定 `maintain` / `switch` / `compare`：未明确切换时，带 `stock_code` 的股票工具调用只能访问当前标的；显式切换会清理旧标的历史摘要和预取数据；含比较/对比/vs/差异/相比等明确比较意图或多个非当前明确股票代码的问题允许本轮明确出现的多个代码，但不改写当前标的。若模型误把 TTM、PE、MACD 等金融缩写当成股票代码调用工具，后端会返回不可重试的 `stock_scope_violation` 工具结果，而不会执行对应股票工具。
 
 > 兼容性审计证据：
 > - 官方来源：LiteLLM OpenAI-compatible provider 文档 <https://docs.litellm.ai/docs/providers/openai_compatible>；OpenAI Chat API 文档 <https://platform.openai.com/docs/api-reference/chat/create>；DeepSeek API 文档 <https://api-docs.deepseek.com/>。

--- a/src/agent/agents/base_agent.py
+++ b/src/agent/agents/base_agent.py
@@ -119,6 +119,7 @@ class BaseAgent(ABC):
                 max_steps=self.max_steps,
                 progress_callback=progress_callback,
                 max_wall_clock_seconds=timeout_seconds,
+                stock_scope=ctx.meta.get("stock_scope"),
             )
 
             result.tokens_used = loop_result.total_tokens

--- a/src/agent/executor.py
+++ b/src/agent/executor.py
@@ -25,6 +25,7 @@ from src.agent.chat_context import build_agent_chat_context_bundle
 from src.agent.llm_adapter import LLMToolAdapter
 from src.agent.provider_trace import extract_provider_trace_turns
 from src.agent.runner import run_agent_loop, parse_dashboard_json
+from src.agent.stock_scope import StockScope, resolve_stock_scope
 from src.storage import get_db
 from src.agent.tools.registry import ToolRegistry
 from src.report_language import normalize_report_language
@@ -556,6 +557,9 @@ class AgentExecutor:
         """
         from src.agent.conversation import conversation_manager
 
+        scope_resolution = resolve_stock_scope(message, context)
+        context = scope_resolution.effective_context
+
         # Build system prompt with skills
         skills_section = ""
         if self.skill_instructions:
@@ -625,7 +629,13 @@ class AgentExecutor:
         # Persist the user turn immediately so the session appears in history during processing
         user_message_id = conversation_manager.add_message(session_id, "user", message)
 
-        result = self._run_loop(messages, tool_decls, parse_dashboard=False, progress_callback=progress_callback)
+        result = self._run_loop(
+            messages,
+            tool_decls,
+            parse_dashboard=False,
+            progress_callback=progress_callback,
+            stock_scope=scope_resolution.stock_scope,
+        )
 
         # Persist assistant reply (or error note) for context continuity
         if result.success:
@@ -718,7 +728,14 @@ class AgentExecutor:
                     exc_info=True,
                 )
 
-    def _run_loop(self, messages: List[Dict[str, Any]], tool_decls: List[Dict[str, Any]], parse_dashboard: bool, progress_callback: Optional[Callable] = None) -> AgentResult:
+    def _run_loop(
+        self,
+        messages: List[Dict[str, Any]],
+        tool_decls: List[Dict[str, Any]],
+        parse_dashboard: bool,
+        progress_callback: Optional[Callable] = None,
+        stock_scope: Optional[StockScope] = None,
+    ) -> AgentResult:
         """Delegate to the shared runner and adapt the result.
 
         This preserves the exact same observable behaviour as the original
@@ -732,6 +749,7 @@ class AgentExecutor:
             max_steps=self.max_steps,
             progress_callback=progress_callback,
             max_wall_clock_seconds=self.timeout_seconds,
+            stock_scope=stock_scope,
         )
 
         model_str = loop_result.model

--- a/src/agent/orchestrator.py
+++ b/src/agent/orchestrator.py
@@ -41,6 +41,7 @@ from src.agent.protocols import (
     normalize_decision_signal,
 )
 from src.agent.runner import parse_dashboard_json
+from src.agent.stock_scope import resolve_stock_scope
 from src.agent.tools.registry import ToolRegistry
 from src.agent.chat_context import build_visible_chat_history
 from src.config import AGENT_MAX_STEPS_DEFAULT, get_config
@@ -312,9 +313,12 @@ class AgentOrchestrator:
         from src.agent.executor import AgentResult
         from src.agent.conversation import conversation_manager
 
-        ctx = self._build_context(message, context)
+        scope_resolution = resolve_stock_scope(message, context)
+        ctx = self._build_context(message, scope_resolution.effective_context)
         ctx.session_id = session_id
         ctx.meta["response_mode"] = "chat"
+        if scope_resolution.stock_scope is not None:
+            ctx.meta["stock_scope"] = scope_resolution.stock_scope
 
         conversation_manager.get_or_create(session_id)
         config = self.config or getattr(self.llm_adapter, "_config", None) or get_config()

--- a/src/agent/runner.py
+++ b/src/agent/runner.py
@@ -26,6 +26,7 @@ from typing import Any, Callable, Dict, List, Optional
 
 from src.agent.llm_adapter import LLMToolAdapter
 from src.agent.tools.registry import ToolRegistry
+from src.agent.stock_scope import StockScope
 from src.storage import persist_llm_usage as _persist_usage
 
 logger = logging.getLogger(__name__)
@@ -156,6 +157,52 @@ def _is_non_retriable_tool_result(result: Any) -> bool:
         and bool(result.get("error"))
         and result.get("retriable") is False
     )
+
+
+def _is_stock_scoped_tool(tool_registry: ToolRegistry, tool_name: str) -> bool:
+    tool_def = tool_registry.resolve(tool_name)
+    if tool_def is None:
+        return False
+    return any(param.name == "stock_code" for param in tool_def.parameters)
+
+
+def _normalize_guard_stock_code(value: Any) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, float) and value.is_integer():
+        value = int(value)
+    raw = value if isinstance(value, str) else str(value)
+    normalized = _normalize_tool_stock_code(raw)
+    return normalized if isinstance(normalized, str) else str(normalized)
+
+
+def _guard_tool_stock_scope(tool_registry: ToolRegistry, tool_name: str, arguments: Dict[str, Any], stock_scope: Optional[StockScope]) -> Optional[Dict[str, Any]]:
+    if stock_scope is None or not isinstance(arguments, dict):
+        return None
+    if not _is_stock_scoped_tool(tool_registry, tool_name):
+        return None
+    if "stock_code" not in arguments:
+        return None
+
+    requested = _normalize_guard_stock_code(arguments.get("stock_code"))
+
+    expected = _normalize_guard_stock_code(stock_scope.expected_stock_code)
+    allowed = {
+        normalized
+        for code in stock_scope.allowed_stock_codes
+        for normalized in [_normalize_guard_stock_code(code)]
+        if normalized
+    }
+    if requested and (requested == expected or requested in allowed):
+        return None
+
+    return {
+        "error": "stock_scope_violation",
+        "expected_stock_code": expected,
+        "requested_stock_code": requested,
+        "allowed_stock_codes": sorted(allowed),
+        "retriable": False,
+    }
 
 
 def parse_dashboard_json(content: str) -> Optional[Dict[str, Any]]:
@@ -368,6 +415,7 @@ def run_agent_loop(
     thinking_labels: Optional[Dict[str, str]] = None,
     max_wall_clock_seconds: Optional[float] = None,
     tool_call_timeout_seconds: Optional[float] = None,
+    stock_scope: Optional[StockScope] = None,
 ) -> RunLoopResult:
     """Execute the ReAct LLM ↔ tool loop.
 
@@ -536,6 +584,7 @@ def run_agent_loop(
                 tool_calls_log,
                 non_retriable_tool_results,
                 tool_wait_timeout_seconds=effective_tool_timeout,
+                stock_scope=stock_scope,
             )
 
             # Append tool results preserving original call order
@@ -618,6 +667,7 @@ def _execute_tools(
     tool_calls_log: List[Dict[str, Any]],
     non_retriable_tool_results: Optional[Dict[str, str]] = None,
     tool_wait_timeout_seconds: Optional[float] = None,
+    stock_scope: Optional[StockScope] = None,
 ) -> List[Dict[str, Any]]:
     """Execute one or more tool calls, returning ordered result dicts.
 
@@ -627,6 +677,20 @@ def _execute_tools(
     def _exec_single(tc_item):
         t0 = time.time()
         cache_key = _build_tool_cache_key(tc_item.name, tc_item.arguments)
+        guard_result = _guard_tool_stock_scope(tool_registry, tc_item.name, tc_item.arguments, stock_scope)
+        if guard_result is not None:
+            dur = round(time.time() - t0, 2)
+            result_str = serialize_tool_result(guard_result)
+            if cache_key and non_retriable_tool_results is not None:
+                non_retriable_tool_results[cache_key] = result_str
+            logger.warning(
+                "Tool '%s' blocked by stock scope: requested=%s expected=%s allowed=%s",
+                tc_item.name,
+                guard_result.get("requested_stock_code"),
+                guard_result.get("expected_stock_code"),
+                guard_result.get("allowed_stock_codes"),
+            )
+            return tc_item, result_str, False, dur, False, guard_result
 
         if cache_key and non_retriable_tool_results is not None and cache_key in non_retriable_tool_results:
             dur = round(time.time() - t0, 2)
@@ -635,7 +699,7 @@ def _execute_tools(
                 tc_item.name,
                 tc_item.arguments,
             )
-            return tc_item, non_retriable_tool_results[cache_key], False, dur, True
+            return tc_item, non_retriable_tool_results[cache_key], False, dur, True, None
 
         try:
             res = tool_registry.execute(tc_item.name, **tc_item.arguments)
@@ -648,7 +712,7 @@ def _execute_tools(
             ok = False
             logger.warning("Tool '%s' failed: %s", tc_item.name, e)
         dur = round(time.time() - t0, 2)
-        return tc_item, res_str, ok, dur, False
+        return tc_item, res_str, ok, dur, False, None
 
     results: List[Dict[str, Any]] = []
 
@@ -663,7 +727,7 @@ def _execute_tools(
             try:
                 future = pool.submit(ctx.run, _exec_single, tc)
                 try:
-                    _, result_str, success, dur, cached = future.result(timeout=tool_wait_timeout_seconds)
+                    _, result_str, success, dur, cached, guard_result = future.result(timeout=tool_wait_timeout_seconds)
                 except FuturesTimeoutError:
                     timeout_triggered = True
                     future.cancel()
@@ -676,10 +740,11 @@ def _execute_tools(
                     success = False
                     dur = round(tool_wait_timeout_seconds, 2)
                     cached = False
+                    guard_result = None
             finally:
                 pool.shutdown(wait=not timeout_triggered, cancel_futures=timeout_triggered)
         else:
-            _, result_str, success, dur, cached = _exec_single(tc)
+            _, result_str, success, dur, cached, guard_result = _exec_single(tc)
         if progress_callback:
             progress_callback({"type": "tool_done", "step": step, "tool": tc.name, "success": success, "duration": dur})
         log_entry = {
@@ -693,6 +758,13 @@ def _execute_tools(
                     log_entry["timeout"] = True
             except (TypeError, ValueError, json.JSONDecodeError):
                 pass
+        if guard_result is not None:
+            log_entry.update({
+                "guarded": True,
+                "expected_stock_code": guard_result.get("expected_stock_code"),
+                "requested_stock_code": guard_result.get("requested_stock_code"),
+                "allowed_stock_codes": guard_result.get("allowed_stock_codes", []),
+            })
         tool_calls_log.append(log_entry)
         results.append({"tc": tc, "result_str": result_str})
     else:
@@ -710,14 +782,22 @@ def _execute_tools(
                 timeout=tool_wait_timeout_seconds if tool_wait_timeout_seconds and tool_wait_timeout_seconds > 0 else None,
             ):
                 pending.discard(future)
-                tc_item, result_str, success, dur, cached = future.result()
+                tc_item, result_str, success, dur, cached, guard_result = future.result()
                 if progress_callback:
                     progress_callback({"type": "tool_done", "step": step, "tool": tc_item.name, "success": success, "duration": dur})
-                tool_calls_log.append({
+                log_entry = {
                     "step": step, "tool": tc_item.name, "arguments": tc_item.arguments,
                     "success": success, "duration": dur, "result_length": len(result_str),
                     "cached": cached,
-                })
+                }
+                if guard_result is not None:
+                    log_entry.update({
+                        "guarded": True,
+                        "expected_stock_code": guard_result.get("expected_stock_code"),
+                        "requested_stock_code": guard_result.get("requested_stock_code"),
+                        "allowed_stock_codes": guard_result.get("allowed_stock_codes", []),
+                    })
+                tool_calls_log.append(log_entry)
                 results.append({"tc": tc_item, "result_str": result_str})
         except FuturesTimeoutError:
             timeout_triggered = True

--- a/src/agent/stock_scope.py
+++ b/src/agent/stock_scope.py
@@ -1,0 +1,210 @@
+# -*- coding: utf-8 -*-
+"""Stock-scope helpers for ask-stock follow-up chat turns."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from typing import Any, Dict, Iterable, List, Optional, Set
+
+
+SWITCH_CLEANUP_KEYS = {
+    "stock_name",
+    "previous_analysis_summary",
+    "previous_strategy",
+    "previous_price",
+    "previous_change_pct",
+    "realtime_quote",
+    "daily_history",
+    "chip_distribution",
+    "trend_result",
+    "news_context",
+    "fundamental_context",
+    "analysis_context_pack_summary",
+    "market_phase_context",
+}
+
+_STRONG_COMPARE_PATTERN = re.compile(r"比较|对比|vs\b|和[^，。,.!?！？]{0,40}比", re.IGNORECASE)
+_WEAK_COMPARE_HINT_PATTERN = re.compile(r"差异(?!化)|区别|不同|相比|对照|比一比")
+_CHOICE_COMPARE_PATTERN = re.compile(r"哪个|哪只|哪一个|谁更|更值得|更适合|怎么选|选哪|二选一")
+_LINKED_COMPARE_PATTERN = re.compile(
+    r"(?:和|与|跟|同)(?P<body>[^，。,.!?！？]{0,40})(?:差异(?!化)|区别|不同|相比|对照|比一比)"
+)
+_SWITCH_PATTERN = re.compile(r"换成|改看|分析|看看|研究|诊断")
+_LOWERCASE_TICKER_PATTERN = re.compile(r"(?<![a-zA-Z.])([a-z]{2,5}(?:\.[a-z]{1,2})?)(?![a-zA-Z0-9])")
+
+
+@dataclass(frozen=True)
+class StockScope:
+    """Runtime stock-scope contract for one chat turn."""
+
+    expected_stock_code: str = ""
+    allowed_stock_codes: Set[str] = field(default_factory=set)
+    mode: str = "maintain"
+
+    def as_log_payload(self) -> Dict[str, Any]:
+        return {
+            "expected_stock_code": self.expected_stock_code,
+            "allowed_stock_codes": sorted(self.allowed_stock_codes),
+            "mode": self.mode,
+        }
+
+
+@dataclass(frozen=True)
+class StockScopeResolution:
+    """Result produced before a chat turn enters the agent loop."""
+
+    effective_context: Dict[str, Any]
+    stock_scope: Optional[StockScope]
+
+
+def _normalize_stock_code(value: Any) -> str:
+    """Normalize a code with the runner's canonical stock-code rules."""
+    if not isinstance(value, str):
+        return ""
+    text = value.strip()
+    if not text:
+        return ""
+    try:
+        from src.agent.runner import _normalize_tool_stock_code
+
+        normalized = _normalize_tool_stock_code(text)
+    except Exception:
+        normalized = text.strip().upper()
+    return normalized if isinstance(normalized, str) else str(normalized)
+
+
+def _is_denied_candidate(candidate: str) -> bool:
+    try:
+        from src.agent.orchestrator import _COMMON_WORDS
+
+        return candidate.strip().upper() in _COMMON_WORDS
+    except Exception:
+        return False
+
+
+def _append_candidate(candidates: List[str], candidate: str) -> None:
+    normalized = _normalize_stock_code(candidate)
+    if not normalized or _is_denied_candidate(normalized):
+        return
+    if normalized not in candidates:
+        candidates.append(normalized)
+
+
+def extract_stock_codes(text: str) -> List[str]:
+    """Extract all explicit stock-code candidates from free text."""
+    if not text:
+        return []
+
+    candidates: List[str] = []
+
+    for pattern, flags in (
+        (r"(?<![a-zA-Z])(?:SH|SZ|BJ)\d{6}(?!\d)", re.IGNORECASE),
+        (r"(?<![a-zA-Z])hk\d{4,5}(?!\d)", re.IGNORECASE),
+        (r"(?<![a-zA-Z])\d{1,5}\.HK(?![a-zA-Z])", re.IGNORECASE),
+        (r"(?<!\d)(?:[03648]\d{5}|92\d{4})(?!\d)", 0),
+        (r"(?<!\d)\d{5}(?!\d)", 0),
+        (r"(?<![a-zA-Z.])([A-Z]{2,5}(?:\.[A-Z]{1,2})?)(?![a-zA-Z0-9])", 0),
+    ):
+        for match in re.finditer(pattern, text, flags):
+            raw = match.group(1) if match.lastindex else match.group(0)
+            _append_candidate(candidates, raw)
+
+    if (
+        _SWITCH_PATTERN.search(text)
+        or _STRONG_COMPARE_PATTERN.search(text)
+        or _WEAK_COMPARE_HINT_PATTERN.search(text)
+        or _CHOICE_COMPARE_PATTERN.search(text)
+    ):
+        for match in _LOWERCASE_TICKER_PATTERN.finditer(text):
+            _append_candidate(candidates, match.group(1))
+
+    return candidates
+
+
+def _is_compare_message(message: str, candidates: List[str], current_code: str) -> bool:
+    if _STRONG_COMPARE_PATTERN.search(message):
+        return True
+    new_candidates = {code for code in candidates if code != current_code}
+    if len(new_candidates) >= 2:
+        return True
+    if _CHOICE_COMPARE_PATTERN.search(message) and len(candidates) >= 2:
+        return True
+    if not _WEAK_COMPARE_HINT_PATTERN.search(message):
+        return False
+    if len(candidates) >= 2:
+        return True
+
+    if not new_candidates:
+        return False
+
+    for match in _LINKED_COMPARE_PATTERN.finditer(message):
+        body_candidates = set(extract_stock_codes(f"比较 {match.group('body')}"))
+        if body_candidates & new_candidates:
+            return True
+    return False
+
+
+def _with_skills(context: Dict[str, Any], skills: Optional[Iterable[str]]) -> Dict[str, Any]:
+    if skills is None:
+        return context
+    next_context = dict(context)
+    next_context["skills"] = list(skills)
+    return next_context
+
+
+def _switch_context(context: Dict[str, Any], stock_code: str) -> Dict[str, Any]:
+    next_context = {
+        key: value
+        for key, value in context.items()
+        if key not in SWITCH_CLEANUP_KEYS and key != "allowed_stock_codes"
+    }
+    next_context["stock_code"] = stock_code
+    next_context["stock_name"] = ""
+    return next_context
+
+
+def resolve_stock_scope(
+    message: str,
+    context: Optional[Dict[str, Any]],
+    *,
+    skills: Optional[Iterable[str]] = None,
+) -> StockScopeResolution:
+    """Resolve the effective context and stock tool scope for one chat turn."""
+    original_context = dict(context or {})
+    current_code = _normalize_stock_code(original_context.get("stock_code"))
+    original_context.pop("allowed_stock_codes", None)
+
+    if not current_code:
+        return StockScopeResolution(
+            effective_context=_with_skills(original_context, skills),
+            stock_scope=None,
+        )
+
+    candidates = extract_stock_codes(message or "")
+    new_candidates = [code for code in candidates if code != current_code]
+    mode = "maintain"
+    effective_context = dict(original_context)
+    expected = current_code
+    allowed = {current_code}
+
+    if _is_compare_message(message or "", candidates, current_code):
+        mode = "compare"
+        allowed.update(candidates)
+    elif _SWITCH_PATTERN.search(message or "") and len(new_candidates) == 1:
+        mode = "switch"
+        expected = new_candidates[0]
+        allowed = {expected}
+        effective_context = _switch_context(original_context, expected)
+
+    effective_context["stock_code"] = expected if mode == "switch" else current_code
+    effective_context = _with_skills(effective_context, skills)
+
+    return StockScopeResolution(
+        effective_context=effective_context,
+        stock_scope=StockScope(
+            expected_stock_code=expected,
+            allowed_stock_codes=allowed,
+            mode=mode,
+        ),
+    )

--- a/src/agent/tools/registry.py
+++ b/src/agent/tools/registry.py
@@ -110,6 +110,15 @@ class ToolRegistry:
         """Return a tool definition by name."""
         return self._tools.get(name)
 
+    def resolve(self, name: str) -> Optional[ToolDefinition]:
+        """Return a tool definition, accepting provider-namespaced names."""
+        tool_def = self._tools.get(name)
+        if tool_def is None and ":" in name:
+            tool_def = self._tools.get(name.split(":", 1)[-1])
+        if tool_def is None and "." in name:
+            tool_def = self._tools.get(name.rsplit(".", 1)[-1])
+        return tool_def
+
     def list_tools(self, category: Optional[str] = None) -> List[ToolDefinition]:
         """List all tools, optionally filtered by category."""
         tools = list(self._tools.values())
@@ -144,10 +153,7 @@ class ToolRegistry:
 
         Supports Gemini namespaced tool names (e.g. default_api:get_realtime_quote -> get_realtime_quote).
         """
-        tool_def = self._tools.get(name)
-        if tool_def is None and ":" in name:
-            # Gemini may return namespaced names like default_api:get_realtime_quote
-            tool_def = self._tools.get(name.split(":", 1)[-1])
+        tool_def = self.resolve(name)
         if tool_def is None:
             raise KeyError(f"Tool '{name}' not found in registry. Available: {self.list_names()}")
 

--- a/tests/test_agent_chat_api.py
+++ b/tests/test_agent_chat_api.py
@@ -2,7 +2,8 @@
 """Agent chat history API regressions."""
 
 from pathlib import Path
-from unittest.mock import patch
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
 
 from fastapi.testclient import TestClient
 
@@ -60,3 +61,71 @@ def test_chat_session_messages_api_does_not_expose_provider_trace(tmp_path: Path
     assert "SECRET_REASONING" not in response.text
     assert "SECRET_TOOL_RESULT" not in response.text
     assert "tool_calls" not in response.text
+
+
+def test_agent_chat_forwards_stock_context_to_executor(tmp_path: Path) -> None:
+    executor = MagicMock()
+    executor.chat.return_value = SimpleNamespace(
+        success=True,
+        content="ok",
+        error=None,
+    )
+    config = SimpleNamespace(is_agent_available=lambda: True)
+
+    with patch("api.middlewares.auth.is_auth_enabled", return_value=False):
+        with patch("api.v1.endpoints.agent.get_config", return_value=config):
+            with patch("api.v1.endpoints.agent._build_executor", return_value=executor):
+                client = TestClient(create_app(static_dir=tmp_path / "static"))
+                response = client.post(
+                    "/api/v1/agent/chat",
+                    json={
+                        "message": "如果不考虑 TTM 呢",
+                        "session_id": "s1",
+                        "context": {
+                            "stock_code": "600519",
+                            "stock_name": "匿名标的",
+                        },
+                    },
+                )
+
+    assert response.status_code == 200
+    kwargs = executor.chat.call_args.kwargs
+    assert kwargs["message"] == "如果不考虑 TTM 呢"
+    assert kwargs["session_id"] == "s1"
+    assert kwargs["context"]["stock_code"] == "600519"
+    assert kwargs["context"]["stock_name"] == "匿名标的"
+
+
+def test_agent_chat_stream_forwards_stock_context_to_executor(tmp_path: Path) -> None:
+    executor = MagicMock()
+    executor.chat.return_value = SimpleNamespace(
+        success=True,
+        content="ok",
+        error=None,
+        total_steps=1,
+    )
+    config = SimpleNamespace(is_agent_available=lambda: True)
+
+    with patch("api.middlewares.auth.is_auth_enabled", return_value=False):
+        with patch("api.v1.endpoints.agent.get_config", return_value=config):
+            with patch("api.v1.endpoints.agent._build_executor", return_value=executor):
+                client = TestClient(create_app(static_dir=tmp_path / "static"))
+                response = client.post(
+                    "/api/v1/agent/chat/stream",
+                    json={
+                        "message": "如果不考虑 TTM 呢",
+                        "session_id": "s1",
+                        "context": {
+                            "stock_code": "600519",
+                            "stock_name": "匿名标的",
+                        },
+                    },
+                )
+
+    assert response.status_code == 200
+    assert '"type": "done"' in response.text
+    kwargs = executor.chat.call_args.kwargs
+    assert kwargs["message"] == "如果不考虑 TTM 呢"
+    assert kwargs["session_id"] == "s1"
+    assert kwargs["context"]["stock_code"] == "600519"
+    assert kwargs["context"]["stock_name"] == "匿名标的"

--- a/tests/test_agent_executor.py
+++ b/tests/test_agent_executor.py
@@ -36,6 +36,7 @@ from src.agent.executor import (
 )
 from src.agent.llm_adapter import LLMResponse, ToolCall
 from src.agent.runner import parse_dashboard_json, run_agent_loop, serialize_tool_result
+from src.agent.stock_scope import StockScope, resolve_stock_scope
 from src.agent.tools.registry import ToolRegistry, ToolDefinition, ToolParameter
 from src.analysis_context_pack_prompt import format_analysis_context_pack_prompt_section
 from src.config import Config
@@ -62,6 +63,46 @@ def _make_registry_with_echo():
         handler=lambda message: {"echo": message},
     )
     registry.register(tool)
+    return registry
+
+
+def _make_stock_registry(executed_calls):
+    """Create a registry with stock-scoped and non-stock tools."""
+    registry = ToolRegistry()
+    registry.register(
+        ToolDefinition(
+            name="get_realtime_quote",
+            description="Gets realtime quote",
+            parameters=[
+                ToolParameter(name="stock_code", type="string", description="Stock code"),
+            ],
+            handler=lambda stock_code: executed_calls.append(("quote", stock_code)) or {"stock_code": stock_code},
+        )
+    )
+    registry.register(
+        ToolDefinition(
+            name="search_stock_news",
+            description="Searches stock news",
+            parameters=[
+                ToolParameter(name="stock_code", type="string", description="Stock code"),
+                ToolParameter(name="stock_name", type="string", description="Stock name"),
+            ],
+            handler=lambda stock_code, stock_name: executed_calls.append(("news", stock_code, stock_name)) or {
+                "stock_code": stock_code,
+                "stock_name": stock_name,
+            },
+        )
+    )
+    registry.register(
+        ToolDefinition(
+            name="echo",
+            description="Echoes back the input",
+            parameters=[
+                ToolParameter(name="message", type="string", description="Message to echo"),
+            ],
+            handler=lambda message: executed_calls.append(("echo", message)) or {"echo": message},
+        )
+    )
     return registry
 
 
@@ -154,8 +195,9 @@ class TestAgentExecutor(unittest.TestCase):
         executor = AgentExecutor(registry, adapter, max_steps=2)
         captured = {}
 
-        def fake_run_loop(messages, tool_decls, parse_dashboard, progress_callback=None):
+        def fake_run_loop(messages, tool_decls, parse_dashboard, progress_callback=None, stock_scope=None):
             captured["messages"] = messages
+            captured["stock_scope"] = stock_scope
             return AgentResult(success=True, content="assistant reply")
 
         compressed_history = [
@@ -187,6 +229,476 @@ class TestAgentExecutor(unittest.TestCase):
         assert messages[3]["content"].startswith("[系统提供的历史分析上下文，可供参考对比]")
         assert messages[4]["role"] == "assistant"
         assert messages[-1] == {"role": "user", "content": "当前问题"}
+        assert captured["stock_scope"].expected_stock_code == "600519"
+
+    def test_chat_switches_effective_context_and_clears_previous_stock_fields(self):
+        registry = _make_registry_with_echo()
+        adapter = _make_mock_adapter()
+        adapter._config = MagicMock()
+        executor = AgentExecutor(registry, adapter, max_steps=2)
+        captured = {}
+
+        def fake_run_loop(messages, tool_decls, parse_dashboard, progress_callback=None, stock_scope=None):
+            captured["messages"] = messages
+            captured["stock_scope"] = stock_scope
+            return AgentResult(success=True, content="assistant reply")
+
+        stale_context = {
+            "stock_code": "600519",
+            "stock_name": "贵州茅台",
+            "previous_analysis_summary": {"summary": "old"},
+            "previous_strategy": {"action": "hold"},
+            "previous_price": 1800,
+            "previous_change_pct": 1.2,
+            "skills": ["bull_trend"],
+        }
+
+        with patch.object(executor, "_run_loop", side_effect=fake_run_loop):
+            with patch(
+                "src.agent.executor.build_agent_chat_context_bundle",
+                return_value=SimpleNamespace(context_messages=[], diagnostics={}),
+            ):
+                with patch("src.agent.conversation.conversation_manager.get_or_create"):
+                    with patch("src.agent.conversation.conversation_manager.add_message"):
+                        executor.chat("换成 AAPL 看看，不考虑 600519", "session-1", context=stale_context)
+
+        history_context = "\n".join(
+            msg["content"] for msg in captured["messages"] if msg["role"] == "user"
+        )
+        self.assertIn("股票代码: AAPL", history_context)
+        self.assertNotIn("股票名称: 贵州茅台", history_context)
+        self.assertNotIn("上次分析摘要", history_context)
+        self.assertNotIn("上次策略分析", history_context)
+        self.assertEqual(captured["stock_scope"].mode, "switch")
+        self.assertEqual(captured["stock_scope"].expected_stock_code, "AAPL")
+        self.assertEqual(captured["stock_scope"].allowed_stock_codes, {"AAPL"})
+
+    def test_run_does_not_pass_stock_scope_to_dashboard_path(self):
+        registry = _make_registry_with_echo()
+        adapter = _make_mock_adapter()
+        executor = AgentExecutor(registry, adapter, max_steps=2)
+        captured = {}
+
+        def fake_run_loop(messages, tool_decls, parse_dashboard, progress_callback=None, stock_scope=None):
+            captured["stock_scope"] = stock_scope
+            return AgentResult(success=True, content=json.dumps(SAMPLE_DASHBOARD, ensure_ascii=False))
+
+        with patch.object(executor, "_run_loop", side_effect=fake_run_loop):
+            result = executor.run("Analyze 600519", context={"stock_code": "600519"})
+
+        self.assertTrue(result.success)
+        self.assertIsNone(captured["stock_scope"])
+
+    def test_resolve_stock_scope_compare_collects_multiple_normalized_codes(self):
+        result = resolve_stock_scope(
+            "比较 600519 和 AAPL",
+            {"stock_code": "600519", "stock_name": "贵州茅台"},
+        )
+
+        self.assertEqual(result.stock_scope.mode, "compare")
+        self.assertEqual(result.effective_context["stock_code"], "600519")
+        self.assertEqual(result.effective_context["stock_name"], "贵州茅台")
+        self.assertEqual(result.stock_scope.allowed_stock_codes, {"600519", "AAPL"})
+
+    def test_resolve_stock_scope_keeps_ambiguous_bare_code_on_current_stock(self):
+        result = resolve_stock_scope("AAPL", {"stock_code": "600519", "stock_name": "贵州茅台"})
+
+        self.assertEqual(result.stock_scope.mode, "maintain")
+        self.assertEqual(result.effective_context["stock_code"], "600519")
+        self.assertEqual(result.stock_scope.allowed_stock_codes, {"600519"})
+
+    def test_run_agent_loop_blocks_conflicting_stock_scoped_tool_and_keeps_tool_result(self):
+        executed_calls = []
+        registry = _make_stock_registry(executed_calls)
+        adapter = _make_mock_adapter()
+        adapter.call_with_tools.side_effect = [
+            LLMResponse(
+                content="Need quote.",
+                tool_calls=[
+                    ToolCall(id="quote_1", name="get_realtime_quote", arguments={"stock_code": "TTM"}),
+                ],
+                usage={"total_tokens": 10},
+                provider="openai",
+            ),
+            LLMResponse(
+                content="I will stay on the current stock.",
+                tool_calls=[],
+                usage={"total_tokens": 10},
+                provider="openai",
+            ),
+        ]
+
+        messages = [
+            {"role": "system", "content": "system"},
+            {"role": "user", "content": "如果不考虑 TTM 呢"},
+        ]
+        result = run_agent_loop(
+            messages=messages,
+            tool_registry=registry,
+            llm_adapter=adapter,
+            max_steps=3,
+            stock_scope=StockScope(expected_stock_code="600519", allowed_stock_codes={"600519"}),
+        )
+
+        self.assertTrue(result.success)
+        self.assertEqual(executed_calls, [])
+        self.assertEqual(len(result.tool_calls_log), 1)
+        log_entry = result.tool_calls_log[0]
+        self.assertFalse(log_entry["success"])
+        self.assertTrue(log_entry["guarded"])
+        self.assertEqual(log_entry["expected_stock_code"], "600519")
+        self.assertEqual(log_entry["requested_stock_code"], "TTM")
+        tool_messages = [msg for msg in result.messages if msg.get("role") == "tool"]
+        self.assertEqual(len(tool_messages), 1)
+        self.assertEqual(tool_messages[0]["tool_call_id"], "quote_1")
+        self.assertIn("stock_scope_violation", tool_messages[0]["content"])
+
+    def test_run_agent_loop_blocks_numeric_conflicting_stock_code(self):
+        executed_calls = []
+        registry = _make_stock_registry(executed_calls)
+        adapter = _make_mock_adapter()
+        adapter.call_with_tools.side_effect = [
+            LLMResponse(
+                content="Need quote.",
+                tool_calls=[
+                    ToolCall(id="quote_1", name="get_realtime_quote", arguments={"stock_code": 123456}),
+                ],
+                usage={"total_tokens": 10},
+                provider="openai",
+            ),
+            LLMResponse(
+                content="Blocked wrong numeric code.",
+                tool_calls=[],
+                usage={"total_tokens": 10},
+                provider="openai",
+            ),
+        ]
+
+        result = run_agent_loop(
+            messages=[
+                {"role": "system", "content": "system"},
+                {"role": "user", "content": "继续看当前标的"},
+            ],
+            tool_registry=registry,
+            llm_adapter=adapter,
+            max_steps=3,
+            stock_scope=StockScope(expected_stock_code="600519", allowed_stock_codes={"600519"}),
+        )
+
+        self.assertTrue(result.success)
+        self.assertEqual(executed_calls, [])
+        self.assertTrue(result.tool_calls_log[0]["guarded"])
+        self.assertEqual(result.tool_calls_log[0]["requested_stock_code"], "123456")
+        tool_messages = [msg for msg in result.messages if msg.get("role") == "tool"]
+        self.assertEqual(len(tool_messages), 1)
+        self.assertIn("stock_scope_violation", tool_messages[0]["content"])
+
+    def test_run_agent_loop_allows_explicit_allowed_stock_code_and_hk_equivalent(self):
+        executed_calls = []
+        registry = _make_stock_registry(executed_calls)
+        adapter = _make_mock_adapter()
+        adapter.call_with_tools.side_effect = [
+            LLMResponse(
+                content="Need quote.",
+                tool_calls=[
+                    ToolCall(id="quote_1", name="get_realtime_quote", arguments={"stock_code": "1810.HK"}),
+                ],
+                usage={"total_tokens": 10},
+                provider="openai",
+            ),
+            LLMResponse(
+                content="AAPL and HK allowed.",
+                tool_calls=[],
+                usage={"total_tokens": 10},
+                provider="openai",
+            ),
+        ]
+
+        result = run_agent_loop(
+            messages=[
+                {"role": "system", "content": "system"},
+                {"role": "user", "content": "比较 HK01810 和 600519"},
+            ],
+            tool_registry=registry,
+            llm_adapter=adapter,
+            max_steps=3,
+            stock_scope=StockScope(
+                expected_stock_code="600519",
+                allowed_stock_codes={"600519", "HK01810"},
+                mode="compare",
+            ),
+        )
+
+        self.assertTrue(result.success)
+        self.assertEqual(executed_calls, [("quote", "1810.HK")])
+        self.assertFalse(result.tool_calls_log[0].get("guarded", False))
+
+    def test_run_agent_loop_allows_compare_hint_stock_code(self):
+        executed_calls = []
+        registry = _make_stock_registry(executed_calls)
+        adapter = _make_mock_adapter()
+        adapter.call_with_tools.side_effect = [
+            LLMResponse(
+                content="Need quote.",
+                tool_calls=[
+                    ToolCall(id="quote_1", name="get_realtime_quote", arguments={"stock_code": "AAPL"}),
+                ],
+                usage={"total_tokens": 10},
+                provider="openai",
+            ),
+            LLMResponse(
+                content="Compared allowed stock.",
+                tool_calls=[],
+                usage={"total_tokens": 10},
+                provider="openai",
+            ),
+        ]
+        message = "分析 600519 和 AAPL 的差异"
+        scope = resolve_stock_scope(message, {"stock_code": "600519", "stock_name": "贵州茅台"}).stock_scope
+
+        result = run_agent_loop(
+            messages=[
+                {"role": "system", "content": "system"},
+                {"role": "user", "content": message},
+            ],
+            tool_registry=registry,
+            llm_adapter=adapter,
+            max_steps=3,
+            stock_scope=scope,
+        )
+
+        self.assertTrue(result.success)
+        self.assertEqual(scope.mode, "compare")
+        self.assertEqual(scope.allowed_stock_codes, {"600519", "AAPL"})
+        self.assertEqual(executed_calls, [("quote", "AAPL")])
+        self.assertFalse(result.tool_calls_log[0].get("guarded", False))
+
+    def test_run_agent_loop_allows_plain_hk_code_from_compare_scope(self):
+        executed_calls = []
+        registry = _make_stock_registry(executed_calls)
+        adapter = _make_mock_adapter()
+        adapter.call_with_tools.side_effect = [
+            LLMResponse(
+                content="Need quote.",
+                tool_calls=[
+                    ToolCall(id="quote_1", name="get_realtime_quote", arguments={"stock_code": "01810"}),
+                ],
+                usage={"total_tokens": 10},
+                provider="openai",
+            ),
+            LLMResponse(
+                content="Compared allowed HK stock.",
+                tool_calls=[],
+                usage={"total_tokens": 10},
+                provider="openai",
+            ),
+        ]
+        message = "比较 01810 和 AAPL"
+        scope = resolve_stock_scope(message, {"stock_code": "600519", "stock_name": "贵州茅台"}).stock_scope
+
+        result = run_agent_loop(
+            messages=[
+                {"role": "system", "content": "system"},
+                {"role": "user", "content": message},
+            ],
+            tool_registry=registry,
+            llm_adapter=adapter,
+            max_steps=3,
+            stock_scope=scope,
+        )
+
+        self.assertTrue(result.success)
+        self.assertEqual(scope.mode, "compare")
+        self.assertEqual(scope.allowed_stock_codes, {"600519", "HK01810", "AAPL"})
+        self.assertEqual(executed_calls, [("quote", "01810")])
+        self.assertFalse(result.tool_calls_log[0].get("guarded", False))
+
+    def test_run_agent_loop_allows_choice_compare_stock_codes(self):
+        executed_calls = []
+        registry = _make_stock_registry(executed_calls)
+        adapter = _make_mock_adapter()
+        adapter.call_with_tools.side_effect = [
+            LLMResponse(
+                content="Need quotes.",
+                tool_calls=[
+                    ToolCall(id="quote_1", name="get_realtime_quote", arguments={"stock_code": "AAPL"}),
+                    ToolCall(id="quote_2", name="get_realtime_quote", arguments={"stock_code": "TSLA"}),
+                ],
+                usage={"total_tokens": 10},
+                provider="openai",
+            ),
+            LLMResponse(
+                content="Compared allowed stocks.",
+                tool_calls=[],
+                usage={"total_tokens": 10},
+                provider="openai",
+            ),
+        ]
+        message = "AAPL 和 TSLA 哪个更值得买"
+        scope = resolve_stock_scope(message, {"stock_code": "600519", "stock_name": "贵州茅台"}).stock_scope
+
+        result = run_agent_loop(
+            messages=[
+                {"role": "system", "content": "system"},
+                {"role": "user", "content": message},
+            ],
+            tool_registry=registry,
+            llm_adapter=adapter,
+            max_steps=3,
+            stock_scope=scope,
+        )
+
+        self.assertTrue(result.success)
+        self.assertEqual(scope.mode, "compare")
+        self.assertEqual(scope.allowed_stock_codes, {"600519", "AAPL", "TSLA"})
+        self.assertEqual(executed_calls, [("quote", "AAPL"), ("quote", "TSLA")])
+        self.assertFalse(result.tool_calls_log[0].get("guarded", False))
+        self.assertFalse(result.tool_calls_log[1].get("guarded", False))
+
+    def test_run_agent_loop_blocks_exchange_affix_tokens_from_compare_scope(self):
+        cases = [
+            ("比较 1810.HK 和 AAPL", "HK"),
+            ("比较 600519.SH 和 AAPL", "SH"),
+            ("比较 000001.SZ 和 AAPL", "SZ"),
+            ("比较 600519.SS 和 AAPL", "SS"),
+            ("比较 SH600519 和 AAPL", "SH"),
+            ("比较 SZ000001 和 AAPL", "SZ"),
+            ("比较 BJ920748 和 AAPL", "BJ"),
+            ("比较 HK01810 和 AAPL", "HK"),
+        ]
+
+        for message, requested_code in cases:
+            with self.subTest(message=message, requested_code=requested_code):
+                executed_calls = []
+                registry = _make_stock_registry(executed_calls)
+                adapter = _make_mock_adapter()
+                adapter.call_with_tools.side_effect = [
+                    LLMResponse(
+                        content="Need quote.",
+                        tool_calls=[
+                            ToolCall(
+                                id="quote_1",
+                                name="get_realtime_quote",
+                                arguments={"stock_code": requested_code},
+                            ),
+                        ],
+                        usage={"total_tokens": 10},
+                        provider="openai",
+                    ),
+                    LLMResponse(
+                        content="Blocked invalid suffix token.",
+                        tool_calls=[],
+                        usage={"total_tokens": 10},
+                        provider="openai",
+                    ),
+                ]
+                scope = resolve_stock_scope(message, {"stock_code": "600519"}).stock_scope
+
+                self.assertNotIn(requested_code, scope.allowed_stock_codes)
+                result = run_agent_loop(
+                    messages=[
+                        {"role": "system", "content": "system"},
+                        {"role": "user", "content": message},
+                    ],
+                    tool_registry=registry,
+                    llm_adapter=adapter,
+                    max_steps=3,
+                    stock_scope=scope,
+                )
+
+                self.assertTrue(result.success)
+                self.assertEqual(executed_calls, [])
+                self.assertTrue(result.tool_calls_log[0]["guarded"])
+                self.assertEqual(result.tool_calls_log[0]["requested_stock_code"], requested_code)
+                tool_messages = [msg for msg in result.messages if msg.get("role") == "tool"]
+                self.assertEqual(len(tool_messages), 1)
+                self.assertIn("stock_scope_violation", tool_messages[0]["content"])
+
+    def test_run_agent_loop_guards_namespaced_search_tool_stock_code_only(self):
+        executed_calls = []
+        registry = _make_stock_registry(executed_calls)
+        adapter = _make_mock_adapter()
+        adapter.call_with_tools.side_effect = [
+            LLMResponse(
+                content="Need news.",
+                tool_calls=[
+                    ToolCall(
+                        id="news_1",
+                        name="gemini_api.search_stock_news",
+                        arguments={"stock_code": "AAPL", "stock_name": "贵州茅台"},
+                    ),
+                ],
+                usage={"total_tokens": 10},
+                provider="gemini",
+            ),
+            LLMResponse(
+                content="Blocked wrong code.",
+                tool_calls=[],
+                usage={"total_tokens": 10},
+                provider="gemini",
+            ),
+        ]
+
+        result = run_agent_loop(
+            messages=[
+                {"role": "system", "content": "system"},
+                {"role": "user", "content": "如果不考虑 AAPL 呢"},
+            ],
+            tool_registry=registry,
+            llm_adapter=adapter,
+            max_steps=3,
+            stock_scope=StockScope(expected_stock_code="600519", allowed_stock_codes={"600519"}),
+        )
+
+        self.assertTrue(result.success)
+        self.assertEqual(executed_calls, [])
+        self.assertTrue(result.tool_calls_log[0]["guarded"])
+        self.assertEqual(result.tool_calls_log[0]["tool"], "gemini_api.search_stock_news")
+        tool_messages = [msg for msg in result.messages if msg.get("role") == "tool"]
+        self.assertEqual(len(tool_messages), 1)
+        self.assertIn("stock_scope_violation", tool_messages[0]["content"])
+
+    def test_parallel_tool_batch_guards_only_conflicting_stock_calls(self):
+        executed_calls = []
+        registry = _make_stock_registry(executed_calls)
+        adapter = _make_mock_adapter()
+        adapter.call_with_tools.side_effect = [
+            LLMResponse(
+                content="Need mixed tools.",
+                tool_calls=[
+                    ToolCall(id="quote_ok", name="get_realtime_quote", arguments={"stock_code": "600519"}),
+                    ToolCall(id="quote_bad", name="get_realtime_quote", arguments={"stock_code": "AAPL"}),
+                    ToolCall(id="echo_1", name="echo", arguments={"message": "not stock scoped"}),
+                ],
+                usage={"total_tokens": 10},
+                provider="openai",
+            ),
+            LLMResponse(
+                content="Done.",
+                tool_calls=[],
+                usage={"total_tokens": 10},
+                provider="openai",
+            ),
+        ]
+
+        result = run_agent_loop(
+            messages=[
+                {"role": "system", "content": "system"},
+                {"role": "user", "content": "继续看当前标的"},
+            ],
+            tool_registry=registry,
+            llm_adapter=adapter,
+            max_steps=3,
+            stock_scope=StockScope(expected_stock_code="600519", allowed_stock_codes={"600519"}),
+        )
+
+        self.assertTrue(result.success)
+        self.assertIn(("quote", "600519"), executed_calls)
+        self.assertIn(("echo", "not stock scoped"), executed_calls)
+        self.assertNotIn(("quote", "AAPL"), executed_calls)
+        guarded = [entry for entry in result.tool_calls_log if entry.get("guarded")]
+        self.assertEqual(len(guarded), 1)
+        self.assertEqual(guarded[0]["requested_stock_code"], "AAPL")
 
     def test_prompt_omits_hardcoded_trend_baseline_when_default_policy_is_empty(self):
         """Explicit skill runs should not silently keep the legacy trend baseline."""

--- a/tests/test_multi_agent.py
+++ b/tests/test_multi_agent.py
@@ -35,6 +35,7 @@ from src.agent.protocols import (
     StageResult,
     StageStatus,
 )
+from src.agent.stock_scope import StockScope, resolve_stock_scope
 from src.config import AGENT_MAX_STEPS_DEFAULT, Config
 from src.storage import DatabaseManager
 
@@ -193,6 +194,199 @@ class TestExtractStockCode(unittest.TestCase):
             "IS", "WHAT", "HIGH",
         }
         self.assertTrue(expected_in_set.issubset(_COMMON_WORDS))
+
+
+# ============================================================
+# Stock scope resolution
+# ============================================================
+
+class TestStockScopeResolution(unittest.TestCase):
+    """Validate chat stock-scope state transitions."""
+
+    def test_maintain_keeps_current_stock_for_finance_abbrev_followup(self):
+        result = resolve_stock_scope(
+            "如果不考虑 TTM 呢",
+            {"stock_code": "600519", "stock_name": "匿名标的"},
+        )
+
+        self.assertEqual(result.stock_scope.mode, "maintain")
+        self.assertEqual(result.effective_context["stock_code"], "600519")
+        self.assertEqual(result.effective_context["stock_name"], "匿名标的")
+        self.assertEqual(result.stock_scope.allowed_stock_codes, {"600519"})
+
+    def test_switch_clears_old_stock_context_fields(self):
+        result = resolve_stock_scope(
+            "换成 AAPL 看看",
+            {
+                "stock_code": "600519",
+                "stock_name": "匿名标的",
+                "previous_analysis_summary": {"summary": "old"},
+                "previous_strategy": {"action": "hold"},
+                "previous_price": 1800,
+                "previous_change_pct": 1.2,
+                "realtime_quote": {"price": 1800},
+                "analysis_context_pack_summary": "old pack",
+                "report_language": "zh",
+            },
+        )
+
+        self.assertEqual(result.stock_scope.mode, "switch")
+        self.assertEqual(result.stock_scope.expected_stock_code, "AAPL")
+        self.assertEqual(result.stock_scope.allowed_stock_codes, {"AAPL"})
+        self.assertEqual(result.effective_context["stock_code"], "AAPL")
+        self.assertEqual(result.effective_context["stock_name"], "")
+        self.assertEqual(result.effective_context["report_language"], "zh")
+        for stale_key in (
+            "previous_analysis_summary",
+            "previous_strategy",
+            "previous_price",
+            "previous_change_pct",
+            "realtime_quote",
+            "analysis_context_pack_summary",
+        ):
+            self.assertNotIn(stale_key, result.effective_context)
+
+    def test_switch_allows_single_new_code_when_current_code_is_mentioned(self):
+        result = resolve_stock_scope(
+            "换成 AAPL 看看，不考虑 600519",
+            {"stock_code": "600519", "stock_name": "匿名标的"},
+        )
+
+        self.assertEqual(result.stock_scope.mode, "switch")
+        self.assertEqual(result.stock_scope.expected_stock_code, "AAPL")
+        self.assertEqual(result.stock_scope.allowed_stock_codes, {"AAPL"})
+        self.assertEqual(result.effective_context["stock_code"], "AAPL")
+        self.assertEqual(result.effective_context["stock_name"], "")
+
+    def test_compare_allows_multiple_codes_without_polluting_current_context(self):
+        result = resolve_stock_scope(
+            "比较 600519 和 AAPL",
+            {"stock_code": "600519", "stock_name": "匿名标的"},
+        )
+
+        self.assertEqual(result.stock_scope.mode, "compare")
+        self.assertEqual(result.effective_context["stock_code"], "600519")
+        self.assertEqual(result.effective_context["stock_name"], "匿名标的")
+        self.assertEqual(result.stock_scope.allowed_stock_codes, {"600519", "AAPL"})
+
+    def test_compare_allows_plain_five_digit_hk_code(self):
+        result = resolve_stock_scope(
+            "比较 01810 和 AAPL",
+            {"stock_code": "600519", "stock_name": "匿名标的"},
+        )
+
+        self.assertEqual(result.stock_scope.mode, "compare")
+        self.assertEqual(result.effective_context["stock_code"], "600519")
+        self.assertEqual(result.effective_context["stock_name"], "匿名标的")
+        self.assertEqual(result.stock_scope.allowed_stock_codes, {"600519", "HK01810", "AAPL"})
+
+    def test_compare_hints_allow_multiple_codes_without_switching_context(self):
+        cases = [
+            "分析 600519 和 AAPL 的差异",
+            "AAPL 相比 600519 怎么样",
+            "和 AAPL 的差异怎么看",
+        ]
+
+        for message in cases:
+            with self.subTest(message=message):
+                result = resolve_stock_scope(
+                    message,
+                    {"stock_code": "600519", "stock_name": "匿名标的"},
+                )
+
+                self.assertEqual(result.stock_scope.mode, "compare")
+                self.assertEqual(result.effective_context["stock_code"], "600519")
+                self.assertEqual(result.effective_context["stock_name"], "匿名标的")
+                self.assertEqual(result.stock_scope.allowed_stock_codes, {"600519", "AAPL"})
+
+    def test_multiple_explicit_codes_are_compare_scope(self):
+        cases = [
+            ("AAPL 和 TSLA 哪个更值得买", {"600519", "AAPL", "TSLA"}),
+            ("AAPL 和 TSLA 谁更适合", {"600519", "AAPL", "TSLA"}),
+            ("分析 AAPL 和 TSLA", {"600519", "AAPL", "TSLA"}),
+        ]
+
+        for message, expected_allowed in cases:
+            with self.subTest(message=message):
+                result = resolve_stock_scope(
+                    message,
+                    {"stock_code": "600519", "stock_name": "匿名标的"},
+                )
+
+                self.assertEqual(result.stock_scope.mode, "compare")
+                self.assertEqual(result.effective_context["stock_code"], "600519")
+                self.assertEqual(result.effective_context["stock_name"], "匿名标的")
+                self.assertEqual(result.stock_scope.allowed_stock_codes, expected_allowed)
+
+    def test_multiple_lowercase_explicit_codes_are_compare_scope_with_choice_hint(self):
+        result = resolve_stock_scope(
+            "aapl 和 tsla 哪个更值得买",
+            {"stock_code": "600519", "stock_name": "匿名标的"},
+        )
+
+        self.assertEqual(result.stock_scope.mode, "compare")
+        self.assertEqual(result.effective_context["stock_code"], "600519")
+        self.assertEqual(result.stock_scope.allowed_stock_codes, {"600519", "AAPL", "TSLA"})
+
+    def test_single_stock_difference_phrase_still_switches_context(self):
+        result = resolve_stock_scope(
+            "分析 AAPL 的差异化优势",
+            {"stock_code": "600519", "stock_name": "匿名标的"},
+        )
+
+        self.assertEqual(result.stock_scope.mode, "switch")
+        self.assertEqual(result.stock_scope.expected_stock_code, "AAPL")
+        self.assertEqual(result.effective_context["stock_code"], "AAPL")
+        self.assertEqual(result.effective_context["stock_name"], "")
+
+    def test_compare_does_not_treat_exchange_affixes_as_standalone_tickers(self):
+        cases = [
+            ("比较 01810 和 AAPL", {"600519", "HK01810", "AAPL"}, set()),
+            ("比较 1810.HK 和 AAPL", {"600519", "HK01810", "AAPL"}, {"HK"}),
+            ("比较 0700.HK 和 600519", {"600519", "HK00700"}, {"HK"}),
+            ("比较 600519.SH 和 AAPL", {"600519", "AAPL"}, {"SH"}),
+            ("比较 000001.SZ 和 AAPL", {"600519", "000001", "AAPL"}, {"SZ"}),
+            ("比较 600519.SS 和 AAPL", {"600519", "AAPL"}, {"SS"}),
+            ("比较 1810.hk 和 tsla", {"600519", "HK01810", "TSLA"}, {"HK"}),
+            ("比较 SH600519 和 AAPL", {"600519", "AAPL"}, {"SH"}),
+            ("比较 SZ000001 和 AAPL", {"600519", "000001", "AAPL"}, {"SZ"}),
+            ("比较 BJ920748 和 AAPL", {"600519", "920748", "AAPL"}, {"BJ"}),
+            ("比较 HK01810 和 AAPL", {"600519", "HK01810", "AAPL"}, {"HK"}),
+            ("比较 hk01810 和 tsla", {"600519", "HK01810", "TSLA"}, {"HK"}),
+        ]
+
+        for message, expected_allowed, forbidden_tokens in cases:
+            with self.subTest(message=message):
+                result = resolve_stock_scope(
+                    message,
+                    {"stock_code": "600519", "stock_name": "匿名标的"},
+                )
+
+                self.assertEqual(result.stock_scope.mode, "compare")
+                self.assertEqual(result.stock_scope.allowed_stock_codes, expected_allowed)
+                for token in forbidden_tokens:
+                    self.assertNotIn(token, result.stock_scope.allowed_stock_codes)
+
+    def test_switch_recognizes_lowercase_us_ticker_with_explicit_hint(self):
+        result = resolve_stock_scope(
+            "分析tsla",
+            {"stock_code": "600519", "stock_name": "匿名标的"},
+        )
+
+        self.assertEqual(result.stock_scope.mode, "switch")
+        self.assertEqual(result.stock_scope.expected_stock_code, "TSLA")
+        self.assertEqual(result.effective_context["stock_code"], "TSLA")
+        self.assertEqual(result.effective_context["stock_name"], "")
+
+    def test_compare_recognizes_lowercase_us_tickers(self):
+        result = resolve_stock_scope(
+            "比较 600519 和 tsla",
+            {"stock_code": "600519", "stock_name": "匿名标的"},
+        )
+
+        self.assertEqual(result.stock_scope.mode, "compare")
+        self.assertEqual(result.effective_context["stock_code"], "600519")
+        self.assertEqual(result.stock_scope.allowed_stock_codes, {"600519", "TSLA"})
 
 
 # ============================================================
@@ -945,6 +1139,37 @@ class TestOrchestratorExecution(unittest.TestCase):
         self.assertEqual(build_history.call_args.args[0], "session-1")
         self.assertIs(build_history.call_args.args[1], orch.llm_adapter)
 
+    def test_chat_resolves_scope_and_stores_it_for_multi_agent_chain(self):
+        from src.agent.orchestrator import OrchestratorResult
+
+        orch = self._make_orchestrator()
+        captured = {}
+
+        def fake_execute(ctx, parse_dashboard=False, progress_callback=None):
+            captured["ctx"] = ctx
+            return OrchestratorResult(success=True, content="assistant reply")
+
+        with patch.object(orch, "_execute_pipeline", side_effect=fake_execute):
+            with patch("src.agent.orchestrator.build_visible_chat_history", return_value=[]):
+                with patch("src.agent.conversation.conversation_manager.get_or_create"):
+                    with patch("src.agent.conversation.conversation_manager.add_message"):
+                        orch.chat(
+                            "换成 AAPL 看看",
+                            "session-1",
+                            context={
+                                "stock_code": "600519",
+                                "stock_name": "匿名标的",
+                                "previous_analysis_summary": {"summary": "old"},
+                            },
+                        )
+
+        ctx = captured["ctx"]
+        self.assertEqual(ctx.stock_code, "AAPL")
+        self.assertEqual(ctx.stock_name, "")
+        self.assertNotIn("previous_analysis_summary", ctx.meta)
+        self.assertEqual(ctx.meta["stock_scope"].mode, "switch")
+        self.assertEqual(ctx.meta["stock_scope"].expected_stock_code, "AAPL")
+
     def test_chat_does_not_read_or_write_provider_trace(self):
         from src.agent.orchestrator import OrchestratorResult
 
@@ -1250,6 +1475,25 @@ class TestBaseAgentMessageAssembly(unittest.TestCase):
         pack_message = messages[pack_indexes[0]]
         self.assertEqual(pack_message["role"], "user")
         self.assertNotIn("analysis_context_pack_summary", pack_message["content"])
+
+    def test_run_passes_stock_scope_from_context_meta_to_shared_runner(self):
+        from src.agent.runner import RunLoopResult
+
+        agent = self._make_agent()
+        ctx = AgentContext(query="hello", stock_code="600519")
+        ctx.meta["stock_scope"] = StockScope(
+            expected_stock_code="600519",
+            allowed_stock_codes={"600519"},
+        )
+
+        with patch(
+            "src.agent.agents.base_agent.run_agent_loop",
+            return_value=RunLoopResult(success=True, content="ok"),
+        ) as run_loop:
+            result = agent.run(ctx)
+
+        self.assertEqual(result.status, StageStatus.COMPLETED)
+        self.assertIs(run_loop.call_args.kwargs["stock_scope"], ctx.meta["stock_scope"])
 
 
 # ============================================================


### PR DESCRIPTION
## PR Type

- [x] fix
- [ ] feat
- [ ] refactor
- [ ] docs
- [ ] chore
- [x] test

## Background And Problem

Refs #1596

这是 #1617 的 clean replacement：基于最新 `upstream/main` 重新整理为单 commit，减少旧 PR 多轮补丁堆叠造成的 review 噪音。

原问题是 Web 问股从报告页进入后，后续追问可能不再持续携带当前股票上下文；模型在未明确切换标的时可能把 `TTM`、`PE`、`MACD`、英文普通词或交易所片段误当成 `stock_code` 去调用股票工具，导致追问跑偏。

## Scope Of Change

本 PR 固定为 #1596 P2 的最小修复范围：

- Web 问股在页面生命周期内维护 `activeStockContext`：报告页进入后，第二轮及后续追问继续发送 `{ stock_code, stock_name }`。
- 新建会话、切换会话、删除当前会话时先清空 active context；加载目标会话消息后，会从已加载的历史用户消息中轻量恢复基础 active stock，使切换/刷新后无代码追问仍能携带最近明确标的。
- 前端 explicit switch 选择唯一非当前标的，例如 `先不看 600519，换成 AAPL 看看` 会切到 AAPL，而不是误用句中第一个旧代码。
- 前端 `normalizeStockCode()` 与后端 stock scope 对齐 5 位港股契约：`01810`/`00700` 归一为 `HK01810`/`HK00700`。
- 后端新增 `src/agent/stock_scope.py`，统一按 `maintain / switch / compare` 判定本轮有效标的上下文与允许工具标的集合。
- `AgentExecutor.chat()` 与 `AgentOrchestrator.chat()` 作为后端权威入口重新计算 stock scope；multi-agent 通过 `ctx.meta["stock_scope"] -> BaseAgent.run() -> run_agent_loop()` 显式透传。
- `run_agent_loop()` 在工具最终执行前做 `stock_code` guard：非明确切换时阻断越界 stock-scoped tool call，并仍回填 `role: tool` 的 `stock_scope_violation` 结果，保持 provider tool-use/tool-result 配对完整。
- `ToolRegistry.resolve()` 复用同一 resolver，兼容 Gemini namespaced tool name。
- 前后端补齐多代码抽取、大小写美股 ticker 意图门控、A/HK/US 归一化、交易所前后缀过滤、选择型比较语义、历史消息恢复和 final-sink guard 回归测试。
- 更新 `docs/full-guide.md` 与 `docs/CHANGELOG.md`。

不在本 PR 范围内：完整多股比较 UI/体验、`stock_name` 语义一致性 guard、Bot 专用 sticky context、配置项、数据库迁移、第三方模型/provider/fallback 语义。

## Issue Link

Refs #1596

## Semantic Matrix / Review Contract

本 PR 自审时按语义矩阵覆盖，不只验证 helper happy path：

- `maintain`：`如果不考虑 TTM 呢`、`PE 怎么看`、`MACD 还没金叉吗`、`hello tsla` 不切换当前标的；若模型继续请求错误 `stock_code`，runner guard 在最终工具 sink 阻断。
- `switch`：`换成 AAPL 看看`、`换成 AAPL 看看，不考虑 600519`、`先不看 600519，换成 AAPL 看看`、`分析 AAPL 的差异化优势`、`分析tsla`、`看看 tsla` 切换到唯一新标的，并清理旧 `stock_name / previous_* / prefetched_*`。
- `compare`：`比较 600519 和 AAPL`、`分析 600519 和 AAPL 的差异`、`AAPL 相比 600519`、`和 AAPL 的差异怎么看`、`AAPL 和 TSLA 哪个更值得买`、`AAPL 和 TSLA 谁更适合`、`分析 AAPL 和 TSLA` 进入 compare，不污染当前标的，allowed set 包含归一化后的明确代码。
- 交易所与港股表示：`SH600519`、`SZ000001`、`BJ920748`、`HK01810`、`01810`、`600519.SH`、`1810.HK` 不会把 `SH/SZ/BJ/HK` 当成独立 ticker 写入 allowed set；`01810` 与 `HK01810` 等价放行。
- 状态恢复：已加载历史用户消息为 `600519 -> AAPL` 后，下一轮 `继续看支撑位` 会发送 AAPL 的基础 context；无明确历史标的时保持 unset。
- final sink：allowed set 内的 AAPL/TSLA/HK 等价代码会执行 handler；越界 `SH/SZ/BJ/HK/TTM` 会返回 `stock_scope_violation` 且 handler 不执行；非 stock-scoped tool 不受影响。

## Verification Commands And Results

实际在 clean branch 上执行：

```bash
python -m pytest tests/test_agent_executor.py tests/test_multi_agent.py -q
cd apps/dsa-web && npm test -- src/pages/__tests__/ChatPage.test.tsx src/utils/__tests__/stockCode.test.ts -- --runInBand
python -m pytest tests/test_agent_executor.py tests/test_multi_agent.py tests/test_agent_chat_api.py tests/test_agent_pipeline.py -q
python -m py_compile src/agent/stock_scope.py src/agent/runner.py
cd apps/dsa-web && npm run lint && npm run build
git diff --check
PATH=/private/tmp/dsa-flake8-bin:$PATH ./scripts/ci_gate.sh
```

关键输出/结论：

- 目标后端测试：`195 passed, 1 warning`
- 目标前端测试：`64 passed`
- 扩展后端回归：`275 passed, 3 warnings`
- `py_compile`：通过，无输出
- Web lint/build：通过，`✓ built`
- `git diff --check`：通过，无空白问题
- `./scripts/ci_gate.sh`：`2803 passed, 2 deselected, 23 warnings, 284 subtests passed`，`backend-gate: all checks passed`

## Visual Evidence (if applicable)

- 截图 / Screenshots: 未附截图
- 不适用原因 / Reason if not applicable: 本 PR 修改 Web 问股发送 payload 的上下文保持/清空/恢复逻辑和后端工具 guard，不修改页面布局、样式、报告格式或报告渲染效果；视觉截图无法展示被发送的 `context` 或 runner 层 `stock_scope_violation`，因此以前端 payload 单测、后端 final-sink 工具调用测试和完整 gate 作为可验证证据。

## Compatibility And Risk

兼容性：

- 不修改 `.env.example`、`requirements.txt`、数据库迁移、Docker、GitHub Actions、模型配置、provider fallback 或 runtime config 保存逻辑。
- 不修改 `validateStockCode()` 的既有语义；前端只新增多代码抽取 helper，并保持 `extractStockCodeFromMessage()` 返回第一个结果的兼容行为。
- `normalizeStockCode()` 新增纯 5 位港股 canonicalization，用来对齐 `validateStockCode()` 已接受的港股契约。
- 历史消息恢复只基于已加载的用户消息推断基础 `{ stock_code, stock_name: null }`，不新增持久化字段、会话元数据或数据库迁移。
- `run()` 主分析路径不传 `stock_scope`，guard 默认为 no-op，不影响 dashboard 主分析链路。
- Search tools 在本 PR 只按 `stock_code` guard；`stock_name`-only 不一致仍作为 follow-up。

残余风险：

- 本 PR 只覆盖明确比较 cue、选择型比较表达和多代码 compare；完全隐晦、无比较信号的多标的自然语言仍可能按保守逻辑处理。
- Bot 路径未新增专用 context，当前没有 stock scope 时 guard 惰性放行，后续如需 Bot sticky context 应单独做。
- 前后端均有轻量正则/NLU 逻辑，后端是最终权威；未来新增语义时需要同步扩展测试矩阵，避免 drift。

第三方模型/API 兼容性：不涉及第三方模型、API 请求参数、provider fallback、路由前缀或 Base URL 语义变化。`ToolRegistry.resolve()` 仅用于工具名解析与 guard/execute 行为一致，不改变模型配置或外部调用协议。

## Rollback Plan

Revert this PR 的单个 commit 即可回滚；无配置、依赖、数据迁移或数据库状态需要额外回滚。

## EXTRACT_PROMPT Change (if applicable)

不适用。本 PR 未修改 `src/services/image_stock_extractor.py` 或 `EXTRACT_PROMPT`。

<details>
<summary>展开 / Expand: Full EXTRACT_PROMPT</summary>

```text
N/A
```

</details>

## Checklist

- [x] 本 PR 有明确动机和业务价值 / This PR has a clear motivation and value
- [x] 已提供可复现的验证命令与结果 / Reproducible verification commands and results are included
- [x] 已评估兼容性与风险 / Compatibility and risk have been assessed
- [x] 已提供回滚方案 / A rollback plan is provided
- [x] 若修改报告格式或 Web UI 界面，已附受影响报告 / 页面截图 / If report formatting or Web UI changed, affected report/page screenshots are attached
- [x] 若涉及用户可见变更，已同步更新相关文档与 `docs/CHANGELOG.md`；`README.md` 仅在首页级信息变化时更新，细节优先写入 `docs/*.md` / If user-visible changes are included, relevant docs and `docs/CHANGELOG.md` are updated; `README.md` is updated only for homepage-level changes, with details kept in `docs/*.md`
