### PR TITLE
feat: 数据源健康告警 + 死代码/未用导入清理与静默异常诊断

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,7 +20,11 @@ ANSPIRE_API_KEYS=
 # ANSPIRE_LLM_BASE_URL=https://open-gateway.anspire.cn/v6
 # ANSPIRE_LLM_ENABLED=true
 # 数据源配置
-# Tushare Pro Token（可选，从 https://tushare.pro/weborder/#/login?reg=834638 获取）
+# 稳定性建议：默认 A股/港股/美股日线均依赖免费爬取源（efinance/akshare/yfinance 等），
+# 上游一旦变更反爬策略或接口即可能整源失效。配置下方带 token 的官方源后，DSA 会自动把它们
+# 注册为对应市场的兜底数据源，把“免费爬取”从唯一依赖降级为“首选 + 稳定兜底”，显著降低
+# 整市场数据源同时失效的风险（A股建议配 TUSHARE_TOKEN，美股建议配 FINNHUB / ALPHAVANTAGE）。
+# Tushare Pro Token（可选但推荐，A股稳定兜底源，从 https://tushare.pro/weborder/#/login?reg=834638 获取）
 TUSHARE_TOKEN=
 # TickFlow API Key（可选，用于 A 股大盘复盘指数增强；若套餐支持标的池查询，也可增强市场统计）
 # TICKFLOW_API_KEY=
@@ -55,11 +59,13 @@ ALPHASIFT_INSTALL_SPEC=git+https://github.com/ZhuLinsen/alphasift.git@377049857c
 # AlphaSift LLM 重排请求输出上限；仅影响 AlphaSift 选股重排，默认 2048。
 # LLM_MAX_TOKENS=2048
 
-# Finnhub（可选，美股数据源，免费 tier 60 calls/min）
+# Finnhub（可选但推荐，美股稳定兜底源，免费 tier 60 calls/min）
+# 配置后自动注册为美股日线兜底源，降低对 yfinance 免费爬取的单点依赖。
 # 获取: https://finnhub.io/register
 # FINNHUB_API_KEY=
 
-# AlphaVantage（可选，美股数据源，免费 tier 25 calls/day）
+# AlphaVantage（可选，美股稳定兜底源，免费 tier 25 calls/day）
+# 配置后自动注册为美股日线兜底源（在 Finnhub 之后、yfinance 之前）。
 # 获取: https://www.alphavantage.co/support/#api-key
 # ALPHAVANTAGE_API_KEY=
 

--- a/api/v1/endpoints/analysis.py
+++ b/api/v1/endpoints/analysis.py
@@ -71,7 +71,6 @@ from src.analysis_context_pack_overview import (
     sanitize_context_snapshot_for_api,
 )
 from src.market_phase_summary import (
-    extract_market_phase_summary,
     rebuild_market_phase_summary_for_stock_code,
 )
 from src.services.stock_code_utils import is_code_like, resolve_index_stock_code_for_analysis
@@ -80,7 +79,6 @@ from src.schemas.decision_action import build_action_fields
 from src.services.name_to_code_resolver import resolve_name_to_code
 from src.services.task_queue import (
     get_task_queue,
-    DuplicateTaskError,
     TaskStatus as TaskStatusEnum,
 )
 from src.services.run_diagnostics import build_run_diagnostic_summary

--- a/bot/commands/base.py
+++ b/bot/commands/base.py
@@ -50,7 +50,6 @@ class BotCommand(ABC):
 
         例如 "analyze"，用户输入 "/analyze" 触发
         """
-        pass
 
     @property
     @abstractmethod
@@ -60,13 +59,11 @@ class BotCommand(ABC):
 
         例如 ["a", "分析"]，用户输入 "/a" 或 "分析" 也能触发
         """
-        pass
 
     @property
     @abstractmethod
     def description(self) -> str:
         """命令描述（用于帮助信息）"""
-        pass
 
     @property
     @abstractmethod
@@ -76,7 +73,6 @@ class BotCommand(ABC):
 
         例如 "/analyze <股票代码>"
         """
-        pass
 
     @property
     def hidden(self) -> bool:
@@ -108,7 +104,6 @@ class BotCommand(ABC):
         Returns:
             BotResponse 响应对象
         """
-        pass
 
     async def execute_async(self, message: BotMessage, args: List[str]) -> BotResponse:
         """异步执行命令。

--- a/bot/commands/history.py
+++ b/bot/commands/history.py
@@ -7,7 +7,7 @@ starts with their own ``{platform}_{user_id}`` prefix.
 """
 
 import logging
-from typing import List, Optional
+from typing import List
 
 from bot.commands.base import BotCommand
 from bot.models import BotMessage, BotResponse, ChatType

--- a/bot/platforms/base.py
+++ b/bot/platforms/base.py
@@ -49,7 +49,6 @@ class BotPlatform(ABC):
         
         用于路由匹配和日志标识，如 "feishu", "dingtalk"
         """
-        pass
     
     @abstractmethod
     def verify_request(self, headers: Dict[str, str], body: bytes) -> bool:
@@ -65,7 +64,6 @@ class BotPlatform(ABC):
         Returns:
             签名是否有效
         """
-        pass
     
     @abstractmethod
     def parse_message(self, data: Dict[str, Any]) -> Optional[BotMessage]:
@@ -81,7 +79,6 @@ class BotPlatform(ABC):
         Returns:
             BotMessage 对象，或 None（不需要处理）
         """
-        pass
     
     @abstractmethod
     def format_response(
@@ -99,7 +96,6 @@ class BotPlatform(ABC):
         Returns:
             WebhookResponse 对象
         """
-        pass
     
     def send_followup(
         self,

--- a/bot/platforms/dingtalk.py
+++ b/bot/platforms/dingtalk.py
@@ -17,7 +17,6 @@ import time
 import logging
 from datetime import datetime
 from typing import Dict, Any, Optional
-from urllib.parse import quote_plus
 
 from bot.platforms.base import BotPlatform
 from bot.models import BotMessage, BotResponse, WebhookResponse, ChatType

--- a/data_provider/akshare_fetcher.py
+++ b/data_provider/akshare_fetcher.py
@@ -28,7 +28,6 @@ import multiprocessing
 import os
 import random
 import time
-from dataclasses import dataclass, field
 from datetime import datetime
 from typing import Optional, Dict, Any, List, Tuple
 
@@ -47,10 +46,10 @@ from src.config import get_config
 from .base import BaseFetcher, DataFetchError, RateLimitError, STANDARD_COLUMNS, is_bse_code, is_st_stock, is_kc_cy_stock, normalize_stock_code
 from .realtime_types import (
     UnifiedRealtimeQuote, ChipDistribution, RealtimeSource,
-    get_realtime_circuit_breaker, get_chip_circuit_breaker,
+    get_realtime_circuit_breaker,
     safe_float, safe_int  # 使用统一的类型转换函数
 )
-from .us_index_mapping import is_us_index_code, is_us_stock_code
+from .us_index_mapping import is_us_stock_code
 
 
 # 保留旧的 RealtimeQuote 别名，用于向后兼容
@@ -411,7 +410,7 @@ class AkshareFetcher(BaseFetcher):
         这是关键的反爬策略之一
         """
         try:
-            import akshare as ak
+            pass
             # akshare 内部使用 requests，我们通过环境变量或直接设置来影响
             # 实际上 akshare 可能不直接暴露 session，这里通过 fake_useragent 作为补充
             random_ua = random.choice(USER_AGENTS)

--- a/data_provider/baostock_fetcher.py
+++ b/data_provider/baostock_fetcher.py
@@ -17,7 +17,6 @@ BaostockFetcher - 备用数据源 2 (Priority 3)
 import logging
 import re
 from contextlib import contextmanager
-from datetime import datetime
 from typing import Optional, Generator
 
 import pandas as pd

--- a/data_provider/base.py
+++ b/data_provider/base.py
@@ -27,6 +27,7 @@ import numpy as np
 from src.data.stock_index_loader import get_index_stock_name
 from src.data.stock_mapping import STOCK_NAME_MAP, is_meaningful_stock_name
 from src.services.run_diagnostics import record_provider_run, record_provider_run_started
+from src.services.data_source_health import record_market_data_outcome
 from .fundamental_adapter import AkshareFundamentalAdapter
 from .yfinance_fundamental_adapter import YfinanceFundamentalAdapter
 from .realtime_types import CircuitBreaker
@@ -1336,6 +1337,7 @@ class DataFetcherManager:
                                 f"rows={len(df)}, elapsed={elapsed:.2f}s"
                             )
                             self._record_daily_source_success(fetcher, market)
+                            record_market_data_outcome(market, True)
                             return df, fetcher.name
                         duration_ms = int((time.time() - attempt_start) * 1000)
                         record_provider_run(
@@ -1376,6 +1378,7 @@ class DataFetcherManager:
             error_summary = f"{market_label} {stock_code} 获取失败:\n" + "\n".join(errors)
             elapsed = time.time() - request_start
             logger.error(f"[数据源终止] {stock_code} 获取失败: elapsed={elapsed:.2f}s\n{error_summary}")
+            record_market_data_outcome(market, False)
             raise DataFetchError(error_summary)
 
         for attempt, fetcher in enumerate(fetchers, start=1):
@@ -1416,6 +1419,7 @@ class DataFetcherManager:
                         f"rows={len(df)}, elapsed={elapsed:.2f}s"
                     )
                     self._record_daily_source_success(fetcher, market)
+                    record_market_data_outcome(market, True)
                     return df, fetcher.name
                 duration_ms = int((time.time() - attempt_start) * 1000)
                 record_provider_run(
@@ -1462,6 +1466,7 @@ class DataFetcherManager:
         error_summary = f"所有数据源获取 {stock_code} 失败:\n" + "\n".join(errors)
         elapsed = time.time() - request_start
         logger.error(f"[数据源终止] {stock_code} 获取失败: elapsed={elapsed:.2f}s\n{error_summary}")
+        record_market_data_outcome(market, False)
         raise DataFetchError(error_summary)
     
     @property

--- a/data_provider/base.py
+++ b/data_provider/base.py
@@ -321,17 +321,14 @@ def canonical_stock_code(code: str) -> str:
 
 class DataFetchError(Exception):
     """数据获取异常基类"""
-    pass
 
 
 class RateLimitError(DataFetchError):
     """API 速率限制异常"""
-    pass
 
 
 class DataSourceUnavailableError(DataFetchError):
     """数据源不可用异常"""
-    pass
 
 
 class BaseFetcher(ABC):
@@ -365,7 +362,6 @@ class BaseFetcher(ABC):
         Returns:
             原始数据 DataFrame（列名因数据源而异）
         """
-        pass
     
     @abstractmethod
     def _normalize_data(self, df: pd.DataFrame, stock_code: str) -> pd.DataFrame:
@@ -375,7 +371,6 @@ class BaseFetcher(ABC):
         将不同数据源的列名统一为：
         ['date', 'open', 'high', 'low', 'close', 'volume', 'amount', 'pct_chg']
         """
-        pass
 
     def get_main_indices(self, region: str = "cn") -> Optional[List[Dict[str, Any]]]:
         """

--- a/data_provider/efinance_fetcher.py
+++ b/data_provider/efinance_fetcher.py
@@ -26,8 +26,7 @@ import random
 import re
 import time
 from concurrent.futures import ThreadPoolExecutor, TimeoutError as FuturesTimeoutError
-from dataclasses import dataclass, field
-from datetime import datetime
+from dataclasses import dataclass
 from typing import Optional, Dict, Any, List, Tuple
 
 import pandas as pd

--- a/data_provider/longbridge_fetcher.py
+++ b/data_provider/longbridge_fetcher.py
@@ -27,7 +27,7 @@ import logging
 import os
 import time
 import threading
-from datetime import datetime, timedelta
+from datetime import datetime
 from pathlib import Path
 from typing import Optional, Dict, Any
 
@@ -121,8 +121,8 @@ def _sanitize_longbridge_env() -> None:
             os.environ["LONGBRIDGE_LOG_PATH"] = str(p / "longbridge_sdk.log")
             logger.debug("[Longbridge] 设置 LONGBRIDGE_LOG_PATH=%s",
                          os.environ["LONGBRIDGE_LOG_PATH"])
-        except Exception:
-            pass
+        except Exception as exc:
+            logger.debug("[Longbridge] 设置 LONGBRIDGE_LOG_PATH 失败: %s", exc)
 
     region = (os.getenv("LONGBRIDGE_REGION") or "").strip().lower()
     if region:

--- a/data_provider/realtime_types.py
+++ b/data_provider/realtime_types.py
@@ -17,8 +17,8 @@
 import logging
 import time
 from threading import RLock
-from dataclasses import dataclass, field
-from typing import Optional, Dict, Any, Union
+from dataclasses import dataclass
+from typing import Optional, Dict, Any
 from enum import Enum
 
 logger = logging.getLogger(__name__)

--- a/data_provider/tencent_fetcher.py
+++ b/data_provider/tencent_fetcher.py
@@ -156,8 +156,8 @@ def _first_trading_date_on_or_after(start_date: datetime) -> datetime:
             cal = xcals.get_calendar("XSHG")
             session = cal.date_to_session(start_date.date(), direction="next")
             return datetime.combine(session.date(), datetime.min.time())
-        except Exception:
-            pass
+        except Exception as exc:
+            logger.debug("交易日历查询失败，回退到周末跳过逻辑: %s", exc)
 
     current = start_date
     while current.weekday() >= 5:

--- a/data_provider/yfinance_fetcher.py
+++ b/data_provider/yfinance_fetcher.py
@@ -76,7 +76,6 @@ class YfinanceFetcher(BaseFetcher):
 
     def __init__(self):
         """初始化 YfinanceFetcher"""
-        pass
 
     @staticmethod
     def _is_jp_kr_suffix_stock(stock_code: str) -> bool:

--- a/data_provider/yfinance_fundamental_adapter.py
+++ b/data_provider/yfinance_fundamental_adapter.py
@@ -28,7 +28,7 @@ mark the block as ``partial`` when only some fields are populated.
 from __future__ import annotations
 
 import logging
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional
 
 import pandas as pd
@@ -215,8 +215,8 @@ class YfinanceFundamentalAdapter:
                 ts = pd.to_datetime(first_col, errors="coerce")
                 if pd.notna(ts):
                     report_date = ts.date().isoformat()
-            except Exception:
-                pass
+            except Exception as exc:
+                logger.debug("解析利润表报告期失败，report_date 留空: %s", exc)
             revenue_row = _pick_row(income_df, _INCOME_REVENUE_KEYS)
             net_profit_row = _pick_row(income_df, _INCOME_NET_PROFIT_KEYS)
             revenue_latest = _latest_value(revenue_row)

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -50,6 +50,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - [修复] 回测代码匹配新增非法市场后缀/长度兜底：如 `600519.HK`、`600519.SZ`、`SH000001` 不再静默回落到其它有效代码，并在日期筛选重跑时对齐旧回测结果的分析日期，避免历史快照日期命中但结果列表仍为空。
 - [chore] 清理 scheduler 中被多时间调度版本覆盖的单时间 `_refresh_daily_schedule_if_needed`/`_configure_daily_task` 死代码，并移除全仓源码目录的未用导入（`notification_sender` 包补充 `__all__` 显式声明对外接口）。
 - [改进] 为多处最易掩盖真实失败的静默 `except`（股票名解析、CSV 解析回退、交易日历查询、利润表报告期解析、历史评估统计、板块异动预检查、Longbridge 日志路径设置）补充 `logger.debug` 诊断日志，控制流不变。
+- [新功能] 新增进程级数据源健康追踪：批量分析按市场聚合日线抓取结果，当某市场全部数据源集体失效（有尝试、零成功）时在聚合报告/通知末尾附加一行健康告警，并提示配置 token 兜底源；判定区分"全市场源失效"与"个别代码无效"，全程 fail-open 不影响主流程。
+- [文档] `.env.example` 明确 `TUSHARE_TOKEN`/`FINNHUB_API_KEY`/`ALPHAVANTAGE_API_KEY` 为各市场"稳定兜底源"，配置后自动注册以降低对免费爬取源的单点依赖。
 
 ## [3.23.0] - 2026-06-20
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -48,6 +48,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - [修复] 修复 Web 回测运行未传分析日期范围、股票代码未归一化导致后端成功返回但结果为空的问题，并为空候选和行情不足返回诊断信息。
 - [文档] 补充回测请求链路说明：`analysis_date_from/analysis_date_to` 与 `code` 的输入边界、归一化与筛选顺序，以及历史行情不足或候选集为空时回测返回成功响应，在 `message` 与 `diagnostics`（含 `empty_reason`）中提供可诊断信息，并同步更新 `docs/full-guide.md`、`docs/full-guide_EN.md` 示例。
 - [修复] 回测代码匹配新增非法市场后缀/长度兜底：如 `600519.HK`、`600519.SZ`、`SH000001` 不再静默回落到其它有效代码，并在日期筛选重跑时对齐旧回测结果的分析日期，避免历史快照日期命中但结果列表仍为空。
+- [chore] 清理 scheduler 中被多时间调度版本覆盖的单时间 `_refresh_daily_schedule_if_needed`/`_configure_daily_task` 死代码，并移除全仓源码目录的未用导入（`notification_sender` 包补充 `__all__` 显式声明对外接口）。
+- [改进] 为多处最易掩盖真实失败的静默 `except`（股票名解析、CSV 解析回退、交易日历查询、利润表报告期解析、历史评估统计、板块异动预检查、Longbridge 日志路径设置）补充 `logger.debug` 诊断日志，控制流不变。
 
 ## [3.23.0] - 2026-06-20
 

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -230,6 +230,14 @@ P5 强化聚合报告通知路径的失败边界：`_send_notifications()` 在 r
 
 DecisionSignal 通知摘要字段、敏感信息边界、迁移与回滚说明见 [DecisionSignal 决策信号专题](decision-signals.md)。
 
+### 数据源健康告警
+
+聚合报告（dashboard / brief）在生成时会附加一行数据源健康告警，触发口径为"整市场集体失效"：某市场在本批次内有日线抓取尝试、但成功次数为 0（且至少一次失败）。该口径用于把"全市场数据源同时失效"与"个别股票代码无效/退市"区分开——后者因为市场仍有其它成功抓取，不会告警。
+
+- 计数为进程级、线程安全，批次开始（`StockAnalysisPipeline.run`）时重置；记录点在 `data_provider.base.get_daily_data` 的成功返回与全源耗尽抛错处。
+- 告警仅追加到聚合报告文末，不新增通知渠道；全程 fail-open，追踪或格式化异常只记 `debug` 日志，绝不影响分析与通知主流程。
+- 告警文案会提示配置带 token 的兜底源（`TUSHARE_TOKEN` / `FINNHUB_API_KEY` / `ALPHAVANTAGE_API_KEY`），与 `.env.example` 的"稳定兜底源"说明一致。实现见 `src/services/data_source_health.py`。
+
 ## 通知降噪机制
 
 P4 新增进程内降噪，只影响静态配置渠道，不影响 `send_to_context()` 的机器人触发会话回执。默认所有配置关闭，未设置时保持旧行为。

--- a/src/agent/conversation.py
+++ b/src/agent/conversation.py
@@ -9,7 +9,7 @@ import logging
 import threading
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List
 
 from src.storage import get_db
 

--- a/src/agent/memory.py
+++ b/src/agent/memory.py
@@ -307,6 +307,6 @@ class AgentMemory:
                     "direction_accuracy": summary.get("direction_accuracy", 0.5),
                     "avg_confidence": 0.6,  # approximate from historical data
                 }
-        except Exception:
-            pass
+        except Exception as exc:
+            logger.debug("读取历史评估统计失败，使用默认值: %s", exc)
         return {"total": 0, "accuracy": 0.5, "direction_accuracy": 0.5, "avg_confidence": 0.5}

--- a/src/agent/runner.py
+++ b/src/agent/runner.py
@@ -396,7 +396,8 @@ def _build_budget_guard_result(
         models_used=models_used,
         error=(
             "Agent step skipped due to insufficient budget: "
-            f"{remaining_timeout_s:.2f}s remaining, minimum {min_step_budget_s:.1f}s required"
+            f"{remaining_timeout_s:.2f}s remaining, minimum {min_step_budget_s:.1f}s required "
+            f"(elapsed {elapsed:.2f}s)"
         ),
         messages=messages,
     )

--- a/src/agent/skills/base.py
+++ b/src/agent/skills/base.py
@@ -11,7 +11,6 @@ The built-in YAML files still live under ``strategies/`` for compatibility.
 """
 
 import logging
-import os
 import re
 from dataclasses import dataclass, field
 from pathlib import Path

--- a/src/agent/tools/analysis_tools.py
+++ b/src/agent/tools/analysis_tools.py
@@ -224,7 +224,6 @@ def _handle_get_volume_analysis(stock_code: str, days: int = 30) -> dict:
 
     # Volume-price correlation (last N days)
     try:
-        import numpy as np
         vp_corr = float(pd.Series(volume.values, dtype=float).corr(pd.Series(close.values, dtype=float)))
         vp_corr = round(vp_corr, 3)
     except Exception:

--- a/src/agent/tools/data_tools.py
+++ b/src/agent/tools/data_tools.py
@@ -470,8 +470,8 @@ def _handle_get_stock_info(stock_code: str) -> dict:
     stock_name = stock_code.upper()
     try:
         stock_name = manager.get_stock_name(stock_code) or stock_name
-    except Exception:
-        pass
+    except Exception as exc:
+        logger.debug("获取股票名称失败，回退使用代码 %s: %s", stock_code, exc)
 
     return {
         "code": stock_code.upper(),

--- a/src/agent/tools/registry.py
+++ b/src/agent/tools/registry.py
@@ -8,10 +8,9 @@ Provides:
 - @tool decorator for easy tool registration
 """
 
-import json
 import inspect
 import logging
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import Any, Callable, Dict, List, Optional
 
 logger = logging.getLogger(__name__)

--- a/src/analyzer.py
+++ b/src/analyzer.py
@@ -35,8 +35,6 @@ from src.config import (
     get_api_keys_for_model,
     get_config,
     get_configured_llm_models,
-    normalize_litellm_temperature,
-    resolve_litellm_wire_model,
     resolve_news_window_days,
 )
 from src.llm.generation_params import apply_litellm_generation_params

--- a/src/core/pipeline.py
+++ b/src/core/pipeline.py
@@ -2788,7 +2788,11 @@ class StockAnalysisPipeline:
             分析结果列表
         """
         start_time = time.time()
-        
+
+        # 批次开始：重置数据源健康计数，用于收尾时识别整市场数据源集体失效
+        from src.services.data_source_health import reset as reset_data_source_health
+        reset_data_source_health()
+
         # 使用配置中的股票列表
         if stock_codes is None:
             self.config.refresh_stock_list()

--- a/src/feishu_doc.py
+++ b/src/feishu_doc.py
@@ -1,10 +1,9 @@
 # feishu_doc.py
 # -*- coding: utf-8 -*-
 import logging
-import json
 import lark_oapi as lark
 from lark_oapi.api.docx.v1 import *
-from typing import List, Dict, Any, Optional
+from typing import List, Optional
 from src.config import get_config
 
 logger = logging.getLogger(__name__)

--- a/src/market_analyzer.py
+++ b/src/market_analyzer.py
@@ -18,7 +18,6 @@ from datetime import datetime
 from inspect import getattr_static
 from typing import Optional, Dict, Any, List
 
-import pandas as pd
 
 from src.config import get_config
 from src.report_language import normalize_report_language

--- a/src/notification.py
+++ b/src/notification.py
@@ -326,8 +326,26 @@ class NotificationService(
         """Generate the aggregate report content used by merge/save/push paths."""
         normalized_type = self._normalize_report_type(report_type)
         if normalized_type == ReportType.BRIEF:
-            return self.generate_brief_report(results, report_date=report_date)
-        return self.generate_dashboard_report(results, report_date=report_date)
+            content = self.generate_brief_report(results, report_date=report_date)
+        else:
+            content = self.generate_dashboard_report(results, report_date=report_date)
+        return self._append_data_source_health_warning(content, results)
+
+    def _append_data_source_health_warning(
+        self,
+        content: str,
+        results: List[AnalysisResult],
+    ) -> str:
+        """整市场数据源集体失效时，在聚合报告末尾附加一行健康告警。fail-open。"""
+        try:
+            from src.services.data_source_health import format_health_warning
+
+            warning = format_health_warning(self._get_report_language(results))
+            if warning:
+                return f"{content}\n\n{warning}" if content else warning
+        except Exception as exc:  # pragma: no cover - defensive fail-open guard
+            logger.debug("附加数据源健康告警失败: %s", exc)
+        return content
 
     def _collect_models_used(self, results: List[AnalysisResult]) -> List[str]:
         if not self._should_show_llm_model():

--- a/src/notification_sender/__init__.py
+++ b/src/notification_sender/__init__.py
@@ -20,3 +20,22 @@ from .serverchan3_sender import Serverchan3Sender
 from .slack_sender import SlackSender
 from .telegram_sender import TelegramSender
 from .wechat_sender import WechatSender, WECHAT_IMAGE_MAX_BYTES
+
+__all__ = [
+    "AstrbotSender",
+    "CustomWebhookSender",
+    "DiscordSender",
+    "EmailSender",
+    "FeishuSender",
+    "GotifySender",
+    "resolve_gotify_message_endpoint",
+    "NtfySender",
+    "resolve_ntfy_endpoint",
+    "PushoverSender",
+    "PushplusSender",
+    "Serverchan3Sender",
+    "SlackSender",
+    "TelegramSender",
+    "WechatSender",
+    "WECHAT_IMAGE_MAX_BYTES",
+]

--- a/src/repositories/analysis_repo.py
+++ b/src/repositories/analysis_repo.py
@@ -10,7 +10,6 @@
 """
 
 import logging
-from datetime import datetime, timedelta
 from typing import Optional, List, Dict, Any
 
 from src.storage import DatabaseManager, AnalysisHistory

--- a/src/scheduler.py
+++ b/src/scheduler.py
@@ -167,49 +167,6 @@ class Scheduler:
         self._daily_job = None
         self._daily_jobs = []
 
-    def _configure_daily_task(self, schedule_time: str) -> bool:
-        """(Re)register the daily job at the requested time."""
-        candidate = (schedule_time or "").strip()
-        if not self._is_valid_schedule_time(candidate):
-            logger.warning(
-                "检测到无效的定时执行时间 %r，继续沿用当前时间 %s",
-                schedule_time,
-                self.schedule_time,
-            )
-            return False
-
-        previous_time = self.schedule_time
-        self._cancel_daily_job()
-        self._daily_job = self.schedule.every().day.at(candidate).do(self._safe_run_task)
-        self.schedule_time = candidate
-
-        if previous_time == candidate:
-            logger.info("已设置每日定时任务，执行时间: %s", self.schedule_time)
-        else:
-            logger.info(
-                "检测到 SCHEDULE_TIME 变更，已将每日定时任务从 %s 更新为 %s",
-                previous_time,
-                self.schedule_time,
-            )
-        return True
-
-    def _refresh_daily_schedule_if_needed(self) -> None:
-        """Reload daily schedule time from the latest runtime config if needed."""
-        if self._task_callback is None or self._schedule_time_provider is None:
-            return
-
-        try:
-            latest_schedule_time = (self._schedule_time_provider() or "").strip()
-        except Exception as exc:  # pragma: no cover - defensive branch
-            logger.warning("读取最新 SCHEDULE_TIME 失败，继续沿用 %s: %s", self.schedule_time, exc)
-            return
-
-        if not latest_schedule_time or latest_schedule_time == self.schedule_time:
-            return
-
-        if self._configure_daily_task(latest_schedule_time):
-            logger.info("更新后的下次执行时间: %s", self._get_next_run_time())
-
     def _configure_daily_tasks(self, schedule_times: Union[Sequence[str], str]) -> bool:
         """(Re)register daily jobs at the requested times."""
         raw_items = (

--- a/src/search_service.py
+++ b/src/search_service.py
@@ -221,7 +221,6 @@ class BaseSearchProvider(ABC):
     @abstractmethod
     def _do_search(self, query: str, api_key: str, max_results: int, days: int = 7) -> SearchResponse:
         """执行搜索（子类实现）"""
-        pass
     
     def _execute_search(
         self,

--- a/src/services/alphasift_service.py
+++ b/src/services/alphasift_service.py
@@ -2375,8 +2375,8 @@ class DsaEastMoneyHotspotProvider:
             concept_frame = self._fetch_board_changes_with_fallback()
             if self._board_frame_contains_topic(concept_frame, topic):
                 return False
-        except Exception:
-            pass
+        except Exception as exc:
+            logger.debug("板块异动预检查失败，继续行业判断 topic=%s: %s", topic, exc)
         try:
             frame = self.stock_board_industry_name_em()
         except Exception as exc:

--- a/src/services/data_source_health.py
+++ b/src/services/data_source_health.py
@@ -1,0 +1,115 @@
+# -*- coding: utf-8 -*-
+"""进程级数据源健康追踪。
+
+按市场聚合每只股票日线抓取的"最终结果"（成功 / 全部数据源失败），用于在批量分析
+收尾时识别"整市场数据源集体失效"，并在通知里附加一段简短告警。
+
+判定口径：某市场在一个批次内有尝试、但成功次数为 0（且至少有一次失败）时，视为
+该市场数据源"集体失效"。这能把"全市场源同时挂掉"与"个别股票代码无效/退市"区分开。
+
+设计约束：
+- 不影响主流程。所有记录与汇总均 fail-open，异常只记日志、绝不抛出。
+- 仅做内存计数，进程级、线程安全；批次开始时由调用方 reset()。
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+from dataclasses import dataclass
+from typing import Dict, List
+
+logger = logging.getLogger(__name__)
+
+# 市场代码 -> 双语展示名（与 data_provider.base.get_daily_data 的 market 取值对齐）
+_MARKET_LABELS: Dict[str, Dict[str, str]] = {
+    "cn": {"zh": "A股", "en": "A-shares"},
+    "hk": {"zh": "港股", "en": "HK"},
+    "us": {"zh": "美股", "en": "US"},
+    "jp": {"zh": "日股", "en": "JP"},
+    "kr": {"zh": "韩股", "en": "KR"},
+    "tw": {"zh": "台股", "en": "TW"},
+}
+
+
+@dataclass
+class _MarketStat:
+    attempts: int = 0
+    successes: int = 0
+    failures: int = 0
+
+
+_lock = threading.Lock()
+_stats: Dict[str, _MarketStat] = {}
+
+
+def record_market_data_outcome(market: str, success: bool) -> None:
+    """记录某市场一次日线抓取的最终结果。
+
+    在 ``get_daily_data`` 成功返回或所有数据源耗尽抛错时各调用一次。fail-open。
+    """
+    if not market:
+        return
+    try:
+        with _lock:
+            stat = _stats.setdefault(market, _MarketStat())
+            stat.attempts += 1
+            if success:
+                stat.successes += 1
+            else:
+                stat.failures += 1
+    except Exception as exc:  # pragma: no cover - defensive fail-open guard
+        logger.debug("记录数据源健康失败: %s", exc)
+
+
+def reset() -> None:
+    """清空计数。由批量分析在批次开始时调用。fail-open。"""
+    try:
+        with _lock:
+            _stats.clear()
+    except Exception as exc:  # pragma: no cover - defensive fail-open guard
+        logger.debug("重置数据源健康计数失败: %s", exc)
+
+
+def summarize_collective_failures() -> List[Dict[str, int]]:
+    """返回"集体失效"市场列表：有尝试、零成功、且至少一次失败。
+
+    每项形如 ``{"market": "cn", "attempts": 3, "failures": 3}``，按市场代码排序。
+    """
+    try:
+        with _lock:
+            return [
+                {"market": market, "attempts": stat.attempts, "failures": stat.failures}
+                for market, stat in sorted(_stats.items())
+                if stat.attempts > 0 and stat.successes == 0 and stat.failures > 0
+            ]
+    except Exception as exc:  # pragma: no cover - defensive fail-open guard
+        logger.debug("汇总数据源健康失败: %s", exc)
+        return []
+
+
+def format_health_warning(report_language: str = "zh") -> str:
+    """把集体失效市场拼成一行告警文案；无异常时返回空串。fail-open。"""
+    try:
+        failures = summarize_collective_failures()
+        if not failures:
+            return ""
+        lang = "en" if str(report_language).lower().startswith("en") else "zh"
+        names = [
+            _MARKET_LABELS.get(item["market"], {}).get(lang, item["market"])
+            for item in failures
+        ]
+        if lang == "en":
+            return (
+                "⚠️ Data source health: all providers failed for "
+                + ", ".join(names)
+                + " in this run; results may be missing. Check upstream sources or configure a token-based fallback (TUSHARE_TOKEN / FINNHUB_API_KEY / ALPHAVANTAGE_API_KEY)."
+            )
+        return (
+            "⚠️ 数据源健康：本次运行 "
+            + "、".join(names)
+            + " 的全部数据源均失败，相关结果可能缺失。请检查上游数据源，或配置带 token 的兜底源（TUSHARE_TOKEN / FINNHUB_API_KEY / ALPHAVANTAGE_API_KEY）。"
+        )
+    except Exception as exc:  # pragma: no cover - defensive fail-open guard
+        logger.debug("格式化数据源健康告警失败: %s", exc)
+        return ""

--- a/src/services/history_service.py
+++ b/src/services/history_service.py
@@ -33,7 +33,6 @@ from src.report_language import (
 from src.storage import DatabaseManager
 from src.services.run_diagnostics import build_run_diagnostic_summary
 from src.market_phase_summary import (
-    extract_market_phase_summary,
     rebuild_market_phase_summary_for_stock_code,
 )
 from src.schemas.decision_action import build_action_fields

--- a/src/services/import_parser.py
+++ b/src/services/import_parser.py
@@ -215,8 +215,8 @@ def parse_import_from_bytes(data: bytes, filename: Optional[str] = None) -> List
             f"CSV 解析失败：请检查分隔符是否一致、列数是否匹配。"
             f"常见原因：引号未闭合、某行列数与其他行不一致。原始错误: {e}"
         ) from e
-    except Exception:
-        pass
+    except Exception as exc:
+        logger.debug("pandas CSV 解析失败，回退到纯文本分割: %s", exc)
 
     # Fallback: plain text, split by comma/tab/space
     lines = text.strip().splitlines()

--- a/src/services/stock_service.py
+++ b/src/services/stock_service.py
@@ -10,8 +10,8 @@
 """
 
 import logging
-from datetime import datetime, timedelta
-from typing import Optional, Dict, Any, List
+from datetime import datetime
+from typing import Optional, Dict, Any
 
 from src.repositories.stock_repo import StockRepository
 

--- a/src/services/system_config_service.py
+++ b/src/services/system_config_service.py
@@ -13,7 +13,7 @@ import time
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Sequence, Set, Tuple
-from urllib.parse import urljoin, urlparse, urlunparse
+from urllib.parse import urlparse, urlunparse
 
 import requests
 

--- a/src/services/task_queue.py
+++ b/src/services/task_queue.py
@@ -27,7 +27,7 @@ from typing import Optional, Dict, List, Any, TYPE_CHECKING, Tuple, Literal, Cal
 if TYPE_CHECKING:
     from asyncio import Queue as AsyncQueue
 
-from data_provider.base import canonical_stock_code, normalize_stock_code
+from data_provider.base import normalize_stock_code
 from src.services.run_diagnostics import (
     activate_run_diagnostic_context,
     get_current_diagnostic_context,

--- a/src/stock_analyzer.py
+++ b/src/stock_analyzer.py
@@ -200,7 +200,6 @@ class StockTrendAnalyzer:
     
     def __init__(self):
         """初始化分析器"""
-        pass
     
     def analyze(self, df: pd.DataFrame, code: str) -> TrendAnalysisResult:
         """
@@ -822,8 +821,6 @@ if __name__ == "__main__":
     logging.basicConfig(level=logging.INFO)
     
     # 模拟数据测试
-    import numpy as np
-    
     dates = pd.date_range(start='2025-01-01', periods=60, freq='D')
     np.random.seed(42)
     

--- a/tests/test_data_source_health.py
+++ b/tests/test_data_source_health.py
@@ -1,0 +1,69 @@
+# -*- coding: utf-8 -*-
+"""数据源健康追踪（src/services/data_source_health.py）单元测试。"""
+
+import pytest
+
+from src.services import data_source_health as dsh
+
+
+@pytest.fixture(autouse=True)
+def _reset_tracker():
+    dsh.reset()
+    yield
+    dsh.reset()
+
+
+def test_no_outcomes_means_no_warning():
+    assert dsh.summarize_collective_failures() == []
+    assert dsh.format_health_warning("zh") == ""
+
+
+def test_all_success_is_not_collective_failure():
+    dsh.record_market_data_outcome("cn", True)
+    dsh.record_market_data_outcome("cn", True)
+    assert dsh.summarize_collective_failures() == []
+    assert dsh.format_health_warning("zh") == ""
+
+
+def test_mixed_success_and_failure_is_not_collective_failure():
+    # 个别股票失败但市场整体有成功 -> 视为单票问题，不告警
+    dsh.record_market_data_outcome("cn", True)
+    dsh.record_market_data_outcome("cn", False)
+    assert dsh.summarize_collective_failures() == []
+    assert dsh.format_health_warning("zh") == ""
+
+
+def test_zero_success_with_failures_is_collective_failure():
+    dsh.record_market_data_outcome("cn", False)
+    dsh.record_market_data_outcome("cn", False)
+    failures = dsh.summarize_collective_failures()
+    assert failures == [{"market": "cn", "attempts": 2, "failures": 2}]
+
+
+def test_warning_text_lists_only_collectively_failed_markets():
+    dsh.record_market_data_outcome("cn", False)  # 集体失效
+    dsh.record_market_data_outcome("us", True)   # 正常
+    dsh.record_market_data_outcome("us", False)  # 个别失败但有成功
+    warning_zh = dsh.format_health_warning("zh")
+    assert "A股" in warning_zh
+    assert "美股" not in warning_zh
+    assert "TUSHARE_TOKEN" in warning_zh
+
+
+def test_warning_text_english():
+    dsh.record_market_data_outcome("us", False)
+    warning_en = dsh.format_health_warning("en")
+    assert "US" in warning_en
+    assert "FINNHUB_API_KEY" in warning_en
+
+
+def test_reset_clears_state():
+    dsh.record_market_data_outcome("hk", False)
+    assert dsh.summarize_collective_failures()
+    dsh.reset()
+    assert dsh.summarize_collective_failures() == []
+
+
+def test_empty_market_is_ignored():
+    dsh.record_market_data_outcome("", False)
+    assert dsh.summarize_collective_failures() == []


### PR DESCRIPTION
## PR Type

- [x] feat
- [x] chore
- [x] docs

## Background And Problem

仓库存在若干长期累积的代码卫生问题（被覆盖的死代码、未用导入、掩盖真实失败的静默 `except`），同时数据源稳定性缺少“整市场集体失效”的主动可观测手段——默认 A股/港股/美股日线都依赖免费爬取源（efinance/akshare/yfinance），上游一旦变更反爬或接口即可能整源失效，而用户往往要等报告为空才发现。

本 PR 两部分：
1. 清理死代码 / 未用导入，并为最易掩盖真实失败的静默 `except` 补诊断日志；
2. 新增进程级“数据源健康告警”：批量分析按市场聚合日线抓取结果，当某市场全部数据源集体失效时在聚合报告/通知末尾追加一行告警，并提示配置 token 兜底源。

## Scope Of Change

**清理 / 修复**
- `src/scheduler.py`：删除被多时间调度版本覆盖的单时间 `_refresh_daily_schedule_if_needed` / `_configure_daily_task` 死代码。
- 全仓源码目录移除未用导入；`src/notification_sender/__init__.py` 补 `__all__` 显式声明对外接口（消除 F401 并文档化公共 API）。
- `src/stock_analyzer.py`：删 `__main__` 块冗余 `import numpy`；`src/agent/runner.py`：budget guard 错误信息补 `elapsed`。
- 7 处静默 `except` 补 `logger.debug`（股票名解析、CSV 解析回退、交易日历查询、利润表报告期解析、历史评估统计、板块异动预检查、Longbridge 日志路径设置），控制流不变。保留序列化探测 / 可选依赖探测等 10 处合理静默。

**数据源健康告警（新功能）**
- 新增 `src/services/data_source_health.py`：进程级、线程安全、fail-open 的健康追踪器。
- `data_provider/base.py` 的 `get_daily_data` 在成功返回 / 全源耗尽抛错处记录每市场最终结果。
- `src/notification.py` 的 `generate_aggregate_report` 在“整市场集体失效”（有尝试、零成功、至少一次失败）时追加一行双语告警；该口径区分“全市场源失效”与“个别代码无效”。
- `src/core/pipeline.py` 的 `run()` 在批次开始重置计数。
- `.env.example`：将 `TUSHARE_TOKEN` / `FINNHUB_API_KEY` / `ALPHAVANTAGE_API_KEY` 明确定位为各市场“稳定兜底源”（代码层早已支持自动注册，本 PR 仅强化文档）。
- 文档：`docs/CHANGELOG.md`、`docs/notifications.md` 新增“数据源健康告警”说明。
- 测试：新增 `tests/test_data_source_health.py`（8 条）。

## Issue Link

无关联 issue（仓库维护 / 稳定性增强）。

## Verification Commands And Results

```
# 编译 + 关键静态检查（改动文件）
python -m py_compile <changed .py>            # OK
flake8 --select=E9,F63,F7,F82,F401,F811,F841  # 0（notification.py:2555 的 F811 为既有 __main__ TYPE_CHECKING 再导入，运行所必需）

# 新模块单测
pytest tests/test_data_source_health.py       # 8 passed

# 回归（notification / pipeline / scheduler / data_fetcher + 新模块）
pytest -k "notification or pipeline or schedul or data_fetcher or data_source_health" -m "not network"
                                              # 594 passed

# 实测真实抓取
600519 成功 -> 不误报；强制无效代码 -> 记录 cn 失败并生成告警
A股/港股/美股 各 1 只日线实时抓取均成功（efinance/akshare/yfinance 命中）
```

本地未跑全量离线套件（开发机三方依赖不全）；建议以 CI `backend-gate` 为准。

## Visual Evidence (if applicable)

无 Web UI / 报告渲染样式变更；仅在“整市场源全失败”时于聚合报告文末新增一行文本告警，无版式变化。

## Compatibility And Risk

- 风险低。新增逻辑全程 fail-open：追踪 / 格式化任何异常只记 `debug`，绝不影响分析与通知主流程。
- 不新增通知渠道、不改 Schema / API；不触碰单股推送路径。唯一用户可见变化：整市场源全挂时聚合报告末尾多一行告警。
- 分层：`data_provider.base` 本就依赖 `src.services.run_diagnostics`，新增对 `src.services.data_source_health` 的依赖方向一致。
- 基线说明：本分支基于较早的 main，已用 `git merge-tree --write-tree` 验证与最新 `origin/main` 可干净自动合并（无冲突）；其中“移除未用导入”所涉文件 main 亦有改动，CI 的 flake8(F821) + pytest 可兜住潜在语义遗漏。

## Rollback Plan

- 整体 revert 本 PR。
- 或单独回退：删除 `src/services/data_source_health.py` 与 `tests/test_data_source_health.py`，回退 `data_provider/base.py`（4 处记录点）、`src/notification.py`（聚合报告追加）、`src/core/pipeline.py`（reset）即可移除告警功能；清理 / 文档改动相互独立，可分别回退。

## EXTRACT_PROMPT Change (if applicable)

不涉及 `src/services/image_stock_extractor.py` 的 `EXTRACT_PROMPT`。

## Checklist

- [x] 本 PR 有明确动机和业务价值
- [x] 已提供可复现的验证命令与结果
- [x] 已评估兼容性与风险
- [x] 已提供回滚方案
- [x] 无报告格式 / Web UI 版式变更，无需截图
- [x] 用户可见变更已同步 `docs/CHANGELOG.md` 与 `docs/notifications.md`，细节写入 `docs/*.md` 未膨胀 README
