### PR TITLE
[codex] fix agent news context pack inputs

### DIFF
--- a/data_provider/akshare_fetcher.py
+++ b/data_provider/akshare_fetcher.py
@@ -62,6 +62,8 @@ logger = logging.getLogger(__name__)
 SINA_REALTIME_ENDPOINT = "hq.sinajs.cn/list"
 TENCENT_REALTIME_ENDPOINT = "qt.gtimg.cn/q"
 _AKSHARE_HISTORY_CALL_TIMEOUT = 30.0
+_AKSHARE_CHIP_CALL_TIMEOUT = 20.0
+_AKSHARE_CHIP_CALL_ATTEMPTS = 2
 _AKSHARE_TIMEOUT_PROCESS_JOIN_GRACE = 1.0
 _AKSHARE_TIMEOUT_PROCESS_START_METHOD = "spawn"
 
@@ -1604,51 +1606,74 @@ class AkshareFetcher(BaseFetcher):
             logger.debug(f"[API跳过] {stock_code} 是 ETF/指数，无筹码分布数据")
             return None
         
-        try:
-            # 防封禁策略
-            self._set_random_user_agent()
-            self._enforce_rate_limit()
-            
-            logger.info(f"[API调用] ak.stock_cyq_em(symbol={stock_code}) 获取筹码分布...")
-            import time as _time
-            api_start = _time.time()
-            
-            df = ak.stock_cyq_em(symbol=stock_code)
-            
-            api_elapsed = _time.time() - api_start
-            
-            if df.empty:
-                logger.warning(f"[API返回] ak.stock_cyq_em 返回空数据, 耗时 {api_elapsed:.2f}s")
-                return None
-            
-            logger.info(f"[API返回] ak.stock_cyq_em 成功: 返回 {len(df)} 天数据, 耗时 {api_elapsed:.2f}s")
-            logger.debug(f"[API返回] 筹码数据列名: {list(df.columns)}")
-            
-            # 取最新一天的数据
-            latest = df.iloc[-1]
-            
-            # 使用 realtime_types.py 中的统一转换函数
-            chip = ChipDistribution(
-                code=stock_code,
-                date=str(latest.get('日期', '')),
-                profit_ratio=safe_float(latest.get('获利比例')),
-                avg_cost=safe_float(latest.get('平均成本')),
-                cost_90_low=safe_float(latest.get('90成本-低')),
-                cost_90_high=safe_float(latest.get('90成本-高')),
-                concentration_90=safe_float(latest.get('90集中度')),
-                cost_70_low=safe_float(latest.get('70成本-低')),
-                cost_70_high=safe_float(latest.get('70成本-高')),
-                concentration_70=safe_float(latest.get('70集中度')),
-            )
-            
-            logger.info(f"[筹码分布] {stock_code} 日期={chip.date}: 获利比例={chip.profit_ratio:.1%}, "
-                       f"平均成本={chip.avg_cost}, 90%集中度={chip.concentration_90:.2%}, "
-                       f"70%集中度={chip.concentration_70:.2%}")
-            return chip
-            
-        except Exception as e:
-            logger.error(f"[API错误] 获取 {stock_code} 筹码分布失败: {e}")
-            return None
+        last_error = None
+        for attempt in range(1, _AKSHARE_CHIP_CALL_ATTEMPTS + 1):
+            try:
+                # 防封禁策略
+                self._set_random_user_agent()
+                self._enforce_rate_limit()
+
+                logger.info(
+                    "[API调用] ak.stock_cyq_em(symbol=%s) 获取筹码分布 (attempt=%s/%s)...",
+                    stock_code,
+                    attempt,
+                    _AKSHARE_CHIP_CALL_ATTEMPTS,
+                )
+                api_start = time.time()
+
+                df = _akshare_call_with_timeout(
+                    ak.stock_cyq_em,
+                    symbol=stock_code,
+                    timeout=_AKSHARE_CHIP_CALL_TIMEOUT,
+                    call_name=f"stock_cyq_em_{stock_code}",
+                )
+
+                api_elapsed = time.time() - api_start
+
+                if df.empty:
+                    logger.warning(f"[API返回] ak.stock_cyq_em 返回空数据, 耗时 {api_elapsed:.2f}s")
+                    return None
+
+                logger.info(f"[API返回] ak.stock_cyq_em 成功: 返回 {len(df)} 天数据, 耗时 {api_elapsed:.2f}s")
+                logger.debug(f"[API返回] 筹码数据列名: {list(df.columns)}")
+
+                # 取最新一天的数据
+                latest = df.iloc[-1]
+
+                # 使用 realtime_types.py 中的统一转换函数
+                chip = ChipDistribution(
+                    code=stock_code,
+                    date=str(latest.get('日期', '')),
+                    profit_ratio=safe_float(latest.get('获利比例')),
+                    avg_cost=safe_float(latest.get('平均成本')),
+                    cost_90_low=safe_float(latest.get('90成本-低')),
+                    cost_90_high=safe_float(latest.get('90成本-高')),
+                    concentration_90=safe_float(latest.get('90集中度')),
+                    cost_70_low=safe_float(latest.get('70成本-低')),
+                    cost_70_high=safe_float(latest.get('70成本-高')),
+                    concentration_70=safe_float(latest.get('70集中度')),
+                )
+
+                logger.info(f"[筹码分布] {stock_code} 日期={chip.date}: 获利比例={chip.profit_ratio:.1%}, "
+                           f"平均成本={chip.avg_cost}, 90%集中度={chip.concentration_90:.2%}, "
+                           f"70%集中度={chip.concentration_70:.2%}")
+                return chip
+
+            except Exception as e:
+                last_error = e
+                if attempt < _AKSHARE_CHIP_CALL_ATTEMPTS:
+                    logger.warning(
+                        "[API错误] 获取 %s 筹码分布失败，将重试: %s",
+                        stock_code,
+                        e,
+                    )
+                    time.sleep(min(2 * attempt, 5))
+                    continue
+                logger.error(f"[API错误] 获取 {stock_code} 筹码分布失败: {e}")
+
+        if last_error is not None:
+            logger.debug("[筹码分布] %s 最后失败原因: %s", stock_code, last_error)
+        return None
     
     def get_enhanced_data(self, stock_code: str, days: int = 60) -> Dict[str, Any]:
         """

--- a/src/core/pipeline.py
+++ b/src/core/pipeline.py
@@ -1210,6 +1210,25 @@ class StockAnalysisPipeline:
                 )
                 logger.info(f"[{code}] Agent mode: local intelligence evidence injected into news_context")
 
+            prefetched_news_response = None
+            agent_news_context, agent_news_count, prefetched_news_response = self._fetch_agent_news_context(
+                code=code,
+                stock_name=stock_name,
+            )
+            if agent_news_context:
+                existing = initial_context.get("news_context")
+                initial_context["news_context"] = (
+                    f"{existing}\n\n{agent_news_context}"
+                    if existing
+                    else agent_news_context
+                )
+                initial_context["news_result_count"] = agent_news_count
+                logger.info(
+                    "[%s] Agent mode: news context prefetched for AnalysisContextPack (%s items)",
+                    code,
+                    agent_news_count,
+                )
+
             # Issue #1066: ensure deep history is in DB before agent tools run
             self._ensure_agent_history(code)
 
@@ -1347,26 +1366,44 @@ class StockAnalysisPipeline:
 
             resolved_stock_name = result.name if result and result.name else stock_name
 
-            # 保存新闻情报到数据库（Agent 工具结果仅用于 LLM 上下文，未持久化，Fixes #396）
-            # 使用 search_stock_news（与 Agent 工具调用逻辑一致），仅 1 次 API 调用，无额外延迟
-            if self.search_service is not None and self.search_service.is_available:
+            # 保存新闻情报到数据库。优先复用 Agent 前置检索结果，避免二次 API 调用；
+            # 如果前置检索失败，则保留旧的后置保存兜底路径。
+            news_response_to_save = prefetched_news_response
+            if (
+                news_response_to_save is None
+                and self.search_service is not None
+                and self.search_service.is_available
+            ):
                 try:
-                    news_response = self.search_service.search_stock_news(
+                    news_response_to_save = self.search_service.search_stock_news(
                         stock_code=code,
                         stock_name=resolved_stock_name,
                         max_results=5
                     )
-                    if news_response.success and news_response.results:
-                        query_context = self._build_query_context(query_id=query_id)
-                        self.db.save_news_intel(
-                            code=code,
-                            name=resolved_stock_name,
-                            dimension="latest_news",
-                            query=news_response.query,
-                            response=news_response,
-                            query_context=query_context
-                        )
-                        logger.info(f"[{code}] Agent 模式: 新闻情报已保存 {len(news_response.results)} 条")
+                except Exception as e:
+                    logger.warning(f"[{code}] Agent 模式补充检索新闻情报失败: {e}")
+                    news_response_to_save = None
+
+            if (
+                news_response_to_save is not None
+                and getattr(news_response_to_save, "success", False)
+                and getattr(news_response_to_save, "results", None)
+            ):
+                try:
+                    query_context = self._build_query_context(query_id=query_id)
+                    self.db.save_news_intel(
+                        code=code,
+                        name=resolved_stock_name,
+                        dimension="latest_news",
+                        query=getattr(news_response_to_save, "query", None),
+                        response=news_response_to_save,
+                        query_context=query_context
+                    )
+                    logger.info(
+                        "[%s] Agent 模式: 新闻情报已保存 %s 条",
+                        code,
+                        len(getattr(news_response_to_save, "results", []) or []),
+                    )
                 except Exception as e:
                     logger.warning(f"[{code}] Agent 模式保存新闻情报失败: {e}")
 
@@ -1379,6 +1416,7 @@ class StockAnalysisPipeline:
                             "stock_name": resolved_stock_name,
                         },
                         news_content=initial_context.get("news_context"),
+                        news_result_count=initial_context.get("news_result_count"),
                         realtime_quote=realtime_quote,
                         chip_data=chip_data,
                         analysis_context_pack_overview=analysis_context_pack_overview,
@@ -1390,7 +1428,7 @@ class StockAnalysisPipeline:
                         result=result,
                         query_id=query_id,
                         report_type=report_type.value,
-                        news_content=None,
+                        news_content=initial_context.get("news_context"),
                         context_snapshot=agent_context_snapshot,
                         save_snapshot=self.save_context_snapshot,
                     )
@@ -2448,6 +2486,58 @@ class StockAnalysisPipeline:
             logger.debug("读取本地资讯证据失败（fail-open）: %s", exc)
             return None
 
+    def _fetch_agent_news_context(
+        self,
+        *,
+        code: str,
+        stock_name: str,
+        max_results: int = 5,
+    ) -> Tuple[Optional[str], Optional[int], Optional[Any]]:
+        """Fetch stock news before Agent execution so it enters the LLM input pack."""
+        if self.search_service is None or not getattr(self.search_service, "is_available", False):
+            return None, None, None
+
+        try:
+            response = self.search_service.search_stock_news(
+                stock_code=code,
+                stock_name=stock_name,
+                max_results=max_results,
+            )
+        except Exception as exc:
+            logger.warning("[%s] Agent mode news prefetch failed: %s", code, exc)
+            return None, None, None
+
+        results = getattr(response, "results", None) or []
+        if not getattr(response, "success", False) or not results:
+            return None, 0, response
+
+        try:
+            context = self.search_service.format_intel_report(
+                {"latest_news": response},
+                stock_name,
+            )
+        except Exception:
+            context = None
+
+        if not isinstance(context, str) or not context.strip():
+            lines = [f"【{stock_name} 情报搜索结果】", "\n📰 最新消息:"]
+            for idx, item in enumerate(results[:max_results], 1):
+                if isinstance(item, dict):
+                    title = str(item.get("title") or "未命名资讯").strip()
+                    snippet = str(item.get("snippet") or "").strip()
+                    published_date = item.get("published_date")
+                else:
+                    title = str(getattr(item, "title", None) or "未命名资讯").strip()
+                    snippet = str(getattr(item, "snippet", None) or "").strip()
+                    published_date = getattr(item, "published_date", None)
+                date_text = f" [{published_date}]" if published_date else ""
+                lines.append(f"  {idx}. {title}{date_text}")
+                if snippet:
+                    lines.append(f"     {snippet[:150]}...")
+            context = "\n".join(lines)
+
+        return context, len(results), response
+
     def _build_legacy_analysis_artifacts(
         self,
         *,
@@ -2528,7 +2618,11 @@ class StockAnalysisPipeline:
             chip_data=initial_context.get("chip_distribution"),
             fundamental_context=fundamental_context,
             news_context=initial_context.get("news_context"),
-            news_result_count=None,
+            news_result_count=(
+                initial_context.get("news_result_count")
+                if isinstance(initial_context.get("news_result_count"), int)
+                else None
+            ),
             metadata={
                 "query_id": query_id,
                 "trigger_source": self.query_source,

--- a/tests/test_agent_pipeline.py
+++ b/tests/test_agent_pipeline.py
@@ -1634,8 +1634,8 @@ class TestPipelineRouting(unittest.TestCase):
 class TestAnalyzeWithAgentStockName(unittest.TestCase):
     """Test stock-name handling in _analyze_with_agent."""
 
-    def test_analyze_with_agent_uses_resolved_name_for_news_persistence(self):
-        """Should use resolved stock name from dashboard for search and DB persistence."""
+    def test_analyze_with_agent_prefetches_news_for_context_pack_and_persists_resolved_name(self):
+        """Agent news should enter the LLM input pack and still persist with resolved stock name."""
         with patch('src.core.pipeline.get_config') as mock_config, \
              patch('src.core.pipeline.get_db'), \
              patch('src.core.pipeline.DataFetcherManager'), \
@@ -1685,12 +1685,21 @@ class TestAnalyzeWithAgentStockName(unittest.TestCase):
             mock_build_executor.return_value = mock_executor
             mock_agent_run.return_value = agent_result
 
-            news_response = MagicMock()
-            news_response.success = True
-            news_response.results = [{"title": "test"}]
-            news_response.query = "test query"
+            news_response = SimpleNamespace(
+                success=True,
+                results=[
+                    SimpleNamespace(
+                        title="科创芯片ETF 调仓公告",
+                        snippet="半导体主题 ETF 发布最新调仓信息",
+                        published_date="2026-06-25",
+                    )
+                ],
+                query="test query",
+                provider="UnitTestSearch",
+            )
             pipeline.search_service.is_available = True
             pipeline.search_service.search_stock_news.return_value = news_response
+            pipeline.search_service.format_intel_report.return_value = "formatted latest news"
 
             result = pipeline._analyze_with_agent(
                 code="588200",
@@ -1705,12 +1714,21 @@ class TestAnalyzeWithAgentStockName(unittest.TestCase):
             self.assertEqual(result.name, "科创芯片ETF")
             pipeline.search_service.search_stock_news.assert_called_once_with(
                 stock_code="588200",
-                stock_name="科创芯片ETF",
+                stock_name="股票588200",
                 max_results=5
             )
+            agent_context = mock_executor.run.call_args.kwargs["context"]
+            self.assertIn("formatted latest news", agent_context["news_context"])
+            self.assertEqual(agent_context["news_result_count"], 1)
             pipeline.db.save_news_intel.assert_called_once()
             saved_kwargs = pipeline.db.save_news_intel.call_args.kwargs
             self.assertEqual(saved_kwargs["name"], "科创芯片ETF")
+            history_kwargs = pipeline.db.save_analysis_history.call_args.kwargs
+            self.assertIn("formatted latest news", history_kwargs["news_content"])
+            overview = history_kwargs["context_snapshot"]["analysis_context_pack_overview"]
+            news_block = next(block for block in overview["blocks"] if block["key"] == "news")
+            self.assertEqual(news_block["status"], "available")
+            self.assertEqual(overview["metadata"]["news_result_count"], 1)
 
     def test_analyze_with_agent_keeps_dashboard_top_level_fields_after_stability(self):
         """Decision stability downgrade in agent flow should sync dashboard and top-level decision fields."""


### PR DESCRIPTION
## Summary

Fixes Agent-mode analysis input transparency so news collected for a stock actually enters the current LLM input context and persisted history snapshot.

## Root Cause

In Agent mode, `AnalysisContextPack` was built before the stock news lookup used for persistence. The pipeline later saved news rows, but `initial_context["news_context"]`, `analysis_history.news_content`, and the public context-pack overview still treated news as missing.

The chip block could also remain missing after transient AkShare/Eastmoney disconnects because `stock_cyq_em` had no bounded retry around the call.

## Changes

- Prefetch stock news before Agent execution and before `AnalysisContextPack` construction.
- Reuse the prefetched news response for `news_intel` persistence to avoid a second API call.
- Persist Agent `news_content` and `news_result_count` into analysis history snapshots.
- Add a regression test proving Agent news becomes an available context-pack block.
- Add bounded timeout/retry handling for AkShare chip distribution calls.

## Validation

- `docker run --rm -v ...:/app -w /app daily-stock-analysis:auth-preflight-fix python -m unittest tests.test_agent_pipeline.TestAnalyzeWithAgentStockName.test_analyze_with_agent_prefetches_news_for_context_pack_and_persists_resolved_name tests.test_pipeline_market_phase_context.PipelineMarketPhaseContextTestCase.test_agent_analysis_artifacts_helper_maps_initial_context_zero_fetch`
- `docker run --rm -v ...:/app -w /app daily-stock-analysis:auth-preflight-fix python -m py_compile src/core/pipeline.py data_provider/akshare_fetcher.py`
- `git diff --check`