### PR TITLE
fix: strip chain-of-thought fences before JSON extraction in analyzer

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
-- [修复] 分析器 JSON 解析器在遇到带 `<think>`/`<reasoning>`/`<|begin▁of▁thought|>` 等 CoT 围栏的 LLM 响应时被误判为 `ambiguous_json`，导致正常返回被丢进文本兜底（DeepSeek R1、GPT-OSS、MiniMax-M3、Claude extended thinking 等推理模型会受影响）。解析前先剥离 CoT 围栏，保留"多 JSON 围栏/嵌入 JSON 仍判歧义"的硬约束。
+- [修复] 分析器 JSON 解析器在遇到带 `<think>`/`<reasoning>`/`<|begin▁of▁thought|>` 等 CoT 围栏的 LLM 响应时被误判为 `ambiguous_json`，导致正常返回被丢进文本兜底。CoT 剥离仅作用于 JSON 候选边界（fence body 或首个 `raw_decode` 出的 `{...}`）之外；JSON 字段值里的 CoT 类字面量不再被静默改写；保留"多 JSON 围栏/嵌入 JSON 仍判歧义"的硬约束。
 - [修复] Discord 长报告推送按 2000 字符上限分片逐段发送，遇到 429 限流会按 `retry_after`/`Retry-After` 有限重试，避免中途失败后只收到前半段报告。
 - [改进] #1777 台股三大法人 fetcher（`TwInstitutionalFetcher`）增加缓存防击穿：并发同 (市场, 日期) 调用合并为单次上游请求，保护 TWSE T86 ~3 req/5s 限流额度；不同 key 仍并行；新增并发单次抓取、不同 key 各抓一次、HTTP 错误 fail-open 回归测试。
 - [修复] 修复桌面端启动时 `.env` 中 `WEBUI_PORT` 与 Electron 自动选择端口不一致会导致窗口继续等待旧端口并连接超时的问题。

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+- [修复] 分析器 JSON 解析器在遇到带 `<think>`/`<reasoning>`/`<|begin▁of▁thought|>` 等 CoT 围栏的 LLM 响应时被误判为 `ambiguous_json`，导致正常返回被丢进文本兜底（DeepSeek R1、GPT-OSS、MiniMax-M3、Claude extended thinking 等推理模型会受影响）。解析前先剥离 CoT 围栏，保留"多 JSON 围栏/嵌入 JSON 仍判歧义"的硬约束。
 - [修复] Discord 长报告推送按 2000 字符上限分片逐段发送，遇到 429 限流会按 `retry_after`/`Retry-After` 有限重试，避免中途失败后只收到前半段报告。
 - [改进] #1777 台股三大法人 fetcher（`TwInstitutionalFetcher`）增加缓存防击穿：并发同 (市场, 日期) 调用合并为单次上游请求，保护 TWSE T86 ~3 req/5s 限流额度；不同 key 仍并行；新增并发单次抓取、不同 key 各抓一次、HTTP 错误 fail-open 回归测试。
 - [修复] 修复桌面端启动时 `.env` 中 `WEBUI_PORT` 与 Electron 自动选择端口不一致会导致窗口继续等待旧端口并连接超时的问题。

--- a/src/analyzer.py
+++ b/src/analyzer.py
@@ -4248,10 +4248,40 @@ class GeminiAnalyzer:
         """Delegate to module-level apply_placeholder_fill."""
         apply_placeholder_fill(result, missing_fields)
 
+    # Chain-of-thought wrappers emitted by reasoning-capable LLMs (DeepSeek R1,
+    # GPT-OSS, MiniMax-M3, Claude extended thinking, ...). Stripped before JSON
+    # extraction so a single ```json``` fence wrapped in CoT still parses cleanly.
+    # The patterns target the *outer* CoT envelope only; ```json``` fences and
+    # embedded JSON objects are intentionally left untouched so the existing
+    # ambiguity checks (`len(fenced_matches) > 1`, embedded JSON detection) keep
+    # catching genuinely ambiguous payloads.
+    _COT_FENCE_PATTERNS: Tuple["re.Pattern[str]", ...] = (
+        re.compile(r"<think>.*?</think>", flags=re.DOTALL),
+        re.compile(r"<reasoning>.*?</reasoning>", flags=re.DOTALL),
+        re.compile(r"<\|reasoning\|>.*?<\|/reasoning\|>", flags=re.DOTALL),
+        re.compile(r"<\|thinking\|>.*?<\|/thinking\|>", flags=re.DOTALL),
+        re.compile(r"<\|begin▁of▁thought\|>.*?<\|/thought\|>", flags=re.DOTALL),
+        re.compile(r"<\|begin_of_thinking\|>.*?<\|end_of_thinking\|>", flags=re.DOTALL),
+    )
+
+    @classmethod
+    def _strip_cot_fences(cls, text: str) -> str:
+        """Strip known chain-of-thought wrappers from LLM output.
+
+        Only removes the outer CoT envelope; does NOT touch ```` ```json``` ````
+        fences or embedded JSON objects. After stripping, the existing
+        fence_pattern and ``_contains_embedded_json_object`` checks decide
+        whether the remaining text is a unique parseable JSON.
+        """
+        out = text
+        for pattern in cls._COT_FENCE_PATTERNS:
+            out = pattern.sub("", out)
+        return out
+
     def _extract_analysis_json_object(self, response_text: str) -> Tuple[str, Dict[str, Any]]:
         """Extract the single allowed JSON object from an LLM response."""
 
-        text = response_text or ""
+        text = self._strip_cot_fences(response_text or "")
         stripped = text.strip()
         if not stripped:
             raise ValueError("empty_response")

--- a/src/analyzer.py
+++ b/src/analyzer.py
@@ -4248,13 +4248,12 @@ class GeminiAnalyzer:
         """Delegate to module-level apply_placeholder_fill."""
         apply_placeholder_fill(result, missing_fields)
 
-    # Chain-of-thought wrappers emitted by reasoning-capable LLMs (DeepSeek R1,
-    # GPT-OSS, MiniMax-M3, Claude extended thinking, ...). Stripped before JSON
-    # extraction so a single ```json``` fence wrapped in CoT still parses cleanly.
-    # The patterns target the *outer* CoT envelope only; ```json``` fences and
-    # embedded JSON objects are intentionally left untouched so the existing
-    # ambiguity checks (`len(fenced_matches) > 1`, embedded JSON detection) keep
-    # catching genuinely ambiguous payloads.
+    # Chain-of-thought wrappers observed in reasoning-model outputs (e.g.
+    # ``<think>...``, ``<|begin▁of▁thought|>...<|/thought|>``). Stripped
+    # before JSON extraction so a single ```` ```json``` ```` fence wrapped in
+    # CoT still parses cleanly. This is a parser-level robustness fix against
+    # observed wrapper formats; it does not assume, endorse, or enumerate any
+    # specific model's behavior.
     _COT_FENCE_PATTERNS: Tuple["re.Pattern[str]", ...] = (
         re.compile(r"<think>.*?</think>", flags=re.DOTALL),
         re.compile(r"<reasoning>.*?</reasoning>", flags=re.DOTALL),
@@ -4279,9 +4278,15 @@ class GeminiAnalyzer:
         return out
 
     def _extract_analysis_json_object(self, response_text: str) -> Tuple[str, Dict[str, Any]]:
-        """Extract the single allowed JSON object from an LLM response."""
+        """Extract the single allowed JSON object from an LLM response.
 
-        text = self._strip_cot_fences(response_text or "")
+        CoT wrappers are stripped ONLY from text outside the selected JSON
+        candidate (fence body when present, else the first raw_decode-able
+        object). This keeps string literals inside JSON fields (e.g. a value
+        containing ``<think>private``) intact.
+        """
+
+        text = response_text or ""
         stripped = text.strip()
         if not stripped:
             raise ValueError("empty_response")
@@ -4293,6 +4298,7 @@ class GeminiAnalyzer:
         fenced_matches = list(fence_pattern.finditer(text))
         if len(fenced_matches) > 1:
             raise ValueError("ambiguous_json")
+
         if len(fenced_matches) == 1:
             match = fenced_matches[0]
             outside = (text[:match.start()] + text[match.end():]).strip()
@@ -4301,19 +4307,55 @@ class GeminiAnalyzer:
             fence_lang = (match.group("lang") or "").strip().lower()
             if fence_lang not in {"", "json"}:
                 raise ValueError("ambiguous_json")
+
+            cleaned_outside = self._strip_cot_fences(outside)
+            if cleaned_outside.strip():
+                raise ValueError("ambiguous_json")
+
             json_str = match.group("body").strip()
             data = self._load_analysis_json_candidate(json_str)
             return json_str, data
+
         if "```" in text:
             raise ValueError("ambiguous_json")
 
+        decoder = json.JSONDecoder()
+        candidate_start: int = -1
+        candidate_end: int = 0
+        for index, char in enumerate(text):
+            if char != "{":
+                continue
+            try:
+                _obj, end = decoder.raw_decode(text[index:])
+            except json.JSONDecodeError:
+                continue
+            candidate_start = index
+            candidate_end = index + end
+            break
+
+        if candidate_start != -1:
+            candidate = text[candidate_start:candidate_end]
+            outside = (text[:candidate_start] + text[candidate_end:]).strip()
+            cleaned_outside = self._strip_cot_fences(outside)
+            if cleaned_outside.strip():
+                raise ValueError("ambiguous_json")
+
+            candidate_for_parse = candidate.strip()
+            data = self._load_analysis_json_candidate(candidate_for_parse)
+            return candidate_for_parse, data
+
+        cleaned = self._strip_cot_fences(text)
+        cleaned_stripped = cleaned.strip()
+        if not cleaned_stripped:
+            raise ValueError("empty_response")
+
         try:
-            data = self._load_analysis_json_candidate(stripped)
+            data = self._load_analysis_json_candidate(cleaned_stripped)
         except json.JSONDecodeError as exc:
-            if self._contains_embedded_json_object(text):
+            if self._contains_embedded_json_object(cleaned):
                 raise ValueError("ambiguous_json") from exc
             raise
-        return stripped, data
+        return cleaned_stripped, data
 
     def _load_analysis_json_candidate(self, json_str: str) -> Dict[str, Any]:
         """Parse one already-selected JSON candidate, repairing common LLM JSON drift."""

--- a/tests/test_market_analyzer_generate_text.py
+++ b/tests/test_market_analyzer_generate_text.py
@@ -3328,9 +3328,8 @@ Sector text.
 # 1f91024d). The parser raised ValueError("ambiguous_json") for any LLM
 # response that contained a <think>...</think> (or similar) envelope around a
 # single ```json``` fence, which made every analysis run by reasoning-capable
-# models (DeepSeek R1, GPT-OSS, MiniMax-M3, Claude extended thinking, ...)
-# fall through to the text-only fallback and trigger an integrity-completion
-# retry loop.
+# models fall through to the text-only fallback and trigger an
+# integrity-completion retry loop.
 #
 # The fix is _strip_cot_fences: it removes the outer CoT wrappers before the
 # existing fence_pattern and _contains_embedded_json_object checks decide
@@ -3526,3 +3525,42 @@ class TestAnalyzerCotFenceStripping:
         _json_str, data = analyzer._extract_analysis_json_object(text)
         assert data["stock_name"] == "Z"
         assert data["sentiment_score"] == 33
+
+    # ---- 4. JSON field values containing CoT-like literals must be preserved ----
+
+    def test_cot_tag_inside_fenced_json_field_value_preserved(self):
+        """A <think>private literal INSIDE a fenced JSON field value must be preserved verbatim.
+
+        Repro for chatgpt-codex-connector P2 / maintainer correctness blocker:
+        global CoT stripping would silently rewrite the field value to
+        "contains  marker". The fix scopes stripping to text outside the
+        JSON candidate boundary.
+        """
+        analyzer = self._make_analyzer()
+        text = (
+            "<think>outer reasoning that the model emitted before the fence\n"
+            "```json\n"
+            '{"stock_name": "X", "analysis_summary": "contains <think>private marker",'
+            ' "sentiment_score": 50, "trend_prediction": "震荡",'
+            ' "operation_advice": "持有", "confidence_level": "中"}\n'
+            "```\n"
+        )
+        json_str, data = analyzer._extract_analysis_json_object(text)
+        assert "<think>private" in data["analysis_summary"]
+        assert data["analysis_summary"] == "contains <think>private marker"
+        assert "<think>outer reasoning" not in json_str
+
+    def test_cot_tag_inside_plain_json_field_value_preserved(self):
+        """A <think>private literal INSIDE a plain JSON field value must be preserved verbatim."""
+        analyzer = self._make_analyzer()
+        text = (
+            "<think>outer reasoning before the plain JSON"
+            '{"stock_name": "Y", "analysis_summary": "contains <think>private marker",'
+            ' "sentiment_score": 60, "trend_prediction": "看多",'
+            ' "operation_advice": "持有", "confidence_level": "高"}'
+        )
+        json_str, data = analyzer._extract_analysis_json_object(text)
+        assert "<think>private" in data["analysis_summary"]
+        assert data["analysis_summary"] == "contains <think>private marker"
+        assert "<think>outer reasoning" not in json_str
+        assert "<think>private" in json_str

--- a/tests/test_market_analyzer_generate_text.py
+++ b/tests/test_market_analyzer_generate_text.py
@@ -3318,3 +3318,211 @@ Sector text.
         assert violations == [], (
             f"market_analyzer.py still accesses private Analyzer attributes: {violations}"
         )
+
+
+# ---------------------------------------------------------------------------
+# CoT (chain-of-thought) fence stripping for the JSON extractor
+# ---------------------------------------------------------------------------
+#
+# Regression suite for the analyzer parser introduced via PR #1769 (commit
+# 1f91024d). The parser raised ValueError("ambiguous_json") for any LLM
+# response that contained a <think>...</think> (or similar) envelope around a
+# single ```json``` fence, which made every analysis run by reasoning-capable
+# models (DeepSeek R1, GPT-OSS, MiniMax-M3, Claude extended thinking, ...)
+# fall through to the text-only fallback and trigger an integrity-completion
+# retry loop.
+#
+# The fix is _strip_cot_fences: it removes the outer CoT wrappers before the
+# existing fence_pattern and _contains_embedded_json_object checks decide
+# whether the remaining text is a unique parseable JSON. These tests guard:
+#   1. Each known CoT wrapper is stripped (5 positive cases).
+#   2. Genuine multi-fence / embedded-JSON ambiguity is still rejected
+#      (1 regression case).
+# ---------------------------------------------------------------------------
+
+
+class TestAnalyzerCotFenceStripping:
+    def _make_analyzer(self):
+        """Mirror TestAnalyzerGenerateText._make_analyzer without inheriting it."""
+        with patch("src.analyzer.get_config") as mock_cfg:
+            cfg = MagicMock()
+            cfg.litellm_model = "gemini/gemini-2.0-flash"
+            cfg.litellm_fallback_models = []
+            cfg.gemini_api_keys = ["sk-gemini-testkey-1234"]
+            cfg.anthropic_api_keys = []
+            cfg.openai_api_keys = []
+            cfg.deepseek_api_keys = []
+            cfg.llm_model_list = []
+            cfg.openai_base_url = None
+            cfg.generation_backend = "litellm"
+            cfg.generation_fallback_backend = "litellm"
+            mock_cfg.return_value = cfg
+            from src.analyzer import GeminiAnalyzer
+            analyzer = GeminiAnalyzer.__new__(GeminiAnalyzer)
+            analyzer._router = None
+            analyzer._litellm_available = True
+            analyzer._config_override = cfg
+            return analyzer
+
+    # ---- 1. positive cases: known CoT wrappers must be stripped ----
+
+    def test_strip_think_block_allows_valid_json_fence(self):
+        """<think>...</think> + ```json``` must parse successfully (MiniMax-M3 repro)."""
+        analyzer = self._make_analyzer()
+        text = (
+            '<think>\nLet me analyze this carefully.\n'
+            'I will construct the JSON.\n</think>\n\n'
+            '```json\n{"stock_name": "京东方A", "sentiment_score": 55}\n```\n'
+        )
+        json_str, data = analyzer._extract_analysis_json_object(text)
+        assert data["stock_name"] == "京东方A"
+        assert data["sentiment_score"] == 55
+        assert "<think>" not in json_str
+        assert "</think>" not in json_str
+
+    def test_strip_reasoning_block_allows_valid_json(self):
+        analyzer = self._make_analyzer()
+        text = (
+            "<reasoning>Detailed thoughts here.</reasoning>"
+            '{"stock_name": "贵州茅台", "sentiment_score": 80}\n'
+        )
+        _json_str, data = analyzer._extract_analysis_json_object(text)
+        assert data["stock_name"] == "贵州茅台"
+        assert data["sentiment_score"] == 80
+
+    def test_strip_pipelined_reasoning_block_allows_valid_json(self):
+        analyzer = self._make_analyzer()
+        text = (
+            "<|reasoning|>Some CoT|<|/reasoning|>"
+            '{"stock_name": "Tencent", "sentiment_score": 60}'
+        )
+        _json_str, data = analyzer._extract_analysis_json_object(text)
+        assert data["stock_name"] == "Tencent"
+        assert data["sentiment_score"] == 60
+
+    def test_strip_begin_of_thought_block_allows_valid_json(self):
+        analyzer = self._make_analyzer()
+        text = (
+            "<|begin▁of▁thought|>long chain of thought<|/thought|>"
+            '{"stock_name": "AAPL", "sentiment_score": 70}'
+        )
+        _json_str, data = analyzer._extract_analysis_json_object(text)
+        assert data["stock_name"] == "AAPL"
+        assert data["sentiment_score"] == 70
+
+    def test_strip_begin_of_thinking_block_allows_valid_json(self):
+        analyzer = self._make_analyzer()
+        text = (
+            "<|begin_of_thinking|>chain<|end_of_thinking|>"
+            '{"stock_name": "HK00700", "sentiment_score": 65}'
+        )
+        _json_str, data = analyzer._extract_analysis_json_object(text)
+        assert data["stock_name"] == "HK00700"
+        assert data["sentiment_score"] == 65
+
+    def test_strip_thinking_block_allows_valid_json(self):
+        analyzer = self._make_analyzer()
+        text = (
+            "<|thinking|>some thoughts<|/thinking|>"
+            '{"stock_name": "NVDA", "sentiment_score": 75}'
+        )
+        _json_str, data = analyzer._extract_analysis_json_object(text)
+        assert data["stock_name"] == "NVDA"
+        assert data["sentiment_score"] == 75
+
+    def test_strip_multiple_cot_wrappers_with_fence(self):
+        """Two non-overlapping <think> blocks plus one real ```json``` fence must parse."""
+        analyzer = self._make_analyzer()
+        text = (
+            '<think>first reasoning block that mentions ```json as an example.</think>\n'
+            '<think>second reasoning block.</think>\n'
+            '```json\n{"stock_name": "TSLA", "sentiment_score": 88}\n```\n'
+        )
+        _json_str, data = analyzer._extract_analysis_json_object(text)
+        assert data["stock_name"] == "TSLA"
+        assert data["sentiment_score"] == 88
+
+    def test_strip_cot_then_no_fence_plain_json(self):
+        """CoT wrapper around a plain JSON object (no ``` fences) must parse."""
+        analyzer = self._make_analyzer()
+        text = (
+            "<think>some thinking</think>"
+            '{"stock_name": "BABA", "sentiment_score": 50}'
+        )
+        _json_str, data = analyzer._extract_analysis_json_object(text)
+        assert data["stock_name"] == "BABA"
+        assert data["sentiment_score"] == 50
+
+    def test_strip_cot_block_validate_json_response_does_not_raise(self):
+        """_validate_json_response (used as response_validator) must not raise on CoT-wrapped fence."""
+        from src.analyzer import GeminiAnalyzer
+
+        text = (
+            "<think>deep reasoning</think>\n"
+            "```json\n"
+            '{"stock_name": "X", "sentiment_score": 50, "trend_prediction": "震荡",'
+            ' "operation_advice": "持有", "confidence_level": "中", "analysis_summary": "ok"}\n'
+            "```\n"
+        )
+        # Should not raise; GeminiAnalyzer._validate_json_response is the entrypoint
+        # that downstream _call_litellm invokes as response_validator.
+        GeminiAnalyzer._validate_json_response(GeminiAnalyzer.__new__(GeminiAnalyzer), text)
+
+    # ---- 2. regression: genuine ambiguity must STILL be rejected ----
+
+    def test_ambiguous_kept_after_cot_strip(self):
+        """CoT-stripping must not let multi-fence ambiguity slip through."""
+        analyzer = self._make_analyzer()
+        text = (
+            '<think>first thoughts</think>\n'
+            '```json\n{"a": 1}\n```\n'
+            '<think>second thoughts</think>\n'
+            '```json\n{"b": 2}\n```\n'
+        )
+        with pytest.raises(ValueError) as excinfo:
+            analyzer._extract_analysis_json_object(text)
+        assert str(excinfo.value) == "ambiguous_json"
+
+    def test_ambiguous_kept_when_two_embedded_json_after_strip(self):
+        """Even after CoT stripping, two embedded JSON objects must still raise."""
+        analyzer = self._make_analyzer()
+        text = (
+            "<think>reasoning</think>"
+            '{"a": 1}\n'
+            '<!-- a comment -->\n'
+            '{"b": 2}'
+        )
+        with pytest.raises(ValueError) as excinfo:
+            analyzer._extract_analysis_json_object(text)
+        assert str(excinfo.value) == "ambiguous_json"
+
+    def test_empty_response_still_raises_empty_response(self):
+        """Stripping must not consume the empty_response sentinel."""
+        analyzer = self._make_analyzer()
+        with pytest.raises(ValueError) as excinfo:
+            analyzer._extract_analysis_json_object("")
+        assert str(excinfo.value) == "empty_response"
+
+    def test_cot_only_response_without_json_raises_invalid(self):
+        """A response that is JUST a CoT block (no JSON) must not be silently accepted."""
+        analyzer = self._make_analyzer()
+        with pytest.raises(ValueError):
+            analyzer._extract_analysis_json_object(
+                "<think>only thinking, no JSON at all</think>"
+            )
+
+    # ---- 3. no-op behavior for already-clean payloads ----
+
+    def test_no_cot_block_unchanged_behavior_plain_fence(self):
+        analyzer = self._make_analyzer()
+        text = '```json\n{"stock_name": "Y", "sentiment_score": 42}\n```'
+        _json_str, data = analyzer._extract_analysis_json_object(text)
+        assert data["stock_name"] == "Y"
+        assert data["sentiment_score"] == 42
+
+    def test_no_cot_block_unchanged_behavior_plain_json(self):
+        analyzer = self._make_analyzer()
+        text = '{"stock_name": "Z", "sentiment_score": 33}'
+        _json_str, data = analyzer._extract_analysis_json_object(text)
+        assert data["stock_name"] == "Z"
+        assert data["sentiment_score"] == 33


### PR DESCRIPTION
## PR Type

- [x] fix
- [ ] feat
- [ ] refactor
- [ ] docs
- [ ] chore
- [ ] test

## Background And Problem

`stock_analysis_debug_20260702.log`（京东方A 000725 个股分析失败现场）暴露出一个真实 bug：commit `1f91024d` (PR #1769) 引入的新 JSON 解析器 `_extract_analysis_json_object` 会把任何带 `<think>...` / `<reasoning>...</reasoning>` / `<|begin▁of▁thought|>...<|/thought|>` 等 CoT 围栏的 LLM 响应判为 `ambiguous_json`，于是：

1. LiteLLM 的 `response_validator=_validate_json_response` 抛 `GenerationError(INVALID_JSON)` → 同模型重试 → 切到 fallback 模型；
2. fallback 仍带 CoT → 抛 `_AllModelsFailedError`；
3. 主路径拿 `last_response_text` 走 `_parse_response` → 再次 `ambiguous_json` → 落进 `_parse_text_response` 关键词打分兜底；
4. 兜底结果缺 `dashboard.*` 字段 → 触发完整性补全重试（log line 410），但重试 prompt 把带 `<think>` 的上一轮整段回传，第二轮**同样 `ambiguous_json`**，陷入失败循环直到占位填充。

影响范围：任何带 CoT 的 LLM（DeepSeek R1、GPT-OSS、MiniMax-M3、Claude extended thinking 等）。直接后果：单次分析耗时 80s 但 `success=False`、`sentiment_score=50 / 持有 / 低`，dashboard 字段全空，对应页面渲染失败或回落到极简文本。

**触发场景**：在 `analyze()` 主路径中调用 `_call_litellm(..., response_validator=self._validate_json_response)`（`src/analyzer.py:3454`）。任何返回结构里带 `<think>` 等 CoT 围栏的模型都会踩到。

## Scope Of Change

- 文件总数：**3 个**
- 变更行数：+240 / -1
- 文件清单（按实际 diff 全量）：

```
docs/CHANGELOG.md                           |   1 +
src/analyzer.py                             |  32 +++-
tests/test_market_analyzer_generate_text.py | 208 ++++++++++++++++++++++++++++
3 files changed, 240 insertions(+), 1 deletion(-)
```

- 文档更新文件（`docs/*`）：`docs/CHANGELOG.md`（`[Unreleased]` 段追加 1 行 `- [修复]` 条目，扁平格式）

未触及：`src/llm/generation_backend.py`（`GenerationError` / `GenerationErrorCode` 不动）、`src/agent/llm_adapter.py`（agent 链路不走 `_validate_json_response`，无影响）、`apps/dsa-web` / `apps/dsa-desktop`（渲染层只接 `AnalysisResult`，无影响）、`.env.example`（无新配置项）。

## Issue Link

无独立 issue。触发源是 `stock_analysis_debug_20260702.log`（仓库内未跟踪的本地诊断日志，按 AGENTS.md 不入仓）。

动机与验收标准：

- **动机**：让带 CoT 围栏的合法 LLM 响应不再被误判为 `ambiguous_json`，避免每次都掉进文本兜底再触发完整性补全重试循环。
- **验收**：
  1. `<think>...```json{...}``` ` 的输入能正确解析出 `dashboard.*` 字段。
  2. 真正的多 JSON 围栏 / 嵌入多个 JSON 仍按现有契约抛 `ambiguous_json`（不放松硬约束）。
  3. `empty_response` / 纯 CoT 无 JSON 等边界场景不沉默吞错。

## Verification Commands And Results

按改动面执行：

```bash
# 1. 最低后端要求：py_compile（已通过）
$ python3 -m py_compile src/analyzer.py
$ python3 -m py_compile tests/test_market_analyzer_generate_text.py
# 两者均无输出，表示 OK

# 2. ci_gate.sh 涉及的 syntax_check 段（用 python3 替代 python）
$ python3 -m py_compile main.py src/config.py src/auth.py src/analyzer.py src/notification.py
$ python3 -m py_compile src/storage.py src/scheduler.py src/search_service.py
$ python3 -m py_compile src/market_analyzer.py src/stock_analyzer.py
$ python3 -m py_compile data_provider/*.py
# 全部通过

# 3. flake8 关键检查（CI 跑, 本地未安装）
# flake8 not installed locally; CI will run E9/F63/F7/F82

# 4. pytest 新增用例
# 未能本地执行：环境缺 litellm / json_repair（pip install --break-system-packages
# 触发 auto mode 拒绝，属于本仓库的依赖安装策略约束）。CI backend-gate 会跑
# python -m pytest -m "not network"，覆盖 TestAnalyzerCotFenceStripping 的 15 个用例。
```

关键输出/结论：

- 【最低验证】`py_compile` 通过；`ci_gate.sh` 涉及的 `syntax_check` 段全部通过。
- 【本地缺口】`pytest tests/test_market_analyzer_generate_text.py::TestAnalyzerCotFenceStripping -v` 本地未执行（依赖安装受限）；等待 `backend-gate` workflow 跑全量测试给出结论。
- 【预期 CI】`ai-governance:pass / backend-gate:pass / docker-build:pass / web-gate:N/A`（未改 web 前端）。完整结果会贴到本 PR 评论。

> **Full-suite note**：当前 Head CI 待跑（PR 创建后由 workflow 触发）。提交前本地最低验证已通过；完整测试待 CI。

## Visual Evidence (if applicable)

不适用。本 PR 修改 `src/analyzer.py` 的私有 JSON 解析函数，不涉及：

- 报告格式 / 报告渲染
- Web UI 界面
- 设置页字段 / 文案

无需截图。

## Compatibility And Risk

- 兼容性影响：
  - `_extract_analysis_json_object` 的输入契约不变（接收 `response_text: str`），输出契约不变（`(json_str, dict)`）。
  - `_validate_json_response` 的 `reason` 取值（`"ambiguous_json"` / `"invalid_json"` / `"empty_response"`）和对应 `GenerationError.message` 文案完全保留。
  - 多 JSON 围栏 / 嵌入 JSON / `empty_response` / 纯 CoT 无 JSON 四个硬约束行为不变。
- 潜在风险：
  1. **漏剥离新型 CoT 围栏**：新模型引入未覆盖的标签。缓解：`_COT_FENCE_PATTERNS` 是模块级 tuple，扩展只需新增一行正则；测试用例覆盖每个 tag。
  2. **误剥离合法内容**：业务 JSON 字面值里恰好出现 `<think>` 等标记。缓解：现有业务 JSON 不含这些标记；如未来需要，改为更严格的"只剥离行首"逻辑。
  3. **剥离后误放行多 JSON 场景**：剥离函数只删 CoT 围栏，不动 ` ``` ` 围栏；多 JSON 仍走 `len(fenced_matches) > 1` 检查（用例 `test_ambiguous_kept_after_cot_strip` 守住回归）。
- 第三方 API / provider / model / base URL 兼容性：**未触及**。
- 运行时配置保存/清理/迁移：**未触及**。
- 本 PR 未变更 provider/model/base URL、运行时配置清理迁移语义；历史配置保持不变；回滚方式为 revert 本提交。

## Rollback Plan

最小回滚：`git revert <commit-hash>`，无 schema / migration / 配置改动，无需清理步骤。回滚后 `_extract_analysis_json_object` 恢复为只检查 ` ``` ` 围栏的原始行为，行为契约与本 PR 前完全一致。

## EXTRACT_PROMPT Change (if applicable)

不适用。`src/services/image_stock_extractor.py` 中 `EXTRACT_PROMPT` 未修改。

## Checklist

- [x] 本 PR 有明确动机和业务价值 / This PR has a clear motivation and value
- [x] 已提供可复现的验证命令与结果 / Reproducible verification commands and results are included
- [x] 已评估兼容性与风险 / Compatibility and risk have been assessed
- [x] 已提供回滚方案 / A rollback plan is provided
- [x] 若修改报告格式或 Web UI 界面，已在 PR 描述/评论附受影响报告 / 页面截图，且未把一次性验收截图作为仓库文件合入（本 PR 不涉及报告 / Web UI，无截图需求）
- [x] 若本 PR 修改 Web 设置字段（本 PR 不涉及 settings 字段）
- [x] 若涉及用户可见变更，已同步更新相关文档与 `docs/CHANGELOG.md`（已加 `[Unreleased]` 段 1 行 `- [修复]`）；`README.md` 仅在首页级信息变化时更新（本 PR 不触发）