### PR TITLE
docs: add README tutorial links

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@
 
 ## 🚀 快速开始
 
-### 方式一：GitHub Actions（推荐）
+### 方式一：[GitHub Actions（推荐）](https://www.bilibili.com/video/BV11FEb66EXG/)
 
 > 5 分钟完成部署，零成本，无需服务器。
 
@@ -137,7 +137,7 @@
 
 默认每个**工作日 18:00（北京时间）**自动执行，也可手动触发。默认非交易日（含 A/H/US 节假日）不执行；强制运行、交易日检查、断点续传等规则见 [完整指南](docs/full-guide.md#定时任务配置)。
 
-### 方式二：本地运行 / Docker 部署
+### 方式二：[客户端配置教程](https://www.bilibili.com/video/BV11FEb66Eyr/) / 本地运行 / Docker 部署
 
 ```bash
 # 克隆项目

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+- [文档] README 与繁中 README 快速开始入口补充视频教程链接，并将桌面客户端入口文案调整为客户端配置教程。
 - [修复] 问股从历史报告进入后的追问会持续携带当前标的，切回或重载已有会话时可从历史消息恢复基础当前标的，并由后端阻断未明确切换时的错误股票工具调用、交易所片段和指标缩写误路由。
 - [修复] 自选股加入和删除按等价股票代码匹配港股及大小写美股变体，避免 `00700`、`HK00700`、`00700.HK` 或 `aapl`、`AAPL` 被误判为不同标的。
 - [改进] #1390 P0 为个股分析与历史/回测展示新增可选八态 `action` / `action_label` 建议动作字段，保留 `operation_advice` 自由文本和 `decision_type=buy|hold|sell` 统计口径，不新增迁移或配置项。

--- a/docs/README_CHT.md
+++ b/docs/README_CHT.md
@@ -64,7 +64,7 @@
 
 ## 🚀 快速開始
 
-### 方式一：GitHub Actions（推薦）
+### 方式一：[GitHub Actions（推薦）](https://www.bilibili.com/video/BV11FEb66EXG/)
 
 > 5 分鐘完成部署，零成本，無需伺服器。
 
@@ -138,7 +138,7 @@
 
 預設每個工作日 18:00（北京時間）自動執行，也可手動觸發。預設非交易日（含 A/H/US 節假日）不執行；強制運行、交易日檢查、斷點續傳等規則見 [完整指南](./full-guide.md#定时任务配置)。
 
-### 方式二：本地運行 / Docker 部署
+### 方式二：[客戶端配置教程](https://www.bilibili.com/video/BV11FEb66Eyr/) / 本地運行 / Docker 部署
 
 ```bash
 # 克隆項目


### PR DESCRIPTION
## 改了什么

- 在 README 快速开始的 GitHub Actions 入口补充对应视频教程链接。
- 将第二种快速开始入口中的桌面客户端相关文案调整为「客户端配置教程」，并链接到对应视频教程。
- 更新 `docs/CHANGELOG.md` 的 Unreleased 文档记录。

## 为什么这么改

让新用户能在快速开始区域直接打开对应教程，同时避免新增独立章节，保持 README 结构精简。

## 验证情况

Docs only, tests not run. 已检查 diff，仅包含 README 与 changelog 文档改动。

## 未验证项

- 未运行代码测试，改动不涉及运行时代码。

## 风险点

- 风险较低，主要风险是外部 B 站链接后续失效。

## 回滚方式

- Revert commit `a6097de3` 即可恢复原 README 文案。