### PR TITLE
feat: 接入 Hermes 本地 HTTP 生成

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -210,6 +210,14 @@ GEMINI_API_KEY=
 # LLM_OLLAMA_BASE_URL=http://localhost:11434
 # LLM_OLLAMA_MODELS=qwen3:8b,llama3.2
 #
+# 示例：Hermes 本地 HTTP generation（Phase 3，仅普通分析/JSON；不支持 Agent tools、Stream、Vision）
+# LLM_CHANNELS=hermes
+# LLM_HERMES_PROTOCOL=openai
+# LLM_HERMES_BASE_URL=http://127.0.0.1:8642/v1
+# LLM_HERMES_API_KEY=sk-local-hermes
+# LLM_HERMES_MODELS=hermes-agent
+# LITELLM_MODEL=openai/hermes-agent
+#
 # 常用厂商模板（任选其一复制到 .env；完整说明见 docs/llm-providers.md）
 #
 # Anspire Open（共享搜索与 LLM Key，OpenAI Compatible）

--- a/.github/workflows/00-daily-analysis.yml
+++ b/.github/workflows/00-daily-analysis.yml
@@ -88,6 +88,13 @@ jobs:
           LLM_PROMPT_CACHE_HINTS_ENABLED: ${{ vars.LLM_PROMPT_CACHE_HINTS_ENABLED || secrets.LLM_PROMPT_CACHE_HINTS_ENABLED }}
           LLM_PROMPT_CACHE_DIAGNOSTICS_LEVEL: ${{ vars.LLM_PROMPT_CACHE_DIAGNOSTICS_LEVEL || secrets.LLM_PROMPT_CACHE_DIAGNOSTICS_LEVEL }}
           LLM_CHANNELS: ${{ vars.LLM_CHANNELS || secrets.LLM_CHANNELS }}
+          # Hermes 是本地 loopback generation preset；API Key 只从 Secrets 注入。
+          # GitHub-hosted runner 的 127.0.0.1 不是用户电脑，本配置通常只适合 self-hosted runner。
+          LLM_HERMES_PROTOCOL: ${{ vars.LLM_HERMES_PROTOCOL || secrets.LLM_HERMES_PROTOCOL }}
+          LLM_HERMES_BASE_URL: ${{ vars.LLM_HERMES_BASE_URL || secrets.LLM_HERMES_BASE_URL }}
+          LLM_HERMES_API_KEY: ${{ secrets.LLM_HERMES_API_KEY }}
+          LLM_HERMES_MODELS: ${{ vars.LLM_HERMES_MODELS || secrets.LLM_HERMES_MODELS }}
+          LLM_HERMES_ENABLED: ${{ vars.LLM_HERMES_ENABLED || secrets.LLM_HERMES_ENABLED }}
 
           # Gemini AI（主选）
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}

--- a/api/v1/endpoints/system_config.py
+++ b/api/v1/endpoints/system_config.py
@@ -411,6 +411,7 @@ def test_llm_channel(
             enabled=request.enabled,
             timeout_seconds=request.timeout_seconds,
             capability_checks=request.capability_checks,
+            use_saved_secret=request.use_saved_secret,
         )
         return TestLLMChannelResponse.model_validate(payload)
     except (ValueError, TypeError) as exc:
@@ -499,6 +500,7 @@ def discover_llm_channel_models(
             api_key=request.api_key,
             models=request.models,
             timeout_seconds=request.timeout_seconds,
+            use_saved_secret=request.use_saved_secret,
         )
         return DiscoverLLMChannelModelsResponse.model_validate(payload)
     except (ValueError, TypeError) as exc:

--- a/api/v1/schemas/system_config.py
+++ b/api/v1/schemas/system_config.py
@@ -200,6 +200,7 @@ class TestLLMChannelRequest(BaseModel):
     enabled: bool = True
     timeout_seconds: float = 20.0
     capability_checks: List[LLMCapabilityCheck] = Field(default_factory=list)
+    use_saved_secret: bool = False
 
 
 class LLMCapabilityCheckResult(BaseModel):
@@ -276,6 +277,7 @@ class DiscoverLLMChannelModelsRequest(BaseModel):
     api_key: str = ""
     models: List[str] = Field(default_factory=list)
     timeout_seconds: float = 20.0
+    use_saved_secret: bool = False
 
 
 class DiscoverLLMChannelModelsResponse(BaseModel):

--- a/apps/dsa-web/src/api/systemConfig.ts
+++ b/apps/dsa-web/src/api/systemConfig.ts
@@ -97,6 +97,7 @@ function toSnakeTestChannelPayload(payload: TestLLMChannelRequest): Record<strin
     models: payload.models,
     enabled: payload.enabled ?? true,
     timeout_seconds: payload.timeoutSeconds ?? 20,
+    use_saved_secret: payload.useSavedSecret ?? false,
   };
   if (payload.capabilityChecks && payload.capabilityChecks.length > 0) {
     request.capability_checks = payload.capabilityChecks;
@@ -126,6 +127,7 @@ function toSnakeDiscoverModelsPayload(payload: DiscoverLLMChannelModelsRequest):
     api_key: payload.apiKey ?? '',
     models: payload.models,
     timeout_seconds: payload.timeoutSeconds ?? 20,
+    use_saved_secret: payload.useSavedSecret ?? false,
   };
 }
 

--- a/apps/dsa-web/src/components/settings/LLMChannelEditor.tsx
+++ b/apps/dsa-web/src/components/settings/LLMChannelEditor.tsx
@@ -51,6 +51,8 @@ const KNOWN_MODEL_PREFIXES = new Set([
 const CHANNEL_FIELD_SUFFIXES = ['PROTOCOL', 'BASE_URL', 'API_KEY', 'API_KEYS', 'MODELS', 'EXTRA_HEADERS', 'ENABLED'] as const;
 const CHANNEL_FIELD_KEY_PATTERN = /^LLM_([A-Z0-9_]+)_(PROTOCOL|BASE_URL|API_KEY|API_KEYS|MODELS|EXTRA_HEADERS|ENABLED)$/;
 const FALSEY_VALUES = new Set(['0', 'false', 'no', 'off']);
+const HERMES_CHANNEL_NAME = 'hermes';
+const HERMES_DEFAULT_MODEL = 'hermes-agent';
 
 const RUNTIME_CAPABILITY_OPTIONS: Array<{ value: LLMCapabilityCheck; label: string; hint: string }> = [
   { value: 'json', label: 'JSON', hint: '检测 response_format JSON 输出是否可用。' },
@@ -64,6 +66,54 @@ const CAPABILITY_STATUS_LABELS: Record<LLMCapabilityCheckResult['status'], strin
   failed: '失败',
   skipped: '跳过',
 };
+
+const isHermesChannel = (channel: Pick<ChannelConfig, 'name'>): boolean => (
+  channel.name.trim().toLowerCase() === HERMES_CHANNEL_NAME
+);
+
+function canonicalizeHermesRouteModel(model: string): string {
+  const trimmed = model.trim() || HERMES_DEFAULT_MODEL;
+  return trimmed.startsWith('openai/') ? trimmed : `openai/${trimmed}`;
+}
+
+function routeIdentityCandidates(model: string): Set<string> {
+  const trimmed = model.trim();
+  if (!trimmed) return new Set();
+  const candidates = new Set<string>([trimmed]);
+  if (!trimmed.startsWith('openai/') && !trimmed.includes('/')) {
+    candidates.add(`openai/${trimmed}`);
+  }
+  return candidates;
+}
+
+function getRouteProvenance(
+  routeProvenanceMap: Map<string, RouteProvenance>,
+  model: string,
+): RouteProvenance | undefined {
+  for (const candidate of routeIdentityCandidates(model)) {
+    const origin = routeProvenanceMap.get(candidate);
+    if (origin) return origin;
+  }
+  return undefined;
+}
+
+const shouldUseSavedHermesSecret = (
+  channel: Pick<ChannelConfig, 'name' | 'apiKey'>,
+  maskToken: string,
+  hasPersistedSecret: boolean,
+): boolean => (
+  isHermesChannel(channel) && channel.apiKey === maskToken && hasPersistedSecret
+);
+
+const hasRuntimeOnlyMaskedHermesSecret = (
+  channel: Pick<ChannelConfig, 'name' | 'apiKey'>,
+  maskToken: string,
+  hasPersistedSecret: boolean,
+): boolean => (
+  isHermesChannel(channel) && channel.apiKey === maskToken && !hasPersistedSecret
+);
+
+const RUNTIME_ONLY_HERMES_SECRET_MESSAGE = '运行时注入的 Hermes Key 不会回传；如需在设置页测试，请重新输入 Key 或保存到 .env。';
 
 interface ChannelConfig {
   id: string;
@@ -211,6 +261,9 @@ function resolveInitialChannelApiKeySource(
   const apiKeysValue = (initialItemValueByKey.get(apiKeysKey) || '').trim();
   const apiKeyValue = (initialItemValueByKey.get(apiKeyKey) || '').trim();
 
+  if (channelName.trim().toLowerCase() === HERMES_CHANNEL_NAME && apiKeyValue && initialItemSourceByKey.has(apiKeyKey)) {
+    return initialItemSourceByKey.get(apiKeyKey);
+  }
   if (apiKeysValue && initialItemSourceByKey.has(apiKeysKey)) {
     return initialItemSourceByKey.get(apiKeysKey);
   }
@@ -239,6 +292,9 @@ function resolveInitialChannelApiKeyValue(
   const apiKeysValue = (itemValueByKey.get(apiKeysKey) || '').trim();
   const apiKeyValue = (itemValueByKey.get(apiKeyKey) || '').trim();
 
+  if (channelName.trim().toLowerCase() === HERMES_CHANNEL_NAME && apiKeyValue) {
+    return apiKeyValue;
+  }
   if (apiKeysValue && itemSourceByKey.has(apiKeysKey)) {
     return apiKeysValue;
   }
@@ -365,6 +421,9 @@ const ChannelRow: React.FC<ChannelRowProps> = ({
   const providerSources = showProviderTemplateDetails ? (preset?.officialSources || []) : [];
   const providerHint = showProviderTemplateDetails ? preset?.configHint : undefined;
   const selectedModels = splitModels(channel.models);
+  const runtimeCapabilityOptions = isHermesChannel(channel)
+    ? RUNTIME_CAPABILITY_OPTIONS.filter((option) => option.value === 'json')
+    : RUNTIME_CAPABILITY_OPTIONS;
   const discoveredModels = discoveryState?.models || [];
   const manualOnlyModels = selectedModels.filter(
     (model) => !discoveredModels.some((discoveredModel) => areModelsEquivalent(model, discoveredModel, channel.protocol)),
@@ -748,7 +807,7 @@ const ChannelRow: React.FC<ChannelRowProps> = ({
             </div>
 
             <div className="flex flex-wrap gap-2">
-              {RUNTIME_CAPABILITY_OPTIONS.map((option) => (
+              {runtimeCapabilityOptions.map((option) => (
                 <Tooltip key={option.value} content={option.hint}>
                   <label className="inline-flex cursor-pointer items-center gap-1.5 rounded-lg border border-[var(--settings-border)] bg-[var(--settings-surface)] px-2 py-1 text-[11px] text-secondary-text">
                     <input
@@ -957,6 +1016,44 @@ function resolveModelPreview(models: string, protocol: ChannelProtocol): string[
   return splitModels(models).map((model) => normalizeModelForRuntime(model, protocol));
 }
 
+interface RouteProvenance {
+  routeName: string;
+  hasHermes: boolean;
+  hasNonHermes: boolean;
+}
+
+function resolveChannelRouteModels(channel: ChannelConfig): string[] {
+  if (isHermesChannel(channel)) {
+    const models = splitModels(channel.models);
+    return (models.length > 0 ? models : [HERMES_DEFAULT_MODEL]).map(canonicalizeHermesRouteModel);
+  }
+  return resolveModelPreview(channel.models, channel.protocol);
+}
+
+function buildRouteProvenanceMap(channels: ChannelConfig[]): Map<string, RouteProvenance> {
+  const provenance = new Map<string, RouteProvenance>();
+  for (const channel of channels) {
+    if (!channel.enabled || !channel.name.trim()) {
+      continue;
+    }
+    const hermes = isHermesChannel(channel);
+    for (const routeName of resolveChannelRouteModels(channel)) {
+      if (!routeName) continue;
+      const existing = provenance.get(routeName) || {
+        routeName,
+        hasHermes: false,
+        hasNonHermes: false,
+      };
+      provenance.set(routeName, {
+        ...existing,
+        hasHermes: existing.hasHermes || hermes,
+        hasNonHermes: existing.hasNonHermes || !hermes,
+      });
+    }
+  }
+  return provenance;
+}
+
 function buildModelOptions(models: string[], selectedModel: string, autoLabel: string): Array<{ value: string; label: string }> {
   const options: Array<{ value: string; label: string }> = [{ value: '', label: autoLabel }];
   if (selectedModel && !models.includes(selectedModel)) {
@@ -1137,26 +1234,43 @@ function hasLegacyRuntimeSource(model: string, itemMap: Map<string, string>): bo
 }
 
 function isRuntimeModelAvailable(model: string, availableModels: string[], itemMap: Map<string, string>): boolean {
-  return availableModels.includes(model)
+  const normalizedModel = model.trim();
+  const matchesAvailableModel = normalizedModel.length > 0 && availableModels.includes(normalizedModel);
+  return matchesAvailableModel
     || usesDirectEnvProvider(model)
     || (availableModels.length === 0 && hasLegacyRuntimeSource(model, itemMap));
 }
 
+function hasCanonicalRouteAliasMismatch(model: string, availableModels: string[]): boolean {
+  const normalizedModel = model.trim();
+  if (!normalizedModel || availableModels.includes(normalizedModel) || usesDirectEnvProvider(normalizedModel)) {
+    return false;
+  }
+  for (const candidate of routeIdentityCandidates(normalizedModel)) {
+    if (candidate !== normalizedModel && availableModels.includes(candidate)) {
+      return true;
+    }
+  }
+  return false;
+}
+
 function sanitizeRuntimeConfigForSave(
   runtimeConfig: RuntimeConfig,
-  availableModels: string[],
+  generationModels: string[],
+  agentSafeModels: string[],
+  visionSafeModels: string[],
   itemMap: Map<string, string>,
 ): RuntimeConfig {
-  const primaryModel = runtimeConfig.primaryModel && !isRuntimeModelAvailable(runtimeConfig.primaryModel, availableModels, itemMap)
+  const primaryModel = runtimeConfig.primaryModel && !isRuntimeModelAvailable(runtimeConfig.primaryModel, generationModels, itemMap)
     ? ''
     : runtimeConfig.primaryModel;
-  const agentPrimaryModel = runtimeConfig.agentPrimaryModel && !isRuntimeModelAvailable(runtimeConfig.agentPrimaryModel, availableModels, itemMap)
+  const agentPrimaryModel = runtimeConfig.agentPrimaryModel && !isRuntimeModelAvailable(runtimeConfig.agentPrimaryModel, agentSafeModels, itemMap)
     ? ''
     : runtimeConfig.agentPrimaryModel;
-  const visionModel = runtimeConfig.visionModel && !isRuntimeModelAvailable(runtimeConfig.visionModel, availableModels, itemMap)
+  const visionModel = runtimeConfig.visionModel && !isRuntimeModelAvailable(runtimeConfig.visionModel, visionSafeModels, itemMap)
     ? ''
     : runtimeConfig.visionModel;
-  const fallbackModels = runtimeConfig.fallbackModels.filter((model) => isRuntimeModelAvailable(model, availableModels, itemMap));
+  const fallbackModels = runtimeConfig.fallbackModels.filter((model) => isRuntimeModelAvailable(model, generationModels, itemMap));
 
   return {
     ...runtimeConfig,
@@ -1296,8 +1410,14 @@ function channelsToUpdateItems(
     updates.push({ key: `${prefix}_PROTOCOL`, value: channel.protocol });
     updates.push({ key: `${prefix}_BASE_URL`, value: channel.baseUrl });
     updates.push({ key: `${prefix}_ENABLED`, value: channel.enabled ? 'true' : 'false' });
-    updates.push({ key: `${prefix}_API_KEY${isMultiKey ? 'S' : ''}`, value: channel.apiKey });
-    updates.push({ key: `${prefix}_API_KEY${isMultiKey ? '' : 'S'}`, value: '' });
+    if (isHermesChannel(channel)) {
+      updates.push({ key: `${prefix}_API_KEY`, value: channel.apiKey });
+      updates.push({ key: `${prefix}_API_KEYS`, value: '' });
+      updates.push({ key: `${prefix}_EXTRA_HEADERS`, value: '' });
+    } else {
+      updates.push({ key: `${prefix}_API_KEY${isMultiKey ? 'S' : ''}`, value: channel.apiKey });
+      updates.push({ key: `${prefix}_API_KEY${isMultiKey ? '' : 'S'}`, value: '' });
+    }
     updates.push({ key: `${prefix}_MODELS`, value: channel.models });
   }
 
@@ -1367,6 +1487,9 @@ export const LLMChannelEditor: React.FC<LLMChannelEditorProps> = ({
   const initialNames = useMemo(() => initialChannels.map((channel) => channel.name), [initialChannels]);
   const initialRuntimeConfig = useMemo(() => parseRuntimeConfigFromItems(items), [items]);
   const savedItemMap = useMemo(() => new Map(items.map((item) => [item.key.toUpperCase(), item.value])), [items]);
+  const hasPersistedHermesSecret = (channel: ChannelConfig): boolean => (
+    isHermesChannel(channel) && initialItemSourceByKey.get('LLM_HERMES_API_KEY') === true
+  );
   const hasLitellmConfig = useMemo(
     () => items.some((item) => item.key === 'LITELLM_CONFIG' && item.value.trim().length > 0),
     [items],
@@ -1429,26 +1552,49 @@ export const LLMChannelEditor: React.FC<LLMChannelEditorProps> = ({
     setIsCollapsed(false);
   }, [channelsFingerprint, runtimeFingerprint, initialChannels, initialRuntimeConfig]);
 
-  const availableModels = useMemo(() => {
+  const routeProvenanceMap = useMemo(() => {
     if (!managesRuntimeConfig) {
-      return [];
+      return new Map<string, RouteProvenance>();
     }
-    const seen = new Set<string>();
-    const models: string[] = [];
-    for (const channel of channels) {
-      if (!channel.enabled || !channel.name.trim()) {
-        continue;
-      }
-      for (const model of resolveModelPreview(channel.models, channel.protocol)) {
-        if (!model || seen.has(model)) {
-          continue;
-        }
-        seen.add(model);
-        models.push(model);
-      }
-    }
-    return models;
+    return buildRouteProvenanceMap(channels);
   }, [channels, managesRuntimeConfig]);
+
+  const availableModels = useMemo(
+    () => Array.from(routeProvenanceMap.values())
+      .filter((origin) => !(origin.hasHermes && origin.hasNonHermes))
+      .map((origin) => origin.routeName),
+    [routeProvenanceMap],
+  );
+
+  const agentSafeModels = useMemo(
+    () => Array.from(routeProvenanceMap.values())
+      .filter((origin) => !origin.hasHermes || origin.hasNonHermes)
+      .map((origin) => origin.routeName),
+    [routeProvenanceMap],
+  );
+
+  const visionSafeModels = useMemo(
+    () => Array.from(routeProvenanceMap.values())
+      .filter((origin) => !origin.hasHermes)
+      .map((origin) => origin.routeName),
+    [routeProvenanceMap],
+  );
+
+  const agentSelectedModelForOptions = useMemo(() => {
+    if (!runtimeConfig.agentPrimaryModel || agentSafeModels.includes(runtimeConfig.agentPrimaryModel)) {
+      return runtimeConfig.agentPrimaryModel;
+    }
+    const origin = getRouteProvenance(routeProvenanceMap, runtimeConfig.agentPrimaryModel);
+    return origin?.hasHermes && !origin.hasNonHermes ? '' : runtimeConfig.agentPrimaryModel;
+  }, [agentSafeModels, routeProvenanceMap, runtimeConfig.agentPrimaryModel]);
+
+  const visionSelectedModelForOptions = useMemo(() => {
+    if (!runtimeConfig.visionModel || visionSafeModels.includes(runtimeConfig.visionModel)) {
+      return runtimeConfig.visionModel;
+    }
+    const origin = getRouteProvenance(routeProvenanceMap, runtimeConfig.visionModel);
+    return origin?.hasHermes ? '' : runtimeConfig.visionModel;
+  }, [routeProvenanceMap, runtimeConfig.visionModel, visionSafeModels]);
 
   const hasChanges = useMemo(() => {
     const runtimeChanged = (
@@ -1604,8 +1750,33 @@ export const LLMChannelEditor: React.FC<LLMChannelEditorProps> = ({
       return;
     }
 
+    if (managesRuntimeConfig) {
+      const mixedPrimary = runtimeConfig.primaryModel
+        && getRouteProvenance(routeProvenanceMap, runtimeConfig.primaryModel)?.hasHermes
+        && getRouteProvenance(routeProvenanceMap, runtimeConfig.primaryModel)?.hasNonHermes;
+      const mixedFallback = runtimeConfig.fallbackModels.find((model) => {
+        const origin = getRouteProvenance(routeProvenanceMap, model);
+        return origin?.hasHermes && origin.hasNonHermes;
+      });
+      if (mixedPrimary || mixedFallback) {
+        setSaveMessage({ type: 'local-error', text: 'Mixed Hermes/non-Hermes route 暂不支持作为主生成或备选模型，请选择纯 Hermes 或纯非 Hermes route。' });
+        return;
+      }
+
+      const nonCanonicalRouteAlias = (
+        hasCanonicalRouteAliasMismatch(runtimeConfig.primaryModel, availableModels)
+        || hasCanonicalRouteAliasMismatch(runtimeConfig.agentPrimaryModel, agentSafeModels)
+        || hasCanonicalRouteAliasMismatch(runtimeConfig.visionModel, visionSafeModels)
+        || runtimeConfig.fallbackModels.some((model) => hasCanonicalRouteAliasMismatch(model, availableModels))
+      );
+      if (nonCanonicalRouteAlias) {
+        setSaveMessage({ type: 'local-error', text: '当前运行时模型使用非规范 route alias，请从下拉框重新选择规范模型。' });
+        return;
+      }
+    }
+
     const runtimeConfigForSave = managesRuntimeConfig
-      ? sanitizeRuntimeConfigForSave(runtimeConfig, availableModels, savedItemMap)
+      ? sanitizeRuntimeConfigForSave(runtimeConfig, availableModels, agentSafeModels, visionSafeModels, savedItemMap)
       : runtimeConfig;
     if (!runtimeConfigsAreEqual(runtimeConfigForSave, runtimeConfig)) {
       setRuntimeConfig(runtimeConfigForSave);
@@ -1620,9 +1791,9 @@ export const LLMChannelEditor: React.FC<LLMChannelEditorProps> = ({
       }
 
       const invalidAgentPrimaryModel = runtimeConfigForSave.agentPrimaryModel
-        && !isRuntimeModelAvailable(runtimeConfigForSave.agentPrimaryModel, availableModels, savedItemMap);
+        && !isRuntimeModelAvailable(runtimeConfigForSave.agentPrimaryModel, agentSafeModels, savedItemMap);
       if (invalidAgentPrimaryModel) {
-        setSaveMessage({ type: 'local-error', text: '当前 Agent 主模型不在已启用渠道的模型列表中，请重新选择。' });
+        setSaveMessage({ type: 'local-error', text: '当前 Agent 主模型没有 Agent-safe 非 Hermes deployment，请重新选择。' });
         return;
       }
 
@@ -1635,9 +1806,9 @@ export const LLMChannelEditor: React.FC<LLMChannelEditorProps> = ({
       }
 
       const invalidVisionModel = runtimeConfigForSave.visionModel
-        && !isRuntimeModelAvailable(runtimeConfigForSave.visionModel, availableModels, savedItemMap);
+        && !isRuntimeModelAvailable(runtimeConfigForSave.visionModel, visionSafeModels, savedItemMap);
       if (invalidVisionModel) {
-        setSaveMessage({ type: 'local-error', text: '当前 Vision 模型不在已启用渠道的模型列表中，请重新选择。' });
+        setSaveMessage({ type: 'local-error', text: '当前 Vision 模型不能包含 Hermes deployment，请重新选择纯非 Hermes route。' });
         return;
       }
     }
@@ -1687,6 +1858,14 @@ export const LLMChannelEditor: React.FC<LLMChannelEditorProps> = ({
   };
 
   const handleTest = async (channel: ChannelConfig, index: number) => {
+    if (hasRuntimeOnlyMaskedHermesSecret(channel, maskToken, hasPersistedHermesSecret(channel))) {
+      setTestStates((previous) => ({
+        ...previous,
+        [index]: { status: 'error', text: RUNTIME_ONLY_HERMES_SECRET_MESSAGE },
+      }));
+      return;
+    }
+
     setTestStates((previous) => ({
       ...previous,
       [index]: { status: 'loading', text: '测试中...' },
@@ -1700,6 +1879,7 @@ export const LLMChannelEditor: React.FC<LLMChannelEditorProps> = ({
         apiKey: channel.apiKey,
         models: splitModels(channel.models),
         enabled: channel.enabled,
+        useSavedSecret: shouldUseSavedHermesSecret(channel, maskToken, hasPersistedHermesSecret(channel)),
       });
 
       const text = result.success
@@ -1725,6 +1905,19 @@ export const LLMChannelEditor: React.FC<LLMChannelEditorProps> = ({
   };
 
   const handleDiscoverModels = async (channel: ChannelConfig) => {
+    if (hasRuntimeOnlyMaskedHermesSecret(channel, maskToken, hasPersistedHermesSecret(channel))) {
+      setDiscoveryStates((previous) => ({
+        ...previous,
+        [channel.id]: {
+          status: 'error',
+          text: RUNTIME_ONLY_HERMES_SECRET_MESSAGE,
+          hint: undefined,
+          models: previous[channel.id]?.models || [],
+        },
+      }));
+      return;
+    }
+
     const requestId = discoveryRequestIdRef.current + 1;
     discoveryRequestIdRef.current = requestId;
     discoveryNonceRef.current[channel.id] = requestId;
@@ -1747,6 +1940,7 @@ export const LLMChannelEditor: React.FC<LLMChannelEditorProps> = ({
         baseUrl: channel.baseUrl,
         apiKey: channel.apiKey,
         models: splitModels(channel.models),
+        useSavedSecret: shouldUseSavedHermesSecret(channel, maskToken, hasPersistedHermesSecret(channel)),
       });
 
       if (discoveryNonceRef.current[channel.id] !== nonce) return;
@@ -1799,8 +1993,24 @@ export const LLMChannelEditor: React.FC<LLMChannelEditorProps> = ({
   };
 
   const handleCapabilityCheck = async (channel: ChannelConfig) => {
-    const selected = capabilityStates[channel.id]?.selected || [];
+    const selected = (capabilityStates[channel.id]?.selected || []).filter(
+      (capability) => !isHermesChannel(channel) || capability === 'json',
+    );
     if (selected.length === 0) return;
+
+    if (hasRuntimeOnlyMaskedHermesSecret(channel, maskToken, hasPersistedHermesSecret(channel))) {
+      setCapabilityStates((previous) => ({
+        ...previous,
+        [channel.id]: {
+          selected,
+          status: 'error',
+          text: RUNTIME_ONLY_HERMES_SECRET_MESSAGE,
+          hint: undefined,
+          results: {},
+        },
+      }));
+      return;
+    }
 
     const requestId = capabilityRequestIdRef.current + 1;
     capabilityRequestIdRef.current = requestId;
@@ -1827,6 +2037,7 @@ export const LLMChannelEditor: React.FC<LLMChannelEditorProps> = ({
         models: splitModels(channel.models),
         enabled: channel.enabled,
         capabilityChecks: selected,
+        useSavedSecret: shouldUseSavedHermesSecret(channel, maskToken, hasPersistedHermesSecret(channel)),
       });
 
       if (capabilityNonceRef.current[channel.id] !== nonce) return;
@@ -2053,7 +2264,11 @@ export const LLMChannelEditor: React.FC<LLMChannelEditorProps> = ({
                         ...previous,
                         agentPrimaryModel: normalizeAgentPrimaryModel(value),
                       }))}
-                      options={buildModelOptions(availableModels, runtimeConfig.agentPrimaryModel, '自动（继承普通分析主模型）')}
+                      options={buildModelOptions(
+                        agentSafeModels,
+                        agentSelectedModelForOptions,
+                        '自动（继承普通分析主模型）',
+                      )}
                       disabled={busy}
                       placeholder=""
                     />
@@ -2099,7 +2314,11 @@ export const LLMChannelEditor: React.FC<LLMChannelEditorProps> = ({
                       id="runtime-vision-model"
                       value={runtimeConfig.visionModel}
                       onChange={(value) => setRuntimeConfig((previous) => ({ ...previous, visionModel: value }))}
-                      options={buildModelOptions(availableModels, runtimeConfig.visionModel, '自动（跟随 Vision 默认逻辑）')}
+                      options={buildModelOptions(
+                        visionSafeModels,
+                        visionSelectedModelForOptions,
+                        '自动（跟随 Vision 默认逻辑）',
+                      )}
                       disabled={busy}
                       placeholder=""
                     />

--- a/apps/dsa-web/src/components/settings/__tests__/LLMChannelEditor.test.tsx
+++ b/apps/dsa-web/src/components/settings/__tests__/LLMChannelEditor.test.tsx
@@ -28,6 +28,11 @@ describe('LLMChannelEditor', () => {
     discoverLLMChannelModels.mockReset();
   });
 
+  function selectOptionValues(label: string): string[] {
+    const select = screen.getByLabelText(label) as HTMLSelectElement;
+    return Array.from(select.options).map((option) => option.value);
+  }
+
   it('renders API Key input with controlled visibility', async () => {
     render(
       <LLMChannelEditor
@@ -113,6 +118,142 @@ describe('LLMChannelEditor', () => {
     expect(screen.getByText(/运行时主模型 \/ 备选模型 \/ Vision \/ Temperature 仍由下方通用字段决定/i)).toBeInTheDocument();
     expect(screen.queryByText(/LiteLLM/i)).not.toBeInTheDocument();
     expect(screen.queryByText(/LITELLM_CONFIG/i)).not.toBeInTheDocument();
+  });
+
+  it('excludes Hermes-only route from Agent and Vision runtime selects', () => {
+    render(
+      <LLMChannelEditor
+        items={[
+          { key: 'LLM_CHANNELS', value: 'hermes' },
+          { key: 'LLM_HERMES_PROTOCOL', value: 'openai' },
+          { key: 'LLM_HERMES_BASE_URL', value: 'http://127.0.0.1:8642/v1' },
+          { key: 'LLM_HERMES_ENABLED', value: 'true' },
+          { key: 'LLM_HERMES_API_KEY', value: '******' },
+          { key: 'LLM_HERMES_MODELS', value: 'hermes-agent' },
+        ]}
+        configVersion="v1"
+        maskToken="******"
+        onSaved={() => {}}
+      />
+    );
+
+    expect(selectOptionValues('主模型')).toContain('openai/hermes-agent');
+    expect(selectOptionValues('Agent 主模型')).not.toContain('openai/hermes-agent');
+    expect(selectOptionValues('Vision 模型')).not.toContain('openai/hermes-agent');
+  });
+
+  it('keeps mixed Hermes route for Agent but excludes it from Vision', () => {
+    render(
+      <LLMChannelEditor
+        items={[
+          { key: 'LLM_CHANNELS', value: 'hermes,remote,pure' },
+          { key: 'LLM_HERMES_PROTOCOL', value: 'openai' },
+          { key: 'LLM_HERMES_BASE_URL', value: 'http://127.0.0.1:8642/v1' },
+          { key: 'LLM_HERMES_ENABLED', value: 'true' },
+          { key: 'LLM_HERMES_API_KEY', value: '******' },
+          { key: 'LLM_HERMES_MODELS', value: 'shared-route' },
+          { key: 'LLM_REMOTE_PROTOCOL', value: 'openai' },
+          { key: 'LLM_REMOTE_BASE_URL', value: 'https://api.example.com/v1' },
+          { key: 'LLM_REMOTE_ENABLED', value: 'true' },
+          { key: 'LLM_REMOTE_API_KEY', value: 'sk-remote' },
+          { key: 'LLM_REMOTE_MODELS', value: 'shared-route' },
+          { key: 'LLM_PURE_PROTOCOL', value: 'openai' },
+          { key: 'LLM_PURE_BASE_URL', value: 'https://api.example.com/v1' },
+          { key: 'LLM_PURE_ENABLED', value: 'true' },
+          { key: 'LLM_PURE_API_KEY', value: 'sk-pure' },
+          { key: 'LLM_PURE_MODELS', value: 'pure-route' },
+        ]}
+        configVersion="v1"
+        maskToken="******"
+        onSaved={() => {}}
+      />
+    );
+
+    expect(selectOptionValues('主模型')).not.toContain('openai/shared-route');
+    expect(selectOptionValues('主模型')).toContain('openai/pure-route');
+    expect(selectOptionValues('Agent 主模型')).toContain('openai/shared-route');
+    expect(selectOptionValues('Vision 模型')).not.toContain('openai/shared-route');
+  });
+
+  it('rejects bare mixed Hermes route before saving runtime generation config', async () => {
+    render(
+      <LLMChannelEditor
+        items={[
+          { key: 'LLM_CHANNELS', value: 'hermes,remote' },
+          { key: 'LITELLM_MODEL', value: 'shared-route' },
+          { key: 'LLM_HERMES_PROTOCOL', value: 'openai' },
+          { key: 'LLM_HERMES_BASE_URL', value: 'http://127.0.0.1:8642/v1' },
+          { key: 'LLM_HERMES_ENABLED', value: 'true' },
+          { key: 'LLM_HERMES_API_KEY', value: 'sk-hermes' },
+          { key: 'LLM_HERMES_MODELS', value: 'shared-route' },
+          { key: 'LLM_REMOTE_PROTOCOL', value: 'openai' },
+          { key: 'LLM_REMOTE_BASE_URL', value: 'https://api.example.com/v1' },
+          { key: 'LLM_REMOTE_ENABLED', value: 'true' },
+          { key: 'LLM_REMOTE_API_KEY', value: 'sk-remote' },
+          { key: 'LLM_REMOTE_MODELS', value: 'shared-route' },
+        ]}
+        configVersion="v1"
+        maskToken="******"
+        onSaved={() => {}}
+      />
+    );
+
+    fireEvent.change(screen.getByRole('slider'), { target: { value: '0.2' } });
+    fireEvent.click(screen.getByRole('button', { name: '保存 AI 配置' }));
+
+    expect(await screen.findByText(/Mixed Hermes\/non-Hermes route 暂不支持作为主生成或备选模型/i)).toBeInTheDocument();
+    expect(update).not.toHaveBeenCalled();
+  });
+
+  it('does not test runtime-only masked Hermes secrets from the settings UI', async () => {
+    render(
+      <LLMChannelEditor
+        items={[
+          { key: 'LLM_CHANNELS', value: 'hermes' },
+          { key: 'LLM_HERMES_PROTOCOL', value: 'openai' },
+          { key: 'LLM_HERMES_BASE_URL', value: 'http://127.0.0.1:8642/v1' },
+          { key: 'LLM_HERMES_ENABLED', value: 'true' },
+          { key: 'LLM_HERMES_API_KEY', value: '******', rawValueExists: false },
+          { key: 'LLM_HERMES_MODELS', value: 'hermes-agent' },
+        ]}
+        configVersion="v1"
+        maskToken="******"
+        onSaved={() => {}}
+      />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /Hermes/i }));
+    fireEvent.click(screen.getByRole('button', { name: '测试连接' }));
+    fireEvent.click(screen.getByRole('button', { name: '获取模型' }));
+    fireEvent.click(screen.getByLabelText('JSON'));
+    fireEvent.click(screen.getByRole('button', { name: '检测能力' }));
+
+    const messages = await screen.findAllByText(/运行时注入的 Hermes Key 不会回传/i);
+    expect(messages.length).toBeGreaterThanOrEqual(3);
+    expect(testLLMChannel).not.toHaveBeenCalled();
+    expect(discoverLLMChannelModels).not.toHaveBeenCalled();
+  });
+
+  it('keeps pure non-Hermes route in Agent and Vision runtime selects', () => {
+    render(
+      <LLMChannelEditor
+        items={[
+          { key: 'LLM_CHANNELS', value: 'remote' },
+          { key: 'LLM_REMOTE_PROTOCOL', value: 'openai' },
+          { key: 'LLM_REMOTE_BASE_URL', value: 'https://api.example.com/v1' },
+          { key: 'LLM_REMOTE_ENABLED', value: 'true' },
+          { key: 'LLM_REMOTE_API_KEY', value: 'sk-remote' },
+          { key: 'LLM_REMOTE_MODELS', value: 'gpt-4o-mini' },
+        ]}
+        configVersion="v1"
+        maskToken="******"
+        onSaved={() => {}}
+      />
+    );
+
+    expect(selectOptionValues('主模型')).toContain('openai/gpt-4o-mini');
+    expect(selectOptionValues('Agent 主模型')).toContain('openai/gpt-4o-mini');
+    expect(selectOptionValues('Vision 模型')).toContain('openai/gpt-4o-mini');
   });
 
   it('keeps minimax-prefixed models in runtime selections', () => {
@@ -359,6 +500,55 @@ describe('LLMChannelEditor', () => {
         expect.objectContaining({ key: 'LLM_MINIMAX_MODELS', value: 'MiniMax-M3,MiniMax-M2.7,MiniMax-M2.7-highspeed' }),
       ]),
     );
+  });
+
+  it('clears active Hermes unsupported multi-key and extra-header env keys on save', async () => {
+    update.mockResolvedValue({
+      success: true,
+      configVersion: 'v2',
+      appliedCount: 1,
+      skippedMaskedCount: 0,
+      reloadTriggered: true,
+      updatedKeys: ['LLM_HERMES_API_KEYS', 'LLM_HERMES_EXTRA_HEADERS'],
+      warnings: [
+        '检测到已清理 Hermes Phase 3 不支持的配置项：LLM_HERMES_API_KEYS, LLM_HERMES_EXTRA_HEADERS。Hermes reserved channel 只支持单个 LLM_HERMES_API_KEY，不支持多 Key 或额外 Header；如需恢复旧值，请从 .env 备份、Git 历史或桌面端导出备份手动还原，但非空 LLM_HERMES_API_KEYS / LLM_HERMES_EXTRA_HEADERS 仍会被后端校验拒绝。',
+      ],
+    });
+
+    render(
+      <LLMChannelEditor
+        items={[
+          { key: 'LLM_CHANNELS', value: 'hermes' },
+          { key: 'LLM_HERMES_PROTOCOL', value: 'openai' },
+          { key: 'LLM_HERMES_BASE_URL', value: 'http://127.0.0.1:8642/v1' },
+          { key: 'LLM_HERMES_ENABLED', value: 'true' },
+          { key: 'LLM_HERMES_API_KEY', value: 'sk-hermes-test-value' },
+          { key: 'LLM_HERMES_API_KEYS', value: 'sk-old-a,sk-old-b' },
+          { key: 'LLM_HERMES_EXTRA_HEADERS', value: '{"X":"Y"}' },
+          { key: 'LLM_HERMES_MODELS', value: 'hermes-agent' },
+        ]}
+        configVersion="v1"
+        maskToken="******"
+        onSaved={() => {}}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /Hermes/i }));
+    fireEvent.change(screen.getByLabelText('模型（逗号分隔）'), { target: { value: 'hermes-agent,hermes-agent-2' } });
+    fireEvent.click(screen.getByRole('button', { name: '保存 AI 配置' }));
+
+    await waitFor(() => {
+      expect(update).toHaveBeenCalled();
+    });
+
+    const updatePayload = update.mock.calls[0][0];
+    const updateItemMap = new Map(updatePayload.items.map((item: { key: string; value: string }) => [item.key, item.value]));
+
+    expect(updateItemMap.get('LLM_HERMES_API_KEY')).toBe('sk-hermes-test-value');
+    expect(updateItemMap.get('LLM_HERMES_API_KEYS')).toBe('');
+    expect(updateItemMap.get('LLM_HERMES_EXTRA_HEADERS')).toBe('');
+    expect(await screen.findByText(/已清理 Hermes Phase 3 不支持的配置项/i)).toBeInTheDocument();
+    expect(screen.getByText(/如需恢复旧值，请从 \.env 备份/i)).toBeInTheDocument();
   });
 
   it('only persists edited values for runtime-only channel keys', async () => {
@@ -622,6 +812,99 @@ describe('LLMChannelEditor', () => {
         expect.objectContaining({ key: 'LITELLM_FALLBACK_MODELS', value: 'deepseek/deepseek-v4-pro,cohere/command-r-plus' }),
         expect.objectContaining({ key: 'VISION_MODEL', value: '' }),
         expect.objectContaining({ key: 'LLM_DEEPSEEK_MODELS', value: 'deepseek-v4-flash,deepseek-v4-pro' }),
+      ]),
+    );
+  });
+
+  it('prompts when bare runtime models loosely match canonical OpenAI route aliases', async () => {
+    update.mockResolvedValue({
+      success: true,
+      configVersion: 'v2',
+      appliedCount: 1,
+      skippedMaskedCount: 0,
+      reloadTriggered: true,
+      updatedKeys: ['LLM_PRIMARY_BASE_URL', 'LITELLM_MODEL', 'LITELLM_FALLBACK_MODELS'],
+      warnings: [],
+    });
+
+    render(
+      <LLMChannelEditor
+        items={[
+          { key: 'LLM_CHANNELS', value: 'primary' },
+          { key: 'LLM_PRIMARY_PROTOCOL', value: 'openai' },
+          { key: 'LLM_PRIMARY_BASE_URL', value: 'https://api.example.com/v1' },
+          { key: 'LLM_PRIMARY_ENABLED', value: 'true' },
+          { key: 'LLM_PRIMARY_API_KEY', value: 'sk-test' },
+          { key: 'LLM_PRIMARY_MODELS', value: 'gpt-4o-mini' },
+          { key: 'LITELLM_MODEL', value: 'gpt-4o-mini' },
+          { key: 'LITELLM_FALLBACK_MODELS', value: 'gpt-4o-mini' },
+          { key: 'AGENT_LITELLM_MODEL', value: '' },
+          { key: 'VISION_MODEL', value: '' },
+        ]}
+        configVersion="v1"
+        maskToken="******"
+        onSaved={() => {}}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /primary/i }));
+    fireEvent.change(screen.getByLabelText('Base URL'), {
+      target: { value: 'https://api.example.com/compatible/v1' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: '保存 AI 配置' }));
+
+    await waitFor(() => {
+      expect(screen.getByText('当前运行时模型使用非规范 route alias，请从下拉框重新选择规范模型。')).toBeInTheDocument();
+    });
+
+    expect(update).not.toHaveBeenCalled();
+  });
+
+  it('does not treat direct-env provider models as non-canonical route aliases', async () => {
+    update.mockResolvedValue({
+      success: true,
+      configVersion: 'v2',
+      appliedCount: 1,
+      skippedMaskedCount: 0,
+      reloadTriggered: true,
+      updatedKeys: ['LLM_PRIMARY_BASE_URL', 'LITELLM_MODEL'],
+      warnings: [],
+    });
+
+    render(
+      <LLMChannelEditor
+        items={[
+          { key: 'LLM_CHANNELS', value: 'primary' },
+          { key: 'LLM_PRIMARY_PROTOCOL', value: 'openai' },
+          { key: 'LLM_PRIMARY_BASE_URL', value: 'https://api.example.com/v1' },
+          { key: 'LLM_PRIMARY_ENABLED', value: 'true' },
+          { key: 'LLM_PRIMARY_API_KEY', value: 'sk-test' },
+          { key: 'LLM_PRIMARY_MODELS', value: 'cohere/command-r-plus' },
+          { key: 'LITELLM_MODEL', value: 'cohere/command-r-plus' },
+          { key: 'AGENT_LITELLM_MODEL', value: '' },
+          { key: 'LITELLM_FALLBACK_MODELS', value: '' },
+          { key: 'VISION_MODEL', value: '' },
+        ]}
+        configVersion="v1"
+        maskToken="******"
+        onSaved={() => {}}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /primary/i }));
+    fireEvent.change(screen.getByLabelText('Base URL'), {
+      target: { value: 'https://api.example.com/compatible/v1' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: '保存 AI 配置' }));
+
+    await waitFor(() => {
+      expect(update).toHaveBeenCalled();
+    });
+
+    const updatePayload = update.mock.calls[0][0];
+    expect(updatePayload.items).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ key: 'LITELLM_MODEL', value: 'cohere/command-r-plus' }),
       ]),
     );
   });

--- a/apps/dsa-web/src/types/systemConfig.ts
+++ b/apps/dsa-web/src/types/systemConfig.ts
@@ -181,6 +181,7 @@ export interface TestLLMChannelRequest {
   enabled?: boolean;
   timeoutSeconds?: number;
   capabilityChecks?: LLMCapabilityCheck[];
+  useSavedSecret?: boolean;
 }
 
 export type LLMCapabilityCheck = 'json' | 'tools' | 'vision' | 'stream';
@@ -262,6 +263,7 @@ export interface DiscoverLLMChannelModelsRequest {
   apiKey?: string;
   models?: string[];
   timeoutSeconds?: number;
+  useSavedSecret?: boolean;
 }
 
 export interface DiscoverLLMChannelModelsResponse {

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - [新功能] 大盘复盘、Web 报告页和通知关联板块补齐概念板块排行与概念信号展示。
 - [改进] 将 Docker Compose 默认内存建议从 512M 提升到 1G，并补充低配部署说明。
 - [改进] 每日分析 workflow 兼容误将 `STOCK_LIST` 配到同名 Environment variables 的场景，同时保留 Repository variables 作为推荐配置入口。
+- [新功能] #1743 Phase 3 新增 reserved Hermes 本地 HTTP generation 渠道，提供 JSON generation、no-proxy 本地调用、saved secret endpoint 绑定，并明确不支持 stream/SSE、tools、Vision、Agent tools 与 remote Hermes。
 - [新功能] #1772 新增台湾（台股）suffix-only 个股分析 MVP（**市场识别与数据路由层**）：手输 `.TW`（TWSE 上市）/ `.TWO`（TPEx 上柜）代码可走 YFinance 日线与近实时行情，补充市场识别、交易日历（XTAI / Asia/Taipei）、Prompt 语义与能力边界文档；加权指数 `^TWII`、柜买指数 `^TWOII`。台股股票索引/种子、Web 自动补全与告警（大盘红绿灯）市场放行作为后续 PR。
 - [文档] #1772 明确本次为台股 suffix 仅路由兼容改造，对齐 #1718 日韩模式；不涉及 provider/model/base URL/运行时配置变更；回退方式为 revert 本次改动或移除 tw 入口恢复既有行为。
 - [新功能] #1772 台股 `tw` 纳入 DecisionSignal / Portfolio / Intelligence 服务层与 API 市场枚举（VALID_MARKETS / _ALLOWED_MARKETS + Pydantic Literal + api_spec.json），修复数据层 MVP 下 tw 分析在 pipeline 自动抽取 DecisionSignal 时被 _normalize_market 静默丢弃的缺陷，并同步放行 DecisionSignal/Portfolio 前端市场类型与筛选及相关专题文档，对齐 #1720 日韩；告警（大盘红绿灯）市场仍为 cn/hk/us。

--- a/docs/LLM_CONFIG_GUIDE.md
+++ b/docs/LLM_CONFIG_GUIDE.md
@@ -218,6 +218,18 @@ LLM_OLLAMA_MODELS=qwen3:8b,llama3.2
 LITELLM_MODEL=ollama/qwen3:8b
 ```
 
+### 示例：Hermes 本地 HTTP Generation（Phase 3）
+```env
+LLM_CHANNELS=hermes
+LLM_HERMES_PROTOCOL=openai
+LLM_HERMES_BASE_URL=http://127.0.0.1:8642/v1
+LLM_HERMES_API_KEY=sk-local-hermes
+LLM_HERMES_MODELS=hermes-agent
+LITELLM_MODEL=openai/hermes-agent
+```
+
+Hermes 是保留渠道名，只支持本机 loopback `/v1` OpenAI-compatible generation。Phase 3 只验证普通分析与 JSON 输出；不支持 Stream/SSE、Tools、Vision、Agent tools、远程 Hermes 或进程生命周期管理。Hermes API Key 只能使用单个 `LLM_HERMES_API_KEY`，不要配置 `LLM_HERMES_API_KEYS` 或 `LLM_HERMES_EXTRA_HEADERS`。如果 Hermes 配置非法，系统会阻止 legacy provider silent fallback，避免错误地改用外部模型。Web 设置页保存 reserved Hermes 渠道时，会显式清空旧的 `LLM_HERMES_API_KEYS` / `LLM_HERMES_EXTRA_HEADERS` 并返回 warning；如需恢复旧值，请从 `.env` 备份、Git 历史或桌面端导出备份手动还原，但 Phase 3 仍会拒绝非空的多 Key / Extra Headers 配置。
+
 ### MiniMax 渠道模型填写说明
 
 - 如果你通过 OpenAI Compatible 渠道接 MiniMax，请在渠道模型里直接填写 `minimax/<模型名>`，例如 `minimax/MiniMax-M1`。

--- a/docs/LLM_CONFIG_GUIDE_EN.md
+++ b/docs/LLM_CONFIG_GUIDE_EN.md
@@ -211,6 +211,18 @@ LLM_OLLAMA_MODELS=qwen3:8b,llama3.2
 LITELLM_MODEL=ollama/qwen3:8b
 ```
 
+### Example: Hermes Local HTTP Generation (Phase 3)
+```env
+LLM_CHANNELS=hermes
+LLM_HERMES_PROTOCOL=openai
+LLM_HERMES_BASE_URL=http://127.0.0.1:8642/v1
+LLM_HERMES_API_KEY=sk-local-hermes
+LLM_HERMES_MODELS=hermes-agent
+LITELLM_MODEL=openai/hermes-agent
+```
+
+`hermes` is a reserved channel name for local loopback `/v1` OpenAI-compatible generation. Phase 3 only verifies regular analysis and JSON output. It does not support Stream/SSE, tools, Vision, Agent tools, remote Hermes, or process lifecycle management. Use exactly one `LLM_HERMES_API_KEY`; do not configure `LLM_HERMES_API_KEYS` or `LLM_HERMES_EXTRA_HEADERS`. If enabled Hermes config is invalid, DSA blocks legacy provider silent fallback so requests do not unexpectedly switch to an external model. When the Web settings page saves the reserved Hermes channel, it explicitly clears stale `LLM_HERMES_API_KEYS` / `LLM_HERMES_EXTRA_HEADERS` values and returns a warning. To recover previous values, restore them from a `.env` backup, Git history, or a desktop export backup, but Phase 3 will still reject non-empty multi-key or extra-header Hermes settings.
+
 ### MiniMax Model Naming in Channel Mode
 
 - If you access MiniMax through an OpenAI-compatible channel, enter the model as `minimax/<model-name>` in the channel model list, for example `minimax/MiniMax-M1`.

--- a/docs/full-guide.md
+++ b/docs/full-guide.md
@@ -241,6 +241,9 @@ daily_stock_analysis/
 | `AGENT_CONTEXT_PROTECTED_TURNS` | 压缩时最近 N 个用户轮次及其后的回复保留原文；留空则跟随 profile preset | - | 否 |
 | `LITELLM_FALLBACK_MODELS` | 备选模型，逗号分隔 | - | 否 |
 | `LLM_CHANNELS` | 渠道名称列表（逗号分隔），配合 `LLM_{NAME}_*` 使用，详见 [LLM 配置指南](LLM_CONFIG_GUIDE.md) | - | 否 |
+| `LLM_HERMES_API_KEY` | Hermes reserved 本地 HTTP generation 的单一 API Key；只应来自 `.env`、运行时配置或 Secrets | - | Hermes 使用时必填 |
+| `LLM_HERMES_BASE_URL` | Hermes 本地 loopback `/v1` 地址；默认 `http://127.0.0.1:8642/v1`，不支持远程地址 | `http://127.0.0.1:8642/v1` | 否 |
+| `LLM_HERMES_MODELS` | Hermes 原始模型列表；Phase 3 默认 `hermes-agent`，运行时 route 为 `openai/hermes-agent`，不支持 Vision / stream / tools / Agent tools | `hermes-agent` | 否 |
 | `LITELLM_CONFIG` | 高级模型路由 YAML 配置文件路径（高级） | - | 否 |
 | `LLM_PROMPT_CACHE_TELEMETRY_ENABLED` | Provider prompt cache usage / diagnostics 遥测；不控制 provider implicit cache | `true` | 否 |
 | `LLM_PROMPT_CACHE_HINTS_ENABLED` | 主分析路径是否主动发送已验证的 provider-specific prompt cache hints；Agent 路径当前仅记录 diagnostics，不主动发 hints；默认关闭 | `false` | 否 |

--- a/docs/full-guide_EN.md
+++ b/docs/full-guide_EN.md
@@ -206,6 +206,9 @@ Default schedule: Every weekday at **18:00 (Beijing Time)** automatic execution.
 | `AGENT_LITELLM_MODEL` | Optional Agent-only primary model; when empty it inherits the primary model, and bare names are normalized to `openai/<model>` | - | No |
 | `LITELLM_FALLBACK_MODELS` | Fallback models, comma-separated | - | No |
 | `LLM_CHANNELS` | Channel names (comma-separated), use with `LLM_{NAME}_*`, see [LLM Config Guide](LLM_CONFIG_GUIDE_EN.md) | - | No |
+| `LLM_HERMES_API_KEY` | Single API key for the reserved Hermes local HTTP generation channel; provide it through `.env`, runtime config, or Secrets only | - | Required for Hermes |
+| `LLM_HERMES_BASE_URL` | Hermes local loopback `/v1` endpoint; defaults to `http://127.0.0.1:8642/v1`; remote endpoints are not supported | `http://127.0.0.1:8642/v1` | No |
+| `LLM_HERMES_MODELS` | Raw Hermes model list; Phase 3 defaults to `hermes-agent`, maps to runtime route `openai/hermes-agent`, and does not support Vision, stream, tools, or Agent tools | `hermes-agent` | No |
 | `LITELLM_CONFIG` | Advanced model routing YAML path (expert use) | - | No |
 | `LLM_USAGE_HMAC_SECRET` | Secret for LLM usage telemetry message HMACs; leave empty to use a generated local data-dir secret file | - | No |
 | `LLM_USAGE_HMAC_KEY_VERSION` | Version label for the LLM usage HMAC key; update it when rotating the secret | `local-v1` | No |

--- a/docs/llm-providers.md
+++ b/docs/llm-providers.md
@@ -128,11 +128,28 @@ OpenAI-compatible Base URL 只填到服务商兼容入口，不额外拼接 `/ch
 | `LLM_USAGE_HMAC_SECRET` | Secrets | 可选；只有需要跨部署比较 usage message HMAC 时才配置同一个高熵随机密钥，例如 `openssl rand -hex 32`；不要放 Variables 或提交到版本控制。 |
 | `LLM_USAGE_HMAC_KEY_VERSION` | Variables 或 Secrets | 可选；轮换 `LLM_USAGE_HMAC_SECRET` 时同步更新版本标签，避免误比较不同密钥生成的 HMAC。 |
 
-默认 workflow 已显式映射 `primary`、`secondary`、`aihubmix`、`anspire`、`deepseek`、`dashscope`、`zhipu`、`moonshot`、`minimax`、`volcengine`、`siliconflow`、`openrouter`、`gemini`、`anthropic`、`openai`、`ollama`；`mimo` 未在默认 workflow 中映射。若使用 `mimo`（或任何未列渠道名），除了在 Variables/Secrets 配置同名 `LLM_<CHANNEL>_*` 外，还需在 workflow 中同步补齐对应 env 映射；本地 `.env`、Docker 和自托管脚本不受这个限制。
+默认 workflow 已显式映射 `primary`、`secondary`、`aihubmix`、`anspire`、`deepseek`、`dashscope`、`zhipu`、`moonshot`、`minimax`、`volcengine`、`siliconflow`、`openrouter`、`gemini`、`anthropic`、`openai`、`ollama`、`hermes`；`mimo` 未在默认 workflow 中映射。若使用 `mimo`（或任何未列渠道名），除了在 Variables/Secrets 配置同名 `LLM_<CHANNEL>_*` 外，还需在 workflow 中同步补齐对应 env 映射；本地 `.env`、Docker 和自托管脚本不受这个限制。
 
 回滚 HMAC 遥测显式配置时，可移除 `LLM_USAGE_HMAC_SECRET` 并恢复或删除 `LLM_USAGE_HMAC_KEY_VERSION`；留空后系统会回到本地生成 `.llm_usage_hmac_secret` 的默认行为。
 
 Ollama 默认 Base URL `http://127.0.0.1:11434` 主要面向本地、Docker 或能访问该服务的 self-hosted runner。GitHub-hosted runner 通常没有本地 Ollama 服务，直接配置 `LLM_CHANNELS=ollama` 大概率会连接失败。
+
+### Hermes 本地 HTTP generation（Phase 3）
+
+Hermes 是 reserved 本地 HTTP generation preset，只通过 `LLM_CHANNELS=hermes` 启用。默认协议为 `openai`，默认地址为 `http://127.0.0.1:8642/v1`，默认模型为 `hermes-agent`：
+
+```env
+LLM_CHANNELS=hermes
+LLM_HERMES_PROTOCOL=openai
+LLM_HERMES_BASE_URL=http://127.0.0.1:8642/v1
+LLM_HERMES_API_KEY=sk-local-hermes
+LLM_HERMES_MODELS=hermes-agent
+LITELLM_MODEL=openai/hermes-agent
+```
+
+Phase 3 只支持普通分析 / JSON generation，不支持 stream/SSE、tools、Vision、Agent tools、remote Hermes 或进程生命周期管理。`LLM_HERMES_API_KEY` 应来自本地 `.env`、运行时配置或 GitHub Secrets；不要写入仓库。Hermes 只允许 loopback `/v1` endpoint，`localhost` 会按 `127.0.0.1` 规范化，`LLM_HERMES_API_KEYS` 与 `LLM_HERMES_EXTRA_HEADERS` 不受支持。Web 设置页保存 reserved Hermes 渠道时会清空这两个旧字段并显示 warning；恢复旧值请使用 `.env` 备份、Git 历史或桌面端导出备份，但非空多 Key / Extra Headers 仍会被后端拒绝。
+
+在 GitHub Actions 中，GitHub-hosted runner 的 `127.0.0.1` 是 runner 自身，不是用户电脑。只有 self-hosted runner 或同机服务能访问本地 Hermes；否则会连接失败。
 
 ## 常见错误与处理建议
 

--- a/src/agent/chat_context.py
+++ b/src/agent/chat_context.py
@@ -13,6 +13,7 @@ from src.config import (
     get_effective_agent_primary_model,
     get_effective_agent_models_to_try,
 )
+from src.agent.litellm_route_resolution import resolve_agent_litellm_route
 from src.agent.provider_trace import (
     TRACE_MODEL_KEY,
     TRACE_PROVIDER_KEY,
@@ -140,8 +141,11 @@ def build_agent_chat_context_bundle(
     state = _build_visible_history_state(session_id, llm_adapter, config)
     diagnostics = TraceDiagnostics(visible_tokens=state.visible_tokens)
     db = get_db()
-    candidate_models = get_effective_agent_models_to_try(config)
-    if not candidate_models:
+    resolution = resolve_agent_litellm_route(config)
+    candidate_models = resolution.models_to_try if resolution.available else []
+    if not candidate_models and not resolution.reason:
+        candidate_models = get_effective_agent_models_to_try(config)
+    if not candidate_models and not resolution.reason:
         candidate_models = [get_effective_agent_primary_model(config)]
     candidate_trace_targets = _build_trace_match_targets(candidate_models, config)
     turns = db.get_agent_provider_turns(session_id, must_roundtrip_only=True)

--- a/src/agent/litellm_route_resolution.py
+++ b/src/agent/litellm_route_resolution.py
@@ -1,0 +1,111 @@
+# -*- coding: utf-8 -*-
+"""Agent-safe LiteLLM route resolution."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, List
+
+from src.config import (
+    get_effective_agent_models_to_try,
+    get_effective_agent_primary_model,
+    get_configured_llm_models,
+)
+from src.llm.backend_registry import AUTO_AGENT_BACKEND_ID, CODEX_CLI_BACKEND_ID
+from src.llm.hermes import (
+    build_route_provenance_map,
+    filter_non_hermes_deployments,
+    route_deployment_origins,
+    route_identity_candidates,
+)
+
+
+@dataclass(frozen=True)
+class AgentLiteLLMRouteResolution:
+    available: bool
+    primary_model: str = ""
+    models_to_try: List[str] = field(default_factory=list)
+    model_list: List[Dict[str, Any]] = field(default_factory=list)
+    reason: str = ""
+
+
+def _is_model_agent_safe(config: Any, model: str, provenance: Dict[str, Any]) -> bool:
+    if not model:
+        return False
+    route = route_deployment_origins(getattr(config, "llm_model_list", []) or [], model)
+    if route.has_hermes or route.has_non_hermes:
+        return route.has_non_hermes
+    route = provenance.get(model)
+    if route is not None:
+        return route.has_non_hermes
+    return True
+
+
+def _matched_route_alias(model: str, provenance: Dict[str, Any]) -> str:
+    for candidate in route_identity_candidates(model):
+        if candidate in provenance:
+            return candidate
+    return (model or "").strip()
+
+
+def resolve_agent_litellm_route(config: Any) -> AgentLiteLLMRouteResolution:
+    """Resolve the Agent LiteLLM route without allowing Hermes-only deployments."""
+
+    agent_backend = str(
+        getattr(config, "agent_generation_backend", AUTO_AGENT_BACKEND_ID)
+        or AUTO_AGENT_BACKEND_ID
+    ).strip().lower()
+    if agent_backend == CODEX_CLI_BACKEND_ID:
+        return AgentLiteLLMRouteResolution(False, reason="unsupported_agent_backend")
+
+    primary = get_effective_agent_primary_model(config)
+    if not primary:
+        return AgentLiteLLMRouteResolution(False, reason="no_agent_primary")
+
+    model_list = list(getattr(config, "llm_model_list", []) or [])
+    provenance = build_route_provenance_map(model_list)
+    filtered_model_list = filter_non_hermes_deployments(model_list)
+    configured_models = set(get_configured_llm_models(model_list))
+    configured_agent_model = bool((getattr(config, "agent_litellm_model", "") or "").strip())
+
+    primary_route = route_deployment_origins(model_list, primary)
+    if primary_route is not None and primary_route.has_hermes and not primary_route.has_non_hermes:
+        return AgentLiteLLMRouteResolution(
+            False,
+            primary_model=primary,
+            model_list=filtered_model_list,
+            reason=(
+                "explicit_agent_model_no_safe_deployment"
+                if configured_agent_model
+                else "hermes_primary_not_agent_safe"
+            ),
+        )
+    safe_models: List[str] = []
+    seen = set()
+    for model in get_effective_agent_models_to_try(config):
+        normalized = (model or "").strip()
+        if not normalized or normalized in seen:
+            continue
+        if not _is_model_agent_safe(config, normalized, provenance):
+            continue
+        safe_model = _matched_route_alias(normalized, provenance)
+        if safe_model in seen:
+            continue
+        seen.add(safe_model)
+        safe_models.append(safe_model)
+
+    if not safe_models:
+        return AgentLiteLLMRouteResolution(
+            False,
+            primary_model=primary,
+            model_list=filtered_model_list,
+            reason="no_safe_agent_models",
+        )
+
+    return AgentLiteLLMRouteResolution(
+        True,
+        primary_model=safe_models[0],
+        models_to_try=safe_models,
+        model_list=filtered_model_list,
+        reason="",
+    )

--- a/src/agent/llm_adapter.py
+++ b/src/agent/llm_adapter.py
@@ -24,6 +24,10 @@ from src.config import (
     get_effective_agent_models_to_try,
     get_effective_agent_primary_model,
 )
+from src.agent.litellm_route_resolution import (
+    AgentLiteLLMRouteResolution,
+    resolve_agent_litellm_route,
+)
 from src.agent.provider_trace import (
     TRACE_MODEL_KEY,
     TRACE_PROVIDER_KEY,
@@ -346,6 +350,7 @@ class LLMToolAdapter:
         self._litellm_available = False
         self._backend_error: Optional[GenerationError] = None
         self._generation_backend_id = ""
+        self._route_resolution: AgentLiteLLMRouteResolution = AgentLiteLLMRouteResolution(False)
         self._register_custom_model_pricing()
         self._init_litellm()
 
@@ -401,7 +406,24 @@ class LLMToolAdapter:
             )
             return
 
-        litellm_model = get_effective_agent_primary_model(config)
+        self._route_resolution = resolve_agent_litellm_route(config)
+        litellm_model = self._route_resolution.primary_model or get_effective_agent_primary_model(config)
+        if not self._route_resolution.available and litellm_model:
+            self._backend_error = GenerationError(
+                error_code=GenerationErrorCode.UNSUPPORTED_TOOL_CALLING,
+                stage="generation",
+                retryable=False,
+                fallbackable=False,
+                backend=LITELLM_BACKEND_ID,
+                provider="agent",
+                details={
+                    "field": "AGENT_LITELLM_MODEL",
+                    "reason": self._route_resolution.reason,
+                    "primary_model": litellm_model,
+                },
+            )
+            logger.error("Agent LLM unavailable: %s", self._route_resolution.reason)
+            return
         if not litellm_model:
             generation_backend = str(
                 getattr(config, "generation_backend", LITELLM_BACKEND_ID) or LITELLM_BACKEND_ID
@@ -434,11 +456,25 @@ class LLMToolAdapter:
             logger.warning("Agent LLM: no effective primary model configured")
             return
 
-        self._litellm_available = True
-
         # --- Channel / YAML path ---
         if self._has_channel_config():
-            model_list = config.llm_model_list
+            model_list = self._route_resolution.model_list
+            if not model_list:
+                self._backend_error = GenerationError(
+                    error_code=GenerationErrorCode.UNSUPPORTED_TOOL_CALLING,
+                    stage="generation",
+                    retryable=False,
+                    fallbackable=False,
+                    backend=LITELLM_BACKEND_ID,
+                    provider="agent",
+                    details={
+                        "field": "AGENT_LITELLM_MODEL",
+                        "reason": self._route_resolution.reason or "no_safe_agent_models",
+                        "primary_model": litellm_model,
+                    },
+                )
+                logger.warning("Agent LLM: no Agent-safe channel deployments after Hermes filtering")
+                return
             self._router = Router(
                 model_list=model_list,
                 routing_strategy="simple-shuffle",
@@ -460,6 +496,7 @@ class LLMToolAdapter:
                 f"Agent LLM: litellm initialized (model={litellm_model}, "
                 f"API key from environment)"
             )
+            self._litellm_available = True
             return
 
         if len(keys) > 1:
@@ -487,6 +524,7 @@ class LLMToolAdapter:
             )
         else:
             logger.info(f"Agent LLM: litellm initialized (model={litellm_model})")
+        self._litellm_available = True
 
     @property
     def is_available(self) -> bool:
@@ -565,7 +603,8 @@ class LLMToolAdapter:
             )
             logger.error(error_msg)
             return LLMResponse(content=error_msg, provider="error")
-        models_to_try = get_effective_agent_models_to_try(config)
+        route_resolution = resolve_agent_litellm_route(config)
+        models_to_try = route_resolution.models_to_try
         if not models_to_try:
             error_msg = (
                 "No LLM configured. Please set LITELLM_MODEL, LLM_CHANNELS, "
@@ -671,13 +710,14 @@ class LLMToolAdapter:
 
         # Use Router for primary model (multi-key), direct litellm for others
         use_channel_router = self._has_channel_config()
-        _router_model_names = set(get_configured_llm_models(self._config.llm_model_list))
-        agent_primary_model = get_effective_agent_primary_model(self._config)
+        resolution = getattr(self, "_route_resolution", None) or resolve_agent_litellm_route(self._config)
+        _router_model_names = set(get_configured_llm_models(resolution.model_list))
+        agent_primary_model = resolution.primary_model or get_effective_agent_primary_model(self._config)
         uses_router = (
             bool(use_channel_router and self._router and model in _router_model_names)
             or bool(self._router and model == agent_primary_model and not use_channel_router)
         )
-        recovery_model_list = self._config.llm_model_list
+        recovery_model_list = resolution.model_list or self._config.llm_model_list
         if self._router and model == agent_primary_model and not use_channel_router:
             recovery_model_list = self._legacy_router_model_list or self._config.llm_model_list
         if not uses_router:
@@ -710,7 +750,7 @@ class LLMToolAdapter:
                 caps.cache_activation,
             )
         register_fallback_model_pricing(
-            resolve_fallback_litellm_wire_models(model, self._config.llm_model_list)
+            resolve_fallback_litellm_wire_models(model, recovery_model_list)
         )
         if use_channel_router and self._router and model in _router_model_names:
             # Channel / YAML path: Router manages all models in its model_list
@@ -738,7 +778,7 @@ class LLMToolAdapter:
                 lambda kwargs: litellm.completion(**kwargs),
                 model=model,
                 call_kwargs=call_kwargs,
-                model_list=self._config.llm_model_list,
+                model_list=recovery_model_list,
                 logger=logger,
             )
 
@@ -817,7 +857,12 @@ class LLMToolAdapter:
     def _trace_provider_for_target(self, target_model: Optional[str]) -> str:
         if not target_model:
             return ""
-        model_list = getattr(getattr(self, "_config", None), "llm_model_list", []) or []
+        resolution = getattr(self, "_route_resolution", None)
+        model_list = (
+            getattr(resolution, "model_list", None)
+            or getattr(getattr(self, "_config", None), "llm_model_list", [])
+            or []
+        )
         return resolved_provider_namespace(target_model, model_list)
 
     def _parse_litellm_response(

--- a/src/analyzer.py
+++ b/src/analyzer.py
@@ -39,6 +39,18 @@ from src.config import (
     resolve_litellm_wire_model,
     resolve_news_window_days,
 )
+from src.llm.hermes import (
+    HERMES_CHANNEL_NAME,
+    build_hermes_redaction_values,
+    canonicalize_hermes_model_ref,
+    filter_non_hermes_deployments,
+    hermes_blocked_route_candidates,
+    is_masked_secret_placeholder,
+    open_hermes_no_proxy_client,
+    route_deployment_origins,
+    route_has_hermes,
+    sanitize_hermes_error_text,
+)
 from src.llm.generation_params import apply_litellm_generation_params
 from src.llm.errors import call_litellm_with_param_recovery
 from src.llm.backend_registry import (
@@ -2316,6 +2328,9 @@ class GeminiAnalyzer:
     def _init_litellm(self) -> None:
         """Initialize litellm Router from channels / YAML / legacy keys."""
         config = self._get_runtime_config()
+        if self._get_hermes_config_error(config) is not None:
+            logger.error("Analyzer LLM: Hermes channel configuration blocks legacy fallback")
+            return
         litellm_model = config.litellm_model
         if not litellm_model:
             backend_id = ""
@@ -2337,9 +2352,23 @@ class GeminiAnalyzer:
         # --- Channel / YAML path: build Router from pre-built model_list ---
         if self._has_channel_config(config):
             model_list = config.llm_model_list
+            if self._get_mixed_hermes_route_error(config, litellm_model) is not None:
+                self._litellm_available = False
+                logger.error("Analyzer LLM: mixed Hermes/non-Hermes route requires deployment-level no-proxy support")
+                return
+            router_model_list = model_list
+            if route_has_hermes(model_list, litellm_model):
+                # Hermes-only routes are dispatched directly with a request-scoped
+                # no-proxy OpenAI client. Keeping them out of Router prevents the
+                # default proxy-aware transport from seeing the Hermes bearer key.
+                router_model_list = filter_non_hermes_deployments(model_list)
+                if not router_model_list:
+                    self._litellm_available = True
+                    logger.info("Analyzer LLM: Hermes-only route will use direct no-proxy completion")
+                    return
             try:
                 self._router = Router(
-                    model_list=model_list,
+                    model_list=router_model_list,
                     routing_strategy="simple-shuffle",
                     num_retries=2,
                 )
@@ -2352,7 +2381,7 @@ class GeminiAnalyzer:
                 ))
                 logger.info(
                     f"Analyzer LLM: Router initialized from channels/YAML — "
-                    f"{len(model_list)} deployment(s), models: {unique_models}"
+                    f"{len(router_model_list)} deployment(s), models: {unique_models}"
                 )
                 return
 
@@ -2442,6 +2471,14 @@ class GeminiAnalyzer:
         """Return a structured backend config error, if the backend cannot run."""
         try:
             backend_id, _fallback_backend_id = self._resolve_generation_backend_config()
+            config = self._get_runtime_config()
+            hermes_error = self._get_hermes_config_error(config)
+            if hermes_error is not None:
+                return hermes_error
+            for model in [getattr(config, "litellm_model", "")] + list(getattr(config, "litellm_fallback_models", []) or []):
+                mixed_error = self._get_mixed_hermes_route_error(config, model)
+                if mixed_error is not None:
+                    return mixed_error
             if backend_id == CODEX_CLI_BACKEND_ID:
                 backend = self._get_generation_backend(backend_id)
                 get_config_error = getattr(backend, "get_config_error", None)
@@ -2450,6 +2487,113 @@ class GeminiAnalyzer:
         except GenerationError as exc:
             return exc
         return None
+
+    def _get_hermes_config_error(self, config: Config) -> Optional[GenerationError]:
+        issues = list(getattr(config, "llm_channel_config_issues", []) or [])
+        if not getattr(config, "llm_blocks_legacy_fallback", False) or not issues:
+            return None
+        blocked_routes = set(getattr(config, "llm_blocked_hermes_routes", []) or [])
+        selected_models = [
+            ("LITELLM_MODEL", getattr(config, "litellm_model", "") or ""),
+            *[
+                ("LITELLM_FALLBACK_MODELS", fallback_model)
+                for fallback_model in list(getattr(config, "litellm_fallback_models", []) or [])
+            ],
+        ]
+        selected_blocked_route = ""
+        selected_field = ""
+        for field_name, model in selected_models:
+            raw_model = str(model or "").strip()
+            if not raw_model:
+                continue
+            candidates = hermes_blocked_route_candidates(raw_model)
+            candidates.add(raw_model)
+            try:
+                candidates.add(canonicalize_hermes_model_ref(raw_model).route_model)
+            except (TypeError, ValueError) as exc:
+                logger.debug("Failed to canonicalize selected Hermes route candidate %r: %s", raw_model, exc)
+            matched = candidates & blocked_routes
+            if matched:
+                selected_blocked_route = sorted(matched)[0]
+                selected_field = field_name
+                break
+        if blocked_routes and not selected_blocked_route and getattr(config, "llm_model_list", None):
+            return None
+        first = issues[0]
+        code = (
+            "explicit_hermes_route_invalid"
+            if selected_blocked_route
+            else first.get("code", "invalid_hermes_channel")
+        )
+        return GenerationError(
+            error_code=GenerationErrorCode.UNSAFE_CONFIG,
+            stage="configuration",
+            retryable=False,
+            fallbackable=False,
+            backend=LITELLM_BACKEND_ID,
+            provider=HERMES_CHANNEL_NAME,
+            details={
+                "field": selected_field or first.get("field", "LLM_HERMES_API_KEY"),
+                "code": code,
+                "reason": code,
+                "message": first.get("message", "Hermes channel configuration is invalid"),
+                "issues": issues,
+                "route_name": selected_blocked_route or None,
+            },
+        )
+
+    def _get_mixed_hermes_route_error(self, config: Config, model: str) -> Optional[GenerationError]:
+        if not model:
+            return None
+        origins = route_deployment_origins(getattr(config, "llm_model_list", []) or [], model)
+        if not origins.is_mixed:
+            return None
+        return GenerationError(
+            error_code=GenerationErrorCode.UNSAFE_CONFIG,
+            stage="configuration",
+            retryable=False,
+            fallbackable=False,
+            backend=LITELLM_BACKEND_ID,
+            provider=HERMES_CHANNEL_NAME,
+            details={
+                "field": "LLM_CHANNELS",
+                "code": "mixed_hermes_route_unsupported",
+                "reason": "router_deployment_no_proxy_unavailable",
+                "route_name": model,
+            },
+        )
+
+    def _hermes_redaction_values_for_model(self, config: Config, model: str = "") -> set[str]:
+        redactions: set[str] = set()
+        deployments = list(getattr(config, "llm_model_list", []) or [])
+        selected_deployments = deployments
+        if model:
+            origins = route_deployment_origins(deployments, model)
+            selected_deployments = list(origins.hermes_deployments or [])
+            if not selected_deployments and not origins.has_hermes:
+                return redactions
+        for deployment in selected_deployments:
+            if not isinstance(deployment, dict):
+                continue
+            if not route_has_hermes([deployment], str(deployment.get("model_name") or "")):
+                continue
+            params = deployment.get("litellm_params") or {}
+            if isinstance(params, dict):
+                redactions.update(build_hermes_redaction_values(params.get("api_key")))
+        return redactions
+
+    def _sanitize_hermes_exception_text(
+        self,
+        exc: Any,
+        *,
+        config: Optional[Config] = None,
+        model: str = "",
+    ) -> str:
+        runtime_config = config or self._get_runtime_config()
+        redactions = self._hermes_redaction_values_for_model(runtime_config, model)
+        if not redactions:
+            return str(exc)
+        return sanitize_hermes_error_text(exc, redaction_values=redactions)
 
     def _dispatch_litellm_completion(
         self,
@@ -2461,6 +2605,26 @@ class GeminiAnalyzer:
         router_model_names: set[str],
     ) -> Any:
         """Dispatch a LiteLLM completion through router or direct fallback."""
+        origins = route_deployment_origins(config.llm_model_list, model)
+        if origins.is_mixed:
+            raise RuntimeError("Hermes/non-Hermes mixed generation route is not supported without deployment-level no-proxy client support")
+        if origins.is_hermes_only:
+            deployment = origins.hermes_deployments[0]
+            params = dict(deployment.get("litellm_params") or {})
+            api_key = str(params.get("api_key") or "").strip()
+            base_url = str(params.get("api_base") or "").strip()
+            if is_masked_secret_placeholder(api_key):
+                raise RuntimeError("Hermes API key is a masked placeholder and cannot be used for generation")
+            timeout = float(call_kwargs.get("timeout") or 30.0)
+            hermes_kwargs = dict(call_kwargs)
+            hermes_kwargs["model"] = str(params.get("model") or model)
+            hermes_kwargs["stream"] = False
+            hermes_kwargs.pop("api_key", None)
+            hermes_kwargs.pop("api_base", None)
+            with open_hermes_no_proxy_client(api_key=api_key, base_url=base_url, timeout=timeout) as client:
+                hermes_kwargs["client"] = client
+                return litellm.completion(**hermes_kwargs)
+
         wire_models = resolve_fallback_litellm_wire_models(model, config.llm_model_list)
         register_fallback_model_pricing(wire_models)
         effective_kwargs = dict(call_kwargs)
@@ -2665,6 +2829,9 @@ class GeminiAnalyzer:
         audit_context: Optional[Dict[str, Any]] = None,
     ) -> Tuple[str, str, Dict[str, Any]]:
         """Compatibility wrapper around the configured generation backend."""
+        preflight_error = self.get_generation_backend_config_error()
+        if preflight_error is not None and not self._can_use_generation_fallback(preflight_error):
+            raise preflight_error
         backend_id, fallback_backend_id = self._resolve_generation_backend_config()
         try:
             result = self._get_generation_backend(backend_id).generate(
@@ -2811,6 +2978,8 @@ class GeminiAnalyzer:
         effective_system_prompt = system_prompt or self.TEXT_SYSTEM_PROMPT
         router_model_names = set(get_configured_llm_models(config.llm_model_list))
         for model in models_to_try:
+            origins = route_deployment_origins(config.llm_model_list, model)
+            model_stream = bool(stream and not origins.has_hermes)
             recovery_model_list = config.llm_model_list
             legacy_router_model_list = getattr(self, "_legacy_router_model_list", None) or []
             if legacy_router_model_list and model == config.litellm_model and not use_channel_router:
@@ -2889,7 +3058,7 @@ class GeminiAnalyzer:
                 _stream_text: Optional[str] = None
                 _stream_usage: Dict[str, Any] = {}
 
-                if stream:
+                if model_stream:
                     try:
                         stream_response = call_litellm_with_param_recovery(
                             lambda kwargs: self._dispatch_litellm_completion(
@@ -2976,8 +3145,9 @@ class GeminiAnalyzer:
                 raise ValueError("LLM returned empty response")
 
             except Exception as e:
-                logger.warning(f"[LiteLLM] {model} failed: {e}")
-                last_error = e
+                safe_error = self._sanitize_hermes_exception_text(e, config=config, model=model)
+                logger.warning("[LiteLLM] %s failed: %s", model, safe_error)
+                last_error = RuntimeError(safe_error) if safe_error != str(e) else e
                 continue
 
         raise _AllModelsFailedError(
@@ -3297,7 +3467,8 @@ class GeminiAnalyzer:
             return result
             
         except Exception as e:
-            logger.error(f"AI 分析 {name}({code}) 失败: {e}")
+            safe_error = self._sanitize_hermes_exception_text(e)
+            logger.error("AI 分析 %s(%s) 失败: %s", name, code, safe_error)
             return AnalysisResult(
                 code=code,
                 name=name,
@@ -3305,10 +3476,10 @@ class GeminiAnalyzer:
                 trend_prediction='Sideways' if report_language == "en" else '震荡',
                 operation_advice='Hold' if report_language == "en" else '持有',
                 confidence_level='Low' if report_language == "en" else '低',
-                analysis_summary=(f'Analysis failed: {str(e)[:100]}' if report_language == "en" else f'分析过程出错: {str(e)[:100]}'),
+                analysis_summary=(f'Analysis failed: {safe_error[:100]}' if report_language == "en" else f'分析过程出错: {safe_error[:100]}'),
                 risk_warning='Analysis failed. Please retry later or review manually.' if report_language == "en" else '分析失败，请稍后重试或手动分析',
                 success=False,
-                error_message=str(e),
+                error_message=safe_error,
                 model_used=None,
                 report_language=report_language,
             )

--- a/src/config.py
+++ b/src/config.py
@@ -54,6 +54,18 @@ from src.llm.local_cli_backend import (
     MAX_LOCAL_CLI_TIMEOUT_SECONDS,
 )
 from src.llm import generation_params as llm_generation_params
+from src.llm.hermes import (
+    HERMES_DEFAULT_BASE_URL,
+    HERMES_DEFAULT_MODEL,
+    HERMES_DEFAULT_PROTOCOL,
+    HermesConfigIssue,
+    hermes_model_info,
+    is_reserved_hermes_name,
+    parse_hermes_channel,
+    route_identity_candidates,
+    route_deployment_origins,
+    route_has_hermes,
+)
 from src.scheduler import normalize_schedule_times
 
 logger = logging.getLogger(__name__)
@@ -77,6 +89,7 @@ class ConfigIssue:
     severity: Literal["error", "warning", "info"]
     message: str
     field: str = ""
+    code: str = ""
 
     def __str__(self) -> str:  # noqa: D105
         return self.message
@@ -564,6 +577,17 @@ def _uses_direct_env_provider(model: str) -> bool:
     return bool(provider) and provider not in _MANAGED_LITELLM_KEY_PROVIDERS
 
 
+def _matches_route_set(model: str, routes: set[str]) -> bool:
+    """Loose safety match for Hermes/provenance checks, not normal route availability."""
+    return bool(route_identity_candidates(model) & set(routes or set()))
+
+
+def _matches_exact_route(model: str, routes: set[str]) -> bool:
+    """Match the Router's top-level model_name exactly for normal availability checks."""
+    normalized_model = str(model or "").strip()
+    return bool(normalized_model) and normalized_model in set(routes or set())
+
+
 def normalize_agent_litellm_model(
     model: str,
     configured_models: Optional[set[str]] = None,
@@ -720,6 +744,12 @@ class Config:
     # Raw channel names requested through LLM_CHANNELS, including channels that
     # were skipped during parsing because required channel fields were missing.
     llm_channel_names: List[str] = field(default_factory=list)
+    # Structured parse issues raised while turning LLM_CHANNELS into deployments.
+    llm_channel_config_issues: List[Dict[str, str]] = field(default_factory=list)
+    # True when invalid explicit channel config must prevent legacy key inference.
+    llm_blocks_legacy_fallback: bool = False
+    # Canonical Hermes route names that were requested but blocked by atomic parse issues.
+    llm_blocked_hermes_routes: List[str] = field(default_factory=list)
     # Pre-built LiteLLM Router model_list (populated from channels, YAML, or legacy keys)
     llm_model_list: List[Dict[str, Any]] = field(default_factory=list)
 
@@ -1271,49 +1301,34 @@ class Config:
             openai_api_keys = list(anspire_api_keys)
             openai_base_url = anspire_llm_base_url
 
-        # LITELLM_MODEL: explicit config takes precedence; else infer from available keys
-        litellm_model = os.getenv('LITELLM_MODEL', '').strip()
+        # LITELLM_MODEL / LITELLM_FALLBACK_MODELS explicit values are recorded
+        # before YAML/channels are parsed, but legacy inference is delayed until
+        # the higher-priority sources and Hermes blocking issues are known.
+        litellm_model_explicit = os.getenv('LITELLM_MODEL', '').strip()
+        litellm_model = litellm_model_explicit
         inferred_legacy_deepseek_model = False
         _openai_model_env = os.getenv('OPENAI_MODEL', '').strip()
         if using_anspire_llm_legacy:
             _openai_model_name = _anspire_llm_model_env or _openai_model_env or ANSPIRE_LLM_MODEL_DEFAULT
         else:
             _openai_model_name = _openai_model_env or 'gpt-5.5'
-        if not litellm_model:
-            _gemini_model_name = os.getenv('GEMINI_MODEL', 'gemini-3.1-pro-preview').strip()
-            _anthropic_model_name = os.getenv('ANTHROPIC_MODEL', 'claude-sonnet-4-6').strip()
-            if gemini_api_keys:
-                litellm_model = f'gemini/{_gemini_model_name}'
-            elif anthropic_api_keys:
-                litellm_model = f'anthropic/{_anthropic_model_name}'
-            elif deepseek_api_keys:
-                litellm_model = 'deepseek/deepseek-chat'
-                inferred_legacy_deepseek_model = True
-            elif openai_api_keys:
-                # For openai-compatible models, add prefix only if not already prefixed
-                if '/' not in _openai_model_name:
-                    litellm_model = f'openai/{_openai_model_name}'
-                else:
-                    litellm_model = _openai_model_name
 
         # LITELLM_FALLBACK_MODELS: comma-separated list of fallback models
         _fallback_str = os.getenv('LITELLM_FALLBACK_MODELS', '')
+        litellm_fallback_models_explicit = bool(_fallback_str.strip())
         if _fallback_str.strip():
             litellm_fallback_models = [m.strip() for m in _fallback_str.split(',') if m.strip()]
         else:
-            # Backward compat: use gemini_model_fallback when primary is gemini
-            _gemini_fallback = os.getenv('GEMINI_MODEL_FALLBACK', 'gemini-3-flash-preview').strip()
-            if litellm_model.startswith('gemini/') and _gemini_fallback:
-                _fb = f'gemini/{_gemini_fallback}' if '/' not in _gemini_fallback else _gemini_fallback
-                litellm_fallback_models = [_fb]
-            else:
-                litellm_fallback_models = []
+            litellm_fallback_models = []
 
         # === LLM Channels + YAML config ===
         litellm_config_path = os.getenv('LITELLM_CONFIG', '').strip() or None
         llm_models_source = "legacy_env"
         llm_channels: List[Dict[str, Any]] = []
         llm_channel_names: List[str] = []
+        llm_channel_config_issues: List[Dict[str, str]] = []
+        llm_blocks_legacy_fallback = False
+        llm_blocked_hermes_routes: List[str] = []
         llm_model_list: List[Dict[str, Any]] = []
 
         # Priority 1: LITELLM_CONFIG (standard LiteLLM YAML config file)
@@ -1331,13 +1346,31 @@ class Config:
                     for ch in _channels_str.split(',')
                     if ch.strip()
                 ]
-                llm_channels = cls._parse_llm_channels(_channels_str)
+                (
+                    llm_channels,
+                    hermes_issues,
+                    llm_blocks_legacy_fallback,
+                    llm_blocked_hermes_routes,
+                ) = cls._parse_llm_channels_with_issues(_channels_str)
+                llm_channel_config_issues = [issue.as_dict() for issue in hermes_issues]
                 llm_model_list = cls._channels_to_model_list(llm_channels)
                 if llm_model_list:
                     llm_models_source = "llm_channels"
 
-        # Priority 3: Legacy env vars → auto-build model_list (backward compatible)
-        if not llm_model_list:
+        route_models = get_configured_llm_models(llm_model_list)
+        if route_models:
+            if not litellm_model:
+                litellm_model = route_models[0]
+            if not litellm_fallback_models and not litellm_fallback_models_explicit and litellm_model:
+                _seen = {litellm_model}
+                litellm_fallback_models = [
+                    model for model in route_models
+                    if model not in _seen and not _seen.add(model)  # type: ignore[func-returns-value]
+                ]
+
+        # Priority 3: Legacy env vars → auto-build model_list (backward compatible).
+        # This is skipped when an explicit invalid Hermes channel blocks legacy fallback.
+        if not llm_model_list and not llm_blocks_legacy_fallback:
             llm_model_list = cls._legacy_keys_to_model_list(
                 gemini_api_keys, anthropic_api_keys, openai_api_keys,
                 openai_base_url,
@@ -1345,6 +1378,30 @@ class Config:
             )
             if llm_model_list:
                 llm_models_source = "legacy_env"
+
+            if not litellm_model:
+                _gemini_model_name = os.getenv('GEMINI_MODEL', 'gemini-3.1-pro-preview').strip()
+                _anthropic_model_name = os.getenv('ANTHROPIC_MODEL', 'claude-sonnet-4-6').strip()
+                if gemini_api_keys:
+                    litellm_model = f'gemini/{_gemini_model_name}'
+                elif anthropic_api_keys:
+                    litellm_model = f'anthropic/{_anthropic_model_name}'
+                elif deepseek_api_keys:
+                    litellm_model = 'deepseek/deepseek-chat'
+                    inferred_legacy_deepseek_model = True
+                elif openai_api_keys:
+                    # For openai-compatible models, add prefix only if not already prefixed
+                    if '/' not in _openai_model_name:
+                        litellm_model = f'openai/{_openai_model_name}'
+                    else:
+                        litellm_model = _openai_model_name
+
+            if not litellm_fallback_models and not litellm_fallback_models_explicit:
+                # Backward compat: use gemini_model_fallback when primary is gemini
+                _gemini_fallback = os.getenv('GEMINI_MODEL_FALLBACK', 'gemini-3-flash-preview').strip()
+                if litellm_model.startswith('gemini/') and _gemini_fallback:
+                    _fb = f'gemini/{_gemini_fallback}' if '/' not in _gemini_fallback else _gemini_fallback
+                    litellm_fallback_models = [_fb]
 
         if (
             inferred_legacy_deepseek_model
@@ -1356,24 +1413,6 @@ class Config:
                 "deepseek-chat will be deprecated on 2026-07-24,\n"
                 "please migrate to deepseek-v4-flash."
             )
-
-        # Auto-infer LITELLM_MODEL from channels when not explicitly set
-        if not litellm_model and llm_channels:
-            for _ch in llm_channels:
-                if _ch.get('models'):
-                    litellm_model = _ch['models'][0]
-                    break
-
-        # Auto-infer LITELLM_FALLBACK_MODELS from channels when not explicitly set
-        if not litellm_fallback_models and llm_channels and litellm_model:
-            _all_ch_models: List[str] = []
-            for _ch in llm_channels:
-                _all_ch_models.extend(_ch.get('models', []))
-            _seen = {litellm_model}
-            litellm_fallback_models = [
-                m for m in _all_ch_models
-                if m not in _seen and not _seen.add(m)  # type: ignore[func-returns-value]
-            ]
 
         generation_backend = (
             os.getenv('GENERATION_BACKEND', LITELLM_BACKEND_ID).strip().lower()
@@ -1573,6 +1612,9 @@ class Config:
             llm_models_source=llm_models_source,
             llm_channels=llm_channels,
             llm_channel_names=llm_channel_names,
+            llm_channel_config_issues=llm_channel_config_issues,
+            llm_blocks_legacy_fallback=llm_blocks_legacy_fallback,
+            llm_blocked_hermes_routes=llm_blocked_hermes_routes,
             llm_model_list=llm_model_list,
             llm_prompt_cache_telemetry_enabled=parse_env_bool(
                 os.getenv("LLM_PROMPT_CACHE_TELEMETRY_ENABLED"),
@@ -2028,6 +2070,15 @@ class Config:
 
     @classmethod
     def _parse_llm_channels(cls, channels_str: str) -> List[Dict[str, Any]]:
+        """Backward-compatible channel parser returning only valid channels."""
+        channels, _issues, _blocks, _blocked_routes = cls._parse_llm_channels_with_issues(channels_str)
+        return channels
+
+    @classmethod
+    def _parse_llm_channels_with_issues(
+        cls,
+        channels_str: str,
+    ) -> Tuple[List[Dict[str, Any]], List[HermesConfigIssue], bool, List[str]]:
         """Parse LLM_CHANNELS env var and per-channel env vars.
 
         Format:
@@ -2042,6 +2093,9 @@ class Config:
         _logger = logging.getLogger(__name__)
 
         channels: List[Dict[str, Any]] = []
+        issues: List[HermesConfigIssue] = []
+        blocks_legacy_fallback = False
+        blocked_hermes_routes: List[str] = []
         for raw_name in channels_str.split(','):
             ch_name = raw_name.strip()
             if not ch_name:
@@ -2065,8 +2119,8 @@ class Config:
             # API keys: LLM_{NAME}_API_KEYS (multi) > LLM_{NAME}_API_KEY (single)
             api_keys_raw = os.getenv(f'LLM_{ch_upper}_API_KEYS', '')
             api_keys = [k.strip() for k in api_keys_raw.split(',') if k.strip()]
+            single_key = os.getenv(f'LLM_{ch_upper}_API_KEY', '').strip()
             if not api_keys:
-                single_key = os.getenv(f'LLM_{ch_upper}_API_KEY', '').strip()
                 if single_key:
                     api_keys = [single_key]
             if not api_keys and ch_lower == "anspire":
@@ -2082,6 +2136,34 @@ class Config:
                 ).strip()
                 if anspire_model:
                     raw_models = [anspire_model]
+
+            if is_reserved_hermes_name(ch_name):
+                if not raw_models:
+                    raw_models = [HERMES_DEFAULT_MODEL]
+                result = parse_hermes_channel(
+                    enabled=enabled,
+                    protocol=protocol_raw or HERMES_DEFAULT_PROTOCOL,
+                    base_url=base_url or HERMES_DEFAULT_BASE_URL,
+                    api_key=single_key,
+                    api_keys_raw=api_keys_raw,
+                    extra_headers_raw=os.getenv(f'LLM_{ch_upper}_EXTRA_HEADERS', ''),
+                    models=raw_models,
+                )
+                issues.extend(result.issues)
+                blocks_legacy_fallback = blocks_legacy_fallback or result.blocks_legacy_fallback
+                for route_name in result.blocked_route_names:
+                    if route_name not in blocked_hermes_routes:
+                        blocked_hermes_routes.append(route_name)
+                if result.channel is None:
+                    if not enabled:
+                        _logger.info("LLM channel '%s': disabled, skipped", ch_name)
+                    else:
+                        _logger.warning("LLM channel '%s': invalid reserved Hermes channel, skipped", ch_name)
+                    continue
+                channels.append(result.channel)
+                _logger.info("LLM channel '%s': Hermes preset with %d model(s)", ch_name, len(result.channel["models"]))
+                continue
+
             protocol = resolve_llm_channel_protocol(protocol_raw, base_url=base_url, models=raw_models, channel_name=ch_name)
             models = [normalize_llm_channel_model(m, protocol, base_url) for m in raw_models]
 
@@ -2127,7 +2209,7 @@ class Config:
             })
             _logger.info(f"LLM channel '{ch_name}': {len(models)} model(s), {len(api_keys)} key(s)")
 
-        return channels
+        return channels, issues, blocks_legacy_fallback, blocked_hermes_routes
 
     @classmethod
     def _channels_to_model_list(cls, channels: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
@@ -2139,10 +2221,17 @@ class Config:
         """
         model_list: List[Dict[str, Any]] = []
         for ch in channels:
+            hermes_refs = {
+                str(ref.get("route_model") or ""): ref
+                for ref in (ch.get("model_refs") or [])
+                if isinstance(ref, dict)
+            }
             for model_name in ch['models']:
                 for api_key in ch['api_keys']:
+                    model_ref = hermes_refs.get(str(model_name))
+                    wire_model = str((model_ref or {}).get("wire_model") or model_name)
                     litellm_params: Dict[str, Any] = {
-                        'model': model_name,
+                        'model': wire_model,
                     }
                     if api_key:
                         litellm_params['api_key'] = api_key
@@ -2155,10 +2244,15 @@ class Config:
                     if headers:
                         litellm_params['extra_headers'] = headers
 
-                    model_list.append({
+                    entry: Dict[str, Any] = {
                         'model_name': model_name,
                         'litellm_params': litellm_params,
-                    })
+                    }
+                    if ch.get("is_hermes") or is_reserved_hermes_name(str(ch.get("name") or "")):
+                        entry["model_info"] = hermes_model_info(
+                            str((model_ref or {}).get("display_model") or "")
+                        )
+                    model_list.append(entry)
         return model_list
 
     @classmethod
@@ -2522,25 +2616,39 @@ class Config:
 
         Decision table:
 
-        +-----------------------+----------------------------------+---------+
-        | AGENT_MODE env        | effective Agent primary model set| Result  |
-        +-----------------------+----------------------------------+---------+
-        | ``true``              | any                              | True    |
-        | ``false`` (explicit)  | any                              | False   |
-        | not set (default)     | yes                              | True    |
-        | not set (default)     | no                               | False   |
-        +-----------------------+----------------------------------+---------+
+        +-----------------------+----------------------------+-----------------+
+        | AGENT_MODE env        | Agent-safe route available | Result          |
+        +-----------------------+----------------------------+-----------------+
+        | ``false`` (explicit)  | any                        | False           |
+        | ``true``              | yes                        | True            |
+        | ``true``              | no                         | False           |
+        | not set (default)     | yes                        | True            |
+        | not set (default)     | no                         | False           |
+        +-----------------------+----------------------------+-----------------+
 
-        This keeps backward compatibility: users who never touch
-        ``AGENT_MODE`` get agent features automatically once they configure an
-        Agent-effective model, while ``AGENT_MODE=false`` acts as an explicit
-        kill-switch.
+        ``AGENT_MODE=true`` expresses user intent, but Phase 3 Hermes safety
+        still requires a non-Hermes Agent route. Hermes-only deployments cannot
+        satisfy Agent tool roundtrip support; mixed routes are usable only via
+        their non-Hermes deployments. ``AGENT_MODE=false`` remains an explicit
+        kill-switch. Explicit ``AGENT_GENERATION_BACKEND=codex_cli`` is also
+        unavailable because codex_cli is a text generation backend, not an
+        Agent tool-calling runtime.
         """
-        # Explicit AGENT_MODE takes full precedence
+        if (self.agent_generation_backend or AUTO_AGENT_BACKEND_ID).strip().lower() == CODEX_CLI_BACKEND_ID:
+            return False
+        # Phase 3 no longer lets AGENT_MODE=true bypass tool-route safety.
         if self._agent_mode_explicit:
-            return self.agent_mode
+            if not self.agent_mode:
+                return False
+            primary_model = get_effective_agent_primary_model(self)
+            origins = route_deployment_origins(self.llm_model_list, primary_model)
+            return not origins.is_hermes_only
         # Auto-detect: Agent inherits global model when AGENT_LITELLM_MODEL is empty.
-        return bool(get_effective_agent_primary_model(self))
+        primary_model = get_effective_agent_primary_model(self)
+        if not primary_model:
+            return False
+        origins = route_deployment_origins(self.llm_model_list, primary_model)
+        return not origins.is_hermes_only
 
     def refresh_stock_list(self) -> None:
         """
@@ -2681,6 +2789,14 @@ class Config:
             ))
 
         # --- LLM availability ---
+        for raw_issue in self.llm_channel_config_issues or []:
+            issues.append(ConfigIssue(
+                severity=raw_issue.get("severity", "error"),  # type: ignore[arg-type]
+                message=raw_issue.get("message", "LLM channel configuration is invalid"),
+                field=raw_issue.get("field", "LLM_CHANNELS"),
+                code=raw_issue.get("code", "invalid_channel_config"),
+            ))
+
         # llm_model_list is populated for YAML / channels / managed legacy keys.
         # Other LiteLLM-native providers (for example cohere/*) run through the
         # direct litellm env path and therefore do not populate llm_model_list.
@@ -2748,10 +2864,22 @@ class Config:
         effective_agent_primary_model = get_effective_agent_primary_model(self)
 
         if available_router_model_set:
+            if self.litellm_model:
+                origins = route_deployment_origins(self.llm_model_list, self.litellm_model)
+                if origins.is_mixed:
+                    issues.append(ConfigIssue(
+                        severity="error",
+                        message=(
+                            "Hermes/non-Hermes mixed generation routes are not supported in Phase 3. "
+                            "请选择纯 Hermes 或纯非 Hermes 主模型。"
+                        ),
+                        field="LITELLM_MODEL",
+                        code="mixed_hermes_route_unsupported",
+                    ))
             if (
                 self.litellm_model
                 and not _uses_direct_env_provider(self.litellm_model)
-                and self.litellm_model not in available_router_model_set
+                and not _matches_exact_route(self.litellm_model, available_router_model_set)
             ):
                 issues.append(ConfigIssue(
                     severity="error",
@@ -2762,11 +2890,24 @@ class Config:
                     field="LITELLM_MODEL",
                 ))
 
+            if configured_agent_primary_model and effective_agent_primary_model:
+                origins = route_deployment_origins(self.llm_model_list, effective_agent_primary_model)
+                if origins.is_hermes_only:
+                    issues.append(ConfigIssue(
+                        severity="error",
+                        message=(
+                            "Hermes-only route 不能作为 Agent 主模型。"
+                            "请选择包含非 Hermes deployment 的 Agent-safe route。"
+                        ),
+                        field="AGENT_LITELLM_MODEL",
+                        code="explicit_agent_model_no_safe_deployment",
+                    ))
+
             if (
                 configured_agent_primary_model
                 and effective_agent_primary_model
                 and not _uses_direct_env_provider(effective_agent_primary_model)
-                and effective_agent_primary_model not in available_router_model_set
+                and not _matches_exact_route(effective_agent_primary_model, available_router_model_set)
             ):
                 issues.append(ConfigIssue(
                     severity="error",
@@ -2777,9 +2918,24 @@ class Config:
                     field="AGENT_LITELLM_MODEL",
                 ))
 
+            mixed_fallbacks = [
+                model for model in (self.litellm_fallback_models or [])
+                if route_deployment_origins(self.llm_model_list, model).is_mixed
+            ]
+            if mixed_fallbacks:
+                issues.append(ConfigIssue(
+                    severity="error",
+                    message=(
+                        "Hermes/non-Hermes mixed generation routes are not supported as fallback models in Phase 3: "
+                        f"{', '.join(mixed_fallbacks[:3])}"
+                    ),
+                    field="LITELLM_FALLBACK_MODELS",
+                    code="mixed_hermes_route_unsupported",
+                ))
+
             invalid_fallbacks = [
                 model for model in (self.litellm_fallback_models or [])
-                if model and model not in available_router_model_set
+                if model and not _matches_exact_route(model, available_router_model_set)
                 and not _uses_direct_env_provider(model)
             ]
             if invalid_fallbacks:
@@ -2795,7 +2951,7 @@ class Config:
             if (
                 self.vision_model
                 and not _uses_direct_env_provider(self.vision_model)
-                and self.vision_model not in available_router_model_set
+                and not _matches_exact_route(self.vision_model, available_router_model_set)
             ):
                 issues.append(ConfigIssue(
                     severity="warning",
@@ -2804,6 +2960,15 @@ class Config:
                         f" 当前可用模型：{', '.join(available_router_models[:6])}"
                     ),
                     field="VISION_MODEL",
+                ))
+            if self.vision_model and route_has_hermes(self.llm_model_list, self.vision_model):
+                issues.append(ConfigIssue(
+                    severity="error",
+                    message=(
+                        "Hermes Phase 3 未验证 Vision 能力，VISION_MODEL 不能选择包含 Hermes deployment 的 route。"
+                    ),
+                    field="VISION_MODEL",
+                    code="hermes_vision_unsupported",
                 ))
         elif (
             configured_agent_primary_model

--- a/src/llm/hermes.py
+++ b/src/llm/hermes.py
@@ -1,0 +1,459 @@
+# -*- coding: utf-8 -*-
+"""Hermes local HTTP generation helpers.
+
+Hermes Phase 3 is intentionally narrow: a reserved local OpenAI-compatible
+generation channel with no tools, streaming, vision, remote hosts, or key
+load-balancing support.
+"""
+
+from __future__ import annotations
+
+import re
+from contextlib import contextmanager
+from dataclasses import dataclass, field
+from typing import Any, Dict, Iterable, Iterator, List, Optional, Sequence, Set, Tuple
+from urllib.parse import quote, unquote, urlparse, urlunparse
+
+
+HERMES_CHANNEL_NAME = "hermes"
+HERMES_DEPLOYMENT_MARKER_KEY = "dsa_channel"
+HERMES_DEPLOYMENT_MARKER_VALUE = "hermes"
+HERMES_DEFAULT_PROTOCOL = "openai"
+HERMES_DEFAULT_BASE_URL = "http://127.0.0.1:8642/v1"
+HERMES_DEFAULT_MODEL = "hermes-agent"
+MASKED_SECRET_TOKENS = {"******"}
+
+
+@dataclass(frozen=True)
+class HermesConfigIssue:
+    """Structured Hermes channel parse issue."""
+
+    field: str
+    code: str
+    message: str
+    severity: str = "error"
+
+    def as_dict(self) -> Dict[str, str]:
+        return {
+            "field": self.field,
+            "code": self.code,
+            "message": self.message,
+            "severity": self.severity,
+        }
+
+
+@dataclass(frozen=True)
+class HermesChannelParseResult:
+    """Atomic result of parsing a reserved Hermes channel."""
+
+    channel: Optional[Dict[str, Any]]
+    issues: Tuple[HermesConfigIssue, ...] = ()
+    blocks_legacy_fallback: bool = False
+    blocked_route_names: Tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class HermesModelRef:
+    """Hermes model names split by routing identity and UI display label."""
+
+    route_model: str
+    wire_model: str
+    display_model: str
+
+
+@dataclass(frozen=True)
+class RouteDeploymentOrigins:
+    """Origin classification for all deployments under one Router route alias."""
+
+    route_name: str
+    has_hermes: bool
+    has_non_hermes: bool
+    hermes_deployments: Tuple[Dict[str, Any], ...] = field(default_factory=tuple)
+    non_hermes_deployments: Tuple[Dict[str, Any], ...] = field(default_factory=tuple)
+
+    @property
+    def is_hermes_only(self) -> bool:
+        return self.has_hermes and not self.has_non_hermes
+
+    @property
+    def is_mixed(self) -> bool:
+        return self.has_hermes and self.has_non_hermes
+
+
+def is_reserved_hermes_name(name: str) -> bool:
+    return (name or "").strip().lower() == HERMES_CHANNEL_NAME
+
+
+def is_masked_secret_placeholder(value: str) -> bool:
+    return str(value or "").strip() in MASKED_SECRET_TOKENS
+
+
+def build_hermes_redaction_values(*values: Any) -> Set[str]:
+    redactions: Set[str] = set()
+    for value in values:
+        if value is None:
+            continue
+        raw_value = str(value).strip()
+        if raw_value:
+            redactions.add(raw_value)
+            redactions.add(f"Bearer {raw_value}")
+            redactions.add(f"Authorization: Bearer {raw_value}")
+        for segment in str(value).split(","):
+            token = segment.strip()
+            if token:
+                redactions.add(token)
+                redactions.add(f"Bearer {token}")
+                redactions.add(f"Authorization: Bearer {token}")
+    return redactions
+
+
+def _comma_flexible_secret_pattern(secret: str) -> Optional[re.Pattern[str]]:
+    normalized = re.sub(r"(?i)^\s*authorization\s*[:=]\s*", "", str(secret or "").strip())
+    normalized = re.sub(r"(?i)^\s*bearer\s+", "", normalized)
+    parts = [part.strip() for part in normalized.split(",") if part.strip()]
+    if len(parts) <= 1:
+        return None
+    return re.compile(
+        r"(?i)(?:authorization\s*[:=]\s*)?(?:bearer\s+)?"
+        + r"\s*,\s*".join(re.escape(part) for part in parts)
+    )
+
+
+def sanitize_hermes_error_text(
+    text: Any,
+    *,
+    redaction_values: Optional[Iterable[str]] = None,
+) -> str:
+    if text is None:
+        return ""
+    sanitized = str(text).strip()
+    if not sanitized:
+        return ""
+    values = set(redaction_values or set())
+    for secret in sorted(values, key=len, reverse=True):
+        pattern = _comma_flexible_secret_pattern(secret)
+        if pattern is not None:
+            sanitized = pattern.sub("[REDACTED]", sanitized)
+    for secret in sorted(values, key=len, reverse=True):
+        if secret:
+            sanitized = sanitized.replace(secret, "[REDACTED]")
+    patterns = [
+        (r"(?i)(authorization\s*[:=]\s*)(bearer\s+)?([^\s,;]+)", r"\1[REDACTED]"),
+        (r"(?i)(api[_-]?key\s*[:=]\s*)([^\s,;]+)", r"\1[REDACTED]"),
+        (r"(?i)(cookie\s*[:=]\s*)([^\s,;]+)", r"\1[REDACTED]"),
+        (r"(?i)bearer\s+[a-z0-9._\-]+", "Bearer [REDACTED]"),
+        (r"(?i)sk-[a-z0-9_\-]+", "[REDACTED]"),
+    ]
+    for pattern, replacement in patterns:
+        sanitized = re.sub(pattern, replacement, sanitized)
+    return " ".join(sanitized.split())[:300]
+
+
+def canonicalize_hermes_protocol(protocol: str) -> str:
+    normalized = (protocol or HERMES_DEFAULT_PROTOCOL).strip().lower() or HERMES_DEFAULT_PROTOCOL
+    if normalized != HERMES_DEFAULT_PROTOCOL:
+        raise ValueError("Hermes only supports PROTOCOL=openai")
+    return HERMES_DEFAULT_PROTOCOL
+
+
+def canonicalize_hermes_base_url(base_url: str) -> str:
+    """Return canonical Hermes base URL or raise ValueError.
+
+    Allowed forms are loopback HTTP(S) URLs whose path is exactly /v1 or /v1/.
+    localhost is canonicalized to 127.0.0.1 to avoid DNS/hosts ambiguity.
+    """
+
+    raw = (base_url or HERMES_DEFAULT_BASE_URL).strip() or HERMES_DEFAULT_BASE_URL
+    parsed = urlparse(raw)
+    if parsed.scheme.lower() not in {"http", "https"}:
+        raise ValueError("Hermes BASE_URL must use http or https")
+    if not parsed.netloc or not parsed.hostname:
+        raise ValueError("Hermes BASE_URL must include a loopback host")
+    if parsed.username or parsed.password:
+        raise ValueError("Hermes BASE_URL must not include userinfo")
+    if parsed.params or parsed.query or parsed.fragment:
+        raise ValueError("Hermes BASE_URL must not include params, query, or fragment")
+
+    raw_path = parsed.path or ""
+    decoded_path = unquote(raw_path)
+    if decoded_path not in {"/v1", "/v1/"}:
+        raise ValueError("Hermes BASE_URL path must be /v1")
+    if quote(decoded_path, safe="/") != raw_path.rstrip("/") and raw_path not in {"/v1", "/v1/"}:
+        raise ValueError("Hermes BASE_URL path must not contain encoded segments")
+
+    hostname = parsed.hostname.strip().lower()
+    if hostname == "localhost":
+        hostname = "127.0.0.1"
+    elif hostname not in {"127.0.0.1", "::1"}:
+        raise ValueError("Hermes BASE_URL must point to 127.0.0.1, localhost, or [::1]")
+
+    try:
+        port = parsed.port
+    except ValueError as exc:
+        raise ValueError("Hermes BASE_URL contains an invalid port") from exc
+
+    netloc = f"[{hostname}]" if ":" in hostname else hostname
+    if port is not None:
+        netloc = f"{netloc}:{port}"
+    return urlunparse(parsed._replace(netloc=netloc, path="/v1", params="", query="", fragment=""))
+
+
+def canonicalize_hermes_model_ref(raw_model: str) -> HermesModelRef:
+    """Return the canonical DSA route and LiteLLM wire model for Hermes.
+
+    Hermes is OpenAI-compatible over local HTTP, so both route identity and
+    outbound wire model use LiteLLM's openai/ namespace.  The display label is
+    only UI metadata and must not be used for routing or provider detection.
+    """
+
+    display_model = str(raw_model or "").strip() or HERMES_DEFAULT_MODEL
+    if display_model.startswith("openai/"):
+        canonical = display_model
+    else:
+        canonical = f"openai/{display_model}"
+    return HermesModelRef(
+        route_model=canonical,
+        wire_model=canonical,
+        display_model=display_model,
+    )
+
+
+def hermes_blocked_route_candidates(raw_model: str) -> set[str]:
+    """Return route identities used only to match invalid Hermes selections."""
+
+    text = str(raw_model or "").strip()
+    if not text:
+        return set()
+    candidates = {text}
+    if text.startswith("openai/"):
+        candidates.add(text)
+    else:
+        candidates.add(f"openai/{text}")
+    return candidates
+
+
+def route_identity_candidates(model: str) -> set[str]:
+    """Return route aliases that should share Hermes safety decisions.
+
+    This helper is for route provenance lookups, not invalid raw Hermes model
+    blocking. Keep provider-looking route aliases such as ``anthropic/foo``
+    distinct from ``openai/anthropic/foo`` so valid non-Hermes routes are not
+    marked as Hermes by a separate Hermes channel. Invalid Hermes raw tokens use
+    hermes_blocked_route_candidates(), which intentionally matches more broadly.
+    """
+
+    text = str(model or "").strip()
+    if not text:
+        return set()
+    candidates = {text}
+    if not text.startswith("openai/") and "/" not in text:
+        candidates.add(f"openai/{text}")
+    return candidates
+
+
+def normalize_hermes_models(models: Sequence[str]) -> Tuple[List[HermesModelRef], List[str]]:
+    normalized: List[HermesModelRef] = []
+    seen = set()
+    errors: List[str] = []
+    for raw in models:
+        model = str(raw or "").strip()
+        if not model:
+            continue
+        if any(ch.isspace() for ch in model) or "," in model or model.startswith("-"):
+            errors.append(model)
+            continue
+        ref = canonicalize_hermes_model_ref(model)
+        if ref.route_model in seen:
+            continue
+        seen.add(ref.route_model)
+        normalized.append(ref)
+    if not normalized:
+        normalized = [canonicalize_hermes_model_ref(HERMES_DEFAULT_MODEL)]
+    return normalized, errors
+
+
+def parse_hermes_channel(
+    *,
+    enabled: bool,
+    protocol: str,
+    base_url: str,
+    api_key: str,
+    api_keys_raw: str,
+    extra_headers_raw: str,
+    models: Sequence[str],
+) -> HermesChannelParseResult:
+    """Parse the reserved Hermes channel atomically."""
+
+    raw_model_tokens = [str(raw or "").strip() for raw in models if str(raw or "").strip()]
+    resolved_models, malformed_models = normalize_hermes_models(models)
+    blocked_candidates: List[str] = []
+    if raw_model_tokens:
+        for raw_model in raw_model_tokens:
+            for candidate in hermes_blocked_route_candidates(raw_model):
+                if candidate not in blocked_candidates:
+                    blocked_candidates.append(candidate)
+    else:
+        blocked_candidates = [ref.route_model for ref in resolved_models]
+    blocked_route_names = tuple(blocked_candidates)
+
+    if not enabled:
+        # Disabled Hermes is an intentional absence of deployment, not invalid
+        # configuration, and therefore does not block lower-priority legacy env.
+        return HermesChannelParseResult(
+            channel=None,
+            issues=(),
+            blocks_legacy_fallback=False,
+            blocked_route_names=(),
+        )
+
+    issues: List[HermesConfigIssue] = []
+    try:
+        resolved_protocol = canonicalize_hermes_protocol(protocol)
+    except ValueError as exc:
+        issues.append(HermesConfigIssue("LLM_HERMES_PROTOCOL", "invalid_protocol", str(exc)))
+        resolved_protocol = HERMES_DEFAULT_PROTOCOL
+
+    try:
+        resolved_base_url = canonicalize_hermes_base_url(base_url)
+    except ValueError as exc:
+        issues.append(HermesConfigIssue("LLM_HERMES_BASE_URL", "invalid_base_url", str(exc)))
+        resolved_base_url = ""
+
+    single_key = (api_key or "").strip()
+    has_unsupported_api_keys = bool((api_keys_raw or "").strip())
+    if not single_key and not has_unsupported_api_keys:
+        issues.append(HermesConfigIssue("LLM_HERMES_API_KEY", "missing_api_key", "Hermes requires one non-empty API key"))
+    if is_masked_secret_placeholder(single_key):
+        issues.append(HermesConfigIssue("LLM_HERMES_API_KEY", "masked_secret_not_reusable", "Hermes API key is a masked placeholder; re-enter the real key"))
+    if "," in single_key:
+        issues.append(HermesConfigIssue("LLM_HERMES_API_KEY", "multiple_api_keys", "Hermes API key must not contain commas"))
+    if has_unsupported_api_keys:
+        issues.append(HermesConfigIssue(
+            "LLM_HERMES_API_KEYS",
+            "unsupported_api_keys",
+            "Hermes Phase 3 only supports single LLM_HERMES_API_KEY. Move the value from LLM_HERMES_API_KEYS to LLM_HERMES_API_KEY.",
+        ))
+    if (extra_headers_raw or "").strip():
+        issues.append(HermesConfigIssue("LLM_HERMES_EXTRA_HEADERS", "unsupported_extra_headers", "Hermes does not support EXTRA_HEADERS in Phase 3"))
+
+    if malformed_models:
+        issues.append(HermesConfigIssue("LLM_HERMES_MODELS", "invalid_model", "Hermes model IDs must be non-empty IDs without whitespace or commas"))
+
+    if issues:
+        return HermesChannelParseResult(
+            channel=None,
+            issues=tuple(issues),
+            blocks_legacy_fallback=True,
+            blocked_route_names=blocked_route_names,
+        )
+
+    return HermesChannelParseResult(
+        channel={
+            "name": HERMES_CHANNEL_NAME,
+            "protocol": resolved_protocol,
+            "enabled": True,
+            "base_url": resolved_base_url,
+            "api_keys": [single_key],
+            "models": [ref.route_model for ref in resolved_models],
+            "model_refs": [
+                {
+                    "route_model": ref.route_model,
+                    "wire_model": ref.wire_model,
+                    "display_model": ref.display_model,
+                }
+                for ref in resolved_models
+            ],
+            "extra_headers": None,
+            "is_hermes": True,
+        },
+        issues=(),
+        blocks_legacy_fallback=False,
+        blocked_route_names=(),
+    )
+
+
+def hermes_model_info(display_model: str = "") -> Dict[str, str]:
+    info = {HERMES_DEPLOYMENT_MARKER_KEY: HERMES_DEPLOYMENT_MARKER_VALUE}
+    if display_model:
+        info["dsa_display_model"] = display_model
+    return info
+
+
+def is_hermes_deployment(deployment: Dict[str, Any]) -> bool:
+    model_info = deployment.get("model_info") if isinstance(deployment, dict) else None
+    if not isinstance(model_info, dict):
+        return False
+    return str(model_info.get(HERMES_DEPLOYMENT_MARKER_KEY, "")).lower() == HERMES_DEPLOYMENT_MARKER_VALUE
+
+
+def route_deployment_origins(model_list: Sequence[Dict[str, Any]], route_name: str) -> RouteDeploymentOrigins:
+    hermes: List[Dict[str, Any]] = []
+    non_hermes: List[Dict[str, Any]] = []
+    candidates = route_identity_candidates(route_name)
+    for deployment in model_list or []:
+        if not isinstance(deployment, dict):
+            continue
+        deployment_route_name = str(deployment.get("model_name") or "").strip()
+        if deployment_route_name not in candidates:
+            continue
+        if is_hermes_deployment(deployment):
+            hermes.append(deployment)
+        else:
+            non_hermes.append(deployment)
+    return RouteDeploymentOrigins(
+        route_name=route_name,
+        has_hermes=bool(hermes),
+        has_non_hermes=bool(non_hermes),
+        hermes_deployments=tuple(hermes),
+        non_hermes_deployments=tuple(non_hermes),
+    )
+
+
+def build_route_provenance_map(model_list: Sequence[Dict[str, Any]]) -> Dict[str, RouteDeploymentOrigins]:
+    route_names: List[str] = []
+    seen = set()
+    for deployment in model_list or []:
+        if not isinstance(deployment, dict):
+            continue
+        route_name = str(deployment.get("model_name") or "").strip()
+        if route_name and route_name not in seen:
+            seen.add(route_name)
+            route_names.append(route_name)
+    return {route_name: route_deployment_origins(model_list, route_name) for route_name in route_names}
+
+
+def route_has_hermes(model_list: Sequence[Dict[str, Any]], route_name: str) -> bool:
+    """Whether a route alias or display/raw candidate has a Hermes deployment.
+
+    The lookup uses route_identity_candidates() so bare UI values and canonical
+    OpenAI-compatible route aliases share the same safety result.
+    """
+    return route_deployment_origins(model_list, route_name).has_hermes
+
+
+def filter_non_hermes_deployments(model_list: Sequence[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    return [deployment for deployment in (model_list or []) if not is_hermes_deployment(deployment)]
+
+
+@contextmanager
+def open_hermes_no_proxy_client(*, api_key: str, base_url: str, timeout: float) -> Iterator[Any]:
+    """Yield an OpenAI client with a no-proxy httpx transport and close it."""
+
+    import httpx
+    import openai
+
+    canonical_base_url = canonicalize_hermes_base_url(base_url)
+    http_client = httpx.Client(
+        trust_env=False,
+        follow_redirects=False,
+        timeout=timeout,
+    )
+    client = openai.OpenAI(
+        api_key=api_key,
+        base_url=canonical_base_url,
+        http_client=http_client,
+    )
+    try:
+        yield client
+    finally:
+        http_client.close()

--- a/src/services/agent_model_service.py
+++ b/src/services/agent_model_service.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 from typing import Any, Dict, List
 
 from src.config import get_effective_agent_models_to_try, get_effective_agent_primary_model
+from src.agent.litellm_route_resolution import resolve_agent_litellm_route
 from src.llm.backend_registry import CODEX_CLI_BACKEND_ID
 
 
@@ -35,11 +36,13 @@ def _get_model_provider(model_name: str) -> str:
 
 def _build_non_legacy_deployments(config) -> List[Dict[str, Any]]:
     source = _get_models_source(config)
-    primary_model = get_effective_agent_primary_model(config)
-    fallback_models = set(get_effective_agent_models_to_try(config)[1:])
+    resolution = resolve_agent_litellm_route(config)
+    primary_model = resolution.primary_model or get_effective_agent_primary_model(config)
+    fallback_models = set((resolution.models_to_try or [])[1:])
+    model_list = resolution.model_list
     deployments: List[Dict[str, Any]] = []
 
-    for index, entry in enumerate(getattr(config, "llm_model_list", []) or []):
+    for index, entry in enumerate(model_list):
         params = entry.get("litellm_params", {}) or {}
         model_name = str(params.get("model") or "").strip()
         if not model_name or model_name.startswith("__legacy_"):

--- a/src/services/image_stock_extractor.py
+++ b/src/services/image_stock_extractor.py
@@ -20,6 +20,7 @@ import time
 from typing import List, Optional, Tuple
 
 from src.config import Config, get_config
+from src.llm.hermes import route_has_hermes
 
 logger = logging.getLogger(__name__)
 
@@ -242,6 +243,8 @@ def _call_litellm_vision(image_b64: str, mime_type: str, api_key: Optional[str] 
     model = _resolve_vision_model()
     if not model:
         raise ValueError("未配置 Vision API。请设置 LITELLM_MODEL 或相关 API Key。")
+    if route_has_hermes(getattr(cfg, "llm_model_list", []) or [], model):
+        raise ValueError("Hermes Vision 未验证：VISION_MODEL 不能选择包含 Hermes deployment 的 route。")
 
     keys = _get_api_keys_for_model(model, cfg)
     if not keys:

--- a/src/services/system_config_service.py
+++ b/src/services/system_config_service.py
@@ -36,6 +36,19 @@ from src.config import (
     resolve_llm_channel_protocol,
     setup_env,
 )
+from src.llm.hermes import (
+    HERMES_DEFAULT_BASE_URL,
+    HERMES_DEFAULT_MODEL,
+    HERMES_DEFAULT_PROTOCOL,
+    build_hermes_redaction_values,
+    canonicalize_hermes_model_ref,
+    canonicalize_hermes_base_url,
+    is_masked_secret_placeholder,
+    is_reserved_hermes_name,
+    open_hermes_no_proxy_client,
+    parse_hermes_channel,
+    route_identity_candidates,
+)
 from src.core.config_manager import ConfigManager
 from src.core.config_registry import (
     build_schema_response,
@@ -125,6 +138,9 @@ class SystemConfigService:
     }
     _SERVER_MASKED_CONFIG_KEYS: Set[str] = {
         "ALPHASIFT_INSTALL_SPEC",
+        "LLM_HERMES_API_KEY",
+        "LLM_HERMES_API_KEYS",
+        "LLM_HERMES_EXTRA_HEADERS",
         "LLM_USAGE_HMAC_SECRET",
     }
     _NOTIFICATION_TEST_CHANNELS: Tuple[str, ...] = (
@@ -583,6 +599,183 @@ class SystemConfigService:
             reload_now=reload_now,
         )
 
+    def _resolve_hermes_saved_secret(
+        self,
+        *,
+        channel_name: str,
+        protocol: str,
+        base_url: str,
+        submitted_api_key: str,
+        use_saved_secret: bool,
+        stage: str,
+    ) -> Tuple[Optional[str], Dict[str, Any], Set[str]]:
+        """Resolve a saved Hermes key only when the submitted endpoint is unchanged."""
+
+        redaction_values = self._build_redaction_values(submitted_api_key)
+        if not use_saved_secret:
+            return submitted_api_key, {}, redaction_values
+
+        if not is_reserved_hermes_name(channel_name):
+            return None, self._build_llm_channel_result(
+                success=False,
+                message="Saved secret scope mismatch",
+                error="Saved Hermes secret can only be used with the reserved hermes channel",
+                stage=stage,
+                error_code="saved_secret_scope_mismatch",
+                retryable=False,
+                details={"reason": "channel_identity_mismatch"},
+                resolved_protocol=None,
+                models=[] if stage == "model_discovery" else None,
+                latency_ms=None,
+                redaction_values=redaction_values,
+            ), redaction_values
+
+        saved_map = self._manager.read_config_map()
+        saved_key = (saved_map.get("LLM_HERMES_API_KEY") or "").strip()
+        if not saved_key or is_masked_secret_placeholder(saved_key):
+            error_code = (
+                "runtime_secret_not_reusable"
+                if is_masked_secret_placeholder(saved_key) or (os.environ.get("LLM_HERMES_API_KEY") or "").strip()
+                else "missing_saved_secret"
+            )
+            return None, self._build_llm_channel_result(
+                success=False,
+                message=(
+                    "Runtime Hermes secret is not reusable"
+                    if error_code == "runtime_secret_not_reusable"
+                    else "Missing saved Hermes secret"
+                ),
+                error=(
+                    "Runtime-injected LLM_HERMES_API_KEY cannot be reused from the settings test flow"
+                    if error_code == "runtime_secret_not_reusable"
+                    else "No saved LLM_HERMES_API_KEY is available for this endpoint"
+                ),
+                stage=stage,
+                error_code=error_code,
+                retryable=False,
+                details={"reason": error_code},
+                resolved_protocol=None,
+                models=[] if stage == "model_discovery" else None,
+                latency_ms=None,
+                redaction_values=redaction_values,
+            ), redaction_values
+
+        redaction_values.update(self._build_redaction_values(saved_key))
+        saved_protocol = (saved_map.get("LLM_HERMES_PROTOCOL") or "openai").strip()
+        saved_base_url = (saved_map.get("LLM_HERMES_BASE_URL") or "").strip()
+        try:
+            submitted_protocol = (protocol or "openai").strip().lower() or "openai"
+            saved_protocol_canonical = (saved_protocol or "openai").strip().lower() or "openai"
+            submitted_base = canonicalize_hermes_base_url(base_url)
+            saved_base = canonicalize_hermes_base_url(saved_base_url)
+        except ValueError as exc:
+            return None, self._build_llm_channel_result(
+                success=False,
+                message="Saved secret scope mismatch",
+                error=str(exc),
+                stage=stage,
+                error_code="saved_secret_scope_mismatch",
+                retryable=False,
+                details={"reason": "invalid_hermes_endpoint"},
+                resolved_protocol=None,
+                models=[] if stage == "model_discovery" else None,
+                latency_ms=None,
+                redaction_values=redaction_values,
+            ), redaction_values
+
+        if submitted_protocol != saved_protocol_canonical or submitted_base != saved_base:
+            return None, self._build_llm_channel_result(
+                success=False,
+                message="Saved secret scope mismatch",
+                error="Hermes endpoint changed; re-enter LLM_HERMES_API_KEY before testing",
+                stage=stage,
+                error_code="saved_secret_scope_mismatch",
+                retryable=False,
+                details={
+                    "reason": "endpoint_mismatch",
+                    "submitted_base_url": submitted_base,
+                    "saved_base_url": saved_base,
+                },
+                resolved_protocol=submitted_protocol,
+                models=[] if stage == "model_discovery" else None,
+                latency_ms=None,
+                redaction_values=redaction_values,
+            ), redaction_values
+
+        return saved_key, {}, redaction_values
+
+    def _validate_hermes_submitted_secret(
+        self,
+        *,
+        api_key: str,
+        use_saved_secret: bool,
+        stage: str,
+        models: Optional[List[str]] = None,
+        capability_checks: Sequence[str] = (),
+        redaction_values: Optional[Set[str]] = None,
+    ) -> Optional[Dict[str, Any]]:
+        """Reject Hermes secret shapes that must not reach an outbound request."""
+
+        secret = (api_key or "").strip()
+        redactions = set(redaction_values or set())
+        redactions.update(self._build_redaction_values(secret))
+        if is_masked_secret_placeholder(secret):
+            return self._build_llm_channel_result(
+                success=False,
+                message="Runtime Hermes secret is not reusable",
+                error=(
+                    "Runtime-injected Hermes secret is masked and cannot be reused by "
+                    "test/discovery. Re-enter the key or save it to .env."
+                ),
+                stage=stage,
+                error_code="runtime_secret_not_reusable",
+                retryable=False,
+                details={"reason": "runtime_secret_not_reusable"},
+                resolved_protocol=None,
+                models=models if stage == "model_discovery" else None,
+                latency_ms=None,
+                capability_results=(
+                    self._build_skipped_capability_results(
+                        capability_checks,
+                        "base_test_failed",
+                        "Skipped because the base channel test did not pass",
+                        redaction_values=redactions,
+                    )
+                    if capability_checks
+                    else None
+                ),
+                redaction_values=redactions,
+            )
+        if "," in secret:
+            return self._build_llm_channel_result(
+                success=False,
+                message="Hermes API key is invalid",
+                error="Hermes Phase 3 only supports a single LLM_HERMES_API_KEY",
+                stage=stage,
+                error_code="invalid_config",
+                retryable=False,
+                details={
+                    "issue_key": "LLM_HERMES_API_KEY",
+                    "issue_code": "multiple_api_keys",
+                    "reason": "multiple_api_keys",
+                },
+                resolved_protocol=None,
+                models=models if stage == "model_discovery" else None,
+                latency_ms=None,
+                capability_results=(
+                    self._build_skipped_capability_results(
+                        capability_checks,
+                        "base_test_failed",
+                        "Skipped because the base channel test did not pass",
+                        redaction_values=redactions,
+                    )
+                    if capability_checks
+                    else None
+                ),
+                redaction_values=redactions,
+            )
+        return None
+
     def discover_llm_channel_models(
         self,
         *,
@@ -592,9 +785,52 @@ class SystemConfigService:
         api_key: str,
         models: Sequence[str] = (),
         timeout_seconds: float = 20.0,
-        ) -> Dict[str, Any]:
+        use_saved_secret: bool = False,
+    ) -> Dict[str, Any]:
         """Discover available models from an OpenAI-compatible `/models` endpoint."""
         channel_name = name.strip() or "channel"
+        resolved_secret, secret_error, redaction_values = self._resolve_hermes_saved_secret(
+            channel_name=channel_name,
+            protocol=protocol,
+            base_url=base_url,
+            submitted_api_key=api_key,
+            use_saved_secret=use_saved_secret,
+            stage="model_discovery",
+        )
+        if resolved_secret is None:
+            return secret_error
+        api_key = resolved_secret
+        redaction_values.update(self._build_redaction_values(api_key))
+        if is_reserved_hermes_name(channel_name):
+            secret_error = self._validate_hermes_submitted_secret(
+                api_key=api_key,
+                use_saved_secret=use_saved_secret,
+                stage="model_discovery",
+                models=[],
+                redaction_values=redaction_values,
+            )
+            if secret_error is not None:
+                return secret_error
+            try:
+                base_url = canonicalize_hermes_base_url(base_url)
+            except ValueError as exc:
+                return self._build_llm_channel_result(
+                    success=False,
+                    message="Hermes Base URL is invalid",
+                    error=str(exc),
+                    stage="model_discovery",
+                    error_code="invalid_config",
+                    retryable=False,
+                    details={
+                        "issue_key": "discover_channel_BASE_URL",
+                        "issue_code": "invalid_hermes_url",
+                        "reason": "invalid_hermes_url",
+                    },
+                    resolved_protocol=None,
+                    models=[],
+                    latency_ms=None,
+                    redaction_values=redaction_values,
+                )
         existing_models = [str(m).strip() for m in models if str(m).strip()]
         validation_issues, resolved_protocol = self._validate_llm_channel_connection(
             channel_name=channel_name,
@@ -629,6 +865,7 @@ class SystemConfigService:
                 resolved_protocol=resolved_protocol or None,
                 models=[],
                 latency_ms=None,
+                redaction_values=redaction_values,
             )
 
         if resolved_protocol not in {"openai", "deepseek"}:
@@ -646,10 +883,12 @@ class SystemConfigService:
                 resolved_protocol=resolved_protocol or None,
                 models=[],
                 latency_ms=None,
+                redaction_values=redaction_values,
             )
 
         api_keys = [segment.strip() for segment in api_key.split(",") if segment.strip()]
         selected_api_key = api_keys[0] if api_keys else ""
+        redaction_values.update(self._build_redaction_values(selected_api_key))
         request_headers = {"Accept": "application/json"}
         if selected_api_key:
             request_headers["Authorization"] = f"Bearer {selected_api_key}"
@@ -672,19 +911,37 @@ class SystemConfigService:
                 resolved_protocol=resolved_protocol or None,
                 models=[],
                 latency_ms=None,
+                redaction_values=redaction_values,
             )
 
         try:
             started_at = time.perf_counter()
-            response = requests.get(
-                models_url,
-                headers=request_headers,
-                timeout=max(5.0, float(timeout_seconds)),
-                allow_redirects=False,
-            )
+            if is_reserved_hermes_name(channel_name):
+                session = requests.Session()
+                session.trust_env = False
+                try:
+                    response = session.get(
+                        models_url,
+                        headers=request_headers,
+                        timeout=max(5.0, float(timeout_seconds)),
+                        allow_redirects=False,
+                    )
+                finally:
+                    session.close()
+            else:
+                response = requests.get(
+                    models_url,
+                    headers=request_headers,
+                    timeout=max(5.0, float(timeout_seconds)),
+                    allow_redirects=False,
+                )
             latency_ms = int((time.perf_counter() - started_at) * 1000)
         except requests.RequestException as exc:
-            logger.warning("LLM channel model discovery failed for %s: %s", channel_name, exc)
+            logger.warning(
+                "LLM channel model discovery failed for %s: %s",
+                channel_name,
+                self._sanitize_llm_error_text(exc, redaction_values=redaction_values),
+            )
             diagnostic = self._classify_llm_exception(exc)
             return self._build_llm_channel_result(
                 success=False,
@@ -697,6 +954,7 @@ class SystemConfigService:
                 resolved_protocol=resolved_protocol or None,
                 models=[],
                 latency_ms=None,
+                redaction_values=redaction_values,
             )
 
         if 300 <= response.status_code < 400:
@@ -711,6 +969,7 @@ class SystemConfigService:
                 resolved_protocol=resolved_protocol or None,
                 models=[],
                 latency_ms=latency_ms,
+                redaction_values=redaction_values,
             )
 
         if not response.ok:
@@ -733,6 +992,7 @@ class SystemConfigService:
                 resolved_protocol=resolved_protocol or None,
                 models=[],
                 latency_ms=latency_ms,
+                redaction_values=redaction_values,
             )
 
         try:
@@ -749,6 +1009,7 @@ class SystemConfigService:
                 resolved_protocol=resolved_protocol or None,
                 models=[],
                 latency_ms=latency_ms,
+                redaction_values=redaction_values,
             )
 
         models = self._extract_discovered_llm_models(payload)
@@ -764,6 +1025,7 @@ class SystemConfigService:
                 resolved_protocol=resolved_protocol or None,
                 models=[],
                 latency_ms=latency_ms,
+                redaction_values=redaction_values,
             )
 
         return self._build_llm_channel_result(
@@ -777,6 +1039,7 @@ class SystemConfigService:
             resolved_protocol=resolved_protocol or None,
             models=models,
             latency_ms=latency_ms,
+            redaction_values=redaction_values,
         )
 
     def test_llm_channel(
@@ -790,11 +1053,68 @@ class SystemConfigService:
         enabled: bool = True,
         timeout_seconds: float = 20.0,
         capability_checks: Sequence[str] = (),
+        use_saved_secret: bool = False,
     ) -> Dict[str, Any]:
         """Run a minimal completion call against one channel definition."""
         requested_capabilities = self._normalize_llm_capability_checks(capability_checks)
         raw_models = [str(model).strip() for model in models if str(model).strip()]
         channel_name = name.strip() or "channel"
+        resolved_secret, secret_error, redaction_values = self._resolve_hermes_saved_secret(
+            channel_name=channel_name,
+            protocol=protocol,
+            base_url=base_url,
+            submitted_api_key=api_key,
+            use_saved_secret=use_saved_secret,
+            stage="chat_completion",
+        )
+        if resolved_secret is None:
+            result = secret_error
+            if requested_capabilities and "capability_results" not in result:
+                result["capability_results"] = self._build_skipped_capability_results(
+                    requested_capabilities,
+                    "base_test_failed",
+                    "Skipped because the base channel test did not pass",
+                    redaction_values=redaction_values,
+                )
+            return result
+        api_key = resolved_secret
+        redaction_values.update(self._build_redaction_values(api_key))
+        if is_reserved_hermes_name(channel_name):
+            secret_error = self._validate_hermes_submitted_secret(
+                api_key=api_key,
+                use_saved_secret=use_saved_secret,
+                stage="chat_completion",
+                capability_checks=requested_capabilities,
+                redaction_values=redaction_values,
+            )
+            if secret_error is not None:
+                return secret_error
+            try:
+                base_url = canonicalize_hermes_base_url(base_url)
+            except ValueError as exc:
+                return self._build_llm_channel_result(
+                    success=False,
+                    message="Hermes Base URL is invalid",
+                    error=str(exc),
+                    stage="chat_completion",
+                    error_code="invalid_config",
+                    retryable=False,
+                    details={
+                        "issue_key": "test_channel_BASE_URL",
+                        "issue_code": "invalid_hermes_url",
+                        "reason": "invalid_hermes_url",
+                    },
+                    resolved_protocol=None,
+                    resolved_model=None,
+                    latency_ms=None,
+                    capability_results=self._build_skipped_capability_results(
+                        requested_capabilities,
+                        "base_test_failed",
+                        "Skipped because the base channel test did not pass",
+                        redaction_values=redaction_values,
+                    ),
+                    redaction_values=redaction_values,
+                )
         validation_issues = self._validate_llm_channel_definition(
             channel_name=channel_name,
             protocol_value=protocol,
@@ -826,14 +1146,19 @@ class SystemConfigService:
                     requested_capabilities,
                     "base_test_failed",
                     "Skipped because the base channel test did not pass",
+                    redaction_values=redaction_values,
                 ),
+                redaction_values=redaction_values,
             )
 
         resolved_protocol = resolve_llm_channel_protocol(protocol, base_url=base_url, models=raw_models, channel_name=name)
         resolved_models = [normalize_llm_channel_model(model, resolved_protocol, base_url) for model in raw_models]
         resolved_model = resolved_models[0]
+        if is_reserved_hermes_name(channel_name):
+            resolved_model = canonicalize_hermes_model_ref(raw_models[0]).wire_model
         api_keys = [segment.strip() for segment in api_key.split(",") if segment.strip()]
         selected_api_key = api_keys[0] if api_keys else ""
+        redaction_values.update(self._build_redaction_values(selected_api_key))
 
         call_kwargs: Dict[str, Any] = {
             "model": resolved_model,
@@ -870,13 +1195,32 @@ class SystemConfigService:
             )
 
             started_at = time.perf_counter()
-            response = call_litellm_with_param_recovery(
-                lambda kwargs: litellm.completion(**kwargs),
-                model=resolved_model,
-                call_kwargs=call_kwargs,
-                logger=logger,
-                log_label="[LLM channel test]",
-            )
+            if is_reserved_hermes_name(channel_name):
+                with open_hermes_no_proxy_client(
+                    api_key=selected_api_key,
+                    base_url=base_url,
+                    timeout=max(5.0, float(timeout_seconds)),
+                ) as client:
+                    hermes_call_kwargs = dict(call_kwargs)
+                    hermes_call_kwargs["stream"] = False
+                    hermes_call_kwargs["client"] = client
+                    hermes_call_kwargs.pop("api_key", None)
+                    hermes_call_kwargs.pop("api_base", None)
+                    response = call_litellm_with_param_recovery(
+                        lambda kwargs: litellm.completion(**kwargs),
+                        model=resolved_model,
+                        call_kwargs=hermes_call_kwargs,
+                        logger=logger,
+                        log_label="[Hermes channel test]",
+                    )
+            else:
+                response = call_litellm_with_param_recovery(
+                    lambda kwargs: litellm.completion(**kwargs),
+                    model=resolved_model,
+                    call_kwargs=call_kwargs,
+                    logger=logger,
+                    log_label="[LLM channel test]",
+                )
             latency_ms = int((time.perf_counter() - started_at) * 1000)
             content, parse_error_code, parse_error, parse_reason = self._extract_llm_completion_content(response)
             if parse_error_code:
@@ -900,11 +1244,24 @@ class SystemConfigService:
                         requested_capabilities,
                         "base_test_failed",
                         "Skipped because the base channel test did not pass",
+                        redaction_values=redaction_values,
                     ),
+                    redaction_values=redaction_values,
                 )
 
-            capability_results = (
-                self._run_llm_capability_checks(
+            capability_results: Dict[str, Any] = {}
+            if requested_capabilities and is_reserved_hermes_name(channel_name):
+                capability_results = self._run_hermes_capability_checks(
+                    litellm_module=litellm,
+                    resolved_model=resolved_model,
+                    selected_api_key=selected_api_key,
+                    base_url=base_url,
+                    timeout_seconds=timeout_seconds,
+                    capability_checks=requested_capabilities,
+                    redaction_values=redaction_values,
+                )
+            elif requested_capabilities:
+                capability_results = self._run_llm_capability_checks(
                     litellm_module=litellm,
                     resolved_model=resolved_model,
                     selected_api_key=selected_api_key,
@@ -912,9 +1269,6 @@ class SystemConfigService:
                     timeout_seconds=timeout_seconds,
                     capability_checks=requested_capabilities,
                 )
-                if requested_capabilities
-                else {}
-            )
             return self._build_llm_channel_result(
                 success=True,
                 message="LLM channel test succeeded",
@@ -927,9 +1281,14 @@ class SystemConfigService:
                 resolved_model=resolved_model,
                 latency_ms=latency_ms,
                 capability_results=capability_results,
+                redaction_values=redaction_values,
             )
         except Exception as exc:
-            logger.warning("LLM channel test failed for %s: %s", channel_name, exc)
+            logger.warning(
+                "LLM channel test failed for %s: %s",
+                channel_name,
+                self._sanitize_llm_error_text(exc, redaction_values=redaction_values),
+            )
             diagnostic = self._classify_llm_exception(exc)
             return self._build_llm_channel_result(
                 success=False,
@@ -942,10 +1301,12 @@ class SystemConfigService:
                 resolved_protocol=resolved_protocol or None,
                 resolved_model=resolved_model,
                 latency_ms=None,
+                redaction_values=redaction_values,
                 capability_results=self._build_skipped_capability_results(
                     requested_capabilities,
                     "base_test_failed",
                     "Skipped because the base channel test did not pass",
+                    redaction_values=redaction_values,
                 ),
             )
 
@@ -960,6 +1321,8 @@ class SystemConfigService:
         capability_checks: Sequence[str],
         reason: str,
         message: str,
+        *,
+        redaction_values: Optional[Set[str]] = None,
     ) -> Dict[str, Dict[str, Any]]:
         return {
             capability: cls._build_llm_capability_result(
@@ -969,9 +1332,102 @@ class SystemConfigService:
                 error_code="skipped",
                 retryable=False,
                 details={"reason": reason},
+                redaction_values=redaction_values,
             )
             for capability in capability_checks
         }
+
+    @classmethod
+    def _run_hermes_capability_checks(
+        cls,
+        *,
+        litellm_module: Any,
+        resolved_model: str,
+        selected_api_key: str,
+        base_url: str,
+        timeout_seconds: float,
+        capability_checks: Sequence[str],
+        redaction_values: Optional[Set[str]] = None,
+    ) -> Dict[str, Dict[str, Any]]:
+        results: Dict[str, Dict[str, Any]] = {}
+        for capability in capability_checks:
+            if capability != "json":
+                results[capability] = cls._build_llm_capability_result(
+                    capability=capability,
+                    status="skipped",
+                    message="Hermes Phase 3 does not probe this capability",
+                    error_code="not_probed",
+                    retryable=False,
+                    details={"reason": "not_probed"},
+                    redaction_values=redaction_values,
+                )
+                continue
+            try:
+                started_at = time.perf_counter()
+                with open_hermes_no_proxy_client(
+                    api_key=selected_api_key,
+                    base_url=base_url,
+                    timeout=max(5.0, float(timeout_seconds)),
+                ) as client:
+                    call_kwargs = cls._build_llm_capability_completion_kwargs(
+                        resolved_model=resolved_model,
+                        selected_api_key=selected_api_key,
+                        base_url=base_url,
+                        timeout_seconds=timeout_seconds,
+                        messages=[{"role": "user", "content": 'Return exactly this JSON object: {"status":"ok"}'}],
+                        max_tokens=64,
+                        extra={"response_format": {"type": "json_object"}, "client": client},
+                    )
+                    call_kwargs.pop("api_key", None)
+                    call_kwargs.pop("api_base", None)
+                    response = litellm_module.completion(**call_kwargs)
+                    content, parse_error_code, parse_error, parse_reason = cls._extract_llm_completion_content(response)
+                latency_ms = int((time.perf_counter() - started_at) * 1000)
+                if parse_error_code:
+                    results[capability] = cls._build_llm_capability_result(
+                        capability="json",
+                        status="failed",
+                        message="JSON capability check returned no parseable content",
+                        error_code=parse_error_code,
+                        retryable=False,
+                        latency_ms=latency_ms,
+                        details={"reason": parse_reason, "response_error": parse_error},
+                        redaction_values=redaction_values,
+                    )
+                    continue
+                try:
+                    payload = json.loads(content)
+                except ValueError:
+                    payload = None
+                if not isinstance(payload, dict) or payload.get("status") != "ok":
+                    results[capability] = cls._build_llm_capability_result(
+                        capability="json",
+                        status="failed",
+                        message="JSON capability check returned non-JSON content",
+                        error_code="format_error",
+                        retryable=False,
+                        latency_ms=latency_ms,
+                        details={"reason": "non_json", "response_preview": content[:80]},
+                        redaction_values=redaction_values,
+                    )
+                    continue
+                results[capability] = cls._build_llm_capability_result(
+                    capability="json",
+                    status="passed",
+                    message="JSON output capability check passed",
+                    latency_ms=latency_ms,
+                    details={"reason": "json_valid"},
+                    redaction_values=redaction_values,
+                )
+            except Exception as exc:
+                diagnostic = cls._classify_llm_capability_exception(exc, "json")
+                results[capability] = cls._build_llm_capability_result_from_diagnostic(
+                    "json",
+                    diagnostic,
+                    cls._sanitize_llm_error_text(exc, redaction_values=redaction_values),
+                    redaction_values=redaction_values,
+                )
+        return results
 
     @classmethod
     def _run_llm_capability_checks(
@@ -1308,15 +1764,19 @@ class SystemConfigService:
         retryable: bool = False,
         latency_ms: Optional[int] = None,
         details: Optional[Dict[str, Any]] = None,
+        redaction_values: Optional[Set[str]] = None,
     ) -> Dict[str, Any]:
         return {
             "status": status,
-            "message": cls._sanitize_llm_error_text(message),
+            "message": cls._sanitize_llm_error_text(message, redaction_values=redaction_values),
             "error_code": error_code,
             "stage": f"capability_{capability}",
             "retryable": retryable,
             "latency_ms": latency_ms,
-            "details": cls._sanitize_llm_details({"capability": capability, **(details or {})}),
+            "details": cls._sanitize_llm_details(
+                {"capability": capability, **(details or {})},
+                redaction_values=redaction_values,
+            ),
         }
 
     @classmethod
@@ -1325,6 +1785,8 @@ class SystemConfigService:
         capability: str,
         diagnostic: _LLMDiagnostic,
         error: str,
+        *,
+        redaction_values: Optional[Set[str]] = None,
     ) -> Dict[str, Any]:
         details = cls._merge_llm_diagnostic_details({"error": error}, diagnostic)
         return cls._build_llm_capability_result(
@@ -1334,6 +1796,7 @@ class SystemConfigService:
             error_code=diagnostic.error_code,
             retryable=diagnostic.retryable,
             details=details,
+            redaction_values=redaction_values,
         )
 
     @staticmethod
@@ -1463,10 +1926,17 @@ class SystemConfigService:
                 reload_now=reload_now,
             )
         )
+        update_map = dict(updates)
         warnings.extend(
             self._build_runtime_model_cleanup_warnings(
                 previous_map=previous_map,
-                updates=dict(updates),
+                updates=update_map,
+            )
+        )
+        warnings.extend(
+            self._build_hermes_unsupported_key_cleanup_warnings(
+                previous_map=previous_map,
+                updates=update_map,
             )
         )
         if self._runtime_scheduler is not None and submitted_keys & {
@@ -1663,6 +2133,35 @@ class SystemConfigService:
             "LITELLM_MODEL / AGENT_LITELLM_MODEL / VISION_MODEL / LLM_TEMPERATURE。"
         )
         return [warning]
+
+    @staticmethod
+    def _build_hermes_unsupported_key_cleanup_warnings(
+        *,
+        previous_map: Dict[str, str],
+        updates: Dict[str, str],
+    ) -> List[str]:
+        """Explain when Hermes save clears unsupported Phase 3 key/header fields."""
+        unsupported_labels = {
+            "LLM_HERMES_API_KEYS": "LLM_HERMES_API_KEYS",
+            "LLM_HERMES_EXTRA_HEADERS": "LLM_HERMES_EXTRA_HEADERS",
+        }
+        cleared = [
+            label
+            for key, label in unsupported_labels.items()
+            if previous_map.get(key, "").strip() and key in updates and not updates[key].strip()
+        ]
+        if not cleared:
+            return []
+
+        return [
+            (
+                "检测到已清理 Hermes Phase 3 不支持的配置项："
+                f"{', '.join(cleared)}。"
+                "Hermes reserved channel 只支持单个 LLM_HERMES_API_KEY，不支持多 Key 或额外 Header；"
+                "如需恢复旧值，请从 .env 备份、Git 历史或桌面端导出备份手动还原，"
+                "但非空 LLM_HERMES_API_KEYS / LLM_HERMES_EXTRA_HEADERS 仍会被后端校验拒绝。"
+            )
+        ]
 
     def apply_simple_updates(
         self,
@@ -2586,6 +3085,22 @@ class SystemConfigService:
                         or ANSPIRE_LLM_MODEL_DEFAULT
                     ).strip()
                 ]
+            if is_reserved_hermes_name(name):
+                result = parse_hermes_channel(
+                    enabled=True,
+                    protocol=protocol or HERMES_DEFAULT_PROTOCOL,
+                    base_url=base_url or HERMES_DEFAULT_BASE_URL,
+                    api_key=(effective_map.get(f"{prefix}_API_KEY") or "").strip(),
+                    api_keys_raw=(effective_map.get(f"{prefix}_API_KEYS") or "").strip(),
+                    extra_headers_raw=(effective_map.get(f"{prefix}_EXTRA_HEADERS") or "").strip(),
+                    models=raw_models or [HERMES_DEFAULT_MODEL],
+                )
+                channel = result.channel or {}
+                for raw_model in channel.get("models") or []:
+                    if raw_model and raw_model not in seen:
+                        seen.add(raw_model)
+                        models.append(raw_model)
+                continue
             resolved_protocol = resolve_llm_channel_protocol(
                 protocol,
                 base_url=base_url,
@@ -2736,6 +3251,8 @@ class SystemConfigService:
             )
 
         agent_model_raw = (effective_map.get("AGENT_LITELLM_MODEL") or "").strip()
+        hermes_routes = set(self._collect_hermes_channel_models_from_map(effective_map))
+        non_hermes_routes = set(self._collect_non_hermes_channel_models_from_map(effective_map))
         if not agent_model_raw:
             if generation_backend == CODEX_CLI_BACKEND_ID:
                 litellm_model, _source = self._resolve_setup_primary_model(effective_map)
@@ -2768,6 +3285,17 @@ class SystemConfigService:
                     "如需使用 Ask-Stock Agent，请配置 LiteLLM 模型，或将 AGENT_GENERATION_BACKEND 固定为 litellm 后补齐模型配置。",
                 )
             if primary_check["status"] == "configured":
+                primary_model, _source = self._resolve_setup_primary_model(effective_map)
+                if primary_model in hermes_routes and primary_model not in non_hermes_routes:
+                    return self._setup_check(
+                        "llm_agent",
+                        "Agent 渠道",
+                        "agent",
+                        True,
+                        "needs_action",
+                        "Hermes Phase 3 不支持 Agent 工具调用，且当前继承的主模型没有非 Hermes deployment。",
+                        "请选择非 Hermes Agent 模型，或配置包含非 Hermes deployment 的 mixed Agent route。",
+                    )
                 return self._setup_check(
                     "llm_agent",
                     "Agent 渠道",
@@ -2791,6 +3319,16 @@ class SystemConfigService:
             or self._collect_setup_channel_models(effective_map)
         )
         agent_model = normalize_agent_litellm_model(agent_model_raw, configured_models=configured_models)
+        if agent_model in hermes_routes and agent_model not in non_hermes_routes:
+            return self._setup_check(
+                "llm_agent",
+                "Agent 渠道",
+                "agent",
+                True,
+                "needs_action",
+                f"Agent 主模型 {agent_model} 只有 Hermes deployment，Phase 3 不支持 Agent 工具调用。",
+                "请选择非 Hermes Agent 模型，或配置 mixed route 中的非 Hermes deployment。",
+            )
         if _uses_direct_env_provider(agent_model):
             return self._setup_check(
                 "llm_agent",
@@ -3040,24 +3578,31 @@ class SystemConfigService:
         models: Optional[List[str]] = None,
         latency_ms: Optional[int] = None,
         capability_results: Optional[Dict[str, Any]] = None,
+        redaction_values: Optional[Set[str]] = None,
     ) -> Dict[str, Any]:
         payload: Dict[str, Any] = {
             "success": success,
-            "message": cls._sanitize_llm_error_text(message),
-            "error": cls._sanitize_llm_error_text(error) if error else None,
+            "message": cls._sanitize_llm_error_text(message, redaction_values=redaction_values),
+            "error": cls._sanitize_llm_error_text(error, redaction_values=redaction_values) if error else None,
             "stage": stage,
             "error_code": error_code,
             "retryable": retryable,
-            "details": cls._sanitize_llm_details(details),
-            "resolved_protocol": resolved_protocol,
+            "details": cls._sanitize_llm_details(details, redaction_values=redaction_values),
+            "resolved_protocol": cls._sanitize_llm_error_text(
+                resolved_protocol,
+                redaction_values=redaction_values,
+            ) if resolved_protocol is not None else None,
             "latency_ms": latency_ms,
         }
         if resolved_model is not None or models is None:
-            payload["resolved_model"] = resolved_model
+            payload["resolved_model"] = cls._sanitize_llm_error_text(
+                resolved_model,
+                redaction_values=redaction_values,
+            ) if resolved_model is not None else resolved_model
         if models is not None:
-            payload["models"] = models
+            payload["models"] = cls._sanitize_llm_value(models, redaction_values=redaction_values)
         if capability_results is not None:
-            payload["capability_results"] = cls._sanitize_llm_details(capability_results)
+            payload["capability_results"] = cls._sanitize_llm_value(capability_results, redaction_values=redaction_values)
         return payload
 
     @staticmethod
@@ -3072,12 +3617,35 @@ class SystemConfigService:
         return details
 
     @staticmethod
-    def _sanitize_llm_error_text(text: Any) -> str:
+    def _build_redaction_values(*values: Any) -> Set[str]:
+        return build_hermes_redaction_values(*values)
+
+    @staticmethod
+    def _comma_flexible_secret_pattern(secret: str) -> Optional[re.Pattern[str]]:
+        normalized = re.sub(r"(?i)^\s*authorization\s*[:=]\s*", "", str(secret or "").strip())
+        normalized = re.sub(r"(?i)^\s*bearer\s+", "", normalized)
+        parts = [part.strip() for part in normalized.split(",") if part.strip()]
+        if len(parts) <= 1:
+            return None
+        return re.compile(
+            r"(?i)(?:authorization\s*[:=]\s*)?(?:bearer\s+)?"
+            + r"\s*,\s*".join(re.escape(part) for part in parts)
+        )
+
+    @classmethod
+    def _sanitize_llm_error_text(cls, text: Any, *, redaction_values: Optional[Set[str]] = None) -> str:
         if text is None:
             return ""
         sanitized = str(text).strip()
         if not sanitized:
             return ""
+        for secret in sorted((redaction_values or set()), key=len, reverse=True):
+            pattern = cls._comma_flexible_secret_pattern(secret)
+            if pattern is not None:
+                sanitized = pattern.sub("[REDACTED]", sanitized)
+        for secret in sorted((redaction_values or set()), key=len, reverse=True):
+            if secret:
+                sanitized = sanitized.replace(secret, "[REDACTED]")
 
         patterns = [
             (r"(?i)(authorization\s*[:=]\s*)(bearer\s+)?([^\s,;]+)", r"\1[REDACTED]"),
@@ -3092,23 +3660,40 @@ class SystemConfigService:
         return sanitized[:300]
 
     @classmethod
-    def _sanitize_llm_details(cls, details: Optional[Dict[str, Any]]) -> Dict[str, Any]:
+    def _sanitize_llm_details(
+        cls,
+        details: Optional[Dict[str, Any]],
+        *,
+        redaction_values: Optional[Set[str]] = None,
+    ) -> Dict[str, Any]:
         if not details:
             return {}
-        sanitized: Dict[str, Any] = {}
-        for key, value in details.items():
-            if isinstance(value, str):
-                sanitized[key] = cls._sanitize_llm_error_text(value)
-            elif isinstance(value, dict):
-                sanitized[key] = cls._sanitize_llm_details(value)
-            elif isinstance(value, list):
-                sanitized[key] = [
-                    cls._sanitize_llm_error_text(item) if isinstance(item, str) else item
-                    for item in value
-                ]
-            else:
-                sanitized[key] = value
-        return sanitized
+        sanitized = cls._sanitize_llm_value(details, redaction_values=redaction_values)
+        return sanitized if isinstance(sanitized, dict) else {}
+
+    @classmethod
+    def _sanitize_llm_value(cls, value: Any, *, redaction_values: Optional[Set[str]] = None) -> Any:
+        if isinstance(value, str):
+            return cls._sanitize_llm_error_text(value, redaction_values=redaction_values)
+        if isinstance(value, dict):
+            return {
+                cls._sanitize_llm_error_text(key, redaction_values=redaction_values): cls._sanitize_llm_value(
+                    item,
+                    redaction_values=redaction_values,
+                )
+                for key, item in value.items()
+            }
+        if isinstance(value, list):
+            return [
+                cls._sanitize_llm_value(item, redaction_values=redaction_values)
+                for item in value
+            ]
+        if isinstance(value, tuple):
+            return [
+                cls._sanitize_llm_value(item, redaction_values=redaction_values)
+                for item in value
+            ]
+        return value
 
     @staticmethod
     def _classify_llm_http_error(status_code: int, error_text: str) -> _LLMDiagnostic:
@@ -3623,6 +4208,28 @@ class SystemConfigService:
             if name.lower() == "anspire" and not (enabled_raw or "").strip():
                 enabled_raw = effective_map.get("ANSPIRE_LLM_ENABLED")
             enabled = parse_env_bool(enabled_raw, default=True)
+            if is_reserved_hermes_name(name):
+                result = parse_hermes_channel(
+                    enabled=enabled,
+                    protocol=protocol_value or HERMES_DEFAULT_PROTOCOL,
+                    base_url=base_url_value or HERMES_DEFAULT_BASE_URL,
+                    api_key=(effective_map.get(f"{prefix}_API_KEY") or "").strip(),
+                    api_keys_raw=(effective_map.get(f"{prefix}_API_KEYS") or "").strip(),
+                    extra_headers_raw=(effective_map.get(f"{prefix}_EXTRA_HEADERS") or "").strip(),
+                    models=models_value or [HERMES_DEFAULT_MODEL],
+                )
+                for issue in result.issues:
+                    issues.append(
+                        {
+                            "key": issue.field,
+                            "code": issue.code,
+                            "message": issue.message,
+                            "severity": issue.severity,
+                            "expected": "valid reserved Hermes channel",
+                            "actual": "",
+                        }
+                    )
+                continue
             issues.extend(
                 SystemConfigService._validate_llm_channel_definition(
                     channel_name=name,
@@ -3681,6 +4288,22 @@ class SystemConfigService:
                         or ANSPIRE_LLM_MODEL_DEFAULT
                     ).strip()
                 ]
+            if is_reserved_hermes_name(name):
+                result = parse_hermes_channel(
+                    enabled=True,
+                    protocol=protocol_value or HERMES_DEFAULT_PROTOCOL,
+                    base_url=base_url_value or HERMES_DEFAULT_BASE_URL,
+                    api_key=(effective_map.get(f"{prefix}_API_KEY") or "").strip(),
+                    api_keys_raw=(effective_map.get(f"{prefix}_API_KEYS") or "").strip(),
+                    extra_headers_raw=(effective_map.get(f"{prefix}_EXTRA_HEADERS") or "").strip(),
+                    models=raw_models or [HERMES_DEFAULT_MODEL],
+                )
+                channel = result.channel or {}
+                for model in channel.get("models") or []:
+                    if model and model not in seen:
+                        seen.add(model)
+                        models.append(model)
+                continue
             resolved_protocol = resolve_llm_channel_protocol(protocol_value, base_url=base_url_value, models=raw_models, channel_name=name)
             for model in raw_models:
                 normalized_model = normalize_llm_channel_model(model, resolved_protocol, base_url_value)
@@ -3690,6 +4313,107 @@ class SystemConfigService:
                 models.append(normalized_model)
 
         return models
+
+    @staticmethod
+    def _collect_hermes_channel_models_from_map(effective_map: Dict[str, str]) -> List[str]:
+        """Collect valid reserved Hermes route aliases from channel-style env values."""
+        raw_channels = (effective_map.get("LLM_CHANNELS") or "").strip()
+        if not raw_channels:
+            return []
+
+        models: List[str] = []
+        seen: Set[str] = set()
+        for raw_name in raw_channels.split(","):
+            name = raw_name.strip()
+            if not is_reserved_hermes_name(name):
+                continue
+
+            prefix = f"LLM_{name.upper()}"
+            enabled = parse_env_bool(effective_map.get(f"{prefix}_ENABLED"), default=True)
+            if not enabled:
+                continue
+
+            raw_models = SystemConfigService._split_csv(effective_map.get(f"{prefix}_MODELS") or "")
+            result = parse_hermes_channel(
+                enabled=True,
+                protocol=(effective_map.get(f"{prefix}_PROTOCOL") or HERMES_DEFAULT_PROTOCOL).strip(),
+                base_url=(effective_map.get(f"{prefix}_BASE_URL") or HERMES_DEFAULT_BASE_URL).strip(),
+                api_key=(effective_map.get(f"{prefix}_API_KEY") or "").strip(),
+                api_keys_raw=(effective_map.get(f"{prefix}_API_KEYS") or "").strip(),
+                extra_headers_raw=(effective_map.get(f"{prefix}_EXTRA_HEADERS") or "").strip(),
+                models=raw_models or [HERMES_DEFAULT_MODEL],
+            )
+            channel = result.channel or {}
+            for model in channel.get("models") or []:
+                if model and model not in seen:
+                    seen.add(model)
+                    models.append(model)
+        return models
+
+    @staticmethod
+    def _collect_non_hermes_channel_models_from_map(effective_map: Dict[str, str]) -> List[str]:
+        """Collect enabled non-Hermes channel route aliases from channel-style env values."""
+        raw_channels = (effective_map.get("LLM_CHANNELS") or "").strip()
+        if not raw_channels:
+            return []
+        models: List[str] = []
+        seen: Set[str] = set()
+        for raw_name in raw_channels.split(","):
+            name = raw_name.strip()
+            if not name or is_reserved_hermes_name(name):
+                continue
+            prefix = f"LLM_{name.upper()}"
+            enabled_raw = effective_map.get(f"{prefix}_ENABLED")
+            if name.lower() == "anspire" and not (enabled_raw or "").strip():
+                enabled_raw = effective_map.get("ANSPIRE_LLM_ENABLED")
+            if not parse_env_bool(enabled_raw, default=True):
+                continue
+            base_url_value = (effective_map.get(f"{prefix}_BASE_URL") or "").strip()
+            if name.lower() == "anspire" and not base_url_value:
+                base_url_value = (
+                    effective_map.get("ANSPIRE_LLM_BASE_URL")
+                    or ANSPIRE_LLM_BASE_URL_DEFAULT
+                ).strip()
+            protocol_value = (effective_map.get(f"{prefix}_PROTOCOL") or "").strip()
+            if name.lower() == "anspire" and not protocol_value:
+                protocol_value = "openai"
+            raw_models = SystemConfigService._split_csv(effective_map.get(f"{prefix}_MODELS") or "")
+            if name.lower() == "anspire" and not raw_models:
+                raw_models = [
+                    (
+                        effective_map.get("ANSPIRE_LLM_MODEL")
+                        or ANSPIRE_LLM_MODEL_DEFAULT
+                    ).strip()
+                ]
+            resolved_protocol = resolve_llm_channel_protocol(
+                protocol_value,
+                base_url=base_url_value,
+                models=raw_models,
+                channel_name=name,
+            )
+            for raw_model in raw_models:
+                model = normalize_llm_channel_model(raw_model, resolved_protocol, base_url_value)
+                if model and model not in seen:
+                    seen.add(model)
+                    models.append(model)
+        return models
+
+    @staticmethod
+    def _collect_mixed_hermes_routes_from_map(effective_map: Dict[str, str]) -> Set[str]:
+        hermes_routes = set(SystemConfigService._collect_hermes_channel_models_from_map(effective_map))
+        non_hermes_routes = set(SystemConfigService._collect_non_hermes_channel_models_from_map(effective_map))
+        return hermes_routes & non_hermes_routes
+
+    @staticmethod
+    def _matches_route_set(model: str, routes: Set[str]) -> bool:
+        """Loose safety match for Hermes/provenance checks, not normal route availability."""
+        return bool(route_identity_candidates(model) & set(routes or set()))
+
+    @staticmethod
+    def _matches_exact_route(model: str, routes: Set[str]) -> bool:
+        """Match the Router's top-level model_name exactly for normal availability checks."""
+        normalized_model = str(model or "").strip()
+        return bool(normalized_model) and normalized_model in set(routes or set())
 
     @staticmethod
     def _uses_litellm_yaml(effective_map: Dict[str, str]) -> bool:
@@ -3756,6 +4480,8 @@ class SystemConfigService:
             or SystemConfigService._collect_llm_channel_models_from_map(effective_map)
         )
         available_model_set = set(available_models)
+        hermes_route_set = set(SystemConfigService._collect_hermes_channel_models_from_map(effective_map))
+        mixed_hermes_routes = SystemConfigService._collect_mixed_hermes_routes_from_map(effective_map)
         if not available_model_set:
             raw_channels = (effective_map.get("LLM_CHANNELS") or "").strip()
             if not raw_channels:
@@ -3805,6 +4531,25 @@ class SystemConfigService:
                         "actual": configured_agent_model,
                     }
                 )
+            elif (
+                configured_agent_model_raw
+                and configured_agent_model
+                and SystemConfigService._matches_route_set(configured_agent_model, hermes_route_set)
+                and not SystemConfigService._matches_route_set(configured_agent_model, mixed_hermes_routes)
+            ):
+                issues.append(
+                    {
+                        "key": "AGENT_LITELLM_MODEL",
+                        "code": "explicit_agent_model_no_safe_deployment",
+                        "message": (
+                            "Hermes-only routes are not valid Agent models in Phase 3. "
+                            "Choose a route with at least one non-Hermes deployment."
+                        ),
+                        "severity": "error",
+                        "expected": "Agent-safe route with non-Hermes deployment",
+                        "actual": configured_agent_model,
+                    }
+                )
 
             fallback_models = [
                 model.strip()
@@ -3831,7 +4576,21 @@ class SystemConfigService:
                 )
 
             vision_model = (effective_map.get("VISION_MODEL") or "").strip()
-            if vision_model and not SystemConfigService._has_runtime_source_for_model(vision_model, effective_map):
+            if vision_model and SystemConfigService._matches_route_set(vision_model, hermes_route_set):
+                issues.append(
+                    {
+                        "key": "VISION_MODEL",
+                        "code": "hermes_vision_unsupported",
+                        "message": (
+                            "Hermes routes are not valid Vision models in Phase 3. "
+                            "Choose a pure non-Hermes Vision-capable route."
+                        ),
+                        "severity": "error",
+                        "expected": "pure non-Hermes Vision route",
+                        "actual": vision_model,
+                    }
+                )
+            elif vision_model and not SystemConfigService._has_runtime_source_for_model(vision_model, effective_map):
                 issues.append(
                     {
                         "key": "VISION_MODEL",
@@ -3849,7 +4608,25 @@ class SystemConfigService:
             return issues
 
         primary_model = (effective_map.get("LITELLM_MODEL") or "").strip()
-        if primary_model and primary_model not in available_model_set and not _uses_direct_env_provider(primary_model):
+        if SystemConfigService._matches_route_set(primary_model, mixed_hermes_routes):
+            issues.append(
+                {
+                    "key": "LITELLM_MODEL",
+                    "code": "mixed_hermes_route_unsupported",
+                    "message": (
+                        "Mixed Hermes/non-Hermes generation routes are not supported in Phase 3. "
+                        "Choose a pure Hermes or pure non-Hermes route."
+                    ),
+                    "severity": "error",
+                    "expected": "pure generation route",
+                    "actual": primary_model,
+                }
+            )
+        if (
+            primary_model
+            and not SystemConfigService._matches_exact_route(primary_model, available_model_set)
+            and not _uses_direct_env_provider(primary_model)
+        ):
             issues.append(
                 {
                     "key": "LITELLM_MODEL",
@@ -3873,7 +4650,7 @@ class SystemConfigService:
         if (
             configured_agent_model_raw
             and configured_agent_model
-            and configured_agent_model not in available_model_set
+            and not SystemConfigService._matches_exact_route(configured_agent_model, available_model_set)
             and not _uses_direct_env_provider(configured_agent_model)
         ):
             issues.append(
@@ -3890,15 +4667,52 @@ class SystemConfigService:
                     "actual": configured_agent_model,
                 }
             )
+        elif (
+                configured_agent_model_raw
+                and configured_agent_model
+                and SystemConfigService._matches_route_set(configured_agent_model, hermes_route_set)
+                and not SystemConfigService._matches_route_set(configured_agent_model, mixed_hermes_routes)
+            ):
+            issues.append(
+                {
+                    "key": "AGENT_LITELLM_MODEL",
+                    "code": "explicit_agent_model_no_safe_deployment",
+                    "message": (
+                        "Hermes-only routes are not valid Agent models in Phase 3. "
+                        "Choose a route with at least one non-Hermes deployment."
+                    ),
+                    "severity": "error",
+                    "expected": "Agent-safe route with non-Hermes deployment",
+                    "actual": configured_agent_model,
+                }
+            )
 
         fallback_models = [
             model.strip()
             for model in (effective_map.get("LITELLM_FALLBACK_MODELS") or "").split(",")
             if model.strip()
         ]
+        mixed_fallbacks = [
+            model for model in fallback_models
+            if SystemConfigService._matches_route_set(model, mixed_hermes_routes)
+        ]
+        if mixed_fallbacks:
+            issues.append(
+                {
+                    "key": "LITELLM_FALLBACK_MODELS",
+                    "code": "mixed_hermes_route_unsupported",
+                    "message": (
+                        "Mixed Hermes/non-Hermes generation routes are not supported as fallback models in Phase 3."
+                    ),
+                    "severity": "error",
+                    "expected": "pure generation fallback routes",
+                    "actual": ", ".join(mixed_fallbacks[:3]),
+                }
+            )
         invalid_fallbacks = [
             model for model in fallback_models
-            if model not in available_model_set and not _uses_direct_env_provider(model)
+            if not SystemConfigService._matches_exact_route(model, available_model_set)
+            and not _uses_direct_env_provider(model)
         ]
         if invalid_fallbacks:
             issues.append(
@@ -3916,7 +4730,25 @@ class SystemConfigService:
             )
 
         vision_model = (effective_map.get("VISION_MODEL") or "").strip()
-        if vision_model and vision_model not in available_model_set and not _uses_direct_env_provider(vision_model):
+        if vision_model and SystemConfigService._matches_route_set(vision_model, hermes_route_set):
+            issues.append(
+                {
+                    "key": "VISION_MODEL",
+                    "code": "hermes_vision_unsupported",
+                    "message": (
+                        "Hermes routes are not valid Vision models in Phase 3. "
+                        "Choose a pure non-Hermes Vision-capable route."
+                    ),
+                    "severity": "error",
+                    "expected": "pure non-Hermes Vision route",
+                    "actual": vision_model,
+                }
+            )
+        elif (
+            vision_model
+            and not SystemConfigService._matches_exact_route(vision_model, available_model_set)
+            and not _uses_direct_env_provider(vision_model)
+        ):
             issues.append(
                 {
                     "key": "VISION_MODEL",

--- a/tests/test_agent_litellm_route_resolution.py
+++ b/tests/test_agent_litellm_route_resolution.py
@@ -1,0 +1,293 @@
+# -*- coding: utf-8 -*-
+"""Tests for Agent-safe LiteLLM route resolution."""
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from tests.litellm_stub import ensure_litellm_stub
+
+ensure_litellm_stub()
+
+from src.agent.llm_adapter import LLMToolAdapter
+from src.agent.litellm_route_resolution import resolve_agent_litellm_route
+
+
+def _config(**overrides):
+    base = {
+        "agent_generation_backend": "auto",
+        "generation_backend": "litellm",
+        "agent_litellm_model": "",
+        "litellm_model": "",
+        "litellm_fallback_models": [],
+        "llm_model_list": [],
+    }
+    base.update(overrides)
+    return SimpleNamespace(**base)
+
+
+def _hermes_deployment(model_name: str):
+    return {
+        "model_name": model_name,
+        "litellm_params": {
+            "model": model_name,
+            "api_key": "sk-hermes",
+            "api_base": "http://127.0.0.1:8642/v1",
+        },
+        "model_info": {"dsa_channel": "hermes"},
+    }
+
+
+def _remote_deployment(model_name: str):
+    return {
+        "model_name": model_name,
+        "litellm_params": {
+            "model": "openai/gpt-4o-mini",
+            "api_key": "sk-remote",
+        },
+    }
+
+
+def test_agent_resolver_rejects_hermes_only_route() -> None:
+    resolution = resolve_agent_litellm_route(
+        _config(
+            litellm_model="openai/hermes-agent",
+            llm_model_list=[_hermes_deployment("openai/hermes-agent")],
+        )
+    )
+
+    assert not resolution.available
+    assert resolution.primary_model == "openai/hermes-agent"
+    assert resolution.reason == "hermes_primary_not_agent_safe"
+    assert resolution.models_to_try == []
+    assert resolution.model_list == []
+
+
+def test_agent_resolver_filters_mixed_route_but_keeps_route_alias() -> None:
+    resolution = resolve_agent_litellm_route(
+        _config(
+            litellm_model="shared-route",
+            llm_model_list=[
+                _hermes_deployment("shared-route"),
+                _remote_deployment("shared-route"),
+            ],
+        )
+    )
+
+    assert resolution.available
+    assert resolution.primary_model == "shared-route"
+    assert resolution.models_to_try == ["shared-route"]
+    assert resolution.model_list == [_remote_deployment("shared-route")]
+
+
+def test_agent_resolver_explicit_hermes_alias_is_not_reinterpreted_as_direct_openai() -> None:
+    resolution = resolve_agent_litellm_route(
+        _config(
+            agent_litellm_model="openai/hermes-agent",
+            litellm_model="openai/gpt-4o-mini",
+            llm_model_list=[_hermes_deployment("openai/hermes-agent")],
+        )
+    )
+
+    assert not resolution.available
+    assert resolution.primary_model == "openai/hermes-agent"
+    assert resolution.reason == "explicit_agent_model_no_safe_deployment"
+
+
+def test_agent_resolver_reports_no_safe_models_after_filtering_fallbacks() -> None:
+    resolution = resolve_agent_litellm_route(
+        _config(
+            litellm_model="openai/hermes-agent",
+            litellm_fallback_models=["openai/hermes-fallback"],
+            llm_model_list=[
+                _hermes_deployment("openai/hermes-agent"),
+                _hermes_deployment("openai/hermes-fallback"),
+            ],
+        )
+    )
+
+    assert not resolution.available
+    assert resolution.primary_model == "openai/hermes-agent"
+    assert resolution.reason == "hermes_primary_not_agent_safe"
+
+
+def test_agent_resolver_reports_no_safe_models_when_only_fallback_is_hermes() -> None:
+    with patch(
+        "src.agent.litellm_route_resolution.get_effective_agent_models_to_try",
+        return_value=["openai/hermes-fallback"],
+    ):
+        resolution = resolve_agent_litellm_route(
+            _config(
+                litellm_model="openai/remote-primary",
+                litellm_fallback_models=["openai/hermes-fallback"],
+                llm_model_list=[_hermes_deployment("openai/hermes-fallback")],
+            )
+        )
+
+    assert not resolution.available
+    assert resolution.primary_model == "openai/remote-primary"
+    assert resolution.reason == "no_safe_agent_models"
+
+
+def test_agent_resolver_drops_bare_hermes_fallback_from_non_hermes_primary() -> None:
+    resolution = resolve_agent_litellm_route(
+        _config(
+            litellm_model="openai/gpt-4o-mini",
+            litellm_fallback_models=["hermes-agent"],
+            llm_model_list=[
+                _remote_deployment("openai/gpt-4o-mini"),
+                _hermes_deployment("openai/hermes-agent"),
+            ],
+        )
+    )
+
+    assert resolution.available
+    assert resolution.models_to_try == ["openai/gpt-4o-mini"]
+    assert resolution.model_list == [_remote_deployment("openai/gpt-4o-mini")]
+
+
+def test_agent_resolver_keeps_bare_mixed_fallback_as_canonical_safe_route() -> None:
+    resolution = resolve_agent_litellm_route(
+        _config(
+            litellm_model="openai/gpt-4o-mini",
+            litellm_fallback_models=["shared-route"],
+            llm_model_list=[
+                _remote_deployment("openai/gpt-4o-mini"),
+                _hermes_deployment("openai/shared-route"),
+                _remote_deployment("openai/shared-route"),
+            ],
+        )
+    )
+
+    assert resolution.available
+    assert resolution.models_to_try == ["openai/gpt-4o-mini", "openai/shared-route"]
+    assert resolution.model_list == [
+        _remote_deployment("openai/gpt-4o-mini"),
+        _remote_deployment("openai/shared-route"),
+    ]
+
+
+def test_agent_resolver_preserves_direct_model_without_preflight_credentials() -> None:
+    resolution = resolve_agent_litellm_route(
+        _config(
+            agent_litellm_model="gpt-4o-mini",
+            litellm_model="gemini/gemini-2.5-flash",
+            litellm_fallback_models=["anthropic/claude-3-5-sonnet-20241022"],
+        )
+    )
+
+    assert resolution.available
+    assert resolution.models_to_try == [
+        "openai/gpt-4o-mini",
+        "anthropic/claude-3-5-sonnet-20241022",
+    ]
+
+
+def test_agent_auto_ignores_generation_backend_codex_cli_when_litellm_route_exists() -> None:
+    config = _config(
+        generation_backend="codex_cli",
+        agent_generation_backend="auto",
+        litellm_model="cohere/command-r-plus",
+    )
+
+    resolution = resolve_agent_litellm_route(config)
+
+    assert resolution.available
+    assert resolution.primary_model == "cohere/command-r-plus"
+    assert resolution.reason == ""
+
+
+def test_agent_explicit_codex_cli_backend_remains_unsupported() -> None:
+    resolution = resolve_agent_litellm_route(
+        _config(
+            generation_backend="litellm",
+            agent_generation_backend="codex_cli",
+            litellm_model="cohere/command-r-plus",
+        )
+    )
+
+    assert not resolution.available
+    assert resolution.reason == "unsupported_agent_backend"
+
+
+def test_llm_tool_adapter_available_for_agent_auto_with_generation_codex_cli() -> None:
+    adapter = LLMToolAdapter(
+        _config(
+            generation_backend="codex_cli",
+            agent_generation_backend="auto",
+            litellm_model="cohere/command-r-plus",
+        )
+    )
+
+    assert adapter.is_available is True
+    assert adapter._litellm_available is True
+    assert adapter._backend_error is None
+
+
+def test_llm_tool_adapter_unavailable_when_channel_deployments_filter_to_empty() -> None:
+    config = _config(
+        litellm_model="openai/remote-primary",
+        litellm_fallback_models=["openai/hermes-fallback"],
+        llm_model_list=[_hermes_deployment("openai/hermes-fallback")],
+    )
+
+    with patch(
+        "src.agent.litellm_route_resolution.get_effective_agent_models_to_try",
+        return_value=["openai/remote-primary"],
+    ), patch(
+        "src.agent.llm_adapter.get_effective_agent_models_to_try",
+        return_value=["openai/remote-primary"],
+    ):
+        adapter = LLMToolAdapter(config)
+
+    assert adapter.is_available is False
+    assert adapter._litellm_available is False
+    assert adapter._backend_error is not None
+    assert adapter._backend_error.details["reason"] == "no_safe_agent_models"
+
+
+def test_llm_tool_adapter_does_not_direct_call_dropped_bare_hermes_fallback() -> None:
+    config = _config(
+        litellm_model="openai/gpt-4o-mini",
+        litellm_fallback_models=["hermes-agent"],
+        llm_model_list=[
+            _remote_deployment("openai/gpt-4o-mini"),
+            _hermes_deployment("openai/hermes-agent"),
+        ],
+    )
+    adapter = LLMToolAdapter.__new__(LLMToolAdapter)
+    adapter._config = config
+    adapter._backend_error = None
+    adapter._route_resolution = resolve_agent_litellm_route(config)
+
+    with patch.object(
+        adapter,
+        "_call_litellm_model",
+        side_effect=RuntimeError("primary failed"),
+    ) as call_model:
+        response = adapter.call_completion([{"role": "user", "content": "hello"}])
+
+    assert response.provider == "error"
+    assert [call.args[2] for call in call_model.call_args_list] == ["openai/gpt-4o-mini"]
+
+
+def test_call_completion_does_not_overwrite_adapter_route_resolution() -> None:
+    config = _config(litellm_model="openai/test-model")
+    adapter = LLMToolAdapter.__new__(LLMToolAdapter)
+    adapter._config = config
+    adapter._backend_error = None
+    adapter._route_resolution = resolve_agent_litellm_route(config)
+
+    original_resolution = adapter._route_resolution
+    dynamic_resolution = type(original_resolution)(
+        available=False,
+        primary_model="openai/test-model",
+        models_to_try=[],
+        model_list=[],
+        reason="no_safe_agent_models",
+    )
+
+    with patch("src.agent.llm_adapter.resolve_agent_litellm_route", return_value=dynamic_resolution):
+        response = adapter.call_completion([{"role": "user", "content": "hello"}])
+
+    assert response.provider == "error"
+    assert adapter._route_resolution is original_resolution

--- a/tests/test_agent_models_api.py
+++ b/tests/test_agent_models_api.py
@@ -86,6 +86,26 @@ class AgentModelsApiTestCase(unittest.TestCase):
         self.assertEqual(deployments[0]["source"], "llm_channels")
         self.assertEqual(deployments[0]["api_base"], "https://api.example.com/v1")
 
+    def test_models_endpoint_does_not_return_hermes_only_deployment(self) -> None:
+        config = _build_config(
+            litellm_model="openai/hermes-agent",
+            llm_channels=[{"name": "hermes"}],
+            llm_models_source="llm_channels",
+            llm_model_list=[
+                {
+                    "model_name": "openai/hermes-agent",
+                    "litellm_params": {
+                        "model": "openai/hermes-agent",
+                        "api_key": "secret-h",
+                        "api_base": "http://127.0.0.1:8642/v1",
+                    },
+                    "model_info": {"dsa_channel": "hermes"},
+                }
+            ],
+        )
+
+        self.assertEqual(list_agent_model_deployments(config), [])
+
     def test_models_endpoint_uses_agent_primary_override_for_primary_marker(self) -> None:
         config = _build_config(
             litellm_model="gemini/gemini-2.5-flash",

--- a/tests/test_chat_context.py
+++ b/tests/test_chat_context.py
@@ -312,6 +312,93 @@ def test_bundle_trace_is_replayed_only_for_matching_fallback_attempt() -> None:
     assert fallback_messages[-1]["content"] == "a1-final"
 
 
+def test_bundle_does_not_match_hermes_only_fallback_trace() -> None:
+    db = _reset_db()
+    session_id = "chat-trace-hermes-fallback"
+    user_id = db.save_conversation_message(session_id, "user", "u1")
+    assistant_id = db.save_conversation_message(session_id, "assistant", "a1-final")
+    db.save_agent_provider_turn(
+        session_id=session_id,
+        run_id="run-hermes-fallback",
+        provider="openai",
+        model="openai/hermes-agent",
+        anchor_user_message_id=user_id,
+        anchor_assistant_message_id=assistant_id,
+        messages=[{"role": "assistant", "content": "hermes-trace"}],
+        contains_reasoning=False,
+        contains_tool_calls=False,
+        contains_thinking_blocks=False,
+        must_roundtrip=True,
+        estimated_tokens=10,
+    )
+    config = _config(enabled=False)
+    config.agent_litellm_model = "openai/test-model"
+    config.litellm_model = "openai/test-model"
+    config.litellm_fallback_models = ["openai/hermes-agent"]
+    config.llm_model_list = [
+        {
+            "model_name": "openai/test-model",
+            "litellm_params": {"model": "openai/test-model", "api_key": "sk-openai"},
+        },
+        {
+            "model_name": "openai/hermes-agent",
+            "litellm_params": {
+                "model": "openai/hermes-agent",
+                "api_key": "sk-hermes",
+                "api_base": "http://127.0.0.1:8642/v1",
+            },
+            "model_info": {"dsa_channel": "hermes"},
+        },
+    ]
+
+    bundle = build_agent_chat_context_bundle(session_id, MagicMock(), config)
+
+    assert bundle.diagnostics["trace_injected"] is False
+    assert bundle.diagnostics["model_mismatch"] == 1
+    assert [msg["content"] for msg in bundle.context_messages] == ["u1", "a1-final"]
+
+
+def test_bundle_does_not_fallback_to_unfiltered_try_order_for_hermes_only_agent() -> None:
+    db = _reset_db()
+    session_id = "chat-trace-hermes-only-agent"
+    user_id = db.save_conversation_message(session_id, "user", "u1")
+    assistant_id = db.save_conversation_message(session_id, "assistant", "a1-final")
+    db.save_agent_provider_turn(
+        session_id=session_id,
+        run_id="run-hermes-only-agent",
+        provider="openai",
+        model="openai/hermes-agent",
+        anchor_user_message_id=user_id,
+        anchor_assistant_message_id=assistant_id,
+        messages=[{"role": "assistant", "content": "hermes-trace"}],
+        contains_reasoning=False,
+        contains_tool_calls=False,
+        contains_thinking_blocks=False,
+        must_roundtrip=True,
+        estimated_tokens=10,
+    )
+    config = _config(enabled=False)
+    config.agent_litellm_model = ""
+    config.litellm_model = "openai/hermes-agent"
+    config.litellm_fallback_models = []
+    config.llm_model_list = [
+        {
+            "model_name": "openai/hermes-agent",
+            "litellm_params": {
+                "model": "openai/hermes-agent",
+                "api_key": "sk-hermes",
+                "api_base": "http://127.0.0.1:8642/v1",
+            },
+            "model_info": {"dsa_channel": "hermes"},
+        },
+    ]
+
+    bundle = build_agent_chat_context_bundle(session_id, MagicMock(), config)
+
+    assert bundle.diagnostics["trace_injected"] is False
+    assert bundle.diagnostics["model_mismatch"] == 1
+
+
 def test_bundle_matches_slashless_router_alias_fallback_by_resolved_provider() -> None:
     db = _reset_db()
     session_id = "chat-trace-router-alias"

--- a/tests/test_image_stock_extractor_litellm.py
+++ b/tests/test_image_stock_extractor_litellm.py
@@ -212,6 +212,79 @@ class TestCallLitellmVision:
             with pytest.raises(ValueError, match="returned empty response"):
                 _call_litellm_vision("b64", "image/jpeg")
 
+    def test_rejects_hermes_route_without_calling_litellm(self):
+        cfg = _cfg(
+            vision_model="openai/hermes-agent",
+            llm_model_list=[
+                {
+                    "model_name": "openai/hermes-agent",
+                    "litellm_params": {
+                        "model": "openai/hermes-agent",
+                        "api_key": "sk-hermes-test-value",
+                        "api_base": "http://127.0.0.1:8642/v1",
+                    },
+                    "model_info": {"dsa_channel": "hermes"},
+                }
+            ],
+            openai_api_keys=[_OPENAI_KEY],
+        )
+        with patch("src.services.image_stock_extractor.get_config", return_value=cfg), \
+             patch("src.services.image_stock_extractor.litellm.completion") as mock_comp:
+            with pytest.raises(ValueError, match="Hermes Vision"):
+                _call_litellm_vision("b64", "image/jpeg")
+        mock_comp.assert_not_called()
+
+    def test_rejects_bare_hermes_route_without_calling_litellm(self):
+        cfg = _cfg(
+            vision_model="hermes-agent",
+            llm_model_list=[
+                {
+                    "model_name": "openai/hermes-agent",
+                    "litellm_params": {
+                        "model": "openai/hermes-agent",
+                        "api_key": "sk-hermes-test-value",
+                        "api_base": "http://127.0.0.1:8642/v1",
+                    },
+                    "model_info": {"dsa_channel": "hermes"},
+                }
+            ],
+            openai_api_keys=[_OPENAI_KEY],
+        )
+        with patch("src.services.image_stock_extractor.get_config", return_value=cfg), \
+             patch("src.services.image_stock_extractor.litellm.completion") as mock_comp:
+            with pytest.raises(ValueError, match="Hermes Vision"):
+                _call_litellm_vision("b64", "image/jpeg")
+        mock_comp.assert_not_called()
+
+    def test_rejects_bare_mixed_hermes_route_without_calling_litellm(self):
+        cfg = _cfg(
+            vision_model="shared-route",
+            llm_model_list=[
+                {
+                    "model_name": "openai/shared-route",
+                    "litellm_params": {
+                        "model": "openai/hermes-agent",
+                        "api_key": "sk-hermes-test-value",
+                        "api_base": "http://127.0.0.1:8642/v1",
+                    },
+                    "model_info": {"dsa_channel": "hermes"},
+                },
+                {
+                    "model_name": "openai/shared-route",
+                    "litellm_params": {
+                        "model": "openai/gpt-4o-mini",
+                        "api_key": _OPENAI_KEY,
+                    },
+                },
+            ],
+            openai_api_keys=[_OPENAI_KEY],
+        )
+        with patch("src.services.image_stock_extractor.get_config", return_value=cfg), \
+             patch("src.services.image_stock_extractor.litellm.completion") as mock_comp:
+            with pytest.raises(ValueError, match="Hermes Vision"):
+                _call_litellm_vision("b64", "image/jpeg")
+        mock_comp.assert_not_called()
+
 
 # ---------------------------------------------------------------------------
 # _parse_codes_from_text

--- a/tests/test_llm_channel_config.py
+++ b/tests/test_llm_channel_config.py
@@ -13,11 +13,13 @@ from src.config import (
     ANSPIRE_LLM_BASE_URL_DEFAULT,
     ANSPIRE_LLM_MODEL_DEFAULT,
     Config,
+    get_configured_llm_models,
     get_effective_agent_models_to_try,
     get_effective_agent_primary_model,
     get_fixed_litellm_temperature,
     normalize_litellm_temperature,
 )
+from src.llm.hermes import open_hermes_no_proxy_client, parse_hermes_channel, route_has_hermes
 from src.llm.generation_params import (
     apply_litellm_generation_params,
     resolve_litellm_temperature_directive,
@@ -138,6 +140,566 @@ class LLMChannelConfigTestCase(unittest.TestCase):
         self.assertEqual(config.llm_channels[0]["protocol"], "deepseek")
         self.assertEqual(config.llm_channels[0]["models"], ["deepseek/deepseek-chat"])
         self.assertEqual(config.llm_model_list[0]["litellm_params"]["model"], "deepseek/deepseek-chat")
+
+    @patch("src.config.setup_env")
+    @patch.object(Config, "_parse_litellm_yaml", return_value=[])
+    def test_hermes_channel_adds_deployment_marker(self, _mock_parse_yaml, _mock_setup_env) -> None:
+        env = {
+            "LLM_CHANNELS": "hermes",
+            "LLM_HERMES_API_KEY": "sk-hermes-test-value",
+        }
+
+        with patch.dict(os.environ, env, clear=True):
+            config = Config._load_from_env()
+
+        self.assertEqual(config.llm_models_source, "llm_channels")
+        self.assertEqual(config.litellm_model, "openai/hermes-agent")
+        self.assertFalse(config.llm_blocks_legacy_fallback)
+        self.assertEqual(
+            config.llm_model_list[0]["model_info"],
+            {"dsa_channel": "hermes", "dsa_display_model": "hermes-agent"},
+        )
+        self.assertEqual(config.llm_model_list[0]["model_name"], "openai/hermes-agent")
+        self.assertEqual(config.llm_model_list[0]["litellm_params"]["model"], "openai/hermes-agent")
+        self.assertNotIn("dsa_channel", config.llm_model_list[0]["litellm_params"])
+
+    def test_hermes_no_proxy_client_does_not_create_transport_for_invalid_base_url(self) -> None:
+        with patch("httpx.Client") as http_client_cls:
+            with self.assertRaises(ValueError):
+                with open_hermes_no_proxy_client(
+                    api_key="sk-hermes-test-value",
+                    base_url="http://127.0.0.1:8642/v1?token=bad",
+                    timeout=5.0,
+                ):
+                    pass
+
+        http_client_cls.assert_not_called()
+
+    def test_hermes_parser_rejects_masked_secret_placeholder(self) -> None:
+        result = parse_hermes_channel(
+            enabled=True,
+            protocol="openai",
+            base_url="http://127.0.0.1:8642/v1",
+            api_key="******",
+            api_keys_raw="",
+            extra_headers_raw="",
+            models=["hermes-agent"],
+        )
+
+        self.assertIsNone(result.channel)
+        self.assertTrue(result.blocks_legacy_fallback)
+        self.assertTrue(
+            any(issue.field == "LLM_HERMES_API_KEY" and issue.code == "masked_secret_not_reusable" for issue in result.issues)
+        )
+
+    def test_route_has_hermes_uses_bare_candidates_without_provider_aliasing(self) -> None:
+        model_list = [
+            {
+                "model_name": "openai/hermes-agent",
+                "litellm_params": {"model": "openai/hermes-agent"},
+                "model_info": {"dsa_channel": "hermes"},
+            },
+            {
+                "model_name": "openai/shared-route",
+                "litellm_params": {"model": "openai/shared-route"},
+                "model_info": {"dsa_channel": "hermes"},
+            },
+            {
+                "model_name": "openai/shared-route",
+                "litellm_params": {"model": "openai/gpt-4o-mini"},
+            },
+            {
+                "model_name": "openai/anthropic/foo",
+                "litellm_params": {"model": "openai/anthropic/foo"},
+                "model_info": {"dsa_channel": "hermes"},
+            },
+            {
+                "model_name": "anthropic/foo",
+                "litellm_params": {"model": "anthropic/foo"},
+            },
+        ]
+
+        self.assertTrue(route_has_hermes(model_list, "hermes-agent"))
+        self.assertTrue(route_has_hermes(model_list, "openai/hermes-agent"))
+        self.assertTrue(route_has_hermes(model_list, "shared-route"))
+        self.assertTrue(route_has_hermes(model_list, "openai/shared-route"))
+        self.assertFalse(route_has_hermes(model_list, "anthropic/foo"))
+        self.assertTrue(route_has_hermes(model_list, "openai/anthropic/foo"))
+
+    @patch("src.config.setup_env")
+    @patch.object(Config, "_parse_litellm_yaml", return_value=[])
+    def test_hermes_models_use_canonical_openai_route_identity(self, _mock_parse_yaml, _mock_setup_env) -> None:
+        env = {
+            "LLM_CHANNELS": "hermes",
+            "LLM_HERMES_API_KEY": "sk-hermes-test-value",
+            "LLM_HERMES_MODELS": "hermes-agent,deepseek-ai/DeepSeek-V3,anthropic/foo,openai/foo",
+        }
+
+        with patch.dict(os.environ, env, clear=True):
+            config = Config._load_from_env()
+
+        route_models = [entry["model_name"] for entry in config.llm_model_list]
+        self.assertEqual(
+            route_models,
+            [
+                "openai/hermes-agent",
+                "openai/deepseek-ai/DeepSeek-V3",
+                "openai/anthropic/foo",
+                "openai/foo",
+            ],
+        )
+        self.assertEqual(
+            [entry["litellm_params"]["model"] for entry in config.llm_model_list],
+            route_models,
+        )
+        self.assertEqual(config.llm_model_list[1]["model_info"]["dsa_display_model"], "deepseek-ai/DeepSeek-V3")
+
+    @patch("src.config.setup_env")
+    @patch.object(Config, "_parse_litellm_yaml", return_value=[])
+    def test_invalid_hermes_blocks_legacy_inference_even_with_legacy_key(
+        self,
+        _mock_parse_yaml,
+        _mock_setup_env,
+    ) -> None:
+        env = {
+            "LLM_CHANNELS": "hermes",
+            "OPENAI_API_KEY": "sk-openai-test-value",
+        }
+
+        with patch.dict(os.environ, env, clear=True):
+            config = Config._load_from_env()
+
+        self.assertTrue(config.llm_blocks_legacy_fallback)
+        self.assertEqual(config.llm_model_list, [])
+        self.assertEqual(config.litellm_model, "")
+        self.assertEqual(config.openai_api_keys, ["sk-openai-test-value"])
+        issue = config.llm_channel_config_issues[0]
+        self.assertEqual(issue["field"], "LLM_HERMES_API_KEY")
+        self.assertEqual(issue["code"], "missing_api_key")
+
+    @patch("src.config.setup_env")
+    @patch.object(Config, "_parse_litellm_yaml", return_value=[])
+    def test_hermes_api_keys_points_user_to_single_api_key(
+        self,
+        _mock_parse_yaml,
+        _mock_setup_env,
+    ) -> None:
+        env = {
+            "LLM_CHANNELS": "hermes",
+            "LLM_HERMES_API_KEYS": "sk-hermes-test-value",
+        }
+
+        with patch.dict(os.environ, env, clear=True):
+            config = Config._load_from_env()
+
+        self.assertTrue(config.llm_blocks_legacy_fallback)
+        self.assertEqual(len(config.llm_channel_config_issues), 1)
+        issue = config.llm_channel_config_issues[0]
+        self.assertEqual(issue["field"], "LLM_HERMES_API_KEYS")
+        self.assertEqual(issue["code"], "unsupported_api_keys")
+        self.assertIn("LLM_HERMES_API_KEY", issue["message"])
+
+    @patch("src.config.setup_env")
+    @patch.object(Config, "_parse_litellm_yaml", return_value=[])
+    def test_agent_mode_true_does_not_enable_hermes_only_agent(
+        self,
+        _mock_parse_yaml,
+        _mock_setup_env,
+    ) -> None:
+        env = {
+            "AGENT_MODE": "true",
+            "LLM_CHANNELS": "hermes",
+            "LLM_HERMES_API_KEY": "sk-hermes-test-value",
+        }
+
+        with patch.dict(os.environ, env, clear=True):
+            config = Config._load_from_env()
+
+        self.assertFalse(config.is_agent_available())
+
+    @patch("src.config.setup_env")
+    @patch.object(Config, "_parse_litellm_yaml", return_value=[])
+    def test_agent_mode_unset_does_not_enable_hermes_only_agent(
+        self,
+        _mock_parse_yaml,
+        _mock_setup_env,
+    ) -> None:
+        env = {
+            "LLM_CHANNELS": "hermes",
+            "LLM_HERMES_API_KEY": "sk-hermes-test-value",
+        }
+
+        with patch.dict(os.environ, env, clear=True):
+            config = Config._load_from_env()
+
+        self.assertFalse(config._agent_mode_explicit)
+        self.assertFalse(config.is_agent_available())
+
+    @patch("src.config.setup_env")
+    @patch.object(Config, "_parse_litellm_yaml", return_value=[])
+    def test_agent_mode_true_enables_non_hermes_agent_route(
+        self,
+        _mock_parse_yaml,
+        _mock_setup_env,
+    ) -> None:
+        env = {
+            "AGENT_MODE": "true",
+            "LLM_CHANNELS": "primary",
+            "LLM_PRIMARY_PROTOCOL": "openai",
+            "LLM_PRIMARY_BASE_URL": "https://api.example.com/v1",
+            "LLM_PRIMARY_API_KEY": "sk-primary-test-value",
+            "LLM_PRIMARY_MODELS": "gpt-4o-mini",
+        }
+
+        with patch.dict(os.environ, env, clear=True):
+            config = Config._load_from_env()
+
+        self.assertTrue(config.is_agent_available())
+
+    @patch("src.config.setup_env")
+    @patch.object(Config, "_parse_litellm_yaml", return_value=[])
+    def test_agent_mode_false_disables_non_hermes_agent_route(
+        self,
+        _mock_parse_yaml,
+        _mock_setup_env,
+    ) -> None:
+        env = {
+            "AGENT_MODE": "false",
+            "LLM_CHANNELS": "primary",
+            "LLM_PRIMARY_PROTOCOL": "openai",
+            "LLM_PRIMARY_BASE_URL": "https://api.example.com/v1",
+            "LLM_PRIMARY_API_KEY": "sk-primary-test-value",
+            "LLM_PRIMARY_MODELS": "gpt-4o-mini",
+        }
+
+        with patch.dict(os.environ, env, clear=True):
+            config = Config._load_from_env()
+
+        self.assertFalse(config.is_agent_available())
+
+    @patch("src.config.setup_env")
+    @patch.object(Config, "_parse_litellm_yaml", return_value=[])
+    def test_agent_mode_true_allows_mixed_route_via_non_hermes_deployment(
+        self,
+        _mock_parse_yaml,
+        _mock_setup_env,
+    ) -> None:
+        env = {
+            "AGENT_MODE": "true",
+            "LLM_CHANNELS": "hermes,remote",
+            "LLM_HERMES_API_KEY": "sk-hermes-test-value",
+            "LLM_HERMES_MODELS": "shared-route",
+            "LLM_REMOTE_PROTOCOL": "openai",
+            "LLM_REMOTE_BASE_URL": "https://api.example.com/v1",
+            "LLM_REMOTE_API_KEY": "sk-remote-test-value",
+            "LLM_REMOTE_MODELS": "shared-route",
+        }
+
+        with patch.dict(os.environ, env, clear=True):
+            config = Config._load_from_env()
+
+        self.assertTrue(config.is_agent_available())
+
+    @patch("src.config.setup_env")
+    @patch.object(Config, "_parse_litellm_yaml", return_value=[])
+    def test_agent_generation_backend_codex_cli_is_unavailable_even_with_safe_route(
+        self,
+        _mock_parse_yaml,
+        _mock_setup_env,
+    ) -> None:
+        env = {
+            "AGENT_MODE": "true",
+            "AGENT_GENERATION_BACKEND": "codex_cli",
+            "LLM_CHANNELS": "remote",
+            "LLM_REMOTE_PROTOCOL": "openai",
+            "LLM_REMOTE_BASE_URL": "https://api.example.com/v1",
+            "LLM_REMOTE_API_KEY": "sk-remote-test-value",
+            "LLM_REMOTE_MODELS": "gpt-4o-mini",
+        }
+
+        with patch.dict(os.environ, env, clear=True):
+            config = Config._load_from_env()
+
+        self.assertFalse(config.is_agent_available())
+
+    @patch("src.config.setup_env")
+    @patch.object(Config, "_parse_litellm_yaml", return_value=[])
+    def test_validate_structured_rejects_mixed_generation_route(
+        self,
+        _mock_parse_yaml,
+        _mock_setup_env,
+    ) -> None:
+        env = {
+            "LLM_CHANNELS": "hermes,remote",
+            "LLM_HERMES_API_KEY": "sk-hermes-test-value",
+            "LLM_HERMES_MODELS": "shared-route",
+            "LLM_REMOTE_PROTOCOL": "openai",
+            "LLM_REMOTE_BASE_URL": "https://api.example.com/v1",
+            "LLM_REMOTE_API_KEY": "sk-remote-test-value",
+            "LLM_REMOTE_MODELS": "shared-route",
+            "LITELLM_MODEL": "openai/shared-route",
+            "LITELLM_FALLBACK_MODELS": "openai/shared-route",
+        }
+
+        with patch.dict(os.environ, env, clear=True):
+            config = Config._load_from_env()
+
+        issues = config.validate_structured()
+        self.assertTrue(
+            any(
+                issue.field == "LITELLM_MODEL"
+                and issue.code == "mixed_hermes_route_unsupported"
+                for issue in issues
+            )
+        )
+        self.assertTrue(
+            any(
+                issue.field == "LITELLM_FALLBACK_MODELS"
+                and issue.code == "mixed_hermes_route_unsupported"
+                for issue in issues
+            )
+        )
+
+    @patch("src.config.setup_env")
+    @patch.object(Config, "_parse_litellm_yaml", return_value=[])
+    def test_validate_structured_rejects_bare_mixed_generation_route(
+        self,
+        _mock_parse_yaml,
+        _mock_setup_env,
+    ) -> None:
+        env = {
+            "LLM_CHANNELS": "hermes,remote",
+            "LLM_HERMES_API_KEY": "sk-hermes-test-value",
+            "LLM_HERMES_MODELS": "shared-route",
+            "LLM_REMOTE_PROTOCOL": "openai",
+            "LLM_REMOTE_BASE_URL": "https://api.example.com/v1",
+            "LLM_REMOTE_API_KEY": "sk-remote-test-value",
+            "LLM_REMOTE_MODELS": "shared-route",
+            "LITELLM_MODEL": "shared-route",
+            "LITELLM_FALLBACK_MODELS": "shared-route",
+        }
+
+        with patch.dict(os.environ, env, clear=True):
+            config = Config._load_from_env()
+
+        issues = config.validate_structured()
+        self.assertTrue(
+            any(
+                issue.field == "LITELLM_MODEL"
+                and issue.code == "mixed_hermes_route_unsupported"
+                for issue in issues
+            )
+        )
+        self.assertTrue(
+            any(
+                issue.field == "LITELLM_FALLBACK_MODELS"
+                and issue.code == "mixed_hermes_route_unsupported"
+                for issue in issues
+            )
+        )
+
+    @patch("src.config.setup_env")
+    @patch.object(Config, "_parse_litellm_yaml", return_value=[])
+    def test_validate_structured_requires_exact_primary_route_alias_for_channels(
+        self,
+        _mock_parse_yaml,
+        _mock_setup_env,
+    ) -> None:
+        env = {
+            "LLM_CHANNELS": "primary",
+            "LLM_PRIMARY_PROTOCOL": "openai",
+            "LLM_PRIMARY_BASE_URL": "https://api.example.com/v1",
+            "LLM_PRIMARY_API_KEY": "sk-primary-test-value",
+            "LLM_PRIMARY_MODELS": "gpt-4o-mini",
+            "LITELLM_MODEL": "gpt-4o-mini",
+        }
+
+        with patch.dict(os.environ, env, clear=True):
+            config = Config._load_from_env()
+
+        self.assertIn("openai/gpt-4o-mini", get_configured_llm_models(config.llm_model_list))
+        issues = config.validate_structured()
+        self.assertTrue(
+            any(issue.field == "LITELLM_MODEL" for issue in issues),
+            issues,
+        )
+
+    @patch("src.config.setup_env")
+    @patch.object(Config, "_parse_litellm_yaml", return_value=[])
+    def test_validate_structured_requires_exact_fallback_route_alias_for_channels(
+        self,
+        _mock_parse_yaml,
+        _mock_setup_env,
+    ) -> None:
+        env = {
+            "LLM_CHANNELS": "primary",
+            "LLM_PRIMARY_PROTOCOL": "openai",
+            "LLM_PRIMARY_BASE_URL": "https://api.example.com/v1",
+            "LLM_PRIMARY_API_KEY": "sk-primary-test-value",
+            "LLM_PRIMARY_MODELS": "gpt-4o-mini",
+            "LITELLM_MODEL": "openai/gpt-4o-mini",
+            "LITELLM_FALLBACK_MODELS": "gpt-4o-mini",
+        }
+
+        with patch.dict(os.environ, env, clear=True):
+            config = Config._load_from_env()
+
+        issues = config.validate_structured()
+        self.assertTrue(
+            any(issue.field == "LITELLM_FALLBACK_MODELS" for issue in issues),
+            issues,
+        )
+
+    @patch("src.config.setup_env")
+    @patch.object(Config, "_parse_litellm_yaml", return_value=[])
+    def test_validate_structured_does_not_apply_route_alias_check_to_legacy_env(
+        self,
+        _mock_parse_yaml,
+        _mock_setup_env,
+    ) -> None:
+        env = {
+            "OPENAI_API_KEY": "sk-openai-test-value",
+            "LITELLM_MODEL": "gpt-4o-mini",
+        }
+
+        with patch.dict(os.environ, env, clear=True):
+            config = Config._load_from_env()
+
+        self.assertEqual(config.llm_models_source, "legacy_env")
+        issues = config.validate_structured()
+        self.assertFalse(
+            any(issue.field == "LITELLM_MODEL" and issue.severity == "error" for issue in issues),
+            issues,
+        )
+
+    @patch("src.config.setup_env")
+    @patch.object(Config, "_parse_litellm_yaml", return_value=[])
+    def test_validate_structured_rejects_explicit_hermes_only_agent_route(
+        self,
+        _mock_parse_yaml,
+        _mock_setup_env,
+    ) -> None:
+        env = {
+            "LLM_CHANNELS": "hermes",
+            "LLM_HERMES_API_KEY": "sk-hermes-test-value",
+            "LLM_HERMES_MODELS": "hermes-agent",
+            "AGENT_LITELLM_MODEL": "openai/hermes-agent",
+        }
+
+        with patch.dict(os.environ, env, clear=True):
+            config = Config._load_from_env()
+
+        issues = config.validate_structured()
+        self.assertTrue(
+            any(
+                issue.field == "AGENT_LITELLM_MODEL"
+                and issue.code == "explicit_agent_model_no_safe_deployment"
+                for issue in issues
+            )
+        )
+
+    @patch("src.config.setup_env")
+    @patch.object(Config, "_parse_litellm_yaml", return_value=[])
+    def test_validate_structured_allows_explicit_mixed_agent_route(
+        self,
+        _mock_parse_yaml,
+        _mock_setup_env,
+    ) -> None:
+        env = {
+            "LLM_CHANNELS": "hermes,remote",
+            "LLM_HERMES_API_KEY": "sk-hermes-test-value",
+            "LLM_HERMES_MODELS": "shared-route",
+            "LLM_REMOTE_PROTOCOL": "openai",
+            "LLM_REMOTE_BASE_URL": "https://api.example.com/v1",
+            "LLM_REMOTE_API_KEY": "sk-remote-test-value",
+            "LLM_REMOTE_MODELS": "shared-route",
+            "AGENT_LITELLM_MODEL": "openai/shared-route",
+        }
+
+        with patch.dict(os.environ, env, clear=True):
+            config = Config._load_from_env()
+
+        issues = config.validate_structured()
+        self.assertFalse(
+            any(
+                issue.field == "AGENT_LITELLM_MODEL"
+                and issue.code == "explicit_agent_model_no_safe_deployment"
+                for issue in issues
+            ),
+            issues,
+        )
+
+    @patch("src.config.setup_env")
+    @patch.object(Config, "_parse_litellm_yaml", return_value=[])
+    def test_disabled_hermes_does_not_block_legacy_inference(
+        self,
+        _mock_parse_yaml,
+        _mock_setup_env,
+    ) -> None:
+        env = {
+            "LLM_CHANNELS": "hermes",
+            "LLM_HERMES_ENABLED": "false",
+            "OPENAI_API_KEY": "sk-openai-test-value",
+        }
+
+        with patch.dict(os.environ, env, clear=True):
+            config = Config._load_from_env()
+
+        self.assertFalse(config.llm_blocks_legacy_fallback)
+        self.assertEqual(config.llm_models_source, "legacy_env")
+        self.assertEqual(config.litellm_model, "openai/gpt-5.5")
+        self.assertTrue(config.llm_model_list)
+
+    @patch("src.config.setup_env")
+    @patch.object(Config, "_parse_litellm_yaml", return_value=[])
+    def test_invalid_hermes_with_valid_sibling_uses_sibling_not_legacy(
+        self,
+        _mock_parse_yaml,
+        _mock_setup_env,
+    ) -> None:
+        env = {
+            "LLM_CHANNELS": "hermes,primary",
+            "LLM_PRIMARY_PROTOCOL": "openai",
+            "LLM_PRIMARY_BASE_URL": "https://example.invalid/v1",
+            "LLM_PRIMARY_API_KEY": "sk-primary-test-value",
+            "LLM_PRIMARY_MODELS": "gpt-sibling",
+            "OPENAI_API_KEY": "sk-openai-test-value",
+        }
+
+        with patch.dict(os.environ, env, clear=True):
+            config = Config._load_from_env()
+
+        self.assertTrue(config.llm_blocks_legacy_fallback)
+        self.assertEqual(config.llm_models_source, "llm_channels")
+        self.assertEqual(config.litellm_model, "openai/gpt-sibling")
+        self.assertEqual(config.llm_model_list[0]["model_name"], "openai/gpt-sibling")
+
+    @patch("src.config.setup_env")
+    @patch.object(Config, "_parse_litellm_yaml", return_value=[])
+    def test_invalid_hermes_raw_model_records_blocking_candidates(
+        self,
+        _mock_parse_yaml,
+        _mock_setup_env,
+    ) -> None:
+        env = {
+            "LLM_CHANNELS": "hermes,primary",
+            "LLM_HERMES_API_KEY": "sk-hermes-test-value",
+            "LLM_HERMES_MODELS": "bad model",
+            "LLM_PRIMARY_PROTOCOL": "openai",
+            "LLM_PRIMARY_BASE_URL": "https://example.invalid/v1",
+            "LLM_PRIMARY_API_KEY": "sk-primary-test-value",
+            "LLM_PRIMARY_MODELS": "gpt-sibling",
+            "OPENAI_API_KEY": "sk-openai-test-value",
+            "LITELLM_MODEL": "bad model",
+        }
+
+        with patch.dict(os.environ, env, clear=True):
+            config = Config._load_from_env()
+
+        self.assertTrue(config.llm_blocks_legacy_fallback)
+        self.assertIn("bad model", config.llm_blocked_hermes_routes)
+        self.assertIn("openai/bad model", config.llm_blocked_hermes_routes)
+        self.assertEqual(config.llm_model_list[0]["model_name"], "openai/gpt-sibling")
 
     @patch("src.config.setup_env")
     @patch.object(Config, "_parse_litellm_yaml", return_value=[])

--- a/tests/test_market_analyzer_generate_text.py
+++ b/tests/test_market_analyzer_generate_text.py
@@ -11,6 +11,7 @@ Covers:
 """
 import json
 import sys
+from contextlib import contextmanager
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
@@ -953,6 +954,455 @@ class TestAnalyzerGenerateText:
         assert len(dispatch_calls) == 2
         assert dispatch_calls[0]["stream"] is True
         assert "stream" not in dispatch_calls[1]
+
+    def test_call_litellm_hermes_route_forces_non_stream_direct_client(self):
+        analyzer = self._make_analyzer()
+        analyzer._config_override = SimpleNamespace(
+            litellm_model="openai/hermes-agent",
+            litellm_fallback_models=[],
+            llm_model_list=[
+                {
+                    "model_name": "openai/hermes-agent",
+                    "litellm_params": {
+                        "model": "openai/hermes-agent",
+                        "api_key": "sk-hermes-test-value",
+                        "api_base": "http://127.0.0.1:8642/v1",
+                    },
+                    "model_info": {"dsa_channel": "hermes"},
+                }
+            ],
+            llm_temperature=0.0,
+            generation_backend="litellm",
+            generation_fallback_backend="litellm",
+            llm_channel_config_issues=[],
+            llm_blocks_legacy_fallback=False,
+        )
+        response = SimpleNamespace(
+            choices=[SimpleNamespace(message=SimpleNamespace(content="OK"))],
+            usage=SimpleNamespace(prompt_tokens=1, completion_tokens=1, total_tokens=2),
+        )
+        seen_kwargs = {}
+
+        @contextmanager
+        def fake_no_proxy_client(**_kwargs):
+            yield object()
+
+        def fake_completion(**kwargs):
+            seen_kwargs.update(kwargs)
+            return response
+
+        with patch("src.analyzer.open_hermes_no_proxy_client", side_effect=fake_no_proxy_client), \
+             patch("src.analyzer.litellm.completion", side_effect=fake_completion):
+            text, model, _usage = analyzer._call_litellm(
+                "prompt",
+                {"max_tokens": 128, "temperature": 0.0},
+                stream=True,
+            )
+
+        assert text == "OK"
+        assert model == "openai/hermes-agent"
+        assert seen_kwargs["model"] == "openai/hermes-agent"
+        assert seen_kwargs["stream"] is False
+        assert "api_key" not in seen_kwargs
+        assert "api_base" not in seen_kwargs
+        assert "client" in seen_kwargs
+
+    def test_call_litellm_hermes_failure_redacts_secret_from_logs_and_error(self, caplog):
+        from src.analyzer import _AllModelsFailedError
+
+        analyzer = self._make_analyzer()
+        analyzer._config_override = SimpleNamespace(
+            litellm_model="openai/hermes-agent",
+            litellm_fallback_models=[],
+            llm_model_list=[
+                {
+                    "model_name": "openai/hermes-agent",
+                    "litellm_params": {
+                        "model": "openai/hermes-agent",
+                        "api_key": "saved-secret-token",
+                        "api_base": "http://127.0.0.1:8642/v1",
+                    },
+                    "model_info": {"dsa_channel": "hermes"},
+                }
+            ],
+            llm_temperature=0.0,
+            generation_backend="litellm",
+            generation_fallback_backend="",
+            llm_channel_config_issues=[],
+            llm_blocks_legacy_fallback=False,
+        )
+
+        @contextmanager
+        def fake_no_proxy_client(**_kwargs):
+            yield object()
+
+        caplog.set_level("WARNING", logger="src.analyzer")
+        with patch("src.analyzer.open_hermes_no_proxy_client", side_effect=fake_no_proxy_client), \
+             patch("src.analyzer.litellm.completion", side_effect=RuntimeError("upstream saw saved-secret-token")):
+            with pytest.raises(_AllModelsFailedError) as exc_info:
+                analyzer._call_litellm("prompt", {"max_tokens": 4})
+
+        assert "saved-secret-token" not in str(exc_info.value)
+        assert "saved-secret-token" not in caplog.text
+        assert "[REDACTED]" in str(exc_info.value)
+
+    def test_analyze_redacts_hermes_secret_from_final_error_result(self, caplog):
+        analyzer = self._make_analyzer()
+        analyzer._config_override = SimpleNamespace(
+            litellm_model="openai/hermes-agent",
+            litellm_fallback_models=[],
+            llm_model_list=[
+                {
+                    "model_name": "openai/hermes-agent",
+                    "litellm_params": {
+                        "model": "openai/hermes-agent",
+                        "api_key": "saved-secret-token",
+                        "api_base": "http://127.0.0.1:8642/v1",
+                    },
+                    "model_info": {"dsa_channel": "hermes"},
+                }
+            ],
+            generation_backend="litellm",
+            generation_fallback_backend="",
+            llm_channel_config_issues=[],
+            llm_blocks_legacy_fallback=False,
+            llm_temperature=0.0,
+            report_integrity_enabled=False,
+            report_integrity_retry=0,
+            report_language="zh",
+            gemini_request_delay=0,
+        )
+        context = {"code": "600519", "stock_name": "贵州茅台"}
+
+        caplog.set_level("ERROR", logger="src.analyzer")
+        with patch.object(analyzer, "get_generation_backend_config_error", return_value=None), \
+             patch.object(analyzer, "is_available", return_value=True), \
+             patch.object(analyzer, "_get_analysis_system_prompt", return_value="system"), \
+             patch.object(analyzer, "_get_skill_prompt_sections", return_value=("", "", False)), \
+             patch.object(analyzer, "_format_prompt", return_value="prompt"), \
+             patch.object(analyzer, "_call_litellm", side_effect=RuntimeError("upstream saw saved-secret-token")):
+            result = analyzer.analyze(context)
+
+        assert result.success is False
+        assert "saved-secret-token" not in result.error_message
+        assert "saved-secret-token" not in result.analysis_summary
+        assert "saved-secret-token" not in result.risk_warning
+        assert "saved-secret-token" not in caplog.text
+        assert "[REDACTED]" in result.error_message
+
+    def test_generation_config_error_rejects_mixed_hermes_route(self):
+        from src.llm.generation_backend import GenerationErrorCode
+
+        analyzer = self._make_analyzer()
+        analyzer._router = None
+        analyzer._litellm_available = False
+        analyzer._config_override = SimpleNamespace(
+            litellm_model="shared-route",
+            litellm_fallback_models=[],
+            llm_model_list=[
+                {
+                    "model_name": "shared-route",
+                    "litellm_params": {
+                        "model": "hermes-agent",
+                        "api_key": "sk-hermes-test-value",
+                        "api_base": "http://127.0.0.1:8642/v1",
+                    },
+                    "model_info": {"dsa_channel": "hermes"},
+                },
+                {
+                    "model_name": "shared-route",
+                    "litellm_params": {
+                        "model": "openai/gpt-4o-mini",
+                        "api_key": "sk-openai-test-value",
+                    },
+                },
+            ],
+            generation_backend="litellm",
+            generation_fallback_backend="",
+            llm_channel_config_issues=[],
+            llm_blocks_legacy_fallback=False,
+        )
+
+        error = analyzer.get_generation_backend_config_error()
+
+        assert error is not None
+        assert error.error_code is GenerationErrorCode.UNSAFE_CONFIG
+        assert error.details["code"] == "mixed_hermes_route_unsupported"
+
+    def test_generation_config_error_rejects_bare_mixed_hermes_route(self):
+        from src.llm.generation_backend import GenerationErrorCode
+
+        analyzer = self._make_analyzer()
+        analyzer._config_override = SimpleNamespace(
+            litellm_model="shared-route",
+            litellm_fallback_models=[],
+            llm_model_list=[
+                {
+                    "model_name": "openai/shared-route",
+                    "litellm_params": {
+                        "model": "openai/hermes-agent",
+                        "api_key": "sk-hermes-test-value",
+                        "api_base": "http://127.0.0.1:8642/v1",
+                    },
+                    "model_info": {"dsa_channel": "hermes"},
+                },
+                {
+                    "model_name": "openai/shared-route",
+                    "litellm_params": {
+                        "model": "openai/gpt-4o-mini",
+                        "api_key": "sk-openai-test-value",
+                    },
+                },
+            ],
+            generation_backend="litellm",
+            generation_fallback_backend="",
+            llm_channel_config_issues=[],
+            llm_blocks_legacy_fallback=False,
+        )
+
+        error = analyzer.get_generation_backend_config_error()
+
+        assert error is not None
+        assert error.error_code is GenerationErrorCode.UNSAFE_CONFIG
+        assert error.details["code"] == "mixed_hermes_route_unsupported"
+
+    def test_generation_config_error_rejects_mixed_hermes_fallback_route(self):
+        from src.llm.generation_backend import GenerationErrorCode
+
+        analyzer = self._make_analyzer()
+        analyzer._config_override = SimpleNamespace(
+            litellm_model="openai/gpt-4o-mini",
+            litellm_fallback_models=["shared-route"],
+            llm_model_list=[
+                {
+                    "model_name": "shared-route",
+                    "litellm_params": {
+                        "model": "openai/hermes-agent",
+                        "api_key": "sk-hermes-test-value",
+                        "api_base": "http://127.0.0.1:8642/v1",
+                    },
+                    "model_info": {"dsa_channel": "hermes"},
+                },
+                {
+                    "model_name": "shared-route",
+                    "litellm_params": {
+                        "model": "openai/gpt-4o-mini",
+                        "api_key": "sk-openai-test-value",
+                    },
+                },
+            ],
+            generation_backend="litellm",
+            generation_fallback_backend="",
+            llm_channel_config_issues=[],
+            llm_blocks_legacy_fallback=False,
+        )
+
+        error = analyzer.get_generation_backend_config_error()
+
+        assert error is not None
+        assert error.error_code is GenerationErrorCode.UNSAFE_CONFIG
+        assert error.details["code"] == "mixed_hermes_route_unsupported"
+        assert error.details["route_name"] == "shared-route"
+
+    def test_generation_config_error_rejects_bare_mixed_hermes_fallback_route(self):
+        from src.llm.generation_backend import GenerationErrorCode
+
+        analyzer = self._make_analyzer()
+        analyzer._config_override = SimpleNamespace(
+            litellm_model="openai/gpt-4o-mini",
+            litellm_fallback_models=["shared-route"],
+            llm_model_list=[
+                {
+                    "model_name": "openai/shared-route",
+                    "litellm_params": {
+                        "model": "openai/hermes-agent",
+                        "api_key": "sk-hermes-test-value",
+                        "api_base": "http://127.0.0.1:8642/v1",
+                    },
+                    "model_info": {"dsa_channel": "hermes"},
+                },
+                {
+                    "model_name": "openai/shared-route",
+                    "litellm_params": {
+                        "model": "openai/gpt-4o-mini",
+                        "api_key": "sk-openai-test-value",
+                    },
+                },
+            ],
+            generation_backend="litellm",
+            generation_fallback_backend="",
+            llm_channel_config_issues=[],
+            llm_blocks_legacy_fallback=False,
+        )
+
+        error = analyzer.get_generation_backend_config_error()
+
+        assert error is not None
+        assert error.error_code is GenerationErrorCode.UNSAFE_CONFIG
+        assert error.details["code"] == "mixed_hermes_route_unsupported"
+
+    def test_invalid_hermes_with_valid_sibling_keeps_analyzer_available(self):
+        from src.config import Config
+        from src.analyzer import GeminiAnalyzer
+
+        env = {
+            "LLM_CHANNELS": "hermes,primary",
+            "LLM_PRIMARY_PROTOCOL": "openai",
+            "LLM_PRIMARY_BASE_URL": "https://example.invalid/v1",
+            "LLM_PRIMARY_API_KEY": "sk-primary-test-value",
+            "LLM_PRIMARY_MODELS": "gpt-sibling",
+            "OPENAI_API_KEY": "sk-openai-test-value",
+        }
+
+        with patch("src.config.setup_env"), \
+             patch.object(Config, "_parse_litellm_yaml", return_value=[]), \
+             patch.dict("os.environ", env, clear=True):
+            config = Config._load_from_env()
+            analyzer = GeminiAnalyzer(config=config)
+
+        assert config.litellm_model == "openai/gpt-sibling"
+        assert "hermes-agent" in config.llm_blocked_hermes_routes
+        assert "openai/hermes-agent" in config.llm_blocked_hermes_routes
+        assert analyzer.is_available() is True
+        assert analyzer.get_generation_backend_config_error() is None
+
+    def test_explicit_invalid_hermes_primary_with_valid_sibling_is_blocked_before_completion(self):
+        from src.config import Config
+        from src.analyzer import GeminiAnalyzer
+        from src.llm.generation_backend import GenerationError, GenerationErrorCode
+
+        env = {
+            "LLM_CHANNELS": "hermes,primary",
+            "LLM_HERMES_API_KEY": "hermes-key",
+            "LLM_HERMES_MODELS": "bad model",
+            "LLM_PRIMARY_PROTOCOL": "openai",
+            "LLM_PRIMARY_BASE_URL": "https://example.invalid/v1",
+            "LLM_PRIMARY_API_KEY": "sibling-key",
+            "LLM_PRIMARY_MODELS": "gpt-sibling",
+            "OPENAI_API_KEY": "legacy-key",
+            "LITELLM_MODEL": "bad model",
+        }
+
+        with patch("src.config.setup_env"), \
+             patch.object(Config, "_parse_litellm_yaml", return_value=[]), \
+             patch.dict("os.environ", env, clear=True):
+            config = Config._load_from_env()
+            analyzer = GeminiAnalyzer(config=config)
+
+        assert "bad model" in config.llm_blocked_hermes_routes
+        assert "openai/bad model" in config.llm_blocked_hermes_routes
+        error = analyzer.get_generation_backend_config_error()
+        assert error is not None
+        assert error.error_code is GenerationErrorCode.UNSAFE_CONFIG
+        assert error.details["code"] == "explicit_hermes_route_invalid"
+        assert error.details["reason"] == "explicit_hermes_route_invalid"
+        assert error.details["field"] == "LITELLM_MODEL"
+        assert analyzer.is_available() is False
+
+        with patch("src.analyzer.litellm.completion") as completion:
+            with pytest.raises(GenerationError):
+                analyzer._call_litellm("prompt", {"max_tokens": 4})
+        completion.assert_not_called()
+
+    def test_explicit_invalid_hermes_fallback_with_valid_sibling_is_blocked_before_loop(self):
+        from src.config import Config
+        from src.analyzer import GeminiAnalyzer
+        from src.llm.generation_backend import GenerationError, GenerationErrorCode
+
+        env = {
+            "LLM_CHANNELS": "hermes,primary",
+            "LLM_HERMES_API_KEY": "hermes-key",
+            "LLM_HERMES_MODELS": "bad model",
+            "LLM_PRIMARY_PROTOCOL": "openai",
+            "LLM_PRIMARY_BASE_URL": "https://example.invalid/v1",
+            "LLM_PRIMARY_API_KEY": "sibling-key",
+            "LLM_PRIMARY_MODELS": "gpt-sibling",
+            "OPENAI_API_KEY": "legacy-key",
+            "LITELLM_MODEL": "openai/gpt-sibling",
+            "LITELLM_FALLBACK_MODELS": "bad model",
+        }
+
+        with patch("src.config.setup_env"), \
+             patch.object(Config, "_parse_litellm_yaml", return_value=[]), \
+             patch.dict("os.environ", env, clear=True):
+            config = Config._load_from_env()
+            analyzer = GeminiAnalyzer(config=config)
+
+        error = analyzer.get_generation_backend_config_error()
+        assert error is not None
+        assert error.error_code is GenerationErrorCode.UNSAFE_CONFIG
+        assert error.details["code"] == "explicit_hermes_route_invalid"
+        assert error.details["field"] == "LITELLM_FALLBACK_MODELS"
+        assert analyzer.is_available() is False
+
+        with patch("src.analyzer.litellm.completion") as completion:
+            with pytest.raises(GenerationError):
+                analyzer._call_litellm("prompt", {"max_tokens": 4})
+        completion.assert_not_called()
+
+    @pytest.mark.parametrize("selected_model", ["anthropic/foo bad", "openai/anthropic/foo bad"])
+    def test_provider_looking_malformed_hermes_model_is_not_reinterpreted_as_direct_provider(self, selected_model):
+        from src.config import Config
+        from src.analyzer import GeminiAnalyzer
+        from src.llm.generation_backend import GenerationError
+
+        env = {
+            "LLM_CHANNELS": "hermes,primary",
+            "LLM_HERMES_API_KEY": "hermes-key",
+            "LLM_HERMES_MODELS": "anthropic/foo bad",
+            "LLM_PRIMARY_PROTOCOL": "openai",
+            "LLM_PRIMARY_BASE_URL": "https://example.invalid/v1",
+            "LLM_PRIMARY_API_KEY": "sibling-key",
+            "LLM_PRIMARY_MODELS": "gpt-sibling",
+            "ANTHROPIC_API_KEY": "anthropic-legacy-key",
+            "LITELLM_MODEL": selected_model,
+        }
+
+        with patch("src.config.setup_env"), \
+             patch.object(Config, "_parse_litellm_yaml", return_value=[]), \
+             patch.dict("os.environ", env, clear=True):
+            config = Config._load_from_env()
+            analyzer = GeminiAnalyzer(config=config)
+
+        error = analyzer.get_generation_backend_config_error()
+        assert error is not None
+        assert error.details["code"] == "explicit_hermes_route_invalid"
+        assert error.details["field"] == "LITELLM_MODEL"
+
+        with patch("src.analyzer.litellm.completion") as completion:
+            with pytest.raises(GenerationError):
+                analyzer._call_litellm("prompt", {"max_tokens": 4})
+        completion.assert_not_called()
+
+    def test_invalid_hermes_config_error_handles_canonicalize_value_error(self):
+        from src.llm.generation_backend import GenerationErrorCode
+
+        analyzer = self._make_analyzer()
+        analyzer._config_override = SimpleNamespace(
+            litellm_model="bad hermes route",
+            litellm_fallback_models=[],
+            llm_model_list=[],
+            generation_backend="litellm",
+            generation_fallback_backend="",
+            llm_channel_config_issues=[
+                {
+                    "field": "LLM_HERMES_MODELS",
+                    "code": "invalid_model",
+                    "message": "Hermes model IDs must be valid",
+                }
+            ],
+            llm_blocks_legacy_fallback=True,
+            llm_blocked_hermes_routes=["openai/hermes-agent"],
+        )
+
+        with patch("src.analyzer.canonicalize_hermes_model_ref", side_effect=ValueError("bad model")), \
+             patch("src.analyzer.litellm.completion") as completion:
+            error = analyzer.get_generation_backend_config_error()
+
+        assert error is not None
+        assert error.error_code is GenerationErrorCode.UNSAFE_CONFIG
+        assert error.details["code"] == "invalid_model"
+        completion.assert_not_called()
 
     @pytest.mark.parametrize(
         "provider_model,response_payload,expected_text",

--- a/tests/test_system_config_service.py
+++ b/tests/test_system_config_service.py
@@ -2,11 +2,14 @@
 """Unit tests for system configuration service."""
 
 import os
+import json
+import logging
 import tempfile
 import unittest
+from contextlib import contextmanager
 from pathlib import Path
 from types import SimpleNamespace
-from typing import Any, Dict, Optional
+from typing import Any, Dict, List, Optional
 from unittest.mock import Mock, patch
 
 import requests
@@ -79,6 +82,517 @@ class SystemConfigServiceTestCase(unittest.TestCase):
         self.assertEqual(items["ALPHASIFT_INSTALL_SPEC"]["value"], payload["mask_token"])
         self.assertTrue(items["ALPHASIFT_INSTALL_SPEC"]["is_masked"])
         self.assertTrue(items["ALPHASIFT_INSTALL_SPEC"]["schema"]["is_sensitive"])
+
+    def test_get_config_masks_hermes_secret_fields(self) -> None:
+        self._rewrite_env(
+            "STOCK_LIST=600519,000001",
+            "LLM_CHANNELS=hermes",
+            "LLM_HERMES_API_KEY=sk-hermes-secret-value",
+            "LLM_HERMES_API_KEYS=sk-old-secret-value",
+            "LLM_HERMES_EXTRA_HEADERS={\"Authorization\":\"Bearer secret\"}",
+        )
+
+        payload = self.service.get_config(include_schema=True)
+        items = {item["key"]: item for item in payload["items"]}
+
+        self.assertEqual(items["LLM_HERMES_API_KEY"]["value"], payload["mask_token"])
+        self.assertTrue(items["LLM_HERMES_API_KEY"]["is_masked"])
+        self.assertEqual(items["LLM_HERMES_API_KEYS"]["value"], payload["mask_token"])
+        self.assertTrue(items["LLM_HERMES_API_KEYS"]["is_masked"])
+        self.assertEqual(items["LLM_HERMES_EXTRA_HEADERS"]["value"], payload["mask_token"])
+        self.assertTrue(items["LLM_HERMES_EXTRA_HEADERS"]["is_masked"])
+
+    def test_hermes_saved_secret_changed_port_does_not_send_request(self) -> None:
+        self._rewrite_env(
+            "STOCK_LIST=600519,000001",
+            "LLM_CHANNELS=hermes",
+            "LLM_HERMES_PROTOCOL=openai",
+            "LLM_HERMES_BASE_URL=http://127.0.0.1:8642/v1",
+            "LLM_HERMES_API_KEY=sk-hermes-secret-value",
+        )
+
+        with patch("src.services.system_config_service.requests.Session") as session_cls:
+            result = self.service.discover_llm_channel_models(
+                name="hermes",
+                protocol="openai",
+                base_url="http://127.0.0.1:9999/v1",
+                api_key="******",
+                models=["hermes-agent"],
+                use_saved_secret=True,
+            )
+
+        self.assertFalse(result["success"])
+        self.assertEqual(result["error_code"], "saved_secret_scope_mismatch")
+        session_cls.assert_not_called()
+
+    def test_hermes_saved_secret_runtime_env_cannot_rebind_endpoint(self) -> None:
+        self._rewrite_env(
+            "STOCK_LIST=600519,000001",
+            "LLM_CHANNELS=hermes",
+            "LLM_HERMES_PROTOCOL=openai",
+            "LLM_HERMES_BASE_URL=http://127.0.0.1:8642/v1",
+            "LLM_HERMES_API_KEY=saved-secret-token",
+        )
+
+        with patch.dict(os.environ, {"LLM_HERMES_BASE_URL": "http://127.0.0.1:9999/v1"}, clear=False), \
+             patch("src.services.system_config_service.requests.Session") as session_cls:
+            result = self.service.discover_llm_channel_models(
+                name="hermes",
+                protocol="openai",
+                base_url="http://127.0.0.1:9999/v1",
+                api_key="******",
+                models=["hermes-agent"],
+                use_saved_secret=True,
+            )
+
+        self.assertFalse(result["success"])
+        self.assertEqual(result["error_code"], "saved_secret_scope_mismatch")
+        self.assertNotIn("saved-secret-token", str(result))
+        session_cls.assert_not_called()
+
+    def test_hermes_model_discovery_uses_no_proxy_session(self) -> None:
+        observed: Dict[str, Any] = {}
+
+        class FakeSession:
+            def __init__(self) -> None:
+                self.trust_env = True
+
+            def get(self, url: str, **kwargs: Any) -> Any:
+                observed["url"] = url
+                observed["trust_env"] = self.trust_env
+                observed["headers"] = kwargs.get("headers") or {}
+                return SimpleNamespace(
+                    status_code=200,
+                    ok=True,
+                    json=lambda: {"data": [{"id": "hermes-agent"}]},
+                )
+
+            def close(self) -> None:
+                observed["closed"] = True
+
+        with patch("src.services.system_config_service.requests.Session", side_effect=FakeSession), \
+             patch("src.services.system_config_service.requests.get") as requests_get:
+            result = self.service.discover_llm_channel_models(
+                name="hermes",
+                protocol="openai",
+                base_url="http://localhost:8642/v1",
+                api_key="sk-hermes-secret-value",
+                models=["hermes-agent"],
+            )
+
+        self.assertTrue(result["success"])
+        self.assertEqual(observed["url"], "http://127.0.0.1:8642/v1/models")
+        self.assertFalse(observed["trust_env"])
+        self.assertEqual(observed["headers"]["Authorization"], "Bearer sk-hermes-secret-value")
+        self.assertTrue(observed["closed"])
+        requests_get.assert_not_called()
+
+    def test_hermes_model_discovery_invalid_url_fails_before_request(self) -> None:
+        with patch("src.services.system_config_service.requests.Session") as session_cls:
+            result = self.service.discover_llm_channel_models(
+                name="hermes",
+                protocol="openai",
+                base_url="http://127.0.0.1:8642/v1?next=proxy",
+                api_key="saved-secret-token",
+                models=["hermes-agent"],
+            )
+
+        rendered = json.dumps(result, ensure_ascii=False, default=str)
+        self.assertFalse(result["success"])
+        self.assertEqual(result["error_code"], "invalid_config")
+        self.assertEqual(result["details"]["reason"], "invalid_hermes_url")
+        self.assertNotIn("saved-secret-token", rendered)
+        session_cls.assert_not_called()
+
+    def test_hermes_model_discovery_http_error_redacts_non_sk_secret(self) -> None:
+        class FakeSession:
+            def __init__(self) -> None:
+                self.trust_env = True
+
+            def get(self, *_args: Any, **_kwargs: Any) -> Any:
+                return SimpleNamespace(
+                    status_code=500,
+                    ok=False,
+                    json=lambda: {"error": {"message": "upstream saw saved-secret-token"}},
+                    text="upstream saw saved-secret-token",
+                )
+
+            def close(self) -> None:
+                pass
+
+        with patch("src.services.system_config_service.requests.Session", side_effect=FakeSession):
+            result = self.service.discover_llm_channel_models(
+                name="hermes",
+                protocol="openai",
+                base_url="http://127.0.0.1:8642/v1",
+                api_key="saved-secret-token",
+                models=["hermes-agent"],
+            )
+
+        rendered = json.dumps(result, ensure_ascii=False, default=str)
+        self.assertFalse(result["success"])
+        self.assertNotIn("saved-secret-token", rendered)
+        self.assertNotIn("Bearer saved-secret-token", rendered)
+        self.assertIn("[REDACTED]", rendered)
+
+    def test_llm_result_redacts_raw_comma_secret_and_segments(self) -> None:
+        raw_secret = "saved-secret-token,second-part"
+        redactions = self.service._build_redaction_values(raw_secret)
+        variants = [
+            "Bearer saved-secret-token,second-part",
+            "Bearer saved-secret-token, second-part",
+            "Bearer saved-secret-token ,second-part",
+            "Authorization: Bearer saved-secret-token,   second-part",
+            "upstream saw saved-secret-token, second-part",
+        ]
+
+        result = self.service._build_llm_channel_result(
+            success=False,
+            message="; ".join(variants),
+            error=" | ".join(variants),
+            stage="model_discovery",
+            error_code="network_error",
+            retryable=False,
+            details={
+                "raw": raw_secret,
+                "variants": variants,
+                "first": "saved-secret-token",
+                "second": "second-part",
+            },
+            capability_results={
+                "json": {
+                    "status": "failed",
+                    "message": variants[1],
+                    "details": {"echo": variants[3]},
+                }
+            },
+            resolved_protocol="openai",
+            models=[],
+            latency_ms=None,
+            redaction_values=redactions,
+        )
+
+        rendered = json.dumps(result, ensure_ascii=False, default=str)
+        self.assertNotIn(raw_secret, rendered)
+        for variant in variants:
+            self.assertNotIn(variant, rendered)
+        self.assertNotIn("saved-secret-token", rendered)
+        self.assertNotIn("second-part", rendered)
+        self.assertIn("[REDACTED]", rendered)
+
+    def test_llm_result_recursively_redacts_models_details_and_capabilities(self) -> None:
+        raw_secret = "saved-secret-token,second-part"
+        redactions = self.service._build_redaction_values(raw_secret)
+
+        details = self.service._sanitize_llm_details(
+            {
+                "items": [
+                    {"message": "saved-secret-token"},
+                    [{"nested": "Bearer saved-secret-token, second-part"}],
+                ],
+                "saved-secret-token": "second-part",
+            },
+            redaction_values=redactions,
+        )
+        result = self.service._build_llm_channel_result(
+            success=False,
+            message="upstream saw saved-secret-token, second-part",
+            error="Authorization: Bearer saved-secret-token,   second-part",
+            stage="model_discovery",
+            error_code="network_error",
+            retryable=False,
+            details=details,
+            resolved_protocol="openai",
+            resolved_model="saved-secret-token",
+            models=["saved-secret-token", ["second-part"]],
+            capability_results={
+                "json": {
+                    "status": "failed",
+                    "details": {"items": [{"message": "saved-secret-token"}]},
+                }
+            },
+            redaction_values=redactions,
+        )
+
+        rendered = json.dumps(result, ensure_ascii=False, default=str)
+        self.assertNotIn(raw_secret, rendered)
+        self.assertNotIn("saved-secret-token, second-part", rendered)
+        self.assertNotIn("saved-secret-token", rendered)
+        self.assertNotIn("second-part", rendered)
+        self.assertIn("[REDACTED]", rendered)
+
+    def test_hermes_model_discovery_request_exception_redacts_response_and_logs(self) -> None:
+        class FakeSession:
+            def __init__(self) -> None:
+                self.trust_env = True
+
+            def get(self, *_args: Any, **_kwargs: Any) -> Any:
+                raise requests.RequestException("proxy saw saved-secret-token")
+
+            def close(self) -> None:
+                pass
+
+        with patch("src.services.system_config_service.requests.Session", side_effect=FakeSession), \
+             self.assertLogs("src.services.system_config_service", level="WARNING") as logs:
+            result = self.service.discover_llm_channel_models(
+                name="hermes",
+                protocol="openai",
+                base_url="http://127.0.0.1:8642/v1",
+                api_key="saved-secret-token",
+                models=["hermes-agent"],
+            )
+
+        rendered = json.dumps(result, ensure_ascii=False, default=str)
+        log_text = "\n".join(logs.output)
+        self.assertFalse(result["success"])
+        self.assertNotIn("saved-secret-token", rendered)
+        self.assertNotIn("saved-secret-token", log_text)
+        self.assertIn("[REDACTED]", rendered)
+        self.assertIn("[REDACTED]", log_text)
+
+    def test_hermes_request_exception_redacts_comma_secret_variants_from_logs(self) -> None:
+        raw_secret = "saved-secret-token,second-part"
+        variants = [
+            "Bearer saved-secret-token,second-part",
+            "Bearer saved-secret-token, second-part",
+            "Bearer saved-secret-token ,second-part",
+            "Authorization: Bearer saved-secret-token,   second-part",
+            "upstream saw saved-secret-token, second-part",
+        ]
+        redactions = self.service._build_redaction_values(raw_secret)
+        sanitized = self.service._sanitize_llm_error_text(
+            " | ".join(variants),
+            redaction_values=redactions,
+        )
+        with self.assertLogs("src.services.system_config_service", level="WARNING") as logs:
+            logging.getLogger("src.services.system_config_service").warning(
+                "LLM channel model discovery failed for hermes: %s",
+                sanitized,
+            )
+
+        log_text = "\n".join(logs.output)
+        self.assertNotIn(raw_secret, log_text)
+        self.assertNotIn("saved-secret-token, second-part", log_text)
+        self.assertNotIn("saved-secret-token", log_text)
+        self.assertNotIn("second-part", log_text)
+        for variant in variants:
+            self.assertNotIn(variant, log_text)
+        self.assertIn("[REDACTED]", log_text)
+
+    def test_hermes_channel_test_invalid_url_fails_before_completion(self) -> None:
+        with patch("src.services.system_config_service.open_hermes_no_proxy_client") as no_proxy_client, \
+             patch("litellm.completion") as completion:
+            result = self.service.test_llm_channel(
+                name="hermes",
+                protocol="openai",
+                base_url="http://127.0.0.1:8642/v1#fragment",
+                api_key="saved-secret-token",
+                models=["hermes-agent"],
+                capability_checks=["json"],
+            )
+
+        rendered = json.dumps(result, ensure_ascii=False, default=str)
+        self.assertFalse(result["success"])
+        self.assertEqual(result["error_code"], "invalid_config")
+        self.assertEqual(result["details"]["reason"], "invalid_hermes_url")
+        self.assertEqual(result["capability_results"]["json"]["status"], "skipped")
+        self.assertNotIn("saved-secret-token", rendered)
+        no_proxy_client.assert_not_called()
+        completion.assert_not_called()
+
+    def test_hermes_runtime_only_masked_key_is_not_sent_for_channel_test(self) -> None:
+        with patch("src.services.system_config_service.open_hermes_no_proxy_client") as no_proxy_client, \
+             patch("litellm.completion") as completion:
+            result = self.service.test_llm_channel(
+                name="hermes",
+                protocol="openai",
+                base_url="http://127.0.0.1:8642/v1",
+                api_key="******",
+                models=["hermes-agent"],
+                use_saved_secret=False,
+                capability_checks=["json"],
+            )
+
+        self.assertFalse(result["success"])
+        self.assertEqual(result["error_code"], "runtime_secret_not_reusable")
+        self.assertEqual(result["details"]["reason"], "runtime_secret_not_reusable")
+        self.assertEqual(result["capability_results"]["json"]["status"], "skipped")
+        no_proxy_client.assert_not_called()
+        completion.assert_not_called()
+
+    def test_hermes_masked_key_is_not_sent_for_model_discovery(self) -> None:
+        with patch("src.services.system_config_service.requests.Session") as session_cls:
+            result = self.service.discover_llm_channel_models(
+                name="hermes",
+                protocol="openai",
+                base_url="http://127.0.0.1:8642/v1",
+                api_key="******",
+                models=["hermes-agent"],
+                use_saved_secret=False,
+            )
+
+        self.assertFalse(result["success"])
+        self.assertEqual(result["error_code"], "runtime_secret_not_reusable")
+        self.assertEqual(result["details"]["reason"], "runtime_secret_not_reusable")
+        session_cls.assert_not_called()
+
+    def test_hermes_saved_literal_masked_key_is_not_reused(self) -> None:
+        self._rewrite_env(
+            "STOCK_LIST=600519,000001",
+            "LLM_CHANNELS=hermes",
+            "LLM_HERMES_BASE_URL=http://127.0.0.1:8642/v1",
+            "LLM_HERMES_API_KEY=******",
+        )
+
+        with patch("src.services.system_config_service.open_hermes_no_proxy_client") as no_proxy_client, \
+             patch("litellm.completion") as completion:
+            result = self.service.test_llm_channel(
+                name="hermes",
+                protocol="openai",
+                base_url="http://127.0.0.1:8642/v1",
+                api_key="******",
+                models=["hermes-agent"],
+                use_saved_secret=True,
+            )
+
+        self.assertFalse(result["success"])
+        self.assertEqual(result["error_code"], "runtime_secret_not_reusable")
+        no_proxy_client.assert_not_called()
+        completion.assert_not_called()
+
+    def test_hermes_channel_test_rejects_comma_api_key_before_outbound(self) -> None:
+        raw_key = "key-a,key-b"
+        with patch("src.services.system_config_service.open_hermes_no_proxy_client") as no_proxy_client, \
+             patch("litellm.completion") as completion:
+            result = self.service.test_llm_channel(
+                name="hermes",
+                protocol="openai",
+                base_url="http://127.0.0.1:8642/v1",
+                api_key=raw_key,
+                models=["hermes-agent"],
+                capability_checks=["json"],
+            )
+
+        rendered = json.dumps(result, ensure_ascii=False, default=str)
+        self.assertFalse(result["success"])
+        self.assertEqual(result["error_code"], "invalid_config")
+        self.assertEqual(result["details"]["reason"], "multiple_api_keys")
+        self.assertNotIn(raw_key, rendered)
+        self.assertNotIn("key-a", rendered)
+        self.assertNotIn("key-b", rendered)
+        no_proxy_client.assert_not_called()
+        completion.assert_not_called()
+
+    def test_hermes_model_discovery_rejects_comma_api_key_before_outbound(self) -> None:
+        raw_key = "key-a,key-b"
+        with patch("src.services.system_config_service.requests.Session") as session_cls:
+            result = self.service.discover_llm_channel_models(
+                name="hermes",
+                protocol="openai",
+                base_url="http://127.0.0.1:8642/v1",
+                api_key=raw_key,
+                models=["hermes-agent"],
+            )
+
+        rendered = json.dumps(result, ensure_ascii=False, default=str)
+        self.assertFalse(result["success"])
+        self.assertEqual(result["error_code"], "invalid_config")
+        self.assertEqual(result["details"]["reason"], "multiple_api_keys")
+        self.assertNotIn(raw_key, rendered)
+        self.assertNotIn("key-a", rendered)
+        self.assertNotIn("key-b", rendered)
+        session_cls.assert_not_called()
+
+    def test_hermes_unsupported_capabilities_are_skipped_without_probe(self) -> None:
+        no_proxy_calls: List[Dict[str, Any]] = []
+        completion_models: List[str] = []
+
+        @contextmanager
+        def fake_no_proxy_openai_client(**kwargs: Any):
+            no_proxy_calls.append(kwargs)
+            yield object()
+
+        def fake_completion(**kwargs: Any) -> Any:
+            completion_models.append(str(kwargs.get("model") or ""))
+            self.assertFalse(kwargs.get("stream"))
+            self.assertIn("client", kwargs)
+            self.assertNotIn("api_key", kwargs)
+            self.assertNotIn("api_base", kwargs)
+            return self._mock_completion_response("OK")
+
+        with patch("src.services.system_config_service.open_hermes_no_proxy_client", fake_no_proxy_openai_client), \
+             patch("litellm.completion", side_effect=fake_completion):
+            result = self.service.test_llm_channel(
+                name="hermes",
+                protocol="openai",
+                base_url="http://127.0.0.1:8642/v1",
+                api_key="sk-hermes-secret-value",
+                models=["hermes-agent"],
+                capability_checks=["tools", "stream", "vision"],
+            )
+
+        self.assertTrue(result["success"])
+        self.assertEqual(len(no_proxy_calls), 1)
+        self.assertEqual(completion_models, ["openai/hermes-agent"])
+        capability_results = result["capability_results"]
+        self.assertEqual(set(capability_results), {"tools", "stream", "vision"})
+        for capability in ("tools", "stream", "vision"):
+            self.assertEqual(capability_results[capability]["status"], "skipped")
+            self.assertEqual(capability_results[capability]["error_code"], "not_probed")
+
+    def test_hermes_failure_redacts_non_sk_secret_from_response_and_logs(self) -> None:
+        @contextmanager
+        def fake_no_proxy_openai_client(**_kwargs: Any):
+            yield object()
+
+        def fake_completion(**_kwargs: Any) -> Any:
+            raise RuntimeError("upstream echoed saved-secret-token")
+
+        with patch("src.services.system_config_service.open_hermes_no_proxy_client", fake_no_proxy_openai_client), \
+             patch("litellm.completion", side_effect=fake_completion), \
+             self.assertLogs("src.services.system_config_service", level="WARNING") as logs:
+            result = self.service.test_llm_channel(
+                name="hermes",
+                protocol="openai",
+                base_url="http://127.0.0.1:8642/v1",
+                api_key="saved-secret-token",
+                models=["hermes-agent"],
+            )
+
+        self.assertFalse(result["success"])
+        self.assertNotIn("saved-secret-token", str(result))
+        self.assertNotIn("saved-secret-token", "\n".join(logs.output))
+
+    def test_hermes_json_capability_exception_redacts_non_sk_secret(self) -> None:
+        @contextmanager
+        def fake_no_proxy_openai_client(**_kwargs: Any):
+            yield object()
+
+        completion_calls = 0
+
+        def fake_completion(**_kwargs: Any) -> Any:
+            nonlocal completion_calls
+            completion_calls += 1
+            if completion_calls == 1:
+                return self._mock_completion_response("OK")
+            raise RuntimeError("json capability saw saved-secret-token")
+
+        with patch("src.services.system_config_service.open_hermes_no_proxy_client", fake_no_proxy_openai_client), \
+             patch("litellm.completion", side_effect=fake_completion):
+            result = self.service.test_llm_channel(
+                name="hermes",
+                protocol="openai",
+                base_url="http://127.0.0.1:8642/v1",
+                api_key="saved-secret-token",
+                models=["hermes-agent"],
+                capability_checks=["json"],
+            )
+
+        rendered = json.dumps(result, ensure_ascii=False, default=str)
+        self.assertTrue(result["success"])
+        self.assertEqual(result["capability_results"]["json"]["status"], "failed")
+        self.assertNotIn("saved-secret-token", rendered)
+        self.assertIn("[REDACTED]", rendered)
 
     def test_get_config_masks_llm_usage_hmac_secret(self) -> None:
         self._rewrite_env(
@@ -1123,6 +1637,61 @@ class SystemConfigServiceTestCase(unittest.TestCase):
         self.assertFalse(validation["valid"])
         self.assertTrue(any(issue["key"] == "LITELLM_MODEL" and issue["code"] == "unknown_model" for issue in validation["issues"]))
 
+    def test_validate_rejects_bare_primary_when_channel_route_is_openai_canonical(self) -> None:
+        validation = self.service.validate(
+            items=[
+                {"key": "LLM_CHANNELS", "value": "primary"},
+                {"key": "LLM_PRIMARY_PROTOCOL", "value": "openai"},
+                {"key": "LLM_PRIMARY_API_KEY", "value": "sk-test-value"},
+                {"key": "LLM_PRIMARY_MODELS", "value": "gpt-4o-mini"},
+                {"key": "LITELLM_MODEL", "value": "gpt-4o-mini"},
+            ]
+        )
+
+        self.assertFalse(validation["valid"])
+        self.assertTrue(any(issue["key"] == "LITELLM_MODEL" and issue["code"] == "unknown_model" for issue in validation["issues"]))
+
+    def test_validate_rejects_bare_fallback_when_channel_route_is_openai_canonical(self) -> None:
+        validation = self.service.validate(
+            items=[
+                {"key": "LLM_CHANNELS", "value": "primary"},
+                {"key": "LLM_PRIMARY_PROTOCOL", "value": "openai"},
+                {"key": "LLM_PRIMARY_API_KEY", "value": "sk-test-value"},
+                {"key": "LLM_PRIMARY_MODELS", "value": "gpt-4o-mini"},
+                {"key": "LITELLM_MODEL", "value": "openai/gpt-4o-mini"},
+                {"key": "LITELLM_FALLBACK_MODELS", "value": "gpt-4o-mini"},
+            ]
+        )
+
+        self.assertFalse(validation["valid"])
+        self.assertTrue(
+            any(
+                issue["key"] == "LITELLM_FALLBACK_MODELS"
+                and issue["code"] == "unknown_model"
+                for issue in validation["issues"]
+            )
+        )
+
+    def test_validate_reports_bare_vision_when_channel_route_is_openai_canonical(self) -> None:
+        validation = self.service.validate(
+            items=[
+                {"key": "LLM_CHANNELS", "value": "primary"},
+                {"key": "LLM_PRIMARY_PROTOCOL", "value": "openai"},
+                {"key": "LLM_PRIMARY_API_KEY", "value": "sk-test-value"},
+                {"key": "LLM_PRIMARY_MODELS", "value": "gpt-4o-mini"},
+                {"key": "VISION_MODEL", "value": "gpt-4o-mini"},
+            ]
+        )
+
+        self.assertTrue(
+            any(
+                issue["key"] == "VISION_MODEL"
+                and issue["code"] == "unknown_model"
+                for issue in validation["issues"]
+            ),
+            validation["issues"],
+        )
+
     def test_validate_accepts_deepseek_v4_primary_model_for_channel(self) -> None:
         validation = self.service.validate(
             items=[
@@ -1165,6 +1734,129 @@ class SystemConfigServiceTestCase(unittest.TestCase):
 
         self.assertTrue(validation["valid"])
         self.assertEqual(validation["issues"], [])
+
+    def test_validate_rejects_explicit_hermes_only_agent_model(self) -> None:
+        validation = self.service.validate(
+            items=[
+                {"key": "LLM_CHANNELS", "value": "hermes"},
+                {"key": "LLM_HERMES_API_KEY", "value": "sk-hermes-test-value"},
+                {"key": "LLM_HERMES_MODELS", "value": "hermes-agent"},
+                {"key": "AGENT_LITELLM_MODEL", "value": "openai/hermes-agent"},
+            ]
+        )
+
+        self.assertFalse(validation["valid"])
+        self.assertTrue(
+            any(
+                issue["key"] == "AGENT_LITELLM_MODEL"
+                and issue["code"] == "explicit_agent_model_no_safe_deployment"
+                for issue in validation["issues"]
+            )
+        )
+
+    def test_validate_allows_explicit_mixed_agent_model(self) -> None:
+        validation = self.service.validate(
+            items=[
+                {"key": "LLM_CHANNELS", "value": "hermes,remote"},
+                {"key": "LLM_HERMES_API_KEY", "value": "sk-hermes-test-value"},
+                {"key": "LLM_HERMES_MODELS", "value": "shared-route"},
+                {"key": "LLM_REMOTE_PROTOCOL", "value": "openai"},
+                {"key": "LLM_REMOTE_BASE_URL", "value": "https://api.example.com/v1"},
+                {"key": "LLM_REMOTE_API_KEY", "value": "sk-remote-test-value"},
+                {"key": "LLM_REMOTE_MODELS", "value": "shared-route"},
+                {"key": "AGENT_LITELLM_MODEL", "value": "openai/shared-route"},
+            ]
+        )
+
+        self.assertFalse(
+            any(
+                issue["key"] == "AGENT_LITELLM_MODEL"
+                and issue["code"] == "explicit_agent_model_no_safe_deployment"
+                for issue in validation["issues"]
+            ),
+            validation["issues"],
+        )
+
+    def test_validate_rejects_mixed_generation_primary_and_fallback(self) -> None:
+        validation = self.service.validate(
+            items=[
+                {"key": "LLM_CHANNELS", "value": "hermes,remote"},
+                {"key": "LLM_HERMES_API_KEY", "value": "sk-hermes-test-value"},
+                {"key": "LLM_HERMES_MODELS", "value": "shared-route"},
+                {"key": "LLM_REMOTE_PROTOCOL", "value": "openai"},
+                {"key": "LLM_REMOTE_BASE_URL", "value": "https://api.example.com/v1"},
+                {"key": "LLM_REMOTE_API_KEY", "value": "sk-remote-test-value"},
+                {"key": "LLM_REMOTE_MODELS", "value": "shared-route"},
+                {"key": "LITELLM_MODEL", "value": "openai/shared-route"},
+                {"key": "LITELLM_FALLBACK_MODELS", "value": "openai/shared-route"},
+            ]
+        )
+
+        self.assertFalse(validation["valid"])
+        self.assertTrue(
+            any(
+                issue["key"] == "LITELLM_MODEL"
+                and issue["code"] == "mixed_hermes_route_unsupported"
+                for issue in validation["issues"]
+            )
+        )
+        self.assertTrue(
+            any(
+                issue["key"] == "LITELLM_FALLBACK_MODELS"
+                and issue["code"] == "mixed_hermes_route_unsupported"
+                for issue in validation["issues"]
+            )
+        )
+
+    def test_validate_rejects_bare_mixed_generation_primary_and_fallback(self) -> None:
+        validation = self.service.validate(
+            items=[
+                {"key": "LLM_CHANNELS", "value": "hermes,remote"},
+                {"key": "LLM_HERMES_API_KEY", "value": "sk-hermes-test-value"},
+                {"key": "LLM_HERMES_MODELS", "value": "shared-route"},
+                {"key": "LLM_REMOTE_PROTOCOL", "value": "openai"},
+                {"key": "LLM_REMOTE_BASE_URL", "value": "https://api.example.com/v1"},
+                {"key": "LLM_REMOTE_API_KEY", "value": "sk-remote-test-value"},
+                {"key": "LLM_REMOTE_MODELS", "value": "shared-route"},
+                {"key": "LITELLM_MODEL", "value": "shared-route"},
+                {"key": "LITELLM_FALLBACK_MODELS", "value": "shared-route"},
+            ]
+        )
+
+        self.assertFalse(validation["valid"])
+        self.assertTrue(
+            any(
+                issue["key"] == "LITELLM_MODEL"
+                and issue["code"] == "mixed_hermes_route_unsupported"
+                for issue in validation["issues"]
+            )
+        )
+        self.assertTrue(
+            any(
+                issue["key"] == "LITELLM_FALLBACK_MODELS"
+                and issue["code"] == "mixed_hermes_route_unsupported"
+                for issue in validation["issues"]
+            )
+        )
+
+    def test_validate_rejects_bare_hermes_vision_model(self) -> None:
+        validation = self.service.validate(
+            items=[
+                {"key": "LLM_CHANNELS", "value": "hermes"},
+                {"key": "LLM_HERMES_API_KEY", "value": "sk-hermes-test-value"},
+                {"key": "LLM_HERMES_MODELS", "value": "hermes-agent"},
+                {"key": "VISION_MODEL", "value": "hermes-agent"},
+            ]
+        )
+
+        self.assertFalse(validation["valid"])
+        self.assertTrue(
+            any(
+                issue["key"] == "VISION_MODEL"
+                and issue["code"] == "hermes_vision_unsupported"
+                for issue in validation["issues"]
+            )
+        )
 
     @patch.object(
         Config,
@@ -2137,6 +2829,38 @@ class SystemConfigServiceTestCase(unittest.TestCase):
             current_map["LITELLM_FALLBACK_MODELS"],
             "deepseek/deepseek-v4-flash",
         )
+
+    def test_update_warns_when_clearing_unsupported_hermes_keys(self) -> None:
+        self._rewrite_env(
+            "STOCK_LIST=600519,000001",
+            "LLM_CHANNELS=hermes",
+            "LLM_HERMES_PROTOCOL=openai",
+            "LLM_HERMES_BASE_URL=http://127.0.0.1:8642/v1",
+            "LLM_HERMES_API_KEY=sk-hermes-test-value",
+            "LLM_HERMES_API_KEYS=sk-old-a,sk-old-b",
+            'LLM_HERMES_EXTRA_HEADERS={"X":"Y"}',
+            "LLM_HERMES_MODELS=hermes-agent",
+        )
+
+        response = self.service.update(
+            config_version=self.manager.get_config_version(),
+            items=[
+                {"key": "LLM_HERMES_API_KEYS", "value": ""},
+                {"key": "LLM_HERMES_EXTRA_HEADERS", "value": ""},
+            ],
+            reload_now=False,
+        )
+
+        self.assertTrue(response["success"])
+        joined = " | ".join(response["warnings"])
+        self.assertIn("Hermes Phase 3 不支持", joined)
+        self.assertIn("LLM_HERMES_API_KEYS", joined)
+        self.assertIn("LLM_HERMES_EXTRA_HEADERS", joined)
+        self.assertIn("LLM_HERMES_API_KEY", joined)
+        self.assertIn(".env 备份", joined)
+        current_map = self.manager.read_config_map()
+        self.assertEqual(current_map["LLM_HERMES_API_KEYS"], "")
+        self.assertEqual(current_map["LLM_HERMES_EXTRA_HEADERS"], "")
 
     @patch("litellm.completion")
     def test_test_llm_channel_does_not_persist_normalized_kimi_temperature(self, mock_completion) -> None:


### PR DESCRIPTION
## PR Type

- [ ] fix
- [x] feat
- [ ] refactor
- [x] docs
- [ ] chore
- [x] test

## Background And Problem

Refs #1743

本 PR 实现 #1743 的 Phase 3：接入 reserved `hermes` 本地 HTTP generation。目标不是把 Hermes 进程生命周期纳入 DSA 管理，而是支持用户已启动的本机 OpenAI-compatible Hermes endpoint，例如 `http://127.0.0.1:8642/v1`。

Phase 3 的核心边界：

- 只支持本地 loopback OpenAI-compatible `/v1` endpoint。
- 支持 base chat completion / JSON generation。
- 不支持 stream/SSE、tools、Vision、Agent tools、remote Hermes、Hermes process lifecycle。
- invalid Hermes 不 silent fallback 到 legacy provider。
- Hermes 请求必须 no-proxy。
- saved/masked secret 不得成为 loopback credential proxy。
- Agent / Vision / Generation 对 Hermes-only / mixed route 分别按真实运行时能力处理。

## Scope Of Change

- 文件总数 / 变更行数：

```text
30 files changed, 4758 insertions(+), 183 deletions(-)
```

- `git diff --stat upstream/main...HEAD`：

```text
 .env.example                                       |   8 +
 .github/workflows/00-daily-analysis.yml            |   7 +
 api/v1/endpoints/system_config.py                  |   2 +
 api/v1/schemas/system_config.py                    |   2 +
 apps/dsa-web/src/api/systemConfig.ts               |   2 +
 .../src/components/settings/LLMChannelEditor.tsx   | 287 ++++++-
 .../settings/__tests__/LLMChannelEditor.test.tsx   | 283 +++++++
 apps/dsa-web/src/types/systemConfig.ts             |   2 +
 docs/CHANGELOG.md                                  |   1 +
 docs/LLM_CONFIG_GUIDE.md                           |  12 +
 docs/LLM_CONFIG_GUIDE_EN.md                        |  12 +
 docs/full-guide.md                                 |   3 +
 docs/full-guide_EN.md                              |   3 +
 docs/llm-providers.md                              |  19 +-
 src/agent/chat_context.py                          |   8 +-
 src/agent/litellm_route_resolution.py              | 111 +++
 src/agent/llm_adapter.py                           |  67 +-
 src/analyzer.py                                    | 187 +++-
 src/config.py                                      | 307 +++++--
 src/llm/hermes.py                                  | 459 ++++++++++
 src/services/agent_model_service.py                |   9 +-
 src/services/image_stock_extractor.py              |   3 +
 src/services/system_config_service.py              | 936 +++++++++++++++++++--
 tests/test_agent_litellm_route_resolution.py       | 293 +++++++
 tests/test_agent_models_api.py                     |  20 +
 tests/test_chat_context.py                         |  87 ++
 tests/test_image_stock_extractor_litellm.py        |  73 ++
 tests/test_llm_channel_config.py                   | 562 +++++++++++++
 tests/test_market_analyzer_generate_text.py        | 450 ++++++++++
 tests/test_system_config_service.py                | 726 +++++++++++++++-
 30 files changed, 4758 insertions(+), 183 deletions(-)
```

- 文件清单：

```text
.env.example
.github/workflows/00-daily-analysis.yml
api/v1/endpoints/system_config.py
api/v1/schemas/system_config.py
apps/dsa-web/src/api/systemConfig.ts
apps/dsa-web/src/components/settings/LLMChannelEditor.tsx
apps/dsa-web/src/components/settings/__tests__/LLMChannelEditor.test.tsx
apps/dsa-web/src/types/systemConfig.ts
docs/CHANGELOG.md
docs/LLM_CONFIG_GUIDE.md
docs/LLM_CONFIG_GUIDE_EN.md
docs/full-guide.md
docs/full-guide_EN.md
docs/llm-providers.md
src/agent/chat_context.py
src/agent/litellm_route_resolution.py
src/agent/llm_adapter.py
src/analyzer.py
src/config.py
src/llm/hermes.py
src/services/agent_model_service.py
src/services/image_stock_extractor.py
src/services/system_config_service.py
tests/test_agent_litellm_route_resolution.py
tests/test_agent_models_api.py
tests/test_chat_context.py
tests/test_image_stock_extractor_litellm.py
tests/test_llm_channel_config.py
tests/test_market_analyzer_generate_text.py
tests/test_system_config_service.py
```

- 文档更新文件：

```text
.env.example
.github/workflows/00-daily-analysis.yml
docs/CHANGELOG.md
docs/LLM_CONFIG_GUIDE.md
docs/LLM_CONFIG_GUIDE_EN.md
docs/full-guide.md
docs/full-guide_EN.md
docs/llm-providers.md
```

主要改动：

- 新增 `src/llm/hermes.py`，集中处理 Hermes reserved preset、URL canonicalization、model canonicalization、route provenance、redaction、no-proxy OpenAI client helper。
- 重排 Config source precedence：YAML / LLM_CHANNELS 优先于 legacy inference；enabled-invalid Hermes 不再 silent fallback。
- Hermes deployment 写入 `model_info={"dsa_channel": "hermes"}`，Agent/Vision/Generation 均基于 deployment provenance 判断。
- Generation：Hermes-only 强制 non-stream + request-scoped no-proxy direct completion；mixed generation route 不支持。
- Saved secret：仅允许同 saved canonical endpoint 下复用；改端口/协议/channel identity 不会把真实 key 发出去。
- Runtime/API/Web redaction：按实际 token value 做递归脱敏，覆盖 response/details/models/capability_results/logs/exception text。
- Agent：新增 route resolution，Hermes-only unavailable，mixed route 过滤掉 Hermes deployment 后保留 non-Hermes route。
- Chat Context：trace matching 使用同一 Agent-safe `models_to_try`。
- Vision：Phase 3 保守拒绝任何含 Hermes deployment 的 route。
- Web：新增 Hermes preset UX、JSON-only capability UI、Agent/Vision/Generation safe model 派生、masked/runtime-only key guard、comma key guard、canonical route alias guard。

## Issue Link

Refs #1743

## Compatibility References And Contract Sources

- Hermes Agent providers documentation: <https://hermes-agent.nousresearch.com/docs/integrations/providers>。本 PR 使用其中的 Custom / self-hosted OpenAI-compatible endpoint 语义；不管理 Hermes 进程生命周期，也不承诺所有 Hermes proxy provider matrix。
- LiteLLM OpenAI-compatible provider documentation: <https://docs.litellm.ai/docs/providers/openai_compatible>。本 PR 的 Hermes route 使用 `openai/<model>` 走 OpenAI-compatible Chat Completions 形态。
- OpenAI Chat Completions API reference: <https://platform.openai.com/docs/api-reference/chat/create>；OpenAI Python SDK: <https://github.com/openai/openai-python>。Hermes no-proxy path 使用 request-scoped OpenAI SDK client + `httpx.Client(trust_env=False)`。
- DeepSeek official API documentation: <https://api-docs.deepseek.com/>。真实验收中 DeepSeek 作为上游模型/provider 使用；DSA 侧只依赖本地 OpenAI-compatible `/v1` endpoint contract。

兼容性声明：本 PR 的可合入承诺是 DSA 能安全接入用户已经启动的本地 OpenAI-compatible Hermes endpoint；不承诺 DSA 安装/启动 Hermes、不承诺 remote Hermes、不承诺 Hermes 官方 proxy 对每个上游 provider 的覆盖范围。

## Verification Commands And Results

### 本地自动化验证

```bash
python -m pytest -q tests/test_config_validate_structured.py tests/test_llm_channel_config.py tests/test_system_config_service.py tests/test_system_config_api.py
```

结果：

```text
342 passed, 21 warnings
```

```bash
python -m pytest -q tests/test_agent_litellm_route_resolution.py tests/test_agent_models_api.py tests/test_agent_chat_api.py tests/test_chat_context.py
```

结果：

```text
56 passed, 20 warnings
```

```bash
python -m pytest -q tests/test_market_analyzer_generate_text.py tests/test_image_stock_extractor_litellm.py
```

结果：

```text
124 passed
```

```bash
python -m py_compile src/config.py src/llm/hermes.py src/analyzer.py src/services/system_config_service.py src/agent/litellm_route_resolution.py src/agent/llm_adapter.py src/agent/chat_context.py src/services/agent_model_service.py
```

结果：通过。

```bash
npm test -- LLMChannelEditor.test.tsx --run
```

结果：

```text
Test Files  1 passed (1)
Tests  51 passed (51)
```

```bash
npm run lint
```

结果：通过，0 errors；保留一个既有 warning：

```text
apps/dsa-web/src/pages/SettingsPage.tsx
  553:6  warning  React Hook useEffect has a missing dependency: 'status'
```

```bash
npm run build
```

结果：通过，`tsc -b && vite build` 成功。

```bash
git diff --check
```

结果：通过。

```bash
./scripts/ci_gate.sh
```

结果：Hermes / LLM channel / Agent / Vision 相关路径通过；完整 backend gate 仍复现 3 个 JP/KR legacy market phase baseline 失败，和本 PR 的 Hermes 接入无关：

```text
3 failed, 3926 passed, 1 skipped, 2 deselected, 68 warnings

FAILED tests/test_analysis_api_contract.py::AnalysisApiContractTestCase::test_build_analysis_report_rebuilds_legacy_cn_market_summary_for_kr_code
FAILED tests/test_analysis_history.py::AnalysisHistoryTestCase::test_history_display_rebuilds_market_phase_summary_for_legacy_cn_snapshot
FAILED tests/test_analysis_history.py::AnalysisHistoryTestCase::test_history_display_resolves_bare_jp_kr_code_from_stock_pool
```

### 评审反馈后补充验证（commit `4e2bdaee`）

```bash
python -m pytest -q tests/test_system_config_service.py tests/test_system_config_api.py tests/test_llm_channel_config.py
```

结果：

```text
276 passed, 21 warnings
```

```bash
python -m py_compile src/services/system_config_service.py
```

结果：通过。

```bash
npm test -- LLMChannelEditor.test.tsx --run
```

结果：

```text
Test Files  1 passed (1)
Tests  51 passed (51)
```

```bash
npm run lint
```

结果：通过，0 errors；保留一个既有 warning：

```text
apps/dsa-web/src/pages/SettingsPage.tsx
  553:6  warning  React Hook useEffect has a missing dependency: 'status'
```

```bash
npm run build
```

结果：通过，`tsc -b && vite build` 成功。

```bash
git diff --check
```

结果：通过。

### 真实 Hermes / OpenAI-compatible endpoint 验收

验收环境：

- Hermes Agent：`v0.17.0`
- DSA local endpoint：`http://127.0.0.1:8642/v1`
- Runtime model：`openai/deepseek-v4-flash`
- AAPL 报告：`reports/report_20260627.md`
- 验收期间不改源码、不 stage、不 commit；测试前后恢复 `.env`。

已验证：

- Hermes 本体 DeepSeek provider 真实生成通过：
  - `--provider deepseek -m deepseek-v4-flash`
  - `--provider deepseek -m deepseek/deepseek-v4-flash`
  - 独立 `HERMES_HOME` 持久配置 DeepSeek provider 后生成通过
- 本地 OpenAI-compatible `/v1` endpoint 通过：
  - `/v1/models`
  - `/v1/chat/completions`
- DSA Hermes channel live path 通过：
  - model discovery
  - connection test
  - JSON capability
  - stream/tools/vision 返回 `skipped + not_probed`
- Web UI 真实点击验收通过：
  - 添加/编辑 Hermes channel
  - 获取模型
  - 测试连接
  - JSON capability
  - 保存配置
  - 刷新后配置持久化
  - API key 显示为 `******`
- AAPL 主流程通过：
  - 使用保存后的 Hermes 配置运行 AAPL 分析
  - 实际请求命中 `http://127.0.0.1:8642/v1/chat/completions`
  - `成功: 1, 失败: 0`
  - 报告包含 AAPL、结论、评分、理由、模型名
  - 报告不包含 `sk-`、`Bearer`、`Authorization`、`Traceback`、`Exception` 或本地 token
- no-proxy 验收通过：
  - 清空 `NO_PROXY/no_proxy`
  - 设置坏代理 `HTTP_PROXY/HTTPS_PROXY=http://127.0.0.1:9`
  - discover/test/JSON/generation 仍通过
- 安全边界：
  - `key-a,key-b` 被拒绝为 `multiple_api_keys`，无 outbound
  - `******` 不作为真实 key 出站
  - invalid Hermes 不 fallback 到 legacy key
  - mixed generation route 不可用
  - Vision Hermes route 不调用 LiteLLM
  - Agent Hermes-only unavailable，mixed Agent route 只保留 non-Hermes deployment

### 已知 partial / 上游限制

- Hermes Agent 有可用 DeepSeek provider，但当前 `hermes proxy start --provider deepseek` 不支持 DeepSeek upstream；实测 proxy providers 仅列出 `nous` / `xai`。因此本 PR 的承诺是接入 reserved Hermes local OpenAI-compatible endpoint，不承诺 Hermes 官方 proxy 能把 DeepSeek 暴露为 `/v1`。
- `apiKey=******` 且无 saved secret：Web UI 阻止了 outbound request，安全行为符合预期；但该 UI 路径没有走到后端 `runtime_secret_not_reusable` response。后端路径由服务/单测覆盖。
- mixed Hermes/non-Hermes route：运行时 Generation selection 被阻断并提示 warning；保存路径可能表现为 `200 + warning`，不是“保存时硬失败”。
- 当前 Web channel editor 正常路径只提供 canonical route alias 下拉；裸 alias 的后端/API/Web helper 行为由自动化测试覆盖。

## Visual Evidence (if applicable)

- 截图链接 / Screenshot links（必填）：

1. Hermes channel 配置截图：
<img width="1440" height="4540" alt="hermes-webui-02-hermes-channel-expanded" src="https://github.com/user-attachments/assets/ebc9430b-d1b6-44eb-aa9d-c2ae523357b2" />

2. Discover / test / JSON capability 成功截图：
<img width="1440" height="4724" alt="hermes-webui-03-discover-test-json-success" src="https://github.com/user-attachments/assets/b6ab4561-fc44-4d7c-b520-182a6d0f4d5f" />

3. Runtime model filtering 截图：
<img width="1440" height="1500" alt="hermes-webui-04-runtime-model-filtering" src="https://github.com/user-attachments/assets/80070210-8a91-4450-8b18-6ea801017810" />

4. 保存成功截图：
<img width="1440" height="4031" alt="hermes-webui-05-save-success" src="https://github.com/user-attachments/assets/0f484149-afa1-493b-b844-1ea14fd8238e" />

5. 刷新后持久化与 key masked 截图：
<img width="1440" height="4438" alt="hermes-ui-reload-expanded" src="https://github.com/user-attachments/assets/7f6011a8-9c6a-43f1-81ab-07ca141c6fd2" />

6. comma/masked key 边界：
<img width="1440" height="4533" alt="hermes-ui-invalid-keys-reserved" src="https://github.com/user-attachments/assets/ea94b74c-f0d7-4323-8b07-8dced849e946" />

7. mixed route warning：
<img width="1440" height="3666" alt="hermes-ui-mixed-route" src="https://github.com/user-attachments/assets/ec85452a-544f-48d2-af07-94126d07abd2" />



- 前后对比 / Before & After（如有）：

不适用。本 PR 是新增 Hermes reserved local endpoint 接入与设置页能力，不是已有页面视觉改版。


## Compatibility And Risk

- Hermes 只允许 loopback `/v1` endpoint：`127.0.0.1`、`localhost` canonicalized to `127.0.0.1`、或显式 `[::1]`。remote Hermes URL 不支持。
- Hermes Phase 3 不支持 stream/SSE、tools、Vision、Agent tools、remote Hermes、process lifecycle。
- Hermes reserved channel 只支持单 `LLM_HERMES_API_KEY`；`LLM_HERMES_API_KEYS` / `LLM_HERMES_EXTRA_HEADERS` 非空会被拒绝。
- Saved secret 只绑定 saved canonical endpoint；改协议、host、port、reserved identity 都不会复用真实 key。
- Generation mixed Hermes/non-Hermes route 不支持；Agent mixed route 允许但过滤 Hermes deployment；Vision 拒绝任何含 Hermes deployment 的 route。
- Web 保存 Hermes channel 时会显式清理 `LLM_HERMES_API_KEYS` / `LLM_HERMES_EXTRA_HEADERS`，用于修复旧错误配置；API response / Web UI 会显示 warning，文档说明可从 `.env` 备份、Git 历史或桌面端导出备份恢复旧值；非 Hermes channel 不受影响。
- 普通 route availability 恢复严格 top-level route alias 匹配；Hermes safety/provenance 仍使用宽松 candidate matching，避免裸名绕过 safety guard。
- 依赖兼容：代码仍使用现有 LiteLLM 版本范围；Hermes no-proxy direct path 使用 request-scoped OpenAI SDK client，不把 client object 写入 config response、diagnostics 或 `.env`。
- 当前分支已 `git fetch --all --prune` 并合并最新 `upstream/main`（`a2f19f65`）；PR diff 统计按 `upstream/main...HEAD` 生成。

## Rollback Plan

- 最小回滚：revert this PR。
- 回滚后删除或忽略新增 Hermes 配置项即可；无需数据迁移。
- 如用户已在 `.env` 配置 `LLM_CHANNELS=hermes`，回滚后应移除 Hermes 相关 `LLM_HERMES_*` 项或改回 legacy/YAML/channel 配置。

## EXTRACT_PROMPT Change (if applicable)

不适用。本 PR 未修改 `src/services/image_stock_extractor.py` 中的 `EXTRACT_PROMPT`。

<details>
<summary>展开 / Expand: Full EXTRACT_PROMPT</summary>

```text
Not changed.
```

</details>

## Checklist

- [x] 本 PR 有明确动机和业务价值 / This PR has a clear motivation and value
- [x] 已提供可复现的验证命令与结果 / Reproducible verification commands and results are included
- [x] 已评估兼容性与风险 / Compatibility and risk have been assessed
- [x] 已提供回滚方案 / A rollback plan is provided
- [x] 若修改报告格式或 Web UI 界面，已在 PR 描述/评论附受影响报告 / 页面截图，且未把一次性验收截图作为仓库文件合入 / If report formatting or Web UI changed, affected report/page screenshots are linked in the PR body/comments and one-off acceptance screenshots are not committed as repository files
- [x] 若涉及用户可见变更，已同步更新相关文档与 `docs/CHANGELOG.md`；`README.md` 仅在首页级信息变化时更新，细节优先写入 `docs/*.md` / If user-visible changes are included, relevant docs and `docs/CHANGELOG.md` are updated; `README.md` is updated only for homepage-level changes, with details kept in `docs/*.md`



