### PR TITLE
ci: speed up Docker build checks

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,11 +3,19 @@ __pycache__/
 *.py[cod]
 *$py.class
 *.so
+.pytest_cache/
+.mypy_cache/
+.ruff_cache/
+.coverage
+htmlcov/
 
 # 忽略虚拟环境
 venv/
 .venv/
 env/
+.env
+.env.*
+!.env.example
 .env.local
 
 # 忽略 IDE
@@ -16,15 +24,30 @@ env/
 *.swp
 *.swo
 
-# 忽略数据文件（可选，如果想持久化就注释掉）
-# data/
-# logs/
-# reports/
+# 忽略本地仓库、CI 元数据和运行产物
+.git/
+.github/
+.claude/reviews/
+data/
+logs/
+reports/
+*.log
 
-# 忽略测试文件
+# 忽略测试和文档
+tests/
 test_*.py
 *_test.py
-
-# 忽略文档
+docs/
 *.md
 !README.md
+
+# 忽略不参与 Docker 镜像构建的前端/桌面端产物
+apps/dsa-desktop/
+node_modules/
+dist/
+build/
+coverage/
+apps/dsa-web/node_modules/
+apps/dsa-web/dist/
+apps/dsa-web/build/
+apps/dsa-web/coverage/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,14 +79,23 @@ jobs:
   docker-build:
     name: docker-build
     runs-on: ubuntu-latest
-    needs: [backend-gate]
+    needs: [ai-governance]
     steps:
       - name: 📥 Checkout
         uses: actions/checkout@v5
+      - name: 🛠️ Setup Docker Buildx
+        uses: docker/setup-buildx-action@v3
       - name: 🐳 Build image
-        run: |
-          docker build -t stock-analysis:test -f docker/Dockerfile .
-          docker run --rm stock-analysis:test python -c "print('✅ Docker OK')"
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: docker/Dockerfile
+          tags: stock-analysis:test
+          load: true
+          cache-from: type=gha,scope=stock-analysis-ci-docker
+          cache-to: type=gha,mode=max,scope=stock-analysis-ci-docker,ignore-error=true
+      - name: 🐳 Docker smoke
+        run: docker run --rm stock-analysis:test python -c "print('✅ Docker OK')"
       - name: 🔍 Docker smoke imports
         run: |
           docker run --rm stock-analysis:test python -c "

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,3 +1,5 @@
+# syntax=docker/dockerfile:1.7
+
 # ===================================
 # A股自选股智能分析系统 - Docker 镜像
 # ===================================
@@ -8,7 +10,7 @@ FROM node:20-slim AS web-builder
 WORKDIR /app/apps/dsa-web
 
 COPY apps/dsa-web/package.json apps/dsa-web/package-lock.json ./
-RUN npm ci
+RUN --mount=type=cache,target=/root/.npm npm ci
 
 COPY apps/dsa-web/ ./
 RUN npm run build
@@ -44,7 +46,7 @@ RUN groupadd -g 1000 dsa && \
 COPY requirements.txt .
 
 # 安装 Python 依赖
-RUN pip install --no-cache-dir -r requirements.txt
+RUN --mount=type=cache,target=/root/.cache/pip pip install -r requirements.txt
 
 # 复制应用代码
 COPY *.py ./

--- a/tests/test_docker_entrypoint.py
+++ b/tests/test_docker_entrypoint.py
@@ -30,7 +30,8 @@ def test_dockerfile_bundles_default_alphasift_adapter() -> None:
 
     assert "git \\" in dockerfile
     assert "git+https://github.com/ZhuLinsen/alphasift.git@377049857cc04175dc3cca62121ee41adec6cdb8#egg=alphasift" in requirements
-    assert "pip install --no-cache-dir -r requirements.txt" in dockerfile
+    assert "pip install -r requirements.txt" in dockerfile
+    assert "--mount=type=cache,target=/root/.cache/pip" in dockerfile
     assert "import alphasift.dsa_adapter" in dockerfile
 
 


### PR DESCRIPTION
## PR Type

- [ ] fix
- [ ] feat
- [ ] refactor
- [ ] docs
- [x] chore
- [x] test

## Background And Problem

当前 `CI` workflow 的整体耗时通常在 6-7 分钟。最近一次成功样本中：

- `backend-gate`: 约 4m20s
- `docker-build`: 约 2m10s
- `docker-build` 需要等待 `backend-gate` 完成后才开始，导致两段耗时串行叠加。

同时 Docker 构建没有使用 GitHub Actions layer cache，依赖层在 runner 间复用能力有限；Docker build context 也包含了一些不会进入镜像的本地/CI/测试/文档文件。

## Scope Of Change

文件总数 / 变更行数：

```bash
 .dockerignore                   | 37 ++++++++++++++++++++++++++++++-------
 .github/workflows/ci.yml        | 17 +++++++++++++----
 docker/Dockerfile               |  6 ++++--
 tests/test_docker_entrypoint.py |  3 ++-
 4 files changed, 49 insertions(+), 14 deletions(-)
```

文件清单：

- `.github/workflows/ci.yml`
- `.dockerignore`
- `docker/Dockerfile`
- `tests/test_docker_entrypoint.py`

文档更新文件（`docs/*`）：无。此 PR 只调整 CI/Docker 构建路径和对应测试断言，不改变用户可见功能、API、报告结构或配置语义。

## Issue Link

无 Issue。验收标准：

- Docker build job 不再串行等待 backend 测试完成。
- Docker build 在 GitHub Actions 中可复用 GHA layer cache。
- Docker build context 排除无关文件。
- Docker smoke import 检查仍保留。
- backend-gate 中的 Dockerfile 契约测试与 BuildKit cache mount 语义一致。

## What Changed

- 将 `docker-build` 的依赖从 `backend-gate` 改为 `ai-governance`，让 Docker build 与后端测试并行执行。
- 使用 `docker/setup-buildx-action` + `docker/build-push-action`，开启 `type=gha` Docker layer cache，并继续 `load: true` 供后续 smoke 检查使用。
- 收紧 `.dockerignore`，排除 `.git`、`.github`、测试、文档、本地数据、前端/桌面端构建产物等不参与镜像构建的内容。
- 为 Dockerfile 中的 `npm ci` 和 `pip install` 增加 BuildKit cache mount，依赖层失效时可复用 npm/pip 下载缓存；缓存不会写入最终镜像层。
- 更新 `tests/test_docker_entrypoint.py`，不再要求旧的 `pip install --no-cache-dir` 字面量，改为验证 Dockerfile 仍安装 `requirements.txt` 且启用了 pip cache mount。

## Optimization Notes

从最近一次成功 CI 时间线看，当前最大收益来自并行化：`docker-build` 原本在 `backend-gate` 后启动，约多占 2 分钟墙钟时间。改完后冷缓存情况下总耗时预计接近 `backend-gate` 的 4 分多钟，而不是 `backend-gate + docker-build` 的 6-7 分钟。

进一步压缩 backend 的主要方向是拆分 `pytest -m "not network"` 或引入 xdist；但离线测试本身约 3 分多，拆分会影响测试隔离、日志定位和 runner 资源消耗，本 PR 暂不改变测试执行语义。

## Verification Commands And Results

```bash
git diff --check
# passed

python -m py_compile tests/test_docker_entrypoint.py
# passed

python - <<'PY'
from pathlib import Path
text = Path('docker/Dockerfile').read_text(encoding='utf-8')
requirements = Path('requirements.txt').read_text(encoding='utf-8')
assert 'git \\' in text
assert 'git+https://github.com/ZhuLinsen/alphasift.git@377049857cc04175dc3cca62121ee41adec6cdb8#egg=alphasift' in requirements
assert 'pip install -r requirements.txt' in text
assert '--mount=type=cache,target=/root/.cache/pip' in text
assert 'import alphasift.dsa_adapter' in text
print('updated docker entrypoint assertions ok')
PY
# updated docker entrypoint assertions ok

ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ci.yml"); puts "yaml ok"'
# previously passed before the test follow-up commit; workflow YAML was not changed by the follow-up commit

docker buildx version
# previously passed before the test follow-up commit: github.com/docker/buildx v0.11.2 9872040

docker buildx build --progress=plain --load -t stock-analysis:ci-opt -f docker/Dockerfile .
# previously not completed locally: Docker Hub metadata access timed out while resolving docker/dockerfile:1.7, before entering project Dockerfile build steps.
```

GitHub Actions status after the latest push: `backend-gate` passed (4m46s), `docker-build` passed (2m0s), PR Review checks passed, and `web-gate` skipped because no frontend files changed.

Local pytest note: `python -m pytest tests/test_docker_entrypoint.py -q` could not run in this machine's default Python environment because `anyio` was not installed. A temporary venv with the local default Python 3.12 could not install CI dependencies because `longbridge==0.2.75` is not available for that interpreter, while CI uses Python 3.11. This PR relies on GitHub Actions `backend-gate` for the full Python 3.11 offline test suite.

## Visual Evidence (if applicable)

- 截图链接 / Screenshot links（必填）：不适用。
- 前后对比 / Before & After（如有）：不适用。
- 不适用原因 / Reason if not applicable（必填）：本 PR 只修改 CI/Docker 构建流程和对应测试断言，不修改 Web UI、报告格式或报告渲染效果。

## Compatibility And Risk

- 不改变应用运行时配置、API、报告结构、数据库或用户数据。
- CI Docker 构建从串行等待 `backend-gate` 改为等待 `ai-governance` 后并行执行；`ai-governance` 是独立的协作资产校验，不产出 Docker build 所需文件。
- CI Docker 构建切换到 Buildx，并使用 GitHub Actions cache；若 cache restore/export 不可用，构建仍应可以继续执行，`cache-to` 设置了 `ignore-error=true`。
- Dockerfile 使用 BuildKit cache mount；CI 已显式使用 Buildx。较老的本地 Docker legacy builder 可能不支持 `RUN --mount`，需要使用 BuildKit/Buildx 构建。
- `.dockerignore` 排除了测试、文档和本地运行产物；Dockerfile 当前只复制应用运行所需目录和 Web build 产物，未依赖这些被排除内容。

## Rollback Plan

Revert this PR 即可恢复原 CI 串行执行、普通 `docker build` 命令和旧 `.dockerignore` 行为；不需要数据或配置回滚。

## EXTRACT_PROMPT Change (if applicable)

不适用，未修改 `src/services/image_stock_extractor.py`。

## Checklist

- [x] 本 PR 有明确动机和业务价值 / This PR has a clear motivation and value
- [x] 已提供可复现的验证命令与结果 / Reproducible verification commands and results are included
- [x] 已评估兼容性与风险 / Compatibility and risk have been assessed
- [x] 已提供回滚方案 / A rollback plan is provided
- [x] 若修改报告格式或 Web UI 界面，已在 PR 描述/评论附受影响报告 / 页面截图，且未把一次性验收截图作为仓库文件合入 / If report formatting or Web UI changed, affected report/page screenshots are linked in the PR body/comments and one-off acceptance screenshots are not committed as repository files
- [x] 若涉及用户可见变更，已同步更新相关文档与 `docs/CHANGELOG.md`；`README.md` 仅在首页级信息变化时更新，细节优先写入 `docs/*.md` / If user-visible changes are included, relevant docs and `docs/CHANGELOG.md` are updated; `README.md` is updated only for homepage-level changes, with details kept in `docs/*.md`