### PR TITLE
改进: 补充 #1390 P1 DecisionSignal 前端契约与隔离测试

### DIFF
--- a/apps/dsa-web/src/api/__tests__/decisionSignals.test.ts
+++ b/apps/dsa-web/src/api/__tests__/decisionSignals.test.ts
@@ -201,7 +201,7 @@ describe('decisionSignalsApi', () => {
     expect(response.items[0].stockCode).toBe('HK00700');
   });
 
-  it('gets latest signals with an encoded stock code path', async () => {
+  it('gets latest signals with a backend-supported stock code path', async () => {
     get.mockResolvedValueOnce({
       data: {
         items: [],
@@ -211,12 +211,19 @@ describe('decisionSignalsApi', () => {
       },
     });
 
-    const response = await decisionSignalsApi.getLatest('HK/00700', { market: 'hk', limit: 2 });
+    const response = await decisionSignalsApi.getLatest('00700.HK', { market: 'hk', limit: 2 });
 
-    expect(get).toHaveBeenCalledWith('/api/v1/decision-signals/latest/HK%2F00700', {
+    expect(get).toHaveBeenCalledWith('/api/v1/decision-signals/latest/00700.HK', {
       params: { market: 'hk', limit: 2 },
     });
     expect(response.pageSize).toBe(2);
+  });
+
+  it('rejects slash-containing latest stock codes before calling an unsupported backend path', async () => {
+    await expect(decisionSignalsApi.getLatest('HK/00700', { market: 'hk' })).rejects.toThrow(
+      'DecisionSignal latest stockCode cannot contain "/"',
+    );
+    expect(get).not.toHaveBeenCalled();
   });
 
   it('gets one signal and updates status metadata as a full replacement payload', async () => {

--- a/apps/dsa-web/src/api/__tests__/decisionSignals.test.ts
+++ b/apps/dsa-web/src/api/__tests__/decisionSignals.test.ts
@@ -1,0 +1,271 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { decisionSignalsApi } from '../decisionSignals';
+
+const { get, post, patch } = vi.hoisted(() => ({
+  get: vi.fn(),
+  post: vi.fn(),
+  patch: vi.fn(),
+}));
+
+vi.mock('../index', () => ({
+  default: {
+    get,
+    post,
+    patch,
+  },
+}));
+
+describe('decisionSignalsApi', () => {
+  beforeEach(() => {
+    get.mockReset();
+    post.mockReset();
+    patch.mockReset();
+  });
+
+  it('creates signals with top-level field mapping and opaque JSON pass-through', async () => {
+    post.mockResolvedValueOnce({
+      data: {
+        item: {
+          id: 11,
+          stock_code: '600519',
+          stock_name: '贵州茅台',
+          market: 'cn',
+          source_type: 'analysis',
+          source_agent: null,
+          source_report_id: 3001,
+          trace_id: 'trace-3001',
+          market_phase: 'intraday',
+          trigger_source: 'api',
+          action: 'watch',
+          action_label: '观察',
+          confidence: 0.72,
+          score: 76,
+          horizon: '3d',
+          entry_low: 1680,
+          entry_high: 1720,
+          stop_loss: 1600,
+          target_price: 1850,
+          invalidation: '跌破支撑',
+          watch_conditions: '放量突破',
+          reason: '趋势改善',
+          risk_summary: '波动较高',
+          catalyst_summary: '行业修复',
+          evidence: { source_url: 'https://example.com/news' },
+          data_quality_summary: { raw_score: 80, level: 'usable' },
+          plan_quality: 'complete',
+          status: 'active',
+          expires_at: '2026-06-12T08:00:00',
+          created_at: '2026-06-11T08:00:00',
+          updated_at: '2026-06-11T08:00:00',
+          metadata: { task_id: 'task-1' },
+        },
+        created: false,
+      },
+    });
+
+    const response = await decisionSignalsApi.create({
+      stockCode: '600519',
+      stockName: '贵州茅台',
+      market: 'cn',
+      sourceType: 'analysis',
+      sourceReportId: 3001,
+      traceId: 'trace-3001',
+      marketPhase: 'intraday',
+      triggerSource: 'api',
+      action: 'watch',
+      actionLabel: '观察',
+      confidence: 0.72,
+      score: 76,
+      horizon: '3d',
+      entryLow: 1680,
+      entryHigh: 1720,
+      stopLoss: 1600,
+      targetPrice: 1850,
+      invalidation: '跌破支撑',
+      watchConditions: '放量突破',
+      reason: '趋势改善',
+      riskSummary: '波动较高',
+      catalystSummary: '行业修复',
+      evidence: { sourceUrl: 'https://example.com/news' },
+      dataQualitySummary: { level: 'usable' },
+      planQuality: 'complete',
+      status: 'active',
+      expiresAt: '2026-06-12T08:00:00',
+      metadata: { taskId: 'task-1' },
+      reportLanguage: 'zh',
+    });
+
+    expect(post).toHaveBeenCalledWith('/api/v1/decision-signals', {
+      stock_code: '600519',
+      stock_name: '贵州茅台',
+      market: 'cn',
+      source_type: 'analysis',
+      source_report_id: 3001,
+      trace_id: 'trace-3001',
+      market_phase: 'intraday',
+      trigger_source: 'api',
+      action: 'watch',
+      action_label: '观察',
+      confidence: 0.72,
+      score: 76,
+      horizon: '3d',
+      entry_low: 1680,
+      entry_high: 1720,
+      stop_loss: 1600,
+      target_price: 1850,
+      invalidation: '跌破支撑',
+      watch_conditions: '放量突破',
+      reason: '趋势改善',
+      risk_summary: '波动较高',
+      catalyst_summary: '行业修复',
+      evidence: { sourceUrl: 'https://example.com/news' },
+      data_quality_summary: { level: 'usable' },
+      plan_quality: 'complete',
+      status: 'active',
+      expires_at: '2026-06-12T08:00:00',
+      metadata: { taskId: 'task-1' },
+      report_language: 'zh',
+    });
+    expect(response.created).toBe(false);
+    expect(response.item.id).toBe(11);
+    expect(response.item.sourceReportId).toBe(3001);
+    expect(response.item.entryLow).toBe(1680);
+    expect(response.item.evidence).toEqual({ source_url: 'https://example.com/news' });
+    expect(response.item.dataQualitySummary).toEqual({ raw_score: 80, level: 'usable' });
+    expect(response.item.metadata).toEqual({ task_id: 'task-1' });
+  });
+
+  it('lists signals with snake_case query params', async () => {
+    get.mockResolvedValueOnce({
+      data: {
+        items: [
+          {
+            id: 12,
+            stock_code: 'HK00700',
+            market: 'hk',
+            source_type: 'manual',
+            trigger_source: 'web',
+            action: 'hold',
+            plan_quality: 'minimal',
+            status: 'active',
+          },
+        ],
+        total: 1,
+        page: 2,
+        page_size: 10,
+      },
+    });
+
+    const response = await decisionSignalsApi.list({
+      market: 'hk',
+      stockCode: '00700',
+      action: 'hold',
+      marketPhase: 'postmarket',
+      sourceType: 'manual',
+      sourceReportId: 99,
+      traceId: 'trace-99',
+      triggerSource: 'web',
+      status: 'active',
+      createdFrom: '2026-06-01T00:00:00',
+      createdTo: '2026-06-11T00:00:00',
+      expiresFrom: '2026-06-12T00:00:00',
+      expiresTo: '2026-06-30T00:00:00',
+      holdingOnly: true,
+      accountId: 3,
+      page: 2,
+      pageSize: 10,
+    });
+
+    expect(get).toHaveBeenCalledWith('/api/v1/decision-signals', {
+      params: {
+        market: 'hk',
+        stock_code: '00700',
+        action: 'hold',
+        market_phase: 'postmarket',
+        source_type: 'manual',
+        source_report_id: 99,
+        trace_id: 'trace-99',
+        trigger_source: 'web',
+        status: 'active',
+        created_from: '2026-06-01T00:00:00',
+        created_to: '2026-06-11T00:00:00',
+        expires_from: '2026-06-12T00:00:00',
+        expires_to: '2026-06-30T00:00:00',
+        holding_only: true,
+        account_id: 3,
+        page: 2,
+        page_size: 10,
+      },
+    });
+    expect(response.pageSize).toBe(10);
+    expect(response.items[0].stockCode).toBe('HK00700');
+  });
+
+  it('gets latest signals with an encoded stock code path', async () => {
+    get.mockResolvedValueOnce({
+      data: {
+        items: [],
+        total: 0,
+        page: 1,
+        page_size: 2,
+      },
+    });
+
+    const response = await decisionSignalsApi.getLatest('HK/00700', { market: 'hk', limit: 2 });
+
+    expect(get).toHaveBeenCalledWith('/api/v1/decision-signals/latest/HK%2F00700', {
+      params: { market: 'hk', limit: 2 },
+    });
+    expect(response.pageSize).toBe(2);
+  });
+
+  it('gets one signal and updates status metadata as a full replacement payload', async () => {
+    get.mockResolvedValueOnce({
+      data: {
+        id: 13,
+        stock_code: 'AAPL',
+        market: 'us',
+        source_type: 'agent',
+        trigger_source: 'api',
+        action: 'reduce',
+        plan_quality: 'partial',
+        status: 'active',
+      },
+    });
+    patch.mockResolvedValueOnce({
+      data: {
+        id: 13,
+        stock_code: 'AAPL',
+        market: 'us',
+        source_type: 'agent',
+        trigger_source: 'api',
+        action: 'reduce',
+        plan_quality: 'partial',
+        status: 'closed',
+        metadata: { closed_by: 'tester' },
+      },
+    });
+
+    const item = await decisionSignalsApi.get(13);
+    const updated = await decisionSignalsApi.updateStatus(13, {
+      status: 'closed',
+      metadata: { closedBy: 'tester' },
+    });
+
+    expect(get).toHaveBeenCalledWith('/api/v1/decision-signals/13');
+    expect(patch).toHaveBeenCalledWith('/api/v1/decision-signals/13/status', {
+      status: 'closed',
+      metadata: { closedBy: 'tester' },
+    });
+    expect(item.stockCode).toBe('AAPL');
+    expect(updated.status).toBe('closed');
+    expect(updated.metadata).toEqual({ closed_by: 'tester' });
+  });
+
+  it('passes API errors through to the shared client interceptor behavior', async () => {
+    const error = new Error('network failed');
+    get.mockRejectedValueOnce(error);
+
+    await expect(decisionSignalsApi.list()).rejects.toBe(error);
+  });
+});

--- a/apps/dsa-web/src/api/__tests__/decisionSignals.test.ts
+++ b/apps/dsa-web/src/api/__tests__/decisionSignals.test.ts
@@ -201,6 +201,20 @@ describe('decisionSignalsApi', () => {
     expect(response.items[0].stockCode).toBe('HK00700');
   });
 
+  it('rejects malformed list responses instead of treating missing items as empty', async () => {
+    get.mockResolvedValueOnce({
+      data: {
+        total: 0,
+        page: 1,
+        page_size: 20,
+      },
+    });
+
+    await expect(decisionSignalsApi.list()).rejects.toThrow(
+      'DecisionSignal list response items must be an array',
+    );
+  });
+
   it('gets latest signals with a backend-supported stock code path', async () => {
     get.mockResolvedValueOnce({
       data: {
@@ -269,7 +283,7 @@ describe('decisionSignalsApi', () => {
     expect(updated.metadata).toEqual({ closed_by: 'tester' });
   });
 
-  it('passes API errors through to the shared client interceptor behavior', async () => {
+  it('passes API client errors through unchanged', async () => {
     const error = new Error('network failed');
     get.mockRejectedValueOnce(error);
 

--- a/apps/dsa-web/src/api/decisionSignals.ts
+++ b/apps/dsa-web/src/api/decisionSignals.ts
@@ -1,0 +1,152 @@
+import apiClient from './index';
+import { toCamelCase } from './utils';
+import type {
+  DecisionSignalCreateRequest,
+  DecisionSignalItem,
+  DecisionSignalLatestParams,
+  DecisionSignalListParams,
+  DecisionSignalListResponse,
+  DecisionSignalMutationResponse,
+  DecisionSignalStatusUpdateRequest,
+} from '../types/decisionSignals';
+
+function omitUndefined(input: Record<string, unknown>): Record<string, unknown> {
+  return Object.fromEntries(
+    Object.entries(input).filter(([, value]) => value !== undefined),
+  );
+}
+
+function toDecisionSignalItem(data: Record<string, unknown>): DecisionSignalItem {
+  const item = toCamelCase<DecisionSignalItem>(data);
+  if ('evidence' in data) item.evidence = data.evidence;
+  if ('data_quality_summary' in data) item.dataQualitySummary = data.data_quality_summary;
+  if ('metadata' in data) item.metadata = data.metadata;
+  return item;
+}
+
+function toDecisionSignalMutationResponse(data: Record<string, unknown>): DecisionSignalMutationResponse {
+  const response = toCamelCase<DecisionSignalMutationResponse>(data);
+  response.item = toDecisionSignalItem(data.item as Record<string, unknown>);
+  return response;
+}
+
+function toDecisionSignalListResponse(data: Record<string, unknown>): DecisionSignalListResponse {
+  const response = toCamelCase<DecisionSignalListResponse>(data);
+  response.items = ((data.items ?? []) as Record<string, unknown>[]).map(toDecisionSignalItem);
+  return response;
+}
+
+function toSnakeCreatePayload(payload: DecisionSignalCreateRequest): Record<string, unknown> {
+  return omitUndefined({
+    stock_code: payload.stockCode,
+    stock_name: payload.stockName,
+    market: payload.market,
+    source_type: payload.sourceType,
+    source_agent: payload.sourceAgent,
+    source_report_id: payload.sourceReportId,
+    trace_id: payload.traceId,
+    market_phase: payload.marketPhase,
+    trigger_source: payload.triggerSource,
+    action: payload.action,
+    action_label: payload.actionLabel,
+    confidence: payload.confidence,
+    score: payload.score,
+    horizon: payload.horizon,
+    entry_low: payload.entryLow,
+    entry_high: payload.entryHigh,
+    stop_loss: payload.stopLoss,
+    target_price: payload.targetPrice,
+    invalidation: payload.invalidation,
+    watch_conditions: payload.watchConditions,
+    reason: payload.reason,
+    risk_summary: payload.riskSummary,
+    catalyst_summary: payload.catalystSummary,
+    evidence: payload.evidence,
+    data_quality_summary: payload.dataQualitySummary,
+    plan_quality: payload.planQuality,
+    status: payload.status,
+    expires_at: payload.expiresAt,
+    metadata: payload.metadata,
+    report_language: payload.reportLanguage,
+  });
+}
+
+function toListParams(params: DecisionSignalListParams = {}): Record<string, string | number | boolean> {
+  return omitUndefined({
+    market: params.market,
+    stock_code: params.stockCode,
+    action: params.action,
+    market_phase: params.marketPhase,
+    source_type: params.sourceType,
+    source_report_id: params.sourceReportId,
+    trace_id: params.traceId,
+    trigger_source: params.triggerSource,
+    status: params.status,
+    created_from: params.createdFrom,
+    created_to: params.createdTo,
+    expires_from: params.expiresFrom,
+    expires_to: params.expiresTo,
+    holding_only: params.holdingOnly,
+    account_id: params.accountId,
+    page: params.page,
+    page_size: params.pageSize,
+  }) as Record<string, string | number | boolean>;
+}
+
+function toLatestParams(params: DecisionSignalLatestParams = {}): Record<string, string | number> {
+  return omitUndefined({
+    market: params.market,
+    limit: params.limit,
+  }) as Record<string, string | number>;
+}
+
+function toSnakeStatusPayload(payload: DecisionSignalStatusUpdateRequest): Record<string, unknown> {
+  return omitUndefined({
+    status: payload.status,
+    metadata: payload.metadata,
+  });
+}
+
+export const decisionSignalsApi = {
+  async create(payload: DecisionSignalCreateRequest): Promise<DecisionSignalMutationResponse> {
+    const response = await apiClient.post<Record<string, unknown>>(
+      '/api/v1/decision-signals',
+      toSnakeCreatePayload(payload),
+    );
+    return toDecisionSignalMutationResponse(response.data);
+  },
+
+  async list(params: DecisionSignalListParams = {}): Promise<DecisionSignalListResponse> {
+    const response = await apiClient.get<Record<string, unknown>>('/api/v1/decision-signals', {
+      params: toListParams(params),
+    });
+    return toDecisionSignalListResponse(response.data);
+  },
+
+  async get(signalId: number): Promise<DecisionSignalItem> {
+    const response = await apiClient.get<Record<string, unknown>>(`/api/v1/decision-signals/${signalId}`);
+    return toDecisionSignalItem(response.data);
+  },
+
+  async getLatest(
+    stockCode: string,
+    params: DecisionSignalLatestParams = {},
+  ): Promise<DecisionSignalListResponse> {
+    const response = await apiClient.get<Record<string, unknown>>(
+      `/api/v1/decision-signals/latest/${encodeURIComponent(stockCode)}`,
+      { params: toLatestParams(params) },
+    );
+    return toDecisionSignalListResponse(response.data);
+  },
+
+  async updateStatus(
+    signalId: number,
+    payload: DecisionSignalStatusUpdateRequest,
+  ): Promise<DecisionSignalItem> {
+    const response = await apiClient.patch<Record<string, unknown>>(
+      `/api/v1/decision-signals/${signalId}/status`,
+      toSnakeStatusPayload(payload),
+    );
+    return toDecisionSignalItem(response.data);
+  },
+};

--- a/apps/dsa-web/src/api/decisionSignals.ts
+++ b/apps/dsa-web/src/api/decisionSignals.ts
@@ -107,6 +107,15 @@ function toSnakeStatusPayload(payload: DecisionSignalStatusUpdateRequest): Recor
   });
 }
 
+function toLatestStockCodePath(stockCode: string): string {
+  if (stockCode.includes('/')) {
+    throw new Error(
+      'DecisionSignal latest stockCode cannot contain "/" because the backend route accepts a single path segment; use 00700, HK00700, or 00700.HK.',
+    );
+  }
+  return encodeURIComponent(stockCode);
+}
+
 export const decisionSignalsApi = {
   async create(payload: DecisionSignalCreateRequest): Promise<DecisionSignalMutationResponse> {
     const response = await apiClient.post<Record<string, unknown>>(
@@ -133,7 +142,7 @@ export const decisionSignalsApi = {
     params: DecisionSignalLatestParams = {},
   ): Promise<DecisionSignalListResponse> {
     const response = await apiClient.get<Record<string, unknown>>(
-      `/api/v1/decision-signals/latest/${encodeURIComponent(stockCode)}`,
+      `/api/v1/decision-signals/latest/${toLatestStockCodePath(stockCode)}`,
       { params: toLatestParams(params) },
     );
     return toDecisionSignalListResponse(response.data);

--- a/apps/dsa-web/src/api/decisionSignals.ts
+++ b/apps/dsa-web/src/api/decisionSignals.ts
@@ -32,7 +32,10 @@ function toDecisionSignalMutationResponse(data: Record<string, unknown>): Decisi
 
 function toDecisionSignalListResponse(data: Record<string, unknown>): DecisionSignalListResponse {
   const response = toCamelCase<DecisionSignalListResponse>(data);
-  response.items = ((data.items ?? []) as Record<string, unknown>[]).map(toDecisionSignalItem);
+  if (!Array.isArray(data.items)) {
+    throw new Error('DecisionSignal list response items must be an array');
+  }
+  response.items = data.items.map((item) => toDecisionSignalItem(item as Record<string, unknown>));
   return response;
 }
 

--- a/apps/dsa-web/src/types/decisionSignals.ts
+++ b/apps/dsa-web/src/types/decisionSignals.ts
@@ -1,0 +1,125 @@
+import type { DecisionAction, MarketPhaseValue, ReportLanguage } from './analysis';
+
+/**
+ * Opaque JSON fields are passed through without inner key-name conversion.
+ * Only the containing DecisionSignal API field is mapped between camelCase and snake_case.
+ */
+export type DecisionSignalOpaqueJson = unknown;
+
+export type DecisionSignalSourceType = 'analysis' | 'agent' | 'alert' | 'market_review' | 'manual';
+export type DecisionSignalStatus = 'active' | 'expired' | 'invalidated' | 'closed' | 'archived';
+export type DecisionSignalPlanQuality = 'complete' | 'partial' | 'minimal' | 'unknown';
+export type DecisionSignalHorizon = 'intraday' | '1d' | '3d' | '5d' | '10d' | 'swing' | 'long';
+export type DecisionSignalMarket = 'cn' | 'hk' | 'us';
+
+export interface DecisionSignalItem {
+  id: number;
+  stockCode: string;
+  stockName?: string | null;
+  market: DecisionSignalMarket;
+  sourceType: DecisionSignalSourceType;
+  sourceAgent?: string | null;
+  sourceReportId?: number | null;
+  traceId?: string | null;
+  marketPhase?: MarketPhaseValue | null;
+  triggerSource: string;
+  action: DecisionAction;
+  actionLabel?: string | null;
+  confidence?: number | null;
+  score?: number | null;
+  horizon?: DecisionSignalHorizon | null;
+  entryLow?: number | null;
+  entryHigh?: number | null;
+  stopLoss?: number | null;
+  targetPrice?: number | null;
+  invalidation?: string | null;
+  watchConditions?: string | null;
+  reason?: string | null;
+  riskSummary?: string | null;
+  catalystSummary?: string | null;
+  evidence?: DecisionSignalOpaqueJson;
+  dataQualitySummary?: DecisionSignalOpaqueJson;
+  planQuality: DecisionSignalPlanQuality;
+  status: DecisionSignalStatus;
+  expiresAt?: string | null;
+  createdAt?: string | null;
+  updatedAt?: string | null;
+  metadata?: DecisionSignalOpaqueJson;
+}
+
+export interface DecisionSignalCreateRequest {
+  stockCode: string;
+  stockName?: string | null;
+  market: DecisionSignalMarket;
+  sourceType: DecisionSignalSourceType;
+  sourceAgent?: string | null;
+  sourceReportId?: number | null;
+  traceId?: string | null;
+  marketPhase?: MarketPhaseValue | null;
+  triggerSource: string;
+  action: DecisionAction;
+  actionLabel?: string | null;
+  confidence?: number | null;
+  score?: number | null;
+  horizon?: DecisionSignalHorizon | null;
+  entryLow?: number | null;
+  entryHigh?: number | null;
+  stopLoss?: number | null;
+  targetPrice?: number | null;
+  invalidation?: unknown;
+  watchConditions?: unknown;
+  reason?: unknown;
+  riskSummary?: unknown;
+  catalystSummary?: unknown;
+  evidence?: DecisionSignalOpaqueJson;
+  dataQualitySummary?: DecisionSignalOpaqueJson;
+  planQuality?: DecisionSignalPlanQuality | null;
+  status?: DecisionSignalStatus | null;
+  expiresAt?: string | null;
+  /** Opaque JSON object; inner keys are sent exactly as provided. */
+  metadata?: Record<string, unknown> | null;
+  reportLanguage?: ReportLanguage | null;
+}
+
+export interface DecisionSignalListParams {
+  market?: DecisionSignalMarket;
+  stockCode?: string;
+  action?: DecisionAction;
+  marketPhase?: MarketPhaseValue;
+  sourceType?: DecisionSignalSourceType;
+  sourceReportId?: number;
+  traceId?: string;
+  triggerSource?: string;
+  status?: DecisionSignalStatus;
+  createdFrom?: string;
+  createdTo?: string;
+  expiresFrom?: string;
+  expiresTo?: string;
+  holdingOnly?: boolean;
+  accountId?: number;
+  page?: number;
+  pageSize?: number;
+}
+
+export interface DecisionSignalLatestParams {
+  market?: DecisionSignalMarket;
+  limit?: number;
+}
+
+export interface DecisionSignalStatusUpdateRequest {
+  status: DecisionSignalStatus;
+  /** Replaces the persisted metadata object when provided; inner keys are not converted or merged. */
+  metadata?: Record<string, unknown> | null;
+}
+
+export interface DecisionSignalMutationResponse {
+  item: DecisionSignalItem;
+  created: boolean;
+}
+
+export interface DecisionSignalListResponse {
+  items: DecisionSignalItem[];
+  total: number;
+  page: number;
+  pageSize: number;
+}

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - [修复] 自选股加入和删除按等价股票代码匹配港股及大小写美股变体，避免 `00700`、`HK00700`、`00700.HK` 或 `aapl`、`AAPL` 被误判为不同标的。
 - [改进] #1390 P0 为个股分析与历史/回测展示新增可选八态 `action` / `action_label` 建议动作字段，保留 `operation_advice` 自由文本和 `decision_type=buy|hold|sell` 统计口径，不新增迁移或配置项。
 - [新功能] #1390 P1 新增独立 `DecisionSignal` 存储、Repository、Service 与 `/api/v1/decision-signals` API，支持按来源类型/市场/股票/动作/期限/阶段去重、按 `source_report_id` / `trace_id` 查询、同源过期信号续期且保留来源身份字段、禁止 expired 直接 PATCH 复活、价格计划校验、状态更新、懒过期、cache-only 持仓过滤、敏感信息脱敏、敏感 `trace_id` 拒绝和仅清理 `source_type=analysis` 历史绑定信号的历史删除联动。
+- [改进] #1390 P1 补充 Web decision-signals typed API wrapper 与契约隔离测试，暂不接入 UI。
 - [修复] #1390 收紧建议动作 legacy fallback：英文 `not to ...` 与 `avoid selling/reducing/trimming ...` 等否定/回避表达不再误判为买卖动作，Web 旧记录不再把中文金融上下文、`buy or sell`、多 guard 歧义文本或 `buyback` / `buy-back` / `buy back` / `selloff` / `sell-off` / `sell off` 等英文复合词渲染成 action badge，并在有结构化 `action` 时让回测/历史趋势等入口按界面语言显示 action 标签。
 - [改进] 完善运行时日志上下文，补充 logger name、触发来源、市场统计与实时行情预取链路状态，便于排查调度、API、Bot 和数据源降级路径。
 - [新功能] 新增分析任务与历史报告运行流快照 API，提供 lanes、nodes、edges、events、summary 等统一契约，并从任务队列、运行诊断和 AnalysisContextPack overview 构建脱敏数据流/信息流。

--- a/tests/test_decision_signal_contract_isolation.py
+++ b/tests/test_decision_signal_contract_isolation.py
@@ -1,0 +1,83 @@
+# -*- coding: utf-8 -*-
+"""Contract isolation tests for #1390 P1 DecisionSignal fields."""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import BaseModel
+
+from api.v1.schemas.backtest import BacktestResultItem
+from api.v1.schemas.history import (
+    AnalysisReport,
+    HistoryItem,
+    ReportDetails,
+    ReportMeta,
+    ReportStrategy,
+    ReportSummary,
+    StockBarItem,
+)
+
+
+# Only check top-level Pydantic fields on the primary history/report/stock
+# bar/backtest contracts listed below. These names are not globally reserved:
+# nested schemas such as MarketPhaseSummary and AnalysisContextPackOverview,
+# plus unrelated diagnostics contracts, intentionally expose fields like
+# trigger_source, status, or reason for their own contracts. raw_result and
+# context_snapshot are Any payloads and cannot be constrained by this test.
+FORBIDDEN_PRIMARY_CONTRACT_SIGNAL_FIELDS = {
+    "decision_signals",
+    "plan_quality",
+    "horizon",
+    "source_type",
+    "source_agent",
+    "source_report_id",
+    "trace_id",
+    "trigger_source",
+    "expires_at",
+    "invalidation",
+    "watch_conditions",
+    "reason",
+    "risk_summary",
+    "catalyst_summary",
+    "evidence",
+    "data_quality_summary",
+    "status",
+    "confidence",
+    "score",
+    "entry_low",
+    "entry_high",
+    "target_price",
+    "metadata",
+}
+
+ALLOWED_SHARED_FIELDS = {
+    "action",
+    "action_label",
+    "operation_advice",
+    "market_phase",
+    "stop_loss",
+    "take_profit",
+}
+
+
+@pytest.mark.parametrize(
+    "schema_model",
+    [
+        HistoryItem,
+        StockBarItem,
+        BacktestResultItem,
+        AnalysisReport,
+        ReportMeta,
+        ReportSummary,
+        ReportStrategy,
+        ReportDetails,
+    ],
+)
+def test_decision_signal_fields_do_not_leak_into_primary_contracts(schema_model: type[BaseModel]) -> None:
+    fields = set(schema_model.model_fields)
+
+    assert not fields & FORBIDDEN_PRIMARY_CONTRACT_SIGNAL_FIELDS
+
+
+def test_contract_isolation_guard_does_not_forbid_existing_shared_fields() -> None:
+    assert not ALLOWED_SHARED_FIELDS & FORBIDDEN_PRIMARY_CONTRACT_SIGNAL_FIELDS


### PR DESCRIPTION
## PR Type

- [ ] fix
- [x] feat
- [ ] refactor
- [ ] docs
- [ ] chore
- [x] test

## Background And Problem

#1390 P1 后端主体已经在 main 中提供独立 `DecisionSignal` 存储、Repository、Service 与 `/api/v1/decision-signals` API。本 PR 只补齐可消费契约和边界守护：让 Web 代码层可以通过 typed API wrapper 调用信号 API，同时用后端 schema 测试防止信号池字段被平铺进 history/report/stock bar/backtest 主契约。

本 PR 不接 UI，不从报告自动提取信号，不改现有后端 API 路由，不新增生产依赖、配置项或 README 内容。

## Scope Of Change

- 新增 `tests/test_decision_signal_contract_isolation.py`，只检查 history/report/stock bar/backtest 目标 Pydantic 模型顶层字段，避免 DecisionSignal 专有字段污染主契约。
- 新增 `apps/dsa-web/src/types/decisionSignals.ts`，定义 DecisionSignal Web 内部类型和请求/响应类型。
- 新增 `apps/dsa-web/src/api/decisionSignals.ts`，封装 create、list、get、getLatest、updateStatus。
- 新增 `apps/dsa-web/src/api/__tests__/decisionSignals.test.ts`，覆盖顶层字段 snake_case 映射、opaque JSON 原样透传、latest 后端支持路径格式与 slash 输入拒绝、status PATCH、去重响应和错误透传。
- 更新 `docs/CHANGELOG.md` 的 `[Unreleased]` 扁平条目。

## Issue Link

Refs #1390

## Verification Commands And Results

```bash
PATH=/opt/anaconda3/bin:$PATH ./scripts/ci_gate.sh
/opt/anaconda3/bin/python -m pytest tests/test_decision_signal_contract_isolation.py tests/test_api_schema_pydantic.py tests/test_decision_signal_api.py tests/test_analysis_history.py tests/test_backtest_service.py -q
cd apps/dsa-web && npm run test
cd apps/dsa-web && npm run lint
cd apps/dsa-web && npm run build
git diff --check
npm run test -- decisionSignals
```

关键输出/结论：

- `./scripts/ci_gate.sh`：`3082 passed, 2 deselected, 51 warnings`，`backend-gate: all checks passed`
- targeted pytest：`102 passed`
- Web Vitest：`68` 个 test files passed，`657 passed | 2 skipped`
- Web lint：passed
- Web build：passed
- `git diff --check`：无输出
- 最新增量验证：`npm run test -- decisionSignals`：`1` 个 test file passed，`6 passed`

## Visual Evidence (if applicable)

- 截图链接 / Screenshot links: 无
- 不适用原因 / Reason if not applicable: 本 PR 不修改 Web UI、报告格式或报告渲染效果，只新增 typed API wrapper、类型与测试。

## Compatibility And Risk

- 后端公开 API 不变：`/api/v1/decision-signals` 现有 create/list/detail/latest/status 路由未改动。
- Web 新增的是内部 typed wrapper，当前未接入页面或持仓页，不改变现有用户可见行为。
- `evidence`、`data_quality_summary`、`metadata` 作为 opaque JSON 处理：只转换外层 API 字段名，内部键名按调用方提供或后端返回原样透传。
- `updateStatus.metadata` 保持后端整包替换语义，不在前端做局部 merge。
- `getLatest` 使用后端已支持的单段股票代码路径；包含 `/` 的股票代码会在 Web wrapper 层 fail-fast，避免生成后端不支持的 encoded slash 路径。
- 未验证真实 Admin Cookie 联调和 Desktop 打包路径；本 PR 未改认证、桌面端或 UI 消费路径。

## Rollback Plan

- revert this PR 即可回滚新增 Web wrapper、类型、测试和 changelog 条目；不涉及数据库迁移、配置迁移或依赖回滚。

## EXTRACT_PROMPT Change (if applicable)

不适用；本 PR 未修改 `src/services/image_stock_extractor.py` 或 `EXTRACT_PROMPT`。

<details>
<summary>展开 / Expand: Full EXTRACT_PROMPT</summary>

```
N/A
```

</details>

## Checklist

- [x] 本 PR 有明确动机和业务价值 / This PR has a clear motivation and value
- [x] 已提供可复现的验证命令与结果 / Reproducible verification commands and results are included
- [x] 已评估兼容性与风险 / Compatibility and risk have been assessed
- [x] 已提供回滚方案 / A rollback plan is provided
- [x] 若修改报告格式或 Web UI 界面，已在 PR 描述/评论附受影响报告 / 页面截图，且未把一次性验收截图作为仓库文件合入 / If report formatting or Web UI changed, affected report/page screenshots are linked in the PR body/comments and one-off acceptance screenshots are not committed as repository files
- [x] 若涉及用户可见变更，已同步更新相关文档与 `docs/CHANGELOG.md`；`README.md` 仅在首页级信息变化时更新，细节优先写入 `docs/*.md` / If user-visible changes are included, relevant docs and `docs/CHANGELOG.md` are updated; `README.md` is updated only for homepage-level changes, with details kept in `docs/*.md`
