### PR TITLE
fix: support STOCK_LIST environment variables

### DIFF
--- a/.github/workflows/00-daily-analysis.yml
+++ b/.github/workflows/00-daily-analysis.yml
@@ -31,6 +31,9 @@ concurrency:
 jobs:
   analyze:
     runs-on: ubuntu-latest
+    # 兼容误将 STOCK_LIST 配到同名 Environment variables 的场景；
+    # 推荐位置仍是 Settings -> Secrets and variables -> Actions -> Repository variables。
+    environment: STOCK_LIST
     # 添加超时限制，防止任务卡死
     timeout-minutes: ${{ fromJSON(vars.ANALYSIS_TIMEOUT_MINUTES || '30') }}
     
@@ -359,7 +362,8 @@ jobs:
           # ==========================================
           # 自选股配置
           # ==========================================
-          STOCK_LIST: ${{ vars.STOCK_LIST || secrets.STOCK_LIST || '600519' }}
+          # 避免直接写入 STOCK_LIST，保留同名 Environment variables 的 runner 环境值。
+          STOCK_LIST_CONFIG: ${{ vars.STOCK_LIST || secrets.STOCK_LIST }}
           MARKET_REVIEW_REGION: ${{ vars.MARKET_REVIEW_REGION || secrets.MARKET_REVIEW_REGION || 'cn' }}
           MARKET_REVIEW_COLOR_SCHEME: ${{ vars.MARKET_REVIEW_COLOR_SCHEME || secrets.MARKET_REVIEW_COLOR_SCHEME || 'green_up' }}
           
@@ -387,6 +391,16 @@ jobs:
           REALTIME_SOURCE_PRIORITY: ${{ vars.REALTIME_SOURCE_PRIORITY || 'tencent,akshare_sina,efinance,akshare_em' }}
           
         run: |
+          # 解析自选股配置：
+          # 1. Repository/Environment secrets 或 Repository variables（STOCK_LIST_CONFIG）
+          # 2. 同名 Environment variables 注入的 runner 环境变量（STOCK_LIST）
+          # 3. 最小默认值
+          if [ -n "${STOCK_LIST_CONFIG:-}" ]; then
+            export STOCK_LIST="$STOCK_LIST_CONFIG"
+          elif [ -z "${STOCK_LIST:-}" ]; then
+            export STOCK_LIST="600519"
+          fi
+
           # 处理 LITELLM YAML 配置文件
           if [ -n "$LITELLM_CONFIG_YAML" ] && [ -n "$LITELLM_CONFIG" ]; then
             echo "📝 使用 GitHub Actions Secrets/Variables 中的 LITELLM_CONFIG_YAML 配置"

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - [新功能] #1595 P1.5 新增 Provider Cache Capability Registry，按 provider、api surface、gateway 和 verification status 建模 prompt cache 能力，未知 OpenAI-compatible route 默认 telemetry only。
 - [改进] #1595 P1 新增 prompt cache telemetry / analysis-path hints / diagnostics 最小配置，默认不改变 provider 请求 shape，并复用 LLM usage HMAC secret 做 domain-separated cache hint 派生。
 - [改进] 将 Docker Compose 默认内存建议从 512M 提升到 1G，并补充低配部署说明。
+- [改进] 每日分析 workflow 兼容误将 `STOCK_LIST` 配到同名 Environment variables 的场景，同时保留 Repository variables 作为推荐配置入口。
 <!-- 新条目格式：- [类型] 描述（类型取值：新功能/改进/修复/文档/测试/chore）-->
 <!-- 每条独立一行追加到本段末尾，无需分类标题，合并时冲突最小 -->
 

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -88,6 +88,8 @@
    - `GEMINI_MODEL`
    - `REPORT_TYPE`
 
+> 兼容说明：每日分析 workflow 也会绑定名为 `STOCK_LIST` 的 Environment，因此误把 `STOCK_LIST` 填到该 Environment variables 中也能被读取；但推荐位置仍是 Repository variables。除非你希望每日任务等待人工审批，否则不要给该 Environment 配置 required reviewers、wait timer 或部署分支限制。
+
 ---
 
 ### Q6: 修改 .env 文件后配置没有生效？

--- a/docs/FAQ_EN.md
+++ b/docs/FAQ_EN.md
@@ -86,6 +86,8 @@ This document compiles common issues encountered by users and their solutions.
    - `GEMINI_MODEL`
    - `REPORT_TYPE`
 
+> Compatibility note: the daily analysis workflow also binds the `STOCK_LIST` environment, so a `STOCK_LIST` value mistakenly added under that Environment's variables can still be read. Repository variables remain the recommended location. Unless you want the daily job to wait for manual approval, do not add required reviewers, wait timers, or deployment branch restrictions to this Environment.
+
 ---
 
 ### Q6: Configuration not taking effect after modifying .env file?


### PR DESCRIPTION
## Summary

- Bind the daily analysis job to the `STOCK_LIST` GitHub Environment so misconfigured Environment variables can be used.
- Avoid directly setting `STOCK_LIST` in the step `env`; resolve `STOCK_LIST_CONFIG`, runner-injected `STOCK_LIST`, then the existing `600519` fallback at runtime.
- Document the compatibility path and the environment protection-rule caveat in Chinese and English FAQ, plus changelog.

## Why

Users can easily add `STOCK_LIST` under `Settings -> Secrets and variables -> Actions -> Environment variables` instead of Repository variables. The previous workflow only worked reliably for Repository variables/secrets and the hardcoded fallback, so the UI-visible Environment variable could appear configured while the daily run still ignored it.

## Impact

- Recommended configuration remains Repository variables.
- Existing Repository variable/secret behavior is preserved.
- The same-name `STOCK_LIST` Environment variable now works when present.
- Risk: if the `STOCK_LIST` Environment later gets required reviewers, wait timers, or deployment branch restrictions, scheduled analysis can wait or be blocked by those protection rules.

## Validation

- `git diff --check -- .github/workflows/00-daily-analysis.yml docs/FAQ.md docs/FAQ_EN.md docs/CHANGELOG.md`
- Python/PyYAML parse of `.github/workflows/00-daily-analysis.yml`, asserting:
  - `jobs.analyze.environment == 'STOCK_LIST'`
  - the analysis step uses `STOCK_LIST_CONFIG`
  - the step no longer directly overrides `STOCK_LIST`

## Rollback

Remove the `environment: STOCK_LIST` binding, restore direct `STOCK_LIST` step env fallback if desired, and remove the FAQ/changelog notes.