### PR TITLE
fix: verify packaged AlphaSift adapter at runtime

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 <!-- 新条目格式：- [类型] 描述（类型取值：新功能/改进/修复/文档/测试/chore）-->
 <!-- 每条独立一行追加到本段末尾，无需分类标题，合并时冲突最小 -->
+- [修复] 桌面发布打包改用冻结可执行文件运行时探针校验 `alphasift.dsa_adapter`，避免 macOS PyInstaller 将模块内嵌进可执行文件时被文件系统/zip 扫描误判为缺失。
 
 ## [3.21.0] - 2026-06-07
 
@@ -80,6 +81,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 ### chore
 
 - 移除随 issue / PR 验收流程误入库的截图资产，并明确一次性截图证据应保留在 PR 描述、评论、附件或 artifact 中，不作为仓库文件合入。
+- [修复] `/health` 根路径健康检查现在始终返回 JSON，避免静态 Web fallback 吞掉健康探针；`/api/health` 与 `/api/v1/health` 继续保持兼容。
+- [改进] API 错误响应构造收敛到共享 helper，保持既有错误 envelope 形状并降低 endpoint 重复代码。
+- [改进] WebUI 绑定公网地址或 CORS 全开放且未启用管理员认证时新增运行时 warning；仅增加可观测性，不阻断启动、不改写配置。
+- [改进] 数据库初始化新增 `schema_migrations` baseline 标记表与幂等记录，用于后续 schema 演进追踪；不迁移、不清理、不改写既有业务表数据。
+- [测试] Web 测试运行时声明 Node `>=20.19.0 <27` 与 npm `>=10`，并补 localStorage 测试兜底以稳定 Vitest。
+- [改进] #1386 P6 复用市场阶段与 AnalysisContextPack 公开摘要联动告警、持仓手动分析、历史、回测和通知展示，不新增数据库迁移。
+- [新功能] WebUI 新增独立界面语言状态与中英文切换入口，覆盖主导航、首页、登录、设置页和通用控件文案；不复用或改变报告语言配置语义。
+
+- [新功能] 飞书通知新增应用机器人（App Bot）模式，支持通过 FEISHU_APP_ID / FEISHU_APP_SECRET / FEISHU_CHAT_ID 配置，无需额外创建自定义机器人。
+- [文档] 明确 AnalysisContextPack P6 文档、迁移与回滚边界，并同步既有 `SAVE_CONTEXT_SNAPSHOT` 到 `.env.example`、配置注册表、Web 设置帮助和完整指南。
+- [文档] 补齐 #1386 P7 盘前/盘中/盘后分析的入口、迁移、回滚和用户可见说明。
+- [新功能] 新增默认关闭的 AlphaSift 选股页签，通过 `ALPHASIFT_ENABLED` 明确控制，并保留 `/install` 作为显式修复路径。
+- [改进] AlphaSift 选股 API 与服务层收敛到 `AlphaSiftService`，endpoint 仅做路由参数接收与错误映射。
+- [改进] AlphaSift 与 DSA 的运行时 LLM 兼容桥接改为调用期注入，保留 `provider/model/base_url/custom headers/fallback` 语义链路，不做持久化迁移。
+- [修复] `ALPHASIFT_ENABLED` 关闭时不触发 `alphasift` 运行时注入；开启后优先复用已配置的 DSA/provider 配置并注入 `LITELLM_*` 与 `LLM_*` 运行时变量。
+- [修复] 补齐 openai-compatible 场景下 base URL、`extra_headers` 与 `LITELLM_FALLBACK_MODELS` 的兼容路径与回退链验证。
+- [文档] 为 AlphaSift runtime bridge 增加官方兼容依据落点：补充 `docs/alphasift-integration.md` 中 LiteLLM/OpenAI 官方文档锚点与 `requirements.txt`/`alphasift` commit 版本依据，明确 provider/model/base_url/extra_headers/fallback 与回退边界。
+- [修复] 桌面/镜像打包链路保持与运行时一致的 AlphaSift 适配层预置，避免 `pip install` 作为线上修复依赖。
+- [测试] 增补 AlphaSift runtime bridge 与打包脚本静态验证，覆盖 `LLM_CHANNELS`、`LITELLM_FALLBACK_MODELS`、`alphasift.dsa_adapter`、`--collect-all alphasift`。
 
 ## [3.20.0] - 2026-06-03
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -19,9 +19,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 - feat: 新增 Web UI 中英文界面语言切换和飞书 App Bot 通知模式，提升多人部署和企业通知场景体验。
 - feat: 大盘复盘报告、历史入口和个股栏继续收口到结构化数据与统一 Markdown/GFM 渲染，Web/API 人工触发入口不再被交易日 gate 短路。
+- feat: AlphaSift 选股链路改为可恢复后台任务，并完善 DSA LLM runtime bridge、默认适配层预置和兼容回归。
+- fix: 修复英文界面残留中文、诊断展示、运行时环境变量展示、健康检查、桌面更新路径、工作流变量读取和多处 Web 窄布局问题。
 
 ### 新功能
 
+- WebUI 新增独立界面语言状态与中英文切换入口，覆盖主导航、首页、登录、设置页和通用控件文案；UI 语言与 `report_language` 解耦，不改写报告语言链路。
 - 飞书通知新增应用机器人（App Bot）模式，支持通过 `FEISHU_APP_ID` / `FEISHU_APP_SECRET` / `FEISHU_CHAT_ID` 配置，无需额外创建自定义机器人。
 - Web 大盘复盘报告新增专用展示视图，历史入口和首页即时结果统一使用 Markdown/GFM 渲染并隐藏个股专属模块。
 - 大盘复盘新增结构化 `market_review_payload`，Web、历史详情和推送统一基于结构化数据渲染，并保留 Markdown 兼容展示。
@@ -32,6 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - Web/API 大盘复盘人工触发入口不再因交易日检查或相关市场休市而短路跳过；定时任务、GitHub Actions 手动运行和 CLI 默认入口仍保持原交易日 gate。
 - AlphaSift Web 选股改为后台任务提交与状态轮询，新增可恢复任务状态展示，避免外部快照、行情或 LLM 变慢时浏览器长请求超时。
 - AlphaSift 选股 API 与服务层收敛到 `AlphaSiftService`，endpoint 仅做路由参数接收与错误映射。
+- AlphaSift 与 DSA 的运行时 LLM 兼容桥接改为调用期注入，保留 `provider/model/base_url/custom headers/fallback` 语义链路，不做持久化迁移。
 - Web 首页侧栏不再单独展示大盘复盘历史集合，最新大盘复盘作为 `MARKET` 并入个股栏，按最近分析时间参与排序，并复用个股栏的选择、删除、完整报告与历史趋势查看能力。
 - 多股通知报告将市场阶段收敛为总览下方单行 `市场状态`，不再在每只股票摘要下重复展示数据质量和限制详情。
 - API 错误响应构造收敛到共享 helper，保持既有错误 envelope 形状并降低 endpoint 重复代码。
@@ -54,37 +58,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - Docker Web 设置页读取配置时在活跃 `.env` 文件缺项时回退展示启动注入的同名环境变量，并补清相关挂载边界文档。
 - 报告页运行诊断会区分数据源抓取成功与进入 LLM 分析输入，相关新闻区标注为报告页补充/后续检索资讯，避免与输入数据块状态互相误读。
 - `/health` 根路径健康检查现在始终返回 JSON，避免静态 Web fallback 吞掉健康探针；`/api/health` 与 `/api/v1/health` 继续保持兼容。
+- `ALPHASIFT_ENABLED` 关闭时不触发 `alphasift` 运行时注入；开启后优先复用已配置的 DSA/provider 配置并注入 `LITELLM_*` 与 `LLM_*` 运行时变量。
+- 补齐 openai-compatible 场景下 base URL、`extra_headers` 与 `LITELLM_FALLBACK_MODELS` 的兼容路径与回退链验证。
 - 桌面/镜像打包链路保持与运行时一致的 AlphaSift 适配层预置，避免 `pip install` 作为线上修复依赖。
 
 ### 文档
 
 - 明确 Issue #777 UI 语言切换采用仓内 `UiLanguageContext` + `uiText` 实现，持久化 key 为 `dsa.uiLanguage`，并补充对应可视化验收指引。
 - 明确大盘复盘展示链路、结构化 payload、语言行为、交易日 gate 差异和回滚边界。
+- 补充 LLM / LiteLLM 兼容键在 Settings 展示与校验上下文中的回退边界，说明不改写、不迁移、不清理用户现有 provider/model/base URL 持久化配置。
 - 补齐 #1602 运行诊断口径修复覆盖范围，说明仅统一输入与展示口径，回滚方式为常规发布回滚。
 - 明确 AnalysisContextPack P6 文档、迁移与回滚边界，并同步既有 `SAVE_CONTEXT_SNAPSHOT` 到 `.env.example`、配置注册表、Web 设置帮助和完整指南。
 - 补齐 #1386 P7 盘前/盘中/盘后分析的入口、迁移、回滚和用户可见说明。
+- 为 AlphaSift runtime bridge 增加官方兼容依据落点，明确 provider/model/base_url/extra_headers/fallback 与回退边界。
 
 ### 测试
 
 - Web 方向执行 `npm run lint`、`npm run build`、相关 Vitest 和 smoke 命令；未设置 `DSA_WEB_SMOKE_PASSWORD` 时 smoke 用例按设计 skip。
 - Web 测试运行时声明 Node `>=20.19.0 <27` 与 npm `>=10`，并补 localStorage 测试兜底以稳定 Vitest。
+- 增补 AlphaSift runtime bridge 与打包脚本静态验证，覆盖 `LLM_CHANNELS`、`LITELLM_FALLBACK_MODELS`、`alphasift.dsa_adapter`、`--collect-all alphasift`。
 
 ### chore
 
 - 移除随 issue / PR 验收流程误入库的截图资产，并明确一次性截图证据应保留在 PR 描述、评论、附件或 artifact 中，不作为仓库文件合入。
-- [修复] `/health` 根路径健康检查现在始终返回 JSON，避免静态 Web fallback 吞掉健康探针；`/api/health` 与 `/api/v1/health` 继续保持兼容。
-- [改进] API 错误响应构造收敛到共享 helper，保持既有错误 envelope 形状并降低 endpoint 重复代码。
-- [改进] WebUI 绑定公网地址或 CORS 全开放且未启用管理员认证时新增运行时 warning；仅增加可观测性，不阻断启动、不改写配置。
-- [改进] 数据库初始化新增 `schema_migrations` baseline 标记表与幂等记录，用于后续 schema 演进追踪；不迁移、不清理、不改写既有业务表数据。
-- [测试] Web 测试运行时声明 Node `>=20.19.0 <27` 与 npm `>=10`，并补 localStorage 测试兜底以稳定 Vitest。
-- [改进] #1386 P6 复用市场阶段与 AnalysisContextPack 公开摘要联动告警、持仓手动分析、历史、回测和通知展示，不新增数据库迁移。
-
-- [新功能] 飞书通知新增应用机器人（App Bot）模式，支持通过 FEISHU_APP_ID / FEISHU_APP_SECRET / FEISHU_CHAT_ID 配置，无需额外创建自定义机器人。
-- [文档] 明确 AnalysisContextPack P6 文档、迁移与回滚边界，并同步既有 `SAVE_CONTEXT_SNAPSHOT` 到 `.env.example`、配置注册表、Web 设置帮助和完整指南。
-- [文档] 补齐 #1386 P7 盘前/盘中/盘后分析的入口、迁移、回滚和用户可见说明。
-- [新功能] 新增默认关闭的 AlphaSift 选股页签，通过 `ALPHASIFT_ENABLED` 明确控制，并保留 `/install` 作为显式修复路径。
-- [改进] AlphaSift 选股 API 与服务层收敛到 `AlphaSiftService`，endpoint 仅做路由参数接收与错误映射。
-- [修复] 桌面/镜像打包链路保持与运行时一致的 AlphaSift 适配层预置，避免 `pip install` 作为线上修复依赖。
 
 ## [3.20.0] - 2026-06-03
 
@@ -159,9 +155,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### 文档
 
+- 明确 AlphaSift 与 LiteLLM 兼容边界：仅桥接 DSA 已声明 provider/model/base URL 为调用期注入，不对 `.env` 做 provider/model 路由迁移；回退方式为关闭 AlphaSift 并恢复原有 `LITELLM_*`/`LLM_*` 配置。
 - 明确 AlphaSift 仅复用 DSA 现有 LLM/LiteLLM 配置语义，不新增 `LITELLM_MODEL`、`OPENAI_MODEL`、`OPENAI_BASE_URL`、`LLM_TIMEOUT_SEC` 等模型语义迁移；失败提示与回退路径统一沿用既有系统配置链路，仅影响 AlphaSift 选股能力本身。
 - 明确 AlphaSift 自动安装来源锁定、`missing_module` 与运行时异常行为边界，以及 LLM/provider/base URL 与自定义通道回退路径，便于问题溯源与回滚到原有 LLM 配置。
 - 明确同股历史趋势新增模型字段为历史快照展示元数据，不影响运行时 LLM Provider/Model/Base URL 路由与配置迁移清理；回退方式为按常规发布回滚本变更。
+- 明确 #1311 的兼容性边界：渲染层仅消费分析结果 `model_used` 展示字段，未改动 `wechat/slack/feishu/telegram` sender 发送链路，不触发 provider/model/base_url 兼容迁移。
 - 明确 AlphaSift 锁定 commit 的 `alphasift.dsa_adapter` 契约依据，以及当前 DSA API/Web 调用结构的兼容边界。
 - 明确 Settings 页面对 LLM 配置仅做展示分组与字段归并，不改写或触发 LLM 迁移/回退路径；兼容现有 `LLM` 配置保存与回退语义。
 - 新增 AnalysisContextPack P0 上下文盘点。
@@ -390,6 +388,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - Agent 模式未生成有效决策仪表盘时保留本地趋势分析的评分、趋势和操作建议，并将强买/强卖 fallback 归一到兼容的 `buy`/`sell` 决策类型，避免首页结果被 `50 / 观望 / 未知` 缺省值覆盖。
 - 持仓快照现价缺失时不再静默回退为持仓成本；当天快照优先使用历史收盘价，仅在缺失时使用实时价 fallback，缺价持仓不再污染市值与未实现盈亏汇总，并为持仓明细返回价格来源、日期、stale 与缺价状态。
 - 分析 Prompt 在注入 `trend_analysis` 前按最终 `trend_status` / `ma_alignment` 清洗互斥理由：空头结构移除看多理由、多头结构移除空头结构风险，并在事件/技术冲突与异常放量（>10 倍）时强制提示“事件先行、技术待确认”与量能降权。
+- LLM 返回非 JSON 响应时同样触发备用模型切换：主模型成功返回但无法解析 JSON 时，不再立即降级为纯文本 fallback，而是依次尝试 `LITELLM_FALLBACK_MODELS` 中的备用模型；所有模型均无法返回合法 JSON 时，再降级为文本 fallback。
 - LiteLLM 内部 DEBUG 日志默认压低到 WARNING，避免流式生成时 token 级日志污染 `stock_analysis_debug_*.log`；如需排查 LiteLLM 内部细节，可临时设置 `LITELLM_LOG_LEVEL=DEBUG`（Fixes #1156）。
 
 ### 文档
@@ -1013,6 +1012,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 ### Added
 - 📡 **LiteLLM Direct Integration + Multi API Key Support** (#454, Fixes #421 #428)
   - Removed native SDKs (google-generativeai, google-genai, anthropic); unified through `litellm>=1.80.10`
+  - New config: `LITELLM_MODEL`, `LITELLM_FALLBACK_MODELS`, `GEMINI_API_KEYS`, `ANTHROPIC_API_KEYS`, `OPENAI_API_KEYS`
   - Multi-key auto-builds LiteLLM Router (simple-shuffle) with 429 cooldown
   - **Breaking**: `.env` `GEMINI_MODEL` (no prefix) only for fallback; explicit config must include provider prefix
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -19,12 +19,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 - feat: 新增 Web UI 中英文界面语言切换和飞书 App Bot 通知模式，提升多人部署和企业通知场景体验。
 - feat: 大盘复盘报告、历史入口和个股栏继续收口到结构化数据与统一 Markdown/GFM 渲染，Web/API 人工触发入口不再被交易日 gate 短路。
-- feat: AlphaSift 选股链路改为可恢复后台任务，并完善 DSA LLM runtime bridge、默认适配层预置和兼容回归。
-- fix: 修复英文界面残留中文、诊断展示、运行时环境变量展示、健康检查、桌面更新路径、工作流变量读取和多处 Web 窄布局问题。
 
 ### 新功能
 
-- WebUI 新增独立界面语言状态与中英文切换入口，覆盖主导航、首页、登录、设置页和通用控件文案；UI 语言与 `report_language` 解耦，不改写报告语言链路。
 - 飞书通知新增应用机器人（App Bot）模式，支持通过 `FEISHU_APP_ID` / `FEISHU_APP_SECRET` / `FEISHU_CHAT_ID` 配置，无需额外创建自定义机器人。
 - Web 大盘复盘报告新增专用展示视图，历史入口和首页即时结果统一使用 Markdown/GFM 渲染并隐藏个股专属模块。
 - 大盘复盘新增结构化 `market_review_payload`，Web、历史详情和推送统一基于结构化数据渲染，并保留 Markdown 兼容展示。
@@ -35,7 +32,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - Web/API 大盘复盘人工触发入口不再因交易日检查或相关市场休市而短路跳过；定时任务、GitHub Actions 手动运行和 CLI 默认入口仍保持原交易日 gate。
 - AlphaSift Web 选股改为后台任务提交与状态轮询，新增可恢复任务状态展示，避免外部快照、行情或 LLM 变慢时浏览器长请求超时。
 - AlphaSift 选股 API 与服务层收敛到 `AlphaSiftService`，endpoint 仅做路由参数接收与错误映射。
-- AlphaSift 与 DSA 的运行时 LLM 兼容桥接改为调用期注入，保留 `provider/model/base_url/custom headers/fallback` 语义链路，不做持久化迁移。
 - Web 首页侧栏不再单独展示大盘复盘历史集合，最新大盘复盘作为 `MARKET` 并入个股栏，按最近分析时间参与排序，并复用个股栏的选择、删除、完整报告与历史趋势查看能力。
 - 多股通知报告将市场阶段收敛为总览下方单行 `市场状态`，不再在每只股票摘要下重复展示数据质量和限制详情。
 - API 错误响应构造收敛到共享 helper，保持既有错误 envelope 形状并降低 endpoint 重复代码。
@@ -58,25 +54,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - Docker Web 设置页读取配置时在活跃 `.env` 文件缺项时回退展示启动注入的同名环境变量，并补清相关挂载边界文档。
 - 报告页运行诊断会区分数据源抓取成功与进入 LLM 分析输入，相关新闻区标注为报告页补充/后续检索资讯，避免与输入数据块状态互相误读。
 - `/health` 根路径健康检查现在始终返回 JSON，避免静态 Web fallback 吞掉健康探针；`/api/health` 与 `/api/v1/health` 继续保持兼容。
-- `ALPHASIFT_ENABLED` 关闭时不触发 `alphasift` 运行时注入；开启后优先复用已配置的 DSA/provider 配置并注入 `LITELLM_*` 与 `LLM_*` 运行时变量。
-- 补齐 openai-compatible 场景下 base URL、`extra_headers` 与 `LITELLM_FALLBACK_MODELS` 的兼容路径与回退链验证。
 - 桌面/镜像打包链路保持与运行时一致的 AlphaSift 适配层预置，避免 `pip install` 作为线上修复依赖。
 
 ### 文档
 
 - 明确 Issue #777 UI 语言切换采用仓内 `UiLanguageContext` + `uiText` 实现，持久化 key 为 `dsa.uiLanguage`，并补充对应可视化验收指引。
 - 明确大盘复盘展示链路、结构化 payload、语言行为、交易日 gate 差异和回滚边界。
-- 补充 LLM / LiteLLM 兼容键在 Settings 展示与校验上下文中的回退边界，说明不改写、不迁移、不清理用户现有 provider/model/base URL 持久化配置。
 - 补齐 #1602 运行诊断口径修复覆盖范围，说明仅统一输入与展示口径，回滚方式为常规发布回滚。
 - 明确 AnalysisContextPack P6 文档、迁移与回滚边界，并同步既有 `SAVE_CONTEXT_SNAPSHOT` 到 `.env.example`、配置注册表、Web 设置帮助和完整指南。
 - 补齐 #1386 P7 盘前/盘中/盘后分析的入口、迁移、回滚和用户可见说明。
-- 为 AlphaSift runtime bridge 增加官方兼容依据落点，明确 provider/model/base_url/extra_headers/fallback 与回退边界。
 
 ### 测试
 
 - Web 方向执行 `npm run lint`、`npm run build`、相关 Vitest 和 smoke 命令；未设置 `DSA_WEB_SMOKE_PASSWORD` 时 smoke 用例按设计 skip。
 - Web 测试运行时声明 Node `>=20.19.0 <27` 与 npm `>=10`，并补 localStorage 测试兜底以稳定 Vitest。
-- 增补 AlphaSift runtime bridge 与打包脚本静态验证，覆盖 `LLM_CHANNELS`、`LITELLM_FALLBACK_MODELS`、`alphasift.dsa_adapter`、`--collect-all alphasift`。
 
 ### chore
 
@@ -87,19 +78,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - [改进] 数据库初始化新增 `schema_migrations` baseline 标记表与幂等记录，用于后续 schema 演进追踪；不迁移、不清理、不改写既有业务表数据。
 - [测试] Web 测试运行时声明 Node `>=20.19.0 <27` 与 npm `>=10`，并补 localStorage 测试兜底以稳定 Vitest。
 - [改进] #1386 P6 复用市场阶段与 AnalysisContextPack 公开摘要联动告警、持仓手动分析、历史、回测和通知展示，不新增数据库迁移。
-- [新功能] WebUI 新增独立界面语言状态与中英文切换入口，覆盖主导航、首页、登录、设置页和通用控件文案；不复用或改变报告语言配置语义。
 
 - [新功能] 飞书通知新增应用机器人（App Bot）模式，支持通过 FEISHU_APP_ID / FEISHU_APP_SECRET / FEISHU_CHAT_ID 配置，无需额外创建自定义机器人。
 - [文档] 明确 AnalysisContextPack P6 文档、迁移与回滚边界，并同步既有 `SAVE_CONTEXT_SNAPSHOT` 到 `.env.example`、配置注册表、Web 设置帮助和完整指南。
 - [文档] 补齐 #1386 P7 盘前/盘中/盘后分析的入口、迁移、回滚和用户可见说明。
 - [新功能] 新增默认关闭的 AlphaSift 选股页签，通过 `ALPHASIFT_ENABLED` 明确控制，并保留 `/install` 作为显式修复路径。
 - [改进] AlphaSift 选股 API 与服务层收敛到 `AlphaSiftService`，endpoint 仅做路由参数接收与错误映射。
-- [改进] AlphaSift 与 DSA 的运行时 LLM 兼容桥接改为调用期注入，保留 `provider/model/base_url/custom headers/fallback` 语义链路，不做持久化迁移。
-- [修复] `ALPHASIFT_ENABLED` 关闭时不触发 `alphasift` 运行时注入；开启后优先复用已配置的 DSA/provider 配置并注入 `LITELLM_*` 与 `LLM_*` 运行时变量。
-- [修复] 补齐 openai-compatible 场景下 base URL、`extra_headers` 与 `LITELLM_FALLBACK_MODELS` 的兼容路径与回退链验证。
-- [文档] 为 AlphaSift runtime bridge 增加官方兼容依据落点：补充 `docs/alphasift-integration.md` 中 LiteLLM/OpenAI 官方文档锚点与 `requirements.txt`/`alphasift` commit 版本依据，明确 provider/model/base_url/extra_headers/fallback 与回退边界。
 - [修复] 桌面/镜像打包链路保持与运行时一致的 AlphaSift 适配层预置，避免 `pip install` 作为线上修复依赖。
-- [测试] 增补 AlphaSift runtime bridge 与打包脚本静态验证，覆盖 `LLM_CHANNELS`、`LITELLM_FALLBACK_MODELS`、`alphasift.dsa_adapter`、`--collect-all alphasift`。
 
 ## [3.20.0] - 2026-06-03
 
@@ -174,11 +159,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### 文档
 
-- 明确 AlphaSift 与 LiteLLM 兼容边界：仅桥接 DSA 已声明 provider/model/base URL 为调用期注入，不对 `.env` 做 provider/model 路由迁移；回退方式为关闭 AlphaSift 并恢复原有 `LITELLM_*`/`LLM_*` 配置。
 - 明确 AlphaSift 仅复用 DSA 现有 LLM/LiteLLM 配置语义，不新增 `LITELLM_MODEL`、`OPENAI_MODEL`、`OPENAI_BASE_URL`、`LLM_TIMEOUT_SEC` 等模型语义迁移；失败提示与回退路径统一沿用既有系统配置链路，仅影响 AlphaSift 选股能力本身。
 - 明确 AlphaSift 自动安装来源锁定、`missing_module` 与运行时异常行为边界，以及 LLM/provider/base URL 与自定义通道回退路径，便于问题溯源与回滚到原有 LLM 配置。
 - 明确同股历史趋势新增模型字段为历史快照展示元数据，不影响运行时 LLM Provider/Model/Base URL 路由与配置迁移清理；回退方式为按常规发布回滚本变更。
-- 明确 #1311 的兼容性边界：渲染层仅消费分析结果 `model_used` 展示字段，未改动 `wechat/slack/feishu/telegram` sender 发送链路，不触发 provider/model/base_url 兼容迁移。
 - 明确 AlphaSift 锁定 commit 的 `alphasift.dsa_adapter` 契约依据，以及当前 DSA API/Web 调用结构的兼容边界。
 - 明确 Settings 页面对 LLM 配置仅做展示分组与字段归并，不改写或触发 LLM 迁移/回退路径；兼容现有 `LLM` 配置保存与回退语义。
 - 新增 AnalysisContextPack P0 上下文盘点。
@@ -407,7 +390,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - Agent 模式未生成有效决策仪表盘时保留本地趋势分析的评分、趋势和操作建议，并将强买/强卖 fallback 归一到兼容的 `buy`/`sell` 决策类型，避免首页结果被 `50 / 观望 / 未知` 缺省值覆盖。
 - 持仓快照现价缺失时不再静默回退为持仓成本；当天快照优先使用历史收盘价，仅在缺失时使用实时价 fallback，缺价持仓不再污染市值与未实现盈亏汇总，并为持仓明细返回价格来源、日期、stale 与缺价状态。
 - 分析 Prompt 在注入 `trend_analysis` 前按最终 `trend_status` / `ma_alignment` 清洗互斥理由：空头结构移除看多理由、多头结构移除空头结构风险，并在事件/技术冲突与异常放量（>10 倍）时强制提示“事件先行、技术待确认”与量能降权。
-- LLM 返回非 JSON 响应时同样触发备用模型切换：主模型成功返回但无法解析 JSON 时，不再立即降级为纯文本 fallback，而是依次尝试 `LITELLM_FALLBACK_MODELS` 中的备用模型；所有模型均无法返回合法 JSON 时，再降级为文本 fallback。
 - LiteLLM 内部 DEBUG 日志默认压低到 WARNING，避免流式生成时 token 级日志污染 `stock_analysis_debug_*.log`；如需排查 LiteLLM 内部细节，可临时设置 `LITELLM_LOG_LEVEL=DEBUG`（Fixes #1156）。
 
 ### 文档
@@ -1031,7 +1013,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 ### Added
 - 📡 **LiteLLM Direct Integration + Multi API Key Support** (#454, Fixes #421 #428)
   - Removed native SDKs (google-generativeai, google-genai, anthropic); unified through `litellm>=1.80.10`
-  - New config: `LITELLM_MODEL`, `LITELLM_FALLBACK_MODELS`, `GEMINI_API_KEYS`, `ANTHROPIC_API_KEYS`, `OPENAI_API_KEYS`
   - Multi-key auto-builds LiteLLM Router (simple-shuffle) with 429 cooldown
   - **Breaking**: `.env` `GEMINI_MODEL` (no prefix) only for fallback; explicit config must include provider prefix
 

--- a/main.py
+++ b/main.py
@@ -44,6 +44,19 @@ if os.getenv("GITHUB_ACTIONS") != "true" and os.getenv("USE_PROXY", "false").low
     os.environ["http_proxy"] = proxy_url
     os.environ["https_proxy"] = proxy_url
 
+if os.getenv("DSA_PACKAGED_ALPHASIFT_IMPORT_PROBE") == "1":
+    import importlib
+    import sys
+
+    try:
+        importlib.import_module("alphasift.dsa_adapter")
+    except Exception as exc:
+        print(f"ERROR: packaged AlphaSift adapter import failed: {exc}", file=sys.stderr)
+        sys.exit(1)
+
+    print("OK: packaged AlphaSift adapter import succeeded")
+    sys.exit(0)
+
 import argparse
 import logging
 import sys

--- a/scripts/build-backend-macos.sh
+++ b/scripts/build-backend-macos.sh
@@ -136,76 +136,11 @@ if ! "${packaged_entry}" --help >/tmp/alphasift-packaged-help.log 2>&1; then
   exit 1
 fi
 
-if "${PYTHON_BIN}" -S - <<'PY' "${packaged_root}"
-import pathlib
-import sys
-import zipfile
-import importlib
-
-
-def _as_importable_paths(root: pathlib.Path):
-    candidates = [root]
-    internal = root / "_internal"
-    if internal.is_dir():
-        candidates.append(internal)
-
-    for base in candidates:
-        yield base
-        for archive_name in ("*.pyz", "*.zip"):
-            for archive in base.glob(archive_name):
-                yield archive
-
-
-def _can_import_from_candidates(root: pathlib.Path) -> bool:
-    for candidate in _as_importable_paths(root):
-        if not candidate.exists():
-            continue
-
-        baseline_path = list(sys.path)
-        sys.path = [str(candidate)]
-        for key in list(sys.modules):
-            if key == "alphasift" or key.startswith("alphasift."):
-                del sys.modules[key]
-
-        try:
-            importlib.invalidate_caches()
-            importlib.import_module("alphasift.dsa_adapter")
-            print(f"OK (import) from: {candidate}")
-            return True
-        except Exception:
-            continue
-        finally:
-            sys.path = baseline_path
-
-    return False
-
-
-def _zip_contains_alphasift_adapter(root: pathlib.Path) -> bool:
-    for candidate in _as_importable_paths(root):
-        if not candidate.is_file() or candidate.suffix not in {".pyz", ".zip"}:
-            continue
-
-        try:
-            with zipfile.ZipFile(candidate, "r") as zf:
-                for name in zf.namelist():
-                    normalized = name.replace("\\", "/").lstrip("/")
-                    if normalized.startswith("alphasift/dsa_adapter.") or normalized.startswith("alphasift/dsa_adapter/"):
-                        print(f"OK (archive) from: {candidate}")
-                        return True
-        except Exception:
-            continue
-
-    return False
-
-
-root = pathlib.Path(sys.argv[1]).resolve()
-if not _can_import_from_candidates(root) and not _zip_contains_alphasift_adapter(root):
-    raise SystemExit(f"Missing alphasift adapter in packaged artifact: {root}")
-PY
-then
-  echo "Verifying packaged AlphaSift importability..."
+if DSA_PACKAGED_ALPHASIFT_IMPORT_PROBE=1 "${packaged_entry}" >/tmp/alphasift-packaged-import.log 2>&1; then
+  cat /tmp/alphasift-packaged-import.log
 else
-  echo "ERROR: packaged backend artifact is missing alphasift modules in ${packaged_root}."
+  echo "ERROR: packaged backend artifact cannot import alphasift.dsa_adapter."
+  cat /tmp/alphasift-packaged-import.log
   exit 1
 fi
 

--- a/scripts/build-backend.ps1
+++ b/scripts/build-backend.ps1
@@ -149,9 +149,9 @@ if (-not (Test-Path $packagedEntry)) {
 $previousProbe = $env:DSA_PACKAGED_ALPHASIFT_IMPORT_PROBE
 try {
   $env:DSA_PACKAGED_ALPHASIFT_IMPORT_PROBE = '1'
-  & $packagedEntry
-  if ($LASTEXITCODE -ne 0) {
-    throw "Packaged backend cannot import alphasift.dsa_adapter; probe exited with code $LASTEXITCODE."
+  $probeProcess = Start-Process -FilePath $packagedEntry -Wait -PassThru
+  if ($probeProcess.ExitCode -ne 0) {
+    throw "Packaged backend cannot import alphasift.dsa_adapter; probe exited with code $($probeProcess.ExitCode)."
   }
 } finally {
   if ($null -eq $previousProbe) {

--- a/scripts/build-backend.ps1
+++ b/scripts/build-backend.ps1
@@ -141,6 +141,26 @@ if (!(Test-Path 'dist\stock_analysis')) {
 
 Copy-Item -Path 'dist\stock_analysis' -Destination 'dist\backend\stock_analysis' -Recurse -Force
 
+Write-Host 'Verifying packaged AlphaSift importability...'
+$packagedEntry = Join-Path 'dist\backend\stock_analysis' 'stock_analysis.exe'
+if (-not (Test-Path $packagedEntry)) {
+  throw "Packaged backend entrypoint not found: $packagedEntry"
+}
+$previousProbe = $env:DSA_PACKAGED_ALPHASIFT_IMPORT_PROBE
+try {
+  $env:DSA_PACKAGED_ALPHASIFT_IMPORT_PROBE = '1'
+  & $packagedEntry
+  if ($LASTEXITCODE -ne 0) {
+    throw "Packaged backend cannot import alphasift.dsa_adapter; probe exited with code $LASTEXITCODE."
+  }
+} finally {
+  if ($null -eq $previousProbe) {
+    Remove-Item Env:DSA_PACKAGED_ALPHASIFT_IMPORT_PROBE -ErrorAction SilentlyContinue
+  } else {
+    $env:DSA_PACKAGED_ALPHASIFT_IMPORT_PROBE = $previousProbe
+  }
+}
+
 Write-Host 'Verifying static asset references (packaged)...'
 $packagedStatic = Join-Path 'dist\backend\stock_analysis' '_internal\static'
 if (-not (Test-Path $packagedStatic)) {

--- a/tests/test_packaging_build_scripts.py
+++ b/tests/test_packaging_build_scripts.py
@@ -22,6 +22,9 @@ def test_windows_backend_build_script_collects_alphasift_adapter() -> None:
     assert "hiddenImports" in script
     assert "Verifying packaged AlphaSift importability" in script
     assert "DSA_PACKAGED_ALPHASIFT_IMPORT_PROBE" in script
+    assert "Start-Process -FilePath $packagedEntry -Wait -PassThru" in script
+    assert "$probeProcess.ExitCode" in script
+    assert "& $packagedEntry" not in script
     assert "Packaged backend cannot import alphasift.dsa_adapter" in script
     assert "DSA_PACKAGED_ALPHASIFT_IMPORT_PROBE" in main_py
     assert 'importlib.import_module("alphasift.dsa_adapter")' in main_py

--- a/tests/test_packaging_build_scripts.py
+++ b/tests/test_packaging_build_scripts.py
@@ -13,25 +13,34 @@ def _read_text(path: Path) -> str:
 
 def test_windows_backend_build_script_collects_alphasift_adapter() -> None:
     script = _read_text(REPO_ROOT / "scripts" / "build-backend.ps1")
+    main_py = _read_text(REPO_ROOT / "main.py")
 
     assert "Checking AlphaSift adapter availability" in script
     assert "import alphasift.dsa_adapter" in script
     assert "--collect-all" in script
     assert "alphasift.dsa_adapter" in script
     assert "hiddenImports" in script
+    assert "Verifying packaged AlphaSift importability" in script
+    assert "DSA_PACKAGED_ALPHASIFT_IMPORT_PROBE" in script
+    assert "Packaged backend cannot import alphasift.dsa_adapter" in script
+    assert "DSA_PACKAGED_ALPHASIFT_IMPORT_PROBE" in main_py
+    assert 'importlib.import_module("alphasift.dsa_adapter")' in main_py
 
 
 def test_macos_backend_build_script_collects_alphasift_adapter() -> None:
     script = _read_text(REPO_ROOT / "scripts" / "build-backend-macos.sh")
+    main_py = _read_text(REPO_ROOT / "main.py")
 
     assert "Checking AlphaSift adapter availability..." in script
     assert "import alphasift.dsa_adapter" in script
     assert "--collect-all" in script
     assert "cmd+=(\"--collect-all\" \"alphasift\")" in script
-    assert "zipfile" in script
-    assert 'normalized.startswith("alphasift/dsa_adapter.")' in script
-    assert 'normalized.startswith("alphasift/dsa_adapter/")' in script
-    assert 'normalized.endswith("alphasift/__init__.py")' not in script
     assert "packaged_entry=\"${packaged_root}/stock_analysis\"" in script
     assert "--help" in script
+    assert "DSA_PACKAGED_ALPHASIFT_IMPORT_PROBE=1" in script
+    assert "alphasift-packaged-import.log" in script
     assert "PathFinder.find_spec(" not in script
+    assert "zipfile" not in script
+    assert 'normalized.startswith("alphasift/dsa_adapter.")' not in script
+    assert "DSA_PACKAGED_ALPHASIFT_IMPORT_PROBE" in main_py
+    assert 'importlib.import_module("alphasift.dsa_adapter")' in main_py


### PR DESCRIPTION
## PR Type

- [x] fix
- [ ] feat
- [ ] refactor
- [ ] docs
- [ ] chore
- [ ] test

## Background And Problem

最新 `Desktop Release` CI 在 macOS 打包后校验 AlphaSift 适配层时失败：

- run id: `27095644587`
- 失败点：`scripts/build-backend-macos.sh` 的 `Verifying packaged AlphaSift importability...`
- 错误：`Missing alphasift adapter in packaged artifact`

根因是原校验脚本通过文件系统 / `.pyz` / `.zip` 扫描判断 `alphasift.dsa_adapter` 是否存在，但 macOS PyInstaller onedir 构建可能把纯 Python 模块内嵌进冻结可执行文件的 CArchive/PYZ 中，扫描不到就误判缺失。CI 日志中 PyInstaller 已显示分析了 `alphasift` 与 `alphasift.dsa_adapter` hidden import，且构建前导入检查已通过。

## Scope Of Change

- `main.py`
  - 新增内部探针 `DSA_PACKAGED_ALPHASIFT_IMPORT_PROBE=1`，在主程序早期只验证 `importlib.import_module("alphasift.dsa_adapter")` 后退出，避免进入完整业务启动。
- `scripts/build-backend-macos.sh`
  - 移除文件系统 / zip 扫描式判断。
  - 改为运行冻结后的 `stock_analysis` 可执行文件执行真实运行时导入探针。
- `scripts/build-backend.ps1`
  - Windows 打包链路同步补充冻结可执行文件运行时探针。
- `tests/test_packaging_build_scripts.py`
  - 更新静态验证，覆盖新的运行时探针和脚本保护。
- `docs/CHANGELOG.md`
  - 记录本次桌面发布打包修复。

## Issue Link

无 Issue。动机是修复最新 `Desktop Release` CI 失败；验收标准为打包脚本不再用文件扫描误判 AlphaSift 模块缺失，而是以冻结可执行文件真实运行时导入结果为准，并保留本地静态验证覆盖。

## Verification Commands And Results

```bash
python -m pytest tests/test_packaging_build_scripts.py tests/test_agent_frozen_context.py::DesktopBackendPackagingAssetsTestCase -q
python -m py_compile main.py
bash -n scripts/build-backend-macos.sh
./scripts/ci_gate.sh syntax
PYTHONPATH=/home/ubuntu/alphasift DSA_PACKAGED_ALPHASIFT_IMPORT_PROBE=1 python main.py
```

关键输出/结论：

- `tests/test_packaging_build_scripts.py` + `DesktopBackendPackagingAssetsTestCase`: `4 passed`
- `python -m py_compile main.py`: passed
- `bash -n scripts/build-backend-macos.sh`: passed
- `./scripts/ci_gate.sh syntax`: passed
- 本地探针在可导入 AlphaSift 时输出：`OK: packaged AlphaSift adapter import succeeded`

未执行完整 macOS / Windows 桌面 PyInstaller 构建：当前验证环境是 Linux，无法真实复现 GitHub macOS/Windows release runner；本 PR 修复的是失败点的校验逻辑，CI 会在 PR 上继续覆盖打包链路。

## Visual Evidence (if applicable)

- 截图链接 / Screenshot links: 不适用
- 不适用原因 / Reason if not applicable: 本 PR 只修改桌面后端打包校验脚本和内部探针，不修改报告格式、Web UI 或渲染效果。

## Compatibility And Risk

- 不改写、不迁移、不清理任何运行时配置或用户数据。
- 新增的 `DSA_PACKAGED_ALPHASIFT_IMPORT_PROBE` 是内部打包校验开关；默认未设置时不会改变 CLI/API/分析流程。
- 风险：如果未来 `main.py` 更早期引入重依赖，探针仍应保持在重业务 import 之前；当前实现已放在 `data_provider` 等业务导入之前。

## Rollback Plan

- 最小回滚方式：revert this PR。
- 不需要额外配置回滚或数据迁移。

## EXTRACT_PROMPT Change (if applicable)

不适用；未修改 `src/services/image_stock_extractor.py` 或 `EXTRACT_PROMPT`。

## Checklist

- [x] 本 PR 有明确动机和业务价值 / This PR has a clear motivation and value
- [x] 已提供可复现的验证命令与结果 / Reproducible verification commands and results are included
- [x] 已评估兼容性与风险 / Compatibility and risk have been assessed
- [x] 已提供回滚方案 / A rollback plan is provided
- [x] 若修改报告格式或 Web UI 界面，已在 PR 描述/评论附受影响报告 / 页面截图，且未把一次性验收截图作为仓库文件合入 / If report formatting or Web UI changed, affected report/page screenshots are linked in the PR body/comments and one-off acceptance screenshots are not committed as repository files
- [x] 若涉及用户可见变更，已同步更新相关文档与 `docs/CHANGELOG.md`；`README.md` 仅在首页级信息变化时更新，细节优先写入 `docs/*.md` / If user-visible changes are included, relevant docs and `docs/CHANGELOG.md` are updated; `README.md` is updated only for homepage-level changes, with details kept in `docs/*.md`
