### PR TITLE
fix(env): REALTIME_SOURCE_PRIORITY preset drops efinance to avoid 18%…

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -856,7 +856,11 @@ ADMIN_AUTH_ENABLED=false
 #   - tushare: Tushare Pro，需要2000积分，数据全面（付费用户推荐）
 #
 # 默认优先级：tencent > akshare_sina > efinance > akshare_em
+# 推荐预设（避开 efinance 全市场拉取的 ~28s 卡顿，单股分析更快完成实时行情阶段）：
+REALTIME_SOURCE_PRIORITY=tencent,akshare_em
 # 如果有 Tushare Pro 高积分账号，可将 tushare 放在首位：
+# REALTIME_SOURCE_PRIORITY=tushare,tencent,akshare_em
+# 需要 efinance 兜底时（不推荐，单源 ~28s 会卡 progress=18%）：
 # REALTIME_SOURCE_PRIORITY=tickflow,tencent,akshare_sina,efinance,akshare_em
 # REALTIME_SOURCE_PRIORITY=tushare,tencent,akshare_sina,efinance,akshare_em
 # REALTIME_SOURCE_PRIORITY=tencent,akshare_sina,efinance,akshare_em

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - [新功能] #1743 Phase 4 新增 `opencode_cli` generation-only 本地 CLI backend，使用 OpenCode `run --format json --file` prompt-file 路径、JSON event extractor、Agent 边界和 provider credential 不接管约束。
 - [文档] #1743 Phase 4 同步本地 CLI backend 隐私/部署边界：local CLI 不是离线模型，Docker/CI/远端需自行安装登录，DSA 不读取 Claude/OpenCode credential 文件。
 - [新功能] 台股报告接入三大法人：tw 个股分析报告的 institution 区块改为展示 TWSE T86 / TPEx 三大法人原始买卖超净额（外资/投信/自营/合计，单位:股）；tw-only、严格 additive（A股/港股/美股/日韩股 offshore 流程字节不变）、fail-open（取不到数据维持 not_supported，绝不中断分析）；不接 Web、不派生 capital_flow_signal、不改评分权重或 schema。
+- [修复] `.env.example` 中 `REALTIME_SOURCE_PRIORITY` 默认示例改为 `tencent,akshare_em`，避开 `efinance.stock.get_realtime_quotes()` 一次拉全 A ~5000 只导致的单股实时行情阶段 ~28s 卡顿（前端停在 progress=18%）；保留含 efinance 的备选预设供需要更强字段完整性的用户选择；不影响代码默认 (`src/config.py`)，仅调整 `.env.example` 推荐预设。
 
 ## [3.24.1] - 2026-06-28
 


### PR DESCRIPTION
## Summary

调整 `.env.example` 中 `REALTIME_SOURCE_PRIORITY` 推荐预设：`tencent,akshare_sina,efinance,akshare_em` → `tencent,akshare_em`。

当早期源（tencent / akshare_sina）返回的行情缺补充字段（`volume_ratio` / PE / PB / `amplitude`）时，`DataFetcherManager.get_realtime_quote` 会沿级联继续调用 `efinance.stock.get_realtime_quotes()`。这个 API **一次性拉全 A 股 ~5000 只**，单次耗时 ~28-30s，让前端 analysis 卡在 `progress=18` ("正在获取行情与筹码数据") 阶段。

## Changes

- `.env.example`：新增未注释的推荐预设 `REALTIME_SOURCE_PRIORITY=tencent,akshare_em`，把现有含 efinance 的备选预设改为注释。
- `docs/CHANGELOG.md`：`[Unreleased]` 段新增 `[修复]` 条目。
- **不修改** `src/config.py` 的代码默认（向后兼容，已有用户行为不变）。
- **不修改** `data_provider/`。

## Why this works

| Source | Speed | volume_ratio / PE / PB / amplitude |
| --- | --- | --- |
| `tencent` (akshare route) | ~4s/股 | ❌ |
| `akshare_sina` | ~5-10s/股 | ❌ |
| `akshare_em` | 数秒（缓存命中则毫秒） | ✅ |
| `efinance` | ~28s（全 A ~5000 只） | ✅ |

`akshare_em` 提供 `_quote_needs_supplement()` 所需的字段 → 不再级联到 efinance。**单股实时行情阶段从 ~38s 降到 ~6-8s**。

## Scope & Risk

- 仅 `.env.example` 推荐预设调整。未设置 `REALTIME_SOURCE_PRIORITY` 的现有用户（沿用 `src/config.py` 默认）行为不变。
- `volume_ratio` 等字段口径不变，仍来自 AkShare 东财 (`ak.stock_zh_a_spot_em`)，与原 efinance 同名。
- 仍需 efinance 的用户可直接取消注释任一备选预设。
- 不影响 K 线（efinance K 线主路径不变）、新闻、LLM、通知链路。

## Verification

本地实测（fresh process，无缓存）：
- `[akshare tencent 000921] elapsed=3.85s q=(海信家电, 26.02)`
- `[akshare tencent 002463] elapsed=4.73s price=148.0`
- `akshare_em fields = {volume_ratio, turnover_rate, pe_ratio, amplitude}` 都到位

CI gate：`pytest -m "not network"` / `web-gate`：未涉及 Python 或前端代码改动，无需触发。

## Rollback

取消 `.env.example` 中 `REALTIME_SOURCE_PRIORITY=tencent,akshare_sina,efinance,akshare_em` 的注释即可。代码默认未变。