### PR TITLE
fix: 修正 opencode_cli 静态指令输出格式约束

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - [修复] 修复 Web 设置页定时任务“立即执行一次”后台线程未传 `stock_codes` 导致任务崩溃的问题。
 - [新功能] #1743 Phase 4 新增 `claude_code_cli` generation-only 本地 CLI backend，保留 LiteLLM 默认路径、Agent 工具调用边界、per-preset extractor、最小 env allowlist 与结构化错误。
 - [新功能] #1743 Phase 4 新增 `opencode_cli` generation-only 本地 CLI backend，使用 OpenCode `run --format json --file` prompt-file 路径、JSON event extractor、Agent 边界和 provider credential 不接管约束。
+- [修复] #1743 Phase 4 修正 `opencode_cli` 静态指令，避免全局 JSON-only 约束影响 `generate_text()` 与大盘复盘自由文本输出。
 - [文档] #1743 Phase 4 同步本地 CLI backend 隐私/部署边界：local CLI 不是离线模型，Docker/CI/远端需自行安装登录，DSA 不读取 Claude/OpenCode credential 文件。
 - [新功能] 台股报告接入三大法人：tw 个股分析报告的 institution 区块改为展示 TWSE T86 / TPEx 三大法人原始买卖超净额（外资/投信/自营/合计，单位:股）；tw-only、严格 additive（A股/港股/美股/日韩股 offshore 流程字节不变）、fail-open（取不到数据维持 not_supported，绝不中断分析）；不接 Web、不派生 capital_flow_signal、不改评分权重或 schema。
 - [改进] 台股报告完整消费三大法人：tw 个股报告的 `institution` 区块现会在报告中渲染三大法人净买卖超表格，并注入 LLM 分析 prompt 作为台股筹码过滤器（此前仅接入数据层，报告与 prompt 均未消费，导致报告出现「筹码结构：数据缺失」）；同时三大法人整市场抓取改用剩余 stage 预算而非较小的 per-symbol fetch 超时，避免单股/首档分析因冷抓取（~4-5s）超时而降级为 not_supported。tw-only、严格 additive、fail-open。

--- a/src/llm/local_cli_backend.py
+++ b/src/llm/local_cli_backend.py
@@ -140,11 +140,10 @@ _CLAUDE_CODE_STATIC_INSTRUCTION = (
 )
 _PROMPT_FILE_PLACEHOLDER = "{prompt_file}"
 _OPENCODE_STATIC_INSTRUCTION = (
-    "Generate the requested DSA stock analysis from the attached prompt file. "
-    "Return only one JSON object that satisfies the DSA parser contract. "
-    "The JSON must include at least one of sentiment_score, trend_prediction, "
-    "operation_advice, analysis_summary, or dashboard. Do not use tools, read "
-    "additional files, browse the web, edit files, ask questions, or request approval."
+    "Generate the requested DSA output from the attached prompt file. "
+    "Follow the output format required by that prompt. Return only the final response "
+    "content. Do not use tools, do not read additional files, do not browse the web, "
+    "do not edit files, do not ask questions, and do not request approval."
 )
 _OPENCODE_ALLOWED_EVENT_TYPES = {"step_start", "text", "step_finish"}
 _OPENCODE_BLOCKED_EVENT_TYPES = {

--- a/tests/test_local_cli_backend.py
+++ b/tests/test_local_cli_backend.py
@@ -376,6 +376,53 @@ print(json.dumps({{"type": "step_finish", "reason": "stop"}}))
     assert result.usage["backend"] == "opencode_cli"
 
 
+def test_opencode_static_instruction_does_not_force_stock_json_contract() -> None:
+    instruction = " ".join(str(arg) for arg in OPENCODE_CLI_PRESET.argv)
+    normalized_instruction = instruction.lower()
+
+    assert "attached prompt file" in instruction
+    assert "json object" not in normalized_instruction
+    assert "parser contract" not in normalized_instruction
+    for field_name in (
+        "sentiment_score",
+        "trend_prediction",
+        "operation_advice",
+        "analysis_summary",
+        "dashboard",
+    ):
+        assert field_name not in instruction
+
+
+def test_opencode_preset_accepts_free_text_without_json_validator(tmp_path: Path) -> None:
+    review = "## 今日复盘\n\n市场震荡，保持观察。"
+    script = _script(
+        tmp_path,
+        f"""
+import json
+print(json.dumps({{"type": "step_start"}}))
+print(json.dumps({{"type": "text", "part": {{"text": {review!r}}}}}, ensure_ascii=False))
+print(json.dumps({{"type": "step_finish", "reason": "stop"}}))
+""",
+    )
+    preset = LocalCliPreset(
+        preset_id="opencode_cli",
+        executable=sys.executable,
+        argv=(script, *OPENCODE_CLI_PRESET.argv),
+        display_name="Mock OpenCode CLI",
+        extractor=OPENCODE_CLI_PRESET.extractor,
+        contract_args=OPENCODE_CLI_PRESET.contract_args,
+        prompt_transport=OPENCODE_CLI_PRESET.prompt_transport,
+    )
+    backend = LocalCliGenerationBackend(
+        _config(generation_backend="opencode_cli"),
+        preset=preset,
+    )
+
+    result = backend.generate("请生成 Markdown 复盘", {}, response_validator=None)
+
+    assert result.text == review
+
+
 def test_opencode_model_override_inserts_model_arg(tmp_path: Path) -> None:
     argv_path = tmp_path / "argv.json"
     script = _script(


### PR DESCRIPTION
## PR Type

- [x] fix
- [ ] feat
- [ ] refactor
- [ ] docs
- [ ] chore
- [x] test

## Background And Problem

这个 PR 修复一个在 `opencode_cli` generation backend 中发现的输出格式污染问题。

`opencode_cli` 的全局静态 instruction 原本写死要求返回股票主分析 JSON，并点名 `DSA parser contract` 以及 `sentiment_score`、`trend_prediction`、`operation_advice`、`analysis_summary`、`dashboard` 等主分析字段。这个 backend 不只服务个股主分析，也会被 `GeminiAnalyzer.generate_text()` 复用；大盘复盘等路径期望模型返回 Markdown / 普通文本。

因此，旧静态 instruction 会把所有 OpenCode CLI 调用都压向“主分析 JSON”语义，和自由文本调用方的 prompt 要求冲突。根因不是 `generate_text()` 或 `MarketAnalyzer` 调用链错误，而是 OpenCode preset 的全局静态 instruction 过度绑定了主分析输出契约。

本 PR 采用最小修复：只把 OpenCode 静态 instruction 改为输出格式中立，让最终输出格式由 attached prompt file 决定；主分析 JSON 仍由现有主分析 prompt、`response_validator`、parser contract 和 retry/fallback 流程保证。

## Scope Of Change

文件总数 / 变更行数：

```text
 docs/CHANGELOG.md               |  1 +
 src/llm/local_cli_backend.py    |  9 ++++----
 tests/test_local_cli_backend.py | 47 +++++++++++++++++++++++++++++++++++++++++
 3 files changed, 52 insertions(+), 5 deletions(-)
```

文件清单：

- `src/llm/local_cli_backend.py`
  - 只修改 `_OPENCODE_STATIC_INSTRUCTION`。
  - 删除 OpenCode 全局静态 instruction 中的 JSON-only / 主分析字段约束。
  - 保留安全边界：从 attached prompt file 生成、遵循 prompt 要求的输出格式、只返回最终内容、不使用工具、不读额外文件、不联网、不编辑文件、不提问、不请求审批。
  - 明确使用 `do not read additional files`，避免和 `--file <prompt-file>` 自相矛盾。

- `tests/test_local_cli_backend.py`
  - 增加 OpenCode 静态 instruction 回归测试，确认不再包含 JSON-only / parser contract / 主分析字段词。
  - 增加 OpenCode 自由文本输出测试，mock OpenCode JSON event stream 返回 Markdown/普通文本，验证 `response_validator=None` 时 backend 最终返回原文。

- `docs/CHANGELOG.md`
  - 在 `[Unreleased]` 添加一条扁平 `[修复]` 记录。

文档更新文件：

- `docs/CHANGELOG.md`

明确不包含：

- 不修改 `GeminiAnalyzer.generate_text()`。
- 不修改 `MarketAnalyzer`。
- 不修改 API / Web / Agent / backend registry / fallback / 错误码。
- 不新增配置项、caller mode、response mode、格式探测或 parser fallback。
- 不修改 `docs/LLM_CONFIG_GUIDE*`、`docs/llm-providers.md`；这些文档描述的是 OpenCode event stream / 配置边界，不包含本次被修正的主分析 JSON-only 静态 instruction。

## Issue Link

无独立 Issue。

这是一个在上一个 OpenCode CLI backend PR 合并后进行后续自审时发现的回归风险：OpenCode backend 的全局静态 instruction 把所有调用路径都约束成股票主分析 JSON，可能污染 `generate_text()` / 大盘复盘自由文本输出。本 PR 作为跟踪修复提交。

验收标准：

- `opencode_cli` 静态 instruction 不再包含 JSON-only / DSA parser contract / 主分析字段词。
- `opencode_cli` 在 `response_validator=None` 的自由文本路径中可以原样返回 Markdown / 普通文本。
- 主分析 JSON 校验路径不改，由现有 prompt、validator、parser 和 retry 流程继续负责。
- 不引入新配置、新 fallback 或调用链分支。

## Verification Commands And Results

实际执行命令：

```bash
git fetch --all --prune
git merge --ff-only upstream/main
python -m pytest tests/test_local_cli_backend.py -k opencode
python -m py_compile src/llm/local_cli_backend.py
git diff --check
./scripts/ci_gate.sh
```

关键输出 / 结论：

- `python -m pytest tests/test_local_cli_backend.py -k opencode`
  - `32 passed, 45 deselected`

- `python -m py_compile src/llm/local_cli_backend.py`
  - 通过，无输出

- `git diff --check`
  - 通过，无输出

- `./scripts/ci_gate.sh`
  - `4163 passed, 1 skipped, 4 deselected, 68 warnings`
  - `backend-gate: all checks passed`

当前 Head CI：

- ai-governance：`pass`，https://github.com/ZhuLinsen/daily_stock_analysis/actions/runs/28522290639/job/84549394117
- backend-gate：`pass`，https://github.com/ZhuLinsen/daily_stock_analysis/actions/runs/28522290639/job/84549441083
- docker-build：`pass`，https://github.com/ZhuLinsen/daily_stock_analysis/actions/runs/28522290639/job/84549440995
- web-gate：`skipping`（本 PR 不修改 Web 前端），https://github.com/ZhuLinsen/daily_stock_analysis/actions/runs/28522290639/job/84549442124

补充 checks：

- Change Detection：`pass`，https://github.com/ZhuLinsen/daily_stock_analysis/actions/runs/28522290639/job/84549394107
- pr-review 静态检查：`pass`，https://github.com/ZhuLinsen/daily_stock_analysis/actions/runs/28522290330/job/84549428654
- 自动标签：`pass`，https://github.com/ZhuLinsen/daily_stock_analysis/actions/runs/28522290330/job/84549393574
- 安全检查：`pass`，https://github.com/ZhuLinsen/daily_stock_analysis/actions/runs/28522290330/job/84549393680

Full-suite note：

- 当前状态：全部通过（pass）；web-gate 因本 PR 不修改前端而 skipping。
- 未执行真实 OpenCode CLI live smoke；本 PR 只修改静态 instruction 文案，并通过 mocked OpenCode JSON event stream 覆盖 DSA backend 最终返回路径。之前 OpenCode CLI 真实 provider 验证属于上一个 PR 的范围，本 PR 不重新声明 live OpenCode 兼容性。

## Visual Evidence (if applicable)

不适用。

本 PR 不修改 Web UI、设置页字段、报告渲染、通知展示或截图可见界面；只修正 OpenCode CLI backend 静态 instruction 与对应回归测试。使用 diff、单元测试和 backend gate 作为可追溯证据更准确。

## Compatibility And Risk

兼容性影响：

- 本 PR 未变更 provider/model/base URL、运行时配置清理迁移语义；历史配置保持不变；回滚方式为 revert 本提交。
- 不改变 OpenCode CLI preset 的 `argv` 结构、`--file` prompt transport、JSON event extractor、工具禁用边界、Agent 支持声明或 registry 行为。
- 不改变主分析 JSON contract。主分析仍通过现有主分析 prompt、`response_validator`、parser contract 和 retry/fallback 流程约束。

风险：

- 真实 OpenCode 模型是否完全遵循新自然语言 instruction，仍取决于模型行为；本 PR 不声称做过新的 live OpenCode CLI 验证。
- 该风险已通过最小修改面控制：不改 subprocess 调用、不改 extractor、不改 validator、不改 fallback，只移除全局 JSON-only 静态约束。

## Rollback Plan

如果需要回滚，直接 revert 本提交即可。

不需要额外配置回滚、数据迁移或缓存清理；本 PR 不写入运行时配置、不修改数据库、不改变用户已有 provider/model/base URL 配置。

## EXTRACT_PROMPT Change (if applicable)

不适用。本 PR 不修改 `src/services/image_stock_extractor.py` 或 `EXTRACT_PROMPT`。

## Checklist

- [x] 本 PR 有明确动机和业务价值 / This PR has a clear motivation and value
- [x] 已提供可复现的验证命令与结果 / Reproducible verification commands and results are included
- [x] 已评估兼容性与风险 / Compatibility and risk have been assessed
- [x] 已提供回滚方案 / A rollback plan is provided
- [x] 若修改报告格式或 Web UI 界面，已在 PR 描述/评论附受影响报告 / 页面截图，且未把一次性验收截图作为仓库文件合入 / If report formatting or Web UI changed, affected report/page screenshots are linked in the PR body/comments and one-off acceptance screenshots are not committed as repository files
- [x] 若本 PR 修改 Web 设置字段（字段、文案或帮助文本），请补充设置页截图；无法截图时需提供替代可视证据（命令 + 产物路径），并指向对应变更项 / If Web settings fields changed (labels or help text), screenshots of the settings page are required; if unavailable, provide alternative visual evidence with command + artifact path that points to the changed item.
- [x] 若涉及用户可见变更，已同步更新相关文档与 `docs/CHANGELOG.md`；`README.md` 仅在首页级信息变化时更新，细节优先写入 `docs/*.md` / If user-visible changes are included, relevant docs and `docs/CHANGELOG.md` are updated; `README.md` is updated only for homepage-level changes, with details kept in `docs/*.md`

