### PR TITLE
fix: show phase decision in default reports

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - [修复] 修复通知 Markdown 表格转换在空单元格后将后续内容错配到错误表头的问题。
 - [修复] 将 Docker 可安装的 Longbridge SDK 版本固定为 0.2.75，避免 `longbridge>=0.2.77` 从包索引消失后导致 docker-build 失败。
 
+- [修复] 默认通知报告补充展示 `dashboard.phase_decision` 盘中决策护栏字段，避免与模板渲染路径展示不一致。
 - [改进] Web 设置页新增首次启动配置检查卡，串联基础配置状态、自选股入口、模型配置入口和一次简短试跑。
 - [改进] 通知报告的分析结果摘要不再展开 AI 决策信号明细，完整信号保留在个股详情和单股报告中。
 - [新功能] #1595 P1.5 新增 Provider Cache Capability Registry，按 provider、api surface、gateway 和 verification status 建模 prompt cache 能力，未知 OpenAI-compatible route 默认 telemetry only。

--- a/src/notification.py
+++ b/src/notification.py
@@ -1019,6 +1019,72 @@ class NotificationService(
                 return value[len(prefix):]
         return value
 
+    @staticmethod
+    def _phase_decision_list(value: Any) -> List[str]:
+        if not isinstance(value, list):
+            return []
+        return [str(item).strip() for item in value if str(item).strip()]
+
+    @classmethod
+    def _phase_decision_has_content(cls, phase_decision: Dict[str, Any]) -> bool:
+        text_keys = (
+            "action_window",
+            "immediate_action",
+            "next_check_time",
+            "confidence_reason",
+        )
+        if any(str(phase_decision.get(key) or "").strip() for key in text_keys):
+            return True
+        return bool(
+            cls._phase_decision_list(phase_decision.get("watch_conditions"))
+            or cls._phase_decision_list(phase_decision.get("data_limitations"))
+        )
+
+    def _append_phase_decision_block(
+        self,
+        report_lines: List[str],
+        dashboard: Dict[str, Any],
+        labels: Dict[str, str],
+    ) -> None:
+        phase_decision = dashboard.get("phase_decision") if dashboard else None
+        if not isinstance(phase_decision, dict):
+            return
+        if not self._phase_decision_has_content(phase_decision):
+            return
+
+        watch_conditions = self._phase_decision_list(phase_decision.get("watch_conditions"))
+        data_limitations = self._phase_decision_list(phase_decision.get("data_limitations"))
+
+        report_lines.extend([
+            f"### 🛡️ {labels['phase_decision_heading']}",
+            "",
+            f"| {labels['action_window_label']} | {labels['immediate_action_label']} | {labels['next_check_time_label']} |",
+            "|---------|---------|---------|",
+            f"| {phase_decision.get('action_window') or 'N/A'} | "
+            f"{phase_decision.get('immediate_action') or 'N/A'} | "
+            f"{phase_decision.get('next_check_time') or 'N/A'} |",
+            "",
+        ])
+
+        if watch_conditions:
+            report_lines.append(f"**{labels['watch_conditions_label']}**:")
+            for condition in watch_conditions:
+                report_lines.append(f"- {condition}")
+            report_lines.append("")
+
+        confidence_reason = str(phase_decision.get("confidence_reason") or "").strip()
+        if confidence_reason:
+            report_lines.extend([
+                f"**{labels['confidence_reason_label']}**: {confidence_reason}",
+                "",
+            ])
+
+        if data_limitations:
+            report_lines.append(f"**{labels['data_limitations_label']}**:")
+            for limitation in data_limitations:
+                report_lines.append(f"- {limitation}")
+            report_lines.append("")
+
     def _get_signal_level(self, result: AnalysisResult) -> tuple:
         """Get localized signal level and color based on operation advice."""
         return get_signal_level(
@@ -1255,6 +1321,8 @@ class NotificationService(
                                 f"**{labels['chip_label']}**: {chip_unavailable_reason}",
                                 "",
                             ])
+
+                self._append_phase_decision_block(report_lines, dashboard, labels)
                 
                 # ========== 作战计划 ==========
                 battle = dashboard.get('battle_plan', {}) if dashboard else {}

--- a/tests/test_notification.py
+++ b/tests/test_notification.py
@@ -640,6 +640,67 @@ class TestNotificationServiceReportGeneration(unittest.TestCase):
         self.assertIn("*分析模型：gemini/gemini-2.5-flash*", out)
 
     @mock.patch("src.notification.get_config")
+    def test_generate_dashboard_report_shows_phase_decision_in_default_renderer(
+        self, mock_get_config: mock.MagicMock
+    ):
+        mock_get_config.return_value = _make_config(report_renderer_enabled=False)
+        service = NotificationService()
+        result = AnalysisResult(
+            code="600519",
+            name="贵州茅台",
+            sentiment_score=72,
+            trend_prediction="看多",
+            operation_advice="持有",
+            analysis_summary="等待确认",
+            dashboard={
+                "core_conclusion": {"one_sentence": "等待确认"},
+                "phase_decision": {
+                    "action_window": "盘中跟踪",
+                    "immediate_action": "等待确认",
+                    "watch_conditions": ["放量突破"],
+                    "next_check_time": "14:30",
+                    "confidence_reason": "数据质量可用",
+                    "data_limitations": ["quote: stale"],
+                },
+            },
+        )
+
+        out = service.generate_dashboard_report([result], report_date="2026-02-01")
+
+        self.assertIn("盘中决策护栏", out)
+        self.assertIn("盘中跟踪", out)
+        self.assertIn("等待确认", out)
+        self.assertIn("放量突破", out)
+        self.assertIn("quote: stale", out)
+
+    @mock.patch("src.notification.get_config")
+    def test_generate_dashboard_report_skips_context_only_phase_decision_default_renderer(
+        self, mock_get_config: mock.MagicMock
+    ):
+        mock_get_config.return_value = _make_config(report_renderer_enabled=False)
+        service = NotificationService()
+        result = AnalysisResult(
+            code="600519",
+            name="贵州茅台",
+            sentiment_score=72,
+            trend_prediction="看多",
+            operation_advice="持有",
+            analysis_summary="等待确认",
+            dashboard={
+                "core_conclusion": {"one_sentence": "等待确认"},
+                "phase_decision": {
+                    "phase_context": {"phase": "intraday", "market": "cn"},
+                    "watch_conditions": [],
+                    "data_limitations": [],
+                },
+            },
+        )
+
+        out = service.generate_dashboard_report([result], report_date="2026-02-01")
+
+        self.assertNotIn("盘中决策护栏", out)
+
+    @mock.patch("src.notification.get_config")
     def test_generate_dashboard_report_appends_decision_signal_excerpt_fallback(
         self, mock_get_config: mock.MagicMock
     ):


### PR DESCRIPTION
## Summary

- Fixes #1797.
- Adds `dashboard.phase_decision` rendering to the default `generate_dashboard_report()` path.
- Keeps Jinja2 renderer behavior unchanged.
- Skips context-only/empty phase decision shells to avoid noisy reports.

## Root Cause

`phase_decision` was implemented in the schema, prompt/guardrail path, report labels, and Jinja2 template, but the default notification renderer (`REPORT_RENDERER_ENABLED=false`) never consumed it.

## Validation

- `python -m py_compile src/notification.py`
- `python -m pytest tests/test_notification.py`

## Compatibility / Risk

- Detailed default notifications can include an additional phase decision block when actionable content exists.
- Empty mechanical phase context is skipped to avoid report noise.

## Rollback

Revert this PR to remove the default-renderer phase decision block and restore the previous report output.