### PR TITLE
feat: multi database support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -636,7 +636,25 @@ FEISHU_STREAM_ENABLED=false
 # FEISHU_WEBHOOK_SECRET=your_feishu_webhook_secret
 # FEISHU_WEBHOOK_KEYWORD=股票日报
 
-# 数据库路径
+# ===================================
+# 数据库配置（三选一，按优先级）
+# ===================================
+# 方式一：完整 SQLAlchemy 连接串（推荐用于 MySQL/PostgreSQL）
+# DATABASE_URL=mysql+pymysql://user:password@host:3306/dbname
+# DATABASE_URL=postgresql+psycopg2://user:password@host:5432/dbname
+
+# 方式二：结构化字段（等价于方式一，自动拼接连接串）
+# DATABASE_TYPE=mysql          # mysql | postgresql | sqlite
+# DATABASE_HOST=127.0.0.1
+# DATABASE_PORT=3306           # MySQL 默认 3306，PostgreSQL 默认 5432（不设则自动选）
+# DATABASE_NAME=stock
+# DATABASE_USERNAME=stock
+# DATABASE_PASSWORD=your_password
+
+# 驱动说明：MySQL 需要 pymysql，PostgreSQL 需要 psycopg2-binary
+# 两个驱动均已包含在 requirements.txt 中（pip install -r requirements.txt 即可）
+
+# 方式三：SQLite（默认，下面两行不设时自动使用）
 DATABASE_PATH=./data/stock_analysis.db
 # SQLite 写入优化：文件库默认启用 WAL，降低批量写入和并发回写时的锁竞争
 SQLITE_WAL_ENABLED=true

--- a/README.md
+++ b/README.md
@@ -219,6 +219,16 @@ python main.py --serve-only
 
 完整环境变量、模型渠道、通知渠道、数据源优先级、交易纪律、基本面 P0 语义和部署说明请参考 [完整配置指南](docs/full-guide.md)。
 
+### 数据库配置
+
+| 配置方式 | 说明 | 适用场景 |
+|---------|------|---------|
+| SQLite（默认） | 无需额外配置，默认写入 `DATABASE_PATH`（`./data/stock_analysis.db`） | 单机部署、低负载 |
+| 结构化字段 | 设置 `DATABASE_TYPE` + `DATABASE_HOST` / `DATABASE_PORT` / `DATABASE_NAME` / `DATABASE_USERNAME` / `DATABASE_PASSWORD` | MySQL / PostgreSQL 标准部署 |
+| 完整连接串 | 直接设置 `DATABASE_URL`（最高优先级），如 `mysql+pymysql://user:pass@host:3306/db` | 需要自定义连接参数时 |
+
+驱动 `pymysql`（MySQL）和 `psycopg2-binary`（PostgreSQL）已包含在 `requirements.txt` 中。如只使用 SQLite，可移除不需要的驱动以精简部署。完整优先级、字段说明和示例见 `.env.example` 数据库配置段。
+
 ## 🖥️ Web 界面
 
 Web 工作台提供配置管理、任务监控、手动分析、历史报告、完整 Markdown 报告、Agent 问股、回测、持仓管理、智能导入和浅色 / 深色主题。启动方式：

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+- [新功能] 数据库层新增 MySQL / PostgreSQL 支持，通过 `DATABASE_URL`（完整连接串）或 `DATABASE_TYPE` + 结构化字段配置，默认仍使用 SQLite；Storage 层 upsert 按 SQLite / PostgreSQL / MySQL 使用各自方言实现。驱动 `pymysql` 与 `psycopg2-binary` 已包含在 `requirements.txt` 中。
 - [改进] #1390 P0 为个股分析与历史/回测展示新增可选八态 `action` / `action_label` 建议动作字段，保留 `operation_advice` 自由文本和 `decision_type=buy|hold|sell` 统计口径，不新增迁移或配置项。
 - [修复] #1390 收紧建议动作 legacy fallback：英文 `not to ...` 与 `avoid selling/reducing/trimming ...` 等否定/回避表达不再误判为买卖动作，Web 旧记录不再把中文金融上下文、`buy or sell`、多 guard 歧义文本或 `buyback` / `buy-back` / `buy back` / `selloff` / `sell-off` / `sell off` 等英文复合词渲染成 action badge，并在有结构化 `action` 时让回测/历史趋势等入口按界面语言显示 action 标签。
 <!-- 新条目格式：- [类型] 描述（类型取值：新功能/改进/修复/文档/测试/chore）-->

--- a/docs/README_CHT.md
+++ b/docs/README_CHT.md
@@ -207,6 +207,16 @@ python main.py --serve-only
 
 完整環境變數、模型渠道、通知渠道、數據源優先級、交易紀律、基本面 P0 語義和部署說明請參考 [完整配置指南](./full-guide.md)。
 
+### 資料庫配置
+
+| 配置方式 | 說明 | 適用場景 |
+|---------|------|---------|
+| SQLite（默認） | 無需額外配置，默認寫入 `DATABASE_PATH`（`./data/stock_analysis.db`） | 單機部署、低負載 |
+| 結構化字段 | 設置 `DATABASE_TYPE` + `DATABASE_HOST` / `DATABASE_PORT` / `DATABASE_NAME` / `DATABASE_USERNAME` / `DATABASE_PASSWORD` | MySQL / PostgreSQL 標準部署 |
+| 完整連接串 | 直接設置 `DATABASE_URL`（最高優先級），如 `mysql+pymysql://user:pass@host:3306/db` | 需要自定義連接參數時 |
+
+驅動 `pymysql`（MySQL）和 `psycopg2-binary`（PostgreSQL）已包含在 `requirements.txt` 中。如只使用 SQLite，可移除不需要的驅動以精簡部署。完整優先級、字段說明和示例見 `.env.example` 資料庫配置段。
+
 ## 🖥️ Web 介面
 
 Web 工作台提供配置管理、任務監控、手動分析、歷史報告、完整 Markdown 報告、Agent 問股、回測、持倉管理、智能匯入和淺色 / 深色主題。啟動方式：

--- a/docs/README_EN.md
+++ b/docs/README_EN.md
@@ -207,6 +207,16 @@ Up: 3920 | Down: 1349 | Limit up: 155 | Limit down: 3
 
 Full environment variables, model routing, notification channels, data-source priority, trading rules, fundamental P0 semantics, and deployment details are in the [Full Guide](./full-guide_EN.md).
 
+### Database Configuration
+
+| Method | Description | Use Case |
+|--------|-------------|----------|
+| SQLite (default) | No extra config needed; writes to `DATABASE_PATH` (`./data/stock_analysis.db`) | Single-node, light load |
+| Structured fields | Set `DATABASE_TYPE` + `DATABASE_HOST` / `DATABASE_PORT` / `DATABASE_NAME` / `DATABASE_USERNAME` / `DATABASE_PASSWORD` | Standard MySQL / PostgreSQL deployment |
+| Full connection URL | Set `DATABASE_URL` directly (highest priority), e.g. `mysql+pymysql://user:pass@host:3306/db` | When custom connection parameters are needed |
+
+Drivers `pymysql` (MySQL) and `psycopg2-binary` (PostgreSQL) are included in `requirements.txt`. Remove unused drivers for leaner deployments. See `.env.example` database section for full priority rules, field details, and examples.
+
 ## 🖥️ Web UI
 
 The Web workspace supports settings, task monitoring, manual analysis, history reports, full Markdown reports, Agent strategy chat, backtest, portfolio management, smart import, and light/dark themes.

--- a/requirements.txt
+++ b/requirements.txt
@@ -67,3 +67,8 @@ jinja2>=3.1.0               # Jinja2 template engine for report rendering
 fastapi>=0.109.0            # Modern Python Web framework
 uvicorn[standard]>=0.27.0   # ASGI server
 python-multipart>=0.0.6     # FastAPI File/Form upload support
+
+# Database drivers — both installed by default for multi-DB support.
+# Remove the one you don't need to keep the deployment lean.
+pymysql>=1.1.0            # MySQL/MariaDB driver
+psycopg2-binary>=2.9.0    # PostgreSQL driver

--- a/src/config.py
+++ b/src/config.py
@@ -15,7 +15,7 @@ import logging
 import os
 import re
 from pathlib import Path
-from typing import Any, Dict, List, Literal, Optional, Tuple
+from typing import Any, ClassVar, Dict, List, Literal, Optional, Tuple
 from urllib.parse import unquote, urlparse
 from dotenv import load_dotenv, dotenv_values
 from dataclasses import dataclass, field
@@ -865,6 +865,16 @@ class Config:
     prefetch_realtime_quotes: bool = True
 
     # === 数据库配置 ===
+    # 通用：完整 SQLAlchemy 连接串（最高优先级，如 mysql+pymysql://user:pass@host:3306/db）
+    database_url: str = ""
+    # 结构化连接参数：未设置 database_url 时自动拼接
+    database_type: str = ""  # sqlite / mysql / postgresql
+    database_host: str = "127.0.0.1"
+    database_port: int = 0
+    database_name: str = ""
+    database_username: str = ""
+    database_password: str = ""
+    # SQLite 专有配置
     database_path: str = "./data/stock_analysis.db"
     sqlite_wal_enabled: bool = True
     sqlite_busy_timeout_ms: int = 5000
@@ -1654,6 +1664,13 @@ class Config:
             ),
             md2img_engine=cls._parse_md2img_engine(os.getenv('MD2IMG_ENGINE', 'wkhtmltoimage')),
             prefetch_realtime_quotes=os.getenv('PREFETCH_REALTIME_QUOTES', 'true').lower() == 'true',
+            database_url=(os.getenv('DATABASE_URL') or '').strip(),
+            database_type=(os.getenv('DATABASE_TYPE') or '').strip().lower(),
+            database_host=(os.getenv('DATABASE_HOST') or '127.0.0.1').strip(),
+            database_port=cls._parse_database_port(os.getenv('DATABASE_PORT')),
+            database_name=(os.getenv('DATABASE_NAME') or '').strip(),
+            database_username=(os.getenv('DATABASE_USERNAME') or '').strip(),
+            database_password=(os.getenv('DATABASE_PASSWORD') or ''),
             database_path=os.getenv('DATABASE_PATH', './data/stock_analysis.db'),
             sqlite_wal_enabled=os.getenv('SQLITE_WAL_ENABLED', 'true').lower() == 'true',
             sqlite_busy_timeout_ms=parse_env_int(
@@ -2862,12 +2879,74 @@ class Config:
         """
         return [issue.message for issue in self.validate_structured()]
     
-    def get_db_url(self) -> str:
+    _DEFAULT_DB_PORTS: ClassVar[Dict[str, int]] = {"mysql": 3306, "postgresql": 5432, "postgres": 5432}
+
+    @staticmethod
+    def _parse_database_port(raw: Optional[str]) -> int:
+        """Parse DATABASE_PORT env value; 0 means 'use type default'."""
+        val = (raw or "").strip()
+        if not val:
+            return 0
+        try:
+            p = int(val)
+        except (ValueError, TypeError):
+            logger.warning("DATABASE_PORT=%r is not a valid integer; using 0 (type default)", raw)
+            return 0
+        if 1 <= p <= 65535:
+            return p
+        logger.warning("DATABASE_PORT=%r out of range; using 0 (type default)", raw)
+        return 0
+
+    def get_db_url(self):
+        """获取 SQLAlchemy 数据库连接 URL。
+
+        优先级: DATABASE_URL > DATABASE_TYPE 结构化参数 > DATABASE_PATH (SQLite 默认)
         """
-        获取 SQLAlchemy 数据库连接 URL
-        
-        自动创建数据库目录（如果不存在）
-        """
+        from sqlalchemy.engine import URL
+
+        # 1) 完整连接串
+        db_url = (self.database_url or "").strip()
+        if db_url:
+            return db_url
+
+        # 2) 结构化参数（通过 SQLAlchemy URL.create 安全构造，避免特殊字符破坏 URL 解析）
+        db_type = (self.database_type or "").strip().lower()
+        if db_type and db_type != "sqlite":
+            host = (self.database_host or "127.0.0.1").strip()
+            port = self.database_port or self._DEFAULT_DB_PORTS.get(db_type, 0)
+            name = (self.database_name or "").strip()
+            user = (self.database_username or "").strip()
+            password = self.database_password or ""
+            if not name:
+                raise ValueError("DATABASE_NAME 未设置，结构化数据库配置不完整")
+            if db_type == "postgres":
+                db_type = "postgresql"
+            driver = "pymysql" if db_type == "mysql" else "psycopg2"
+            # 预检驱动可用性，避免连接时才报 ImportError
+            if driver == "pymysql":
+                try:
+                    import pymysql  # noqa: F401
+                except ImportError:
+                    raise ImportError(
+                        "MySQL 驱动 pymysql 未安装，请执行: pip install pymysql"
+                    )
+            elif driver == "psycopg2":
+                try:
+                    import psycopg2  # noqa: F401
+                except ImportError:
+                    raise ImportError(
+                        "PostgreSQL 驱动 psycopg2 未安装，请执行: pip install psycopg2-binary"
+                    )
+            return URL.create(
+                drivername=f"{db_type}+{driver}",
+                username=user or None,
+                password=password or None,
+                host=host,
+                port=port,
+                database=name,
+            ).render_as_string(hide_password=False)
+
+        # 3) SQLite 默认
         db_path = Path(self.database_path)
         db_path.parent.mkdir(parents=True, exist_ok=True)
         return f"sqlite:///{db_path.absolute()}"

--- a/src/storage.py
+++ b/src/storage.py
@@ -841,7 +841,8 @@ class DatabaseManager(metaclass=_DatabaseManagerMeta):
                 **engine_kwargs,
             )
             self._engine = created_engine
-            self._is_sqlite_engine = self._engine.url.get_backend_name() == 'sqlite'
+            self._db_backend_name = self._engine.url.get_backend_name()
+            self._is_sqlite_engine = self._db_backend_name == 'sqlite'
             self._sqlite_file_db = self._is_sqlite_engine and self._is_file_sqlite_database()
             self._install_sqlite_pragma_handler()
 
@@ -2453,13 +2454,30 @@ class DatabaseManager(metaclass=_DatabaseManagerMeta):
                 "estimated_tokens": int(estimated_tokens or 0),
                 "updated_at": now,
             }
-            stmt = sqlite_insert(ConversationSummary).values(**values)
-            session.execute(
-                stmt.on_conflict_do_update(
+            backend = self._db_backend_name
+            if backend == "sqlite":
+                from sqlalchemy.dialects.sqlite import insert as _dialect_insert
+                stmt = _dialect_insert(ConversationSummary).values(**values)
+                stmt = stmt.on_conflict_do_update(
                     index_elements=["session_id"],
                     set_=values,
                 )
-            )
+            elif backend == "postgresql":
+                from sqlalchemy.dialects.postgresql import insert as _dialect_insert
+                stmt = _dialect_insert(ConversationSummary).values(**values)
+                stmt = stmt.on_conflict_do_update(
+                    index_elements=["session_id"],
+                    set_=values,
+                )
+            elif backend == "mysql":
+                from sqlalchemy.dialects.mysql import insert as _dialect_insert
+                stmt = _dialect_insert(ConversationSummary).values(**values)
+                stmt = stmt.on_duplicate_key_update(**values)
+            else:
+                raise RuntimeError(
+                    f"Unsupported database backend for upsert: {backend}"
+                )
+            session.execute(stmt)
 
     def conversation_session_exists(self, session_id: str) -> bool:
         """Return True when at least one message exists for the given session."""


### PR DESCRIPTION
feat: multi database support — 支持 MySQL/PostgreSQL
  
  PR 描述

  Summary

  - 新增 MySQL 和 PostgreSQL 数据库支持，原有的 SQLite 仍保留为默认选项
  - 支持三种配置方式：完整 DATABASE_URL 连接串 > 结构化字段（DATABASE_TYPE 等）> SQLite 文件路径默认

  Changed files

  ┌──────────────────┬───────────────────────────────────────────────────────────────────────────────────────────────────┐
  │       文件       │                                               说明                                                │
  ├──────────────────┼───────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ .env.example     │ 新增多数据库配置说明和示例                                                                        │
  ├──────────────────┼───────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ requirements.txt │ 新增 pymysql 驱动依赖，预留 psycopg2-binary                                                       │
  ├──────────────────┼───────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ src/config.py    │ 新增数据库连接参数解析和 get_db_url() 多数据库 URL 拼接逻辑                                       │
  ├──────────────────┼───────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ src/storage.py   │ 修复 ConversationSummary upsert 语句在非 SQLite 数据库的兼容性问题（sqlite_insert → 通用 insert） │
  └──────────────────┴───────────────────────────────────────────────────────────────────────────────────────────────────┘

  Configuration

  # 方式一：完整连接串（推荐）
  DATABASE_URL=mysql+pymysql://user:password@host:3306/dbname

  # 方式二：结构化字段
  DATABASE_TYPE=mysql
  DATABASE_HOST=127.0.0.1
  DATABASE_PORT=3306
  DATABASE_NAME=stock
  DATABASE_USERNAME=stock
  DATABASE_PASSWORD=your_password

  # 方式三：SQLite（默认，无需额外配置）
  DATABASE_PATH=./data/stock_analysis.db