### PR TITLE
docs: update Trendshift badge and PR workflow rules

### DIFF
--- a/.claude/skills/analyze-issue/SKILL.md
+++ b/.claude/skills/analyze-issue/SKILL.md
@@ -14,7 +14,22 @@
 
 分析时使用简洁中文，优先遵循仓库根目录 `AGENTS.md`。
 
-### Step 1: 拉取 Issue 信息
+### Step 1: 同步最新代码基线
+
+分析 issue 前必须先刷新远端状态，并尽量把本地安全推进到最新基线：
+
+```bash
+git status --short
+git fetch --all --prune
+# 仅当工作区干净且当前分支可 fast-forward 时执行：
+git pull --ff-only
+```
+
+- 只有在工作区干净、当前分支有可 fast-forward 的上游时，才执行并接受 `git pull --ff-only` 的结果。
+- 如存在本地改动、冲突状态、未跟踪风险文件、无上游分支或无法 fast-forward，不要执行 `stash`、`reset`、强制切分支或覆盖本地状态；改用已 fetch 的 `origin/main` 或相关远端 refs 做分析。
+- 在输出文档的 `Evidence` 中记录同步结果：本地 HEAD、使用的远端基线，以及未更新本地工作树的原因（如有）。
+
+### Step 2: 拉取 Issue 信息
 
 ```bash
 gh issue view <issue_number> --repo ZhuLinsen/daily_stock_analysis
@@ -28,21 +43,21 @@ gh issue view <issue_number> --repo ZhuLinsen/daily_stock_analysis --comments
 - 运行环境与复现步骤
 - 日志或报错信息
 
-### Step 2: 回答 4 个核心问题
+### Step 3: 回答 4 个核心问题
 
 1. 版本是否明确
 2. 问题是否真实且可验证
 3. 是否属于仓库责任边界
 4. 是否值得立即处理
 
-### Step 3: 结合仓库现状做证据检查
+### Step 4: 结合仓库现状做证据检查
 
 - 阅读相关代码、配置、测试、脚本、工作流与文档
 - 如果问题涉及 API、数据源 fallback、报告生成、通知发送、认证、桌面端、发布流程，明确写出影响面
 - 判断是实际 bug、环境配置问题、使用方式问题、还是外部依赖问题
 - 如怀疑已被修复，检查当前代码而不是只看 issue 描述
 
-### Step 4: 形成结论
+### Step 5: 形成结论
 
 至少给出以下字段：
 
@@ -56,7 +71,7 @@ gh issue view <issue_number> --repo ZhuLinsen/daily_stock_analysis --comments
 - `难度`：`easy / medium / hard`
 - `建议动作`：`立即修复 / 排期修复 / 文档澄清 / 关闭`
 
-### Step 5: 生成分析文档
+### Step 6: 生成分析文档
 
 保存到 `.claude/reviews/issues/issue-<number>.md`
 
@@ -82,6 +97,7 @@ gh issue view <issue_number> --repo ZhuLinsen/daily_stock_analysis --comments
 
 ## Evidence
 
+- 代码同步基线：
 - 关键 issue 信息：
 - 关键代码/脚本/工作流证据：
 
@@ -113,6 +129,7 @@ gh issue view <issue_number> --repo ZhuLinsen/daily_stock_analysis --comments
 ## Allowed Auto-Actions (No Confirmation Needed)
 
 - 拉取 issue 详情与评论
+- 执行 `git fetch --all --prune`，并在工作区干净且可 fast-forward 时执行 `git pull --ff-only`
 - 阅读相关代码、配置、脚本、工作流和文档
 - 生成分析文档
 

--- a/.claude/skills/analyze-pr/SKILL.md
+++ b/.claude/skills/analyze-pr/SKILL.md
@@ -14,7 +14,22 @@
 
 分析时使用简洁中文，优先遵循仓库根目录 `AGENTS.md` 和 `.github/PULL_REQUEST_TEMPLATE.md`。
 
-### Step 1: 拉取 PR 基本信息
+### Step 1: 同步最新代码基线
+
+分析 PR 前必须先刷新远端状态，并尽量把本地安全推进到最新基线：
+
+```bash
+git status --short
+git fetch --all --prune
+# 仅当工作区干净且当前分支可 fast-forward 时执行：
+git pull --ff-only
+```
+
+- 只有在工作区干净、当前分支有可 fast-forward 的上游时，才执行并接受 `git pull --ff-only` 的结果。
+- 如存在本地改动、冲突状态、未跟踪风险文件、无上游分支或无法 fast-forward，不要执行 `stash`、`reset`、强制切分支或覆盖本地状态；改用已 fetch 的 `origin/main`、PR head 或 GitHub diff 做分析。
+- 在输出文档的 `Validation Evidence` 中记录同步结果：本地 HEAD、使用的远端基线，以及未更新本地工作树的原因（如有）。
+
+### Step 2: 拉取 PR 基本信息
 
 ```bash
 gh pr view <pr_number> --repo ZhuLinsen/daily_stock_analysis
@@ -29,7 +44,7 @@ gh pr diff <pr_number> --repo ZhuLinsen/daily_stock_analysis
 gh run view <run_id> --log-failed
 ```
 
-### Step 2: 检查标题与描述完整性
+### Step 3: 检查标题与描述完整性
 
 先检查 PR title 是否符合 `AGENTS.md` 的非阻断建议：
 
@@ -59,7 +74,7 @@ gh run view <run_id> --log-failed
 
 若 PR 修改报告格式、报告渲染效果或 Web UI 界面，还要检查 `Visual Evidence` 是否附受影响报告 / 页面截图；涉及前后差异时优先检查前后对比。若无法截图，描述中应说明原因与替代可视证据。
 
-### Step 3: 优先使用 CI / Diff 证据
+### Step 4: 优先使用 CI / Diff 证据
 
 - 先根据 `gh pr checks`、PR diff、现有测试与工作流日志判断问题
 - 仅当 CI 未覆盖改动面、CI 结果不足以定性问题、或需要验证关键回归风险时，再补充本地最小验证
@@ -71,7 +86,7 @@ gh run view <run_id> --log-failed
 - 前端：`cd apps/dsa-web && npm ci && npm run lint && npm run build`
 - 桌面端：先构建 Web，再构建 Electron
 
-### Step 4: 评估正确性与风险
+### Step 5: 评估正确性与风险
 
 重点检查：
 
@@ -80,7 +95,7 @@ gh run view <run_id> --log-failed
 - 是否破坏 fallback、降级路径、通知链路或发布流程
 - 是否存在明显逻辑错误、异常吞没、安全问题、配置语义变化未同步文档
 
-### Step 5: 生成评审文档
+### Step 6: 生成评审文档
 
 保存到 `.claude/reviews/prs/pr-<number>.md`
 
@@ -109,6 +124,7 @@ gh run view <run_id> --log-failed
 
 ## Validation Evidence
 
+- 代码同步基线：
 - CI 结论：
 - 本地补充验证（如有）：
 
@@ -129,6 +145,7 @@ gh run view <run_id> --log-failed
 ## Allowed Auto-Actions (No Confirmation Needed)
 
 - 拉取 PR 元数据、diff、评论和 CI 状态
+- 执行 `git fetch --all --prune`，并在工作区干净且可 fast-forward 时执行 `git pull --ff-only`
 - 阅读相关代码、模板、工作流与文档
 - 在必要时执行最小化本地验证
 - 生成评审文档

--- a/.claude/skills/fix-issue/SKILL.md
+++ b/.claude/skills/fix-issue/SKILL.md
@@ -20,10 +20,21 @@
 
 检查 `.claude/reviews/issues/issue-<number>.md` 是否存在；如果不存在，先补做 issue 分析或在本次修复中补齐最小分析结论。
 
-### Step 2: 选择安全的工作方式
+### Step 2: 同步最新代码基线并选择安全的工作方式
+
+开始修复或准备创建 / 更新 PR 前，先按 `AGENTS.md` 拉新：
+
+```bash
+git status --short
+git fetch --all --prune
+# 仅当工作区干净且当前分支可 fast-forward 时执行：
+git pull --ff-only
+```
 
 - 默认基于当前工作树做最小相关改动
-- 不要默认执行 `git pull`
+- 只有在工作区干净、当前分支有可 fast-forward 的上游时，才执行并接受 `git pull --ff-only` 的结果
+- 如存在本地改动、冲突状态、未跟踪风险文件、无上游分支或无法 fast-forward，不要执行 `stash`、`reset`、强制切分支或覆盖本地状态；先记录本地 HEAD、使用的远端基线与无法更新本地工作树的原因
+- 若后续要创建 / 更新 PR，先说明当前分支与目标基线差异；必要时请求用户确认 rebase、merge 或继续基于当前分支推进
 - 不要默认切换分支或改写用户当前工作状态
 - 如果用户明确要求建分支，再执行最小必要的分支操作
 
@@ -95,6 +106,7 @@
 ## Allowed Auto-Actions (No Confirmation Needed)
 
 - 阅读和分析代码
+- 执行 `git fetch --all --prune`，并在工作区干净且可 fast-forward 时执行 `git pull --ff-only`
 - 应用与当前任务直接相关的最小修复
 - 运行非破坏性的本地验证
 - 更新本地 issue 分析文档

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -12,6 +12,7 @@ If any instruction in this file conflicts with `AGENTS.md`, follow `AGENTS.md`.
   - Desktop: `apps/dsa-desktop/`
   - Deployment/workflows: `scripts/`, `.github/workflows/`, `docker/`
 - Do not run `git commit`, `git tag`, or `git push` without explicit user confirmation.
+- Before creating/updating PRs, PR review, or issue analysis, refresh the latest code baseline with `git fetch --all --prune`; if the worktree is clean and the current branch can fast-forward, run `git pull --ff-only`. If local changes, conflicts, missing upstream, or non-fast-forward history make that unsafe, do not stash/reset/overwrite local state; analyze against fetched remote refs or record the baseline gap before proceeding.
 - PR titles should use `<type>: <change summary>` such as `fix: 修复大盘分析历史记录丢失`; use `fix`/`feat`/`refactor`/`docs`/`chore`/`test`/`ci` where possible, and avoid `[codex]`, `codex`, `autocode`, `copilot`, or other tool/agent source prefixes. Treat this as process guidance and do not use title format mismatches as a hard review blocker.
 - Do not hardcode secrets, accounts, ports, model names, absolute environment-specific paths, or environment-specific branches.
 - Reuse existing modules, configuration entrypoints, scripts, and tests instead of adding parallel implementations.

--- a/.github/instructions/governance.instructions.md
+++ b/.github/instructions/governance.instructions.md
@@ -8,6 +8,7 @@ applyTo: "README.md,docs/**,AGENTS.md,CLAUDE.md,.github/**,.claude/skills/**,scr
 - `AGENTS.md` is the canonical AI collaboration document; if its meaning changes, sync `CLAUDE.md`, `.github/copilot-instructions.md`, `.github/instructions/*.instructions.md`, and repository skills as needed.
 - Root `SKILL.md` and `docs/openclaw-skill-integration.md` describe product or external integration behavior, not repository governance.
 - Explain which pipeline, release path, deployment path, review automation, or governance asset is affected and what the rollback path is.
+- Before creating/updating PRs, PR review, or issue analysis, refresh the latest code baseline with `git fetch --all --prune`; only run `git pull --ff-only` when the worktree is clean and the current branch can fast-forward. If not, keep local state intact and record the fetched remote baseline or branch gap before proceeding.
 - Keep `README.md` limited to homepage-level content such as positioning, high-level capabilities, quick start, main entrypoints, and sponsorship/cooperation; put detailed behavior, configuration, troubleshooting, field contracts, and edge cases in `docs/*.md`.
 - Avoid widening permissions, secret exposure, or destructive automation without a clearly documented need.
 - Preserve the repository's opt-in auto-tag behavior (`#patch`, `#minor`, `#major`) unless the change explicitly updates release policy.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -231,8 +231,9 @@ gh run view <run_id> --log-failed
   - `.claude/skills/fix-issue/SKILL.md`
 - 如果任务明确是 issue 分析、PR 审查、issue 修复，优先按对应 skill 执行，并将产物保存到 `.claude/reviews/`。
 - skill 中的命令、模板、验证顺序和交付结构必须与 `AGENTS.md` 保持一致。
+- 每次进行 PR 创建 / 更新、PR 审查或 issue 分析前，必须先同步最新代码基线：先检查工作区状态并执行 `git fetch --all --prune`；若工作区干净且当前分支可 fast-forward，则执行 `git pull --ff-only`。如存在本地改动、冲突状态、未跟踪风险文件或无法 fast-forward，不得强行切分支、stash、reset 或覆盖本地状态；PR 审查 / issue 分析可改用已 fetch 的远端 refs/PR head 做分析，并在分析文档中明确记录未更新本地工作树的原因、当前本地 HEAD 与使用的远端基线；PR 创建 / 更新应先说明当前分支与目标基线差异，必要时请求用户确认 rebase、merge 或继续基于当前分支推进。
 - skill 默认优先读取 CI / 工作流证据，再决定是否补本地验证。
-- skill 不得默认执行 `git pull`、`git push`、`git tag`、`gh pr create` 等会改变远端或当前分支状态的操作；这些操作必须要求用户确认。
+- 除上述 PR 创建 / 更新、PR 审查 / issue 分析的安全 fast-forward 同步外，skill 不得默认执行 `git pull`、`git push`、`git tag`、`gh pr create` 等会改变远端或当前分支状态的操作；这些操作必须要求用户确认。
 - PR 审查默认顺序：
   1. 必要性
   2. 关联性

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 [![Docker](https://img.shields.io/badge/Docker-Ready-2496ED?logo=docker&logoColor=white)](https://hub.docker.com/r/zhulinsen/daily_stock_analysis)
 
 <p align="center">
-  <a href="https://trendshift.io/repositories/18527" target="_blank"><img src="https://trendshift.io/api/badge/repositories/18527" alt="ZhuLinsen%2Fdaily_stock_analysis | Trendshift" width="230" /></a>&nbsp;<a href="https://hellogithub.com/repository/ZhuLinsen/daily_stock_analysis" target="_blank"><img src="https://api.hellogithub.com/v1/widgets/recommend.svg?rid=6daa16e405ce46ed97b4a57706aeb29f&claim_uid=pfiJMqhR9uvDGlT&theme=neutral" alt="Featured｜HelloGitHub" width="230" /></a>
+  <img src="https://trendshift.io/api/badge/trendshift/repositories/18527/daily?language=Python" alt="#1 Python Repository Of The Day | Trendshift" width="250" height="55"/>&nbsp;<a href="https://hellogithub.com/repository/ZhuLinsen/daily_stock_analysis" target="_blank"><img src="https://api.hellogithub.com/v1/widgets/recommend.svg?rid=6daa16e405ce46ed97b4a57706aeb29f&claim_uid=pfiJMqhR9uvDGlT&theme=neutral" alt="Featured｜HelloGitHub" width="230" /></a>
 </p>
 
 > 🤖 基于 AI 大模型的 A股/港股/美股/日股/韩股自选股智能分析系统，每日自动分析并推送「决策仪表盘」到企业微信/飞书/Telegram/Discord/Slack/邮箱

--- a/docs/README_CHT.md
+++ b/docs/README_CHT.md
@@ -10,7 +10,7 @@
 [![Docker](https://img.shields.io/badge/Docker-Ready-2496ED?logo=docker&logoColor=white)](https://hub.docker.com/r/zhulinsen/daily_stock_analysis)
 
 <p align="center">
-  <a href="https://trendshift.io/repositories/18527" target="_blank"><img src="https://trendshift.io/api/badge/repositories/18527" alt="ZhuLinsen%2Fdaily_stock_analysis | Trendshift" width="230" /></a>&nbsp;<a href="https://hellogithub.com/repository/ZhuLinsen/daily_stock_analysis" target="_blank"><img src="https://api.hellogithub.com/v1/widgets/recommend.svg?rid=6daa16e405ce46ed97b4a57706aeb29f&claim_uid=pfiJMqhR9uvDGlT&theme=neutral" alt="Featured｜HelloGitHub" width="230" /></a>
+  <img src="https://trendshift.io/api/badge/trendshift/repositories/18527/daily?language=Python" alt="#1 Python Repository Of The Day | Trendshift" width="250" height="55"/>&nbsp;<a href="https://hellogithub.com/repository/ZhuLinsen/daily_stock_analysis" target="_blank"><img src="https://api.hellogithub.com/v1/widgets/recommend.svg?rid=6daa16e405ce46ed97b4a57706aeb29f&claim_uid=pfiJMqhR9uvDGlT&theme=neutral" alt="Featured｜HelloGitHub" width="230" /></a>
 </p>
 
 **基於 AI 大模型的 A股/港股/美股/日股/韓股自選股智能分析系統**

--- a/docs/README_EN.md
+++ b/docs/README_EN.md
@@ -10,7 +10,7 @@
 [![Docker](https://img.shields.io/badge/Docker-Ready-2496ED?logo=docker&logoColor=white)](https://hub.docker.com/r/zhulinsen/daily_stock_analysis)
 
 <p align="center">
-  <a href="https://trendshift.io/repositories/18527" target="_blank"><img src="https://trendshift.io/api/badge/repositories/18527" alt="ZhuLinsen%2Fdaily_stock_analysis | Trendshift" width="230" /></a>&nbsp;<a href="https://hellogithub.com/repository/ZhuLinsen/daily_stock_analysis" target="_blank"><img src="https://api.hellogithub.com/v1/widgets/recommend.svg?rid=6daa16e405ce46ed97b4a57706aeb29f&claim_uid=pfiJMqhR9uvDGlT&theme=neutral" alt="Featured｜HelloGitHub" width="230" /></a>
+  <img src="https://trendshift.io/api/badge/trendshift/repositories/18527/daily?language=Python" alt="#1 Python Repository Of The Day | Trendshift" width="250" height="55"/>&nbsp;<a href="https://hellogithub.com/repository/ZhuLinsen/daily_stock_analysis" target="_blank"><img src="https://api.hellogithub.com/v1/widgets/recommend.svg?rid=6daa16e405ce46ed97b4a57706aeb29f&claim_uid=pfiJMqhR9uvDGlT&theme=neutral" alt="Featured｜HelloGitHub" width="230" /></a>
 </p>
 
 **AI-powered stock analysis system for A-shares / Hong Kong / US / Japanese / Korean stocks**


### PR DESCRIPTION
## PR Type

- [ ] fix
- [ ] feat
- [ ] refactor
- [x] docs
- [ ] chore
- [ ] test

## Background And Problem

README and mirrored README docs still used the older Trendshift GitHub Trending badge, which renders the `#4 Repository Of The Day` badge from `https://trendshift.io/api/badge/repositories/18527`.

Repository collaboration rules also needed to make the latest-code baseline explicit before creating/updating PRs, reviewing PRs, or analyzing issues.

## Scope Of Change

- Update the Trendshift badge in `README.md`, `docs/README_EN.md`, and `docs/README_CHT.md` to use the Trendshift daily Python `#1 Repository Of The Day` SVG.
- Update `AGENTS.md` to require latest-code baseline refresh before PR creation/update, PR review, and issue analysis.
- Sync the related repository skills and Copilot/GitHub governance instruction mirrors:
  - `.claude/skills/analyze-issue/SKILL.md`
  - `.claude/skills/analyze-pr/SKILL.md`
  - `.claude/skills/fix-issue/SKILL.md`
  - `.github/copilot-instructions.md`
  - `.github/instructions/governance.instructions.md`

## Issue Link

No issue. Acceptance criteria: README renders the Trendshift daily Python `#1 Repository Of The Day` badge, and PR/issue workflows explicitly refresh the latest remote baseline before proceeding.

## Verification Commands And Results

```bash
git fetch --all --prune
python scripts/check_ai_assets.py
git diff --check
curl -L -A 'Mozilla/5.0' -s 'https://trendshift.io/api/badge/trendshift/repositories/18527/daily?language=Python' | rg -n "aria-label|#1 Repository Of The Day" -C 1
rg -n "api/badge/repositories/18527|trendshift.io/repositories/18527|api/badge/trendshift/repositories/18527/daily" README.md docs/README_EN.md docs/README_CHT.md
git rebase origin/main
```

Key output / conclusion:

- `git fetch --all --prune` updated `origin/main` to `3b1daa4f`.
- Local branch was rebased successfully onto latest `origin/main`.
- `python scripts/check_ai_assets.py` returned `[ai-assets] OK`.
- `git diff --check` passed with no whitespace errors.
- Trendshift SVG response contains `aria-label="Trendshift: number 1 Python repository of the day"` and `#1 Repository Of The Day`.
- README mirrors now use `https://trendshift.io/api/badge/trendshift/repositories/18527/daily?language=Python`; the old badge endpoint is no longer present in those files.

## Visual Evidence (if applicable)

- Screenshot links: N/A
- Reason if not applicable: This PR changes README badge markup and repository governance docs, not report formatting, report rendering, or Web UI pages. SVG content was verified via `curl` as noted above.

## Compatibility And Risk

- No runtime, API, Web, Desktop, config, Docker, or GitHub Actions behavior changes.
- The PR workflow rule now allows safe `git pull --ff-only` only when the worktree is clean and the branch can fast-forward; otherwise it preserves local state and records the baseline gap.
- No `docs/CHANGELOG.md` update: this is a docs/governance/README badge update and does not change product capability, CLI/API behavior, deployment, notification, or report structure.

## Rollback Plan

Revert this PR. No config, data, or migration rollback is required.

## EXTRACT_PROMPT Change (if applicable)

N/A. This PR does not modify `src/services/image_stock_extractor.py`.

## Checklist

- [x] 本 PR 有明确动机和业务价值 / This PR has a clear motivation and value
- [x] 已提供可复现的验证命令与结果 / Reproducible verification commands and results are included
- [x] 已评估兼容性与风险 / Compatibility and risk have been assessed
- [x] 已提供回滚方案 / A rollback plan is provided
- [x] 若修改报告格式或 Web UI 界面，已在 PR 描述/评论附受影响报告 / 页面截图，且未把一次性验收截图作为仓库文件合入 / Not applicable; no report formatting or Web UI page changes
- [x] 若涉及用户可见变更，已同步更新相关文档与 `docs/CHANGELOG.md`；`README.md` 仅在首页级信息变化时更新，细节优先写入 `docs/*.md` / README mirrors are synchronized; changelog is not applicable because this is a docs/governance badge update with no product behavior change