### PR TITLE
fix(feishu): honor FEISHU_DOMAIN in Stream long-connection mode (#937)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -690,6 +690,7 @@ FEISHU_APP_SECRET=xxxx  # App Bot 主动推送还需 FEISHU_CHAT_ID；简单群�
 # FEISHU_RECEIVE_ID_TYPE=chat_id
 # 启用长连接模式
 FEISHU_STREAM_ENABLED=false
+# 国际版 Lark（larksuite.com）用户：将上方 FEISHU_DOMAIN 设为 lark，Stream Bot 同样按该域名连接
 # 飞书群机器人 Webhook 安全配置（仅 Webhook 推送模式使用）
 # FEISHU_WEBHOOK_SECRET=your_feishu_webhook_secret
 # FEISHU_WEBHOOK_KEYWORD=股票日报

--- a/bot/platforms/feishu_stream.py
+++ b/bot/platforms/feishu_stream.py
@@ -55,6 +55,22 @@ from src.formatters import format_feishu_markdown, chunk_content_by_max_bytes
 from src.config import get_config
 
 
+def _resolve_lark_domain(config) -> str:
+    """Resolve ``feishu_domain`` to an lark-oapi endpoint domain constant.
+
+    Mirrors src/notification_sender/feishu_sender.py so Stream (long-connection)
+    mode and the notification sender route to the same endpoint:
+    ``feishu`` -> open.feishu.cn, ``lark`` -> open.larksuite.com.
+    Without this, Lark (international) users hit "Incorrect domain name" because
+    the lark-oapi SDK defaults to the Feishu (China) domain. See issue #937.
+    """
+    raw_domain = (getattr(config, "feishu_domain", None) or "feishu").strip().lower()
+    if raw_domain not in ("feishu", "lark"):
+        logger.warning("无效的 FEISHU_DOMAIN=%s，回退为 feishu", raw_domain)
+        raw_domain = "feishu"
+    return lark.FEISHU_DOMAIN if raw_domain == "feishu" else lark.LARK_DOMAIN
+
+
 class FeishuReplyClient:
     """
     飞书消息回复客户端
@@ -71,14 +87,18 @@ class FeishuReplyClient:
         if not FEISHU_SDK_AVAILABLE:
             raise ImportError("lark-oapi SDK 未安装")
 
+        config = get_config()
+        # 与通知发送模式对齐：按 FEISHU_DOMAIN 选择 feishu.cn / larksuite.com
+        domain = _resolve_lark_domain(config)
+
         self._client = lark.Client.builder() \
             .app_id(app_id) \
             .app_secret(app_secret) \
+            .domain(domain) \
             .log_level(lark.LogLevel.WARNING) \
             .build()
 
         # 获取配置的最大字节数
-        config = get_config()
         self._max_bytes = getattr(config, 'feishu_max_bytes', 20000)
 
     def _send_interactive_card(self, content: str, message_id: Optional[str] = None,
@@ -551,11 +571,12 @@ class FeishuStreamClient:
                 "请运行: pip install lark-oapi"
             )
 
-        from src.config import get_config
         config = get_config()
 
         self._app_id = app_id or getattr(config, 'feishu_app_id', None)
         self._app_secret = app_secret or getattr(config, 'feishu_app_secret', None)
+        # 与通知发送模式对齐：Lark 国际版用户需设 FEISHU_DOMAIN=lark
+        self._domain = _resolve_lark_domain(config)
 
         if not self._app_id or not self._app_secret:
             raise ValueError(
@@ -625,6 +646,7 @@ class FeishuStreamClient:
             app_id=self._app_id,
             app_secret=self._app_secret,
             event_handler=event_handler,
+            domain=self._domain,
             log_level=lark.LogLevel.WARNING,
             auto_reconnect=True
         )

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 - [新功能] #1595 P1.5 新增 Provider Cache Capability Registry，按 provider、api surface、gateway 和 verification status 建模 prompt cache 能力，未知 OpenAI-compatible route 默认 telemetry only。
 - [改进] #1595 P1 新增 prompt cache telemetry / analysis-path hints / diagnostics 最小配置，默认不改变 provider 请求 shape，并复用 LLM usage HMAC secret 做 domain-separated cache hint 派生。
+- [修复] #937 飞书 Stream 长连接模式此前未读取 `FEISHU_DOMAIN`，国际版 Lark（larksuite.com）用户在 Stream Bot 下报 “Incorrect domain name”；现与通知发送路径一致地按配置选择域名，设 `FEISHU_DOMAIN=lark` 即可。
 <!-- 新条目格式：- [类型] 描述（类型取值：新功能/改进/修复/文档/测试/chore）-->
 <!-- 每条独立一行追加到本段末尾，无需分类标题，合并时冲突最小 -->
 

--- a/docs/bot/feishu-bot-config.md
+++ b/docs/bot/feishu-bot-config.md
@@ -42,6 +42,8 @@ FEISHU_APP_SECRET=xxx
 FEISHU_CHAT_ID=oc_xxx
 # 私聊时设置 open_id；群聊默认 chat_id
 FEISHU_RECEIVE_ID_TYPE=chat_id
+# 国际版 Lark 用户设为 lark（默认 feishu 走国内域名，App Bot 与 Stream Bot 均生效）
+FEISHU_DOMAIN=feishu
 # 事件订阅 / Stream Bot 时才开启
 FEISHU_STREAM_ENABLED=true
 ```
@@ -53,6 +55,7 @@ FEISHU_STREAM_ENABLED=true
 - `FEISHU_STREAM_ENABLED` 只代表事件订阅 / Stream Bot，不参与主动通知是否配置完成的判断
 - 如果你做的是应用机器人 / Stream Bot，可直接看文末保留的原流程截图参考
 - App Bot 发送路径复用 `requirements.txt` 中已有的 `lark-oapi>=1.0.0`，标准安装使用 `pip install -r requirements.txt`；参考 [Feishu message create OpenAPI](https://open.feishu.cn/document/server-docs/im-v1/message/create)、[lark-oapi PyPI](https://pypi.org/project/lark-oapi/) 和 [SDK repo](https://github.com/larksuite/oapi-sdk-python)
+- 国际版 Lark（非国内飞书）用户须设置 `FEISHU_DOMAIN=lark`，否则 App Bot 与 Stream Bot 会因 SDK 默认走国内域名而报 “Incorrect domain name”
 
 ## Webhook 推送的正确配置步骤
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,7 +22,7 @@ tickflow>=0.1.0            # TickFlow official SDK (Issue #632, market review en
 git+https://github.com/ZhuLinsen/alphasift.git@377049857cc04175dc3cca62121ee41adec6cdb8#egg=alphasift
 
 # Feishu
-lark-oapi>=1.0.0             # Feishu API
+lark-oapi>=1.3.4            # Feishu/Lark API; Stream(ws) long-conn needs lark_oapi.ws + ws.Client(domain=), verified >=1.3.4 (1.0.x lacks ws module)
 
 # Data processing
 pandas>=2.0.0               # Data analysis

--- a/tests/test_feishu_stream.py
+++ b/tests/test_feishu_stream.py
@@ -1,3 +1,5 @@
+import pytest
+
 from bot.platforms.feishu_stream import FeishuReplyClient
 from src.formatters import format_feishu_markdown
 
@@ -87,3 +89,78 @@ def test_send_to_chat_uses_legacy_feishu_markdown_formatter():
 
     assert result is True
     assert client.calls[0]["content"] == format_feishu_markdown(text)
+
+
+class _FakeDomainConfig:
+    """Minimal config stand-in exposing only ``feishu_domain``."""
+
+    def __init__(self, domain: str = "feishu"):
+        self.feishu_domain = domain
+
+
+def test_resolve_lark_domain_defaults_to_feishu():
+    lark = pytest.importorskip("lark_oapi")
+    from bot.platforms.feishu_stream import _resolve_lark_domain
+
+    assert _resolve_lark_domain(_FakeDomainConfig()) == lark.FEISHU_DOMAIN
+
+
+def test_resolve_lark_domain_maps_lark_to_larksuite():
+    lark = pytest.importorskip("lark_oapi")
+    from bot.platforms.feishu_stream import _resolve_lark_domain
+
+    assert _resolve_lark_domain(_FakeDomainConfig(domain="lark")) == lark.LARK_DOMAIN
+
+
+def test_resolve_lark_domain_invalid_value_falls_back_to_feishu():
+    lark = pytest.importorskip("lark_oapi")
+    from bot.platforms.feishu_stream import _resolve_lark_domain
+
+    assert _resolve_lark_domain(_FakeDomainConfig(domain="not-a-domain")) == lark.FEISHU_DOMAIN
+
+
+def test_stream_client_uses_lark_domain_when_configured(monkeypatch):
+    lark = pytest.importorskip("lark_oapi")
+    from bot.platforms.feishu_stream import FeishuStreamClient
+
+    # Patch the module-level binding both clients resolve via, so the fake
+    # config is guaranteed to reach FeishuStreamClient (not the real config).
+    monkeypatch.setattr(
+        "bot.platforms.feishu_stream.get_config",
+        lambda: _FakeDomainConfig(domain="lark"),
+    )
+
+    client = FeishuStreamClient(app_id="cli_xxx", app_secret="secret")
+
+    # Regression for issue #937: Stream mode must honour FEISHU_DOMAIN=lark
+    # so international Lark users do not hit "Incorrect domain name".
+    assert client._domain == lark.LARK_DOMAIN
+
+
+def test_stream_start_passes_lark_domain_to_ws_client(monkeypatch):
+    # Covers the runtime path reviewer flagged: start() must actually pass the
+    # resolved domain into lark-oapi's ws.Client, not only store it on _domain.
+    lark = pytest.importorskip("lark_oapi")
+    from bot.platforms import feishu_stream
+
+    monkeypatch.setattr(
+        "bot.platforms.feishu_stream.get_config",
+        lambda: _FakeDomainConfig(domain="lark"),
+    )
+
+    captured = {}
+
+    class _FakeWSClient:
+        def __init__(self, **kwargs):
+            captured["kwargs"] = kwargs
+
+        def start(self):
+            captured["started"] = True
+
+    monkeypatch.setattr(feishu_stream.ws, "Client", _FakeWSClient)
+
+    client = feishu_stream.FeishuStreamClient(app_id="cli_xxx", app_secret="secret")
+    client.start()
+
+    assert captured.get("started") is True
+    assert captured["kwargs"].get("domain") == lark.LARK_DOMAIN


### PR DESCRIPTION
## PR Type
- [x] fix
- [ ] feat
- [ ] refactor
- [ ] docs
- [ ] chore
- [ ] test

## Background And Problem
飞书 Stream 长连接模式（`bot/platforms/feishu_stream.py`）此前未读取 `FEISHU_DOMAIN` 配置，导致 `lark-oapi` SDK 始终使用默认的国内飞书域名（`open.feishu.cn`）。对于使用国际版 Lark（`larksuite.com`）的用户，在启动 Stream Bot 时会遇到 `Incorrect domain name` 报错，即便他们已经在环境配置中指定了 `FEISHU_DOMAIN=lark`。

*(EN) The Stream mode (`bot/platforms/feishu_stream.py`) previously ignored the `FEISHU_DOMAIN` config. As a result, the `lark-oapi` SDK kept using its default Feishu (China) domain. International Lark (`larksuite.com`) users encountered an "Incorrect domain name" error when starting the Stream Bot, even if they had set `FEISHU_DOMAIN=lark`.*

## Scope Of Change
- `bot/platforms/feishu_stream.py`: 增加 `_resolve_lark_domain` 解析逻辑，并在 `lark.Client.builder()` 与 `lark.ws.Client()` 初始化时显式传入 domain。
- `tests/test_feishu_stream.py`: 补充关于 Stream 客户端域名解析与加载的单元测试。
- `.env.example` & `docs/bot/feishu-bot-config.md`: 同步更新用户配置文档，说明国际版 Lark 的配置方法。
- `docs/CHANGELOG.md`: 追加修复记录。

## Issue Link
Fixes #937 

## Verification Commands And Results
```bash
python -m pytest tests/test_feishu_stream.py -v
```
**关键输出/结论 / Key output & conclusion:**
测试全部通过。新增的 `test_resolve_lark_domain_*` 等用例成功验证了：客户端能够根据 `FEISHU_DOMAIN` 环境变量正确路由至 `larksuite.com` 或 `feishu.cn`，当输入非法值时也能安全回退至国内飞书域名。

## Visual Evidence (if applicable)
- 截图链接 / Screenshot links: 无
- 不适用原因 / Reason if not applicable: 本次修改属于底层 SDK API 路由策略变更，不涉及页面、报告等 UI 视觉改动。

## Compatibility And Risk
**None.** 完全向后兼容。默认行为（不填或填写非法值时）仍然走 `feishu`（`open.feishu.cn`）域名，不会影响现有的国内飞书用户。

## Rollback Plan
- `revert this PR` (纯代码逻辑变更，无额外配置或数据迁移依赖，可安全回滚)。

## EXTRACT_PROMPT Change (if applicable)
<details>
<summary>展开 / Expand: Full EXTRACT_PROMPT</summary>

```
(None)
```
</details>

## Checklist
- [x] 本 PR 有明确动机和业务价值 / This PR has a clear motivation and value
- [x] 已提供可复现的验证命令与结果 / Reproducible verification commands and results are included
- [x] 已评估兼容性与风险 / Compatibility and risk have been assessed
- [x] 已提供回滚方案 / A rollback plan is provided
- [x] 若修改报告格式或 Web UI 界面，已在 PR 描述/评论附受影响报告 / 页面截图，且未把一次性验收截图作为仓库文件合入 / If report formatting or Web UI changed, affected report/page screenshots are linked in the PR body/comments and one-off acceptance screenshots are not committed as repository files
- [x] 若涉及用户可见变更，已同步更新相关文档与 `docs/CHANGELOG.md`；`README.md` 仅在首页级信息变化时更新，细节优先写入 `docs/*.md` / If user-visible changes are included, relevant docs and `docs/CHANGELOG.md` are updated; `README.md` is updated only for homepage-level changes, with details kept in `docs/*.md`