### PR TITLE
fix: 提升 Discord 长报告分片发送可靠性

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -599,6 +599,7 @@ AGENT_SKILLS=
 # DISCORD_BOT_TOKEN=
 # DISCORD_MAIN_CHANNEL_ID=
 # DISCORD_CHANNEL_ID=   # 兼容旧变量名，推荐改用 DISCORD_MAIN_CHANNEL_ID
+# DISCORD_MAX_WORDS=2000 # Discord 单条 content 上限为 2000；运行时会自动截到不超过 2000 并分片发送长报告
 # 如果你要接收 Discord Interaction / Webhook 回调，必须配置公钥用于验签
 # 获取方式：Discord Developer Portal -> General Information -> Public Key
 # DISCORD_INTERACTIONS_PUBLIC_KEY=

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+- [修复] Discord 长报告推送按 2000 字符上限分片逐段发送，遇到 429 限流会按 `retry_after`/`Retry-After` 有限重试，避免中途失败后只收到前半段报告。
 - [改进] #1777 台股三大法人 fetcher（`TwInstitutionalFetcher`）增加缓存防击穿：并发同 (市场, 日期) 调用合并为单次上游请求，保护 TWSE T86 ~3 req/5s 限流额度；不同 key 仍并行；新增并发单次抓取、不同 key 各抓一次、HTTP 错误 fail-open 回归测试。
 - [修复] A 股个股分析遇到空 `belong_boards` 占位时会继续补查所属板块，关联板块模块在已有板块时稳定展示；对应涨跌幅缺失时只显示板块，不再输出占位涨跌幅。
 - [修复] 大盘复盘在 LLM 标题漂移或正文缺少板块段时，会从结构化 `sectors` 兜底渲染板块表，避免 Web 与推送报告偶发缺少板块主线。

--- a/docs/full-guide.md
+++ b/docs/full-guide.md
@@ -288,7 +288,7 @@ daily_stock_analysis/
 | `DISCORD_BOT_TOKEN` | Discord Bot Token（与 Webhook 二选一） | 可选 |
 | `DISCORD_MAIN_CHANNEL_ID` | Discord Channel ID（使用 Bot 时需要） | 可选 |
 | `DISCORD_INTERACTIONS_PUBLIC_KEY` | Discord Public Key（仅入站 Interaction/Webhook 回调验签时需要） | 可选 |
-| `DISCORD_MAX_WORDS` | Discord 最大字数限制（默认 免费服务器限制2000） | 可选 |
+| `DISCORD_MAX_WORDS` | Discord 单条消息 content 上限（默认 2000；运行时不会超过 Discord 2000 字符限制，长报告会自动分片并对 429 限流做有限重试） | 可选 |
 | `SLACK_BOT_TOKEN` | Slack Bot Token（推荐，支持图片上传；同时配置时优先于 Webhook） | 可选 |
 | `SLACK_CHANNEL_ID` | Slack Channel ID（使用 Bot 时需要） | 可选 |
 | `SLACK_WEBHOOK_URL` | Slack Incoming Webhook URL（仅文本，不支持图片） | 可选 |
@@ -1095,6 +1095,8 @@ GOTIFY_TOKEN=app-token
 ### Discord
 
 Discord 支持两种方式推送：
+
+长报告会按 Discord 单条 content 2000 字符上限自动分片发送；如果某一片遇到 429 限流，发送器会按 Discord 返回的 `retry_after` 或 `Retry-After` 做有限重试，并继续尝试后续分片。`DISCORD_MAX_WORDS` 可调低单片长度，但运行时不会允许超过 2000。
 
 **方式一：Webhook（推荐，简单）**
 

--- a/docs/full-guide_EN.md
+++ b/docs/full-guide_EN.md
@@ -245,7 +245,7 @@ For the notification baseline, diagnostics, and deployment notes, see [Notificat
 | `DISCORD_BOT_TOKEN` | Discord Bot Token (choose one with Webhook) | Optional |
 | `DISCORD_MAIN_CHANNEL_ID` | Discord Channel ID (required when using Bot) | Optional |
 | `DISCORD_INTERACTIONS_PUBLIC_KEY` | Discord Public Key (required only for inbound Interaction/Webhook signature verification) | Optional |
-| `DISCORD_MAX_WORDS` | Discord Word Limit (default 2000 for un-upgraded servers) | Optional |
+| `DISCORD_MAX_WORDS` | Discord per-message content limit (default 2000; runtime never exceeds Discord's 2000-character content limit, long reports are chunked, and 429 rate limits are retried a limited number of times) | Optional |
 | `SLACK_BOT_TOKEN` | Slack Bot Token (recommended, supports image upload; takes priority over Webhook when both set) | Optional |
 | `SLACK_CHANNEL_ID` | Slack Channel ID (required when using Bot) | Optional |
 | `SLACK_WEBHOOK_URL` | Slack Incoming Webhook URL (text only, no image support) | Optional |
@@ -977,6 +977,8 @@ while Gotify uses `/message` as a fixed server API.
 ### Discord
 
 Discord supports two push methods:
+
+Long reports are automatically split under Discord's 2000-character per-message `content` limit. If a chunk receives a 429 rate limit response, the sender follows Discord's `retry_after` or `Retry-After` value for a limited retry and continues attempting later chunks. `DISCORD_MAX_WORDS` can lower the chunk size, but runtime delivery will not exceed 2000.
 
 **Method 1: Webhook (Recommended, Simple)**
 

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -24,6 +24,8 @@
 | 飞书会话 | 运行时上下文 | - | - | 从来源消息上下文提取，交互式命令结果仅回到来源会话 |
 | Telegram 会话 | 运行时上下文 | - | - | 从来源消息上下文提取，交互式命令结果仅回到来源会话 |
 
+Discord 长报告发送复用现有分片链路：单条 `content` 运行时不会超过 Discord 2000 字符限制，Webhook 与 Bot API 都会逐片发送并在片与片之间短暂等待；遇到 429 时按 Discord 返回的 `retry_after` 或 `Retry-After` 做有限重试，避免中途限流后只收到前半段报告。
+
 ## Minimal / Advanced 分层
 
 - Minimal key：足以启用一个通知渠道的最小配置。

--- a/src/notification_sender/discord_sender.py
+++ b/src/notification_sender/discord_sender.py
@@ -216,7 +216,7 @@ class DiscordSender:
         for attempt in range(1, DISCORD_MAX_RETRIES + 1):
             try:
                 response = requests.post(url, **request_kwargs)
-            except (requests.exceptions.ConnectionError, requests.exceptions.Timeout) as e:
+            except requests.exceptions.RequestException as e:
                 if attempt < DISCORD_MAX_RETRIES:
                     delay = 2 ** attempt
                     logger.warning(

--- a/src/notification_sender/discord_sender.py
+++ b/src/notification_sender/discord_sender.py
@@ -6,15 +6,21 @@ Discord 发送提醒服务
 1. 通过 webhook 或 Discord bot API 发送 Discord 消息
 """
 import logging
+import time
 from typing import Optional
 
 import requests
 
 from src.config import Config
-from src.formatters import chunk_content_by_max_words
+from src.formatters import MIN_MAX_WORDS, chunk_content_by_max_words
 
 
 logger = logging.getLogger(__name__)
+
+
+DISCORD_MAX_CONTENT_LENGTH = 2000
+DISCORD_MAX_RETRIES = 3
+DISCORD_CHUNK_SLEEP_SECONDS = 1
 
 
 class DiscordSender:
@@ -31,8 +37,18 @@ class DiscordSender:
             'channel_id': getattr(config, 'discord_main_channel_id', None),
             'webhook_url': getattr(config, 'discord_webhook_url', None),
         }
-        self._discord_max_words = getattr(config, 'discord_max_words', 2000)
+        self._discord_max_words = self._normalize_max_words(
+            getattr(config, 'discord_max_words', DISCORD_MAX_CONTENT_LENGTH)
+        )
         self._webhook_verify_ssl = getattr(config, 'webhook_verify_ssl', True)
+
+    @staticmethod
+    def _normalize_max_words(value) -> int:
+        try:
+            configured = int(value)
+        except (TypeError, ValueError):
+            configured = DISCORD_MAX_CONTENT_LENGTH
+        return max(MIN_MAX_WORDS, min(configured, DISCORD_MAX_CONTENT_LENGTH))
     
     def _is_discord_configured(self) -> bool:
         """检查 Discord 配置是否完整（支持 Bot 或 Webhook）"""
@@ -52,22 +68,75 @@ class DiscordSender:
             是否发送成功
         """
         # 分割内容，避免单条消息超过 Discord 限制
-        try:
-            chunks = chunk_content_by_max_words(content, self._discord_max_words)
-        except ValueError as e:
-            logger.error(f"分割 Discord 消息失败: {e}, 尝试整段发送。")
-            chunks = [content]
+        chunks = self._split_discord_content(content)
 
         # 优先使用 Webhook（配置简单，权限低）
         if self._discord_config['webhook_url']:
-            return all(self._send_discord_webhook(chunk, timeout_seconds=timeout_seconds) for chunk in chunks)
+            return self._send_discord_chunks(
+                chunks,
+                self._send_discord_webhook,
+                "Webhook",
+                timeout_seconds=timeout_seconds,
+            )
 
         # 其次使用 Bot API（权限高，需要 channel_id）
         if self._discord_config['bot_token'] and self._discord_config['channel_id']:
-            return all(self._send_discord_bot(chunk, timeout_seconds=timeout_seconds) for chunk in chunks)
+            return self._send_discord_chunks(
+                chunks,
+                self._send_discord_bot,
+                "Bot",
+                timeout_seconds=timeout_seconds,
+            )
 
         logger.warning("Discord 配置不完整，跳过推送")
         return False
+
+    def _split_discord_content(self, content: str) -> list[str]:
+        """按 Discord content 上限拆分消息。"""
+        try:
+            chunks = chunk_content_by_max_words(content, self._discord_max_words)
+            if len(chunks) > 1:
+                chunks = chunk_content_by_max_words(
+                    content,
+                    self._discord_max_words,
+                    add_page_marker=True,
+                )
+            return chunks
+        except ValueError as e:
+            logger.error("分割 Discord 消息失败: %s", e)
+            return chunk_content_by_max_words(
+                content,
+                DISCORD_MAX_CONTENT_LENGTH,
+                add_page_marker=True,
+            )
+
+    def _send_discord_chunks(
+        self,
+        chunks: list[str],
+        send_once,
+        channel_name: str,
+        *,
+        timeout_seconds: Optional[float] = None,
+    ) -> bool:
+        """逐片发送 Discord 消息；失败片不应阻断后续片尝试。"""
+        total_chunks = len(chunks)
+        success_count = 0
+
+        if total_chunks > 1:
+            logger.info("Discord %s 分批发送：共 %d 批", channel_name, total_chunks)
+
+        for i, chunk in enumerate(chunks):
+            if send_once(chunk, timeout_seconds=timeout_seconds):
+                success_count += 1
+                if total_chunks > 1:
+                    logger.info("Discord %s 第 %d/%d 批发送成功", channel_name, i + 1, total_chunks)
+            else:
+                logger.error("Discord %s 第 %d/%d 批发送失败", channel_name, i + 1, total_chunks)
+
+            if i < total_chunks - 1:
+                time.sleep(DISCORD_CHUNK_SLEEP_SECONDS)
+
+        return success_count == total_chunks
 
   
     def _send_discord_webhook(self, content: str, *, timeout_seconds: Optional[float] = None) -> bool:
@@ -82,29 +151,20 @@ class DiscordSender:
         Returns:
             是否发送成功
         """
-        try:
-            payload = {
-                'content': content,
-                'username': 'A股分析机器人',
-                'avatar_url': 'https://picsum.photos/200'
-            }
-            
-            response = requests.post(
-                self._discord_config['webhook_url'],
-                json=payload,
-                timeout=timeout_seconds or 10,
-                verify=self._webhook_verify_ssl
-            )
-            
-            if response.status_code in [200, 204]:
-                logger.info("Discord Webhook 消息发送成功")
-                return True
-            else:
-                logger.error(f"Discord Webhook 发送失败: {response.status_code} {response.text}")
-                return False
-        except Exception as e:
-            logger.error(f"Discord Webhook 发送异常: {e}")
-            return False
+        payload = {
+            'content': content,
+            'username': 'A股分析机器人',
+            'avatar_url': 'https://picsum.photos/200'
+        }
+
+        return self._post_discord_message(
+            self._discord_config['webhook_url'],
+            payload,
+            success_statuses=(200, 204),
+            verify=self._webhook_verify_ssl,
+            timeout_seconds=timeout_seconds,
+            channel_name="Webhook",
+        )
     
     def _send_discord_bot(self, content: str, *, timeout_seconds: Optional[float] = None) -> bool:
         """
@@ -116,25 +176,115 @@ class DiscordSender:
         Returns:
             是否发送成功
         """
-        try:
-            headers = {
-                'Authorization': f'Bot {self._discord_config["bot_token"]}',
-                'Content-Type': 'application/json'
-            }
-            
-            payload = {
-                'content': content
-            }
-            
-            url = f'https://discord.com/api/v10/channels/{self._discord_config["channel_id"]}/messages'
-            response = requests.post(url, json=payload, headers=headers, timeout=timeout_seconds or 10)
-            
-            if response.status_code == 200:
-                logger.info("Discord Bot 消息发送成功")
-                return True
-            else:
-                logger.error(f"Discord Bot 发送失败: {response.status_code} {response.text}")
+        headers = {
+            'Authorization': f'Bot {self._discord_config["bot_token"]}',
+            'Content-Type': 'application/json'
+        }
+        payload = {'content': content}
+        url = f'https://discord.com/api/v10/channels/{self._discord_config["channel_id"]}/messages'
+
+        return self._post_discord_message(
+            url,
+            payload,
+            headers=headers,
+            success_statuses=(200,),
+            timeout_seconds=timeout_seconds,
+            channel_name="Bot",
+        )
+
+    def _post_discord_message(
+        self,
+        url: str,
+        payload: dict,
+        *,
+        success_statuses: tuple[int, ...],
+        headers: Optional[dict] = None,
+        verify: Optional[bool] = None,
+        timeout_seconds: Optional[float] = None,
+        channel_name: str,
+    ) -> bool:
+        """发送单条 Discord 消息，并复用 Telegram 的有限重试思路处理 429/5xx。"""
+        request_kwargs = {
+            'json': payload,
+            'timeout': timeout_seconds or 10,
+        }
+        if headers:
+            request_kwargs['headers'] = headers
+        if verify is not None:
+            request_kwargs['verify'] = verify
+
+        for attempt in range(1, DISCORD_MAX_RETRIES + 1):
+            try:
+                response = requests.post(url, **request_kwargs)
+            except (requests.exceptions.ConnectionError, requests.exceptions.Timeout) as e:
+                if attempt < DISCORD_MAX_RETRIES:
+                    delay = 2 ** attempt
+                    logger.warning(
+                        "Discord %s 请求异常（%d/%d）：%s，%s 秒后重试",
+                        channel_name,
+                        attempt,
+                        DISCORD_MAX_RETRIES,
+                        e,
+                        delay,
+                    )
+                    time.sleep(delay)
+                    continue
+                logger.error("Discord %s 请求重试后仍失败: %s", channel_name, e)
                 return False
-        except Exception as e:
-            logger.error(f"Discord Bot 发送异常: {e}")
+
+            if response.status_code in success_statuses:
+                logger.info("Discord %s 消息发送成功", channel_name)
+                return True
+
+            if response.status_code == 429 and attempt < DISCORD_MAX_RETRIES:
+                retry_after = self._get_retry_after_seconds(response, attempt)
+                logger.warning(
+                    "Discord %s 触发限流，%s 秒后重试（%d/%d）",
+                    channel_name,
+                    retry_after,
+                    attempt,
+                    DISCORD_MAX_RETRIES,
+                )
+                time.sleep(retry_after)
+                continue
+
+            if response.status_code >= 500 and attempt < DISCORD_MAX_RETRIES:
+                delay = 2 ** attempt
+                logger.warning(
+                    "Discord %s 服务端错误 HTTP %s（%d/%d），%s 秒后重试",
+                    channel_name,
+                    response.status_code,
+                    attempt,
+                    DISCORD_MAX_RETRIES,
+                    delay,
+                )
+                time.sleep(delay)
+                continue
+
+            logger.error(
+                "Discord %s 发送失败: %s %s",
+                channel_name,
+                response.status_code,
+                response.text,
+            )
             return False
+
+        return False
+
+    @staticmethod
+    def _get_retry_after_seconds(response, attempt: int) -> float:
+        try:
+            retry_after = response.json().get('retry_after')
+            if retry_after is not None:
+                return max(0.0, float(retry_after))
+        except (AttributeError, TypeError, ValueError):
+            pass
+
+        try:
+            retry_after = response.headers.get('Retry-After')
+            if retry_after is not None:
+                return max(0.0, float(retry_after))
+        except AttributeError:
+            pass
+
+        return float(2 ** attempt)

--- a/tests/test_notification.py
+++ b/tests/test_notification.py
@@ -537,8 +537,14 @@ class TestNotificationServiceSendToMethods(unittest.TestCase):
         mock_post.assert_called_once()
         
     @mock.patch("src.notification.get_config")
+    @mock.patch("src.notification_sender.discord_sender.time.sleep", return_value=None)
     @mock.patch("requests.post")
-    def test_send_to_discord_via_notification_service_with_bot_requires_chunking(self, mock_post: mock.MagicMock, mock_get_config: mock.MagicMock):
+    def test_send_to_discord_via_notification_service_with_bot_requires_chunking(
+        self,
+        mock_post: mock.MagicMock,
+        _mock_sleep: mock.MagicMock,
+        mock_get_config: mock.MagicMock,
+    ):
         cfg = _make_config(
             discord_bot_token="TOKEN",
             discord_main_channel_id="123",

--- a/tests/test_notification_sender.py
+++ b/tests/test_notification_sender.py
@@ -136,6 +136,75 @@ class TestDiscordSender(unittest.TestCase):
         call_kw = mock_post.call_args[1]
         self.assertEqual(call_kw["headers"]["Authorization"], "Bot TOKEN")
 
+    @mock.patch("src.notification_sender.discord_sender.time.sleep", return_value=None)
+    @mock.patch("src.notification_sender.discord_sender.requests.post")
+    def test_send_webhook_long_content_sends_all_chunks(self, mock_post, mock_sleep):
+        mock_post.return_value = _response(204)
+        cfg = _config(discord_webhook_url="https://discord.com/webhook/1", discord_max_words=2000)
+        sender = DiscordSender(cfg)
+
+        result = sender.send_to_discord("A" * 6000)
+
+        self.assertTrue(result)
+        self.assertGreater(mock_post.call_count, 1)
+        self.assertEqual(mock_sleep.call_count, mock_post.call_count - 1)
+        payload_lengths = [len(call.kwargs["json"]["content"]) for call in mock_post.call_args_list]
+        self.assertTrue(all(length <= 2000 for length in payload_lengths))
+
+    @mock.patch("src.notification_sender.discord_sender.time.sleep", return_value=None)
+    @mock.patch("src.notification_sender.discord_sender.requests.post")
+    def test_send_webhook_long_content_retries_429_and_continues(self, mock_post, mock_sleep):
+        mock_post.side_effect = [
+            _response(204),
+            _response(429, {"retry_after": 0}),
+            _response(204),
+            _response(204),
+            _response(204),
+        ]
+        cfg = _config(discord_webhook_url="https://discord.com/webhook/1", discord_max_words=2000)
+        sender = DiscordSender(cfg)
+
+        result = sender.send_to_discord("A" * 6000)
+
+        self.assertTrue(result)
+        self.assertEqual(mock_post.call_count, 5)
+        mock_sleep.assert_any_call(0.0)
+
+    @mock.patch("src.notification_sender.discord_sender.time.sleep", return_value=None)
+    @mock.patch("src.notification_sender.discord_sender.requests.post")
+    def test_send_webhook_long_content_does_not_short_circuit_after_failed_chunk(self, mock_post, _mock_sleep):
+        mock_post.side_effect = [
+            _response(204),
+            _response(400),
+            _response(204),
+            _response(204),
+        ]
+        cfg = _config(discord_webhook_url="https://discord.com/webhook/1", discord_max_words=2000)
+        sender = DiscordSender(cfg)
+
+        result = sender.send_to_discord("A" * 6000)
+
+        self.assertFalse(result)
+        self.assertEqual(mock_post.call_count, 4)
+
+    @mock.patch("src.notification_sender.discord_sender.time.sleep", return_value=None)
+    @mock.patch("src.notification_sender.discord_sender.requests.post")
+    def test_send_bot_clamps_configured_limit_to_discord_content_limit(self, mock_post, _mock_sleep):
+        mock_post.return_value = _response(200)
+        cfg = _config(
+            discord_bot_token="TOKEN",
+            discord_main_channel_id="CH123",
+            discord_max_words=5000,
+        )
+        sender = DiscordSender(cfg)
+
+        result = sender.send_to_discord("A" * 4500)
+
+        self.assertTrue(result)
+        self.assertGreater(mock_post.call_count, 1)
+        payload_lengths = [len(call.kwargs["json"]["content"]) for call in mock_post.call_args_list]
+        self.assertTrue(all(length <= 2000 for length in payload_lengths))
+
 
 class TestWechatSender(unittest.TestCase):
     """Unit tests for WechatSender."""

--- a/tests/test_notification_sender.py
+++ b/tests/test_notification_sender.py
@@ -189,6 +189,25 @@ class TestDiscordSender(unittest.TestCase):
 
     @mock.patch("src.notification_sender.discord_sender.time.sleep", return_value=None)
     @mock.patch("src.notification_sender.discord_sender.requests.post")
+    def test_send_webhook_long_content_continues_after_request_exception(self, mock_post, _mock_sleep):
+        cfg = _config(discord_webhook_url="https://discord.com/webhook/1", discord_max_words=2000)
+        sender = DiscordSender(cfg)
+        content = "A" * 6000
+        chunk_count = len(sender._split_discord_content(content))
+        request_error = requests.exceptions.ChunkedEncodingError("broken response")
+        mock_post.side_effect = (
+            [_response(204)]
+            + [request_error] * 3
+            + [_response(204)] * (chunk_count - 2)
+        )
+
+        result = sender.send_to_discord(content)
+
+        self.assertFalse(result)
+        self.assertEqual(mock_post.call_count, chunk_count + 2)
+
+    @mock.patch("src.notification_sender.discord_sender.time.sleep", return_value=None)
+    @mock.patch("src.notification_sender.discord_sender.requests.post")
     def test_send_bot_clamps_configured_limit_to_discord_content_limit(self, mock_post, _mock_sleep):
         mock_post.return_value = _response(200)
         cfg = _config(


### PR DESCRIPTION
## PR Type

- [x] fix
- [ ] feat
- [ ] refactor
- [x] docs
- [ ] chore
- [x] test

## Background And Problem

Fixes #1845。Discord 单条 `content` 有 2000 字符上限，当前实现虽然会对长报告做分片，但 Webhook/Bot 路径都使用 `all(...)` 发送分片。一旦中间某一片遇到 429 限流、5xx 或临时网络失败，后续分片会被短路跳过，用户实际只能收到报告前半段。

## Scope Of Change

- 文件总数 / 变更行数：

```text
 .env.example                              |   1 +
 docs/CHANGELOG.md                         |   1 +
 docs/full-guide.md                        |   4 +-
 docs/full-guide_EN.md                     |   4 +-
 docs/notifications.md                     |   2 +
 src/notification_sender/discord_sender.py | 254 ++++++++++++++++++++++++------
 tests/test_notification.py                |   8 +-
 tests/test_notification_sender.py         |  69 ++++++++
 8 files changed, 288 insertions(+), 55 deletions(-)
```

- 文件清单：`.env.example`、`docs/CHANGELOG.md`、`docs/full-guide.md`、`docs/full-guide_EN.md`、`docs/notifications.md`、`src/notification_sender/discord_sender.py`、`tests/test_notification.py`、`tests/test_notification_sender.py`
- 文档更新文件：`.env.example`、`docs/CHANGELOG.md`、`docs/full-guide.md`、`docs/full-guide_EN.md`、`docs/notifications.md`

## Issue Link

Fixes #1845

## Verification Commands And Results

```bash
python -m py_compile src/notification_sender/discord_sender.py src/notification.py
# pass

PYTHONUTF8=1 python -m pytest tests/test_notification_sender.py::TestDiscordSender tests/test_notification.py::TestNotificationServiceSendToMethods::test_send_to_discord_via_notification_service_with_bot_requires_chunking
# 12 passed

PYTHONUTF8=1 bash ./scripts/ci_gate.sh syntax
# pass

PYTHONUTF8=1 python -m pytest -m "not network" tests/test_notification.py
# 77 passed

python -m flake8 src/notification_sender/discord_sender.py tests/test_notification_sender.py tests/test_notification.py --select=E9,F63,F7,F82 --max-line-length=120
# pass

git diff --check
# pass
```

Full-suite note: 本地执行 `PYTHONUTF8=1 python -m pytest -m "not network" tests/test_notification_sender.py tests/test_notification.py` 时，Discord 与 `tests/test_notification.py` 均通过；`tests/test_notification_sender.py` 中 6 个 Feishu App Bot 既有测试在本地失败，原因是当前 Windows/Anaconda 环境缺少或未暴露 `CreateMessageRequest` SDK 符号，和本 PR 的 Discord 改动无关。

当前 Head CI（run 28443074262）：ai-governance:pass / backend-gate:pending / docker-build:pass / web-gate:skipped

## Visual Evidence (if applicable)

- 截图链接 / Screenshot links：不适用。本 PR 不修改 Web UI、报告渲染效果或报告正文结构。
- 不适用原因：变更范围是 Discord 通知发送链路；可复现证据为上述单元测试，覆盖长报告分片、429 重试、失败分片不短路后续分片，以及 NotificationService Discord 入口。

## Compatibility And Risk

本 PR 未变更 provider/model/base URL、运行时配置清理迁移语义；历史配置保持不变；回滚方式为 revert 本提交。

兼容性：继续复用既有 `DISCORD_WEBHOOK_URL`、`DISCORD_BOT_TOKEN`、`DISCORD_MAIN_CHANNEL_ID` 和 `DISCORD_MAX_WORDS`。`DISCORD_MAX_WORDS` 可调低单片长度，但运行时会 clamp 到 Discord 2000 字符上限以内，避免用户配置过大导致平台拒收。

风险：长报告遇到 429/5xx 时会增加重试等待时间；如果某一片最终失败，发送器仍会继续尝试后续分片，并最终返回失败，用户可能收到带缺口的消息，但日志会记录失败片编号。

## Rollback Plan

revert this PR。无需额外配置或数据回滚；回滚后 Discord 恢复旧行为：长报告可分片，但中途失败会短路后续分片，且没有 429 `retry_after` 重试。

## EXTRACT_PROMPT Change (if applicable)

不适用，未修改 `src/services/image_stock_extractor.py`。

## Checklist

- [x] 本 PR 有明确动机和业务价值 / This PR has a clear motivation and value
- [x] 已提供可复现的验证命令与结果 / Reproducible verification commands and results are included
- [x] 已评估兼容性与风险 / Compatibility and risk have been assessed
- [x] 已提供回滚方案 / A rollback plan is provided
- [x] 若涉及用户可见变更，已同步更新相关文档与 `docs/CHANGELOG.md` / Relevant docs and `docs/CHANGELOG.md` are updated