### PR TITLE
fix: avoid AlphaSift hotspot import on cache miss

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - [修复] 桌面发布打包改用冻结可执行文件运行时探针校验 `alphasift.dsa_adapter`，避免 macOS PyInstaller 将模块内嵌进可执行文件时被文件系统/zip 扫描误判为缺失。
 - [新功能] 新增 AlphaSift 热点题材链路：后端新增 `/api/v1/alphasift/hotspots` 与 `/api/v1/alphasift/hotspots/{topic}` API，Web 选股页新增“热点题材”区域并支持发酵路线与概念股查看。
 - [改进] 新增 AlphaSift 热点题材读取与刷新策略：默认优先读取上次成功热点缓存，手动刷新才实时拉取并覆盖缓存，实时拉取失败时尽量回退旧缓存。
+- [修复] AlphaSift 热点题材默认加载在无缓存且旧适配层缺少 `alphasift.hotspot` 模块时返回空态，不再一打开选股页就显示 AlphaSift 未就绪；手动刷新仍会提示依赖需更新。
 - [改进] 改造 `main.py --webui-only` 启动行为：若 FastAPI 监听端口已被占用，启动即 fail-fast 抛出明确错误并退出，避免 Windows 下 `WinError 10048`。
 - [文档] 补充 `docs/alphasift-integration.md`：明确 AlphaSift 锁定 commit 来源、Hotspot 契约边界、LLM/LiteLLM 兼容语义与关闭开关下回退路径。
 - [修复] 为 THS 发酵路线补充列名兜底：当 `stock_board_concept_summary_ths` 返回缺列时仅跳过该来源富化，不影响 `/api/v1/alphasift/hotspots/{topic}` 返回。

--- a/src/services/alphasift_service.py
+++ b/src/services/alphasift_service.py
@@ -185,18 +185,33 @@ class AlphaSiftService:
     def hotspots(self, *, provider: str = "", top: int = 12, refresh: bool = False) -> Dict[str, Any]:
         _ensure_alphasift_enabled(self.config)
         _ensure_alphasift_available_for_use()
-        hotspot_module = _import_alphasift_hotspot()
-        discover_hotspots = _get_adapter_callable(
-            hotspot_module,
-            "discover_hotspots",
-            "discover_hotspots() is not callable.",
-        )
         provider_name, provider_arg = _resolve_hotspot_provider(provider)
         top_count = max(1, min(int(top or 12), 50))
         if not refresh:
             cached = _load_alphasift_hotspot_cache(provider=provider_name, top=top_count)
             if cached is not None:
                 return cached
+            return {
+                "enabled": True,
+                "provider": provider_name,
+                "provider_used": "",
+                "fallback_used": False,
+                "cache_used": False,
+                "cached_at": None,
+                "source_errors": [],
+                "stale": False,
+                "stale_age_hours": None,
+                "hotspots": [],
+                "hotspot_count": 0,
+                "message": "No cached AlphaSift hotspot snapshot. Click refresh to fetch live hotspots.",
+            }
+
+        hotspot_module = _import_alphasift_hotspot()
+        discover_hotspots = _get_adapter_callable(
+            hotspot_module,
+            "discover_hotspots",
+            "discover_hotspots() is not callable.",
+        )
 
         try:
             with _alphasift_runtime_env(self.config):

--- a/tests/test_alphasift_api.py
+++ b/tests/test_alphasift_api.py
@@ -292,7 +292,7 @@ class AlphaSiftOpportunitiesApiTestCase(unittest.TestCase):
             patch("src.services.alphasift_service._get_alphasift_status_snapshot", return_value=({}, True, {})),
             patch("src.services.alphasift_service._import_alphasift_hotspot", return_value=SimpleNamespace(discover_hotspots=discover)),
         ):
-            payload = self._hotspots(config=config, provider="akshare", top=6)
+            payload = self._hotspots(config=config, provider="akshare", top=6, refresh=True)
 
         self.assertEqual(payload["enabled"], True)
         self.assertEqual(payload["provider"], "akshare")
@@ -305,6 +305,27 @@ class AlphaSiftOpportunitiesApiTestCase(unittest.TestCase):
         self.assertTrue(hasattr(provider, "stock_board_concept_name_em"))
         self.assertTrue(hasattr(provider, "stock_board_industry_name_em"))
         self.assertEqual(discover.call_args.kwargs["top"], 6)
+
+    def test_hotspots_default_cache_miss_does_not_import_hotspot_module(self) -> None:
+        config = self._config(enabled=True)
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cache_path = Path(tmpdir) / "missing-hotspots.json"
+            import_hotspot = MagicMock(side_effect=AssertionError("default cache read must not import live hotspot module"))
+            with (
+                patch("src.services.alphasift_service.DSA_ALPHASIFT_HOTSPOT_CACHE_PATH", cache_path),
+                patch("src.services.alphasift_service._get_alphasift_status_snapshot", return_value=({}, True, {})),
+                patch("src.services.alphasift_service._import_alphasift_hotspot", import_hotspot),
+            ):
+                payload = self._hotspots(config=config, provider="akshare", top=6, refresh=False)
+
+        self.assertEqual(payload["enabled"], True)
+        self.assertEqual(payload["provider"], "akshare")
+        self.assertEqual(payload["cache_used"], False)
+        self.assertEqual(payload["hotspots"], [])
+        self.assertEqual(payload["hotspot_count"], 0)
+        self.assertEqual(payload["source_errors"], [])
+        import_hotspot.assert_not_called()
 
     def test_hotspots_uses_last_success_cache_by_default(self) -> None:
         config = self._config(enabled=True)


### PR DESCRIPTION
## PR Type

- [x] fix
- [ ] feat
- [ ] refactor
- [x] docs
- [ ] chore
- [x] test

## Background And Problem

AlphaSift 热点题材功能默认会在打开选股页时请求 `/api/v1/alphasift/hotspots`，此时 `refresh=false`，预期是优先读取上次成功缓存；如果没有缓存，页面应该展示空态并等待用户手动刷新。

当前服务层在读取缓存前就导入 `alphasift.hotspot`，所以当运行环境仍是旧 AlphaSift 适配层、缺少该模块时，页面一打开就显示：

`AlphaSift 未就绪：AlphaSift hotspot module is unavailable: No module named 'alphasift.hotspot'`

根因是默认缓存读取路径和实时热点刷新路径共享了 live hotspot module 导入步骤，导致非刷新场景也被新依赖阻断。

## Scope Of Change

- `src/services/alphasift_service.py`
  - `refresh=false` 时先读取 last-success hotspot cache。
  - 无缓存时直接返回标准空态 payload，不导入 `alphasift.hotspot`。
  - 仅在 `refresh=true` 手动刷新时导入并调用 live hotspot discovery，因此缺少新模块时仍会在刷新路径暴露依赖问题。
- `tests/test_alphasift_api.py`
  - 将 live discovery 用例显式改为 `refresh=true`。
  - 新增默认缓存 miss 不导入 hotspot module 的回归测试。
- `docs/CHANGELOG.md`
  - 补充用户可见修复记录。

## Issue Link

无 Issue。验收标准：AlphaSift 已启用且基础适配可用时，默认打开热点题材区域在无缓存/旧热点模块缺失情况下不再返回 `AlphaSift 未就绪`，而是返回空态；用户点击刷新时仍可触发实时依赖检查和明确错误。

## Verification Commands And Results

```bash
/tmp/dsa-hotspot-pr-venv/bin/python -m pytest tests/test_alphasift_api.py -q
/tmp/dsa-hotspot-pr-venv/bin/python -m py_compile src/services/alphasift_service.py tests/test_alphasift_api.py && git diff --check
```

关键输出/结论：

- `tests/test_alphasift_api.py`: `60 passed, 4 warnings`
- `py_compile` 通过
- `git diff --check` 通过

补充说明：系统 Python 环境缺少 `anyio.to_thread`，因此使用临时 venv `/tmp/dsa-hotspot-pr-venv` 安装 `requirements.txt` 与 `pytest` 后执行验证。

## Visual Evidence (if applicable)

- 截图链接 / Screenshot links:
- 不适用原因 / Reason if not applicable: 本 PR 不修改 Web UI 布局或报告渲染，只调整后端默认 API 行为，并通过 API 回归测试覆盖。

## Compatibility And Risk

- 兼容性影响：默认 `refresh=false` 请求不再强依赖 `alphasift.hotspot`，对旧运行环境更宽容；`refresh=true` 实时刷新路径仍保持对 live hotspot module 的显式依赖。
- 风险：首次打开且没有缓存时会返回空热点列表，前端会展示无数据/空态；用户仍需手动刷新或更新 AlphaSift 依赖才能获得实时热点。
- 不涉及配置改写、数据库迁移、第三方 API 请求参数或 provider fallback 语义变化。

## Rollback Plan

- 最小回滚方式：revert this PR。
- 不需要额外回滚配置、缓存或数据库迁移。

## EXTRACT_PROMPT Change (if applicable)

未修改 `src/services/image_stock_extractor.py` 中的 `EXTRACT_PROMPT`。

<details>
<summary>展开 / Expand: Full EXTRACT_PROMPT</summary>

```
N/A
```

</details>

## Checklist

- [x] 本 PR 有明确动机和业务价值 / This PR has a clear motivation and value
- [x] 已提供可复现的验证命令与结果 / Reproducible verification commands and results are included
- [x] 已评估兼容性与风险 / Compatibility and risk have been assessed
- [x] 已提供回滚方案 / A rollback plan is provided
- [x] 若修改报告格式或 Web UI 界面，已在 PR 描述/评论附受影响报告 / 页面截图，且未把一次性验收截图作为仓库文件合入 / If report formatting or Web UI changed, affected report/page screenshots are linked in the PR body/comments and one-off acceptance screenshots are not committed as repository files
- [x] 若涉及用户可见变更，已同步更新相关文档与 `docs/CHANGELOG.md`；`README.md` 仅在首页级信息变化时更新，细节优先写入 `docs/*.md` / If user-visible changes are included, relevant docs and `docs/CHANGELOG.md` are updated; `README.md` is updated only for homepage-level changes, with details kept in `docs/*.md`
