### PR TITLE
fix: 精简分析结果摘要中的决策信号展示

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+- [改进] 通知报告的分析结果摘要不再展开 AI 决策信号明细，完整信号保留在个股详情和单股报告中。
 - [新功能] #1595 P1.5 新增 Provider Cache Capability Registry，按 provider、api surface、gateway 和 verification status 建模 prompt cache 能力，未知 OpenAI-compatible route 默认 telemetry only。
 - [改进] #1595 P1 新增 prompt cache telemetry / analysis-path hints / diagnostics 最小配置，默认不改变 provider 请求 shape，并复用 LLM usage HMAC secret 做 domain-separated cache hint 派生。
 - [改进] 将 Docker Compose 默认内存建议从 512M 提升到 1G，并补充低配部署说明。

--- a/src/notification.py
+++ b/src/notification.py
@@ -850,9 +850,6 @@ class NotificationService(
                     f"{labels['score_label']} {r.sentiment_score} | "
                     f"{localize_trend_prediction(r.trend_prediction, report_language)}"
                 )
-                signal_excerpt = self._decision_signal_excerpt(r, report_language)
-                if signal_excerpt:
-                    report_lines.append(signal_excerpt)
         else:
             report_lines.extend([f"## 📈 {labels['report_title']}", ""])
             # 逐个股票的详细分析
@@ -1105,9 +1102,6 @@ class NotificationService(
                     f"{labels['score_label']} {r.sentiment_score} | "
                     f"{localize_trend_prediction(r.trend_prediction, report_language)}"
                 )
-                signal_excerpt = self._decision_signal_excerpt(r, report_language)
-                if signal_excerpt:
-                    report_lines.append(signal_excerpt)
             report_lines.extend([
                 "",
                 "---",
@@ -1127,6 +1121,9 @@ class NotificationService(
                     f"## {signal_emoji} {stock_name} ({result.code})",
                     "",
                 ])
+                signal_excerpt = self._decision_signal_excerpt(result, report_language)
+                if signal_excerpt:
+                    report_lines.extend([signal_excerpt, ""])
                 
                 # ========== 舆情与基本面概览（放在最前面）==========
                 intel = dashboard.get('intelligence', {}) if dashboard else {}
@@ -1410,9 +1407,6 @@ class NotificationService(
                     f"{labels['score_label']} {r.sentiment_score} | "
                     f"{localize_trend_prediction(r.trend_prediction, report_language)}"
                 )
-                signal_excerpt = self._decision_signal_excerpt(r, report_language)
-                if signal_excerpt:
-                    lines.append(signal_excerpt)
         else:
             for result in sorted_results:
                 signal_text, signal_emoji, _ = self._get_signal_level(result)
@@ -1567,9 +1561,6 @@ class NotificationService(
                 f"{labels['score_label']}:{result.sentiment_score} | "
                 f"{localize_trend_prediction(result.trend_prediction, report_language)}"
             )
-            signal_excerpt = self._decision_signal_excerpt(result, report_language)
-            if signal_excerpt:
-                lines.append(signal_excerpt)
             
             # 操作理由（截断）
             if hasattr(result, 'buy_reason') and result.buy_reason:
@@ -1657,9 +1648,6 @@ class NotificationService(
                 f"{localize_operation_advice(r.operation_advice, report_language)} | "
                 f"{labels['score_label']} {r.sentiment_score} | {one}"
             )
-            signal_excerpt = self._decision_signal_excerpt(r, report_language)
-            if signal_excerpt:
-                lines.append(signal_excerpt)
         lines.append("")
         lines.append(f"*{datetime.now().strftime('%Y-%m-%d %H:%M:%S')}*")
         models = self._collect_models_used(results)

--- a/templates/report_brief.j2
+++ b/templates/report_brief.j2
@@ -10,10 +10,6 @@
 {% set core = (dash.get('core_conclusion') or {}) if dash else {} %}
 {% set one = (core.get('one_sentence') or e.result.analysis_summary or '')[:60] %}
 **{{ e.stock_name }}({{ e.result.code }})** {{ e.signal_emoji }} {{ e.localized_operation_advice }} | {{ labels.score_label }} {{ e.result.sentiment_score }} | {{ one }}
-{% set signal_excerpt = decision_signal_excerpt(e.result) %}
-{% if signal_excerpt %}
-{{ signal_excerpt }}
-{% endif %}
 {% endfor %}
 
 *{{ report_timestamp }}*

--- a/templates/report_markdown.j2
+++ b/templates/report_markdown.j2
@@ -10,10 +10,6 @@
 
 {% for e in enriched %}
 {{ e.signal_emoji }} **{{ e.stock_name }}({{ e.result.code }})**: {{ e.localized_operation_advice }} | {{ labels.score_label }} {{ e.result.sentiment_score }} | {{ e.localized_trend_prediction }}
-{% set signal_excerpt = decision_signal_excerpt(e.result) %}
-{% if signal_excerpt %}
-{{ signal_excerpt }}
-{% endif %}
 {% endfor %}
 
 ---
@@ -27,6 +23,11 @@
 {% set data_persp = dashboard.get('data_perspective') or {} %}
 
 ## {{ e.signal_emoji }} {{ e.stock_name }} ({{ result.code }})
+
+{% set signal_excerpt = decision_signal_excerpt(result) %}
+{% if signal_excerpt %}
+{{ signal_excerpt }}
+{% endif %}
 
 {% if intel %}
 ### 📰 {{ labels.info_heading }}

--- a/templates/report_wechat.j2
+++ b/templates/report_wechat.j2
@@ -9,10 +9,6 @@
 **📊 {{ labels.summary_heading }}**
 {% for e in enriched %}
 {{ e.signal_emoji }} **{{ e.stock_name }}({{ e.result.code }})**: {{ e.localized_operation_advice }} | {{ labels.score_label }} {{ e.result.sentiment_score }} | {{ e.localized_trend_prediction }}
-{% set signal_excerpt = decision_signal_excerpt(e.result) %}
-{% if signal_excerpt %}
-{{ signal_excerpt }}
-{% endif %}
 {% endfor %}
 {% else %}
 {% for e in enriched %}

--- a/tests/test_notification.py
+++ b/tests/test_notification.py
@@ -656,10 +656,12 @@ class TestNotificationServiceReportGeneration(unittest.TestCase):
 
         out = service.generate_dashboard_report([result], report_date="2026-02-01")
 
-        self.assertIn("AI 决策信号", out)
-        self.assertIn("动作: 卖出", out)
-        self.assertIn("周期: 1d", out)
-        self.assertIn("理由: 技术面走弱", out)
+        summary_section, detail_section = out.split("---", 1)
+        self.assertNotIn("AI 决策信号", summary_section)
+        self.assertIn("AI 决策信号", detail_section)
+        self.assertIn("动作: 卖出", detail_section)
+        self.assertIn("周期: 1d", detail_section)
+        self.assertIn("理由: 技术面走弱", detail_section)
 
     @mock.patch("src.notification.get_config")
     def test_generate_daily_report_appends_decision_signal_excerpt_fallback(
@@ -679,10 +681,13 @@ class TestNotificationServiceReportGeneration(unittest.TestCase):
             service = NotificationService()
             service._report_summary_only = summary_only
             out = service.generate_daily_report([result], report_date="2026-02-01")
-            self.assertEqual(out.count("AI 决策信号"), 1)
-            self.assertIn("动作: 卖出", out)
-            self.assertIn("周期: 1d", out)
-            self.assertIn("理由: 技术面走弱", out)
+            self.assertEqual(out.count("AI 决策信号"), 0 if summary_only else 1)
+            if summary_only:
+                self.assertNotIn("动作: 卖出", out)
+            else:
+                self.assertIn("动作: 卖出", out)
+                self.assertIn("周期: 1d", out)
+                self.assertIn("理由: 技术面走弱", out)
 
     @mock.patch("src.notification.get_config")
     def test_generate_wechat_dashboard_appends_decision_signal_excerpt_fallback(
@@ -702,13 +707,16 @@ class TestNotificationServiceReportGeneration(unittest.TestCase):
             service = NotificationService()
             service._report_summary_only = summary_only
             out = service.generate_wechat_dashboard([result])
-            self.assertIn("AI 决策信号", out)
-            self.assertIn("动作: 卖出", out)
-            self.assertIn("周期: 1d", out)
-            self.assertIn("理由: 技术面走弱", out)
+            self.assertEqual(out.count("AI 决策信号"), 0 if summary_only else 1)
+            if summary_only:
+                self.assertNotIn("动作: 卖出", out)
+            else:
+                self.assertIn("动作: 卖出", out)
+                self.assertIn("周期: 1d", out)
+                self.assertIn("理由: 技术面走弱", out)
 
     @mock.patch("src.notification.get_config")
-    def test_generate_wechat_summary_appends_decision_signal_excerpt(
+    def test_generate_wechat_summary_omits_decision_signal_excerpt(
         self, mock_get_config: mock.MagicMock
     ):
         mock_get_config.return_value = _make_config(report_renderer_enabled=False)
@@ -724,10 +732,8 @@ class TestNotificationServiceReportGeneration(unittest.TestCase):
 
         out = service.generate_wechat_summary([result])
 
-        self.assertEqual(out.count("AI 决策信号"), 1)
-        self.assertIn("动作: 卖出", out)
-        self.assertIn("周期: 1d", out)
-        self.assertIn("理由: 技术面走弱", out)
+        self.assertNotIn("AI 决策信号", out)
+        self.assertNotIn("动作: 卖出", out)
 
     @mock.patch("src.notification.get_config")
     def test_generate_dashboard_report_appends_decision_signal_excerpt_with_renderer(
@@ -746,10 +752,12 @@ class TestNotificationServiceReportGeneration(unittest.TestCase):
 
         out = service.generate_dashboard_report([result], report_date="2026-02-01")
 
-        self.assertIn("AI 决策信号", out)
-        self.assertIn("动作: 卖出", out)
-        self.assertIn("周期: 1d", out)
-        self.assertIn("理由: 技术面走弱", out)
+        summary_section, detail_section = out.split("---", 1)
+        self.assertNotIn("AI 决策信号", summary_section)
+        self.assertIn("AI 决策信号", detail_section)
+        self.assertIn("动作: 卖出", detail_section)
+        self.assertIn("周期: 1d", detail_section)
+        self.assertIn("理由: 技术面走弱", detail_section)
 
     @mock.patch("src.notification.get_config")
     def test_aggregate_reports_show_compact_market_status_only(self, mock_get_config: mock.MagicMock):

--- a/tests/test_report_renderer.py
+++ b/tests/test_report_renderer.py
@@ -90,16 +90,22 @@ class TestReportRenderer(unittest.TestCase):
         self.assertIn("作战计划", out)
         self.assertNotIn("盘中决策护栏", out)
 
-    def test_render_markdown_includes_decision_signal_excerpt(self) -> None:
-        """Markdown summary and full templates include DecisionSignal excerpts."""
-        for summary_only in (True, False):
-            r = _with_decision_signal_summary(_make_result())
-            out = render("markdown", [r], summary_only=summary_only)
-            self.assertIsNotNone(out)
-            self.assertIn("AI 决策信号", out)
-            self.assertIn("动作: 卖出", out)
-            self.assertIn("周期: 1d", out)
-            self.assertIn("理由: 技术面走弱", out)
+    def test_render_markdown_keeps_decision_signal_out_of_summary(self) -> None:
+        """Markdown summary stays compact while full details keep DecisionSignal excerpts."""
+        r = _with_decision_signal_summary(_make_result())
+
+        summary_out = render("markdown", [r], summary_only=True)
+        self.assertIsNotNone(summary_out)
+        self.assertNotIn("AI 决策信号", summary_out)
+
+        full_out = render("markdown", [r], summary_only=False)
+        self.assertIsNotNone(full_out)
+        summary_section, detail_section = full_out.split("---", 1)
+        self.assertNotIn("AI 决策信号", summary_section)
+        self.assertIn("AI 决策信号", detail_section)
+        self.assertIn("动作: 卖出", detail_section)
+        self.assertIn("周期: 1d", detail_section)
+        self.assertIn("理由: 技术面走弱", detail_section)
 
     def test_render_markdown_phase_decision_section(self) -> None:
         """Markdown renders phase_decision when present."""
@@ -158,16 +164,20 @@ class TestReportRenderer(unittest.TestCase):
         self.assertIsNotNone(out)
         self.assertIn("贵州茅台", out)
 
-    def test_render_wechat_includes_decision_signal_excerpt(self) -> None:
-        """Wechat summary and full templates include DecisionSignal excerpts."""
-        for summary_only in (True, False):
-            r = _with_decision_signal_summary(_make_result())
-            out = render("wechat", [r], summary_only=summary_only)
-            self.assertIsNotNone(out)
-            self.assertIn("AI 决策信号", out)
-            self.assertIn("动作: 卖出", out)
-            self.assertIn("周期: 1d", out)
-            self.assertIn("理由: 技术面走弱", out)
+    def test_render_wechat_keeps_decision_signal_out_of_summary(self) -> None:
+        """Wechat summary-only stays compact while full details keep DecisionSignal excerpts."""
+        r = _with_decision_signal_summary(_make_result())
+
+        summary_out = render("wechat", [r], summary_only=True)
+        self.assertIsNotNone(summary_out)
+        self.assertNotIn("AI 决策信号", summary_out)
+
+        full_out = render("wechat", [r], summary_only=False)
+        self.assertIsNotNone(full_out)
+        self.assertIn("AI 决策信号", full_out)
+        self.assertIn("动作: 卖出", full_out)
+        self.assertIn("周期: 1d", full_out)
+        self.assertIn("理由: 技术面走弱", full_out)
 
     def test_render_brief(self) -> None:
         """Brief platform renders 3-5 sentence summary."""
@@ -176,6 +186,14 @@ class TestReportRenderer(unittest.TestCase):
         self.assertIsNotNone(out)
         self.assertIn("决策简报", out)
         self.assertIn("贵州茅台", out)
+
+    def test_render_brief_omits_decision_signal_excerpt(self) -> None:
+        r = _with_decision_signal_summary(_make_result())
+
+        out = render("brief", [r])
+
+        self.assertIsNotNone(out)
+        self.assertNotIn("AI 决策信号", out)
 
     def test_render_brief_respects_model_visibility_toggle(self) -> None:
         r = _make_result(model_used="gemini/gemini-2.5-flash")


### PR DESCRIPTION
## PR Type

- [x] fix
- [ ] feat
- [ ] refactor
- [ ] docs
- [ ] chore
- [x] test

## Background And Problem

`分析结果摘要` 当前会直接展开每只股票的 `AI 决策信号` 明细，包括动作、周期、报告编号、理由、观察条件和风险。多股报告里这会让摘要区变得很长，快速扫读的股票结论被淹没。

## Scope Of Change

- 从通知/报告摘要列表中移除 `AI 决策信号` 明细输出：
  - `src/notification.py`
  - `templates/report_markdown.j2`
  - `templates/report_wechat.j2`
  - `templates/report_brief.j2`
- 完整 Markdown dashboard fallback 与模板正文仍在个股详情段保留完整决策信号。
- 更新相关通知与模板渲染测试。
- 更新 `docs/CHANGELOG.md`。

## Issue Link

Fixes #1780

## Verification Commands And Results

```bash
python -m pytest tests/test_notification.py::TestNotificationServiceReportGeneration::test_generate_dashboard_report_appends_decision_signal_excerpt_fallback tests/test_notification.py::TestNotificationServiceReportGeneration::test_generate_daily_report_appends_decision_signal_excerpt_fallback tests/test_notification.py::TestNotificationServiceReportGeneration::test_generate_wechat_dashboard_appends_decision_signal_excerpt_fallback tests/test_notification.py::TestNotificationServiceReportGeneration::test_generate_wechat_summary_omits_decision_signal_excerpt tests/test_notification.py::TestNotificationServiceReportGeneration::test_generate_dashboard_report_appends_decision_signal_excerpt_with_renderer tests/test_report_renderer.py::TestReportRenderer::test_render_markdown_keeps_decision_signal_out_of_summary tests/test_report_renderer.py::TestReportRenderer::test_render_wechat_keeps_decision_signal_out_of_summary tests/test_report_renderer.py::TestReportRenderer::test_render_brief_omits_decision_signal_excerpt
python -m py_compile src\notification.py src\services\report_renderer.py
git diff --check
```

Key output & conclusion:

- Pytest: `8 passed, 2 warnings`
- `py_compile`: passed
- `git diff --check`: passed, only local CRLF conversion warnings from Git

## Visual Evidence (if applicable)

- Screenshot links: not attached
- Reason if not applicable: this change affects generated text/Markdown notification content rather than an interactive UI page. The replacement evidence is the updated tests that assert summary sections no longer contain `AI 决策信号`, while full report detail sections still do.

## Compatibility And Risk

- No API/schema/config changes.
- Intended behavior change: `REPORT_SUMMARY_ONLY` / brief-style outputs no longer include decision-signal details. Users who need the full AI decision rationale should use the full report, individual stock report, or decision signal page.
- Risk is limited to report text layout/notification expectations.

## Rollback Plan

Revert this PR. No data migration, config rollback, or database cleanup is required.

## EXTRACT_PROMPT Change (if applicable)

Not applicable.

## Checklist

- [x] This PR has a clear motivation and value
- [x] Reproducible verification commands and results are included
- [x] Compatibility and risk have been assessed
- [x] A rollback plan is provided
- [x] If report formatting or Web UI changed, affected evidence is linked/described in the PR body and no one-off screenshot files are committed
- [x] User-visible change is recorded in `docs/CHANGELOG.md`