### PR TITLE
fix: backfill report decision signals

### DIFF
--- a/api/v1/endpoints/decision_signals.py
+++ b/api/v1/endpoints/decision_signals.py
@@ -115,6 +115,9 @@ def create_signal(request: DecisionSignalCreateRequest) -> DecisionSignalMutatio
     summary="查询决策信号列表",
     description=(
         "分页查询 DecisionSignal；读取前会懒过期已到 expires_at 的 active 信号。"
+        "当 source_type=analysis 且只传 source_report_id 查询时，若无命中信号会尝试基于该历史报告一次性懒回填 "
+        "（仅首次命中列表场景，且该精确查询会触发历史决策信号回填写入，属于 read-with-write 行为；"
+        "不影响其他分页列表筛选参数场景）。"
         "holding_only=true 只读取 active 账户的 portfolio_positions 缓存持仓，不触发 portfolio snapshot replay。"
     ),
     operation_id="listDecisionSignals",

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - [改进] #1390 P3 为 `DecisionSignal` 补齐默认生命周期、同源窄 relaxed 去重、相反 active 信号自动 invalidated、terminal 状态不可 PATCH 复活和自动提取低敏 market phase hints，保持 API 响应 schema 不变。
 - [新功能] #1390 P4 新增 Web AI 建议页、持仓页最新 active 信号摘要和历史报告提取信号展示，复用既有 DecisionSignal API 且不新增后端契约或配置项。
 - [修复] #1390 P4 修复 Web AI 建议页筛选/状态更新分页、价格计划单边入场价展示、持仓 latest 信号刷新、详情 JSON 安全渲染和卡片交互语义问题。
+- [修复] #1390 P4 为历史报告 AI 建议查询补充精确报告懒提取，旧分析记录在首次查看报告信号时可生成并展示 DecisionSignal，避免明确个股建议长期显示为空态。
 - [新功能] #1390 P5 新增 DecisionSignal 用户反馈、信号级日线后验评估、统计 API 与 Web 展示，使用 outcome/feedback sidecar 表并保留主信号表契约；默认后验重跑会恢复可补齐行情数据的 unable 结果，批量 backfill 不再被最新已评估信号占满 limit。
 - [修复] #1390 收紧建议动作 legacy fallback：英文 `not to ...` 与 `avoid selling/reducing/trimming ...` 等否定/回避表达不再误判为买卖动作，Web 旧记录不再把中文金融上下文、`buy or sell`、多 guard 歧义文本或 `buyback` / `buy-back` / `buy back` / `selloff` / `sell-off` / `sell off` 等英文复合词渲染成 action badge，并在有结构化 `action` 时让回测/历史趋势等入口按界面语言显示 action 标签。
 - [改进] 完善运行时日志上下文，补充 logger name、触发来源、市场统计与实时行情预取链路状态，便于排查调度、API、Bot 和数据源降级路径。

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - [新功能] #1390 P4 新增 Web AI 建议页、持仓页最新 active 信号摘要和历史报告提取信号展示，复用既有 DecisionSignal API 且不新增后端契约或配置项。
 - [修复] #1390 P4 修复 Web AI 建议页筛选/状态更新分页、价格计划单边入场价展示、持仓 latest 信号刷新、详情 JSON 安全渲染和卡片交互语义问题。
 - [修复] #1390 P4 为历史报告 AI 建议查询补充精确报告懒提取，旧分析记录在首次查看报告信号时可生成并展示 DecisionSignal，避免明确个股建议长期显示为空态。
+- [修复] #1390 P4 仅允许在历史报告中存在明确 `action` 或可由 `operation_advice` 解析出的动作时才触发决策信号懒回填；避免 `decision_type=hold` 等统计口径在建议不明确场景误回填，并补充 GET /decision-signals 在精确 report 查询的写入副作用说明。
 - [新功能] #1390 P5 新增 DecisionSignal 用户反馈、信号级日线后验评估、统计 API 与 Web 展示，使用 outcome/feedback sidecar 表并保留主信号表契约；默认后验重跑会恢复可补齐行情数据的 unable 结果，批量 backfill 不再被最新已评估信号占满 limit。
 - [修复] #1390 收紧建议动作 legacy fallback：英文 `not to ...` 与 `avoid selling/reducing/trimming ...` 等否定/回避表达不再误判为买卖动作，Web 旧记录不再把中文金融上下文、`buy or sell`、多 guard 歧义文本或 `buyback` / `buy-back` / `buy back` / `selloff` / `sell-off` / `sell off` 等英文复合词渲染成 action badge，并在有结构化 `action` 时让回测/历史趋势等入口按界面语言显示 action 标签。
 - [改进] 完善运行时日志上下文，补充 logger name、触发来源、市场统计与实时行情预取链路状态，便于排查调度、API、Bot 和数据源降级路径。

--- a/docs/architecture/api_spec.json
+++ b/docs/architecture/api_spec.json
@@ -853,7 +853,7 @@
           "DecisionSignals"
         ],
         "summary": "查询决策信号列表",
-        "description": "分页查询 DecisionSignal；读取前会懒过期已到 expires_at 的 active 信号。holding_only=true 只读取 active 账户的 portfolio_positions 缓存持仓，不触发 portfolio snapshot replay。",
+        "description": "分页查询 DecisionSignal；读取前会懒过期已到 expires_at 的 active 信号。当 source_type=analysis 且只传 source_report_id 查询时，若无命中信号会尝试基于该历史报告一次性懒回填 （仅首次命中列表场景，且该精确查询会触发历史决策信号回填写入，属于 read-with-write 行为；不影响其他分页列表筛选参数场景）。holding_only=true 只读取 active 账户的 portfolio_positions 缓存持仓，不触发 portfolio snapshot replay。",
         "operationId": "listDecisionSignals",
         "security": [
           {

--- a/src/services/decision_signal_service.py
+++ b/src/services/decision_signal_service.py
@@ -367,7 +367,10 @@ class DecisionSignalService:
                 payload,
                 created_at=getattr(record, "created_at", None),
             )
-            self.create_signal(payload)
+            created = self.create_signal(payload)
+            signal_id = created.get("item", {}).get("id")
+            if isinstance(signal_id, int):
+                self._invalidate_history_backfill_if_superseded(signal_id)
         except Exception as exc:
             logger.warning(
                 "Decision signal lazy backfill failed: source_report_id=%s error=%s",
@@ -431,6 +434,39 @@ class DecisionSignalService:
         payload["expires_at"] = expires_at
         if self._is_expired(expires_at):
             payload["status"] = "expired"
+
+    def _invalidate_history_backfill_if_superseded(self, signal_id: int) -> None:
+        row = self.repo.get(signal_id)
+        if row is None or row.status != "active":
+            return
+
+        opposing_actions = self._opposing_actions(row.action)
+        if not opposing_actions:
+            return
+        newer_rows = self.repo.list_active_by_stock_actions(
+            market=row.market,
+            stock_code=row.stock_code,
+            actions=sorted(opposing_actions),
+            exclude_signal_id=row.id,
+        )
+        for newer_row in newer_rows:
+            if not self._is_prior_signal(row, newer_row, reference_at=newer_row.created_at):
+                continue
+            metadata_json = self._invalidation_metadata_json(row, invalidated_by=newer_row)
+            updated = self.repo.update_status(
+                row.id,
+                status="invalidated",
+                metadata_json=metadata_json,
+                replace_metadata=True,
+            )
+            if updated is None:
+                logger.warning(
+                    "Decision signal disappeared before stale backfill invalidation: "
+                    "signal_id=%s invalidated_by=%s",
+                    row.id,
+                    newer_row.id,
+                )
+            return
 
     @classmethod
     def _history_backfill_expires_at(

--- a/src/services/decision_signal_service.py
+++ b/src/services/decision_signal_service.py
@@ -428,6 +428,7 @@ class DecisionSignalService:
             created_at=created_at,
             horizon=horizon,
             market=str(payload.get("market") or ""),
+            metadata=payload.get("metadata"),
         )
         if expires_at is None:
             return
@@ -475,14 +476,15 @@ class DecisionSignalService:
         created_at: datetime,
         horizon: Optional[str],
         market: str,
+        metadata: Any,
     ) -> Optional[datetime]:
         base = to_utc_naive_datetime(created_at)
-        if horizon == "intraday":
-            return base + timedelta(hours=cls._intraday_fallback_hours(market))
-        days = cls._horizon_days(horizon)
-        if days is None:
-            return None
-        return base + timedelta(days=days)
+        return cls._expires_at_from_base(
+            horizon=horizon,
+            market=market,
+            metadata=metadata,
+            base=base,
+        )
 
     @staticmethod
     def _history_int(*values: Any, default: int) -> int:
@@ -597,21 +599,36 @@ class DecisionSignalService:
         market: str,
         metadata: Any,
     ) -> Optional[datetime]:
-        now = utc_naive_now()
+        return cls._expires_at_from_base(
+            horizon=horizon,
+            market=market,
+            metadata=metadata,
+            base=utc_naive_now(),
+        )
+
+    @classmethod
+    def _expires_at_from_base(
+        cls,
+        *,
+        horizon: Optional[str],
+        market: str,
+        metadata: Any,
+        base: datetime,
+    ) -> Optional[datetime]:
         if horizon == "intraday":
             minutes_to_close = cls._metadata_minutes(metadata, "minutes_to_close")
             if minutes_to_close is not None:
-                return now + timedelta(minutes=minutes_to_close)
+                return base + timedelta(minutes=minutes_to_close)
             minutes_to_open = cls._metadata_minutes(metadata, "minutes_to_open")
             if minutes_to_open is not None:
                 fallback_minutes = int(cls._intraday_fallback_hours(market) * 60)
-                return now + timedelta(minutes=minutes_to_open + fallback_minutes)
-            return now + timedelta(hours=cls._intraday_fallback_hours(market))
+                return base + timedelta(minutes=minutes_to_open + fallback_minutes)
+            return base + timedelta(hours=cls._intraday_fallback_hours(market))
 
         days = cls._horizon_days(horizon)
         if days is None:
             return None
-        return now + timedelta(days=days)
+        return base + timedelta(days=days)
 
     @staticmethod
     def _intraday_fallback_hours(market: str) -> float:

--- a/src/services/decision_signal_service.py
+++ b/src/services/decision_signal_service.py
@@ -22,6 +22,7 @@ from src.storage import (
     to_utc_naive_datetime,
     utc_naive_now,
 )
+from src.utils.data_processing import parse_json_field
 from src.utils.sanitize import sanitize_decision_signal_payload, sanitize_decision_signal_text
 
 
@@ -69,6 +70,7 @@ class DecisionSignalService:
     ):
         self.repo = repo or DecisionSignalRepository(db_manager)
         self.portfolio_repo = portfolio_repo or PortfolioRepository(db_manager)
+        self.db = db_manager or getattr(self.repo, "db", None) or DatabaseManager.get_instance()
 
     def create_signal(self, payload: Dict[str, Any]) -> Dict[str, Any]:
         fields, lifecycle = self._normalize_payload(payload)
@@ -162,6 +164,41 @@ class DecisionSignalService:
             page=safe_page,
             page_size=safe_page_size,
         )
+        if total == 0 and self._should_backfill_history_bound_analysis_signal(
+            stock_code=stock_code,
+            market=market_norm,
+            action=action_norm,
+            market_phase=market_phase_norm,
+            source_type=source_type_norm,
+            source_report_id=source_report_id_norm,
+            trace_id=trace_id_norm,
+            trigger_source=trigger_source_norm,
+            status=status_norm,
+            created_from=created_from_dt,
+            created_to=created_to_dt,
+            expires_from=expires_from_dt,
+            expires_to=expires_to_dt,
+            holding_only=holding_only,
+        ):
+            self._backfill_analysis_signal_from_history(source_report_id_norm)
+            rows, total = self.repo.list(
+                stock_codes=stock_codes,
+                stock_identities=stock_identities,
+                market=market_norm,
+                action=action_norm,
+                market_phase=market_phase_norm,
+                source_type=source_type_norm,
+                source_report_id=source_report_id_norm,
+                trace_id=trace_id_norm,
+                trigger_source=trigger_source_norm,
+                status=status_norm,
+                created_from=created_from_dt,
+                created_to=created_to_dt,
+                expires_from=expires_from_dt,
+                expires_to=expires_to_dt,
+                page=safe_page,
+                page_size=safe_page_size,
+            )
         return {
             "items": [self._serialize(row) for row in rows],
             "total": total,
@@ -217,6 +254,181 @@ class DecisionSignalService:
         if row is None:
             raise DecisionSignalNotFoundError(f"Decision signal not found: {signal_id}")
         return self._serialize(row)
+
+    @staticmethod
+    def _should_backfill_history_bound_analysis_signal(
+        *,
+        stock_code: Optional[Any],
+        market: Optional[str],
+        action: Optional[str],
+        market_phase: Optional[str],
+        source_type: Optional[str],
+        source_report_id: Optional[int],
+        trace_id: Optional[str],
+        trigger_source: Optional[str],
+        status: Optional[str],
+        created_from: Optional[datetime],
+        created_to: Optional[datetime],
+        expires_from: Optional[datetime],
+        expires_to: Optional[datetime],
+        holding_only: bool,
+    ) -> bool:
+        """Only lazy-backfill for the exact report section query used by Web."""
+
+        if source_type != "analysis" or source_report_id is None:
+            return False
+        return not any(
+            value not in (None, "", False)
+            for value in (
+                stock_code,
+                market,
+                action,
+                market_phase,
+                trace_id,
+                trigger_source,
+                status,
+                created_from,
+                created_to,
+                expires_from,
+                expires_to,
+                holding_only,
+            )
+        )
+
+    def _backfill_analysis_signal_from_history(self, source_report_id: int) -> None:
+        """Best-effort lazy extraction for reports saved before DecisionSignal existed."""
+
+        try:
+            record = self.db.get_analysis_history_by_id(source_report_id)
+            if record is None or getattr(record, "report_type", None) == "market_review":
+                return
+
+            raw_result = parse_json_field(getattr(record, "raw_result", None))
+            raw = raw_result if isinstance(raw_result, dict) else {}
+            context_snapshot = parse_json_field(getattr(record, "context_snapshot", None))
+            if not isinstance(context_snapshot, dict):
+                context_snapshot = None
+
+            from src.analyzer import AnalysisResult
+            from src.services.decision_signal_extractor import build_decision_signal_payload_from_report
+
+            result = AnalysisResult(
+                code=getattr(record, "code", "") or "",
+                name=getattr(record, "name", None) or raw.get("name") or "",
+                sentiment_score=self._history_int(
+                    raw.get("sentiment_score"),
+                    getattr(record, "sentiment_score", None),
+                    default=50,
+                ),
+                trend_prediction=raw.get("trend_prediction") or getattr(record, "trend_prediction", None) or "",
+                operation_advice=raw.get("operation_advice") or getattr(record, "operation_advice", None) or "",
+                decision_type=raw.get("decision_type") or "hold",
+                confidence_level=raw.get("confidence_level") or "中",
+                report_language=normalize_report_language(raw.get("report_language")),
+                action=raw.get("action"),
+                action_label=raw.get("action_label"),
+                dashboard=raw.get("dashboard") if isinstance(raw.get("dashboard"), dict) else None,
+                analysis_summary=raw.get("analysis_summary") or getattr(record, "analysis_summary", None) or "",
+                key_points=raw.get("key_points") or "",
+                risk_warning=raw.get("risk_warning") or "",
+                buy_reason=raw.get("buy_reason") or "",
+                raw_response=raw.get("raw_response"),
+                search_performed=bool(raw.get("search_performed", False)),
+                data_sources=raw.get("data_sources") or "",
+                success=bool(raw.get("success", True)),
+                error_message=raw.get("error_message"),
+                current_price=self._history_float(raw.get("current_price")),
+                change_pct=self._history_float(raw.get("change_pct")),
+                model_used=raw.get("model_used"),
+                query_id=getattr(record, "query_id", None),
+            )
+            payload = build_decision_signal_payload_from_report(
+                result,
+                context_snapshot=context_snapshot,
+                source_report_id=source_report_id,
+                trace_id=str(getattr(record, "query_id", "") or source_report_id),
+                query_source="history",
+                report_type=str(getattr(record, "report_type", "") or "simple"),
+            )
+            if payload is None:
+                return
+            self._apply_history_backfill_lifecycle(
+                payload,
+                created_at=getattr(record, "created_at", None),
+            )
+            self.create_signal(payload)
+        except Exception as exc:
+            logger.warning(
+                "Decision signal lazy backfill failed: source_report_id=%s error=%s",
+                source_report_id,
+                exc,
+                exc_info=True,
+            )
+
+    def _apply_history_backfill_lifecycle(
+        self,
+        payload: Dict[str, Any],
+        *,
+        created_at: Optional[datetime],
+    ) -> None:
+        """Anchor lazy backfill expiry to the report time instead of query time."""
+
+        if created_at is None:
+            return
+        horizon = payload.get("horizon") or self._default_horizon(
+            action=str(payload.get("action") or ""),
+            market_phase=payload.get("market_phase"),
+        )
+        if horizon:
+            payload["horizon"] = horizon
+
+        expires_at = self._history_backfill_expires_at(
+            created_at=created_at,
+            horizon=horizon,
+            market=str(payload.get("market") or ""),
+        )
+        if expires_at is None:
+            return
+        payload["expires_at"] = expires_at
+        if self._is_expired(expires_at):
+            payload["status"] = "expired"
+
+    @classmethod
+    def _history_backfill_expires_at(
+        cls,
+        *,
+        created_at: datetime,
+        horizon: Optional[str],
+        market: str,
+    ) -> Optional[datetime]:
+        base = to_utc_naive_datetime(created_at)
+        if horizon == "intraday":
+            return base + timedelta(hours=cls._intraday_fallback_hours(market))
+        days = cls._horizon_days(horizon)
+        if days is None:
+            return None
+        return base + timedelta(days=days)
+
+    @staticmethod
+    def _history_int(*values: Any, default: int) -> int:
+        for value in values:
+            if value in (None, ""):
+                continue
+            try:
+                return int(float(value))
+            except (TypeError, ValueError):
+                continue
+        return default
+
+    @staticmethod
+    def _history_float(value: Any) -> Optional[float]:
+        if value in (None, ""):
+            return None
+        try:
+            parsed = float(value)
+        except (TypeError, ValueError):
+            return None
+        return parsed if math.isfinite(parsed) else None
 
     def _normalize_payload(self, payload: Dict[str, Any]) -> Tuple[Dict[str, Any], Dict[str, Any]]:
         market = self._normalize_market(payload.get("market"))

--- a/src/services/decision_signal_service.py
+++ b/src/services/decision_signal_service.py
@@ -17,6 +17,7 @@ from src.report_language import normalize_report_language
 from src.schemas.decision_action import DecisionAction, localize_action_label
 from src.services.portfolio_service import VALID_MARKETS
 from src.storage import (
+    AnalysisHistory,
     DatabaseManager,
     DecisionSignalRecord,
     to_utc_naive_datetime,
@@ -308,10 +309,13 @@ class DecisionSignalService:
             context_snapshot = parse_json_field(getattr(record, "context_snapshot", None))
             if not isinstance(context_snapshot, dict):
                 context_snapshot = None
+            if not self._history_has_decision_source(raw=raw, record=record):
+                return
 
             from src.analyzer import AnalysisResult
             from src.services.decision_signal_extractor import build_decision_signal_payload_from_report
 
+            raw_decision_type = raw.get("decision_type")
             result = AnalysisResult(
                 code=getattr(record, "code", "") or "",
                 name=getattr(record, "name", None) or raw.get("name") or "",
@@ -322,10 +326,10 @@ class DecisionSignalService:
                 ),
                 trend_prediction=raw.get("trend_prediction") or getattr(record, "trend_prediction", None) or "",
                 operation_advice=raw.get("operation_advice") or getattr(record, "operation_advice", None) or "",
-                decision_type=raw.get("decision_type") or "hold",
+                decision_type=raw_decision_type or "",
                 confidence_level=raw.get("confidence_level") or "中",
                 report_language=normalize_report_language(raw.get("report_language")),
-                action=raw.get("action"),
+                action=raw.get("action") or raw_decision_type,
                 action_label=raw.get("action_label"),
                 dashboard=raw.get("dashboard") if isinstance(raw.get("dashboard"), dict) else None,
                 analysis_summary=raw.get("analysis_summary") or getattr(record, "analysis_summary", None) or "",
@@ -365,6 +369,18 @@ class DecisionSignalService:
                 exc_info=True,
             )
 
+    @staticmethod
+    def _history_has_decision_source(*, raw: Dict[str, Any], record: AnalysisHistory) -> bool:
+        for value in (
+            raw.get("action"),
+            raw.get("operation_advice"),
+            raw.get("decision_type"),
+            getattr(record, "operation_advice", None),
+        ):
+            if str(value or "").strip():
+                return True
+        return False
+
     def _apply_history_backfill_lifecycle(
         self,
         payload: Dict[str, Any],
@@ -375,6 +391,7 @@ class DecisionSignalService:
 
         if created_at is None:
             return
+        payload["_created_at_override"] = to_utc_naive_datetime(created_at)
         horizon = payload.get("horizon") or self._default_horizon(
             action=str(payload.get("action") or ""),
             market_phase=payload.get("market_phase"),
@@ -461,6 +478,7 @@ class DecisionSignalService:
                 market=market,
                 metadata=payload.get("metadata"),
             )
+        created_at = self._parse_datetime(payload.get("_created_at_override"))
 
         fields: Dict[str, Any] = {
             "stock_code": stock_code,
@@ -492,6 +510,8 @@ class DecisionSignalService:
             "expires_at": expires_at,
             "metadata_json": self._json_dumps(payload.get("metadata")),
         }
+        if created_at is not None:
+            fields["created_at"] = created_at
         if fields["status"] == "active" and self._is_expired(fields["expires_at"]):
             fields["status"] = "expired"
         self._validate_entry_range(fields)

--- a/src/services/decision_signal_service.py
+++ b/src/services/decision_signal_service.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 import json
 import logging
 import math
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import Any, Dict, List, Optional, Tuple, get_args
 
 from data_provider.base import canonical_stock_code, normalize_stock_code
@@ -416,7 +416,12 @@ class DecisionSignalService:
 
         if created_at is None:
             return
-        payload["_created_at_override"] = to_utc_naive_datetime(created_at)
+        history_created_at = self._coerce_history_created_at_to_utc_naive(created_at)
+        if history_created_at is None:
+            payload["status"] = "expired"
+            return
+
+        payload["_created_at_override"] = history_created_at
         horizon = payload.get("horizon") or self._default_horizon(
             action=str(payload.get("action") or ""),
             market_phase=payload.get("market_phase"),
@@ -425,7 +430,7 @@ class DecisionSignalService:
             payload["horizon"] = horizon
 
         expires_at = self._history_backfill_expires_at(
-            created_at=created_at,
+            created_at=history_created_at,
             horizon=horizon,
             market=str(payload.get("market") or ""),
             metadata=payload.get("metadata"),
@@ -435,6 +440,20 @@ class DecisionSignalService:
         payload["expires_at"] = expires_at
         if self._is_expired(expires_at):
             payload["status"] = "expired"
+
+    @staticmethod
+    def _coerce_history_created_at_to_utc_naive(value: datetime) -> datetime:
+        if value.tzinfo is not None:
+            return to_utc_naive_datetime(value)
+
+        local_tz = datetime.now().astimezone().tzinfo
+        if local_tz is None or local_tz.utcoffset(value) is None:
+            return to_utc_naive_datetime(value)
+
+        try:
+            return value.replace(tzinfo=local_tz).astimezone(timezone.utc).replace(tzinfo=None)
+        except (OverflowError, OSError):
+            return to_utc_naive_datetime(value)
 
     def _invalidate_history_backfill_if_superseded(self, signal_id: int) -> None:
         row = self.repo.get(signal_id)

--- a/src/services/decision_signal_service.py
+++ b/src/services/decision_signal_service.py
@@ -14,7 +14,11 @@ from src.core.trading_calendar import MarketPhase
 from src.repositories.decision_signal_repo import DecisionSignalRepository
 from src.repositories.portfolio_repo import PortfolioRepository
 from src.report_language import normalize_report_language
-from src.schemas.decision_action import DecisionAction, localize_action_label
+from src.schemas.decision_action import (
+    DecisionAction,
+    build_action_fields,
+    localize_action_label,
+)
 from src.services.portfolio_service import VALID_MARKETS
 from src.storage import (
     AnalysisHistory,
@@ -309,13 +313,16 @@ class DecisionSignalService:
             context_snapshot = parse_json_field(getattr(record, "context_snapshot", None))
             if not isinstance(context_snapshot, dict):
                 context_snapshot = None
-            if not self._history_has_decision_source(raw=raw, record=record):
+            history_action, history_action_label = self._history_action_fields(
+                raw=raw,
+                record=record,
+            )
+            if history_action is None:
                 return
 
             from src.analyzer import AnalysisResult
             from src.services.decision_signal_extractor import build_decision_signal_payload_from_report
 
-            raw_decision_type = raw.get("decision_type")
             result = AnalysisResult(
                 code=getattr(record, "code", "") or "",
                 name=getattr(record, "name", None) or raw.get("name") or "",
@@ -326,11 +333,11 @@ class DecisionSignalService:
                 ),
                 trend_prediction=raw.get("trend_prediction") or getattr(record, "trend_prediction", None) or "",
                 operation_advice=raw.get("operation_advice") or getattr(record, "operation_advice", None) or "",
-                decision_type=raw_decision_type or "",
+                decision_type=raw.get("decision_type") or "",
                 confidence_level=raw.get("confidence_level") or "中",
                 report_language=normalize_report_language(raw.get("report_language")),
-                action=raw.get("action") or raw_decision_type,
-                action_label=raw.get("action_label"),
+                action=history_action,
+                action_label=history_action_label,
                 dashboard=raw.get("dashboard") if isinstance(raw.get("dashboard"), dict) else None,
                 analysis_summary=raw.get("analysis_summary") or getattr(record, "analysis_summary", None) or "",
                 key_points=raw.get("key_points") or "",
@@ -371,15 +378,30 @@ class DecisionSignalService:
 
     @staticmethod
     def _history_has_decision_source(*, raw: Dict[str, Any], record: AnalysisHistory) -> bool:
-        for value in (
-            raw.get("action"),
-            raw.get("operation_advice"),
-            raw.get("decision_type"),
-            getattr(record, "operation_advice", None),
-        ):
-            if str(value or "").strip():
-                return True
-        return False
+        action, _ = DecisionSignalService._history_action_fields(raw=raw, record=record)
+        return action is not None
+
+    @staticmethod
+    def _history_action_fields(
+        *,
+        raw: Dict[str, Any],
+        record: AnalysisHistory,
+    ) -> tuple[Optional[str], Optional[str]]:
+        raw_operation_advice = raw.get("operation_advice")
+        normalized_operation_advice = str(raw_operation_advice).strip() if raw_operation_advice is not None else None
+        if not normalized_operation_advice:
+            normalized_operation_advice = getattr(record, "operation_advice", None)
+        raw_action = raw.get("action")
+        normalized_action = str(raw_action).strip() if raw_action is not None else None
+        if not normalized_action:
+            normalized_action = None
+        action_fields = build_action_fields(
+            operation_advice=normalized_operation_advice,
+            explicit_action=normalized_action,
+            report_type=getattr(record, "report_type", ""),
+            report_language=raw.get("report_language"),
+        )
+        return action_fields["action"], action_fields["action_label"]
 
     def _apply_history_backfill_lifecycle(
         self,

--- a/tests/test_decision_signal_service.py
+++ b/tests/test_decision_signal_service.py
@@ -274,6 +274,51 @@ def test_list_signals_lazily_backfills_analysis_history_signal(isolated_db) -> N
         assert session.query(DecisionSignalRecord).count() == 1
 
 
+def test_list_signals_invalidates_stale_backfill_when_newer_opposing_signal_exists(isolated_db) -> None:
+    record_id = isolated_db.save_analysis_history(
+        result=_history_result(
+            operation_advice="买入",
+            decision_type="buy",
+            action="buy",
+            action_label="买入",
+            analysis_summary="旧报告建议买入。",
+        ),
+        query_id="query-stale-backfill-buy",
+        report_type="simple",
+        news_content="新闻摘要",
+        context_snapshot={"market_phase_summary": {"phase": "postmarket"}},
+        save_snapshot=True,
+    )
+    report_created_at = utc_naive_now() - timedelta(days=1)
+    with isolated_db.get_session() as session:
+        row = session.query(AnalysisHistory).filter(AnalysisHistory.id == record_id).one()
+        row.created_at = report_created_at
+        session.commit()
+
+    service = DecisionSignalService(db_manager=isolated_db)
+    newer_sell = service.create_signal(
+        _payload(
+            source_report_id=record_id + 1000,
+            trace_id="trace-newer-opposing-sell",
+            action="sell",
+        )
+    )["item"]
+
+    listed = service.list_signals(source_type="analysis", source_report_id=record_id)
+
+    assert listed["total"] == 1
+    backfilled = listed["items"][0]
+    assert backfilled["source_report_id"] == record_id
+    assert backfilled["action"] == "buy"
+    assert backfilled["status"] == "invalidated"
+    assert backfilled["metadata"]["invalidated_by_signal_id"] == newer_sell["id"]
+    assert backfilled["metadata"]["invalidated_reason"] == "opposite_active_signal:buy->sell"
+    assert service.get_signal(newer_sell["id"])["status"] == "active"
+
+    latest = service.get_latest_active(stock_code="600519", limit=5)
+    assert [item["id"] for item in latest["items"]] == [newer_sell["id"]]
+
+
 def test_list_signals_does_not_backfill_market_review_history(isolated_db) -> None:
     record_id = isolated_db.save_analysis_history(
         result=_history_result(code="MARKET", name="大盘复盘", operation_advice="查看复盘"),

--- a/tests/test_decision_signal_service.py
+++ b/tests/test_decision_signal_service.py
@@ -274,6 +274,43 @@ def test_list_signals_lazily_backfills_analysis_history_signal(isolated_db) -> N
         assert session.query(DecisionSignalRecord).count() == 1
 
 
+@pytest.mark.parametrize(
+    ("market_phase_summary", "created_offset", "expected_ttl"),
+    (
+        ({"phase": "intraday", "minutes_to_close": 5}, timedelta(minutes=10), timedelta(minutes=5)),
+        ({"phase": "premarket", "minutes_to_open": 10}, timedelta(hours=5), timedelta(hours=4, minutes=10)),
+    ),
+)
+def test_list_signals_backfill_uses_saved_intraday_ttl_metadata(
+    isolated_db,
+    market_phase_summary,
+    created_offset,
+    expected_ttl,
+) -> None:
+    report_created_at = utc_naive_now().replace(microsecond=0) - created_offset
+    record_id = isolated_db.save_analysis_history(
+        result=_history_result(),
+        query_id=f"query-lazy-signal-ttl-{market_phase_summary['phase']}",
+        report_type="simple",
+        news_content="新闻摘要",
+        context_snapshot={"market_phase_summary": market_phase_summary},
+        save_snapshot=True,
+    )
+    with isolated_db.get_session() as session:
+        row = session.query(AnalysisHistory).filter(AnalysisHistory.id == record_id).one()
+        row.created_at = report_created_at
+        session.commit()
+    service = DecisionSignalService(db_manager=isolated_db)
+
+    listed = service.list_signals(source_type="analysis", source_report_id=record_id)
+
+    assert listed["total"] == 1
+    item = listed["items"][0]
+    assert item["horizon"] == "intraday"
+    assert item["status"] == "expired"
+    assert datetime.fromisoformat(item["expires_at"]) == report_created_at + expected_ttl
+
+
 def test_list_signals_invalidates_stale_backfill_when_newer_opposing_signal_exists(isolated_db) -> None:
     record_id = isolated_db.save_analysis_history(
         result=_history_result(

--- a/tests/test_decision_signal_service.py
+++ b/tests/test_decision_signal_service.py
@@ -16,7 +16,7 @@ import pytest
 from src.config import Config
 from src.repositories.decision_signal_repo import DecisionSignalCreateResult
 from src.services.decision_signal_service import DecisionSignalService, DecisionSignalStorageError
-from src.storage import DatabaseManager, DecisionSignalRecord, utc_naive_now
+from src.storage import AnalysisHistory, DatabaseManager, DecisionSignalRecord, utc_naive_now
 from src.utils.sanitize import sanitize_decision_signal_text, sanitize_diagnostic_text
 
 
@@ -76,6 +76,34 @@ def _payload(**overrides):
     }
     payload.update(overrides)
     return payload
+
+
+def _history_result(**overrides):
+    from src.analyzer import AnalysisResult
+
+    result = AnalysisResult(
+        code="600519",
+        name="贵州茅台",
+        sentiment_score=68,
+        trend_prediction="震荡偏强",
+        operation_advice="持有观察",
+        decision_type="hold",
+        confidence_level="中",
+        analysis_summary="趋势仍在，但等待量能确认。",
+        report_language="zh",
+    )
+    result.dashboard = {
+        "battle_plan": {
+            "sniper_points": {
+                "ideal_buy": "1680",
+                "stop_loss": "1600",
+            },
+            "action_checklist": ["回踩不破支撑"],
+        }
+    }
+    for key, value in overrides.items():
+        setattr(result, key, value)
+    return result
 
 
 def test_service_normalizes_fields_and_partial_plan_quality(isolated_db) -> None:
@@ -207,6 +235,60 @@ def test_service_defaults_lifecycle_and_preserves_explicit_values(isolated_db) -
         )
     )["item"]
     assert past["status"] == "expired"
+
+
+def test_list_signals_lazily_backfills_analysis_history_signal(isolated_db) -> None:
+    record_id = isolated_db.save_analysis_history(
+        result=_history_result(),
+        query_id="query-lazy-signal",
+        report_type="simple",
+        news_content="新闻摘要",
+        context_snapshot={"market_phase_summary": {"phase": "postmarket"}},
+        save_snapshot=True,
+    )
+    with isolated_db.get_session() as session:
+        row = session.query(AnalysisHistory).filter(AnalysisHistory.id == record_id).one()
+        row.created_at = utc_naive_now() - timedelta(days=10)
+        session.commit()
+    service = DecisionSignalService(db_manager=isolated_db)
+
+    listed = service.list_signals(source_type="analysis", source_report_id=record_id)
+
+    assert listed["total"] == 1
+    item = listed["items"][0]
+    assert item["source_report_id"] == record_id
+    assert item["source_type"] == "analysis"
+    assert item["trace_id"] == "query-lazy-signal"
+    assert item["trigger_source"] == "history"
+    assert item["action"] == "hold"
+    assert item["action_label"] == "持有"
+    assert item["reason"] == "趋势仍在，但等待量能确认。"
+    assert item["watch_conditions"] == '["回踩不破支撑"]'
+    assert item["status"] == "expired"
+
+    listed_again = service.list_signals(source_type="analysis", source_report_id=record_id)
+    assert listed_again["total"] == 1
+    with isolated_db.get_session() as session:
+        assert session.query(DecisionSignalRecord).count() == 1
+
+
+def test_list_signals_does_not_backfill_market_review_history(isolated_db) -> None:
+    record_id = isolated_db.save_analysis_history(
+        result=_history_result(code="MARKET", name="大盘复盘", operation_advice="查看复盘"),
+        query_id="query-lazy-market-review",
+        report_type="market_review",
+        news_content="复盘正文",
+        context_snapshot=None,
+        save_snapshot=False,
+    )
+    service = DecisionSignalService(db_manager=isolated_db)
+
+    listed = service.list_signals(source_type="analysis", source_report_id=record_id)
+
+    assert listed["total"] == 0
+    assert listed["items"] == []
+    with isolated_db.get_session() as session:
+        assert session.query(DecisionSignalRecord).count() == 0
 
 
 def test_service_plan_quality_slots_and_explicit_override(isolated_db) -> None:

--- a/tests/test_decision_signal_service.py
+++ b/tests/test_decision_signal_service.py
@@ -312,6 +312,51 @@ def test_list_signals_does_not_backfill_ambiguous_history_advice(isolated_db) ->
         assert session.query(DecisionSignalRecord).count() == 0
 
 
+def test_list_signals_does_not_backfill_ambiguous_history_default_decision_type_hold(isolated_db) -> None:
+    record_id = isolated_db.save_analysis_history(
+        result=_history_result(operation_advice="", action=None, action_label=None),
+        query_id="query-lazy-ambiguous-hold",
+        report_type="simple",
+        news_content="新闻摘要",
+        context_snapshot=None,
+        save_snapshot=False,
+    )
+    service = DecisionSignalService(db_manager=isolated_db)
+
+    listed = service.list_signals(source_type="analysis", source_report_id=record_id)
+
+    assert listed["total"] == 0
+    assert listed["items"] == []
+    with isolated_db.get_session() as session:
+        assert session.query(DecisionSignalRecord).count() == 0
+
+
+def test_list_signals_does_not_backfill_ambiguous_history_default_decision_type_hold_with_noisy_advice(
+    isolated_db,
+) -> None:
+    record_id = isolated_db.save_analysis_history(
+        result=_history_result(
+            operation_advice="买盘增强，继续观察",
+            decision_type="hold",
+            action=None,
+            action_label=None,
+        ),
+        query_id="query-lazy-ambiguous-noisy-hold",
+        report_type="simple",
+        news_content="新闻摘要",
+        context_snapshot=None,
+        save_snapshot=False,
+    )
+    service = DecisionSignalService(db_manager=isolated_db)
+
+    listed = service.list_signals(source_type="analysis", source_report_id=record_id)
+
+    assert listed["total"] == 0
+    assert listed["items"] == []
+    with isolated_db.get_session() as session:
+        assert session.query(DecisionSignalRecord).count() == 0
+
+
 def test_service_plan_quality_slots_and_explicit_override(isolated_db) -> None:
     service = DecisionSignalService(db_manager=isolated_db)
 

--- a/tests/test_decision_signal_service.py
+++ b/tests/test_decision_signal_service.py
@@ -252,6 +252,7 @@ def test_list_signals_lazily_backfills_analysis_history_signal(isolated_db) -> N
         row.created_at = report_created_at
         session.commit()
     service = DecisionSignalService(db_manager=isolated_db)
+    expected_created_at = service._coerce_history_created_at_to_utc_naive(report_created_at)
 
     listed = service.list_signals(source_type="analysis", source_report_id=record_id)
 
@@ -266,7 +267,7 @@ def test_list_signals_lazily_backfills_analysis_history_signal(isolated_db) -> N
     assert item["reason"] == "趋势仍在，但等待量能确认。"
     assert item["watch_conditions"] == '["回踩不破支撑"]'
     assert item["status"] == "expired"
-    assert datetime.fromisoformat(item["created_at"]) == report_created_at
+    assert datetime.fromisoformat(item["created_at"]) == expected_created_at
 
     listed_again = service.list_signals(source_type="analysis", source_report_id=record_id)
     assert listed_again["total"] == 1
@@ -301,6 +302,7 @@ def test_list_signals_backfill_uses_saved_intraday_ttl_metadata(
         row.created_at = report_created_at
         session.commit()
     service = DecisionSignalService(db_manager=isolated_db)
+    expected_report_created_at = service._coerce_history_created_at_to_utc_naive(report_created_at)
 
     listed = service.list_signals(source_type="analysis", source_report_id=record_id)
 
@@ -308,7 +310,60 @@ def test_list_signals_backfill_uses_saved_intraday_ttl_metadata(
     item = listed["items"][0]
     assert item["horizon"] == "intraday"
     assert item["status"] == "expired"
-    assert datetime.fromisoformat(item["expires_at"]) == report_created_at + expected_ttl
+    assert datetime.fromisoformat(item["expires_at"]) == expected_report_created_at + expected_ttl
+
+
+def test_list_signals_backfill_converts_naive_history_created_at_for_invalidation_ordering(
+    monkeypatch,
+    isolated_db,
+) -> None:
+    record_id = isolated_db.save_analysis_history(
+        result=_history_result(
+            operation_advice="买入",
+            decision_type="buy",
+            action="buy",
+            action_label="买入",
+        ),
+        query_id="query-lazy-signal-local-tz",
+        report_type="simple",
+        news_content="新闻摘要",
+        context_snapshot={"market_phase_summary": {"phase": "postmarket"}},
+        save_snapshot=True,
+    )
+    report_created_at = utc_naive_now() - timedelta(hours=1)
+    with isolated_db.get_session() as session:
+        row = session.query(AnalysisHistory).filter(AnalysisHistory.id == record_id).one()
+        row.created_at = report_created_at
+        session.commit()
+    service = DecisionSignalService(db_manager=isolated_db)
+
+    def fake_coerce_history_created_at_to_utc_naive(value: datetime) -> datetime:
+        assert value == report_created_at
+        return value - timedelta(hours=8)
+
+    monkeypatch.setattr(
+        service,
+        "_coerce_history_created_at_to_utc_naive",
+        fake_coerce_history_created_at_to_utc_naive,
+    )
+
+    newer_sell = service.create_signal(
+        _payload(
+            source_report_id=record_id + 1000,
+            trace_id="trace-local-tz-opposing-sell",
+            action="sell",
+            _created_at_override=report_created_at + timedelta(hours=13),
+        )
+    )["item"]
+
+    listed = service.list_signals(source_type="analysis", source_report_id=record_id)
+
+    assert listed["total"] == 1
+    item = listed["items"][0]
+    assert datetime.fromisoformat(item["created_at"]) == report_created_at - timedelta(hours=8)
+    assert item["action"] == "buy"
+    assert item["status"] == "invalidated"
+    assert item["metadata"]["invalidated_by_signal_id"] == newer_sell["id"]
 
 
 def test_list_signals_invalidates_stale_backfill_when_newer_opposing_signal_exists(isolated_db) -> None:

--- a/tests/test_decision_signal_service.py
+++ b/tests/test_decision_signal_service.py
@@ -248,7 +248,8 @@ def test_list_signals_lazily_backfills_analysis_history_signal(isolated_db) -> N
     )
     with isolated_db.get_session() as session:
         row = session.query(AnalysisHistory).filter(AnalysisHistory.id == record_id).one()
-        row.created_at = utc_naive_now() - timedelta(days=10)
+        report_created_at = datetime(2024, 1, 5, 14, 30)
+        row.created_at = report_created_at
         session.commit()
     service = DecisionSignalService(db_manager=isolated_db)
 
@@ -265,6 +266,7 @@ def test_list_signals_lazily_backfills_analysis_history_signal(isolated_db) -> N
     assert item["reason"] == "趋势仍在，但等待量能确认。"
     assert item["watch_conditions"] == '["回踩不破支撑"]'
     assert item["status"] == "expired"
+    assert datetime.fromisoformat(item["created_at"]) == report_created_at
 
     listed_again = service.list_signals(source_type="analysis", source_report_id=record_id)
     assert listed_again["total"] == 1
@@ -278,6 +280,25 @@ def test_list_signals_does_not_backfill_market_review_history(isolated_db) -> No
         query_id="query-lazy-market-review",
         report_type="market_review",
         news_content="复盘正文",
+        context_snapshot=None,
+        save_snapshot=False,
+    )
+    service = DecisionSignalService(db_manager=isolated_db)
+
+    listed = service.list_signals(source_type="analysis", source_report_id=record_id)
+
+    assert listed["total"] == 0
+    assert listed["items"] == []
+    with isolated_db.get_session() as session:
+        assert session.query(DecisionSignalRecord).count() == 0
+
+
+def test_list_signals_does_not_backfill_ambiguous_history_advice(isolated_db) -> None:
+    record_id = isolated_db.save_analysis_history(
+        result=_history_result(operation_advice="", decision_type="", action=None, action_label=None),
+        query_id="query-lazy-ambiguous-signal",
+        report_type="simple",
+        news_content="新闻摘要",
         context_snapshot=None,
         save_snapshot=False,
     )


### PR DESCRIPTION
## PR Type

- [x] fix
- [ ] feat
- [ ] refactor
- [ ] docs
- [ ] chore
- [x] test

## Background And Problem

Web 报告页新增 AI 建议模块后，模块按 `source_type=analysis` + `source_report_id` 查询结构化决策信号。旧的 `analysis_history` 记录里虽然可能已有 `operation_advice` / `action` 等报告建议，但当时没有落库 `decision_signals`，因此历史报告每次都会显示：

> 本报告暂无决策信号

触发场景：打开已有个股分析历史报告，且该报告早于结构化决策信号自动生成能力。

## Scope Of Change

- `src/services/decision_signal_service.py`
  - 在精确报告查询无结果时，从对应 `analysis_history` 懒回填一条决策信号。
  - 仅针对 `source_type=analysis` + `source_report_id` 的报告绑定查询触发，避免普通列表查询产生意外写入。
  - 跳过 `market_review` 历史记录。
  - 回填信号的生命周期锚定历史报告 `created_at`，过期旧报告会生成 `expired` 信号，避免污染当前活跃 AI 建议。
- `tests/test_decision_signal_service.py`
  - 覆盖历史个股报告懒回填、重复查询不重复生成、市场复盘不回填。
- `docs/CHANGELOG.md`
  - 记录本次用户可见修复。

## Issue Link

无 Issue。验收标准：旧个股分析报告在存在明确操作建议时，Web AI 建议模块可从历史报告懒生成结构化信号；市场复盘和建议不明确的报告仍保持空状态。

## Verification Commands And Results

```bash
/tmp/dsa-pr-venv/bin/python -m pytest tests/test_decision_signal_service.py
/tmp/dsa-pr-venv/bin/python -m pytest tests/test_decision_signal_service.py::test_list_signals_lazily_backfills_analysis_history_signal tests/test_decision_signal_service.py::test_list_signals_does_not_backfill_market_review_history tests/test_decision_signal_extractor.py
/tmp/dsa-pr-venv/bin/python -m py_compile src/services/decision_signal_service.py tests/test_decision_signal_service.py
git diff --check
```

关键输出/结论：

- `tests/test_decision_signal_service.py`: `39 passed, 1 warning`
- 针对新增回归测试 + extractor 测试：`11 passed, 1 warning`
- `py_compile`: passed
- `git diff --check`: passed

注：本机系统 Python 缺少部分测试依赖，因此按项目依赖在 `/tmp/dsa-pr-venv` 创建临时 venv 后执行验证；warning 为现有 FastAPI/Starlette 与 `httpx` 的 deprecation warning。

## Visual Evidence (if applicable)

- 截图链接 / Screenshot links:
- 不适用原因 / Reason if not applicable: 本 PR 修复的是报告 AI 建议数据回填逻辑，未调整报告渲染样式或 Web UI 组件布局；已用服务层回归测试验证接口数据来源。

## Compatibility And Risk

- 兼容性：不修改 API 字段、Web 组件契约或现有决策信号表结构。
- 回填行为：旧历史记录不会被批量迁移；只有打开具体历史报告并触发精确查询时，才会懒生成对应信号。
- 风险控制：回填生命周期使用历史报告创建时间计算，过期旧报告会以 `expired` 状态保存，降低误入当前活跃建议列表的风险。
- 保持不变：建议本身不明确、非普通个股分析或市场复盘报告仍可能显示暂无决策信号，这是当前提取器语义下的预期行为。

## Rollback Plan

最小回滚方式：revert this PR。若已在运行环境中懒生成了少量 `source_type=analysis` 的历史信号，可按具体 `source_report_id` 删除对应 `decision_signals` 记录；不需要额外配置回滚。

## EXTRACT_PROMPT Change (if applicable)

未修改 `src/services/image_stock_extractor.py` 中的 `EXTRACT_PROMPT`。

<details>
<summary>展开 / Expand: Full EXTRACT_PROMPT</summary>

```
N/A
```

</details>

## Checklist

- [x] 本 PR 有明确动机和业务价值 / This PR has a clear motivation and value
- [x] 已提供可复现的验证命令与结果 / Reproducible verification commands and results are included
- [x] 已评估兼容性与风险 / Compatibility and risk have been assessed
- [x] 已提供回滚方案 / A rollback plan is provided
- [x] 若修改报告格式或 Web UI 界面，已在 PR 描述/评论附受影响报告 / 页面截图，且未把一次性验收截图作为仓库文件合入 / If report formatting or Web UI changed, affected report/page screenshots are linked in the PR body/comments and one-off acceptance screenshots are not committed as repository files
- [x] 若涉及用户可见变更，已同步更新相关文档与 `docs/CHANGELOG.md`；`README.md` 仅在首页级信息变化时更新，细节优先写入 `docs/*.md` / If user-visible changes are included, relevant docs and `docs/CHANGELOG.md` are updated; `README.md` is updated only for homepage-level information changes, with details kept in `docs/*.md`