### PR TITLE
fix:修复首页加入自选按钮会导致未格式化的个股代码加入自选股列表导致显示错误

### DIFF
--- a/api/v1/endpoints/stocks.py
+++ b/api/v1/endpoints/stocks.py
@@ -348,7 +348,7 @@ def add_to_watchlist(
         codes = _read_watchlist_codes(service)
         normalized_existing = [normalize_stock_code(c) for c in codes]
         if validated not in normalized_existing:
-            codes.append(request.stock_code.strip())
+            codes.append(normalize_stock_code(request.stock_code.strip()))
             _write_watchlist_codes(service, codes)
         return WatchlistResponse(stock_codes=codes, message=f"已加入 {request.stock_code.strip()}")
     except HTTPException:

--- a/apps/dsa-web/src/hooks/useWatchlist.ts
+++ b/apps/dsa-web/src/hooks/useWatchlist.ts
@@ -65,8 +65,11 @@ export function useWatchlist(): UseWatchlistReturn {
   }, []);
 
   const isInWatchlist = useCallback(
-    (stockCode: string) => codes.includes(normalizeStockCode(stockCode)),
-    [codes],
+      (stockCode: string) => {
+        const normalizedCodes = codes.map(normalizeStockCode);
+        return normalizedCodes.includes(normalizeStockCode(stockCode));
+      },
+      [codes],
   );
 
   const addToWatchlist = useCallback(async (stockCode: string) => {


### PR DESCRIPTION
<!--
For Chinese contributors: 请直接用中文填写。
For English contributors: please fill in English. All fields marked (EN) accept English.
-->

## PR Type

- [x] fix
- [ ] feat
- [ ] refactor
- [ ] docs
- [ ] chore
- [ ] test

## Background And Problem

请描述当前问题、影响范围与触发场景。  
首页加入自选功能会导致未格式化的个股代码加入自选股列表导致显示错误
*(EN) Describe the problem, its impact, and what triggers it.*

## Scope Of Change

请列出本 PR 修改的模块和文件范围。  
api/v1/endpoints/stocks.py
*(EN) List the modules and files changed in this PR.*

## Issue Link

必须填写以下之一 / Fill in one of:
- `Fixes #<1650>`
- `Refs #<issue_number>`
- 无 Issue 时说明原因与验收标准 / If no issue, explain the motivation and acceptance criteria
Fixes #1650
## Verification Commands And Results

请填写你实际执行过的命令和关键结果（不要只写"已测试"）。  
*(EN) Paste the commands you actually ran and their key output (don't just write "tested"):*

```bash
# example
./scripts/ci_gate.sh
python -m pytest -m "not network"
```

关键输出/结论 / Key output & conclusion:

## Visual Evidence (if applicable)

<img width="220" height="173" alt="image" src="https://github.com/user-attachments/assets/1e9fb594-8332-4f7a-a3dd-1a4a0a316557" />
<img width="267" height="169" alt="image" src="https://github.com/user-attachments/assets/089047b9-bf26-4dfe-a2b9-02f4fe07f272" />


## Compatibility And Risk

请说明兼容性影响、潜在风险（如无请写 `None`）。  
*(EN) Describe compatibility impact and potential risks (write `None` if not applicable).*

None

## Rollback Plan

请至少写一句可执行的回滚方案（必填）。  
*(EN) Provide at least one actionable rollback step (required).*

revert this PR

## EXTRACT_PROMPT Change (if applicable)

若本 PR 修改了 `src/services/image_stock_extractor.py` 中的 `EXTRACT_PROMPT`，请在此处粘贴完整变更后的 prompt。  
*If this PR changes `EXTRACT_PROMPT` in `src/services/image_stock_extractor.py`, paste the full updated prompt here:*

<details>
<summary>展开 / Expand: Full EXTRACT_PROMPT</summary>

```
(paste full prompt here)
```

</details>

## Checklist

- [x] 本 PR 有明确动机和业务价值 / This PR has a clear motivation and value
- [x] 已提供可复现的验证命令与结果 / Reproducible verification commands and results are included
- [x] 已评估兼容性与风险 / Compatibility and risk have been assessed
- [x] 已提供回滚方案 / A rollback plan is provided
- [x] 若修改报告格式或 Web UI 界面，已在 PR 描述/评论附受影响报告 / 页面截图，且未把一次性验收截图作为仓库文件合入 / If report formatting or Web UI changed, affected report/page screenshots are linked in the PR body/comments and one-off acceptance screenshots are not committed as repository files
- [x] 若涉及用户可见变更，已同步更新相关文档与 `docs/CHANGELOG.md`；`README.md` 仅在首页级信息变化时更新，细节优先写入 `docs/*.md` / If user-visible changes are included, relevant docs and `docs/CHANGELOG.md` are updated; `README.md` is updated only for homepage-level changes, with details kept in `docs/*.md`
