### PR TITLE
fix: pin longbridge to docker-compatible version

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+- [修复] 将 Docker 可安装的 Longbridge SDK 版本固定为 0.2.75，避免 `longbridge>=0.2.77` 从包索引消失后导致 docker-build 失败。
+
 - [改进] Web 设置页新增首次启动配置检查卡，串联基础配置状态、自选股入口、模型配置入口和一次简短试跑。
 - [改进] 通知报告的分析结果摘要不再展开 AI 决策信号明细，完整信号保留在个股详情和单股报告中。
 - [新功能] #1595 P1.5 新增 Provider Cache Capability Registry，按 provider、api surface、gateway 和 verification status 建模 prompt cache 能力，未知 OpenAI-compatible route 默认 telemetry only。

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,7 @@ tushare>=1.4.0              # Priority 2: Tushare Pro API
 pytdx>=1.72                 # Priority 2: Tongdaxin quote servers
 baostock>=0.8.0             # Priority 3: Baostock data
 yfinance>=0.2.0             # Priority 4: Yahoo Finance (Fallback)
-longbridge>=0.2.77           # Priority 5: Longbridge OpenAPI fallback for US/HK stocks; OAuth capability checked at runtime
+longbridge==0.2.75           # Priority 5: Longbridge OpenAPI fallback for US/HK stocks; OAuth capability checked at runtime
 tickflow>=0.1.0            # TickFlow official SDK (Issue #632, market review enhancement)
 # Built-in optional AlphaSift screening engine
 git+https://github.com/ZhuLinsen/alphasift.git@377049857cc04175dc3cca62121ee41adec6cdb8#egg=alphasift


### PR DESCRIPTION
## Summary

- Pin `longbridge` to `0.2.75` so Docker builds can install the SDK on `python:3.11-slim-bookworm`.
- Add a changelog entry for the Docker build dependency fix.

## Root Cause

The Docker CI image uses Debian bookworm / glibc 2.36. Current Longbridge 4.x Linux wheels require a newer manylinux tag, while `longbridge 0.2.77` is no longer returned by the package index. As a result, `pip install -r requirements.txt` fails during docker-build with `No matching distribution found for longbridge>=0.2.77`.

## Validation

- `python -m pip download --only-binary=:all: --python-version 3.11 --platform manylinux2014_x86_64 --implementation cp --abi cp311 --no-deps longbridge==0.2.75`
- `git diff --check`

Docker was not run locally because Docker is not installed in this environment.

## Compatibility / Risk

- This restores Docker installability using the last currently available 0.2.x Linux wheel.
- OAuth-only Longbridge capability remains subject to the existing runtime SDK capability checks and graceful downgrade behavior.

## Rollback

Revert this PR to restore the previous `longbridge>=0.2.77` dependency constraint.