### PR TITLE
feat(market): surface tw 三大法人 in the tw report institution block (Refs #1777)

### DIFF
--- a/data_provider/base.py
+++ b/data_provider/base.py
@@ -2952,10 +2952,63 @@ class DataFetcherManager:
             list(adapter_errors),
         )
 
-        # institution / capital_flow / dragon_tiger / boards: keep as not_supported
-        # for offshore markets — no equivalent data feed today.
-        for block in ("institution", "capital_flow", "dragon_tiger", "boards"):
+        # capital_flow / dragon_tiger / boards: no offshore data feed today -> not_supported.
+        for block in ("capital_flow", "dragon_tiger", "boards"):
             result_ctx[block] = self._build_fundamental_block(
+                "not_supported",
+                {},
+                [{"provider": "fundamental_pipeline", "result": "not_supported", "duration_ms": 0}],
+                ["not supported for offshore market"],
+            )
+
+        # institution: tw (台股) has a free official 三大法人 (institutional net buy/sell)
+        # feed (TWSE T86 / TPEx OpenAPI); every other offshore market keeps not_supported.
+        # tw-only + strictly additive + fail-open: any error or no-data -> not_supported,
+        # which never interrupts the main analysis. Raw net figures only — no derived
+        # signal / score / schema (per the v2 scope confirmed on issue #1777).
+        tw_record = None
+        if market == "tw":
+            fetcher = getattr(self, "_tw_institutional_fetcher", None)
+            if fetcher is None:
+                # Wiring (import + construct) is a one-time op; a failure here is a
+                # programming / deploy bug, so log it LOUD (error). Still fail-open
+                # (never interrupt the main analysis — a hard requirement of #1777).
+                try:
+                    from data_provider.tw_institutional_fetcher import TwInstitutionalFetcher
+
+                    fetcher = TwInstitutionalFetcher()
+                    self._tw_institutional_fetcher = fetcher
+                except Exception as exc:  # noqa: BLE001 - wiring failure: loud but fail-open
+                    logger.error("[tw-inst] fetcher init failed (wiring bug?) code=%s: %s", stock_code, exc)
+                    fetcher = None
+            if fetcher is not None:
+                try:
+                    tw_record = fetcher.get_institutional_net(stock_code)
+                except Exception as exc:  # noqa: BLE001 - fetch failure: fail-open
+                    logger.warning("[tw-inst] fetch failed code=%s: %s", stock_code, exc)
+                    tw_record = None
+        # status 'ok' only when the record carries all core net figures (a genuine 0 is
+        # kept — 0 is not None); None / missing core field / fetch failure -> not_supported.
+        _tw_core = ("foreign_net", "trust_net", "dealer_net", "total_net")
+        if tw_record is not None and all(tw_record.get(key) is not None for key in _tw_core):
+            institution_status = "ok"
+            result_ctx["institution"] = self._build_fundamental_block(
+                "ok",
+                {
+                    "foreign_net": tw_record.get("foreign_net"),
+                    "trust_net": tw_record.get("trust_net"),
+                    "dealer_net": tw_record.get("dealer_net"),
+                    "total_net": tw_record.get("total_net"),
+                    "unit": tw_record.get("unit"),
+                    "date": tw_record.get("date"),
+                    "source": tw_record.get("source"),
+                },
+                [{"provider": tw_record.get("source", "tw-institutional"), "result": "ok", "duration_ms": 0}],
+                [],
+            )
+        else:
+            institution_status = "not_supported"
+            result_ctx["institution"] = self._build_fundamental_block(
                 "not_supported",
                 {},
                 [{"provider": "fundamental_pipeline", "result": "not_supported", "duration_ms": 0}],
@@ -2968,7 +3021,7 @@ class DataFetcherManager:
             "valuation": result_ctx["valuation"].get("status", "not_supported"),
             "growth": growth_status,
             "earnings": earnings_status,
-            "institution": "not_supported",
+            "institution": institution_status,
             "capital_flow": "not_supported",
             "dragon_tiger": "not_supported",
             "boards": "not_supported",

--- a/data_provider/base.py
+++ b/data_provider/base.py
@@ -2982,10 +2982,19 @@ class DataFetcherManager:
                     logger.error("[tw-inst] fetcher init failed (wiring bug?) code=%s: %s", stock_code, exc)
                     fetcher = None
             if fetcher is not None:
-                try:
-                    tw_record = fetcher.get_institutional_net(stock_code)
-                except Exception as exc:  # noqa: BLE001 - fetch failure: fail-open
-                    logger.warning("[tw-inst] fetch failed code=%s: %s", stock_code, exc)
+                # Run the fetch under the SAME fundamental stage/fetch budget as the other
+                # offshore blocks (_run_with_retry) so a slow / rate-limited TWSE/TPEx call
+                # cannot push the analysis past its deadline — it fails open on timeout.
+                inst_timeout = min(fetch_timeout, max(stage_timeout - (time.time() - start_ts), 0.0))
+                if inst_timeout > 0:
+                    tw_record, inst_err, _inst_ms = self._run_with_retry(
+                        lambda: fetcher.get_institutional_net(stock_code),
+                        inst_timeout,
+                        "fundamental_tw_institution",
+                    )
+                    if inst_err:
+                        logger.warning("[tw-inst] fetch failed/timeout code=%s: %s", stock_code, inst_err)
+                else:
                     tw_record = None
         # status 'ok' only when the record carries all core net figures (a genuine 0 is
         # kept — 0 is not None); None / missing core field / fetch failure -> not_supported.
@@ -3032,10 +3041,17 @@ class DataFetcherManager:
             result_ctx["source_chain"].extend(result_ctx[block].get("source_chain", []))
 
         active_statuses = {"valuation": valuation_status, "growth": growth_status, "earnings": earnings_status}
-        if all(value == "not_supported" for value in active_statuses.values()):
+        # tw institution (when present) counts toward the OVERALL status so a report that
+        # only has 三大法人 data still surfaces fundamentals (consumers key off the top-level
+        # status). missing_fields stays the original three blocks, so offshore markets
+        # without institution data are byte-identical (institution is not_supported there).
+        status_values = list(active_statuses.values())
+        if institution_status == "ok":
+            status_values.append("ok")
+        if all(value == "not_supported" for value in status_values):
             result_ctx["status"] = "not_supported"
             result_ctx["data_quality"] = "unavailable"
-        elif "failed" in active_statuses.values() or "partial" in active_statuses.values():
+        elif "failed" in status_values or "partial" in status_values:
             result_ctx["status"] = "partial"
             result_ctx["data_quality"] = "partial"
         else:

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - [修复] 修复 macOS 桌面端从 Finder/Dock 启动时后端 PATH 看不到 Homebrew Codex CLI 的问题，并明确 Codex CLI 主分析与 Agent LiteLLM 工具调用分流诊断。
 - [测试] 台股三大法人 fetcher（TwInstitutionalFetcher）新增真实端点 live-smoke 脚本（tests/tw_institutional_live_smoke.py，非 pytest）与 @pytest.mark.network 漂移检测测试：核对 TWSE T86 / TPEx 核心字段名仍在、解析结果与原始字段一致；仅在非阻断的 network-smoke 定时任务运行，阻断门（pytest -m "not network"）不收集，离线 fixtures 无法察觉的上游字段改名/端点变动由此告警。
 - [修复] 修复 Web 设置页定时任务“立即执行一次”后台线程未传 `stock_codes` 导致任务崩溃的问题。
+- [新功能] 台股报告接入三大法人：tw 个股分析报告的 institution 区块改为展示 TWSE T86 / TPEx 三大法人原始买卖超净额（外资/投信/自营/合计，单位:股）；tw-only、严格 additive（A股/港股/美股/日韩股 offshore 流程字节不变）、fail-open（取不到数据维持 not_supported，绝不中断分析）；不接 Web、不派生 capital_flow_signal、不改评分权重或 schema。
 
 ## [3.24.1] - 2026-06-28
 

--- a/docs/full-guide.md
+++ b/docs/full-guide.md
@@ -412,6 +412,7 @@ daily_stock_analysis/
 > - ETF：返回可得项，缺失能力标记为 `not_supported`，整体不影响原流程；
 > - 美股/港股：通过 yfinance 适配器返回 `valuation/growth/earnings/belong_boards`（来源 `info.sector`/`industry`），`institution/capital_flow/dragon_tiger/boards` 暂无对应数据源仍标记 `not_supported`；yfinance 不可用或字段缺失时整体降级回 `not_supported`，仍走 fail-open；
 > - 日股/韩股：当前仅走 Yfinance 基础路径获取日线与实时行情；`institution`、`capital_flow`、`dragon_tiger`、`boards` 等依赖 A 股专属源/离岸完整版的能力会降级为 `not_supported`（详见 [市场支持与边界](market-support.md)）；
+> - 台股：在美股/港股 offshore 基础路径之外，`institution` 区块额外展示三大法人原始买卖超净额（TWSE T86 / TPEx，默认开启、fail-open，取不到数据时维持 `not_supported`）；`capital_flow`、`dragon_tiger`、`boards` 仍为 `not_supported`；
 > - 任何异常走 fail-open，仅记录错误，不影响技术面/新闻/筹码主链路。
 > - 配置 `TICKFLOW_API_KEY` 后，TickFlow 会作为可选 A 股日 K 数据源和大盘复盘增强源实例化；`TICKFLOW_PRIORITY` 只影响日 K/通用数据源回退链。实时行情优先级由 `REALTIME_SOURCE_PRIORITY` 单独控制，只有显式包含 `tickflow` 时才会使用 TickFlow 实时行情。`REALTIME_SOURCE_PRIORITY` 中排在 `tickflow` 前面的数据源会先被尝试。
 > - TickFlow 日 K 默认 `TICKFLOW_KLINE_ADJUST=none`；日线 `volume` 从手统一转为股，`amount` 保持元口径。

--- a/docs/full-guide_EN.md
+++ b/docs/full-guide_EN.md
@@ -341,6 +341,7 @@ For the notification baseline, diagnostics, and deployment notes, see [Notificat
 > - **ETFs**: Returns available items, marks missing capabilities as `not_supported`, and does not affect the original flow overall.
 > - **US/HK stocks**: Returns `valuation/growth/earnings/belong_boards` (sourced from `info.sector`/`info.industry`) via the yfinance adapter; `institution/capital_flow/dragon_tiger/boards` stay `not_supported` because no offshore data feed exists today. Falls back to a full `not_supported` block if yfinance is unavailable or returns empty payloads. Still fail-open.
 > - **Japanese/Korean stocks**: Current MVP uses Yfinance daily/basic quote coverage only; `institution`, `capital_flow`, `dragon_tiger`, and `boards` are not fully supported and degrade to `not_supported` (see [market boundaries](market-support.md)).
+> - **Taiwan stocks**: On top of the US/HK offshore base path, the `institution` block additionally surfaces raw 三大法人 (institutional) net buy/sell figures (TWSE T86 / TPEx, default-on, fail-open — stays `not_supported` when data is unavailable); `capital_flow`, `dragon_tiger`, and `boards` remain `not_supported`.
 > - Any exception uses fail-open logic, only logs errors without affecting the main technical/news/chip pipeline.
 > - **Field contracts**:
 >   - `fundamental_context.belong_boards` = related board list for the stock; A-shares are sourced from AkShare board membership, US/HK from yfinance `info.sector`/`info.industry`, `[]` when unavailable;

--- a/docs/market-support.md
+++ b/docs/market-support.md
@@ -107,7 +107,7 @@ PY
 - 报告 Prompt 已增加台股市场语义（新台币、三大法人、TWSE/TPEx ±10% 涨跌停），避免套用 A 股北向资金、龙虎榜等概念。
 - 交易日历注册 `tw: XTAI / Asia/Taipei`。TWSE 为 09:00–13:30 连续交易、无午休；收盘集合竞价暂不建模，与 jp/kr 一致。若本地 `exchange-calendars` 版本缺少对应日历，既有 fail-open/fail-closed 语义保持不变。
 - 主要指数提供加权指数 `^TWII` 与柜买指数 `^TWOII`。
-- 三大法人买卖超（institutional flows）资料层：`TwInstitutionalFetcher`（`data_provider/tw_institutional_fetcher.py`）提供上市（TWSE T86，legacy `rwd` 端点）/ 上柜（TPEx OpenAPI）每日外资·投信·自营商·三大法人买卖超（单位：**股数**；按日期+市场做单日全市场缓存再过滤个股，TPEx 民国年转西元有单测覆盖）。接口失败/限流/空响应/字段缺失一律 **fail-open** 返回无数据，不中断分析；仅对 `.TW`/`.TWO` 生效，不改动现有市场流程。资料来源为政府开放资料，采「政府资料开放授权条款第 1 版」(OGDL v1，允许商用与再散布，需标示来源)。**本次仅资料层 fetcher/parser/cache/tests，尚未接入报告展示、Web 展示、评分权重或 `capital_flow_signal` 派生。**
+- 三大法人买卖超（institutional flows）资料层：`TwInstitutionalFetcher`（`data_provider/tw_institutional_fetcher.py`）提供上市（TWSE T86，legacy `rwd` 端点）/ 上柜（TPEx OpenAPI）每日外资·投信·自营商·三大法人买卖超（单位：**股数**；按日期+市场做单日全市场缓存再过滤个股，TPEx 民国年转西元有单测覆盖）。接口失败/限流/空响应/字段缺失一律 **fail-open** 返回无数据，不中断分析；仅对 `.TW`/`.TWO` 生效，不改动现有市场流程。资料来源为政府开放资料，采「政府资料开放授权条款第 1 版」(OGDL v1，允许商用与再散布，需标示来源)。**三大法人已接入台股报告的 `institution` 区块（展示原始买卖超净额，默认开启、fail-open，取不到数据维持 `not_supported`）；Web 展示、评分权重与 `capital_flow_signal` 派生仍为后续。**
 
 不承诺项：
 

--- a/tests/test_tw_institution_report_wiring.py
+++ b/tests/test_tw_institution_report_wiring.py
@@ -1,0 +1,173 @@
+# -*- coding: utf-8 -*-
+"""v2 report-wiring tests: tw 三大法人 (institutional flows) into the offshore institution block.
+
+Pins the maintainer-confirmed contract for issue #1777 v2:
+  - tw with data        -> institution coverage 'ok', raw net figures surfaced.
+  - tw fetch-failed/None -> institution stays 'not_supported' (fail-open, main flow alive).
+  - us/hk/jp/kr          -> institution stays 'not_supported' AND the tw fetcher is never
+                            called (strictly-additive: other markets byte-identical).
+  - tw institution data carries RAW figures only — no capital_flow_signal / score / schema.
+
+Mirrors tests/test_fundamental_context.py's offshore pattern; fully offline (no network),
+so it runs under the blocking backend gate (`pytest -m "not network"`).
+"""
+
+import os
+import sys
+import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from data_provider.base import DataFetcherManager
+
+_TW_FETCHER_METHOD = (
+    "data_provider.tw_institutional_fetcher.TwInstitutionalFetcher.get_institutional_net"
+)
+
+# Shape mirrors TwInstitutionalFetcher._build_record (real 2330 @ 20260629).
+_FAKE_REC = {
+    "stock_code": "2330",
+    "date": "20260629",
+    "market": "上市",
+    "source": "TWSE-T86",
+    "unit": "shares",
+    "foreign_net": -1912490,
+    "trust_net": 919216,
+    "dealer_net": 996850,
+    "total_net": 3576,
+}
+
+_OFFSHORE_CFG = SimpleNamespace(
+    enable_fundamental_pipeline=True,
+    fundamental_cache_ttl_seconds=0,
+    fundamental_stage_timeout_seconds=1.5,
+    fundamental_fetch_timeout_seconds=0.8,
+    fundamental_retry_max=1,
+)
+
+_EMPTY_BUNDLE = {
+    "status": "not_supported",
+    "growth": {},
+    "earnings": {},
+    "belong_boards": [],
+    "source_chain": [],
+    "errors": [],
+}
+
+
+class TestTwInstitutionReportWiring(unittest.TestCase):
+    def _context(self, code, institutional_return=None, institutional_side_effect=None):
+        """Run get_fundamental_context(code) offline; returns (ctx, tw_fetcher_mock)."""
+        manager = DataFetcherManager(fetchers=[])
+        kwargs = {}
+        if institutional_side_effect is not None:
+            kwargs["side_effect"] = institutional_side_effect
+        else:
+            kwargs["return_value"] = institutional_return
+        with patch("src.config.get_config", return_value=_OFFSHORE_CFG), \
+                patch.object(manager, "get_realtime_quote", return_value=None), \
+                patch(
+                    "data_provider.yfinance_fundamental_adapter.YfinanceFundamentalAdapter.get_fundamental_bundle",
+                    return_value=_EMPTY_BUNDLE,
+                ), \
+                patch(_TW_FETCHER_METHOD, **kwargs) as tw_mock:
+            ctx = manager.get_fundamental_context(code)
+        return ctx, tw_mock
+
+    # ---- tw with data: institution surfaces the raw net figures --------------------
+    def test_tw_institution_populated_when_fetcher_has_data(self):
+        ctx, tw_mock = self._context("2330.TW", institutional_return=dict(_FAKE_REC))
+        self.assertEqual(ctx["market"], "tw")
+        self.assertEqual(ctx["coverage"].get("institution"), "ok")
+        data = ctx["institution"]["data"]
+        self.assertEqual(data["foreign_net"], -1912490)
+        self.assertEqual(data["trust_net"], 919216)
+        self.assertEqual(data["dealer_net"], 996850)
+        self.assertEqual(data["total_net"], 3576)
+        self.assertEqual(data["unit"], "shares")
+        self.assertEqual(data["source"], "TWSE-T86")
+        # other offshore blocks untouched
+        for block in ("capital_flow", "dragon_tiger", "boards"):
+            self.assertEqual(ctx["coverage"].get(block), "not_supported")
+        tw_mock.assert_called_once_with("2330.TW")
+
+    # ---- tw genuine-zero day is kept (record present, nets 0) ----------------------
+    def test_tw_institution_keeps_genuine_zero(self):
+        zero_rec = dict(_FAKE_REC, foreign_net=0, trust_net=0, dealer_net=0, total_net=0)
+        ctx, _ = self._context("6488.TWO", institutional_return=zero_rec)
+        self.assertEqual(ctx["coverage"].get("institution"), "ok")
+        self.assertEqual(ctx["institution"]["data"]["foreign_net"], 0)
+        self.assertEqual(ctx["institution"]["data"]["total_net"], 0)
+
+    # ---- tw fail-open: None -> not_supported, no raise -----------------------------
+    def test_tw_institution_fail_open_when_fetcher_returns_none(self):
+        ctx, _ = self._context("2330.TW", institutional_return=None)
+        self.assertEqual(ctx["coverage"].get("institution"), "not_supported")
+        self.assertEqual(ctx["institution"].get("data"), {})
+
+    # ---- tw fail-open: fetcher raises -> not_supported, main flow uninterrupted -----
+    def test_tw_institution_fail_open_when_fetcher_raises(self):
+        ctx, _ = self._context("2330.TW", institutional_side_effect=RuntimeError("boom"))
+        self.assertEqual(ctx["coverage"].get("institution"), "not_supported")
+        self.assertEqual(ctx["institution"].get("data"), {})
+        # the rest of the context still built (no exception bubbled out)
+        self.assertEqual(ctx["market"], "tw")
+
+    # ---- strictly-additive: us is byte-identical AND the tw fetcher is never called -
+    def test_us_institution_unchanged_and_tw_fetcher_not_called(self):
+        ctx, tw_mock = self._context("AAPL", institutional_return=dict(_FAKE_REC))
+        self.assertEqual(ctx["market"], "us")
+        self.assertEqual(ctx["coverage"].get("institution"), "not_supported")
+        self.assertEqual(ctx["institution"].get("data"), {})
+        self.assertEqual(tw_mock.call_count, 0)
+
+    # ---- B2: every other offshore market (hk/jp/kr) untouched + fetcher unused ------
+    def test_other_offshore_markets_institution_unchanged(self):
+        for code, market in (("0700.HK", "hk"), ("7203.T", "jp"), ("005930.KS", "kr")):
+            ctx, tw_mock = self._context(code, institutional_return=dict(_FAKE_REC))
+            self.assertEqual(ctx["market"], market, f"{code} routed to {ctx['market']}")
+            self.assertEqual(ctx["coverage"].get("institution"), "not_supported")
+            self.assertEqual(tw_mock.call_count, 0)
+
+    # ---- fail-open on a fetcher WIRING/init failure (not just a fetch failure) ------
+    def test_tw_institution_fail_open_when_fetcher_init_raises(self):
+        manager = DataFetcherManager(fetchers=[])
+        with patch("src.config.get_config", return_value=_OFFSHORE_CFG), \
+                patch.object(manager, "get_realtime_quote", return_value=None), \
+                patch(
+                    "data_provider.yfinance_fundamental_adapter.YfinanceFundamentalAdapter.get_fundamental_bundle",
+                    return_value=_EMPTY_BUNDLE,
+                ), \
+                patch(
+                    "data_provider.tw_institutional_fetcher.TwInstitutionalFetcher",
+                    side_effect=RuntimeError("init boom"),
+                ):
+            ctx = manager.get_fundamental_context("2330.TW")  # must NOT raise
+        self.assertEqual(ctx["market"], "tw")
+        self.assertEqual(ctx["coverage"].get("institution"), "not_supported")
+        self.assertEqual(ctx["institution"].get("data"), {})
+
+    # ---- a record missing a core net field is NOT shown as a clean 'ok' -------------
+    def test_tw_institution_not_ok_when_core_net_missing(self):
+        broken = dict(_FAKE_REC, foreign_net=None)  # a core component missing
+        ctx, _ = self._context("2330.TW", institutional_return=broken)
+        self.assertEqual(ctx["coverage"].get("institution"), "not_supported")
+        self.assertEqual(ctx["institution"].get("data"), {})
+
+    # ---- negative: institution data carries RAW figures only, no derived signal ----
+    def test_tw_institution_data_has_no_derived_signal_or_score(self):
+        ctx, _ = self._context("2330.TW", institutional_return=dict(_FAKE_REC))
+        data = ctx["institution"]["data"]
+        self.assertEqual(
+            set(data.keys()),
+            {"foreign_net", "trust_net", "dealer_net", "total_net", "unit", "date", "source"},
+        )
+        forbidden = ("capital_flow_signal", "signal", "score", "weight", "normalized", "rating")
+        for key in forbidden:
+            self.assertNotIn(key, data, f"derived key '{key}' leaked into institution data")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_tw_institution_report_wiring.py
+++ b/tests/test_tw_institution_report_wiring.py
@@ -14,6 +14,7 @@ so it runs under the blocking backend gate (`pytest -m "not network"`).
 
 import os
 import sys
+import time
 import unittest
 from types import SimpleNamespace
 from unittest.mock import patch
@@ -91,7 +92,10 @@ class TestTwInstitutionReportWiring(unittest.TestCase):
         # other offshore blocks untouched
         for block in ("capital_flow", "dragon_tiger", "boards"):
             self.assertEqual(ctx["coverage"].get(block), "not_supported")
-        tw_mock.assert_called_once_with("2330.TW")
+        # institution data must surface: the top-level status (which consumers key off)
+        # is not 'not_supported' even though valuation/growth/earnings are unavailable.
+        self.assertNotEqual(ctx["status"], "not_supported")
+        tw_mock.assert_called_with("2330.TW")
 
     # ---- tw genuine-zero day is kept (record present, nets 0) ----------------------
     def test_tw_institution_keeps_genuine_zero(self):
@@ -155,6 +159,35 @@ class TestTwInstitutionReportWiring(unittest.TestCase):
         ctx, _ = self._context("2330.TW", institutional_return=broken)
         self.assertEqual(ctx["coverage"].get("institution"), "not_supported")
         self.assertEqual(ctx["institution"].get("data"), {})
+
+    # ---- a slow fetch must NOT push the analysis past the fundamental stage budget ---
+    def test_tw_institution_fetch_respects_stage_timeout(self):
+        slow_cfg = SimpleNamespace(
+            enable_fundamental_pipeline=True,
+            fundamental_cache_ttl_seconds=0,
+            fundamental_stage_timeout_seconds=0.3,
+            fundamental_fetch_timeout_seconds=0.3,
+            fundamental_retry_max=1,
+        )
+        manager = DataFetcherManager(fetchers=[])
+
+        def _slow(_code):
+            time.sleep(2.0)  # simulate a slow / rate-limited TWSE-TPEx call
+            return dict(_FAKE_REC)
+
+        start = time.time()
+        with patch("src.config.get_config", return_value=slow_cfg), \
+                patch.object(manager, "get_realtime_quote", return_value=None), \
+                patch(
+                    "data_provider.yfinance_fundamental_adapter.YfinanceFundamentalAdapter.get_fundamental_bundle",
+                    return_value=_EMPTY_BUNDLE,
+                ), \
+                patch(_TW_FETCHER_METHOD, side_effect=_slow):
+            ctx = manager.get_fundamental_context("2330.TW")
+        elapsed = time.time() - start
+        # the 2s fetch must be abandoned at the ~0.3s stage budget, not block the analysis
+        self.assertLess(elapsed, 1.5, f"institution fetch ignored the stage timeout ({elapsed:.2f}s)")
+        self.assertEqual(ctx["coverage"].get("institution"), "not_supported")
 
     # ---- negative: institution data carries RAW figures only, no derived signal ----
     def test_tw_institution_data_has_no_derived_signal_or_score(self):


### PR DESCRIPTION
## PR Type

- [x] feat / 新功能

## Issue Link

Refs #1777（v2 报告接入，范围已由 @ZhuLinsen 在 #1777 确认）

## Background

`TwInstitutionalFetcher`（三大法人 fetcher，经 #1829 / #1841 / #1855 合入）此前仅为数据层，**未接入分析报告**。本 PR 按你在 #1777 确认的 v2 范围，把它接到台股报告的 `institution` 区块。

## Scope（tw-only、严格 additive、fail-open、默认开）

在 `data_provider/base.py` 的 `_build_offshore_fundamental_context` 中，**仅 `market == "tw"`** 时，把硬编码的 `not_supported` 换成 fetcher 取得的三大法人**原始买卖超净额**（外资 / 投信 / 自营 / 合计，单位:股）。

- **tw-only + 严格 additive**：cn/hk/us/jp/kr 的 offshore 流程**字节不变**，只动 tw 分支（测试已钉住 us/hk/jp/kr 不变且 fetcher 不被调用）。
- **fail-open + 默认开（无开关）**：任何错误 / 无数据 → `not_supported`，**绝不中断分析**。接线（import/构造）失败记 `error`（可见）但仍 fail-open；抓取失败记 `warning`。
- **仅原始数字**：**不**接 `capital_flow_signal`、**不**做评分/权重、**不**改 schema、**不**接 Web。`institution.data` = `{foreign_net, trust_net, dealer_net, total_net, unit, date, source}`。
- status `"ok"` 仅当四个核心净额齐全（**genuine-0 当日保留**）。

无 `report_schema.py` / renderer 改动 —— institution 块是现有 fundamental-context coverage 路径的通用 dict 透传。

## 报告可见输出（替代可视证据）

接入后，台股报告上下文里的 institution 块从 `not_supported` 翻为 `ok`：

**BEFORE（tw，抓取返回 None — fail-open）**
```
coverage.institution = not_supported
institution.data      = {}
```

**AFTER（tw，三大法人记录存在）**
```
coverage.institution = ok
institution.data = {
  "foreign_net": -1912490, "trust_net": 919216, "dealer_net": 996850,
  "total_net": 3576, "unit": "shares", "date": "20260629", "source": "TWSE-T86"
}
```

**us（AAPL）—— 不变**：`coverage.institution = not_supported`，`data = {}`

（台股 analyst prompt 本就提及三大法人，区块填好后模型即可在报告正文呈现外资/投信/自营净额。）

## Verification

```bash
python -m pytest -m "not network" tests/test_tw_institution_report_wiring.py -q   # 9 passed
python -m pytest -m "not network" tests/test_fundamental_context.py tests/test_tw_market_support.py \
  tests/test_tw_institutional_fetcher.py tests/test_jp_kr_market_support.py -q     # offshore/tw/jp-kr 全绿
```

覆盖：有数据→ok、genuine-zero 保留、None / 抓取抛错 / 接线抛错 三种 fail-open、缺核心净额→not_supported、us/hk/jp/kr 字节不变且 fetcher 不被调用、无派生 key。

## Rollback

Revert 单个 commit 即恢复 tw institution 的 `not_supported`。生产代码仅 `data_provider/base.py` 一处。
