### PR TITLE
fix: 修复 #1722 P6 信号联动遗漏

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 ## [Unreleased]
 
 - [新功能] #1390 P6 将 DecisionSignal 复用到告警、通知和组合风险：告警触发关联 latest active 信号或创建最小 alert 信号，通知追加低敏信号摘要，持仓风险聚合 active sell/reduce/alert 信号并保持 fail-open。
+- [修复] #1722 修复 #1390 P6 DecisionSignal 在组合风险快照语义和默认聚合通知展示中的遗漏。
 - [新功能] #1707 资讯源新增 `newsnow` 类型、`NEWSNOW_BASE_URL` 配置和 `/api/v1/intelligence/sources/defaults` 默认源初始化接口，内置财联社热门、雪球热门股票、华尔街见闻快讯、金十数据和格隆汇事件等财经热点源，可直接拉取落库并进入既有分析证据链路；官方 NewsNow 部署指南见 https://github.com/qqhann/newsnow，生产环境建议自建实例而非使用公开示例。
 
 - [修复] AlphaSift 热点题材刷新在 EastMoney 瞬断且无缓存时返回友好空态，并让桌面更新保留 AlphaSift 热点缓存。

--- a/src/notification.py
+++ b/src/notification.py
@@ -850,6 +850,9 @@ class NotificationService(
                     f"{labels['score_label']} {r.sentiment_score} | "
                     f"{localize_trend_prediction(r.trend_prediction, report_language)}"
                 )
+                signal_excerpt = self._decision_signal_excerpt(r, report_language)
+                if signal_excerpt:
+                    report_lines.append(signal_excerpt)
         else:
             report_lines.extend([f"## 📈 {labels['report_title']}", ""])
             # 逐个股票的详细分析
@@ -866,6 +869,9 @@ class NotificationService(
                     f"**Confidence：{confidence_stars}**",
                     "",
                 ])
+                signal_excerpt = self._decision_signal_excerpt(result, report_language)
+                if signal_excerpt:
+                    report_lines.extend([signal_excerpt, ""])
                 self._append_market_snapshot(report_lines, result)
                 
                 # 核心看点
@@ -1099,6 +1105,9 @@ class NotificationService(
                     f"{labels['score_label']} {r.sentiment_score} | "
                     f"{localize_trend_prediction(r.trend_prediction, report_language)}"
                 )
+                signal_excerpt = self._decision_signal_excerpt(r, report_language)
+                if signal_excerpt:
+                    report_lines.append(signal_excerpt)
             report_lines.extend([
                 "",
                 "---",
@@ -1401,6 +1410,9 @@ class NotificationService(
                     f"{labels['score_label']} {r.sentiment_score} | "
                     f"{localize_trend_prediction(r.trend_prediction, report_language)}"
                 )
+                signal_excerpt = self._decision_signal_excerpt(r, report_language)
+                if signal_excerpt:
+                    lines.append(signal_excerpt)
         else:
             for result in sorted_results:
                 signal_text, signal_emoji, _ = self._get_signal_level(result)
@@ -1420,6 +1432,10 @@ class NotificationService(
                 one_sentence = core.get('one_sentence', result.analysis_summary) if core else result.analysis_summary
                 if one_sentence:
                     lines.append(f"📌 **{one_sentence[:80]}**")
+                    lines.append("")
+                signal_excerpt = self._decision_signal_excerpt(result, report_language)
+                if signal_excerpt:
+                    lines.append(signal_excerpt)
                     lines.append("")
                 
                 # 重要信息区（舆情+基本面）
@@ -1551,6 +1567,9 @@ class NotificationService(
                 f"{labels['score_label']}:{result.sentiment_score} | "
                 f"{localize_trend_prediction(result.trend_prediction, report_language)}"
             )
+            signal_excerpt = self._decision_signal_excerpt(result, report_language)
+            if signal_excerpt:
+                lines.append(signal_excerpt)
             
             # 操作理由（截断）
             if hasattr(result, 'buy_reason') and result.buy_reason:

--- a/src/services/decision_signal_service.py
+++ b/src/services/decision_signal_service.py
@@ -115,6 +115,7 @@ class DecisionSignalService:
         expires_to: Optional[Any] = None,
         holding_only: bool = False,
         account_id: Optional[int] = None,
+        stock_identities: Optional[List[Tuple[str, str]]] = None,
         page: int = 1,
         page_size: int = 20,
     ) -> Dict[str, Any]:
@@ -133,9 +134,27 @@ class DecisionSignalService:
         expires_from_dt = self._parse_datetime(expires_from)
         expires_to_dt = self._parse_datetime(expires_to)
         stock_codes = self._stock_filter_codes(stock_code, market=market_norm)
-        stock_identities = None
+        stock_identity_filters: Optional[List[Tuple[str, str]]] = None
 
-        if holding_only:
+        if stock_identities is not None:
+            # Explicit identities come from a caller-owned snapshot; skip cached holdings entirely.
+            requested_codes = set(stock_codes or [])
+            normalized_identities: set[Tuple[str, str]] = set()
+            for identity_market, identity_code in stock_identities:
+                if not str(identity_code or "").strip():
+                    continue
+                identity_market_norm = self._normalize_market(identity_market)
+                if market_norm and identity_market_norm != market_norm:
+                    continue
+                identity_code_norm = self._normalize_stock_code(identity_code, market=identity_market_norm)
+                if requested_codes and identity_code_norm not in requested_codes:
+                    continue
+                normalized_identities.add((identity_market_norm, identity_code_norm))
+            stock_identity_filters = sorted(normalized_identities)
+            stock_codes = None
+            if not stock_identity_filters:
+                return {"items": [], "total": 0, "page": safe_page, "page_size": safe_page_size}
+        elif holding_only:
             held_identities = self._cached_holding_identities(account_id=account_id)
             if market_norm:
                 held_identities = {
@@ -146,14 +165,14 @@ class DecisionSignalService:
                 held_identities = {
                     identity for identity in held_identities if identity[1] in requested_codes
                 }
-            stock_identities = sorted(held_identities)
+            stock_identity_filters = sorted(held_identities)
             stock_codes = None
-            if not stock_identities:
+            if not stock_identity_filters:
                 return {"items": [], "total": 0, "page": safe_page, "page_size": safe_page_size}
 
         rows, total = self.repo.list(
             stock_codes=stock_codes,
-            stock_identities=stock_identities,
+            stock_identities=stock_identity_filters,
             market=market_norm,
             action=action_norm,
             market_phase=market_phase_norm,
@@ -183,12 +202,13 @@ class DecisionSignalService:
             created_to=created_to_dt,
             expires_from=expires_from_dt,
             expires_to=expires_to_dt,
+            stock_identities=stock_identity_filters,
             holding_only=holding_only,
         ):
             self._backfill_analysis_signal_from_history(source_report_id_norm)
             rows, total = self.repo.list(
                 stock_codes=stock_codes,
-                stock_identities=stock_identities,
+                stock_identities=stock_identity_filters,
                 market=market_norm,
                 action=action_norm,
                 market_phase=market_phase_norm,
@@ -276,6 +296,7 @@ class DecisionSignalService:
         created_to: Optional[datetime],
         expires_from: Optional[datetime],
         expires_to: Optional[datetime],
+        stock_identities: Optional[List[Tuple[str, str]]],
         holding_only: bool,
     ) -> bool:
         """Only lazy-backfill for the exact report section query used by Web."""
@@ -296,6 +317,7 @@ class DecisionSignalService:
                 created_to,
                 expires_from,
                 expires_to,
+                stock_identities,
                 holding_only,
             )
         )

--- a/src/services/portfolio_risk_service.py
+++ b/src/services/portfolio_risk_service.py
@@ -82,7 +82,7 @@ class PortfolioRiskService:
             lookback_days=thresholds["lookback_days"],
         )
         stop_loss = self._build_stop_loss(snapshot, thresholds)
-        decision_signal_risk = self._build_decision_signal_risk(snapshot, account_id=account_id)
+        decision_signal_risk = self._build_decision_signal_risk(snapshot)
 
         return {
             "as_of": as_of_date.isoformat(),
@@ -100,21 +100,22 @@ class PortfolioRiskService:
     def _build_decision_signal_risk(
         self,
         snapshot: Dict[str, Any],
-        *,
-        account_id: Optional[int],
     ) -> Dict[str, Any]:
         try:
             held_positions = self._held_position_identities(snapshot)
             if not held_positions:
                 return self._empty_decision_signal_risk(available=True)
+            stock_identities = sorted({
+                (position["market"], position["signal_stock_code"])
+                for position in held_positions
+            })
 
             defensive_actions = set(DEFENSIVE_DECISION_SIGNAL_ACTIONS)
             latest_by_identity: Dict[Tuple[str, str], Dict[str, Any]] = {}
             page = 1
             while True:
                 response = self.decision_signal_service.list_signals(
-                    holding_only=True,
-                    account_id=account_id,
+                    stock_identities=stock_identities,
                     status="active",
                     page=page,
                     page_size=100,

--- a/templates/report_markdown.j2
+++ b/templates/report_markdown.j2
@@ -10,6 +10,10 @@
 
 {% for e in enriched %}
 {{ e.signal_emoji }} **{{ e.stock_name }}({{ e.result.code }})**: {{ e.localized_operation_advice }} | {{ labels.score_label }} {{ e.result.sentiment_score }} | {{ e.localized_trend_prediction }}
+{% set signal_excerpt = decision_signal_excerpt(e.result) %}
+{% if signal_excerpt %}
+{{ signal_excerpt }}
+{% endif %}
 {% endfor %}
 
 ---

--- a/templates/report_wechat.j2
+++ b/templates/report_wechat.j2
@@ -9,6 +9,10 @@
 **📊 {{ labels.summary_heading }}**
 {% for e in enriched %}
 {{ e.signal_emoji }} **{{ e.stock_name }}({{ e.result.code }})**: {{ e.localized_operation_advice }} | {{ labels.score_label }} {{ e.result.sentiment_score }} | {{ e.localized_trend_prediction }}
+{% set signal_excerpt = decision_signal_excerpt(e.result) %}
+{% if signal_excerpt %}
+{{ signal_excerpt }}
+{% endif %}
 {% endfor %}
 {% else %}
 {% for e in enriched %}
@@ -23,6 +27,10 @@
 {% set one_sentence = core.get('one_sentence', result.analysis_summary) if core else result.analysis_summary %}
 {% if one_sentence %}
 📌 **{{ one_sentence[:80] }}**
+{% endif %}
+{% set signal_excerpt = decision_signal_excerpt(result) %}
+{% if signal_excerpt %}
+{{ signal_excerpt }}
 {% endif %}
 
 {% if intel.get('earnings_outlook') %}

--- a/tests/test_decision_signal_service.py
+++ b/tests/test_decision_signal_service.py
@@ -494,6 +494,84 @@ def test_list_signals_does_not_backfill_ambiguous_history_default_decision_type_
         assert session.query(DecisionSignalRecord).count() == 0
 
 
+def test_list_signals_explicit_stock_identities_override_holding_only_and_intersect_filters(isolated_db) -> None:
+    service = DecisionSignalService(db_manager=isolated_db)
+    service.create_signal(
+        _payload(
+            source_report_id=171501,
+            trace_id="trace-explicit-identity-000001",
+            stock_code="000001",
+            stock_name="平安银行",
+            action="sell",
+        )
+    )
+    service.create_signal(
+        _payload(
+            source_report_id=171502,
+            trace_id="trace-explicit-identity-600519",
+            stock_code="600519",
+            action="reduce",
+        )
+    )
+
+    listed = service.list_signals(
+        stock_identities=[("cn", "000001")],
+        holding_only=True,
+        status="active",
+    )
+
+    assert listed["total"] == 1
+    assert listed["items"][0]["stock_code"] == "000001"
+    assert listed["items"][0]["action"] == "sell"
+
+    mismatched_stock_filter = service.list_signals(
+        stock_code="600519",
+        market="cn",
+        stock_identities=[("cn", "000001")],
+        status="active",
+    )
+
+    assert mismatched_stock_filter == {"items": [], "total": 0, "page": 1, "page_size": 20}
+
+
+def test_list_signals_explicit_empty_stock_identities_returns_empty_without_widening(isolated_db) -> None:
+    service = DecisionSignalService(db_manager=isolated_db)
+    service.create_signal(
+        _payload(
+            source_report_id=171503,
+            trace_id="trace-empty-identity-600519",
+            stock_code="600519",
+            action="sell",
+        )
+    )
+
+    listed = service.list_signals(stock_identities=[], status="active")
+
+    assert listed == {"items": [], "total": 0, "page": 1, "page_size": 20}
+
+
+def test_list_signals_explicit_stock_identities_do_not_trigger_history_backfill(isolated_db) -> None:
+    record_id = isolated_db.save_analysis_history(
+        result=_history_result(operation_advice="卖出", decision_type="sell", action="sell", action_label="卖出"),
+        query_id="query-explicit-identity-no-backfill",
+        report_type="simple",
+        news_content="新闻摘要",
+        context_snapshot={"market_phase_summary": {"phase": "postmarket"}},
+        save_snapshot=True,
+    )
+    service = DecisionSignalService(db_manager=isolated_db)
+
+    listed = service.list_signals(
+        source_type="analysis",
+        source_report_id=record_id,
+        stock_identities=[("cn", "600519")],
+    )
+
+    assert listed == {"items": [], "total": 0, "page": 1, "page_size": 20}
+    with isolated_db.get_session() as session:
+        assert session.query(DecisionSignalRecord).count() == 0
+
+
 def test_service_plan_quality_slots_and_explicit_override(isolated_db) -> None:
     service = DecisionSignalService(db_manager=isolated_db)
 

--- a/tests/test_notification.py
+++ b/tests/test_notification.py
@@ -50,6 +50,16 @@ def _make_response(status_code: int, json: Optional[dict] = None) -> requests.Re
     return response
 
 
+def _attach_decision_signal_summary(result: AnalysisResult) -> AnalysisResult:
+    result.decision_signal_summary = {
+        "action": "sell",
+        "action_label": "卖出",
+        "horizon": "1d",
+        "reason": "技术面走弱",
+    }
+    return result
+
+
 def _make_feishu_message() -> BotMessage:
     return BotMessage(
         platform="feishu",
@@ -628,6 +638,118 @@ class TestNotificationServiceReportGeneration(unittest.TestCase):
         out = service.generate_dashboard_report([result], report_date="2026-02-01")
 
         self.assertIn("*分析模型：gemini/gemini-2.5-flash*", out)
+
+    @mock.patch("src.notification.get_config")
+    def test_generate_dashboard_report_appends_decision_signal_excerpt_fallback(
+        self, mock_get_config: mock.MagicMock
+    ):
+        mock_get_config.return_value = _make_config(report_renderer_enabled=False)
+        service = NotificationService()
+        result = _attach_decision_signal_summary(AnalysisResult(
+            code="600519",
+            name="贵州茅台",
+            sentiment_score=72,
+            trend_prediction="看多",
+            operation_advice="持有",
+            analysis_summary="稳健",
+        ))
+
+        out = service.generate_dashboard_report([result], report_date="2026-02-01")
+
+        self.assertIn("AI 决策信号", out)
+        self.assertIn("动作: 卖出", out)
+        self.assertIn("周期: 1d", out)
+        self.assertIn("理由: 技术面走弱", out)
+
+    @mock.patch("src.notification.get_config")
+    def test_generate_daily_report_appends_decision_signal_excerpt_fallback(
+        self, mock_get_config: mock.MagicMock
+    ):
+        mock_get_config.return_value = _make_config(report_renderer_enabled=False)
+        result = _attach_decision_signal_summary(AnalysisResult(
+            code="600519",
+            name="贵州茅台",
+            sentiment_score=72,
+            trend_prediction="看多",
+            operation_advice="持有",
+            analysis_summary="稳健",
+        ))
+
+        for summary_only in (True, False):
+            service = NotificationService()
+            service._report_summary_only = summary_only
+            out = service.generate_daily_report([result], report_date="2026-02-01")
+            self.assertEqual(out.count("AI 决策信号"), 1)
+            self.assertIn("动作: 卖出", out)
+            self.assertIn("周期: 1d", out)
+            self.assertIn("理由: 技术面走弱", out)
+
+    @mock.patch("src.notification.get_config")
+    def test_generate_wechat_dashboard_appends_decision_signal_excerpt_fallback(
+        self, mock_get_config: mock.MagicMock
+    ):
+        mock_get_config.return_value = _make_config(report_renderer_enabled=False)
+        result = _attach_decision_signal_summary(AnalysisResult(
+            code="600519",
+            name="贵州茅台",
+            sentiment_score=72,
+            trend_prediction="看多",
+            operation_advice="持有",
+            analysis_summary="稳健",
+        ))
+
+        for summary_only in (True, False):
+            service = NotificationService()
+            service._report_summary_only = summary_only
+            out = service.generate_wechat_dashboard([result])
+            self.assertIn("AI 决策信号", out)
+            self.assertIn("动作: 卖出", out)
+            self.assertIn("周期: 1d", out)
+            self.assertIn("理由: 技术面走弱", out)
+
+    @mock.patch("src.notification.get_config")
+    def test_generate_wechat_summary_appends_decision_signal_excerpt(
+        self, mock_get_config: mock.MagicMock
+    ):
+        mock_get_config.return_value = _make_config(report_renderer_enabled=False)
+        service = NotificationService()
+        result = _attach_decision_signal_summary(AnalysisResult(
+            code="600519",
+            name="贵州茅台",
+            sentiment_score=72,
+            trend_prediction="看多",
+            operation_advice="持有",
+            analysis_summary="稳健",
+        ))
+
+        out = service.generate_wechat_summary([result])
+
+        self.assertEqual(out.count("AI 决策信号"), 1)
+        self.assertIn("动作: 卖出", out)
+        self.assertIn("周期: 1d", out)
+        self.assertIn("理由: 技术面走弱", out)
+
+    @mock.patch("src.notification.get_config")
+    def test_generate_dashboard_report_appends_decision_signal_excerpt_with_renderer(
+        self, mock_get_config: mock.MagicMock
+    ):
+        mock_get_config.return_value = _make_config(report_renderer_enabled=True)
+        service = NotificationService()
+        result = _attach_decision_signal_summary(AnalysisResult(
+            code="600519",
+            name="贵州茅台",
+            sentiment_score=72,
+            trend_prediction="看多",
+            operation_advice="持有",
+            analysis_summary="稳健",
+        ))
+
+        out = service.generate_dashboard_report([result], report_date="2026-02-01")
+
+        self.assertIn("AI 决策信号", out)
+        self.assertIn("动作: 卖出", out)
+        self.assertIn("周期: 1d", out)
+        self.assertIn("理由: 技术面走弱", out)
 
     @mock.patch("src.notification.get_config")
     def test_aggregate_reports_show_compact_market_status_only(self, mock_get_config: mock.MagicMock):

--- a/tests/test_portfolio_pr2.py
+++ b/tests/test_portfolio_pr2.py
@@ -561,6 +561,73 @@ class PortfolioPr2TestCase(unittest.TestCase):
         self.assertEqual(signal_actions["300750"], "reduce")
         self.assertEqual(signal_actions["000001"], "alert")
 
+    def test_risk_report_uses_requested_snapshot_for_decision_signal_filters(self) -> None:
+        account = self.service.create_account(name="Main", broker="Demo", market="cn", base_currency="CNY")
+        aid = account["id"]
+        self.service.record_cash_ledger(
+            account_id=aid,
+            event_date=date(2026, 1, 1),
+            direction="in",
+            amount=100000.0,
+            currency="CNY",
+        )
+        self.service.record_trade(
+            account_id=aid,
+            symbol="600519",
+            trade_date=date(2026, 1, 1),
+            side="buy",
+            quantity=10,
+            price=100,
+            market="cn",
+            currency="CNY",
+        )
+        self._save_close("600519", date(2026, 1, 1), 100.0)
+        self._save_close("600519", date(2026, 1, 2), 100.0)
+        self.service.record_trade(
+            account_id=aid,
+            symbol="000001",
+            trade_date=date(2026, 1, 2),
+            side="buy",
+            quantity=10,
+            price=20,
+            market="cn",
+            currency="CNY",
+        )
+        self._save_close("000001", date(2026, 1, 2), 20.0)
+        self._create_signal("000001", "sell")
+
+        original = self.risk_service.decision_signal_service.list_signals
+        with patch.object(
+            self.risk_service.decision_signal_service,
+            "list_signals",
+            wraps=original,
+        ) as spy:
+            report = self.risk_service.get_risk_report(
+                account_id=aid,
+                as_of=date(2026, 1, 2),
+                cost_method="fifo",
+            )
+
+        block = report["decision_signal_risk"]
+        self.assertTrue(block["available"])
+        self.assertEqual(block["total"], 1)
+        self.assertEqual(block["items"][0]["symbol"], "000001")
+        self.assertEqual(block["items"][0]["signal"]["action"], "sell")
+        for call in spy.mock_calls:
+            self.assertIsNot(call.kwargs.get("holding_only"), True)
+        identity_calls = [
+            call.kwargs.get("stock_identities")
+            for call in spy.mock_calls
+            if call.kwargs.get("stock_identities") is not None
+        ]
+        observed_identities = {
+            identity
+            for ids in identity_calls
+            for identity in ids
+        }
+        self.assertIn(("cn", "000001"), observed_identities)
+        self.assertIn(("cn", "600519"), observed_identities)
+
     def test_risk_report_decision_signal_fail_open(self) -> None:
         account = self.service.create_account(name="Main", broker="Demo", market="cn", base_currency="CNY")
         aid = account["id"]

--- a/tests/test_report_renderer.py
+++ b/tests/test_report_renderer.py
@@ -59,6 +59,16 @@ def _make_renderer_config(show_llm_model: bool = True) -> MagicMock:
     return config
 
 
+def _with_decision_signal_summary(result: AnalysisResult) -> AnalysisResult:
+    result.decision_signal_summary = {
+        "action": "sell",
+        "action_label": "卖出",
+        "horizon": "1d",
+        "reason": "技术面走弱",
+    }
+    return result
+
+
 class TestReportRenderer(unittest.TestCase):
     """Report renderer tests."""
 
@@ -79,6 +89,17 @@ class TestReportRenderer(unittest.TestCase):
         self.assertIn("核心结论", out)
         self.assertIn("作战计划", out)
         self.assertNotIn("盘中决策护栏", out)
+
+    def test_render_markdown_includes_decision_signal_excerpt(self) -> None:
+        """Markdown summary and full templates include DecisionSignal excerpts."""
+        for summary_only in (True, False):
+            r = _with_decision_signal_summary(_make_result())
+            out = render("markdown", [r], summary_only=summary_only)
+            self.assertIsNotNone(out)
+            self.assertIn("AI 决策信号", out)
+            self.assertIn("动作: 卖出", out)
+            self.assertIn("周期: 1d", out)
+            self.assertIn("理由: 技术面走弱", out)
 
     def test_render_markdown_phase_decision_section(self) -> None:
         """Markdown renders phase_decision when present."""
@@ -136,6 +157,17 @@ class TestReportRenderer(unittest.TestCase):
         out = render("wechat", [r])
         self.assertIsNotNone(out)
         self.assertIn("贵州茅台", out)
+
+    def test_render_wechat_includes_decision_signal_excerpt(self) -> None:
+        """Wechat summary and full templates include DecisionSignal excerpts."""
+        for summary_only in (True, False):
+            r = _with_decision_signal_summary(_make_result())
+            out = render("wechat", [r], summary_only=summary_only)
+            self.assertIsNotNone(out)
+            self.assertIn("AI 决策信号", out)
+            self.assertIn("动作: 卖出", out)
+            self.assertIn("周期: 1d", out)
+            self.assertIn("理由: 技术面走弱", out)
 
     def test_render_brief(self) -> None:
         """Brief platform renders 3-5 sentence summary."""


### PR DESCRIPTION
## PR Type

- [x] fix
- [ ] feat
- [ ] refactor
- [ ] docs
- [ ] chore
- [ ] test

## Background And Problem

Fixes #1722
Refs #1715
Refs #1390

PR #1715 已合入 main，用于落地 #1390 P6「告警、通知与持仓信号联动」。合入后发现两个有效遗漏：

1. 组合风险接口在补齐 drawdown history 时会回放历史 snapshot，并可能重写 `portfolio_positions` 缓存；随后 `decision_signal_risk` 再用 `holding_only=True` 查询信号，会从可变缓存读取持仓身份，而不是使用当前请求 `as_of` 的 snapshot。
2. P6 `DecisionSignal` 低敏摘要没有覆盖所有通知/报告最终输出路径，部分 legacy daily report / 企业微信摘要路径仍可能漏展示信号摘要。

本 PR 只修复上述两个缺口，不新增配置、不修改数据库 schema、不扩大公开 API。

## Scope Of Change

- `src/services/decision_signal_service.py`
  - 为服务层内部 `list_signals()` 增加 `stock_identities` 可选参数。
  - 显式 identities 传入时跳过 `holding_only` cache 逻辑；空列表返回空结果，避免退化成无过滤查询。
  - 显式 identities 会按现有 market/code normalizer 标准化，并与 `market` / `stock_code` 过滤取交集。
  - lazy backfill 继续限制在 Web 报告详情的精确 `source_report_id` 查询场景。
- `src/services/portfolio_risk_service.py`
  - `decision_signal_risk` 改为只使用请求 snapshot 中的持仓 identity 查询 active 信号。
  - 保留 `sell/reduce/alert` 防御型动作过滤、latest-by-identity 选择、去重和 fail-open 行为。
- `src/notification.py`
  - fallback dashboard / WeChat dashboard 聚合报告摘要区补齐低敏 `DecisionSignal` 摘要。
  - legacy `generate_daily_report()` 的 summary/full 两个分支补齐同一摘要。
  - legacy `generate_wechat_summary()` 在每只股票核心信息行后补齐同一摘要。
- `templates/report_markdown.j2`、`templates/report_wechat.j2`
  - renderer 路径的 markdown / WeChat summary-only 与 full 聚合报告补齐同一摘要。
- `tests/`
  - 增加组合风险 snapshot 语义回归测试，并明确断言 snapshot 中全部持仓 identity 都传入 `stock_identities`。
  - 增加 `list_signals(stock_identities=...)` 服务层边界测试。
  - 增加 notification fallback / renderer / legacy daily / legacy WeChat summary 报告摘要测试。
- `docs/CHANGELOG.md`
  - 增加 #1722 修复记录。

已评估 `docs/notifications.md`、`docs/full-guide.md`、`docs/full-guide_EN.md`：现有 P6 文档已经描述低敏摘要语义，本次是遗漏输出路径补齐，无需正文变更。

## Issue Link

Fixes #1722

## Verification Commands And Results

```bash
.venv/bin/python -m pytest tests/test_notification.py tests/test_portfolio_pr2.py
```

关键输出/结论：

- `97 passed, 5 warnings`
- 覆盖点包括：
  - `generate_daily_report()` summary/full 两个 legacy 分支均输出一次低敏 `DecisionSignal` 摘要。
  - `generate_wechat_summary()` 输出一次低敏 `DecisionSignal` 摘要。
  - 首次请求 `as_of=2026-01-02` 风险报告、drawdown 回填旧 snapshot 后，`decision_signal_risk` 仍包含 `as_of` 当天新增持仓 `000001` 的 active `sell` 信号。
  - snapshot 中 `000001` 和 `600519` 两个持仓 identity 都传入 `stock_identities`，避免只验证活跃信号股票。

```bash
PATH=.venv/bin:$PATH ./scripts/ci_gate.sh
```

关键输出/结论：

- `3525 passed, 2 deselected, 44 warnings, 322 subtests passed`
- `backend-gate: all checks passed`

```bash
git diff --check
git diff --cached --check
```

关键输出/结论：

- 均通过，无 whitespace error。

## Visual Evidence (if applicable)

本 PR 修改报告文本格式，但没有修改 `apps/dsa-web/` 或浏览器页面交互，因此不附 WebUI 截图。受影响报告的可视证据用渲染后的文本片段表示；该片段来自 notification / report renderer 测试覆盖的最终报告输出形态。

示例摘要片段：

```md
**AI 决策信号**
动作: 卖出 | 周期: 1d
- 理由: 技术面走弱
```

- 截图链接 / Screenshot links: 不适用。
- 不适用原因 / Reason if not applicable: 本 PR 只修改后端风险逻辑和报告/通知文本渲染，没有 WebUI 改动；一次性验收截图也不会作为仓库文件提交。

## Compatibility And Risk

- 兼容性：
  - 不新增公开 API query 参数，`stock_identities` 只在服务层内部使用。
  - 不新增数据库表、字段、迁移或配置项。
  - `DecisionSignal` 摘要继续复用 #1715 引入的低敏 formatter，不输出 `metadata`、`evidence`、raw diagnostics、webhook/token 等敏感或诊断字段。
- 结构化检查说明：
  - 本 PR 未修改 `.env.example`、配置 schema、API schema、LLM/provider/router、Base URL、LiteLLM、依赖锁定、migration 或运行时配置保存/清理逻辑。
  - 自动提示中的模型/API/运行时配置风险为关键词误报，触发来源应是 diff 上下文中的既有 `NEWSNOW_BASE_URL` / `gemini/gemini-2.5-flash` 文本，以及新增测试对 `get_config()` 的 mock；这些都不是生产兼容语义或用户配置变更。
  - 本次仅补齐既有 P6 低敏摘要的遗漏输出路径，并为组合风险使用请求 snapshot identities，不新增用户配置、公开 API 参数或新字段契约。
- 风险：
  - 默认聚合报告、legacy daily report、legacy WeChat summary 会多显示低敏 `DecisionSignal` 摘要，属于预期用户可见变化。
  - `decision_signal_risk` 的信号过滤语义从 cached holdings 改为请求 snapshot identities；这是 #1722 的目标修复，避免 drawdown 回填历史 snapshot 影响当前 `as_of` 风险报告。
- 文档：
  - `docs/CHANGELOG.md` 已记录修复。
  - 已评估 `docs/notifications.md`、`docs/full-guide.md`、`docs/full-guide_EN.md`，无需正文变更。
- 不涉及第三方模型 / API 兼容语义、provider fallback 或运行时依赖窗口变更。
- 不涉及运行时配置保存、清理、迁移或回填配置逻辑；旧配置不会被自动改写、清空或迁移。

## Rollback Plan

可直接 revert 本 PR。由于没有新增配置、数据库 schema 或 migration，回滚不需要额外配置回滚、schema downgrade 或数据迁移。

## EXTRACT_PROMPT Change (if applicable)

不适用。本 PR 未修改 `src/services/image_stock_extractor.py` 或 `EXTRACT_PROMPT`。

<details>
<summary>展开 / Expand: Full EXTRACT_PROMPT</summary>

```
N/A
```

</details>

## Checklist

- [x] 本 PR 有明确动机和业务价值 / This PR has a clear motivation and value
- [x] 已提供可复现的验证命令与结果 / Reproducible verification commands and results are included
- [x] 已评估兼容性与风险 / Compatibility and risk have been assessed
- [x] 已提供回滚方案 / A rollback plan is provided
- [x] 若修改报告格式或 Web UI 界面，已在 PR 描述/评论附受影响报告 / 页面截图，且未把一次性验收截图作为仓库文件合入 / If report formatting or Web UI changed, affected report/page screenshots are linked in the PR body/comments and one-off acceptance screenshots are not committed as repository files
- [x] 若涉及用户可见变更，已同步更新相关文档与 `docs/CHANGELOG.md`；`README.md` 仅在首页级信息变化时更新，细节优先写入 `docs/*.md` / If user-visible changes are included, relevant docs and `docs/CHANGELOG.md` are updated; `README.md` is updated only for homepage-level changes, with details kept in `docs/*.md`
