### PR TITLE
fix: web端启动后登录127.0.0.1:8000黑屏 (#1804)

### DIFF
--- a/api/app.py
+++ b/api/app.py
@@ -16,6 +16,7 @@ FastAPI 应用工厂模块
 """
 
 import asyncio
+import html
 import json
 import logging
 import mimetypes
@@ -35,13 +36,14 @@ from starlette.concurrency import run_in_threadpool
 
 logger = logging.getLogger(__name__)
 
-# Match src="/assets/foo.js" / href="/assets/foo.css" produced by the
-# vite build. Used by the startup self-check to surface packaging
+# Match Vite asset references in HTML plus lazy-loaded chunks/preloads in
+# emitted JS/CSS. Used by the startup self-check to surface packaging
 # mismatches early (see GitHub #1064 / #1065 / #1050).
 _INDEX_ASSET_REF_PATTERN = re.compile(
-    r"""(?:src|href)\s*=\s*["'](/assets/[^"']+)["']""",
+    r"""["']((?:/assets/|assets/|\./)[^"']+\.(?:js|css|mjs|json|wasm|svg|png|jpg|jpeg|gif|webp|avif|ico|woff2?|ttf)(?:[?#][^"']*)?)["']""",
     re.IGNORECASE,
 )
+_SCANNABLE_FRONTEND_ASSET_SUFFIXES = {".html", ".js", ".mjs", ".css"}
 _SAFE_MISSING_ASSET_MEDIA_TYPES = frozenset({"text/css", "text/javascript"})
 _FRONTEND_INDEX_NO_CACHE_HEADERS = {
     "Cache-Control": "no-store, no-cache, must-revalidate, max-age=0",
@@ -57,11 +59,74 @@ def _frontend_index_response(static_dir: Path) -> FileResponse:
     )
 
 
+def _frontend_bundle_error_response(missing_assets: List[str]) -> HTMLResponse:
+    missing_items = "\n".join(
+        f"<li><code>{html.escape(asset)}</code></li>"
+        for asset in missing_assets
+    )
+    content = f"""<!DOCTYPE html>
+<html lang="zh-CN"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
+<title>DSA - Frontend Bundle Error</title>
+<style>
+  *{{margin:0;padding:0;box-sizing:border-box}}
+  body{{min-height:100vh;display:flex;align-items:center;justify-content:center;
+       background:#0a0e17;color:#e2e8f0;font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,monospace}}
+  .card{{max-width:680px;padding:2.5rem;border:1px solid #1e293b;border-radius:12px;background:#111827}}
+  h1{{font-size:1.25rem;color:#f59e0b;margin-bottom:.75rem}}
+  p{{font-size:.9rem;line-height:1.7;color:#94a3b8;margin-bottom:.5rem}}
+  code{{background:#1e293b;padding:2px 8px;border-radius:4px;font-size:.85rem;color:#67e8f9}}
+  ul{{margin:.75rem 0 1rem 1.25rem;color:#cbd5e1;font-size:.85rem;line-height:1.7}}
+  .hint{{margin-top:1.25rem;padding:.75rem 1rem;border-left:3px solid #38bdf8;background:#0f172a;border-radius:0 6px 6px 0}}
+  .hint p{{color:#bae6fd;margin:0}}
+  a{{color:#38bdf8;text-decoration:none}}
+  a:hover{{text-decoration:underline}}
+</style></head><body><div class="card">
+<h1>Frontend bundle is incomplete</h1>
+<p>API is running, but the Web UI bundle references static files that are missing on disk. Serving the broken bundle would show a blank page.</p>
+<p>Missing asset(s):</p>
+<ul>{missing_items}</ul>
+<p>Rebuild the frontend and restart WebUI:</p>
+<p><code>cd apps/dsa-web &amp;&amp; npm install &amp;&amp; npm run build</code></p>
+<div class="hint"><p>If you only need the API, visit <a href="/docs">/docs</a> for the interactive API documentation.</p></div>
+</div></body></html>"""
+    return HTMLResponse(
+        content=content,
+        status_code=503,
+        headers=_FRONTEND_INDEX_NO_CACHE_HEADERS,
+    )
+
+
+def _strip_frontend_asset_suffix(ref: str) -> str:
+    return ref.split("?", 1)[0].split("#", 1)[0]
+
+
+def _resolve_frontend_asset_ref(
+    static_dir: Path,
+    source_path: Path,
+    ref: str,
+) -> Optional[Path]:
+    clean_ref = _strip_frontend_asset_suffix(ref)
+    if clean_ref.startswith("/assets/"):
+        return static_dir / clean_ref.lstrip("/")
+    if clean_ref.startswith("assets/"):
+        return static_dir / clean_ref
+    if clean_ref.startswith("./"):
+        return source_path.parent / clean_ref[2:]
+    return None
+
+
+def _display_frontend_asset_ref(static_dir: Path, candidate: Path) -> str:
+    try:
+        return "/" + candidate.relative_to(static_dir).as_posix()
+    except ValueError:
+        return candidate.as_posix()
+
+
 def _check_frontend_assets_consistency(static_dir: Path) -> List[str]:
     """
-    Verify that ``index.html`` only references assets that actually exist
-    under ``static_dir``. Returns the list of missing references; an empty
-    list means the bundle is consistent.
+    Verify that ``index.html`` and the referenced bundle only point to assets
+    that actually exist under ``static_dir``. Returns missing references; an
+    empty list means the bundle is consistent.
 
     Logs an actionable error when a mismatch is detected so the root cause
     is visible in ``logs/desktop.log`` instead of surfacing as a silent
@@ -70,26 +135,51 @@ def _check_frontend_assets_consistency(static_dir: Path) -> List[str]:
     index_html = static_dir / "index.html"
     if not index_html.is_file():
         return []
-    try:
-        html = index_html.read_text(encoding="utf-8", errors="replace")
-    except OSError as exc:
-        logger.warning("Failed to read %s for asset check: %s", index_html, exc)
-        return []
 
     missing: List[str] = []
-    for match in _INDEX_ASSET_REF_PATTERN.finditer(html):
-        ref = match.group(1)
-        candidate = static_dir / ref.lstrip("/")
-        if not candidate.is_file() and ref not in missing:
-            missing.append(ref)
+    scan_queue: List[Path] = [index_html]
+    scanned: set[Path] = set()
+
+    while scan_queue:
+        source_path = scan_queue.pop(0)
+        try:
+            resolved_source = source_path.resolve()
+        except OSError:
+            resolved_source = source_path
+        if resolved_source in scanned:
+            continue
+        scanned.add(resolved_source)
+
+        try:
+            content = source_path.read_text(encoding="utf-8", errors="replace")
+        except OSError as exc:
+            logger.warning("Failed to read %s for asset check: %s", source_path, exc)
+            continue
+
+        for match in _INDEX_ASSET_REF_PATTERN.finditer(content):
+            candidate = _resolve_frontend_asset_ref(
+                static_dir,
+                source_path,
+                match.group(1),
+            )
+            if candidate is None:
+                continue
+            display_ref = _display_frontend_asset_ref(static_dir, candidate)
+            if not candidate.is_file():
+                if display_ref not in missing:
+                    missing.append(display_ref)
+                continue
+            if candidate.suffix.lower() in _SCANNABLE_FRONTEND_ASSET_SUFFIXES:
+                scan_queue.append(candidate)
 
     if missing:
         logger.error(
-            "Frontend bundle is inconsistent: index.html references %d asset(s) "
+            "Frontend bundle is inconsistent: bundle references %d asset(s) "
             "that are not present on disk under %s. This will surface as a "
-            "blank page in the desktop app (see GitHub #1064 / #1065). "
-            "Missing: %s. Re-run the frontend build and make sure the packaging "
-            "step copies the freshly generated static/ directory.",
+            "blank page in the WebUI when the missing entry or lazy-loaded "
+            "chunk is requested (see GitHub #1064 / #1065). Missing: %s. "
+            "Re-run the frontend build and make sure the packaging step copies "
+            "the freshly generated static/ directory.",
             len(missing),
             static_dir,
             ", ".join(missing),
@@ -351,16 +441,19 @@ def create_app(static_dir: Optional[Path] = None) -> FastAPI:
     # ============================================================
     
     has_frontend = static_dir.exists() and (static_dir / "index.html").exists()
+    missing_frontend_assets: List[str] = []
     
     if has_frontend:
         # Surface bundle inconsistencies as soon as the app starts so that
         # blank-page reports (#1064 / #1065 / #1050) can be diagnosed from
-        # logs/desktop.log instead of via browser devtools.
-        _check_frontend_assets_consistency(static_dir)
+        # logs/desktop.log and the browser instead of via devtools only.
+        missing_frontend_assets = _check_frontend_assets_consistency(static_dir)
 
         @app.get("/", include_in_schema=False)
         async def root():
             """根路由 - 返回前端页面"""
+            if missing_frontend_assets:
+                return _frontend_bundle_error_response(missing_frontend_assets)
             return _frontend_index_response(static_dir)
     else:
         _FRONTEND_NOT_BUILT_HTML = """<!DOCTYPE html>
@@ -513,12 +606,16 @@ def create_app(static_dir: Optional[Path] = None) -> FastAPI:
             file_path = _resolve_asset_path(static_dir, full_path) if full_path else None
             if file_path is not None and file_path.is_file():
                 if file_path == (static_dir / "index.html").resolve():
+                    if missing_frontend_assets:
+                        return _frontend_bundle_error_response(missing_frontend_assets)
                     return _frontend_index_response(static_dir)
                 # Issue #520: Explicitly resolve MIME type to avoid
                 # browsers rejecting JS modules served as text/plain.
                 content_type, _ = mimetypes.guess_type(str(file_path))
                 return FileResponse(file_path, media_type=content_type)
 
+            if missing_frontend_assets:
+                return _frontend_bundle_error_response(missing_frontend_assets)
             return _frontend_index_response(static_dir)
     
     return app

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - [修复] 将 Docker 可安装的 Longbridge SDK 版本固定为 0.2.75，避免 `longbridge>=0.2.77` 从包索引消失后导致 docker-build 失败。
 
 - [改进] Web 设置页新增首次启动配置检查卡，串联基础配置状态、自选股入口、模型配置入口和一次简短试跑。
+- [修复] WebUI 静态构建产物缺少入口 JS/CSS 或登录后懒加载 chunk 时不再返回会导致黑屏的 `index.html`，改为显示可见诊断页并提示重新构建前端。
 - [改进] 通知报告的分析结果摘要不再展开 AI 决策信号明细，完整信号保留在个股详情和单股报告中。
 - [新功能] #1595 P1.5 新增 Provider Cache Capability Registry，按 provider、api surface、gateway 和 verification status 建模 prompt cache 能力，未知 OpenAI-compatible route 默认 telemetry only。
 - [改进] #1595 P1 新增 prompt cache telemetry / analysis-path hints / diagnostics 最小配置，默认不改变 provider 请求 shape，并复用 LLM usage HMAC secret 做 domain-separated cache hint 派生。

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 - [改进] Web 设置页新增首次启动配置检查卡，串联基础配置状态、自选股入口、模型配置入口和一次简短试跑。
 - [修复] WebUI 静态构建产物缺少入口 JS/CSS 或登录后懒加载 chunk 时不再返回会导致黑屏的 `index.html`，改为显示可见诊断页并提示重新构建前端。
+- [文档] #1804 Web 端登录后黑屏修复未改变 LLM/外部模型路由契约（provider、model、base URL、headers、fallback 逻辑均保持原状）；如需回退，撤销本次提交即可。
 - [改进] 通知报告的分析结果摘要不再展开 AI 决策信号明细，完整信号保留在个股详情和单股报告中。
 - [新功能] #1595 P1.5 新增 Provider Cache Capability Registry，按 provider、api surface、gateway 和 verification status 建模 prompt cache 能力，未知 OpenAI-compatible route 默认 telemetry only。
 - [改进] #1595 P1 新增 prompt cache telemetry / analysis-path hints / diagnostics 最小配置，默认不改变 provider 请求 shape，并复用 LLM usage HMAC secret 做 domain-separated cache hint 派生。

--- a/scripts/check_static_assets.py
+++ b/scripts/check_static_assets.py
@@ -3,13 +3,13 @@
 """
 Static frontend sanity check for the desktop / server packaging pipeline.
 
-Validates that ``index.html`` only references ``/assets/*.js`` and
-``/assets/*.css`` files that actually exist on disk. A mismatch here is the
-most common cause of the "Preparing backend..." / blank-page bug reported in
+Validates that ``index.html`` and the referenced frontend bundle only point
+to asset files that actually exist on disk. A mismatch here is the most
+common cause of the "Preparing backend..." / blank-page bug reported in
 GitHub issues #1064, #1065, #1050: vite re-builds with a new content hash,
 but the packaging step picks up a stale ``static/`` directory or copies the
 files out of sync, so the browser receives a 404 (often as JSON) for the
-main bundle and refuses to execute it.
+main bundle or a lazy-loaded route chunk and refuses to execute it.
 
 Usage:
     python scripts/check_static_assets.py [<static_dir>]
@@ -22,24 +22,49 @@ from __future__ import annotations
 import re
 import sys
 from pathlib import Path
-from typing import List, Tuple
+from typing import List, Optional, Tuple
 
-# Match src="/assets/foo.js" or href="/assets/foo.css", with single or double
-# quotes. Vite emits absolute paths by default (``base: '/'``).
+# Match Vite asset references in HTML plus lazy-loaded chunks/preloads in
+# emitted JS/CSS. Vite usually emits absolute /assets/* references from
+# index.html and relative ./chunk.js or assets/chunk.css references inside
+# the JS bundle.
 _ASSET_PATTERN = re.compile(
-    r"""(?:src|href)\s*=\s*["'](/assets/[^"']+)["']""",
+    r"""["']((?:/assets/|assets/|\./)[^"']+\.(?:js|css|mjs|json|wasm|svg|png|jpg|jpeg|gif|webp|avif|ico|woff2?|ttf)(?:[?#][^"']*)?)["']""",
     re.IGNORECASE,
 )
+_SCANNABLE_ASSET_SUFFIXES = {".html", ".js", ".mjs", ".css"}
 
 
 def _parse_referenced_assets(index_html: str) -> List[str]:
-    """Return the unique list of ``/assets/...`` paths referenced by ``index.html``."""
+    """Return the unique list of asset paths referenced by bundle text."""
     seen: List[str] = []
     for match in _ASSET_PATTERN.finditer(index_html):
         ref = match.group(1)
         if ref not in seen:
             seen.append(ref)
     return seen
+
+
+def _strip_asset_suffix(ref: str) -> str:
+    return ref.split("?", 1)[0].split("#", 1)[0]
+
+
+def _resolve_asset_ref(static_dir: Path, source_path: Path, ref: str) -> Optional[Path]:
+    clean_ref = _strip_asset_suffix(ref)
+    if clean_ref.startswith("/assets/"):
+        return static_dir / clean_ref.lstrip("/")
+    if clean_ref.startswith("assets/"):
+        return static_dir / clean_ref
+    if clean_ref.startswith("./"):
+        return source_path.parent / clean_ref[2:]
+    return None
+
+
+def _display_asset_ref(static_dir: Path, candidate: Path) -> str:
+    try:
+        return "/" + candidate.relative_to(static_dir).as_posix()
+    except ValueError:
+        return candidate.as_posix()
 
 
 def check_static_dir(static_dir: Path) -> Tuple[List[str], List[str]]:
@@ -54,16 +79,39 @@ def check_static_dir(static_dir: Path) -> Tuple[List[str], List[str]]:
     if not index_html_path.is_file():
         raise FileNotFoundError(f"index.html not found under {static_dir}")
 
-    html = index_html_path.read_text(encoding="utf-8", errors="replace")
-    referenced = _parse_referenced_assets(html)
-
+    referenced: List[str] = []
     missing: List[str] = []
-    for ref in referenced:
-        # ref looks like "/assets/index-xxx.js"; strip the leading slash so
-        # it resolves relative to ``static_dir``.
-        candidate = static_dir / ref.lstrip("/")
-        if not candidate.is_file():
-            missing.append(ref)
+    scan_queue: List[Path] = [index_html_path]
+    scanned: set[Path] = set()
+
+    while scan_queue:
+        source_path = scan_queue.pop(0)
+        try:
+            resolved_source = source_path.resolve()
+        except OSError:
+            resolved_source = source_path
+        if resolved_source in scanned:
+            continue
+        scanned.add(resolved_source)
+
+        try:
+            content = source_path.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            continue
+
+        for ref in _parse_referenced_assets(content):
+            candidate = _resolve_asset_ref(static_dir, source_path, ref)
+            if candidate is None:
+                continue
+            display_ref = _display_asset_ref(static_dir, candidate)
+            if display_ref not in referenced:
+                referenced.append(display_ref)
+            if not candidate.is_file():
+                if display_ref not in missing:
+                    missing.append(display_ref)
+                continue
+            if candidate.suffix.lower() in _SCANNABLE_ASSET_SUFFIXES:
+                scan_queue.append(candidate)
     return referenced, missing
 
 
@@ -96,17 +144,17 @@ def main(argv: List[str]) -> int:
 
     if missing:
         print(
-            "[check_static_assets] ERROR: index.html references assets that "
+            "[check_static_assets] ERROR: frontend bundle references assets that "
             "are not present on disk:",
             file=sys.stderr,
         )
         for ref in missing:
             print(f"  - {ref}", file=sys.stderr)
         print(
-            "[check_static_assets] This produces a blank page on first load "
-            "(see GitHub #1064 / #1065). Re-run the frontend build and make "
-            "sure the packaging step copies the freshly generated static/ "
-            "directory.",
+            "[check_static_assets] This produces a blank page when the missing "
+            "entry or lazy-loaded chunk is requested (see GitHub #1064 / #1065). "
+            "Re-run the frontend build and make sure the packaging step copies "
+            "the freshly generated static/ directory.",
             file=sys.stderr,
         )
         return 1

--- a/tests/test_static_assets_consistency.py
+++ b/tests/test_static_assets_consistency.py
@@ -6,7 +6,7 @@ Both code paths target the blank-page / "Preparing backend..." regression
 captured in GitHub issues #1064, #1065 and #1050: vite produces a fresh
 ``index.html`` that references ``/assets/index-<hash>.js``, but the
 packaging step copies a stale ``static/assets`` directory, so the bundle
-referenced by ``index.html`` does not exist on disk.
+referenced by ``index.html`` or a lazy-loaded route chunk does not exist on disk.
 """
 
 from __future__ import annotations
@@ -73,6 +73,24 @@ def test_check_static_dir_detects_stale_bundle(tmp_path: Path) -> None:
 
     assert "/assets/index-NEW.js" in referenced
     assert sorted(missing) == ["/assets/index-NEW.css", "/assets/index-NEW.js"]
+
+
+def test_check_static_dir_detects_missing_lazy_route_chunk(tmp_path: Path) -> None:
+    """Entry assets exist, but a post-login lazy route chunk is stale/missing."""
+    static_dir = tmp_path / "static"
+    assets_dir = static_dir / "assets"
+    assets_dir.mkdir(parents=True)
+    (assets_dir / "index-abc.js").write_text(
+        'const loadHome = () => import("./HomePage-MISSING.js");',
+        encoding="utf-8",
+    )
+    (assets_dir / "index-abc.css").write_text("/* css */", encoding="utf-8")
+    _write_index(static_dir, _vite_index("index-abc.js", "index-abc.css"))
+
+    referenced, missing = check_static_assets.check_static_dir(static_dir)
+
+    assert "/assets/HomePage-MISSING.js" in referenced
+    assert missing == ["/assets/HomePage-MISSING.js"]
 
 
 def test_check_static_dir_raises_when_index_missing(tmp_path: Path) -> None:
@@ -148,6 +166,58 @@ def test_backend_startup_check_silent_when_bundle_consistent(
         "Frontend bundle is inconsistent" in record.getMessage()
         for record in caplog.records
     )
+
+
+def test_inconsistent_frontend_bundle_returns_visible_diagnostic_page(
+    tmp_path: Path,
+) -> None:
+    from api.app import create_app
+
+    static_dir = tmp_path / "static"
+    (static_dir / "assets").mkdir(parents=True)
+    _write_index(static_dir, _vite_index("index-MISSING.js", "index-MISSING.css"))
+
+    client = TestClient(create_app(static_dir=static_dir))
+
+    responses = [
+        client.get("/"),
+        client.get("/login"),
+        client.get("/index.html"),
+    ]
+
+    for response in responses:
+        assert response.status_code == 503
+        assert response.headers["content-type"].startswith("text/html")
+        assert response.headers["cache-control"] == (
+            "no-store, no-cache, must-revalidate, max-age=0"
+        )
+        assert "Frontend bundle is incomplete" in response.text
+        assert "blank page" in response.text
+        assert "/assets/index-MISSING.js" in response.text
+        assert "npm run build" in response.text
+
+
+def test_missing_lazy_frontend_chunk_returns_visible_diagnostic_page(
+    tmp_path: Path,
+) -> None:
+    from api.app import create_app
+
+    static_dir = tmp_path / "static"
+    assets_dir = static_dir / "assets"
+    assets_dir.mkdir(parents=True)
+    (assets_dir / "index-abc.js").write_text(
+        'const loadHome = () => import("./HomePage-MISSING.js");',
+        encoding="utf-8",
+    )
+    (assets_dir / "index-abc.css").write_text("/* css */", encoding="utf-8")
+    _write_index(static_dir, _vite_index("index-abc.js", "index-abc.css"))
+
+    client = TestClient(create_app(static_dir=static_dir))
+    response = client.get("/")
+
+    assert response.status_code == 503
+    assert "Frontend bundle is incomplete" in response.text
+    assert "/assets/HomePage-MISSING.js" in response.text
 
 
 def test_missing_asset_returns_safe_404_content_types(tmp_path: Path) -> None:


### PR DESCRIPTION
## PR Type
- [x] fix
- [ ] feat
- [ ] refactor
- [ ] docs
- [ ] chore
- [ ] test

## Background And Problem
- 当前问题：先复现并定位 127.0.0.1:8000 登录后黑屏原因，再做最小修复或补充明确排障说明。
- 影响范围：本次改动涉及 4 个文件，Diff 为 `+262 / -46`。
- 触发来源：Issue 自动执行（Issue #1804）。

## Scope Of Change
- `api/app.py`
- `docs/CHANGELOG.md`
- `scripts/check_static_assets.py`
- `tests/test_static_assets_consistency.py`

## Documentation And Changelog
- 已同步更新文档/变更记录：`docs/CHANGELOG.md`。
- 当前补丁尚未包含 `README.md` 或专题文档；如用户可见行为发生变化，请补充文档落点。

## Issue Link
Closes #1804

## Verification Commands And Results
```bash
./scripts/ci_gate.sh flake8
./scripts/ci_gate.sh offline-tests
```

关键输出/结论 / Key output & conclusion:
- lint:PASS, test:TIMEOUT

## Compatibility And Risk
- **Medium**：涉及 `api/app.py`, `docs/CHANGELOG.md`, `scripts/check_static_assets.py`, `tests/test_static_assets_consistency.py`，建议按文件范围复核。
- 前提假设：
  - 问题可能出现在 Web 构建产物加载、前端路由、登录状态初始化、API 基地址、后端静态资源托管或本地启动方式之一。
  - 如果用户只是把后端 API 地址当作 Web 前端入口，或未构建/未启动前端，则更小修复路径应是补充启动说明或排障文档，而不是改应用代码。
  - 当前信息不足以判断是否影响桌面端，但若改动登录状态、路由或 API 客户端，需要同步评估 apps/dsa-desktop。

## Rollback Plan
- `git revert <merge-commit>` 回滚本 PR 提交，重点确认 `api/app.py`, `docs/CHANGELOG.md`, `scripts/check_static_assets.py`, `tests/test_static_assets_consistency.py` 恢复正常。

## Acceptance Criteria
- 本地按仓库推荐方式启动后，访问 WebUI 不再出现登录后黑屏。
- 若是代码缺陷，修复点保持在登录页、路由、API 客户端或静态资源托管的最小范围内。
- 若是使用方式或配置问题，文档明确说明正确访问地址、启动命令和常见黑屏排查步骤。
- 浏览器控制台不再出现导致页面无法渲染的未捕获异常或资源加载失败。

## Checklist
- [x] 本 PR 有明确动机和业务价值 / This PR has a clear motivation and value
- [x] 已提供可复现的验证命令与结果 / Reproducible verification commands and results are included
- [x] 已评估兼容性与风险 / Compatibility and risk have been assessed
- [x] 已提供回滚方案 / A rollback plan is provided
- [ ] 文档与 `docs/CHANGELOG.md` 同步仍需确认；如涉及用户可见变更，请在合并前补充原因与文档落点 / Documentation and `docs/CHANGELOG.md` sync still needs confirmation before merge when user-visible behavior changes