### PR TITLE
fix: 在网页端点击“立即执行一次”后后台线程因缺少 stock_codes… (#1853)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 <!-- 每条独立一行追加到本段末尾，无需分类标题，合并时冲突最小 -->
 
 - [修复] 修复 Web 首页个股栏在 stock-bar 摘要字段缺失或动作建议无法归类时隐藏情绪分与建议标识的问题。
+- [修复] 修复 Web 设置页定时任务“立即执行一次”后台线程未传 `stock_codes` 导致任务崩溃的问题。
 
 ## [3.24.1] - 2026-06-28
 

--- a/src/services/runtime_scheduler.py
+++ b/src/services/runtime_scheduler.py
@@ -341,7 +341,7 @@ class RuntimeSchedulerService:
 
         def run_and_release() -> None:
             try:
-                self._run_analysis_locked()
+                self._run_analysis_locked(None)
             finally:
                 self._run_lock.release()
 

--- a/tests/test_runtime_scheduler_service.py
+++ b/tests/test_runtime_scheduler_service.py
@@ -80,6 +80,12 @@ class _NoopThread:
         return False
 
 
+class _SynchronousThread(_NoopThread):
+    def start(self):
+        if self.target is not None:
+            self.target()
+
+
 class RuntimeSchedulerServiceTestCase(unittest.TestCase):
     def test_run_analysis_args_include_workers(self) -> None:
         config = SimpleNamespace(
@@ -181,6 +187,38 @@ class RuntimeSchedulerServiceTestCase(unittest.TestCase):
         status = service.status()
         self.assertEqual(status["last_skip_reason"], "analysis_already_running")
         self.assertIsNotNone(status["last_skipped_at"])
+
+    def test_run_now_runs_analysis_with_default_stock_scope(self) -> None:
+        config = SimpleNamespace(
+            schedule_enabled=True,
+            schedule_time="18:00",
+            schedule_times=["18:00"],
+        )
+        seen_stock_codes = []
+
+        def runner(config_arg, args, stock_codes):
+            seen_stock_codes.append(stock_codes)
+            return True
+
+        service = RuntimeSchedulerService(
+            config_provider=lambda: config,
+            task_runner=runner,
+        )
+        service._reload_config = lambda: config
+
+        with patch(
+            "src.services.runtime_scheduler.threading.Thread",
+            _SynchronousThread,
+        ):
+            result = service.run_now()
+
+        self.assertTrue(result["accepted"])
+        self.assertEqual(seen_stock_codes, [None])
+        status = service.status()
+        self.assertFalse(status["running"])
+        self.assertIsNotNone(status["last_run_at"])
+        self.assertIsNotNone(status["last_success_at"])
+        self.assertIsNone(status["last_error"])
 
     def test_run_now_uses_shared_lock_across_service_instances(self) -> None:
         config = SimpleNamespace(


### PR DESCRIPTION
## PR Type
- [x] fix
- [ ] feat
- [ ] refactor
- [ ] docs
- [ ] chore
- [ ] test

## Background And Problem
- 当前问题：修复 Web 端“立即执行一次”触发后后台线程因未传 stock_codes 崩溃的问题，并补充回归测试。
- 影响范围：本次改动涉及 3 个文件，Diff 为 `+40 / -1`。
- 触发来源：Issue 自动执行（Issue #1853）。

## Scope Of Change
- `docs/CHANGELOG.md`
- `src/services/runtime_scheduler.py`
- `tests/test_runtime_scheduler_service.py`

## Documentation And Changelog
- 已同步更新文档/变更记录：`docs/CHANGELOG.md`。
- 当前补丁尚未包含 `README.md` 或专题文档；如用户可见行为发生变化，请补充文档落点。

## Issue Link
Closes #1853

## Verification Commands And Results
```bash
./scripts/ci_gate.sh flake8
./scripts/ci_gate.sh offline-tests
```

关键输出/结论 / Key output & conclusion:
- lint:PASS, test:TIMEOUT

## Compatibility And Risk
- **Medium**：涉及 `docs/CHANGELOG.md`, `src/services/runtime_scheduler.py`, `tests/test_runtime_scheduler_service.py`，建议按文件范围复核。
- 前提假设：
  - 按维护者讨论中的明确方向处理：在 run_now 的后台线程回调中调用 _run_analysis_locked(None)。
  - None 表示未指定股票代码时沿用当前配置的默认股票范围。
  - 不改 secrets、workflow、部署配置或调度策略，只修复手动触发路径的参数传递缺陷。
  - run_now 已提前持有运行锁，因此不改为调用 _run_analysis_once，避免重复加锁导致误判任务繁忙。

## Rollback Plan
- `git revert <merge-commit>` 回滚本 PR 提交，重点确认 `docs/CHANGELOG.md`, `src/services/runtime_scheduler.py`, `tests/test_runtime_scheduler_service.py` 恢复正常。

## Acceptance Criteria
- 点击 Web 设置页“立即执行一次”后不再抛出 _run_analysis_locked 缺少 stock_codes 参数的 TypeError。
- 未指定股票代码时按当前配置股票范围执行一次分析。
- 手动触发路径能正确更新上次执行时间、上次成功时间、执行状态和错误状态。
- 运行锁语义保持不变，任务已运行时仍能正确返回繁忙状态或跳过重复执行。
- 新增或更新测试覆盖 run_now 后台线程向 _run_analysis_locked 传入 None 的回归场景。

## Checklist
- [x] 本 PR 有明确动机和业务价值 / This PR has a clear motivation and value
- [x] 已提供可复现的验证命令与结果 / Reproducible verification commands and results are included
- [x] 已评估兼容性与风险 / Compatibility and risk have been assessed
- [x] 已提供回滚方案 / A rollback plan is provided
- [ ] 文档与 `docs/CHANGELOG.md` 同步仍需确认；如涉及用户可见变更，请在合并前补充原因与文档落点 / Documentation and `docs/CHANGELOG.md` sync still needs confirmation before merge when user-visible behavior changes