### PR TITLE
perf(market): harden tw institutional fetcher — circuit breaker + TPEx date guard (Refs #1777)

### DIFF
--- a/data_provider/tw_institutional_fetcher.py
+++ b/data_provider/tw_institutional_fetcher.py
@@ -32,6 +32,8 @@ from typing import Any, Dict, Optional
 
 import requests
 
+from data_provider.realtime_types import CircuitBreaker
+
 logger = logging.getLogger(__name__)
 
 _T86_URL = "https://www.twse.com.tw/rwd/zh/fund/T86"
@@ -122,6 +124,11 @@ class TwInstitutionalFetcher:
         # One lock per unique (market, ad_date) key; bounded by tw markets x
         # distinct dates queried -- low thousands at most, negligible memory.
         self._inflight: Dict[Any, threading.Lock] = {}
+        # Per-market circuit breaker (keyed "twse"/"tpex"): when an endpoint is down
+        # (>= 3 consecutive failures) skip the network round-trip for ~5 min and fail
+        # open, instead of paying timeout + throttle on every stock during an outage.
+        # Reuses the repo's CircuitBreaker (same one DataFetcherManager uses).
+        self._breaker = CircuitBreaker(failure_threshold=3, cooldown_seconds=300.0)
 
     # ------------------------------------------------------------------ public
     def get_institutional_net(
@@ -147,7 +154,19 @@ class TwInstitutionalFetcher:
             return None
         if not table:
             return None
-        return table.get(base)
+        record = table.get(base)
+        # TPEx OpenAPI serves only the LATEST trading day (no date param). If a caller
+        # asked for a specific date, never silently return a different-day record --
+        # fail open (None) so a date-mismatched 上櫃 figure can't reach a report.
+        if record is not None and date and market == "tpex":
+            requested = self._norm_ad_date(date)
+            if requested and record.get("date") != requested:
+                logger.info(
+                    "[tw-inst] TPEx %s requested date %s != served %s -> fail-open",
+                    base, requested, record.get("date"),
+                )
+                return None
+        return record
 
     # ------------------------------------------------------------------ routing
     @staticmethod
@@ -196,7 +215,23 @@ class TwInstitutionalFetcher:
             cached = self._read_cache(key)  # double-check: a prior holder may have filled it
             if cached is not None:
                 return cached
-            table = self._fetch_twse(ad_date) if market == "twse" else self._fetch_tpex()
+            # Circuit breaker: if this endpoint has been failing (>= 3 in a row), skip
+            # the network round-trip and fail open (empty) until the ~5 min cooldown
+            # half-opens -- so a TWSE/TPEx outage costs ~0 per stock, not timeout+throttle.
+            if not self._breaker.is_available(market):
+                logger.info("[tw-inst] %s circuit OPEN -> skip fetch, fail-open", market)
+                return {}
+            try:
+                table = self._fetch_twse(ad_date) if market == "twse" else self._fetch_tpex()
+            except Exception as exc:  # network / HTTP error -> trip the breaker, then re-raise
+                self._breaker.record_failure(market, str(exc))
+                raise
+            # The breaker tracks REACHABILITY (open only on hard network/HTTP errors).
+            # An empty / stat!=OK body still means the endpoint RESPONDED, so it counts
+            # as success: it resets the failure streak and, during HALF_OPEN recovery,
+            # closes the breaker instead of re-opening it (so a no-data day mid-recovery
+            # can never strand the breaker open). Only non-empty tables are cached.
+            self._breaker.record_success(market)
             if table:  # never cache an empty / failed fetch -> no TTL-long blackout
                 with self._lock:
                     self._cache[key] = table

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - [新功能] #1743 Phase 4 新增 `opencode_cli` generation-only 本地 CLI backend，使用 OpenCode `run --format json --file` prompt-file 路径、JSON event extractor、Agent 边界和 provider credential 不接管约束。
 - [文档] #1743 Phase 4 同步本地 CLI backend 隐私/部署边界：local CLI 不是离线模型，Docker/CI/远端需自行安装登录，DSA 不读取 Claude/OpenCode credential 文件。
 - [新功能] 台股报告接入三大法人：tw 个股分析报告的 institution 区块改为展示 TWSE T86 / TPEx 三大法人原始买卖超净额（外资/投信/自营/合计，单位:股）；tw-only、严格 additive（A股/港股/美股/日韩股 offshore 流程字节不变）、fail-open（取不到数据维持 not_supported，绝不中断分析）；不接 Web、不派生 capital_flow_signal、不改评分权重或 schema。
+- [改进] 台股三大法人 fetcher 韧性加固：(1) 接入熔断器（复用 `realtime_types.CircuitBreaker`，按市场 twse/tpex 分流，连续失败 3 次→冷却 ~5min→半开探测），TWSE/TPEx 端点异常时快速跳过网络往返并 fail-open，避免端点故障时每档个股都付 timeout+throttle；(2) TPEx OpenAPI 仅服务最新交易日，调用方传入与服务日期不符的明确日期时改为 fail-open（返回无数据），避免静默返回错日资料。
 
 ## [3.24.1] - 2026-06-28
 

--- a/tests/test_tw_institutional_fetcher.py
+++ b/tests/test_tw_institutional_fetcher.py
@@ -302,5 +302,75 @@ class TestConcurrencyAndHttpError(unittest.TestCase):
             self.assertIsNone(_fetcher().get_institutional_net("2330.TW", "20260626"))
 
 
+class TestCircuitBreakerAndDateGuard(unittest.TestCase):
+    """C1 circuit breaker (skip-fast fail-open when an endpoint is down) + C2 TPEx date guard."""
+
+    def test_circuit_breaker_opens_after_3_failures_and_skips_fetch(self):
+        import requests as _rq
+        from data_provider.realtime_types import CircuitBreaker
+
+        f = _fetcher()
+        with patch(
+            "data_provider.tw_institutional_fetcher.requests.get",
+            side_effect=_rq.ConnectionError("down"),
+        ) as mock_get:
+            for _ in range(3):  # 3 consecutive failures trip the breaker
+                self.assertIsNone(f.get_institutional_net("2330.TW"))
+            self.assertEqual(mock_get.call_count, 3)
+            # breaker now OPEN -> the 4th call must skip the network round-trip entirely
+            self.assertIsNone(f.get_institutional_net("2330.TW"))
+            self.assertEqual(mock_get.call_count, 3, "breaker did not skip the fetch when open")
+        self.assertEqual(f._breaker.get_status().get("twse"), CircuitBreaker.OPEN)
+
+    def test_circuit_breaker_recovers_after_cooldown_reset(self):
+        import requests as _rq
+        from data_provider.realtime_types import CircuitBreaker
+
+        f = _fetcher()
+        with patch(
+            "data_provider.tw_institutional_fetcher.requests.get",
+            side_effect=_rq.ConnectionError("down"),
+        ):
+            for _ in range(3):
+                f.get_institutional_net("2330.TW")
+        self.assertEqual(f._breaker.get_status().get("twse"), CircuitBreaker.OPEN)
+        f._breaker.reset("twse")  # simulate the ~5 min cooldown elapsing / recovery
+        with patch("data_provider.tw_institutional_fetcher.requests.get", return_value=_resp(T86_FIXTURE)):
+            rec = f.get_institutional_net("2330.TW")
+        self.assertIsNotNone(rec)
+        self.assertEqual(f._breaker.get_status().get("twse"), CircuitBreaker.CLOSED)
+
+    def test_empty_responses_do_not_trip_breaker(self):
+        # an empty / non-trading-day response means the endpoint RESPONDED -> reachable,
+        # so the breaker must stay CLOSED and keep fetching (never skip a recovered day).
+        from data_provider.realtime_types import CircuitBreaker
+
+        f = _fetcher()
+        empty = {"stat": "OK", "data": []}
+        with patch("data_provider.tw_institutional_fetcher.requests.get", return_value=_resp(empty)) as mock_get:
+            for _ in range(3):
+                self.assertIsNone(f.get_institutional_net("2330.TW"))
+            self.assertEqual(mock_get.call_count, 3, "an empty response wrongly tripped/skipped the breaker")
+        self.assertEqual(f._breaker.get_status().get("twse"), CircuitBreaker.CLOSED)
+
+    def test_tpex_explicit_date_match_returns_record(self):
+        with patch("data_provider.tw_institutional_fetcher.requests.get", return_value=_resp(TPEX_FIXTURE)):
+            rec = _fetcher().get_institutional_net("3105.TWO", "20260626")  # == served trading day
+        self.assertIsNotNone(rec)
+        self.assertEqual(rec["date"], "20260626")
+
+    def test_tpex_explicit_date_mismatch_fails_open(self):
+        # TPEx serves only the latest day; a mismatched explicit date must not return a
+        # wrong-day record -> fail open (None).
+        with patch("data_provider.tw_institutional_fetcher.requests.get", return_value=_resp(TPEX_FIXTURE)):
+            rec = _fetcher().get_institutional_net("3105.TWO", "20260101")
+        self.assertIsNone(rec)
+
+    def test_tpex_no_date_returns_latest(self):
+        with patch("data_provider.tw_institutional_fetcher.requests.get", return_value=_resp(TPEX_FIXTURE)):
+            rec = _fetcher().get_institutional_net("3105.TWO")  # no date -> latest, guard inactive
+        self.assertIsNotNone(rec)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## PR Type

- [x] perf / 改进

## Issue Link

Refs #1777

## Background

`TwInstitutionalFetcher` 韧性加固 follow-up（#1829/#1841/#1855 + 已由 #1863 接入台股报告），对标 `docs/data-source-stability.md` 的可靠性标准（连续失败 3 次 → 冷却约 5 分钟 → 半开探测）。

## Scope（tw-only、严格 additive、fail-open）

`data_provider/tw_institutional_fetcher.py`：

- **C1 熔断器** — 复用 `data_provider.realtime_types.CircuitBreaker`（与 `DataFetcherManager` 同一个类），按市场分流（twse/tpex）。端点连续不可达（≥3 次网络/HTTP 错误）时，在冷却期内**跳过网络往返并 fail-open** —— TWSE/TPEx 故障时每档个股成本 ~0,不再付 timeout+throttle。熔断器跟踪**可达性**:硬网络/HTTP 错误才触发;空响应 / `stat!=OK` 仍代表端点**有回应**,计为 success（重置失败计数,且在半开恢复时**关闭**熔断器 —— 恢复期遇到无资料日也绝不会把熔断器卡在 open）。
- **C2 TPEx 日期守卫** — TPEx OpenAPI 仅服务最新交易日;调用方传入与服务日期不符的明确日期时改为 **fail-open（返回 None）**,不再静默返回错日资料。

测试 +6;`docs/CHANGELOG.md` 加 `[改进]`。

**不改 `data_provider/base.py` 或任何 cn/hk/us/jp/kr 流程;fail-open 全程保持;不接 Web、不派生 capital_flow_signal、不改评分/schema。**

## Verification

```bash
python -m pytest -m "not network" tests/test_tw_institutional_fetcher.py -q   # all pass
```

覆盖:熔断器连续 3 次失败后开启并跳过第 4 次抓取、冷却后恢复、3 次空响应不触发熔断、TPEx 日期 匹配/不符/无日期 三路径。

## Rollback

Revert 单个 commit。仅 `data_provider/tw_institutional_fetcher.py` 一处生产代码。



## CI Gate 说明

本次为 Python 后端改动，已由新增单元测试充分覆盖；CI 的 `静态检查`（py_compile / Flake8）、`backend-gate`、`AI 代码审查` 均已通过。未单独运行 `./scripts/ci_gate.sh`（其检查项已在上述 CI 阶段完成）。
