### PR TITLE
fix: 评分建议过度归为持有，需收敛 hold/watch/buy/sell… (#1885)

### DIFF
--- a/api/v1/endpoints/analysis.py
+++ b/api/v1/endpoints/analysis.py
@@ -173,6 +173,38 @@ def _run_market_review_background(
         _release_market_review_lock(lock_token)
 
 
+def _coalesce_text(*values: Any) -> Optional[str]:
+    for value in values:
+        if value is None:
+            continue
+        text = str(value).strip()
+        if text:
+            return text
+    return None
+
+
+def _extract_guardrail_reason(raw_result: Any) -> Optional[str]:
+    if not isinstance(raw_result, dict):
+        return None
+    for reason in (
+        raw_result.get("guardrail_reason"),
+        raw_result.get("downgrade_reason"),
+        raw_result.get("decision_score_guardrail_reason"),
+    ):
+        if reason is not None:
+            text = str(reason).strip()
+            if text:
+                return text
+    metadata = raw_result.get("metadata")
+    if isinstance(metadata, dict):
+        metadata_reason = metadata.get("guardrail_reason") or metadata.get("downgrade_reason")
+        if metadata_reason is not None:
+            text = str(metadata_reason).strip()
+            if text:
+                return text
+    return None
+
+
 def _invalid_analysis_input_error() -> HTTPException:
     return api_error(400, "validation_error", "请输入有效的股票代码或股票名称")
 
@@ -867,6 +899,9 @@ def _ensure_report_action_fields(report_data: Dict[str, Any]) -> Dict[str, Any]:
         explicit_action=raw_result.get("action") or summary.get("action"),
         report_type=meta.get("report_type"),
         report_language=report_language,
+        sentiment_score=summary.get("sentiment_score") or raw_result.get("sentiment_score"),
+        guardrail_reason=_extract_guardrail_reason(raw_result),
+        align_with_score=True,
     )
     summary["action"] = action_fields["action"]
     summary["action_label"] = action_fields["action_label"]
@@ -1116,6 +1151,9 @@ def get_analysis_status(task_id: str) -> TaskStatus:
                 explicit_action=raw_dict.get("action"),
                 report_type=getattr(record, 'report_type', None),
                 report_language=report_language,
+                sentiment_score=record.sentiment_score if record.sentiment_score is not None else raw_dict.get("sentiment_score"),
+                guardrail_reason=_extract_guardrail_reason(raw_dict),
+                align_with_score=True,
             )
 
             # Build report from DB record so completed tasks return real data
@@ -1301,6 +1339,13 @@ def _build_analysis_report(
         explicit_action=raw_result_data.get("action") or details_data.get("action") or summary_data.get("action"),
         report_type=meta.report_type,
         report_language=report_language,
+        sentiment_score=(
+            summary_data.get("sentiment_score")
+            or raw_result_data.get("sentiment_score")
+            or details_data.get("sentiment_score")
+        ),
+        guardrail_reason=_extract_guardrail_reason(raw_result_data),
+        align_with_score=True,
     )
 
     summary = ReportSummary(

--- a/api/v1/endpoints/history.py
+++ b/api/v1/endpoints/history.py
@@ -112,6 +112,29 @@ def _coalesce_int(*values: Any) -> Optional[int]:
     return None
 
 
+def _extract_guardrail_reason(raw_result: Any) -> Optional[str]:
+    if not isinstance(raw_result, dict):
+        return None
+    for reason in (
+        raw_result.get("guardrail_reason"),
+        raw_result.get("downgrade_reason"),
+        raw_result.get("decision_score_guardrail_reason"),
+    ):
+        if reason is not None:
+            text = str(reason).strip()
+            if text:
+                return text
+
+    metadata = raw_result.get("metadata")
+    if isinstance(metadata, dict):
+        metadata_reason = metadata.get("guardrail_reason") or metadata.get("downgrade_reason")
+        if metadata_reason is not None:
+            text = str(metadata_reason).strip()
+            if text:
+                return text
+    return None
+
+
 @router.get(
     "",
     response_model=HistoryListResponse,
@@ -341,6 +364,9 @@ def get_stock_bar(
                 report_language=normalize_report_language(
                     _raw_result_value(raw_result, "report_language")
                 ),
+                sentiment_score=sentiment_score,
+                guardrail_reason=_extract_guardrail_reason(raw_result),
+                align_with_score=True,
             )
 
             display_stock_code = service._display_stock_code(record.code)

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - [修复] 修复 Web 首页个股栏在 stock-bar 摘要字段缺失或动作建议无法归类时隐藏情绪分与建议标识的问题。
 - [修复] Web 设置页左侧分类切换时仅在相关分类展示首次启动检查和 AlphaSift 辅助卡片，避免分类内容看起来没有切换。
 - [文档] 本次设置页修复为前端展示层分类可见性改造，不涉及 LLM/provider/Base URL/LiteLLM/默认模型/保存前清理或迁移语义。
+- [修复] 收敛个股分析评分与 DecisionSignal action 口径：统一 80/60/40/20 分段，避免高低分默认坍缩为 hold/watch，并在风控降级时记录 raw/adjusted score、final action 与原因。
 - [修复] 修复 macOS 桌面端从 Finder/Dock 启动时后端 PATH 看不到 Homebrew Codex CLI 的问题，并明确 Codex CLI 主分析与 Agent LiteLLM 工具调用分流诊断。
 - [测试] 台股三大法人 fetcher（TwInstitutionalFetcher）新增真实端点 live-smoke 脚本（tests/tw_institutional_live_smoke.py，非 pytest）与 @pytest.mark.network 漂移检测测试：核对 TWSE T86 / TPEx 核心字段名仍在、解析结果与原始字段一致；仅在非阻断的 network-smoke 定时任务运行，阻断门（pytest -m "not network"）不收集，离线 fixtures 无法察觉的上游字段改名/端点变动由此告警。
 - [修复] 修复 Web 设置页定时任务“立即执行一次”后台线程未传 `stock_codes` 导致任务崩溃的问题。

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - [修复] Web 设置页左侧分类切换时仅在相关分类展示首次启动检查和 AlphaSift 辅助卡片，避免分类内容看起来没有切换。
 - [文档] 本次设置页修复为前端展示层分类可见性改造，不涉及 LLM/provider/Base URL/LiteLLM/默认模型/保存前清理或迁移语义。
 - [修复] 收敛个股分析评分与 DecisionSignal action 口径：统一 80/60/40/20 分段，避免高低分默认坍缩为 hold/watch，并在风控降级时记录 raw/adjusted score、final action 与原因。
+- [文档] 明确本轮评分/决策口径收敛不变更模型 Provider/Model/Base URL 运行时配置语义，不涉及 `.env`、配置 key 或运行时 provider 迁移。
 - [修复] 修复 macOS 桌面端从 Finder/Dock 启动时后端 PATH 看不到 Homebrew Codex CLI 的问题，并明确 Codex CLI 主分析与 Agent LiteLLM 工具调用分流诊断。
 - [测试] 台股三大法人 fetcher（TwInstitutionalFetcher）新增真实端点 live-smoke 脚本（tests/tw_institutional_live_smoke.py，非 pytest）与 @pytest.mark.network 漂移检测测试：核对 TWSE T86 / TPEx 核心字段名仍在、解析结果与原始字段一致；仅在非阻断的 network-smoke 定时任务运行，阻断门（pytest -m "not network"）不收集，离线 fixtures 无法察觉的上游字段改名/端点变动由此告警。
 - [修复] 修复 Web 设置页定时任务“立即执行一次”后台线程未传 `stock_codes` 导致任务崩溃的问题。

--- a/docs/decision-signals.md
+++ b/docs/decision-signals.md
@@ -33,6 +33,20 @@
 
 Web 展示必须把这些 wire value 映射为当前 UI 语言的用户可读标签；API 响应继续保留原始枚举值。
 
+## Canonical 评分与 action 口径
+
+个股分析、技术评分 fallback、报告展示 fallback 与 `DecisionSignal` 提取共用 `decision-scale-v1` 口径。`decision_type` 只保留 `buy|hold|sell` 兼容统计；更细的可执行语义以八态 `action` 为准。
+
+| score | signal key | `action` | legacy `decision_type` | 语义 |
+| --- | --- | --- | --- | --- |
+| 80-100 | `strong_buy` | `buy` | `buy` | 强烈买入，高胜率机会，可执行买入/加仓计划 |
+| 60-79 | `buy` | `buy` | `buy` | 偏积极机会，允许少量待确认项 |
+| 40-59 | `watch` | `watch` | `hold` | 信号分歧或确认不足，等待触发条件 |
+| 20-39 | `reduce` | `reduce` | `sell` | 风险明显抬升，优先降低暴露 |
+| 0-19 | `sell` | `sell` | `sell` | 趋势或风险显著恶化，优先退出 |
+
+如果 `score >= 60` 但最终 `action` 是 `hold/watch`，或 `score < 40` 但最终 `action` 仍是 `hold/watch`，必须有明确 guardrail 解释，例如 `dashboard.decision_stability.reason`、`dashboard.decision_score_calibration.guardrail_reason` 或 `metadata.guardrail_reason`。风控降级会保留 `raw_score`、`adjusted_score`、`raw_action`、`final_action` 和原因；没有明确原因的中性动作在 DecisionSignal 提取时会按 canonical score 对齐为 `buy/reduce/sell`。
+
 ## 生命周期、去重与状态
 
 `src/services/decision_signal_service.py` 是信号生命周期的主入口：

--- a/docs/decision-signals.md
+++ b/docs/decision-signals.md
@@ -37,6 +37,8 @@ Web 展示必须把这些 wire value 映射为当前 UI 语言的用户可读标
 
 个股分析、技术评分 fallback、报告展示 fallback 与 `DecisionSignal` 提取共用 `decision-scale-v1` 口径。`decision_type` 只保留 `buy|hold|sell` 兼容统计；更细的可执行语义以八态 `action` 为准。
 
+- 用户侧可见面存在两类字段：`operation_advice` 保留文本口径（如“持有观察”），`action` 作为统一 8 态决策口径（如 `hold/watch/reduce`）用于风控、回测与列表展示。新生成或最终保存前重算的个股报告应优先让两者保持一致；历史记录或兼容载荷仍出现语义冲突时，默认以 `action` 为列表、回测、DecisionSignal 等结构化展示的优先字段，`operation_advice` 仅作说明文本保留。
+
 | score | signal key | `action` | legacy `decision_type` | 语义 |
 | --- | --- | --- | --- | --- |
 | 80-100 | `strong_buy` | `buy` | `buy` | 强烈买入，高胜率机会，可执行买入/加仓计划 |

--- a/src/analyzer.py
+++ b/src/analyzer.py
@@ -1847,6 +1847,9 @@ def populate_decision_action_fields(
         explicit_action=action_source,
         report_type=report_type,
         report_language=getattr(result, "report_language", "zh"),
+        sentiment_score=getattr(result, "sentiment_score", None),
+        guardrail_reason=getattr(result, "guardrail_reason", None),
+        align_with_score=True,
     )
     result.action = fields["action"]
     result.action_label = fields["action_label"]

--- a/src/analyzer.py
+++ b/src/analyzer.py
@@ -93,6 +93,10 @@ from src.report_language import (
     normalize_report_language,
 )
 from src.schemas.decision_action import build_action_fields
+from src.schemas.decision_scale import (
+    CANONICAL_DECISION_SCALE_PROMPT_ZH,
+    score_band_metadata,
+)
 from src.schemas.report_schema import AnalysisReportSchema
 from src.market_context import detect_market, get_market_role, get_market_guidelines
 from src.services.daily_market_context import format_daily_market_context_prompt_section
@@ -1338,12 +1342,48 @@ def _set_decision_stability_unavailable(
     _sync_stability_dashboard_fields(result)
 
 
-def _bound_hold_watch_sentiment_score(result: "AnalysisResult") -> None:
+def _record_decision_score_calibration(
+    result: "AnalysisResult",
+    *,
+    raw_score: int,
+    adjusted_score: int,
+    final_action: str,
+    guardrail_reason: Optional[str],
+) -> None:
+    dashboard = result.dashboard if isinstance(result.dashboard, dict) else {}
+    result.dashboard = dashboard
+    calibration = score_band_metadata(raw_score)
+    calibration.update(
+        {
+            "raw_score": raw_score,
+            "adjusted_score": adjusted_score,
+            "final_action": final_action,
+        }
+    )
+    if guardrail_reason:
+        calibration["guardrail_reason"] = guardrail_reason
+    dashboard["decision_score_calibration"] = calibration
+
+
+def _bound_hold_watch_sentiment_score(
+    result: "AnalysisResult",
+    *,
+    reason: Optional[str] = None,
+    final_action: str = "watch",
+) -> None:
     try:
         score = int(getattr(result, "sentiment_score", 50))
     except (TypeError, ValueError):
         score = 50
-    result.sentiment_score = min(59, max(45, score))
+    adjusted_score = min(59, max(45, score))
+    result.sentiment_score = adjusted_score
+    _record_decision_score_calibration(
+        result,
+        raw_score=score,
+        adjusted_score=adjusted_score,
+        final_action=final_action,
+        guardrail_reason=reason,
+    )
 
 
 def _apply_hold_watch_dashboard(
@@ -1388,6 +1428,11 @@ def _apply_hold_watch_dashboard(
     }
     if capital_flow_status is not None:
         stability["capital_flow_status"] = capital_flow_status
+    score_calibration = dashboard.get("decision_score_calibration")
+    if isinstance(score_calibration, dict):
+        stability["raw_score"] = score_calibration.get("raw_score")
+        stability["adjusted_score"] = score_calibration.get("adjusted_score")
+        stability["final_action"] = score_calibration.get("final_action")
     dashboard["decision_stability"] = stability
 
     if reason and reason not in str(result.risk_warning or ""):
@@ -1421,7 +1466,7 @@ def _downgrade_buy_without_capital_flow(
 
     result.decision_type = "hold"
     result.confidence_level = confidence
-    _bound_hold_watch_sentiment_score(result)
+    _bound_hold_watch_sentiment_score(result, reason=reason, final_action="hold")
     _apply_hold_watch_dashboard(
         result,
         language,
@@ -1451,7 +1496,6 @@ def _downgrade_to_structural_hold(
     flow_bias: str,
 ) -> None:
     result.decision_type = "hold"
-    _bound_hold_watch_sentiment_score(result)
     _set_structural_hold_wording(
         result,
         language,
@@ -1461,6 +1505,7 @@ def _downgrade_to_structural_hold(
         support=support,
         resistance=resistance,
         flow_bias=flow_bias,
+        calibrate_score=True,
     )
 
 
@@ -1474,6 +1519,7 @@ def _set_structural_hold_wording(
     support: Optional[float],
     resistance: Optional[float],
     flow_bias: str,
+    calibrate_score: bool = False,
 ) -> None:
     advice_map = {
         "zh": {
@@ -1521,6 +1567,9 @@ def _set_structural_hold_wording(
         },
     }
     reason = reason_templates.get(language, reason_templates["en"]).get(reason_key, "")
+    if calibrate_score:
+        final_action = "watch" if advice_key in {"range", "shakeout"} else "hold"
+        _bound_hold_watch_sentiment_score(result, reason=reason, final_action=final_action)
     result.operation_advice = advice
     if advice_key == "range":
         if language == "zh" and "震荡" not in str(result.trend_prediction):
@@ -1831,6 +1880,8 @@ class GeminiAnalyzer:
 
 """ + CORE_TRADING_SKILL_POLICY_ZH + """
 
+""" + CANONICAL_DECISION_SCALE_PROMPT_ZH + """
+
 ## 输出格式：决策仪表盘 JSON
 
 请严格按照以下 JSON 格式输出，这是一个完整的【决策仪表盘】：
@@ -1842,6 +1893,8 @@ class GeminiAnalyzer:
     "trend_prediction": "强烈看多/看多/震荡/看空/强烈看空",
     "operation_advice": "买入/加仓/持有/减仓/卖出/观望",
     "decision_type": "buy/hold/sell",
+    "action": "buy/add/hold/reduce/sell/watch/avoid/alert",
+    "guardrail_reason": "当分数区间与最终 action 不一致时填写降级/升级原因，否则留空",
     "confidence_level": "高/中/低",
 
     "dashboard": {
@@ -1979,11 +2032,15 @@ class GeminiAnalyzer:
 - ⚠️ 均线缠绕趋势不明
 - ⚠️ 有风险事件
 
-### 卖出/减仓（0-39分）：
-- ❌ 空头排列
-- ❌ 跌破MA20
-- ❌ 放量下跌
-- ❌ 重大利空
+### 减仓（20-39分）：
+- ⚠️ 趋势走弱或跌破关键均线
+- ⚠️ 资金/量能转弱，风险明显高于收益
+- ⚠️ 以降低仓位和保护收益为主
+
+### 卖出（0-19分）：
+- ❌ 空头排列或趋势显著恶化
+- ❌ 跌破关键支撑/止损位
+- ❌ 放量下跌或重大利空
 
 ## 决策仪表盘核心原则
 
@@ -2011,6 +2068,8 @@ class GeminiAnalyzer:
 {default_skill_policy_section}
 {skills_section}
 
+""" + CANONICAL_DECISION_SCALE_PROMPT_ZH + """
+
 ## 输出格式：决策仪表盘 JSON
 
 请严格按照以下 JSON 格式输出，这是一个完整的【决策仪表盘】：
@@ -2022,6 +2081,8 @@ class GeminiAnalyzer:
     "trend_prediction": "强烈看多/看多/震荡/看空/强烈看空",
     "operation_advice": "买入/加仓/持有/减仓/卖出/观望",
     "decision_type": "buy/hold/sell",
+    "action": "buy/add/hold/reduce/sell/watch/avoid/alert",
+    "guardrail_reason": "当分数区间与最终 action 不一致时填写降级/升级原因，否则留空",
     "confidence_level": "高/中/低",
 
     "dashboard": {
@@ -2157,10 +2218,15 @@ class GeminiAnalyzer:
 - ⚠️ 风险与机会大致均衡
 - ⚠️ 更适合等待触发条件或回避不确定性
 
-### 卖出/减仓（0-39分）：
-- ❌ 主要结论转弱，风险明显高于收益
+### 减仓（20-39分）：
+- ⚠️ 主要结论转弱，风险明显高于收益
+- ⚠️ 触发了部分失效条件，现有仓位需要降低暴露
+- ⚠️ 更适合保护收益而不是进攻
+
+### 卖出（0-19分）：
 - ❌ 触发了止损/失效条件或重大利空
-- ❌ 现有仓位更需要保护而不是进攻
+- ❌ 趋势或风险显著恶化
+- ❌ 现有仓位应优先退出
 
 ## 决策仪表盘核心原则
 
@@ -4404,6 +4470,13 @@ class GeminiAnalyzer:
 
             # 提取 dashboard 数据
             dashboard = data.get('dashboard', None)
+            guardrail_reason = data.get("guardrail_reason") or data.get("downgrade_reason")
+            if guardrail_reason and isinstance(dashboard, dict):
+                score_calibration = dashboard.get("decision_score_calibration")
+                if not isinstance(score_calibration, dict):
+                    score_calibration = {}
+                    dashboard["decision_score_calibration"] = score_calibration
+                score_calibration.setdefault("guardrail_reason", str(guardrail_reason).strip())
             # 归一化 signal_attribution（LLM 可能返回字符串/负数/总和≠100）
             normalize_report_signal_attribution(dashboard)
 

--- a/src/analyzer.py
+++ b/src/analyzer.py
@@ -1835,6 +1835,7 @@ def populate_decision_action_fields(
     explicit_action: Any = None,
     report_type: Any = None,
     use_existing_action: bool = True,
+    align_with_score: bool = True,
 ) -> AnalysisResult:
     """Populate optional decision action fields without changing legacy advice."""
 
@@ -1849,7 +1850,7 @@ def populate_decision_action_fields(
         report_language=getattr(result, "report_language", "zh"),
         sentiment_score=getattr(result, "sentiment_score", None),
         guardrail_reason=getattr(result, "guardrail_reason", None),
-        align_with_score=True,
+        align_with_score=align_with_score,
     )
     result.action = fields["action"]
     result.action_label = fields["action_label"]
@@ -4543,7 +4544,11 @@ class GeminiAnalyzer:
                     report_language, en='Technical data', zh='技术面数据', ko='기술적 데이터')),
                 success=True,
             )
-            return populate_decision_action_fields(result, explicit_action=explicit_action)
+            return populate_decision_action_fields(
+                result,
+                explicit_action=explicit_action,
+                align_with_score=False,
+            )
                 
         except json.JSONDecodeError as e:
             logger.warning(f"JSON 解析失败: {e}，标记为解析失败")
@@ -4676,7 +4681,7 @@ class GeminiAnalyzer:
             error_message='LLM response is not valid JSON; analysis result will not be persisted',
             report_language=report_language,
         )
-        return populate_decision_action_fields(result)
+        return populate_decision_action_fields(result, align_with_score=False)
     
     def batch_analyze(
         self, 

--- a/src/core/pipeline.py
+++ b/src/core/pipeline.py
@@ -1889,10 +1889,13 @@ class StockAnalysisPipeline:
     ) -> AnalysisResult:
         previous_advice = str(previous_operation_advice or "").strip()
         current_advice = str(getattr(result, "operation_advice", None) or "").strip()
+        explicit_action = current_advice if previous_advice != current_advice else None
         return populate_decision_action_fields(
             result,
+            explicit_action=explicit_action,
             report_type=report_type,
             use_existing_action=(previous_advice == current_advice),
+            align_with_score=(previous_advice == current_advice),
         )
 
     @staticmethod

--- a/src/report_language.py
+++ b/src/report_language.py
@@ -6,6 +6,8 @@ from __future__ import annotations
 import re
 from typing import Any, Dict, Optional
 
+from src.schemas.decision_scale import signal_key_for_score
+
 SUPPORTED_REPORT_LANGUAGES = ("zh", "en", "ko")
 
 _REPORT_LANGUAGE_ALIASES = {
@@ -969,15 +971,14 @@ def get_signal_level(advice: Any, score: Any, language: Optional[str]) -> tuple[
     except (TypeError, ValueError):
         numeric_score = 50
 
-    if numeric_score >= 80:
+    score_signal = signal_key_for_score(numeric_score)
+    if score_signal == "strong_buy":
         return (_OPERATION_ADVICE_TRANSLATIONS["strong_buy"][normalized_language], "💚", "strong_buy")
-    if numeric_score >= 65:
+    if score_signal == "buy":
         return (_OPERATION_ADVICE_TRANSLATIONS["buy"][normalized_language], "🟢", "buy")
-    if numeric_score >= 55:
-        return (_OPERATION_ADVICE_TRANSLATIONS["hold"][normalized_language], "🟡", "hold")
-    if numeric_score >= 45:
+    if score_signal == "watch":
         return (_OPERATION_ADVICE_TRANSLATIONS["watch"][normalized_language], "⚪", "watch")
-    if numeric_score >= 35:
+    if score_signal == "reduce":
         return (_OPERATION_ADVICE_TRANSLATIONS["reduce"][normalized_language], "🟠", "reduce")
     return (_OPERATION_ADVICE_TRANSLATIONS["sell"][normalized_language], "🔴", "sell")
 

--- a/src/repositories/backtest_repo.py
+++ b/src/repositories/backtest_repo.py
@@ -30,6 +30,7 @@ BacktestResultContextRow = Tuple[
     Optional[str],
     Optional[str],
     Optional[str],
+    Optional[int],
 ]
 
 
@@ -211,6 +212,7 @@ class BacktestRepository:
                     AnalysisHistory.context_snapshot,
                     AnalysisHistory.raw_result,
                     AnalysisHistory.report_type,
+                    AnalysisHistory.sentiment_score,
                 )
                 .join(AnalysisHistory, AnalysisHistory.id == BacktestResult.analysis_history_id)
                 .where(where_clause)
@@ -252,6 +254,7 @@ class BacktestRepository:
                     AnalysisHistory.context_snapshot,
                     AnalysisHistory.raw_result,
                     AnalysisHistory.report_type,
+                    AnalysisHistory.sentiment_score,
                 )
                 .join(AnalysisHistory, AnalysisHistory.id == BacktestResult.analysis_history_id)
                 .where(where_clause)

--- a/src/schemas/decision_action.py
+++ b/src/schemas/decision_action.py
@@ -12,6 +12,7 @@ import re
 from typing import Any, Dict, Literal, Optional, TypedDict, get_args
 
 from src.report_language import normalize_report_language
+from src.schemas.decision_scale import action_for_score, score_action_conflicts_without_guardrail
 
 DecisionAction = Literal["buy", "add", "hold", "reduce", "sell", "watch", "avoid", "alert"]
 
@@ -346,6 +347,8 @@ def normalize_decision_action(value: Any) -> Optional[DecisionAction]:
 
     if len(matches) == 1:
         return next(iter(matches))
+    if matches and matches <= {"hold", "watch"}:
+        return "watch" if "watch" in matches else "hold"
     return None
 
 
@@ -364,6 +367,9 @@ def build_action_fields(
     explicit_action: Any = None,
     report_type: Any = None,
     report_language: Optional[str] = "zh",
+    sentiment_score: Any = None,
+    guardrail_reason: Any = None,
+    align_with_score: bool = False,
 ) -> DecisionActionFields:
     """Build optional public action fields without mutating legacy contracts."""
 
@@ -375,6 +381,15 @@ def build_action_fields(
         advice_text = str(operation_advice or "").strip()
         if advice_text:
             action = normalize_decision_action(advice_text)
+
+    if align_with_score and score_action_conflicts_without_guardrail(
+        score=sentiment_score,
+        action=action,
+        guardrail_reason=guardrail_reason,
+    ):
+        score_action = action_for_score(sentiment_score)
+        if score_action in _ACTION_VALUES:
+            action = score_action  # type: ignore[assignment]
 
     return {
         "action": action,

--- a/src/schemas/decision_scale.py
+++ b/src/schemas/decision_scale.py
@@ -1,0 +1,115 @@
+# -*- coding: utf-8 -*-
+"""Canonical score-to-decision scale shared by reports and DecisionSignal."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Optional
+
+
+CANONICAL_DECISION_SCALE_VERSION = "decision-scale-v1"
+
+
+@dataclass(frozen=True)
+class DecisionScaleBand:
+    min_score: int
+    max_score: int
+    signal_key: str
+    action: str
+    decision_type: str
+    label_zh: str
+    description_zh: str
+
+
+CANONICAL_DECISION_SCALE: tuple[DecisionScaleBand, ...] = (
+    DecisionScaleBand(80, 100, "strong_buy", "buy", "buy", "强烈买入", "高胜率机会，可执行买入/加仓计划"),
+    DecisionScaleBand(60, 79, "buy", "buy", "buy", "买入", "偏积极机会，允许少量待确认项"),
+    DecisionScaleBand(40, 59, "watch", "watch", "hold", "观望", "信号分歧或确认不足，等待触发条件"),
+    DecisionScaleBand(20, 39, "reduce", "reduce", "sell", "减仓", "风险明显抬升，优先降低暴露"),
+    DecisionScaleBand(0, 19, "sell", "sell", "sell", "卖出", "趋势或风险显著恶化，优先退出"),
+)
+
+
+CANONICAL_DECISION_SCALE_PROMPT_ZH = """## Canonical 评分与动作口径
+
+- `sentiment_score`、`operation_advice`、三态 `decision_type` 与八态 `action` 必须按同一口径表达。
+- 80-100：强烈买入，`action=buy`，`decision_type=buy`。
+- 60-79：买入，`action=buy`，`decision_type=buy`。
+- 40-59：观望，`action=watch`，`decision_type=hold`。
+- 20-39：减仓，`action=reduce`，`decision_type=sell`。
+- 0-19：卖出，`action=sell`，`decision_type=sell`。
+- `decision_type` 只保留 `buy|hold|sell` 兼容统计；更细建议必须写入 `action`。
+- 若 score >= 60 但最终 `action` 是 `hold/watch`，或 score < 40 但最终 `action` 是 `hold/watch`，必须在 `guardrail_reason` 或 `dashboard.decision_stability.reason` 中说明降级原因。"""
+
+
+def normalize_score(value: Any) -> Optional[int]:
+    """Return a bounded integer score when possible."""
+
+    try:
+        score = int(float(value))
+    except (TypeError, ValueError):
+        return None
+    if 0 <= score <= 100:
+        return score
+    return None
+
+
+def decision_band_for_score(value: Any) -> Optional[DecisionScaleBand]:
+    """Return the canonical decision band for a 0-100 score."""
+
+    score = normalize_score(value)
+    if score is None:
+        return None
+    for band in CANONICAL_DECISION_SCALE:
+        if band.min_score <= score <= band.max_score:
+            return band
+    return None
+
+
+def signal_key_for_score(value: Any) -> Optional[str]:
+    band = decision_band_for_score(value)
+    return band.signal_key if band else None
+
+
+def action_for_score(value: Any) -> Optional[str]:
+    band = decision_band_for_score(value)
+    return band.action if band else None
+
+
+def decision_type_for_score(value: Any) -> Optional[str]:
+    band = decision_band_for_score(value)
+    return band.decision_type if band else None
+
+
+def score_band_metadata(value: Any) -> dict[str, Any]:
+    """Return stable metadata for persistence and diagnostics."""
+
+    score = normalize_score(value)
+    band = decision_band_for_score(score)
+    if score is None or band is None:
+        return {}
+    return {
+        "scale_version": CANONICAL_DECISION_SCALE_VERSION,
+        "score": score,
+        "score_band": f"{band.min_score}-{band.max_score}",
+        "signal_key": band.signal_key,
+        "canonical_action": band.action,
+        "canonical_decision_type": band.decision_type,
+    }
+
+
+def score_action_conflicts_without_guardrail(
+    *,
+    score: Any,
+    action: Any,
+    guardrail_reason: Any = None,
+) -> bool:
+    """Return True when a neutral action conflicts with a directional score."""
+
+    if str(guardrail_reason or "").strip():
+        return False
+    normalized_action = str(action or "").strip().lower()
+    if normalized_action not in {"hold", "watch"}:
+        return False
+    score_action = action_for_score(score)
+    return score_action in {"buy", "reduce", "sell"}

--- a/src/services/analysis_service.py
+++ b/src/services/analysis_service.py
@@ -180,6 +180,9 @@ class AnalysisService:
             explicit_action=getattr(result, "action", None),
             report_type=report_type,
             report_language=report_language,
+            sentiment_score=getattr(result, "sentiment_score", None),
+            guardrail_reason=getattr(result, "guardrail_reason", None),
+            align_with_score=True,
         )
         diagnostic_context = get_current_diagnostic_context()
         trace_id = diagnostic_context.trace_id if diagnostic_context is not None else query_id

--- a/src/services/backtest_service.py
+++ b/src/services/backtest_service.py
@@ -624,7 +624,7 @@ class BacktestService:
             limit=limit,
         )
         items = []
-        for result, stock_name, trend_prediction, _created_at, context_snapshot, raw_result, report_type in rows:
+        for result, stock_name, trend_prediction, _created_at, context_snapshot, raw_result, report_type, analysis_sentiment_score in rows:
             summary = extract_market_phase_summary(context_snapshot)
             items.append(
                 self._result_to_dict(
@@ -635,6 +635,7 @@ class BacktestService:
                     market_phase=self._phase_bucket_from_summary(summary),
                     raw_result=raw_result,
                     report_type=report_type,
+                    analysis_sentiment_score=analysis_sentiment_score,
                 )
             )
         return {"total": total, "page": page, "limit": limit, "items": items}
@@ -807,6 +808,7 @@ class BacktestService:
                 str,
                 Optional[str],
                 Optional[str],
+                Optional[int],
             ]
         ] = []
 
@@ -839,13 +841,14 @@ class BacktestService:
                 context_snapshot,
                 raw_result,
                 report_type,
+                analysis_sentiment_score,
             ) in batch:
                 summary = extract_market_phase_summary(context_snapshot)
                 bucket = self._phase_bucket_from_summary(summary)
                 if bucket != phase_bucket:
                     continue
                 if matched_total >= page_offset and len(page_rows) < limit:
-                    page_rows.append((result, stock_name, trend_prediction, summary, bucket, raw_result, report_type))
+                    page_rows.append((result, stock_name, trend_prediction, summary, bucket, raw_result, report_type, analysis_sentiment_score))
                 matched_total += 1
             if len(batch) < batch_limit:
                 break
@@ -859,8 +862,9 @@ class BacktestService:
                 market_phase=bucket,
                 raw_result=raw_result,
                 report_type=report_type,
+                analysis_sentiment_score=analysis_sentiment_score,
             )
-            for result, stock_name, trend_prediction, summary, bucket, raw_result, report_type in page_rows
+            for result, stock_name, trend_prediction, summary, bucket, raw_result, report_type, analysis_sentiment_score in page_rows
         ]
         return {"total": matched_total, "page": page, "limit": limit, "items": items}
 
@@ -1010,6 +1014,7 @@ class BacktestService:
         market_phase: Optional[str] = None,
         raw_result: Optional[Any] = None,
         report_type: Optional[str] = None,
+        analysis_sentiment_score: Optional[int] = None,
     ) -> Dict[str, Any]:
         parsed_raw_result = parse_json_field(raw_result)
         raw = parsed_raw_result if isinstance(parsed_raw_result, dict) else {}
@@ -1018,6 +1023,13 @@ class BacktestService:
             explicit_action=raw.get("action"),
             report_type=report_type or ("market_review" if row.code == "market_review" else None),
             report_language=raw.get("report_language"),
+            sentiment_score=(
+                raw.get("sentiment_score")
+                if raw.get("sentiment_score") is not None
+                else analysis_sentiment_score
+            ),
+            guardrail_reason=raw.get("guardrail_reason") or raw.get("downgrade_reason"),
+            align_with_score=True,
         )
         return {
             "analysis_history_id": row.analysis_history_id,

--- a/src/services/decision_signal_extractor.py
+++ b/src/services/decision_signal_extractor.py
@@ -59,7 +59,11 @@ def build_decision_signal_payload_from_report(
         raise ValueError(f"invalid profile_source: {profile_source}")
 
     dashboard = _as_mapping(getattr(result, "dashboard", None))
-    score = _score_from_result(getattr(result, "sentiment_score", None))
+    score_calibration = _as_mapping(dashboard.get("decision_score_calibration"))
+    score = _effective_signal_score(
+        _score_from_result(getattr(result, "sentiment_score", None)),
+        score_calibration,
+    )
     raw_action = _raw_action_from_report(result)
     guardrail_reason = _extract_guardrail_reason(result, dashboard, score=score, raw_action=raw_action)
     action_fields = build_action_fields(
@@ -113,10 +117,16 @@ def build_decision_signal_payload_from_report(
     score_metadata = score_band_metadata(score)
     if score_metadata:
         metadata["score_scale"] = score_metadata
-        metadata["raw_score"] = score_metadata["score"]
-        metadata["adjusted_score"] = _score_from_result(
-            _as_mapping(dashboard.get("decision_score_calibration")).get("adjusted_score")
-        ) or score_metadata["score"]
+        metadata["raw_score"] = _calibrated_or_raw_score(
+            score_calibration,
+            prefer="raw",
+            fallback=score_metadata["score"],
+        )
+        metadata["adjusted_score"] = _calibrated_or_raw_score(
+            score_calibration,
+            prefer="adjusted",
+            fallback=score_metadata["score"],
+        )
         metadata["final_action"] = action
         if raw_action:
             metadata["raw_action"] = raw_action
@@ -204,6 +214,30 @@ def extract_and_persist_from_analysis_result(
 
 def _as_mapping(value: Any) -> Dict[str, Any]:
     return dict(value) if isinstance(value, Mapping) else {}
+
+
+def _calibrated_or_raw_score(
+    calibration: Dict[str, Any],
+    *,
+    prefer: Literal["raw", "adjusted"],
+    fallback: Optional[int] = None,
+) -> Optional[int]:
+    if prefer == "raw":
+        value = calibration.get("raw_score")
+    else:
+        value = calibration.get("adjusted_score")
+    parsed = _score_from_result(value)
+    if parsed is not None:
+        return parsed
+    return fallback
+
+
+def _effective_signal_score(
+    score: Optional[int],
+    calibration: Dict[str, Any],
+) -> Optional[int]:
+    adjusted = _calibrated_or_raw_score(calibration, prefer="adjusted")
+    return adjusted if adjusted is not None else score
 
 
 def _first_text(*values: Any) -> Optional[str]:

--- a/src/services/decision_signal_extractor.py
+++ b/src/services/decision_signal_extractor.py
@@ -11,7 +11,13 @@ from data_provider.base import normalize_stock_code
 
 from src.analyzer import AnalysisResult
 from src.core.trading_calendar import get_market_for_stock
-from src.schemas.decision_action import build_action_fields
+from src.schemas.decision_action import build_action_fields, normalize_decision_action
+from src.schemas.decision_scale import (
+    CANONICAL_DECISION_SCALE_VERSION,
+    action_for_score,
+    score_action_conflicts_without_guardrail,
+    score_band_metadata,
+)
 from src.services.decision_signal_service import DecisionSignalService
 from src.services.portfolio_service import VALID_MARKETS
 from src.utils.sniper_points import extract_sniper_points
@@ -52,11 +58,18 @@ def build_decision_signal_payload_from_report(
     if profile_source not in _PROFILE_SOURCES:
         raise ValueError(f"invalid profile_source: {profile_source}")
 
+    dashboard = _as_mapping(getattr(result, "dashboard", None))
+    score = _score_from_result(getattr(result, "sentiment_score", None))
+    raw_action = _raw_action_from_report(result)
+    guardrail_reason = _extract_guardrail_reason(result, dashboard, score=score, raw_action=raw_action)
     action_fields = build_action_fields(
         operation_advice=getattr(result, "operation_advice", None),
         explicit_action=getattr(result, "action", None),
         report_type=report_type,
         report_language=getattr(result, "report_language", None),
+        sentiment_score=score,
+        guardrail_reason=guardrail_reason,
+        align_with_score=True,
     )
     action = action_fields.get("action")
     if not action:
@@ -79,7 +92,6 @@ def build_decision_signal_payload_from_report(
         )
         return None
 
-    dashboard = _as_mapping(getattr(result, "dashboard", None))
     sniper_points = extract_sniper_points(result)
     entry_low, entry_high = _entry_range(
         sniper_points.get("ideal_buy"),
@@ -96,7 +108,22 @@ def build_decision_signal_payload_from_report(
         "profile_policy_version": "decision-profile-v1",
         "signal_generation_version": "legacy-report-extractor-v1",
         "decision_signal_metadata_version": "decision-signal-metadata-v1",
+        "canonical_decision_scale_version": CANONICAL_DECISION_SCALE_VERSION,
     }
+    score_metadata = score_band_metadata(score)
+    if score_metadata:
+        metadata["score_scale"] = score_metadata
+        metadata["raw_score"] = score_metadata["score"]
+        metadata["adjusted_score"] = _score_from_result(
+            _as_mapping(dashboard.get("decision_score_calibration")).get("adjusted_score")
+        ) or score_metadata["score"]
+        metadata["final_action"] = action
+        if raw_action:
+            metadata["raw_action"] = raw_action
+        if raw_action and raw_action != action:
+            metadata["action_adjustment_reason"] = "canonical_score_alignment"
+    if guardrail_reason:
+        metadata["guardrail_reason"] = guardrail_reason
     market_phase_summary = _extract_market_phase_summary(context_snapshot, result)
     if market_phase_summary:
         metadata["market_phase_summary"] = market_phase_summary
@@ -114,7 +141,7 @@ def build_decision_signal_payload_from_report(
         "action": action,
         "action_label": action_fields.get("action_label"),
         "confidence": _confidence_from_level(getattr(result, "confidence_level", None)),
-        "score": _score_from_result(getattr(result, "sentiment_score", None)),
+        "score": score,
         "entry_low": entry_low,
         "entry_high": entry_high,
         "stop_loss": sniper_points.get("stop_loss"),
@@ -193,6 +220,76 @@ def _score_from_result(value: Any) -> Optional[int]:
     except (TypeError, ValueError):
         return None
     return score if 0 <= score <= 100 else None
+
+
+def _raw_action_from_report(result: AnalysisResult) -> Optional[str]:
+    explicit_action = normalize_decision_action(getattr(result, "action", None))
+    if explicit_action:
+        return explicit_action
+    return normalize_decision_action(getattr(result, "operation_advice", None))
+
+
+_NEUTRAL_GUARDRAIL_HINTS = (
+    "等待",
+    "待",
+    "需要确认",
+    "回踩",
+    "支撑",
+    "压力",
+    "风险",
+    "资金",
+    "突破",
+    "不追",
+    "不宜",
+    "缺少",
+    "缺少确认",
+    "未确认",
+    "wait",
+    "waiting",
+    "pending confirmation",
+    "lack confirmation",
+    "pullback",
+    "support",
+    "resistance",
+    "risk",
+    "flow",
+)
+
+
+def _extract_guardrail_reason(
+    result: AnalysisResult,
+    dashboard: Mapping[str, Any],
+    *,
+    score: Optional[int],
+    raw_action: Optional[str],
+) -> Optional[str]:
+    score_calibration = _as_mapping(dashboard.get("decision_score_calibration"))
+    reason = _first_text(
+        score_calibration.get("guardrail_reason"),
+        _as_mapping(dashboard.get("decision_stability")).get("reason"),
+        getattr(result, "guardrail_reason", None),
+    )
+    if reason:
+        return reason
+
+    if score_action_conflicts_without_guardrail(score=score, action=raw_action):
+        candidates = [getattr(result, "operation_advice", None)]
+        if action_for_score(score) == "buy":
+            candidates.extend(
+                [
+                    getattr(result, "analysis_summary", None),
+                    getattr(result, "buy_reason", None),
+                    _watch_conditions(dashboard),
+                ]
+            )
+        for candidate in candidates:
+            text = _first_text(candidate)
+            if not text:
+                continue
+            normalized = text.lower()
+            if any(hint in normalized for hint in _NEUTRAL_GUARDRAIL_HINTS):
+                return text
+    return None
 
 
 def _confidence_from_level(value: Any) -> Optional[float]:

--- a/src/services/decision_signal_reassess_service.py
+++ b/src/services/decision_signal_reassess_service.py
@@ -7,7 +7,8 @@ import re
 from collections.abc import Mapping
 from typing import Any, Optional
 
-from src.schemas.decision_action import build_action_fields
+from src.schemas.decision_action import build_action_fields, normalize_decision_action
+from src.schemas.decision_scale import action_for_score, score_action_conflicts_without_guardrail
 from src.services.decision_profile_policy import (
     PROFILE_POLICY_VERSION,
     SCORING_VERSION,
@@ -128,6 +129,11 @@ def _build_candidate(
     if not raw_code or not market:
         raise DecisionSignalUnsupportedReportSnapshotError("source report has no supported stock identity")
 
+    score = _score_from_value(_first_present(raw_result.get("sentiment_score"), getattr(record, "sentiment_score", None)))
+    raw_action = normalize_decision_action(raw_result.get("action")) or normalize_decision_action(
+        _first_present(raw_result.get("operation_advice"), getattr(record, "operation_advice", None))
+    )
+    guardrail_reason = _extract_guardrail_reason(raw_result, score=score, raw_action=raw_action)
     action_fields = build_action_fields(
         operation_advice=_first_present(
             raw_result.get("operation_advice"),
@@ -136,6 +142,9 @@ def _build_candidate(
         explicit_action=raw_result.get("action"),
         report_type=report_type,
         report_language=raw_result.get("report_language"),
+        sentiment_score=score,
+        guardrail_reason=guardrail_reason,
+        align_with_score=True,
     )
     action = action_fields.get("action")
     if not action:
@@ -149,7 +158,7 @@ def _build_candidate(
     market_phase = _extract_market_phase(raw_result, context_snapshot)
     return DecisionSignalCandidate(
         action=action,
-        score=_score_from_value(_first_present(raw_result.get("sentiment_score"), getattr(record, "sentiment_score", None))),
+        score=score,
         confidence=_confidence_from_level(raw_result.get("confidence_level")),
         horizon=_extract_horizon(raw_result, context_snapshot, market_phase, action),
         entry_low=entry_low,
@@ -232,6 +241,66 @@ def _score_from_value(value: Any) -> Optional[int]:
     except (TypeError, ValueError):
         return None
     return score if 0 <= score <= 100 else None
+
+
+def _extract_guardrail_reason(
+    raw_result: Mapping[str, Any],
+    *,
+    score: Optional[int],
+    raw_action: Optional[str],
+) -> Optional[str]:
+    dashboard = raw_result.get("dashboard") if isinstance(raw_result.get("dashboard"), Mapping) else {}
+    calibration = (
+        dashboard.get("decision_score_calibration")
+        if isinstance(dashboard.get("decision_score_calibration"), Mapping)
+        else {}
+    )
+    stability = (
+        dashboard.get("decision_stability")
+        if isinstance(dashboard.get("decision_stability"), Mapping)
+        else {}
+    )
+    for candidate in (
+        calibration.get("guardrail_reason"),
+        stability.get("reason"),
+        raw_result.get("guardrail_reason"),
+    ):
+        text = str(candidate or "").strip()
+        if text:
+            return text
+    if score_action_conflicts_without_guardrail(score=score, action=raw_action):
+        candidates = [raw_result.get("operation_advice")]
+        if action_for_score(score) == "buy":
+            candidates.extend(
+                [
+                    raw_result.get("analysis_summary"),
+                    raw_result.get("buy_reason"),
+                    raw_result.get("risk_warning"),
+                ]
+            )
+        hints = (
+            "等待",
+            "待",
+            "需要确认",
+            "缺少确认",
+            "未确认",
+            "回踩",
+            "支撑",
+            "压力",
+            "风险",
+            "资金",
+            "突破",
+            "不追",
+            "不宜",
+        )
+        for candidate in candidates:
+            text = str(candidate or "").strip()
+            if not text:
+                continue
+            normalized = text.lower()
+            if any(hint in normalized for hint in hints):
+                return text
+    return None
 
 
 def _confidence_from_level(value: Any) -> Optional[float]:

--- a/src/services/decision_signal_reassess_service.py
+++ b/src/services/decision_signal_reassess_service.py
@@ -129,7 +129,11 @@ def _build_candidate(
     if not raw_code or not market:
         raise DecisionSignalUnsupportedReportSnapshotError("source report has no supported stock identity")
 
-    score = _score_from_value(_first_present(raw_result.get("sentiment_score"), getattr(record, "sentiment_score", None)))
+    dashboard = _as_mapping(raw_result.get("dashboard"))
+    score = _effective_signal_score(
+        _score_from_value(_first_present(raw_result.get("sentiment_score"), getattr(record, "sentiment_score", None))),
+        dashboard=dashboard,
+    )
     raw_action = normalize_decision_action(raw_result.get("action")) or normalize_decision_action(
         _first_present(raw_result.get("operation_advice"), getattr(record, "operation_advice", None))
     )
@@ -176,6 +180,10 @@ def _build_candidate(
         watch_conditions=_extract_watch_conditions(raw_result),
         market_phase=market_phase,
     )
+
+
+def _as_mapping(value: Any) -> dict[str, Any]:
+    return dict(value) if isinstance(value, Mapping) else {}
 
 
 def _parse_mapping(value: Any) -> Mapping[str, Any]:
@@ -241,6 +249,16 @@ def _score_from_value(value: Any) -> Optional[int]:
     except (TypeError, ValueError):
         return None
     return score if 0 <= score <= 100 else None
+
+
+def _effective_signal_score(
+    score: Optional[int],
+    *,
+    dashboard: Mapping[str, Any],
+) -> Optional[int]:
+    calibration = _as_mapping(dashboard.get("decision_score_calibration"))
+    adjusted = _score_from_value(calibration.get("adjusted_score"))
+    return adjusted if adjusted is not None else score
 
 
 def _extract_guardrail_reason(

--- a/src/services/decision_signal_service.py
+++ b/src/services/decision_signal_service.py
@@ -18,7 +18,9 @@ from src.schemas.decision_action import (
     DecisionAction,
     build_action_fields,
     localize_action_label,
+    normalize_decision_action,
 )
+from src.schemas.decision_scale import action_for_score, score_action_conflicts_without_guardrail
 from src.services.portfolio_service import VALID_MARKETS
 from src.storage import (
     AnalysisHistory,
@@ -421,13 +423,92 @@ class DecisionSignalService:
         normalized_action = str(raw_action).strip() if raw_action is not None else None
         if not normalized_action:
             normalized_action = None
+        score = DecisionSignalService._history_int(
+            raw.get("sentiment_score"),
+            getattr(record, "sentiment_score", None),
+            default=None,
+        )
+        raw_action_value = normalize_decision_action(normalized_action) or normalize_decision_action(
+            normalized_operation_advice
+        )
+        guardrail_reason = DecisionSignalService._history_guardrail_reason(
+            raw=raw,
+            operation_advice=normalized_operation_advice,
+            score=score,
+            raw_action=raw_action_value,
+        )
         action_fields = build_action_fields(
             operation_advice=normalized_operation_advice,
             explicit_action=normalized_action,
             report_type=getattr(record, "report_type", ""),
             report_language=raw.get("report_language"),
+            sentiment_score=score,
+            guardrail_reason=guardrail_reason,
+            align_with_score=True,
         )
         return action_fields["action"], action_fields["action_label"]
+
+    @staticmethod
+    def _history_guardrail_reason(
+        *,
+        raw: Dict[str, Any],
+        operation_advice: Optional[str],
+        score: Optional[int],
+        raw_action: Optional[str],
+    ) -> Optional[str]:
+        dashboard = raw.get("dashboard") if isinstance(raw.get("dashboard"), dict) else {}
+        calibration = (
+            dashboard.get("decision_score_calibration")
+            if isinstance(dashboard.get("decision_score_calibration"), dict)
+            else {}
+        )
+        stability = (
+            dashboard.get("decision_stability")
+            if isinstance(dashboard.get("decision_stability"), dict)
+            else {}
+        )
+        for candidate in (
+            calibration.get("guardrail_reason"),
+            stability.get("reason"),
+            raw.get("guardrail_reason"),
+        ):
+            text = str(candidate or "").strip()
+            if text:
+                return text
+
+        if score_action_conflicts_without_guardrail(score=score, action=raw_action):
+            candidates = [operation_advice]
+            if action_for_score(score) == "buy":
+                candidates.extend(
+                    [
+                        raw.get("analysis_summary"),
+                        raw.get("buy_reason"),
+                        raw.get("risk_warning"),
+                    ]
+                )
+            hints = (
+                "等待",
+                "待",
+                "需要确认",
+                "缺少确认",
+                "未确认",
+                "回踩",
+                "支撑",
+                "压力",
+                "风险",
+                "资金",
+                "突破",
+                "不追",
+                "不宜",
+            )
+            for candidate in candidates:
+                text = str(candidate or "").strip()
+                if not text:
+                    continue
+                normalized = text.lower()
+                if any(hint in normalized for hint in hints):
+                    return text
+        return None
 
     def _apply_history_backfill_lifecycle(
         self,

--- a/src/services/history_service.py
+++ b/src/services/history_service.py
@@ -592,6 +592,9 @@ class HistoryService:
             explicit_action=raw.get("action"),
             report_type=getattr(record, "report_type", None),
             report_language=normalize_report_language(raw.get("report_language")),
+            sentiment_score=getattr(record, "sentiment_score", None),
+            guardrail_reason=raw.get("guardrail_reason") or raw.get("downgrade_reason"),
+            align_with_score=True,
         )
 
     def delete_history_records(self, record_ids: List[int]) -> int:

--- a/src/stock_analyzer.py
+++ b/src/stock_analyzer.py
@@ -741,6 +741,11 @@ class StockTrendAnalyzer:
             TrendStatus.WEAK_BULL,
         ]:
             result.buy_signal = BuySignal.BUY
+        elif score_signal in {"strong_buy", "buy"} and result.trend_status in [
+            TrendStatus.CONSOLIDATION,
+            TrendStatus.WEAK_BEAR,
+        ]:
+            result.buy_signal = BuySignal.WAIT
         elif score_signal == "watch":
             result.buy_signal = BuySignal.WAIT
         elif score_signal == "sell" or result.trend_status in [TrendStatus.BEAR, TrendStatus.STRONG_BEAR]:

--- a/src/stock_analyzer.py
+++ b/src/stock_analyzer.py
@@ -25,6 +25,7 @@ import pandas as pd
 import numpy as np
 
 from src.config import get_config
+from src.schemas.decision_scale import signal_key_for_score
 
 logger = logging.getLogger(__name__)
 
@@ -730,16 +731,19 @@ class StockTrendAnalyzer:
         result.signal_reasons = reasons
         result.risk_factors = risks
 
-        # 生成买入信号（调整阈值以适应新的100分制）
-        if score >= 75 and result.trend_status in [TrendStatus.STRONG_BULL, TrendStatus.BULL]:
+        # 生成买入信号（与 canonical decision scale 保持一致）
+        score_signal = signal_key_for_score(score)
+        if score_signal == "strong_buy" and result.trend_status in [TrendStatus.STRONG_BULL, TrendStatus.BULL]:
             result.buy_signal = BuySignal.STRONG_BUY
-        elif score >= 60 and result.trend_status in [TrendStatus.STRONG_BULL, TrendStatus.BULL, TrendStatus.WEAK_BULL]:
+        elif score_signal in {"strong_buy", "buy"} and result.trend_status in [
+            TrendStatus.STRONG_BULL,
+            TrendStatus.BULL,
+            TrendStatus.WEAK_BULL,
+        ]:
             result.buy_signal = BuySignal.BUY
-        elif score >= 45:
-            result.buy_signal = BuySignal.HOLD
-        elif score >= 30:
+        elif score_signal == "watch":
             result.buy_signal = BuySignal.WAIT
-        elif result.trend_status in [TrendStatus.BEAR, TrendStatus.STRONG_BEAR]:
+        elif score_signal == "sell" or result.trend_status in [TrendStatus.BEAR, TrendStatus.STRONG_BEAR]:
             result.buy_signal = BuySignal.STRONG_SELL
         else:
             result.buy_signal = BuySignal.SELL

--- a/tests/test_analysis_api_contract.py
+++ b/tests/test_analysis_api_contract.py
@@ -1279,6 +1279,31 @@ class AnalysisApiContractTestCase(unittest.TestCase):
         self.assertEqual(report.summary.action, "avoid")
         self.assertEqual(report.summary.action_label, "回避")
 
+    def test_build_analysis_report_aligns_score_and_legacy_advice(self) -> None:
+        if _build_analysis_report is None:
+            self.skipTest("analysis endpoint helpers unavailable in this environment")
+
+        report = _build_analysis_report(
+            report_data={
+                "meta": {"report_type": "detailed", "report_language": "zh"},
+                "summary": {
+                    "analysis_summary": "等待确认",
+                    "operation_advice": "持有",
+                    "sentiment_score": 72,
+                },
+                "strategy": {},
+                "details": {},
+            },
+            query_id="q2",
+            stock_code="600519",
+            stock_name="贵州茅台",
+            context_snapshot=None,
+            fallback_fundamental_payload=None,
+        )
+
+        self.assertEqual(report.summary.action, "buy")
+        self.assertEqual(report.summary.action_label, "买入")
+
     def test_build_analysis_report_reads_decision_action_from_raw_result(self) -> None:
         if _build_analysis_report is None:
             self.skipTest("analysis endpoint helpers unavailable in this environment")

--- a/tests/test_analysis_history.py
+++ b/tests/test_analysis_history.py
@@ -579,8 +579,8 @@ class AnalysisHistoryTestCase(unittest.TestCase):
         self.assertEqual(item["trend_prediction"], "看多")
         self.assertEqual(item["analysis_summary"], "基本面稳健，短期震荡")
         self.assertEqual(item["operation_advice"], "持有")
-        self.assertEqual(item["action"], "hold")
-        self.assertEqual(item["action_label"], "持有")
+        self.assertEqual(item["action"], "buy")
+        self.assertEqual(item["action_label"], "买入")
         self.assertEqual(item["model_used"], "gemini/gemini-2.5-pro")
         self.assertEqual(item["current_price"], 51.5)
         self.assertEqual(item["change_pct"], -4.61)
@@ -755,6 +755,37 @@ class AnalysisHistoryTestCase(unittest.TestCase):
         self.assertEqual(response.items[0].action, "avoid")
         self.assertEqual(response.items[0].action_label, "回避")
 
+    def test_stock_bar_item_aligns_score_and_legacy_advice(self) -> None:
+        if get_stock_bar is None:
+            self.skipTest("fastapi is not installed in this test environment")
+
+        result = self._build_result()
+        result.operation_advice = "持有"
+        result.sentiment_score = 78
+
+        saved = self.db.save_analysis_history(
+            result=result,
+            query_id="query_stock_bar_score_align",
+            report_type="detailed",
+            news_content="个股正文",
+            context_snapshot=None,
+            save_snapshot=False,
+        )
+        self.assertGreater(saved, 0)
+
+        response = get_stock_bar(
+            start_date=None,
+            end_date=None,
+            limit=10,
+            db_manager=self.db,
+        )
+
+        self.assertEqual(len(response.items), 1)
+        self.assertEqual(response.items[0].operation_advice, "持有")
+        self.assertEqual(response.items[0].sentiment_score, 78)
+        self.assertEqual(response.items[0].action, "buy")
+        self.assertEqual(response.items[0].action_label, "买入")
+
     def test_stock_bar_item_falls_back_to_raw_result_summary_fields(self) -> None:
         if get_stock_bar is None:
             self.skipTest("fastapi is not installed in this test environment")
@@ -791,8 +822,8 @@ class AnalysisHistoryTestCase(unittest.TestCase):
         self.assertEqual(len(response.items), 1)
         self.assertEqual(response.items[0].sentiment_score, 78)
         self.assertEqual(response.items[0].operation_advice, "Hold")
-        self.assertEqual(response.items[0].action, "hold")
-        self.assertEqual(response.items[0].action_label, "Hold")
+        self.assertEqual(response.items[0].action, "buy")
+        self.assertEqual(response.items[0].action_label, "Buy")
 
     def test_history_detail_uses_service_resolved_action_fields(self) -> None:
         if get_history_detail is None:

--- a/tests/test_analyzer_news_prompt.py
+++ b/tests/test_analyzer_news_prompt.py
@@ -147,6 +147,24 @@ class AnalyzerNewsPromptTestCase(unittest.TestCase):
         self.assertIn("支撑/压力位", prompt)
         self.assertIn("洗盘观察", prompt)
 
+    def test_analysis_prompt_score_scale_splits_reduce_and_sell_bands(self) -> None:
+        for legacy in (False, True):
+            with self.subTest(legacy=legacy):
+                with patch.object(GeminiAnalyzer, "_init_litellm", return_value=None):
+                    analyzer = GeminiAnalyzer(
+                        skill_instructions="",
+                        default_skill_policy="",
+                        use_legacy_default_prompt=legacy,
+                    )
+
+                prompt = analyzer._get_analysis_system_prompt("zh", stock_code="600519")
+
+                self.assertIn("### 减仓（20-39分）", prompt)
+                self.assertIn("### 卖出（0-19分）", prompt)
+                self.assertIn("20-39：减仓，`action=reduce`，`decision_type=sell`。", prompt)
+                self.assertIn("0-19：卖出，`action=sell`，`decision_type=sell`。", prompt)
+                self.assertNotIn("### 卖出/减仓（0-39分）", prompt)
+
     def test_prompt_contains_time_constraints(self) -> None:
         with patch.object(GeminiAnalyzer, "_init_litellm", return_value=None):
             analyzer = GeminiAnalyzer()

--- a/tests/test_backtest_service.py
+++ b/tests/test_backtest_service.py
@@ -1750,6 +1750,35 @@ class BacktestServiceTestCase(unittest.TestCase):
         self.assertEqual(item["direction_expected"], "up")
         self.assertTrue(item["direction_correct"])
 
+    def test_get_recent_evaluations_aligns_neutral_advice_with_score(self) -> None:
+        service = BacktestService(self.db)
+        with self.db.get_session() as session:
+            history = session.query(AnalysisHistory).filter(AnalysisHistory.query_id == "q1").one()
+            history.operation_advice = "持有"
+            history.sentiment_score = 78
+            history.raw_result = None
+            result = self._make_backtest_result(
+                analysis_history_id=history.id,
+                analysis_date=date(2024, 1, 1),
+                eval_window_days=1,
+            )
+            result.operation_advice = "持有"
+            session.add(result)
+            session.commit()
+
+        data = service.get_recent_evaluations(
+            code="600519",
+            eval_window_days=1,
+            limit=10,
+            page=1,
+        )
+
+        self.assertEqual(data["total"], 1)
+        item = data["items"][0]
+        self.assertEqual(item["operation_advice"], "持有")
+        self.assertEqual(item["action"], "buy")
+        self.assertEqual(item["action_label"], "买入")
+
     def test_get_recent_evaluations_prefers_persisted_raw_action(self) -> None:
         service = BacktestService(self.db)
 
@@ -1761,6 +1790,7 @@ class BacktestServiceTestCase(unittest.TestCase):
                     "operation_advice": "持有观察",
                     "action": "watch",
                     "action_label": "观望",
+                    "guardrail_reason": "市场风险较高，建议观望",
                 },
                 ensure_ascii=False,
             )
@@ -1992,7 +2022,12 @@ class BacktestServiceTestCase(unittest.TestCase):
         service = BacktestService(self.db)
         phase_snapshot = json.dumps({"market_phase_summary": {"phase": "intraday", "market": "cn"}})
         raw_result = json.dumps(
-            {"operation_advice": "持有观察", "action": "watch", "action_label": "观望"},
+            {
+                "operation_advice": "持有观察",
+                "action": "watch",
+                "action_label": "观望",
+                "guardrail_reason": "模型判定观望，保留原始动作",
+            },
             ensure_ascii=False,
         )
         rows = [
@@ -2004,6 +2039,7 @@ class BacktestServiceTestCase(unittest.TestCase):
                 phase_snapshot,
                 raw_result,
                 "simple",
+                78,
             )
             for idx in range(2)
         ]

--- a/tests/test_decision_action.py
+++ b/tests/test_decision_action.py
@@ -8,6 +8,7 @@ from src.schemas.decision_action import (
     localize_action_label,
     normalize_decision_action,
 )
+from src.schemas.decision_scale import action_for_score, decision_type_for_score, signal_key_for_score
 
 
 @pytest.mark.parametrize(
@@ -319,3 +320,49 @@ def test_build_action_fields_keeps_empty_action_without_advice_or_explicit_actio
     )
 
     assert fields == {"action": None, "action_label": None}
+
+
+@pytest.mark.parametrize(
+    ("score", "expected_signal", "expected_action", "expected_decision_type"),
+    [
+        (28, "reduce", "reduce", "sell"),
+        (38, "reduce", "reduce", "sell"),
+        (42, "watch", "watch", "hold"),
+        (55, "watch", "watch", "hold"),
+        (60, "buy", "buy", "buy"),
+        (66, "buy", "buy", "buy"),
+        (72, "buy", "buy", "buy"),
+    ],
+)
+def test_canonical_score_scale_boundaries(
+    score: int,
+    expected_signal: str,
+    expected_action: str,
+    expected_decision_type: str,
+) -> None:
+    assert signal_key_for_score(score) == expected_signal
+    assert action_for_score(score) == expected_action
+    assert decision_type_for_score(score) == expected_decision_type
+
+
+def test_build_action_fields_can_align_neutral_action_with_directional_score() -> None:
+    assert build_action_fields(
+        operation_advice="持有",
+        sentiment_score=72,
+        align_with_score=True,
+    ) == {"action": "buy", "action_label": "买入"}
+
+    assert build_action_fields(
+        operation_advice="观望",
+        sentiment_score=28,
+        align_with_score=True,
+    ) == {"action": "reduce", "action_label": "减仓"}
+
+
+def test_build_action_fields_keeps_neutral_score_conflict_when_guardrail_is_explicit() -> None:
+    assert build_action_fields(
+        operation_advice="持有/观望待回踩",
+        sentiment_score=72,
+        guardrail_reason="等待回踩确认",
+        align_with_score=True,
+    ) == {"action": "watch", "action_label": "观望"}

--- a/tests/test_decision_signal_api.py
+++ b/tests/test_decision_signal_api.py
@@ -1460,6 +1460,40 @@ def test_reassess_success_preview_is_read_only_and_uses_opaque_metadata(client_a
     assert _decision_signal_count(db) == before
 
 
+def test_reassess_preview_prefers_stability_adjusted_score(client_and_db) -> None:
+    client, db = client_and_db
+    raw_result = _valid_reassess_raw(
+        action=None,
+        sentiment_score=72,
+        operation_advice="观望",
+    )
+    dashboard = raw_result["dashboard"]
+    dashboard["decision_score_calibration"] = {
+        "raw_score": 72,
+        "adjusted_score": 59,
+        "final_action": "watch",
+        "guardrail_reason": "资金流偏弱，先观望回撤到 45-59。",
+    }
+    raw_result["dashboard"] = dashboard
+    record_id = _save_reassess_history(
+        db,
+        raw_result=raw_result,
+        context_snapshot=_valid_reassess_context(),
+    )
+
+    response = client.post(
+        "/api/v1/decision-signals/reassess",
+        json={"source_report_id": record_id, "decision_profile": "balanced", "persist": False},
+    )
+
+    assert response.status_code == 200, response.text
+    payload = response.json()
+    assert payload["preview"]["score"] == 59
+    assert payload["preview"]["action"] == "watch"
+    assert payload["preview"]["metadata"]["guardrail_result"]["final_action"] == "watch"
+    assert _decision_signal_count(db) == 0
+
+
 def test_reassess_service_has_no_live_market_provider_imports() -> None:
     source = (Path(__file__).resolve().parents[1] / "src/services/decision_signal_reassess_service.py").read_text(
         encoding="utf-8"

--- a/tests/test_decision_signal_extractor.py
+++ b/tests/test_decision_signal_extractor.py
@@ -210,6 +210,79 @@ def test_build_payload_uses_result_fallbacks_and_optional_catalysts() -> None:
     assert payload["metadata"]["holding_state"] == "unknown"
 
 
+def test_build_payload_aligns_high_neutral_action_without_guardrail_to_buy() -> None:
+    result = _result(
+        sentiment_score=72,
+        operation_advice="持有",
+        decision_type="hold",
+        action=None,
+    )
+
+    payload = build_decision_signal_payload_from_report(
+        result,
+        trace_id="trace-high-neutral",
+        query_source="api",
+        report_type="simple",
+        profile_source=BUILD_PROFILE_SOURCE,
+    )
+
+    assert payload is not None
+    assert payload["action"] == "buy"
+    assert payload["action_label"] == "买入"
+    assert payload["metadata"]["raw_action"] == "hold"
+    assert payload["metadata"]["final_action"] == "buy"
+    assert payload["metadata"]["action_adjustment_reason"] == "canonical_score_alignment"
+    assert payload["metadata"]["score_scale"]["score_band"] == "60-79"
+
+
+def test_build_payload_keeps_high_neutral_action_with_guardrail_reason() -> None:
+    result = _result(
+        sentiment_score=72,
+        operation_advice="持有/观望待回踩",
+        decision_type="hold",
+        action=None,
+    )
+
+    payload = build_decision_signal_payload_from_report(
+        result,
+        trace_id="trace-high-neutral-guarded",
+        query_source="api",
+        report_type="simple",
+        profile_source=BUILD_PROFILE_SOURCE,
+    )
+
+    assert payload is not None
+    assert payload["action"] == "watch"
+    assert payload["action_label"] == "观望"
+    assert payload["metadata"]["raw_action"] == "watch"
+    assert payload["metadata"]["final_action"] == "watch"
+    assert payload["metadata"]["guardrail_reason"] == "持有/观望待回踩"
+
+
+def test_build_payload_aligns_low_neutral_action_to_reduce() -> None:
+    result = _result(
+        sentiment_score=28,
+        operation_advice="观望",
+        decision_type="hold",
+        action=None,
+    )
+
+    payload = build_decision_signal_payload_from_report(
+        result,
+        trace_id="trace-low-neutral",
+        query_source="api",
+        report_type="simple",
+        profile_source=BUILD_PROFILE_SOURCE,
+    )
+
+    assert payload is not None
+    assert payload["action"] == "reduce"
+    assert payload["action_label"] == "减仓"
+    assert payload["metadata"]["raw_action"] == "watch"
+    assert payload["metadata"]["final_action"] == "reduce"
+    assert payload["metadata"]["score_scale"]["score_band"] == "20-39"
+
+
 def test_build_payload_records_empty_holding_state_from_explicit_portfolio_context() -> None:
     payload = build_decision_signal_payload_from_report(
         _result(),

--- a/tests/test_decision_signal_extractor.py
+++ b/tests/test_decision_signal_extractor.py
@@ -259,6 +259,40 @@ def test_build_payload_keeps_high_neutral_action_with_guardrail_reason() -> None
     assert payload["metadata"]["guardrail_reason"] == "持有/观望待回踩"
 
 
+def test_build_payload_uses_stability_calibration_raw_and_adjusted_scores() -> None:
+    result = _result(
+        sentiment_score=59,
+        operation_advice="观望",
+        decision_type="hold",
+        action=None,
+    )
+    dashboard = result.dashboard or {}
+    dashboard["decision_score_calibration"] = {
+        "raw_score": 72,
+        "adjusted_score": 59,
+        "final_action": "watch",
+        "guardrail_reason": "资金流较弱，按风险规则降级",
+    }
+    result.dashboard = dashboard
+
+    payload = build_decision_signal_payload_from_report(
+        result,
+        trace_id="trace-stability-calibration",
+        query_source="api",
+        report_type="simple",
+        profile_source=BUILD_PROFILE_SOURCE,
+    )
+
+    assert payload is not None
+    assert payload["score"] == 59
+    assert payload["metadata"]["raw_score"] == 72
+    assert payload["metadata"]["adjusted_score"] == 59
+    assert payload["metadata"]["score_scale"]["score_band"] == "40-59"
+    assert payload["metadata"]["raw_action"] == "watch"
+    assert payload["metadata"]["final_action"] == "watch"
+    assert payload["metadata"]["guardrail_reason"] == "资金流较弱，按风险规则降级"
+
+
 def test_build_payload_aligns_low_neutral_action_to_reduce() -> None:
     result = _result(
         sentiment_score=28,
@@ -445,6 +479,45 @@ def test_extract_and_persist_reuses_service_dedup_and_sanitization(isolated_db) 
     assert persisted["reason"] == "趋势确认 token=[REDACTED]"
     assert persisted["entry_low"] == 1690.0
     assert persisted["entry_high"] == 1700.0
+
+
+def test_extract_and_persist_reuses_stability_score_metadata(isolated_db) -> None:
+    service = DecisionSignalService(db_manager=isolated_db)
+    result = _result(
+        sentiment_score=59,
+        operation_advice="观望",
+        decision_type="hold",
+        action=None,
+        confidence_level="中",
+    )
+    dashboard = result.dashboard or {}
+    dashboard["decision_score_calibration"] = {
+        "raw_score": 72,
+        "adjusted_score": 59,
+        "final_action": "watch",
+        "guardrail_reason": "资金流较弱，按风险规则降级",
+    }
+    result.dashboard = dashboard
+
+    created = extract_and_persist_from_analysis_result(
+        result,
+        context_snapshot={"market_phase_summary": {"phase": "intraday"}},
+        portfolio_context={"quantity": 10},
+        source_report_id=903,
+        trace_id="trace-stability-persist",
+        query_source="api",
+        report_type="full",
+        profile_source="auto_default",
+        service=service,
+    )
+
+    assert created is not None
+    persisted = service.list_signals(source_report_id=903)["items"][0]
+    assert persisted["metadata"]["raw_score"] == 72
+    assert persisted["metadata"]["adjusted_score"] == 59
+    assert persisted["metadata"]["raw_action"] == "watch"
+    assert persisted["metadata"]["final_action"] == "watch"
+    assert persisted["metadata"]["guardrail_reason"] == "资金流较弱，按风险规则降级"
 
 
 def test_extract_and_persist_writes_tw_signal(isolated_db) -> None:

--- a/tests/test_report_language.py
+++ b/tests/test_report_language.py
@@ -33,6 +33,15 @@ class ReportLanguageTestCase(unittest.TestCase):
         self.assertEqual(emoji, "🟢")
         self.assertEqual(signal_tag, "buy")
 
+    def test_get_signal_level_score_fallback_uses_canonical_scale(self) -> None:
+        self.assertEqual(get_signal_level("", 28, "zh"), ("减仓", "🟠", "reduce"))
+        self.assertEqual(get_signal_level("", 38, "zh"), ("减仓", "🟠", "reduce"))
+        self.assertEqual(get_signal_level("", 42, "zh"), ("观望", "⚪", "watch"))
+        self.assertEqual(get_signal_level("", 55, "zh"), ("观望", "⚪", "watch"))
+        self.assertEqual(get_signal_level("", 60, "zh"), ("买入", "🟢", "buy"))
+        self.assertEqual(get_signal_level("", 66, "zh"), ("买入", "🟢", "buy"))
+        self.assertEqual(get_signal_level("", 72, "zh"), ("买入", "🟢", "buy"))
+
     def test_get_localized_stock_name_replaces_placeholder_for_english(self) -> None:
         self.assertEqual(
             get_localized_stock_name("股票AAPL", "AAPL", "en"),

--- a/tests/test_stock_analyzer_bias.py
+++ b/tests/test_stock_analyzer_bias.py
@@ -312,6 +312,22 @@ class StockAnalyzerBiasTestCase(unittest.TestCase):
                 self.analyzer._generate_signal(result)
                 self.assertEqual(result.signal_score, expected_score)
                 self.assertEqual(signal_key_for_score(result.signal_score), expected_scale_key)
-                self.assertEqual(action_for_score(result.signal_score), expected_scale_action)
-                self.assertEqual(decision_type_for_score(result.signal_score), expected_scale_decision_type)
-                self.assertEqual(result.buy_signal, expected_signal)
+            self.assertEqual(action_for_score(result.signal_score), expected_scale_action)
+            self.assertEqual(decision_type_for_score(result.signal_score), expected_scale_decision_type)
+            self.assertEqual(result.buy_signal, expected_signal)
+
+    @patch("src.stock_analyzer.get_config")
+    def test_non_bull_high_score_falls_back_to_wait(self, mock_get_config: MagicMock) -> None:
+        mock_get_config.return_value.bias_threshold = 5.0
+        result = _make_result(
+            trend_status=TrendStatus.WEAK_BEAR,
+            bias_ma5=-1.5,
+            volume_status=VolumeStatus.SHRINK_VOLUME_DOWN,
+            macd_status=MACDStatus.GOLDEN_CROSS,
+            rsi_status=RSIStatus.OVERSOLD,
+            support_ma5=True,
+            support_ma10=True,
+        )
+        self.analyzer._generate_signal(result)
+        self.assertEqual(result.signal_score, 75)
+        self.assertEqual(result.buy_signal, BuySignal.WAIT)

--- a/tests/test_stock_analyzer_bias.py
+++ b/tests/test_stock_analyzer_bias.py
@@ -8,6 +8,7 @@ import unittest
 from unittest.mock import patch, MagicMock
 
 from src.stock_analyzer import (
+    BuySignal,
     StockTrendAnalyzer,
     TrendAnalysisResult,
     TrendStatus,
@@ -177,3 +178,45 @@ class StockAnalyzerBiasTestCase(unittest.TestCase):
         # else: risks.append 严禁追高 - so we get 严禁追高
         # Because 5.0 is not < 5.0, not > 5.0 when effective=base=5. So we hit the else.
         self._assert_contains(result.risk_factors, "严禁追高")
+
+    @patch("src.stock_analyzer.get_config")
+    def test_signal_thresholds_follow_canonical_score_scale(self, mock_get_config: MagicMock) -> None:
+        mock_get_config.return_value.bias_threshold = 5.0
+        cases = [
+            (
+                _make_result(trend_status=TrendStatus.BULL, bias_ma5=0.0),
+                BuySignal.BUY,
+                60,
+            ),
+            (
+                _make_result(
+                    trend_status=TrendStatus.CONSOLIDATION,
+                    bias_ma5=6.0,
+                    rsi_status=RSIStatus.STRONG_BUY,
+                ),
+                BuySignal.WAIT,
+                40,
+            ),
+            (
+                _make_result(trend_status=TrendStatus.CONSOLIDATION, bias_ma5=6.0),
+                BuySignal.SELL,
+                20,
+            ),
+            (
+                _make_result(
+                    trend_status=TrendStatus.STRONG_BEAR,
+                    bias_ma5=6.0,
+                    volume_status=VolumeStatus.HEAVY_VOLUME_DOWN,
+                    macd_status=MACDStatus.DEATH_CROSS,
+                    rsi_status=RSIStatus.WEAK,
+                ),
+                BuySignal.STRONG_SELL,
+                0,
+            ),
+        ]
+
+        for result, expected_signal, min_score in cases:
+            with self.subTest(expected_signal=expected_signal):
+                self.analyzer._generate_signal(result)
+                self.assertGreaterEqual(result.signal_score, min_score)
+                self.assertEqual(result.buy_signal, expected_signal)

--- a/tests/test_stock_analyzer_bias.py
+++ b/tests/test_stock_analyzer_bias.py
@@ -16,6 +16,7 @@ from src.stock_analyzer import (
     MACDStatus,
     RSIStatus,
 )
+from src.schemas.decision_scale import action_for_score, decision_type_for_score, signal_key_for_score
 
 
 def _make_result(
@@ -184,39 +185,133 @@ class StockAnalyzerBiasTestCase(unittest.TestCase):
         mock_get_config.return_value.bias_threshold = 5.0
         cases = [
             (
-                _make_result(trend_status=TrendStatus.BULL, bias_ma5=0.0),
+                _make_result(
+                    trend_status=TrendStatus.STRONG_BULL,
+                    bias_ma5=-1.0,
+                    volume_status=VolumeStatus.HEAVY_VOLUME_UP,
+                    macd_status=MACDStatus.BULLISH,
+                    rsi_status=RSIStatus.OVERBOUGHT,
+                    support_ma5=True,
+                    support_ma10=True,
+                    trend_strength=75,
+                ),
+                BuySignal.STRONG_BUY,
+                80,
+                signal_key_for_score(80),
+                action_for_score(80),
+                decision_type_for_score(80),
+            ),
+            (
+                _make_result(
+                    trend_status=TrendStatus.STRONG_BULL,
+                    bias_ma5=6.0,
+                    volume_status=VolumeStatus.HEAVY_VOLUME_DOWN,
+                    macd_status=MACDStatus.BULLISH,
+                    rsi_status=RSIStatus.STRONG_BUY,
+                    support_ma5=True,
+                    support_ma10=True,
+                ),
                 BuySignal.BUY,
                 60,
+                signal_key_for_score(60),
+                action_for_score(60),
+                decision_type_for_score(60),
+            ),
+            (
+                _make_result(
+                    trend_status=TrendStatus.BULL,
+                    bias_ma5=6.0,
+                    volume_status=VolumeStatus.HEAVY_VOLUME_DOWN,
+                    macd_status=MACDStatus.CROSSING_UP,
+                    rsi_status=RSIStatus.OVERBOUGHT,
+                ),
+                BuySignal.WAIT,
+                40,
+                signal_key_for_score(40),
+                action_for_score(40),
+                decision_type_for_score(40),
+            ),
+            (
+                _make_result(
+                    trend_status=TrendStatus.STRONG_BULL,
+                    bias_ma5=-1.5,
+                    volume_status=VolumeStatus.SHRINK_VOLUME_DOWN,
+                    macd_status=MACDStatus.GOLDEN_CROSS,
+                    rsi_status=RSIStatus.OVERSOLD,
+                    support_ma5=True,
+                    support_ma10=True,
+                    trend_strength=75,
+                ),
+                BuySignal.STRONG_BUY,
+                97,
+                signal_key_for_score(97),
+                action_for_score(97),
+                decision_type_for_score(97),
+            ),
+            (
+                _make_result(
+                    trend_status=TrendStatus.BULL,
+                    bias_ma5=1.5,
+                    volume_status=VolumeStatus.NORMAL,
+                    macd_status=MACDStatus.BULLISH,
+                    rsi_status=RSIStatus.NEUTRAL,
+                    support_ma5=True,
+                ),
+                BuySignal.BUY,
+                72,
+                signal_key_for_score(72),
+                action_for_score(72),
+                decision_type_for_score(72),
             ),
             (
                 _make_result(
                     trend_status=TrendStatus.CONSOLIDATION,
-                    bias_ma5=6.0,
-                    rsi_status=RSIStatus.STRONG_BUY,
+                    bias_ma5=1.5,
+                    volume_status=VolumeStatus.NORMAL,
+                    macd_status=MACDStatus.BULLISH,
+                    rsi_status=RSIStatus.NEUTRAL,
                 ),
                 BuySignal.WAIT,
-                40,
-            ),
-            (
-                _make_result(trend_status=TrendStatus.CONSOLIDATION, bias_ma5=6.0),
-                BuySignal.SELL,
-                20,
+                53,
+                signal_key_for_score(53),
+                action_for_score(53),
+                decision_type_for_score(53),
             ),
             (
                 _make_result(
-                    trend_status=TrendStatus.STRONG_BEAR,
+                    trend_status=TrendStatus.WEAK_BEAR,
+                    bias_ma5=5.5,
+                    volume_status=VolumeStatus.NORMAL,
+                    macd_status=MACDStatus.BULLISH,
+                    rsi_status=RSIStatus.WEAK,
+                ),
+                BuySignal.SELL,
+                33,
+                signal_key_for_score(33),
+                action_for_score(33),
+                decision_type_for_score(33),
+            ),
+            (
+                _make_result(
+                    trend_status=TrendStatus.BEAR,
                     bias_ma5=6.0,
                     volume_status=VolumeStatus.HEAVY_VOLUME_DOWN,
                     macd_status=MACDStatus.DEATH_CROSS,
-                    rsi_status=RSIStatus.WEAK,
+                    rsi_status=RSIStatus.OVERBOUGHT,
                 ),
                 BuySignal.STRONG_SELL,
-                0,
+                8,
+                signal_key_for_score(8),
+                action_for_score(8),
+                decision_type_for_score(8),
             ),
         ]
 
-        for result, expected_signal, min_score in cases:
+        for result, expected_signal, expected_score, expected_scale_key, expected_scale_action, expected_scale_decision_type in cases:
             with self.subTest(expected_signal=expected_signal):
                 self.analyzer._generate_signal(result)
-                self.assertGreaterEqual(result.signal_score, min_score)
+                self.assertEqual(result.signal_score, expected_score)
+                self.assertEqual(signal_key_for_score(result.signal_score), expected_scale_key)
+                self.assertEqual(action_for_score(result.signal_score), expected_scale_action)
+                self.assertEqual(decision_type_for_score(result.signal_score), expected_scale_decision_type)
                 self.assertEqual(result.buy_signal, expected_signal)


### PR DESCRIPTION
## PR Type
- [x] fix
- [ ] feat
- [ ] refactor
- [ ] docs
- [ ] chore
- [ ] test

## Background And Problem
- 当前问题：以最小改动收敛个股分析评分区间、operation_advice、legacy decision_type 与八态 DecisionSignal action 的 canonical 映射，并补充可解释降级信息。
- 影响范围：本次改动涉及 15 个文件，Diff 为 `+690 / -30`。
- 触发来源：Issue 自动执行（Issue #1885）。

## Scope Of Change
- `docs/CHANGELOG.md`
- `docs/decision-signals.md`
- `src/analyzer.py`
- `src/report_language.py`
- `src/schemas/decision_action.py`
- `src/schemas/decision_scale.py`
- `src/services/decision_signal_extractor.py`
- `src/services/decision_signal_reassess_service.py`
- `src/services/decision_signal_service.py`
- `src/stock_analyzer.py`
- `tests/test_analyzer_news_prompt.py`
- `tests/test_decision_action.py`
- ... and 3 more files

## Documentation And Changelog
- 已同步更新文档/变更记录：`docs/CHANGELOG.md`, `docs/decision-signals.md`。

## Issue Link
Closes #1885

## Verification Commands And Results
```bash
./scripts/ci_gate.sh flake8
./scripts/ci_gate.sh offline-tests
```

关键输出/结论 / Key output & conclusion:
- lint:PASS, test:TIMEOUT

## Compatibility And Risk
- **High**：涉及 `docs/CHANGELOG.md`, `docs/decision-signals.md`, `src/analyzer.py`, `src/report_language.py`, `src/schemas/decision_action.py`, `src/schemas/decision_scale.py`，请重点审查变更范围、验证覆盖与发布影响。
- 前提假设：
  - 以现有 Prompt 中的 80-100 strong_buy、60-79 buy、40-59 watch、0-39 sell/reduce 作为初始 canonical scale，除非维护者另行指定。
  - legacy decision_type 仅保留 buy/hold/sell 兼容统计语义，结构化动作优先使用 buy/add/hold/watch/reduce/sell/avoid/alert 等更细 action。
  - 高分降级为 hold/watch 可以保留，但必须写入明确 guardrail_reason 或等价解释字段。
  - 不做历史数据库迁移；旧记录可通过读取 fallback 或 lazy backfill 保持兼容。

## Rollback Plan
- `git revert <merge-commit>` 回滚本 PR 提交，重点确认 `docs/CHANGELOG.md`, `docs/decision-signals.md`, `src/analyzer.py`, `src/report_language.py` 恢复正常。

## Acceptance Criteria
- Prompt、技术评分、report_language fallback、DecisionSignal 提取或回填使用同一套 canonical 映射 helper 或常量。
- score >= 60 却输出 hold/watch 时，报告或结构化结果中能看到明确降级原因。
- 低分样本不再因 legacy fallback 默认坍缩为 hold，可进入 watch/reduce/sell/avoid 等更清晰动作。
- 新增覆盖 28、38、42、55、60、66、72 等分数边界的回归测试。
- 更新 docs/decision-signals.md 与 docs/CHANGELOG.md，说明 canonical 评分与 action 口径。

## Notes
- Risk is marked as high. Please review scope, validation coverage, and release impact carefully.

## Checklist
- [x] 本 PR 有明确动机和业务价值 / This PR has a clear motivation and value
- [x] 已提供可复现的验证命令与结果 / Reproducible verification commands and results are included
- [x] 已评估兼容性与风险 / Compatibility and risk have been assessed
- [x] 已提供回滚方案 / A rollback plan is provided
- [x] 已同步更新相关文档与 `docs/CHANGELOG.md`，并在 PR 描述中说明文档落点 / Relevant docs and `docs/CHANGELOG.md` are updated, and the documentation location is stated in this PR