### PR TITLE
fix: 发布说明生成在作者查询失败时缺少诊断日志 (#1683)

### DIFF
--- a/.github/scripts/build_release_notes.py
+++ b/.github/scripts/build_release_notes.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import logging
 import os
 import re
 import subprocess
@@ -14,6 +15,7 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[2]
 CHANGELOG = ROOT / "docs" / "CHANGELOG.md"
+LOGGER = logging.getLogger(__name__)
 KNOWN_AUTHOR_LOGINS = {
     "Alfred": "massif-01",
     "massif0601@gmail.com": "massif-01",
@@ -77,6 +79,9 @@ def _commit_authors(previous_tag: str, tag: str) -> list[str]:
 
 
 def _github_login_from_pr(repo: str, token: str, pr_number: str) -> str | None:
+    if not token:
+        return None
+
     request = urllib.request.Request(
         f"https://api.github.com/repos/{repo}/pulls/{pr_number}",
         headers={
@@ -89,7 +94,36 @@ def _github_login_from_pr(repo: str, token: str, pr_number: str) -> str | None:
     try:
         with urllib.request.urlopen(request, timeout=15) as response:
             payload = json.load(response)
-    except (OSError, urllib.error.HTTPError, urllib.error.URLError):
+    except urllib.error.HTTPError as exc:
+        if exc.code == 404:
+            return None
+        LOGGER.warning(
+            "Release notes PR author lookup failed for PR #%s: exception_type=%s status=%s",
+            pr_number,
+            type(exc).__name__,
+            exc.code,
+        )
+        return None
+    except urllib.error.URLError as exc:
+        LOGGER.warning(
+            "Release notes PR author lookup failed for PR #%s: exception_type=%s",
+            pr_number,
+            type(exc).__name__,
+        )
+        return None
+    except OSError as exc:
+        LOGGER.warning(
+            "Release notes PR author lookup failed for PR #%s: exception_type=%s",
+            pr_number,
+            type(exc).__name__,
+        )
+        return None
+    except json.JSONDecodeError as exc:
+        LOGGER.warning(
+            "Release notes PR author lookup failed for PR #%s: exception_type=%s",
+            pr_number,
+            type(exc).__name__,
+        )
         return None
     user = payload.get("user") or {}
     login = user.get("login")
@@ -117,7 +151,7 @@ def _contributors(previous_tag: str, tag: str) -> list[str]:
     for subject in _commit_subjects(previous_tag, tag):
         pr_numbers = re.findall(r"\(#(\d+)\)", subject)
         for pr_number in pr_numbers:
-            login = _github_login_from_pr(repo, token, pr_number) if repo and token else None
+            login = _github_login_from_pr(repo, token, pr_number) if repo else None
             if login and login not in logins:
                 logins.append(login)
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 <!-- 新条目格式：- [类型] 描述（类型取值：新功能/改进/修复/文档/测试/chore）-->
 <!-- 每条独立一行追加到本段末尾，无需分类标题，合并时冲突最小 -->
+- [修复] 发布说明生成查询 PR 作者失败时保留降级并输出包含 PR 编号和异常类型的 warning，便于排查 token、权限、网络或 GitHub API 异常。
 
 ## [3.22.0] - 2026-06-13
 

--- a/tests/test_build_release_notes.py
+++ b/tests/test_build_release_notes.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+import importlib.util
+import io
+import json
+import logging
+import urllib.error
+from pathlib import Path
+
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+SCRIPT_PATH = ROOT_DIR / ".github" / "scripts" / "build_release_notes.py"
+
+
+def _load_release_notes_module():
+    spec = importlib.util.spec_from_file_location("build_release_notes", SCRIPT_PATH)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class _JsonResponse:
+    def __init__(self, payload: dict[str, object]) -> None:
+        self._payload = payload
+
+    def __enter__(self) -> io.StringIO:
+        return io.StringIO(json.dumps(self._payload))
+
+    def __exit__(self, exc_type, exc, tb) -> bool:
+        return False
+
+
+def test_github_login_from_pr_returns_successful_author(monkeypatch) -> None:
+    module = _load_release_notes_module()
+
+    def fake_urlopen(request, timeout):
+        return _JsonResponse({"user": {"login": "octocat"}})
+
+    monkeypatch.setattr(module.urllib.request, "urlopen", fake_urlopen)
+
+    assert module._github_login_from_pr("owner/repo", "token", "123") == "octocat"
+
+
+def test_github_login_from_pr_expected_degrades_without_warning(caplog) -> None:
+    module = _load_release_notes_module()
+
+    with caplog.at_level(logging.WARNING, logger=module.LOGGER.name):
+        assert module._github_login_from_pr("owner/repo", "", "124") is None
+
+    assert not caplog.records
+
+
+def test_github_login_from_pr_404_degrades_without_warning(monkeypatch, caplog) -> None:
+    module = _load_release_notes_module()
+
+    def fake_urlopen(request, timeout):
+        raise urllib.error.HTTPError(
+            url=request.full_url,
+            code=404,
+            msg="Not Found",
+            hdrs=None,
+            fp=None,
+        )
+
+    monkeypatch.setattr(module.urllib.request, "urlopen", fake_urlopen)
+
+    with caplog.at_level(logging.WARNING, logger=module.LOGGER.name):
+        assert module._github_login_from_pr("owner/repo", "token", "125") is None
+
+    assert not caplog.records
+
+
+def test_github_login_from_pr_http_error_warns_with_pr_and_exception_type(
+    monkeypatch,
+    caplog,
+) -> None:
+    module = _load_release_notes_module()
+
+    def fake_urlopen(request, timeout):
+        raise urllib.error.HTTPError(
+            url=request.full_url,
+            code=403,
+            msg="Forbidden",
+            hdrs=None,
+            fp=None,
+        )
+
+    monkeypatch.setattr(module.urllib.request, "urlopen", fake_urlopen)
+
+    with caplog.at_level(logging.WARNING, logger=module.LOGGER.name):
+        assert module._github_login_from_pr("owner/repo", "secret-token", "126") is None
+
+    assert "PR #126" in caplog.text
+    assert "exception_type=HTTPError" in caplog.text
+    assert "status=403" in caplog.text
+    assert "secret-token" not in caplog.text
+
+
+def test_github_login_from_pr_network_error_warns_with_pr_and_exception_type(
+    monkeypatch,
+    caplog,
+) -> None:
+    module = _load_release_notes_module()
+
+    def fake_urlopen(request, timeout):
+        raise urllib.error.URLError(TimeoutError("timed out"))
+
+    monkeypatch.setattr(module.urllib.request, "urlopen", fake_urlopen)
+
+    with caplog.at_level(logging.WARNING, logger=module.LOGGER.name):
+        assert module._github_login_from_pr("owner/repo", "secret-token", "127") is None
+
+    assert "PR #127" in caplog.text
+    assert "exception_type=URLError" in caplog.text
+    assert "secret-token" not in caplog.text


### PR DESCRIPTION
## PR Type
- [x] fix
- [ ] feat
- [ ] refactor
- [ ] docs
- [ ] chore
- [ ] test

## Background And Problem
- 当前问题：在发布说明生成查询 PR 作者失败时保留作者缺失降级行为，并为异常路径补充包含 PR 编号和异常类型的 warning 诊断日志。
- 影响范围：本次改动涉及 3 个文件，Diff 为 `+154 / -2`。
- 触发来源：Issue 自动执行（Issue #1683）。

## Scope Of Change
- `.github/scripts/build_release_notes.py`
- `docs/CHANGELOG.md`
- `tests/test_build_release_notes.py`

## Documentation And Changelog
- 已同步更新文档/变更记录：`docs/CHANGELOG.md`。
- 当前补丁尚未包含 `README.md` 或专题文档；如用户可见行为发生变化，请补充文档落点。

## Issue Link
Closes #1683

## Verification Commands And Results
```bash
./scripts/ci_gate.sh flake8
./scripts/ci_gate.sh offline-tests
```

关键输出/结论 / Key output & conclusion:
- lint:PASS, test:PASS

## Compatibility And Risk
- **Medium**：涉及 `.github/scripts/build_release_notes.py`, `docs/CHANGELOG.md`, `tests/test_build_release_notes.py`，建议按文件范围复核。
- 前提假设：
  - 发布说明生成逻辑位于 .github/scripts/、scripts/ 或相关 release/changelog 生成脚本中。
  - 未配置 token 或 404 可作为预期降级处理，网络错误、认证错误、GitHub API 异常应输出 warning。
  - 日志不得输出 token、请求头、完整敏感响应体或其他 secret。
  - 本次不调整 secrets、workflow、部署流程或发布策略。

## Rollback Plan
- `git revert <merge-commit>` 回滚本 PR 提交，重点确认 `.github/scripts/build_release_notes.py`, `docs/CHANGELOG.md`, `tests/test_build_release_notes.py` 恢复正常。

## Acceptance Criteria
- PR 作者查询失败时不会中断发布说明生成，仍按当前逻辑降级为作者信息缺失。
- 非预期异常分支输出 warning，内容至少包含 PR 编号和异常类型。
- 404 或未配置 token 等预期降级路径与网络错误、认证错误、API 异常路径可区分。
- 新增或更新测试覆盖成功查询、预期降级和异常 warning 三类路径。
- docs/CHANGELOG.md 的 [Unreleased] 增加一条扁平格式修复记录。

## Checklist
- [x] 本 PR 有明确动机和业务价值 / This PR has a clear motivation and value
- [x] 已提供可复现的验证命令与结果 / Reproducible verification commands and results are included
- [x] 已评估兼容性与风险 / Compatibility and risk have been assessed
- [x] 已提供回滚方案 / A rollback plan is provided
- [ ] 文档与 `docs/CHANGELOG.md` 同步仍需确认；如涉及用户可见变更，请在合并前补充原因与文档落点 / Documentation and `docs/CHANGELOG.md` sync still needs confirmation before merge when user-visible behavior changes