### PR TITLE
[codex] Add GenGe cycle bottom strategy

### DIFF
--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -1,0 +1,147 @@
+# GenGe Cycle Bottom Strategy Implementation Plan
+
+## Goal
+
+Add an independent, deterministic historical validation module for the "根哥周期底部硬逻辑策略 / GenGe Cycle Bottom Strategy".
+
+The first phase will cover historical data scanning, signal generation, 5-year/10-year walk-forward backtesting, CSV/JSON/Markdown report output, tests, and documentation.
+
+This module will not connect to any broker, place orders, read account data, or use an LLM to decide signals.
+
+## Existing Modules To Reuse
+
+- `data_provider.DataFetcherManager`
+  - Reuse `get_daily_data()` for A-share daily bars and benchmark index data.
+  - Keep provider failover behavior and readable data-source errors.
+- `data_provider.base.normalize_stock_code`
+  - Normalize A-share codes accepted by the CLI.
+- `src.storage.DatabaseManager` and `src.repositories.StockRepository`
+  - Keep compatibility with existing daily-bar storage, but the first strategy module will operate on DataFrames so it is easy to test and can run without mutating existing DB workflows.
+- `src.core.backtest_engine`
+  - Use its pure-logic style as the reference pattern; the new walk-forward engine will stay DB-agnostic.
+- Existing `tests/` style
+  - Add focused `unittest`/pytest-compatible tests with synthetic data.
+
+## Files To Add
+
+- `src/strategies/genge_cycle_bottom/__init__.py`
+- `src/strategies/genge_cycle_bottom/signals.py`
+  - Signal constants / enum and signal dataclass.
+- `src/strategies/genge_cycle_bottom/features.py`
+  - Price percentile, valuation score, financial safety, trend stabilization, market environment, no-lookahead slicing helpers.
+- `src/strategies/genge_cycle_bottom/strategy.py`
+  - Deterministic strategy scoring and signal classification.
+- `src/strategies/genge_cycle_bottom/backtest.py`
+  - Walk-forward scan and future return / drawdown / benchmark comparison.
+- `src/strategies/genge_cycle_bottom/metrics.py`
+  - Summary aggregation, win rates, median/average return, benchmark outperformance, consecutive losses.
+- `src/strategies/genge_cycle_bottom/report.py`
+  - `signal_details.csv`, `summary.json`, and Chinese `summary.md` writers.
+- `src/strategies/genge_cycle_bottom/cli.py`
+  - `python -m src.strategies.genge_cycle_bottom.cli ...` entrypoint.
+- `docs/genge_cycle_bottom_strategy.md`
+  - Usage, data assumptions, no-lookahead constraints, output format, and limitations.
+- `tests/test_genge_cycle_bottom_features.py`
+- `tests/test_genge_cycle_bottom_strategy.py`
+- `tests/test_genge_cycle_bottom_backtest.py`
+- `tests/test_genge_cycle_bottom_no_lookahead.py`
+
+## Files To Modify
+
+No existing production behavior should be changed for phase one. Existing modules should only be imported by the new strategy package.
+
+If a small compatibility change becomes necessary, it must be isolated and covered by tests, but the current plan does not require one.
+
+## Data And No-Lookahead Rules
+
+- Every feature calculation receives an explicit `as_of_date`.
+- Price/volume/trend windows are filtered to rows with `date <= as_of_date`.
+- Future return calculations are only performed after a signal has been generated and are stored as validation outputs, never as inputs.
+- Valuation and financial data are optional DataFrames. If disclosure dates are unavailable or fields are missing, the strategy records `missing_fields` and lowers confidence instead of looking ahead.
+- The first CLI version supports optional CSV inputs for valuation/financial data; if omitted, those scores are conservative and marked missing.
+
+## CLI Design
+
+Examples:
+
+```bash
+python -m src.strategies.genge_cycle_bottom.cli \
+  --codes 002714,000100 \
+  --years 5 \
+  --benchmark 000300 \
+  --output-dir reports/genge_cycle_bottom
+```
+
+```bash
+python -m src.strategies.genge_cycle_bottom.cli \
+  --stock-pool-file stock_pool_genge.txt \
+  --years 10 \
+  --benchmark 000300 \
+  --output-dir reports/genge_cycle_bottom
+```
+
+Additional test-friendly options:
+
+```bash
+python -m src.strategies.genge_cycle_bottom.cli \
+  --codes 002714,000100 \
+  --price-data-dir tests/fixtures/genge_prices \
+  --benchmark-file tests/fixtures/genge_prices/000300.csv \
+  --output-dir reports/genge_cycle_bottom_smoke
+```
+
+## Output
+
+Each run writes a timestamped directory under the selected output directory:
+
+- `signal_details.csv`
+- `summary.json`
+- `summary.md`
+
+The CSV includes signal fields, component scores, risk/missing fields, 20/60/120/250-day future returns, max drawdowns, benchmark returns, and benchmark outperformance flags.
+
+## Test Plan
+
+- Feature tests:
+  - Low historical percentile scores higher than high percentile.
+  - Insufficient history records `missing_fields`.
+  - Missing valuation/financial data does not crash.
+- Strategy tests:
+  - `REJECT`, `WATCH`, `LEFT_SMALL_BUY`, and `CONFIRM_BUY` classification thresholds.
+  - Financial risk caps signals as required.
+- Backtest tests:
+  - Future 20/60/120/250-day returns and max drawdown are calculated correctly.
+  - Benchmark outperformance is calculated correctly.
+- No-lookahead tests:
+  - Data after `as_of_date` cannot affect feature scores or signal classification.
+
+## Validation Commands
+
+```bash
+pytest tests/test_genge_cycle_bottom_features.py \
+       tests/test_genge_cycle_bottom_strategy.py \
+       tests/test_genge_cycle_bottom_backtest.py \
+       tests/test_genge_cycle_bottom_no_lookahead.py
+```
+
+```bash
+python -m src.strategies.genge_cycle_bottom.cli \
+  --codes 002714,000100 \
+  --years 5 \
+  --benchmark 000300 \
+  --output-dir reports/genge_cycle_bottom
+```
+
+```bash
+python -m src.strategies.genge_cycle_bottom.cli \
+  --codes 002714,000100 \
+  --years 10 \
+  --benchmark 000300 \
+  --output-dir reports/genge_cycle_bottom
+```
+
+## Known Phase-One Limits
+
+- Industry "hard logic" is represented as configurable industry/logic tags and market environment, not as LLM or news interpretation.
+- Financial and valuation history are optional inputs; missing data lowers confidence and appears in diagnostics.
+- The module validates historical signal expectancy; it does not produce trading instructions or execute trades.

--- a/docs/genge_cycle_bottom_strategy.md
+++ b/docs/genge_cycle_bottom_strategy.md
@@ -1,0 +1,72 @@
+# 根哥周期底部硬逻辑策略
+
+`genge_cycle_bottom` 是一个独立的历史滚动验证模块，用来验证“低位 + 估值 + 财务安全 + 止跌确认 + 市场环境”的确定性策略。
+
+本模块只读取公开行情与财务数据，不接入券商账户，不自动下单，也不让 LLM 直接决定买入或卖出。
+
+## 运行命令
+
+```bash
+python -m src.strategies.genge_cycle_bottom.cli \
+  --codes 002714,000100 \
+  --years 5 \
+  --benchmark 000300 \
+  --output-dir reports/genge_cycle_bottom
+```
+
+```bash
+python -m src.strategies.genge_cycle_bottom.cli \
+  --stock-pool-file stock_pool_genge.txt \
+  --years 10 \
+  --benchmark 000300 \
+  --output-dir reports/genge_cycle_bottom
+```
+
+也可以使用本地 CSV 做离线验证：
+
+```bash
+python -m src.strategies.genge_cycle_bottom.cli \
+  --codes 002714,000100 \
+  --years 5 \
+  --benchmark 000300 \
+  --price-data-dir /path/to/price_csv \
+  --valuation-data-dir /path/to/valuation_csv \
+  --financial-data-dir /path/to/financial_csv \
+  --output-dir reports/genge_cycle_bottom
+```
+
+价格 CSV 至少需要 `date,open,high,low,close,volume`。估值 CSV 可包含 `date,pb,pe,ps,market_cap`。财务 CSV 可包含 `report_date,debt_ratio,net_profit,operating_cash_flow,roe`。
+
+## 信号类型
+
+- `REJECT`：不符合，放弃
+- `WATCH`：观察
+- `LEFT_SMALL_BUY`：左侧小仓试错
+- `CONFIRM_BUY`：右侧确认买入
+- `HOLD`：持有
+- `ADD`：加仓
+- `REDUCE`：减仓
+- `SELL`：卖出
+
+第一版回测只对 `LEFT_SMALL_BUY`、`CONFIRM_BUY`、`ADD` 做未来收益验证。
+
+## 防未来函数
+
+策略每次生成信号都必须传入 `as_of_date`。特征层会把价格、估值、财务和基准数据截断到 `as_of_date` 当天及以前。未来 20/60/120/250 日收益只在信号生成之后由回测层计算。
+
+如果财务数据无法确认披露日期，第一版会保守使用 `report_date <= as_of_date` 的记录；拿不到的字段会进入 `missing_fields`，不会编造数据。
+
+## 输出文件
+
+每次运行会在 `reports/genge_cycle_bottom/<时间戳>/` 下生成：
+
+- `signal_details.csv`：每条历史信号明细
+- `summary.json`：胜率、平均收益、中位数收益、回撤、跑赢基准比例、诊断信息
+- `summary.md`：中文摘要与第一版结论
+
+## 当前限制
+
+- 估值和财务字段取决于数据源可得性，缺失会降低置信度。
+- 第一版没有考虑交易费用、滑点和停牌无法成交。
+- 行业硬逻辑只以财务安全、估值和趋势代理表达，尚未接入行业景气度数据库。
+- 输出里的仓位和止损是策略验证参数，不是实盘指令。

--- a/src/strategies/__init__.py
+++ b/src/strategies/__init__.py
@@ -1,0 +1,1 @@
+"""Strategy modules."""

--- a/src/strategies/genge_cycle_bottom/__init__.py
+++ b/src/strategies/genge_cycle_bottom/__init__.py
@@ -1,0 +1,11 @@
+"""GenGe Cycle Bottom Strategy."""
+
+from .signals import SIGNAL_TYPES, SignalType, StrategySignal
+from .strategy import GenGeCycleBottomStrategy
+
+__all__ = [
+    "SIGNAL_TYPES",
+    "SignalType",
+    "StrategySignal",
+    "GenGeCycleBottomStrategy",
+]

--- a/src/strategies/genge_cycle_bottom/backtest.py
+++ b/src/strategies/genge_cycle_bottom/backtest.py
@@ -1,0 +1,149 @@
+"""Walk-forward backtest for GenGe Cycle Bottom Strategy."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date
+from typing import Dict, Iterable, List, Optional
+
+import pandas as pd
+
+from .features import coerce_date, finite_float, prepare_price_frame, slice_as_of
+from .signals import SignalType, StrategySignal
+from .strategy import GenGeCycleBottomStrategy
+
+
+EVAL_WINDOWS = (20, 60, 120, 250)
+ENTRY_SIGNAL_TYPES = {SignalType.LEFT_SMALL_BUY, SignalType.CONFIRM_BUY, SignalType.ADD}
+
+
+@dataclass
+class BacktestInput:
+    code: str
+    stock_name: str
+    price_df: pd.DataFrame
+    valuation_df: Optional[pd.DataFrame] = None
+    financial_df: Optional[pd.DataFrame] = None
+    extra_risk_flags: Optional[List[str]] = None
+
+
+def max_drawdown_from_closes(start_price: float, closes: Iterable[float]) -> Optional[float]:
+    start = finite_float(start_price)
+    if start is None or start <= 0:
+        return None
+    running_peak = start
+    worst = 0.0
+    for close in closes:
+        value = finite_float(close)
+        if value is None:
+            continue
+        running_peak = max(running_peak, value)
+        if running_peak > 0:
+            worst = min(worst, (value - running_peak) / running_peak)
+    return round(worst * 100, 4)
+
+
+def future_return(start_price: float, future_rows: pd.DataFrame, days: int) -> Optional[float]:
+    start = finite_float(start_price)
+    if start is None or start <= 0 or len(future_rows) < days:
+        return None
+    end_close = finite_float(future_rows.iloc[days - 1].get("close"))
+    if end_close is None:
+        return None
+    return round((end_close - start) / start * 100, 4)
+
+
+def benchmark_return(benchmark_df: Optional[pd.DataFrame], as_of_date: date, days: int) -> Optional[float]:
+    if benchmark_df is None or benchmark_df.empty:
+        return None
+    df = prepare_price_frame(benchmark_df)
+    history = df[df["date"] <= as_of_date]
+    future = df[df["date"] > as_of_date].sort_values("date")
+    if history.empty or len(future) < days:
+        return None
+    start_close = finite_float(history.iloc[-1].get("close"))
+    return future_return(start_close, future, days) if start_close is not None else None
+
+
+def evaluate_signal_forward(
+    signal: StrategySignal,
+    price_df: pd.DataFrame,
+    benchmark_df: Optional[pd.DataFrame] = None,
+) -> Dict[str, object]:
+    df = prepare_price_frame(price_df)
+    as_of = coerce_date(signal.as_of_date)
+    history = df[df["date"] <= as_of].sort_values("date")
+    future = df[df["date"] > as_of].sort_values("date")
+    start_close = finite_float(history.iloc[-1].get("close")) if not history.empty else None
+
+    result: Dict[str, object] = {}
+    for days in EVAL_WINDOWS:
+        stock_ret = future_return(start_close, future, days) if start_close is not None else None
+        result[f"future_return_{days}d"] = stock_ret
+        result[f"max_drawdown_{days}d"] = (
+            max_drawdown_from_closes(start_close, future.head(days)["close"]) if start_close is not None and len(future) >= days else None
+        )
+        bench_ret = benchmark_return(benchmark_df, as_of, days)
+        result[f"benchmark_return_{days}d"] = bench_ret
+        result[f"outperform_benchmark_{days}d"] = (
+            bool(stock_ret > bench_ret) if stock_ret is not None and bench_ret is not None else None
+        )
+
+    if signal.stop_loss is not None and start_close is not None:
+        lows = pd.to_numeric(future["low"], errors="coerce") if "low" in future.columns else pd.Series(dtype="float64")
+        result["hit_stop_loss"] = bool((lows <= signal.stop_loss).any()) if not lows.empty else None
+    else:
+        result["hit_stop_loss"] = None
+    return result
+
+
+class WalkForwardBacktester:
+    def __init__(self, strategy: Optional[GenGeCycleBottomStrategy] = None):
+        self.strategy = strategy or GenGeCycleBottomStrategy()
+
+    def run(
+        self,
+        *,
+        inputs: List[BacktestInput],
+        benchmark_df: Optional[pd.DataFrame],
+        start_date,
+        end_date,
+        step_days: int = 20,
+    ) -> List[Dict[str, object]]:
+        start = coerce_date(start_date)
+        end = coerce_date(end_date)
+        rows: List[Dict[str, object]] = []
+
+        for item in inputs:
+            price_df = prepare_price_frame(item.price_df)
+            dates = [
+                d
+                for d in price_df["date"].tolist()
+                if start <= d <= end
+            ]
+            for index, as_of in enumerate(dates):
+                if step_days > 1 and index % step_days != 0:
+                    continue
+                history = slice_as_of(price_df, as_of)
+                if len(history) < 120:
+                    continue
+
+                signal = self.strategy.generate_signal(
+                    code=item.code,
+                    stock_name=item.stock_name,
+                    as_of_date=as_of,
+                    price_df=price_df,
+                    valuation_df=item.valuation_df,
+                    financial_df=item.financial_df,
+                    benchmark_df=benchmark_df,
+                    extra_risk_flags=item.extra_risk_flags,
+                )
+                if signal.signal_type not in ENTRY_SIGNAL_TYPES:
+                    continue
+
+                row = signal.to_dict()
+                row.update(evaluate_signal_forward(signal, price_df, benchmark_df))
+                rows.append(row)
+
+        return rows
+

--- a/src/strategies/genge_cycle_bottom/cli.py
+++ b/src/strategies/genge_cycle_bottom/cli.py
@@ -1,0 +1,214 @@
+"""Command line entry point for GenGe Cycle Bottom Strategy backtests."""
+
+from __future__ import annotations
+
+import argparse
+from datetime import date
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple
+
+import pandas as pd
+
+from .backtest import BacktestInput, WalkForwardBacktester
+from .features import coerce_date, date_years_ago, prepare_price_frame
+from .metrics import compute_summary
+from .report import write_reports
+
+
+def _parse_codes(raw_codes: Optional[str]) -> List[str]:
+    if not raw_codes:
+        return []
+    return [code.strip() for code in raw_codes.split(",") if code.strip()]
+
+
+def _read_stock_pool(path: Optional[str]) -> List[str]:
+    if not path:
+        return []
+    stock_pool_path = Path(path)
+    codes: List[str] = []
+    for line in stock_pool_path.read_text(encoding="utf-8").splitlines():
+        code = line.strip()
+        if not code or code.startswith("#"):
+            continue
+        codes.append(code.split(",")[0].strip())
+    return codes
+
+
+def _load_csv(path: Path) -> pd.DataFrame:
+    if not path.exists():
+        raise FileNotFoundError(f"CSV file not found: {path}")
+    return pd.read_csv(path)
+
+
+def _load_optional_csv(directory: Optional[str], code: str) -> Optional[pd.DataFrame]:
+    if not directory:
+        return None
+    path = Path(directory) / f"{code}.csv"
+    if not path.exists():
+        return None
+    return pd.read_csv(path)
+
+
+def _load_price_from_csv(directory: str, code: str) -> pd.DataFrame:
+    return _load_csv(Path(directory) / f"{code}.csv")
+
+
+def _fetch_price_live(manager, code: str, start_date: date, end_date: date, years: int) -> Tuple[pd.DataFrame, str]:
+    days = int((years + 1) * 365.25)
+    df, source = manager.get_daily_data(
+        code,
+        start_date=start_date.isoformat(),
+        end_date=end_date.isoformat(),
+        days=days,
+    )
+    return df, source
+
+
+def _get_manager():
+    from data_provider.base import DataFetcherManager
+
+    return DataFetcherManager()
+
+
+def _load_inputs(
+    *,
+    codes: List[str],
+    args: argparse.Namespace,
+    start_date: date,
+    end_date: date,
+) -> tuple[list[BacktestInput], dict[str, str], dict[str, str]]:
+    inputs: List[BacktestInput] = []
+    sources: Dict[str, str] = {}
+    errors: Dict[str, str] = {}
+    manager = None
+    manager_error = None
+
+    if not args.price_data_dir:
+        try:
+            manager = _get_manager()
+        except Exception as exc:
+            manager_error = f"{type(exc).__name__}: {exc}"
+
+    for code in codes:
+        try:
+            if manager_error:
+                raise RuntimeError(f"live data provider unavailable: {manager_error}")
+            if args.price_data_dir:
+                price_df = _load_price_from_csv(args.price_data_dir, code)
+                sources[code] = "csv"
+                stock_name = code
+            else:
+                price_df, source = _fetch_price_live(manager, code, start_date, end_date, args.years)
+                sources[code] = source
+                try:
+                    stock_name = manager.get_stock_name(code, allow_realtime=False) or code
+                except Exception:
+                    stock_name = code
+            valuation_df = _load_optional_csv(args.valuation_data_dir, code)
+            financial_df = _load_optional_csv(args.financial_data_dir, code)
+            inputs.append(
+                BacktestInput(
+                    code=code,
+                    stock_name=stock_name,
+                    price_df=prepare_price_frame(price_df),
+                    valuation_df=valuation_df,
+                    financial_df=financial_df,
+                )
+            )
+        except Exception as exc:
+            errors[code] = f"{type(exc).__name__}: {exc}"
+    return inputs, sources, errors
+
+
+def _load_benchmark(args: argparse.Namespace, start_date: date, end_date: date) -> tuple[Optional[pd.DataFrame], Optional[str]]:
+    try:
+        if args.benchmark_file:
+            return prepare_price_frame(_load_csv(Path(args.benchmark_file))), "csv"
+        if args.price_data_dir:
+            path = Path(args.price_data_dir) / f"{args.benchmark}.csv"
+            if path.exists():
+                return prepare_price_frame(_load_csv(path)), "csv"
+        manager = _get_manager()
+        df, source = _fetch_price_live(manager, args.benchmark, start_date, end_date, args.years)
+        return prepare_price_frame(df), source
+    except Exception as exc:
+        return None, f"{type(exc).__name__}: {exc}"
+
+
+def _infer_end_date(inputs: List[BacktestInput], fallback: Optional[str]) -> date:
+    if fallback:
+        return coerce_date(fallback)
+    max_dates = []
+    for item in inputs:
+        df = prepare_price_frame(item.price_df)
+        if not df.empty:
+            max_dates.append(max(df["date"]))
+    return min(max_dates) if max_dates else date.today()
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Run GenGe Cycle Bottom walk-forward backtest.")
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument("--codes", help="Comma-separated stock codes, e.g. 002714,000100")
+    group.add_argument("--stock-pool-file", help="Text file with one stock code per line")
+    parser.add_argument("--years", type=int, default=5, help="Backtest years, e.g. 5 or 10")
+    parser.add_argument("--benchmark", default="000300", help="Benchmark index code")
+    parser.add_argument("--output-dir", default="reports/genge_cycle_bottom", help="Report output directory")
+    parser.add_argument("--start-date", help="Backtest start date YYYY-MM-DD")
+    parser.add_argument("--end-date", help="Backtest end date YYYY-MM-DD")
+    parser.add_argument("--step-days", type=int, default=20, help="Signal scan interval in trading rows")
+    parser.add_argument("--price-data-dir", help="Optional CSV directory with <code>.csv price files")
+    parser.add_argument("--benchmark-file", help="Optional benchmark CSV file")
+    parser.add_argument("--valuation-data-dir", help="Optional CSV directory with valuation files")
+    parser.add_argument("--financial-data-dir", help="Optional CSV directory with financial files")
+    return parser
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    codes = _parse_codes(args.codes) + _read_stock_pool(args.stock_pool_file)
+    codes = list(dict.fromkeys(codes))
+    if not codes:
+        parser.error("no stock codes provided")
+
+    provisional_end = coerce_date(args.end_date) if args.end_date else date.today()
+    provisional_start = coerce_date(args.start_date) if args.start_date else date_years_ago(provisional_end, args.years + 1)
+    inputs, data_sources, data_errors = _load_inputs(
+        codes=codes,
+        args=args,
+        start_date=provisional_start,
+        end_date=provisional_end,
+    )
+    end_date = _infer_end_date(inputs, args.end_date)
+    start_date = coerce_date(args.start_date) if args.start_date else date_years_ago(end_date, args.years)
+    benchmark_df, benchmark_source_or_error = _load_benchmark(args, start_date, end_date)
+
+    rows = WalkForwardBacktester().run(
+        inputs=inputs,
+        benchmark_df=benchmark_df,
+        start_date=start_date,
+        end_date=end_date,
+        step_days=max(1, int(args.step_days)),
+    )
+    diagnostics = {
+        "requested_codes": codes,
+        "loaded_codes": [item.code for item in inputs],
+        "data_sources": data_sources,
+        "data_errors": data_errors,
+        "benchmark": args.benchmark,
+        "benchmark_source_or_error": benchmark_source_or_error,
+        "start_date": start_date.isoformat(),
+        "end_date": end_date.isoformat(),
+        "step_days": max(1, int(args.step_days)),
+    }
+    summary = compute_summary(rows, extra_diagnostics=diagnostics)
+    report_dir = write_reports(rows, summary, args.output_dir)
+    print(f"report_dir={report_dir}")
+    print(f"total_signals={summary['total_signals']}")
+    print(f"data_failures={len(data_errors)}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/strategies/genge_cycle_bottom/features.py
+++ b/src/strategies/genge_cycle_bottom/features.py
@@ -1,0 +1,381 @@
+"""Feature calculation for the GenGe Cycle Bottom Strategy.
+
+All feature helpers accept an explicit ``as_of_date`` and only inspect rows
+whose ``date`` is less than or equal to that date.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import date, datetime, timedelta
+import math
+from typing import Any, Dict, Iterable, List, Optional, Tuple
+
+import numpy as np
+import pandas as pd
+
+
+PRICE_MIN_OBSERVATIONS = 120
+TRADING_DAYS_PER_YEAR = 250
+
+
+@dataclass
+class FeatureSet:
+    as_of_date: date
+    close: Optional[float]
+    price_percentile_score: float = 0.0
+    valuation_score: float = 0.0
+    financial_safety_score: float = 0.0
+    trend_stabilization_score: float = 0.0
+    market_environment_score: float = 0.0
+    price_percentile_3y: Optional[float] = None
+    price_percentile_5y: Optional[float] = None
+    price_percentile_10y: Optional[float] = None
+    ma20: Optional[float] = None
+    ma60: Optional[float] = None
+    ma120: Optional[float] = None
+    ma250: Optional[float] = None
+    risk_flags: List[str] = field(default_factory=list)
+    missing_fields: List[str] = field(default_factory=list)
+    diagnostics: Dict[str, Any] = field(default_factory=dict)
+
+
+def coerce_date(value: Any) -> date:
+    if isinstance(value, date) and not isinstance(value, datetime):
+        return value
+    if isinstance(value, datetime):
+        return value.date()
+    return pd.to_datetime(value).date()
+
+
+def prepare_price_frame(price_df: pd.DataFrame) -> pd.DataFrame:
+    if price_df is None or price_df.empty:
+        return pd.DataFrame(columns=["date", "open", "high", "low", "close", "volume"])
+
+    df = price_df.copy()
+    if "date" not in df.columns:
+        raise ValueError("price data must include a date column")
+    df["date"] = pd.to_datetime(df["date"]).dt.date
+    for col in ("open", "high", "low", "close", "volume", "amount"):
+        if col in df.columns:
+            df[col] = pd.to_numeric(df[col], errors="coerce")
+    return df.sort_values("date").drop_duplicates(subset=["date"], keep="last").reset_index(drop=True)
+
+
+def slice_as_of(df: pd.DataFrame, as_of_date: Any) -> pd.DataFrame:
+    prepared = prepare_price_frame(df)
+    target = coerce_date(as_of_date)
+    return prepared[prepared["date"] <= target].copy().reset_index(drop=True)
+
+
+def finite_float(value: Any) -> Optional[float]:
+    try:
+        number = float(value)
+    except (TypeError, ValueError):
+        return None
+    if not math.isfinite(number):
+        return None
+    return number
+
+
+def percentile_rank(values: Iterable[float], current: float) -> Optional[float]:
+    series = pd.Series(list(values), dtype="float64").dropna()
+    current_value = finite_float(current)
+    if current_value is None or series.empty:
+        return None
+    return float((series <= current_value).sum() / len(series))
+
+
+def score_from_low_percentile(percentile: Optional[float]) -> float:
+    if percentile is None:
+        return 0.0
+    if percentile <= 0.2:
+        return 90.0
+    if percentile <= 0.35:
+        return 75.0
+    if percentile <= 0.5:
+        return 55.0
+    if percentile <= 0.7:
+        return 35.0
+    return 15.0
+
+
+def compute_price_percentile_score(history: pd.DataFrame, current_close: float) -> Tuple[float, Dict[str, Optional[float]], List[str]]:
+    percentiles: Dict[str, Optional[float]] = {}
+    missing: List[str] = []
+
+    for years in (3, 5, 10):
+        window = history.tail(years * TRADING_DAYS_PER_YEAR)
+        key = f"price_percentile_{years}y"
+        if len(window) < PRICE_MIN_OBSERVATIONS:
+            percentiles[key] = None
+            missing.append(key)
+            continue
+        percentiles[key] = percentile_rank(window["close"], current_close)
+
+    preferred = percentiles.get("price_percentile_5y")
+    if preferred is None:
+        preferred = percentiles.get("price_percentile_3y")
+    score = score_from_low_percentile(preferred)
+    if preferred is None:
+        score = 20.0
+    return score, percentiles, missing
+
+
+def _latest_row_as_of(df: Optional[pd.DataFrame], as_of_date: date, date_column: str = "date") -> Optional[pd.Series]:
+    if df is None or df.empty or date_column not in df.columns:
+        return None
+    local = df.copy()
+    local[date_column] = pd.to_datetime(local[date_column]).dt.date
+    local = local[local[date_column] <= as_of_date].sort_values(date_column)
+    if local.empty:
+        return None
+    return local.iloc[-1]
+
+
+def compute_valuation_score(valuation_df: Optional[pd.DataFrame], as_of_date: date) -> Tuple[float, List[str], Dict[str, Any]]:
+    missing: List[str] = []
+    diagnostics: Dict[str, Any] = {}
+    row = _latest_row_as_of(valuation_df, as_of_date)
+    if row is None:
+        return 35.0, ["valuation"], diagnostics
+
+    scores: List[float] = []
+    for field_name in ("pb", "pe", "ps", "market_cap"):
+        if field_name not in row.index:
+            missing.append(field_name)
+            continue
+        value = finite_float(row.get(field_name))
+        if value is None or value <= 0:
+            missing.append(field_name)
+            continue
+        diagnostics[field_name] = value
+        if field_name == "pb":
+            scores.append(90.0 if value <= 1.2 else 75.0 if value <= 2.0 else 50.0 if value <= 4.0 else 25.0)
+        elif field_name == "pe":
+            scores.append(85.0 if value <= 15 else 70.0 if value <= 30 else 45.0 if value <= 60 else 20.0)
+        elif field_name == "ps":
+            scores.append(80.0 if value <= 1.5 else 65.0 if value <= 3.0 else 45.0 if value <= 6.0 else 20.0)
+        else:
+            scores.append(50.0)
+
+    if not scores:
+        return 35.0, missing or ["valuation"], diagnostics
+    penalty = min(15.0, len(missing) * 3.0)
+    return max(0.0, float(np.mean(scores)) - penalty), missing, diagnostics
+
+
+def compute_financial_safety_score(financial_df: Optional[pd.DataFrame], as_of_date: date) -> Tuple[float, List[str], List[str], Dict[str, Any]]:
+    missing: List[str] = []
+    risk_flags: List[str] = []
+    diagnostics: Dict[str, Any] = {}
+    row = _latest_row_as_of(financial_df, as_of_date, date_column="report_date")
+    if row is None:
+        return 45.0, ["financial"], risk_flags, diagnostics
+
+    score = 70.0
+    debt_ratio = finite_float(row.get("debt_ratio")) if "debt_ratio" in row.index else None
+    net_profit = finite_float(row.get("net_profit")) if "net_profit" in row.index else None
+    operating_cash_flow = finite_float(row.get("operating_cash_flow")) if "operating_cash_flow" in row.index else None
+    roe = finite_float(row.get("roe")) if "roe" in row.index else None
+
+    if debt_ratio is None:
+        missing.append("debt_ratio")
+    else:
+        diagnostics["debt_ratio"] = debt_ratio
+        if debt_ratio >= 85:
+            score -= 35
+            risk_flags.append("debt_ratio_extreme")
+        elif debt_ratio >= 70:
+            score -= 20
+            risk_flags.append("debt_ratio_high")
+        elif debt_ratio <= 45:
+            score += 8
+
+    if net_profit is None:
+        missing.append("net_profit")
+    else:
+        diagnostics["net_profit"] = net_profit
+        if net_profit < 0:
+            score -= 30
+            risk_flags.append("loss_making")
+        elif net_profit > 0:
+            score += 6
+
+    if operating_cash_flow is None:
+        missing.append("operating_cash_flow")
+    else:
+        diagnostics["operating_cash_flow"] = operating_cash_flow
+        if operating_cash_flow < 0:
+            score -= 18
+            risk_flags.append("negative_operating_cash_flow")
+        elif operating_cash_flow > 0:
+            score += 6
+
+    if roe is None:
+        missing.append("roe")
+    else:
+        diagnostics["roe"] = roe
+        if roe < 0:
+            score -= 15
+            risk_flags.append("negative_roe")
+        elif roe >= 8:
+            score += 5
+
+    return max(0.0, min(100.0, score)), missing, risk_flags, diagnostics
+
+
+def _moving_average(history: pd.DataFrame, window: int) -> Optional[float]:
+    if len(history) < window:
+        return None
+    value = history["close"].tail(window).mean()
+    return finite_float(value)
+
+
+def compute_trend_stabilization_score(history: pd.DataFrame) -> Tuple[float, Dict[str, Optional[float]], List[str], List[str]]:
+    missing: List[str] = []
+    risk_flags: List[str] = []
+    diagnostics: Dict[str, Optional[float]] = {}
+    if history.empty or "close" not in history.columns:
+        return 0.0, diagnostics, ["daily_price"], ["missing_daily_price"]
+
+    close = finite_float(history.iloc[-1].get("close"))
+    if close is None:
+        return 0.0, diagnostics, ["close"], ["missing_close"]
+
+    ma20 = _moving_average(history, 20)
+    ma60 = _moving_average(history, 60)
+    ma120 = _moving_average(history, 120)
+    ma250 = _moving_average(history, 250)
+    diagnostics.update({"ma20": ma20, "ma60": ma60, "ma120": ma120, "ma250": ma250})
+
+    score = 35.0
+    for name, value in (("ma20", ma20), ("ma60", ma60), ("ma120", ma120), ("ma250", ma250)):
+        if value is None:
+            missing.append(name)
+
+    if ma20 is not None and close >= ma20:
+        score += 25
+    elif ma20 is not None:
+        score -= 10
+
+    if ma60 is not None and close >= ma60:
+        score += 20
+    elif ma60 is not None and close >= ma60 * 0.97:
+        score += 10
+
+    if len(history) >= 15:
+        recent = history.tail(15)
+        recent_return = (recent.iloc[-1]["close"] - recent.iloc[0]["close"]) / recent.iloc[0]["close"]
+        diagnostics["recent_15d_return"] = finite_float(recent_return)
+        if recent_return < -0.12:
+            score -= 25
+            risk_flags.append("accelerating_downtrend")
+        elif abs(recent_return) <= 0.08:
+            score += 8
+
+    if "volume" in history.columns and len(history) >= 40:
+        recent_vol = history["volume"].tail(5).mean()
+        base_vol = history["volume"].tail(40).head(35).mean()
+        if finite_float(recent_vol) is not None and finite_float(base_vol) is not None and base_vol > 0:
+            volume_ratio = float(recent_vol / base_vol)
+            diagnostics["volume_ratio_5d_vs_35d"] = volume_ratio
+            if 1.05 <= volume_ratio <= 1.8:
+                score += 10
+            elif volume_ratio > 2.5:
+                risk_flags.append("volume_spike")
+                score -= 5
+        else:
+            missing.append("volume")
+
+    return max(0.0, min(100.0, score)), diagnostics, missing, risk_flags
+
+
+def compute_market_environment_score(benchmark_history: Optional[pd.DataFrame], as_of_date: date) -> Tuple[float, List[str], Dict[str, Any]]:
+    if benchmark_history is None or benchmark_history.empty:
+        return 50.0, ["benchmark"], {}
+    history = slice_as_of(benchmark_history, as_of_date)
+    if history.empty:
+        return 50.0, ["benchmark"], {}
+    close = finite_float(history.iloc[-1].get("close"))
+    ma20 = _moving_average(history, 20)
+    ma60 = _moving_average(history, 60)
+    ma120 = _moving_average(history, 120)
+    diagnostics = {"benchmark_ma20": ma20, "benchmark_ma60": ma60, "benchmark_ma120": ma120}
+    if close is None or ma20 is None or ma60 is None:
+        return 50.0, ["benchmark_ma"], diagnostics
+
+    score = 45.0
+    if close >= ma20:
+        score += 15
+    if close >= ma60:
+        score += 20
+    if ma120 is not None and close >= ma120:
+        score += 10
+    if close < ma20 and close < ma60:
+        score -= 20
+    return max(0.0, min(100.0, score)), [], diagnostics
+
+
+def build_feature_set(
+    price_df: pd.DataFrame,
+    as_of_date: Any,
+    valuation_df: Optional[pd.DataFrame] = None,
+    financial_df: Optional[pd.DataFrame] = None,
+    benchmark_df: Optional[pd.DataFrame] = None,
+) -> FeatureSet:
+    target = coerce_date(as_of_date)
+    history = slice_as_of(price_df, target)
+    close = finite_float(history.iloc[-1].get("close")) if not history.empty else None
+    features = FeatureSet(as_of_date=target, close=close)
+
+    if close is None:
+        features.missing_fields.append("close")
+        features.risk_flags.append("missing_close")
+        return features
+
+    price_score, percentiles, price_missing = compute_price_percentile_score(history, close)
+    valuation_score, valuation_missing, valuation_diag = compute_valuation_score(valuation_df, target)
+    financial_score, financial_missing, financial_risks, financial_diag = compute_financial_safety_score(financial_df, target)
+    trend_score, trend_diag, trend_missing, trend_risks = compute_trend_stabilization_score(history)
+    market_score, market_missing, market_diag = compute_market_environment_score(benchmark_df, target)
+
+    features.price_percentile_score = price_score
+    features.valuation_score = valuation_score
+    features.financial_safety_score = financial_score
+    features.trend_stabilization_score = trend_score
+    features.market_environment_score = market_score
+    features.price_percentile_3y = percentiles.get("price_percentile_3y")
+    features.price_percentile_5y = percentiles.get("price_percentile_5y")
+    features.price_percentile_10y = percentiles.get("price_percentile_10y")
+    features.ma20 = trend_diag.get("ma20")
+    features.ma60 = trend_diag.get("ma60")
+    features.ma120 = trend_diag.get("ma120")
+    features.ma250 = trend_diag.get("ma250")
+    features.missing_fields = sorted(set(price_missing + valuation_missing + financial_missing + trend_missing + market_missing))
+    features.risk_flags = sorted(set(financial_risks + trend_risks))
+    features.diagnostics.update(valuation_diag)
+    features.diagnostics.update(financial_diag)
+    features.diagnostics.update(trend_diag)
+    features.diagnostics.update(market_diag)
+    return features
+
+
+def estimate_stop_loss(close: Optional[float], ma60: Optional[float]) -> Optional[float]:
+    close_value = finite_float(close)
+    if close_value is None:
+        return None
+    ma_stop = ma60 * 0.97 if ma60 else close_value * 0.9
+    return round(max(close_value * 0.88, ma_stop), 2)
+
+
+def estimate_take_profit(close: Optional[float]) -> Optional[float]:
+    close_value = finite_float(close)
+    if close_value is None:
+        return None
+    return round(close_value * 1.25, 2)
+
+
+def date_years_ago(end_date: date, years: int) -> date:
+    return end_date - timedelta(days=int(years * 365.25))
+

--- a/src/strategies/genge_cycle_bottom/metrics.py
+++ b/src/strategies/genge_cycle_bottom/metrics.py
@@ -1,0 +1,215 @@
+"""Metrics aggregation for GenGe Cycle Bottom walk-forward backtests."""
+
+from __future__ import annotations
+
+from collections import Counter
+from datetime import datetime, timezone
+from statistics import mean, median
+from typing import Any, Dict, Iterable, List, Optional
+
+from .backtest import EVAL_WINDOWS
+
+
+def _finite_number(value: Any) -> Optional[float]:
+    try:
+        number = float(value)
+    except (TypeError, ValueError):
+        return None
+    if number != number:
+        return None
+    return number
+
+
+def _numbers(rows: Iterable[Dict[str, Any]], field_name: str) -> List[float]:
+    values: List[float] = []
+    for row in rows:
+        number = _finite_number(row.get(field_name))
+        if number is not None:
+            values.append(number)
+    return values
+
+
+def _ratio_true(rows: Iterable[Dict[str, Any]], field_name: str) -> Optional[float]:
+    values = [row.get(field_name) for row in rows if row.get(field_name) is not None]
+    if not values:
+        return None
+    return round(sum(1 for value in values if bool(value)) / len(values) * 100, 4)
+
+
+def _win_rate(rows: Iterable[Dict[str, Any]], field_name: str) -> Optional[float]:
+    values = _numbers(rows, field_name)
+    if not values:
+        return None
+    return round(sum(1 for value in values if value > 0) / len(values) * 100, 4)
+
+
+def _win_record(rows: Iterable[Dict[str, Any]], field_name: str) -> Dict[str, Optional[float]]:
+    values = _numbers(rows, field_name)
+    if not values:
+        return {"count": 0, "total": 0, "rate_pct": None}
+    win_count = sum(1 for value in values if value > 0)
+    return {
+        "count": win_count,
+        "total": len(values),
+        "rate_pct": round(win_count / len(values) * 100, 4),
+    }
+
+
+def _avg(values: List[float]) -> Optional[float]:
+    return round(mean(values), 4) if values else None
+
+
+def _median(values: List[float]) -> Optional[float]:
+    return round(median(values), 4) if values else None
+
+
+def _split_flags(rows: Iterable[Dict[str, Any]], field_name: str) -> Dict[str, int]:
+    counter: Counter[str] = Counter()
+    for row in rows:
+        raw = row.get(field_name) or ""
+        if isinstance(raw, (list, tuple, set)):
+            parts = raw
+        else:
+            parts = str(raw).split(";")
+        for part in parts:
+            name = str(part).strip()
+            if name:
+                counter[name] += 1
+    return dict(counter.most_common())
+
+
+def _max_consecutive_losses(rows: List[Dict[str, Any]], return_field: str = "future_return_60d") -> int:
+    ordered = sorted(rows, key=lambda row: (str(row.get("as_of_date") or ""), str(row.get("code") or "")))
+    worst_run = 0
+    current_run = 0
+    for row in ordered:
+        value = _finite_number(row.get(return_field))
+        if value is None:
+            continue
+        if value < 0:
+            current_run += 1
+            worst_run = max(worst_run, current_run)
+        else:
+            current_run = 0
+    return worst_run
+
+
+def _signal_snapshot(row: Dict[str, Any], return_field: str) -> Dict[str, Any]:
+    return {
+        "code": row.get("code"),
+        "stock_name": row.get("stock_name"),
+        "as_of_date": row.get("as_of_date"),
+        "signal_type": row.get("signal_type"),
+        "total_score": row.get("total_score"),
+        return_field: row.get(return_field),
+        "max_drawdown_250d": row.get("max_drawdown_250d"),
+        "risk_flags": row.get("risk_flags"),
+    }
+
+
+def _ranked_signals(rows: List[Dict[str, Any]], return_field: str = "future_return_60d") -> tuple[list[dict], list[dict]]:
+    available = [row for row in rows if _finite_number(row.get(return_field)) is not None]
+    if not available:
+        return [], []
+    ordered = sorted(available, key=lambda row: float(row[return_field]))
+    worst = [_signal_snapshot(row, return_field) for row in ordered[:5]]
+    best = [_signal_snapshot(row, return_field) for row in reversed(ordered[-5:])]
+    return best, worst
+
+
+def _best_signal_type(rows: List[Dict[str, Any]]) -> Optional[str]:
+    grouped: Dict[str, List[float]] = {}
+    for row in rows:
+        signal_type = str(row.get("signal_type") or "")
+        value = _finite_number(row.get("future_return_60d"))
+        if signal_type and value is not None:
+            grouped.setdefault(signal_type, []).append(value)
+    if not grouped:
+        return None
+    return max(grouped, key=lambda key: mean(grouped[key]))
+
+
+def _best_horizon(summary: Dict[str, Any]) -> Optional[str]:
+    candidates = {
+        f"{days}d": summary.get(f"avg_return_{days}d")
+        for days in EVAL_WINDOWS
+        if summary.get(f"avg_return_{days}d") is not None
+    }
+    if not candidates:
+        return None
+    return max(candidates, key=lambda key: float(candidates[key]))
+
+
+def compute_summary(
+    rows: List[Dict[str, Any]],
+    extra_diagnostics: Optional[Dict[str, Any]] = None,
+) -> Dict[str, Any]:
+    """Aggregate signal rows into the required summary.json contract."""
+
+    summary: Dict[str, Any] = {
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "total_signals": len(rows),
+        "signals_by_type": dict(Counter(str(row.get("signal_type") or "UNKNOWN") for row in rows)),
+    }
+
+    for days in EVAL_WINDOWS:
+        return_field = f"future_return_{days}d"
+        drawdown_field = f"max_drawdown_{days}d"
+        returns = _numbers(rows, return_field)
+        summary[f"win_rate_{days}d"] = _win_rate(rows, return_field)
+        summary[f"avg_return_{days}d"] = _avg(returns)
+        summary[f"median_return_{days}d"] = _median(returns)
+        summary[f"outperform_benchmark_rate_{days}d"] = _ratio_true(rows, f"outperform_benchmark_{days}d")
+        summary[f"avg_max_drawdown_{days}d"] = _avg(_numbers(rows, drawdown_field))
+
+    drawdowns = _numbers(rows, "max_drawdown_250d")
+    if not drawdowns:
+        for days in EVAL_WINDOWS:
+            drawdowns.extend(_numbers(rows, f"max_drawdown_{days}d"))
+    best_signals, worst_signals = _ranked_signals(rows)
+    diagnostics = {
+        "missing_fields": _split_flags(rows, "missing_fields"),
+        "risk_flags": _split_flags(rows, "risk_flags"),
+        "best_signal_type_by_avg_60d_return": _best_signal_type(rows),
+        "best_return_horizon_by_average": _best_horizon(summary),
+    }
+    if extra_diagnostics:
+        diagnostics.update(extra_diagnostics)
+
+    summary.update(
+        {
+            "avg_max_drawdown": _avg(drawdowns),
+            "max_drawdown_worst": min(drawdowns) if drawdowns else None,
+            "max_consecutive_losses": _max_consecutive_losses(rows),
+            "best_signals": best_signals,
+            "worst_signals": worst_signals,
+            "wins": {
+                f"{days}d": _win_record(rows, f"future_return_{days}d")
+                for days in EVAL_WINDOWS
+            },
+            "avg_returns": {
+                f"{days}d": summary.get(f"avg_return_{days}d")
+                for days in EVAL_WINDOWS
+            },
+            "median_returns": {
+                f"{days}d": summary.get(f"median_return_{days}d")
+                for days in EVAL_WINDOWS
+            },
+            "drawdown": {
+                "avg_max_drawdown_pct": _avg(drawdowns),
+                "worst_max_drawdown_pct": min(drawdowns) if drawdowns else None,
+                "by_horizon_avg_pct": {
+                    f"{days}d": summary.get(f"avg_max_drawdown_{days}d")
+                    for days in EVAL_WINDOWS
+                },
+            },
+            "benchmark_outperform": {
+                f"{days}d": summary.get(f"outperform_benchmark_rate_{days}d")
+                for days in EVAL_WINDOWS
+            },
+            "best": best_signals,
+            "worst": worst_signals,
+            "diagnostics": diagnostics,
+        }
+    )
+    return summary

--- a/src/strategies/genge_cycle_bottom/report.py
+++ b/src/strategies/genge_cycle_bottom/report.py
@@ -1,0 +1,138 @@
+"""Report writers for GenGe Cycle Bottom Strategy."""
+
+from __future__ import annotations
+
+import csv
+import json
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict, List
+
+
+SIGNAL_DETAIL_COLUMNS = [
+    "code",
+    "stock_name",
+    "as_of_date",
+    "signal_type",
+    "total_score",
+    "price_percentile_score",
+    "valuation_score",
+    "financial_safety_score",
+    "trend_stabilization_score",
+    "market_environment_score",
+    "stop_loss",
+    "take_profit",
+    "max_position_pct",
+    "future_return_20d",
+    "future_return_60d",
+    "future_return_120d",
+    "future_return_250d",
+    "max_drawdown_20d",
+    "max_drawdown_60d",
+    "max_drawdown_120d",
+    "max_drawdown_250d",
+    "benchmark_return_20d",
+    "benchmark_return_60d",
+    "benchmark_return_120d",
+    "benchmark_return_250d",
+    "outperform_benchmark_20d",
+    "outperform_benchmark_60d",
+    "outperform_benchmark_120d",
+    "outperform_benchmark_250d",
+    "hit_stop_loss",
+    "risk_flags",
+    "missing_fields",
+    "invalidation_reason",
+    "explanation",
+]
+
+
+def _run_dir(output_dir: str | Path) -> Path:
+    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+    path = Path(output_dir) / timestamp
+    path.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+def _format_pct(value: Any) -> str:
+    if value is None:
+        return "无可用数据"
+    try:
+        return f"{float(value):.2f}%"
+    except (TypeError, ValueError):
+        return str(value)
+
+
+def _format_value(value: Any) -> str:
+    if value is None:
+        return "无可用数据"
+    return str(value)
+
+
+def _conclusion(summary: Dict[str, Any]) -> str:
+    total = int(summary.get("total_signals") or 0)
+    avg_60d = summary.get("avg_return_60d")
+    win_60d = summary.get("win_rate_60d")
+    drawdown = summary.get("avg_max_drawdown")
+    if total == 0:
+        return "第一版结论：样本未触发可验证信号，需要扩大股票池、补充估值/财务数据后继续研究。"
+    if avg_60d is not None and win_60d is not None and avg_60d > 0 and win_60d >= 50:
+        return "第一版结论：样本呈现正向迹象，可继续研究，但仍需扩大样本和检查交易成本。"
+    if drawdown is not None and drawdown < -20:
+        return "第一版结论：回撤压力偏大，需要调整过滤和风控参数，暂不适合直接实盘。"
+    return "第一版结论：结果仍需调整和复核，暂不适合直接实盘。"
+
+
+def write_signal_details(rows: List[Dict[str, Any]], path: Path) -> None:
+    with path.open("w", newline="", encoding="utf-8") as file:
+        writer = csv.DictWriter(file, fieldnames=SIGNAL_DETAIL_COLUMNS, extrasaction="ignore")
+        writer.writeheader()
+        for row in rows:
+            writer.writerow({column: row.get(column) for column in SIGNAL_DETAIL_COLUMNS})
+
+
+def write_summary_markdown(summary: Dict[str, Any], path: Path) -> None:
+    diagnostics = summary.get("diagnostics") or {}
+    missing_fields = diagnostics.get("missing_fields") or {}
+    risk_flags = diagnostics.get("risk_flags") or {}
+    best_signal_type = diagnostics.get("best_signal_type_by_avg_60d_return") or "无可用数据"
+    best_horizon = diagnostics.get("best_return_horizon_by_average") or "无可用数据"
+
+    lines = [
+        "# 根哥周期底部硬逻辑策略 - 第一版回测摘要",
+        "",
+        "## 核心结果",
+        "",
+        f"- 触发可验证信号数量：{summary.get('total_signals', 0)}",
+        f"- 信号分布：{json.dumps(summary.get('signals_by_type', {}), ensure_ascii=False)}",
+        f"- 表现较好的信号类型：{best_signal_type}",
+        f"- 平均收益较好的验证周期：{best_horizon}",
+        f"- 20 日胜率 / 平均收益 / 中位数收益：{_format_pct(summary.get('win_rate_20d'))} / {_format_pct(summary.get('avg_return_20d'))} / {_format_pct(summary.get('median_return_20d'))}",
+        f"- 60 日胜率 / 平均收益 / 中位数收益：{_format_pct(summary.get('win_rate_60d'))} / {_format_pct(summary.get('avg_return_60d'))} / {_format_pct(summary.get('median_return_60d'))}",
+        f"- 120 日胜率 / 平均收益 / 中位数收益：{_format_pct(summary.get('win_rate_120d'))} / {_format_pct(summary.get('avg_return_120d'))} / {_format_pct(summary.get('median_return_120d'))}",
+        f"- 250 日胜率 / 平均收益 / 中位数收益：{_format_pct(summary.get('win_rate_250d'))} / {_format_pct(summary.get('avg_return_250d'))} / {_format_pct(summary.get('median_return_250d'))}",
+        f"- 平均最大回撤：{_format_pct(summary.get('avg_max_drawdown'))}",
+        f"- 最差最大回撤：{_format_pct(summary.get('max_drawdown_worst'))}",
+        f"- 20/60/120/250 日跑赢基准比例：{_format_pct(summary.get('outperform_benchmark_rate_20d'))} / {_format_pct(summary.get('outperform_benchmark_rate_60d'))} / {_format_pct(summary.get('outperform_benchmark_rate_120d'))} / {_format_pct(summary.get('outperform_benchmark_rate_250d'))}",
+        f"- 最大连续亏损次数：{_format_value(summary.get('max_consecutive_losses'))}",
+        "",
+        "## 风险与缺失",
+        "",
+        f"- 主要风险标签：{json.dumps(risk_flags, ensure_ascii=False) if risk_flags else '无'}",
+        f"- 数据缺失字段：{json.dumps(missing_fields, ensure_ascii=False) if missing_fields else '无'}",
+        "",
+        "## 第一版判断",
+        "",
+        _conclusion(summary),
+        "",
+        "说明：本报告只做历史信号验证，不构成投资建议，不接入券商账户，不自动下单。",
+    ]
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def write_reports(rows: List[Dict[str, Any]], summary: Dict[str, Any], output_dir: str | Path) -> Path:
+    path = _run_dir(output_dir)
+    write_signal_details(rows, path / "signal_details.csv")
+    (path / "summary.json").write_text(json.dumps(summary, ensure_ascii=False, indent=2), encoding="utf-8")
+    write_summary_markdown(summary, path / "summary.md")
+    return path

--- a/src/strategies/genge_cycle_bottom/signals.py
+++ b/src/strategies/genge_cycle_bottom/signals.py
@@ -1,0 +1,50 @@
+"""Signal contracts for the GenGe Cycle Bottom Strategy."""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+from enum import Enum
+from typing import Any, Dict, List, Optional
+
+
+class SignalType(str, Enum):
+    REJECT = "REJECT"
+    WATCH = "WATCH"
+    LEFT_SMALL_BUY = "LEFT_SMALL_BUY"
+    CONFIRM_BUY = "CONFIRM_BUY"
+    HOLD = "HOLD"
+    ADD = "ADD"
+    REDUCE = "REDUCE"
+    SELL = "SELL"
+
+
+SIGNAL_TYPES = tuple(item.value for item in SignalType)
+
+
+@dataclass
+class StrategySignal:
+    code: str
+    stock_name: str
+    as_of_date: str
+    signal_type: SignalType
+    total_score: float
+    price_percentile_score: float
+    valuation_score: float
+    financial_safety_score: float
+    trend_stabilization_score: float
+    market_environment_score: float
+    risk_flags: List[str] = field(default_factory=list)
+    missing_fields: List[str] = field(default_factory=list)
+    stop_loss: Optional[float] = None
+    take_profit: Optional[float] = None
+    invalidation_reason: str = ""
+    max_position_pct: float = 0.0
+    explanation: str = ""
+
+    def to_dict(self) -> Dict[str, Any]:
+        data = asdict(self)
+        data["signal_type"] = self.signal_type.value
+        data["risk_flags"] = ";".join(self.risk_flags)
+        data["missing_fields"] = ";".join(self.missing_fields)
+        return data
+

--- a/src/strategies/genge_cycle_bottom/strategy.py
+++ b/src/strategies/genge_cycle_bottom/strategy.py
@@ -1,0 +1,144 @@
+"""Deterministic GenGe Cycle Bottom Strategy logic."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, Optional
+
+import pandas as pd
+
+from .features import FeatureSet, build_feature_set, estimate_stop_loss, estimate_take_profit
+from .signals import SignalType, StrategySignal
+
+
+REJECT_RISK_FLAGS = {"st_or_delisting_risk", "loss_making"}
+WATCH_CAP_RISK_FLAGS = {"debt_ratio_high", "debt_ratio_extreme", "negative_operating_cash_flow"}
+
+
+@dataclass(frozen=True)
+class StrategyConfig:
+    max_single_position_pct: float = 20.0
+    left_small_buy_position_pct: float = 5.0
+    confirm_buy_position_pct: float = 10.0
+
+
+class GenGeCycleBottomStrategy:
+    """Pure-logic signal generator.
+
+    The strategy never reads future bars. Future returns are calculated only by
+    the backtest module after this class has emitted a signal.
+    """
+
+    def __init__(self, config: Optional[StrategyConfig] = None):
+        self.config = config or StrategyConfig()
+
+    def generate_signal(
+        self,
+        *,
+        code: str,
+        stock_name: str,
+        as_of_date,
+        price_df: pd.DataFrame,
+        valuation_df: Optional[pd.DataFrame] = None,
+        financial_df: Optional[pd.DataFrame] = None,
+        benchmark_df: Optional[pd.DataFrame] = None,
+        extra_risk_flags: Optional[Iterable[str]] = None,
+    ) -> StrategySignal:
+        features = build_feature_set(
+            price_df=price_df,
+            as_of_date=as_of_date,
+            valuation_df=valuation_df,
+            financial_df=financial_df,
+            benchmark_df=benchmark_df,
+        )
+        risk_flags = sorted(set(features.risk_flags + list(extra_risk_flags or [])))
+        total_score = self._total_score(features)
+        signal_type = self._classify(total_score, features, risk_flags)
+        max_position_pct = self._position_for_signal(signal_type)
+        invalidation_reason = self._invalidation_reason(features, risk_flags)
+
+        return StrategySignal(
+            code=code,
+            stock_name=stock_name or code,
+            as_of_date=features.as_of_date.isoformat(),
+            signal_type=signal_type,
+            total_score=round(total_score, 2),
+            price_percentile_score=round(features.price_percentile_score, 2),
+            valuation_score=round(features.valuation_score, 2),
+            financial_safety_score=round(features.financial_safety_score, 2),
+            trend_stabilization_score=round(features.trend_stabilization_score, 2),
+            market_environment_score=round(features.market_environment_score, 2),
+            risk_flags=risk_flags,
+            missing_fields=features.missing_fields,
+            stop_loss=estimate_stop_loss(features.close, features.ma60) if max_position_pct > 0 else None,
+            take_profit=estimate_take_profit(features.close) if max_position_pct > 0 else None,
+            invalidation_reason=invalidation_reason,
+            max_position_pct=max_position_pct,
+            explanation=self._explain(features, total_score, signal_type),
+        )
+
+    @staticmethod
+    def _total_score(features: FeatureSet) -> float:
+        return (
+            features.price_percentile_score * 0.28
+            + features.valuation_score * 0.18
+            + features.financial_safety_score * 0.22
+            + features.trend_stabilization_score * 0.22
+            + features.market_environment_score * 0.10
+        )
+
+    @staticmethod
+    def _classify(total_score: float, features: FeatureSet, risk_flags: list[str]) -> SignalType:
+        if "st_or_delisting_risk" in risk_flags or "debt_ratio_extreme" in risk_flags:
+            return SignalType.REJECT
+        if "loss_making" in risk_flags and features.financial_safety_score < 45:
+            return SignalType.REJECT
+
+        if total_score < 50:
+            signal = SignalType.REJECT
+        elif total_score < 65:
+            signal = SignalType.WATCH
+        elif total_score < 78:
+            signal = SignalType.LEFT_SMALL_BUY
+        elif features.trend_stabilization_score >= 72:
+            signal = SignalType.CONFIRM_BUY
+        else:
+            signal = SignalType.LEFT_SMALL_BUY
+
+        if any(flag in WATCH_CAP_RISK_FLAGS for flag in risk_flags) and signal not in (SignalType.REJECT, SignalType.WATCH):
+            return SignalType.WATCH
+        if features.market_environment_score < 35 and signal == SignalType.CONFIRM_BUY:
+            return SignalType.LEFT_SMALL_BUY
+        return signal
+
+    def _position_for_signal(self, signal_type: SignalType) -> float:
+        if signal_type == SignalType.LEFT_SMALL_BUY:
+            return min(self.config.left_small_buy_position_pct, self.config.max_single_position_pct)
+        if signal_type == SignalType.CONFIRM_BUY:
+            return min(self.config.confirm_buy_position_pct, self.config.max_single_position_pct)
+        if signal_type == SignalType.ADD:
+            return min(15.0, self.config.max_single_position_pct)
+        return 0.0
+
+    @staticmethod
+    def _invalidation_reason(features: FeatureSet, risk_flags: list[str]) -> str:
+        reasons: list[str] = []
+        if features.ma20 is not None:
+            reasons.append("收盘价重新跌破 MA20 且三日无法收回")
+        if features.ma60 is not None:
+            reasons.append("跌破 MA60 或低位平台下沿")
+        if any(flag in risk_flags for flag in ("loss_making", "negative_operating_cash_flow", "debt_ratio_extreme")):
+            reasons.append("财务安全边际恶化")
+        return "；".join(reasons) or "低位修复逻辑失效或数据质量不足"
+
+    @staticmethod
+    def _explain(features: FeatureSet, total_score: float, signal_type: SignalType) -> str:
+        percentile = features.price_percentile_5y
+        percentile_text = "估值/价格分位数据不足" if percentile is None else f"5年价格分位约 {percentile:.1%}"
+        trend_text = "趋势已有右侧确认" if features.trend_stabilization_score >= 72 else "趋势仍偏观察"
+        return (
+            f"{percentile_text}，技术止跌分 {features.trend_stabilization_score:.1f}，"
+            f"财务安全分 {features.financial_safety_score:.1f}，总分 {total_score:.1f}，"
+            f"信号为 {signal_type.value}；{trend_text}。"
+        )
+

--- a/tests/test_genge_cycle_bottom_backtest.py
+++ b/tests/test_genge_cycle_bottom_backtest.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+from datetime import date, timedelta
+
+import pandas as pd
+
+from src.strategies.genge_cycle_bottom.backtest import evaluate_signal_forward
+from src.strategies.genge_cycle_bottom.signals import SignalType, StrategySignal
+
+
+def _price_frame(closes: list[float], start: date = date(2024, 1, 1)) -> pd.DataFrame:
+    rows = []
+    for offset, close in enumerate(closes):
+        rows.append(
+            {
+                "date": (start + timedelta(days=offset)).isoformat(),
+                "open": close,
+                "high": close + 1,
+                "low": close - 1,
+                "close": close,
+                "volume": 1_000_000,
+            }
+        )
+    return pd.DataFrame(rows)
+
+
+def _signal(as_of_date: str) -> StrategySignal:
+    return StrategySignal(
+        code="000001",
+        stock_name="测试股票",
+        as_of_date=as_of_date,
+        signal_type=SignalType.LEFT_SMALL_BUY,
+        total_score=70.0,
+        price_percentile_score=80.0,
+        valuation_score=70.0,
+        financial_safety_score=70.0,
+        trend_stabilization_score=70.0,
+        market_environment_score=60.0,
+        stop_loss=93.0,
+        max_position_pct=5.0,
+    )
+
+
+def test_forward_returns_drawdown_and_benchmark_are_calculated() -> None:
+    closes = [100.0] + [95.0] + [100.0] * 18 + [110.0] + [112.0] * 40 + [120.0] * 60 + [130.0] * 130
+    benchmark_closes = [100.0] + [100.0] * 19 + [105.0] + [106.0] * 230
+    price_df = _price_frame(closes)
+    benchmark_df = _price_frame(benchmark_closes)
+
+    result = evaluate_signal_forward(_signal("2024-01-01"), price_df, benchmark_df)
+
+    assert result["future_return_20d"] == 10.0
+    assert result["max_drawdown_20d"] == -5.0
+    assert result["benchmark_return_20d"] == 5.0
+    assert result["outperform_benchmark_20d"] is True
+    assert result["hit_stop_loss"] is False
+
+
+def test_forward_metrics_return_none_when_future_window_is_missing() -> None:
+    price_df = _price_frame([100.0, 101.0, 102.0])
+
+    result = evaluate_signal_forward(_signal("2024-01-01"), price_df)
+
+    assert result["future_return_20d"] is None
+    assert result["max_drawdown_20d"] is None
+    assert result["benchmark_return_20d"] is None
+    assert result["outperform_benchmark_20d"] is None

--- a/tests/test_genge_cycle_bottom_features.py
+++ b/tests/test_genge_cycle_bottom_features.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+from datetime import date, timedelta
+
+import pandas as pd
+
+from src.strategies.genge_cycle_bottom.features import build_feature_set, compute_price_percentile_score
+
+
+def _price_frame(closes: list[float], start: date = date(2020, 1, 1)) -> pd.DataFrame:
+    rows = []
+    for offset, close in enumerate(closes):
+        current_date = start + timedelta(days=offset)
+        rows.append(
+            {
+                "date": current_date.isoformat(),
+                "open": close,
+                "high": close * 1.02,
+                "low": close * 0.98,
+                "close": close,
+                "volume": 1_000_000 + offset * 1000,
+            }
+        )
+    return pd.DataFrame(rows)
+
+
+def test_price_percentile_low_price_scores_higher_than_high_price() -> None:
+    low_history = _price_frame([100 + index for index in range(199)] + [110])
+    high_history = _price_frame([100 + index for index in range(199)] + [295])
+
+    low_score, low_percentiles, low_missing = compute_price_percentile_score(low_history, 110)
+    high_score, high_percentiles, high_missing = compute_price_percentile_score(high_history, 295)
+
+    assert low_score > high_score
+    assert low_percentiles["price_percentile_5y"] < 0.2
+    assert high_percentiles["price_percentile_5y"] > 0.7
+    assert low_missing == []
+    assert high_missing == []
+
+
+def test_price_percentile_marks_missing_when_history_is_short() -> None:
+    history = _price_frame([10 + index for index in range(50)])
+
+    score, percentiles, missing = compute_price_percentile_score(history, 59)
+
+    assert score == 20.0
+    assert percentiles["price_percentile_3y"] is None
+    assert "price_percentile_3y" in missing
+    assert "price_percentile_5y" in missing
+    assert "price_percentile_10y" in missing
+
+
+def test_missing_valuation_and_financial_data_do_not_crash_and_are_recorded() -> None:
+    price_df = _price_frame([20 - index * 0.02 for index in range(140)])
+
+    features = build_feature_set(price_df=price_df, as_of_date=price_df.iloc[-1]["date"])
+
+    assert features.valuation_score == 35.0
+    assert features.financial_safety_score == 45.0
+    assert "valuation" in features.missing_fields
+    assert "financial" in features.missing_fields
+    assert "benchmark" in features.missing_fields

--- a/tests/test_genge_cycle_bottom_no_lookahead.py
+++ b/tests/test_genge_cycle_bottom_no_lookahead.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+from datetime import date, timedelta
+
+import pandas as pd
+
+from src.strategies.genge_cycle_bottom.strategy import GenGeCycleBottomStrategy
+
+
+def _price_frame(closes: list[float], start: date = date(2020, 1, 1)) -> pd.DataFrame:
+    rows = []
+    for offset, close in enumerate(closes):
+        rows.append(
+            {
+                "date": (start + timedelta(days=offset)).isoformat(),
+                "open": close,
+                "high": close * 1.02,
+                "low": close * 0.98,
+                "close": close,
+                "volume": 1_000_000 + offset * 100,
+            }
+        )
+    return pd.DataFrame(rows)
+
+
+def test_signal_generation_does_not_use_future_price_bars() -> None:
+    historical_closes = [20 - index * 0.03 for index in range(150)]
+    future_spike = [40.0, 42.0, 44.0, 46.0, 48.0]
+    truncated_df = _price_frame(historical_closes)
+    with_future_df = _price_frame(historical_closes + future_spike)
+    as_of_date = truncated_df.iloc[-1]["date"]
+    strategy = GenGeCycleBottomStrategy()
+
+    signal_without_future = strategy.generate_signal(
+        code="000001",
+        stock_name="测试股票",
+        as_of_date=as_of_date,
+        price_df=truncated_df,
+    )
+    signal_with_future = strategy.generate_signal(
+        code="000001",
+        stock_name="测试股票",
+        as_of_date=as_of_date,
+        price_df=with_future_df,
+    )
+
+    assert signal_without_future.signal_type == signal_with_future.signal_type
+    assert signal_without_future.total_score == signal_with_future.total_score
+    assert signal_without_future.price_percentile_score == signal_with_future.price_percentile_score
+    assert signal_without_future.trend_stabilization_score == signal_with_future.trend_stabilization_score

--- a/tests/test_genge_cycle_bottom_strategy.py
+++ b/tests/test_genge_cycle_bottom_strategy.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from datetime import date
+
+from src.strategies.genge_cycle_bottom.features import FeatureSet
+from src.strategies.genge_cycle_bottom.signals import SignalType
+from src.strategies.genge_cycle_bottom.strategy import GenGeCycleBottomStrategy
+
+
+def _feature(trend_score: float = 70.0, financial_score: float = 70.0) -> FeatureSet:
+    return FeatureSet(
+        as_of_date=date(2024, 1, 1),
+        close=10.0,
+        financial_safety_score=financial_score,
+        trend_stabilization_score=trend_score,
+        market_environment_score=60.0,
+    )
+
+
+def test_signal_classification_thresholds() -> None:
+    strategy = GenGeCycleBottomStrategy()
+
+    assert strategy._classify(49.9, _feature(), []) == SignalType.REJECT
+    assert strategy._classify(55.0, _feature(), []) == SignalType.WATCH
+    assert strategy._classify(70.0, _feature(), []) == SignalType.LEFT_SMALL_BUY
+    assert strategy._classify(80.0, _feature(trend_score=80.0), []) == SignalType.CONFIRM_BUY
+
+
+def test_risk_flags_cap_or_reject_signal() -> None:
+    strategy = GenGeCycleBottomStrategy()
+
+    assert strategy._classify(80.0, _feature(trend_score=80.0), ["debt_ratio_high"]) == SignalType.WATCH
+    assert strategy._classify(80.0, _feature(trend_score=80.0), ["debt_ratio_extreme"]) == SignalType.REJECT
+    assert strategy._classify(80.0, _feature(trend_score=80.0, financial_score=30.0), ["loss_making"]) == SignalType.REJECT


### PR DESCRIPTION
## What changed

- Add an independent `src.strategies.genge_cycle_bottom` strategy package for deterministic A-share cycle-bottom signal generation.
- Add walk-forward validation with 20/60/120/250-day future returns, drawdown, benchmark comparison, and no-lookahead boundaries.
- Add CSV/JSON/Markdown report writers and CLI entrypoint for 5-year/10-year runs.
- Add focused tests for features, strategy classification, backtest metrics, and no-lookahead behavior.
- Add first-phase implementation plan and usage documentation.

## Safety scope

This module only reads public market/fundamental data or local CSV inputs. It does not connect to brokers, read accounts, place orders, cancel orders, or use an LLM to make trading decisions.

## Validation

- `/Users/seker./.cache/codex-runtimes/codex-primary-runtime/dependencies/python/bin/python3 -m compileall src/strategies/genge_cycle_bottom`
- `/Users/seker./.cache/codex-runtimes/codex-primary-runtime/dependencies/python/bin/python3 -m pytest tests/test_genge_cycle_bottom_features.py tests/test_genge_cycle_bottom_strategy.py tests/test_genge_cycle_bottom_backtest.py tests/test_genge_cycle_bottom_no_lookahead.py`

Result: 8 passed, 1 third-party warning from `fastapi.testclient` / Starlette.