### PR TITLE
fix: handle result-only market phases in history summaries

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 <!-- 新条目格式：- [类型] 描述（类型取值：新功能/改进/修复/文档/测试/chore）-->
 <!-- 每条独立一行追加到本段末尾，无需分类标题，合并时冲突最小 -->
 
+- [修复] 修复日股/韩股历史列表重建市场阶段摘要时将 non_trading 等结果阶段误传为 analysis_phase 导致列表查询失败的问题。
+
 ## [3.23.0] - 2026-06-20
 
 ### 发布亮点

--- a/src/market_phase_summary.py
+++ b/src/market_phase_summary.py
@@ -34,6 +34,8 @@ _SENSITIVE_MARKERS = (
     "webhook",
 )
 _INTRADAY_BUCKET_PHASES = {"intraday", "lunch_break", "closing_auction"}
+_SUPPORTED_MANUAL_ANALYSIS_PHASES = {"premarket", "intraday", "postmarket"}
+_SUPPORTED_ANALYSIS_INTENTS = {"auto", *_SUPPORTED_MANUAL_ANALYSIS_PHASES}
 _PUBLIC_SOURCE_LABELS_ZH = {
     "alert_trigger_market_context": "告警触发上下文",
     "analysis_history_snapshot": "最近分析快照",
@@ -142,9 +144,9 @@ def rebuild_market_phase_summary_for_stock_code(
         return dict(summary)
 
     phase = str(summary.get("phase", "")).strip()
-    analysis_phase = phase if phase in _ALLOWED_PHASES else "auto"
+    analysis_phase = phase if phase in _SUPPORTED_MANUAL_ANALYSIS_PHASES else "auto"
     analysis_intent = str(summary.get("analysis_intent") or "auto").strip()
-    if not analysis_intent:
+    if analysis_intent not in _SUPPORTED_ANALYSIS_INTENTS:
         analysis_intent = "auto"
 
     rebuilt = build_market_phase_context(

--- a/tests/test_market_phase_summary.py
+++ b/tests/test_market_phase_summary.py
@@ -9,6 +9,7 @@ from src.market_phase_summary import (
     format_public_market_status_line,
     format_public_phase_pack_excerpt,
     normalize_analysis_phase_bucket,
+    rebuild_market_phase_summary_for_stock_code,
     render_market_phase_summary,
 )
 
@@ -123,6 +124,47 @@ def test_normalize_analysis_phase_bucket_maps_public_statistics_buckets() -> Non
     assert normalize_analysis_phase_bucket("non_trading") == "unknown"
     assert normalize_analysis_phase_bucket(None) == "unknown"
     assert normalize_analysis_phase_bucket("bad_phase") == "unknown"
+
+
+def test_rebuild_market_phase_summary_uses_auto_for_result_only_phases(monkeypatch) -> None:
+    calls = []
+
+    class FakeContext:
+        def to_dict(self) -> dict:
+            return {
+                **_phase_context(),
+                "market": "jp",
+                "phase": "non_trading",
+                "analysis_intent": "auto",
+                "warnings": [],
+            }
+
+    def fake_build_market_phase_context(**kwargs):
+        calls.append(kwargs)
+        return FakeContext()
+
+    monkeypatch.setattr(
+        "src.market_phase_summary.build_market_phase_context",
+        fake_build_market_phase_context,
+    )
+
+    summary = {
+        **_phase_context(),
+        "market": "cn",
+        "phase": "non_trading",
+        "analysis_intent": "non_trading",
+    }
+
+    rebuilt = rebuild_market_phase_summary_for_stock_code(
+        "7203.T",
+        {MARKET_PHASE_SUMMARY_KEY: summary},
+    )
+
+    assert rebuilt is not None
+    assert rebuilt["phase"] == "non_trading"
+    assert calls[0]["market"] == "jp"
+    assert calls[0]["analysis_phase"] == "auto"
+    assert calls[0]["analysis_intent"] == "auto"
 
 
 def test_format_public_phase_pack_excerpt_limits_and_redacts_public_fields() -> None:


### PR DESCRIPTION
## What changed

- Normalize rebuilt JP/KR history market-phase summaries so only supported manual request phases are passed as `analysis_phase`.
- Sanitize legacy `analysis_intent` values from persisted summaries before calling `build_market_phase_context`.
- Add a regression test for persisted `non_trading` summaries and update the changelog.

## Why

History records can persist result phases such as `non_trading`, `lunch_break`, `closing_auction`, or `unknown`, while the `analysis_phase` request override only accepts `auto`, `premarket`, `intraday`, and `postmarket`. The JP/KR history display rebuild path was passing result-only phases back as request overrides, causing `/api/v1/history` list conversion to fail and return an empty list after logging `invalid analysis_phase: non_trading`.

## Validation

- `python -m pytest tests\test_market_phase_summary.py`
- `python -m pytest tests\test_trading_calendar.py`
- `python -m py_compile src\market_phase_summary.py tests\test_market_phase_summary.py`
- `git diff --check`

## Compatibility and risk

This keeps the strict public `analysis_phase` contract unchanged. Older persisted summaries with result-only phases now fall back to automatic phase inference during JP/KR display rebuild instead of failing the history list.

## Rollback

Revert commit `6ba77a4e` to restore the previous rebuild behavior.