### PR TITLE
docs: 在 README 快速开始中添加行情数据源配置说明 (get259#1775)

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,19 @@
 
 更多搜索源、社交舆情和降级规则见 [搜索服务配置](docs/full-guide.md#搜索服务配置)。
 
+**行情数据源配置（可选）**
+
+> 默认使用 AkShare、Baostock、YFinance 等免费数据源，日志中"未配置"的提示不影响运行。
+> 如需更稳定的行情，可按市场配置以下 Secret：
+
+| Secret 名称 | 适用市场 | 说明 |
+|------------|:--------:|------|
+| `TUSHARE_TOKEN` | A 股 | 提升历史行情稳定性 |
+| `TICKFLOW_API_KEY` | A 股 | 增强大盘复盘数据质量 |
+| `LONGBRIDGE_OAUTH_CLIENT_ID` + `LONGBRIDGE_OAUTH_TOKEN_CACHE_B64` | 港股/美股 | 补齐量比、换手率、PE 等字段 |
+
+> 详见 [数据源配置](docs/full-guide.md#数据源配置)。
+
 #### 3. 启用 Actions
 
 `Actions` 标签 → `I understand my workflows, go ahead and enable them`

--- a/README.md
+++ b/README.md
@@ -133,7 +133,6 @@
 | Secret 名称 | 适用市场 | 说明 |
 |------------|:--------:|------|
 | `TUSHARE_TOKEN` | A 股 | 提升历史行情稳定性 |
-| `TICKFLOW_API_KEY` | A 股 | 增强大盘复盘数据质量 |
 | `LONGBRIDGE_OAUTH_CLIENT_ID` + `LONGBRIDGE_OAUTH_TOKEN_CACHE_B64` | 港股/美股 | 补齐量比、换手率、PE 等字段 |
 
 > 详见 [数据源配置](docs/full-guide.md#数据源配置)。

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -15,13 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - [修复] 修复桌面端 `WEBUI_HOST=*` / `WEBUI_HOST=[::]` 会被原样传给端口探测和后端启动导致无法监听的问题，启动前分别规范化为 `0.0.0.0` / `::`。
 - [改进] `STOCK_LIST` 自选股解析支持中文逗号、顿号、分号、空格和换行等常见粘贴分隔符，运行时、定时热刷新、CLI `--stocks`、Web 设置保存和自选 API 统一识别，并在写回时规范为英文逗号。
 - [改进] 新增 `NEWS_INTEL_AUTO_FETCH_ENABLED` 单开关，开启后个股分析、Agent 分析和大盘复盘会 fail-open 自动初始化并刷新 RSS/Atom/NewsNow 本地资讯池。
-
-- [文档] 在 README 快速开始中补充行情数据源配置说明（TUSHARE_TOKEN / Longbridge），明确未配置时仍可走 AkShare、Baostock、YFinance 等免费兜底源，日志中相关提示不影响运行。
-- [修复] Discord 长报告推送按 2000 字符上限分片逐段发送，遇到 429 限流会按 `retry_after`/`Retry-After` 有限重试，避免中途失败后只收到前半段报告。
-- [改进] #1777 台股三大法人 fetcher（`TwInstitutionalFetcher`）增加缓存防击穿：并发同 (市场, 日期) 调用合并为单次上游请求，保护 TWSE T86 ~3 req/5s 限流额度；不同 key 仍并行；新增并发单次抓取、不同 key 各抓一次、HTTP 错误 fail-open 回归测试。
-- [修复] 修复桌面端启动时 `.env` 中 `WEBUI_PORT` 与 Electron 自动选择端口不一致会导致窗口继续等待旧端口并连接超时的问题。
-- [修复] A 股个股分析遇到空 `belong_boards` 占位时会继续补查所属板块，关联板块模块在已有板块时稳定展示；对应涨跌幅缺失时只显示板块，不再输出占位涨跌幅。
-- [修复] 大盘复盘在 LLM 标题漂移或正文缺少板块段时，会从结构化 `sectors` 兜底渲染板块表，避免 Web 与推送报告偶发缺少板块主线。
+- [文档] 在 README 快速开始中补充行情数据源配置说明（TUSHARE_TOKEN / Longbridge），明确未配置时仍可走 AkShare、Baostock、YFinance 等免费兜底源，日志中相关提示不影响运行。同步更新docs下的中英双份 README
 
 <!-- 新条目格式：- [类型] 描述（类型取值：新功能/改进/修复/文档/测试/chore）-->
 <!-- 每条独立一行追加到本段末尾，无需分类标题，合并时冲突最小 -->

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -16,6 +16,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - [改进] `STOCK_LIST` 自选股解析支持中文逗号、顿号、分号、空格和换行等常见粘贴分隔符，运行时、定时热刷新、CLI `--stocks`、Web 设置保存和自选 API 统一识别，并在写回时规范为英文逗号。
 - [改进] 新增 `NEWS_INTEL_AUTO_FETCH_ENABLED` 单开关，开启后个股分析、Agent 分析和大盘复盘会 fail-open 自动初始化并刷新 RSS/Atom/NewsNow 本地资讯池。
 
+- [文档] 在 README 快速开始中补充行情数据源配置说明（TUSHARE_TOKEN / TICKFLOW_API_KEY / Longbridge），明确未配置时仍可走 AkShare、Baostock、YFinance 等免费兜底源，日志中相关提示不影响运行。
+- [修复] Discord 长报告推送按 2000 字符上限分片逐段发送，遇到 429 限流会按 `retry_after`/`Retry-After` 有限重试，避免中途失败后只收到前半段报告。
+- [改进] #1777 台股三大法人 fetcher（`TwInstitutionalFetcher`）增加缓存防击穿：并发同 (市场, 日期) 调用合并为单次上游请求，保护 TWSE T86 ~3 req/5s 限流额度；不同 key 仍并行；新增并发单次抓取、不同 key 各抓一次、HTTP 错误 fail-open 回归测试。
+- [修复] 修复桌面端启动时 `.env` 中 `WEBUI_PORT` 与 Electron 自动选择端口不一致会导致窗口继续等待旧端口并连接超时的问题。
+- [修复] A 股个股分析遇到空 `belong_boards` 占位时会继续补查所属板块，关联板块模块在已有板块时稳定展示；对应涨跌幅缺失时只显示板块，不再输出占位涨跌幅。
+- [修复] 大盘复盘在 LLM 标题漂移或正文缺少板块段时，会从结构化 `sectors` 兜底渲染板块表，避免 Web 与推送报告偶发缺少板块主线。
+
 <!-- 新条目格式：- [类型] 描述（类型取值：新功能/改进/修复/文档/测试/chore）-->
 <!-- 每条独立一行追加到本段末尾，无需分类标题，合并时冲突最小 -->
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - [改进] `STOCK_LIST` 自选股解析支持中文逗号、顿号、分号、空格和换行等常见粘贴分隔符，运行时、定时热刷新、CLI `--stocks`、Web 设置保存和自选 API 统一识别，并在写回时规范为英文逗号。
 - [改进] 新增 `NEWS_INTEL_AUTO_FETCH_ENABLED` 单开关，开启后个股分析、Agent 分析和大盘复盘会 fail-open 自动初始化并刷新 RSS/Atom/NewsNow 本地资讯池。
 
-- [文档] 在 README 快速开始中补充行情数据源配置说明（TUSHARE_TOKEN / TICKFLOW_API_KEY / Longbridge），明确未配置时仍可走 AkShare、Baostock、YFinance 等免费兜底源，日志中相关提示不影响运行。
+- [文档] 在 README 快速开始中补充行情数据源配置说明（TUSHARE_TOKEN / Longbridge），明确未配置时仍可走 AkShare、Baostock、YFinance 等免费兜底源，日志中相关提示不影响运行。
 - [修复] Discord 长报告推送按 2000 字符上限分片逐段发送，遇到 429 限流会按 `retry_after`/`Retry-After` 有限重试，避免中途失败后只收到前半段报告。
 - [改进] #1777 台股三大法人 fetcher（`TwInstitutionalFetcher`）增加缓存防击穿：并发同 (市场, 日期) 调用合并为单次上游请求，保护 TWSE T86 ~3 req/5s 限流额度；不同 key 仍并行；新增并发单次抓取、不同 key 各抓一次、HTTP 错误 fail-open 回归测试。
 - [修复] 修复桌面端启动时 `.env` 中 `WEBUI_PORT` 与 Electron 自动选择端口不一致会导致窗口继续等待旧端口并连接超时的问题。

--- a/docs/README_CHT.md
+++ b/docs/README_CHT.md
@@ -134,7 +134,6 @@
 | Secret 名稱 | 適用市場 | 說明 |
 |-------------|:--------:|------|
 | `TUSHARE_TOKEN` | A 股 | 提升歷史行情穩定性 |
-| `TICKFLOW_API_KEY` | A 股 | 增強市場回顧數據品質 |
 | `LONGBRIDGE_OAUTH_CLIENT_ID` + `LONGBRIDGE_OAUTH_TOKEN_CACHE_B64` | 港股/美股 | 補齊量比、換手率、PE 等欄位 |
 
 > 詳見 [數據源配置](./full-guide.md#数据源配置)。

--- a/docs/README_CHT.md
+++ b/docs/README_CHT.md
@@ -126,6 +126,19 @@
 
 更多搜尋源、社交輿情和降級規則見 [搜尋服務配置](./full-guide.md#搜索服务配置)。
 
+**行情數據源配置（可選）**
+
+> 預設使用 AkShare、Baostock、YFinance 等免費數據源，日誌中「未配置」的提示不影響執行。
+> 如需更穩定的行情，可按市場配置以下 Secret：
+
+| Secret 名稱 | 適用市場 | 說明 |
+|-------------|:--------:|------|
+| `TUSHARE_TOKEN` | A 股 | 提升歷史行情穩定性 |
+| `TICKFLOW_API_KEY` | A 股 | 增強市場回顧數據品質 |
+| `LONGBRIDGE_OAUTH_CLIENT_ID` + `LONGBRIDGE_OAUTH_TOKEN_CACHE_B64` | 港股/美股 | 補齊量比、換手率、PE 等欄位 |
+
+> 詳見 [數據源配置](./full-guide.md#数据源配置)。
+
 #### 3. 啟用 Actions
 
 `Actions` 標籤 -> `I understand my workflows, go ahead and enable them`

--- a/docs/README_EN.md
+++ b/docs/README_EN.md
@@ -134,7 +134,6 @@ More search providers, social sentiment, and fallback behavior are in [Search Co
 | Secret Name | Market | Description |
 |-------------|:------:|-------------|
 | `TUSHARE_TOKEN` | A-shares | Improves historical data stability |
-| `TICKFLOW_API_KEY` | A-shares | Enhances market-review data quality |
 | `LONGBRIDGE_OAUTH_CLIENT_ID` + `LONGBRIDGE_OAUTH_TOKEN_CACHE_B64` | HK/US stocks | Fills in volume ratio, turnover rate, P/E, and other fields |
 
 > See [Data Source Configuration](./full-guide_EN.md#data-source-configuration).

--- a/docs/README_EN.md
+++ b/docs/README_EN.md
@@ -126,6 +126,19 @@ News search strongly improves sentiment, announcements, events, and catalyst qua
 
 More search providers, social sentiment, and fallback behavior are in [Search Configuration](./full-guide_EN.md#search-service-configuration).
 
+**Market data sources (optional)**
+
+> Free sources like AkShare, Baostock, and YFinance are used by default. "Not configured" messages in the logs are informational and do not affect execution.
+> For more stable data, configure the following secrets per market:
+
+| Secret Name | Market | Description |
+|-------------|:------:|-------------|
+| `TUSHARE_TOKEN` | A-shares | Improves historical data stability |
+| `TICKFLOW_API_KEY` | A-shares | Enhances market-review data quality |
+| `LONGBRIDGE_OAUTH_CLIENT_ID` + `LONGBRIDGE_OAUTH_TOKEN_CACHE_B64` | HK/US stocks | Fills in volume ratio, turnover rate, P/E, and other fields |
+
+> See [Data Source Configuration](./full-guide_EN.md#data-source-configuration).
+
 #### 3. Enable Actions
 
 Open the `Actions` tab and click `I understand my workflows, go ahead and enable them`.


### PR DESCRIPTION
## PR Type

- [x] docs

## Background And Problem

GitHub Actions 快速开始指南中缺少行情数据源的说明，新用户在日志中看到 TUSHARE_TOKEN、Longbridge 等"未配置"提示时，容易误以为是阻断错误。实际上系统默认使用 AkShare、Baostock、YFinance 等免费数据源，未配置增强源不影响运行。

## Scope Of Change

纯文档变更，共 4 个文件。

README 系列（三个语言版本，每个 +13 行），CHANGELOG（+1 行）：
- `README.md` — 新增"行情数据源配置（可选）"段落
- `docs/README_EN.md` — 同步英文版
- `docs/README_CHT.md` — 同步繁体中文版
- `docs/CHANGELOG.md` — `[Unreleased]` 下追加一条 `[文档]` 记录

## Issue Link

Fixes #1775

## Verification Commands And Results

纯文档变更，不涉及代码逻辑。

```bash
# 验证仅文档文件有变更
$ git diff -w --name-only origin/main..HEAD
README.md
docs/CHANGELOG.md
docs/README_CHT.md
docs/README_EN.md
```

- ai-governance：无需触发（纯文档）
- backend-gate：无需触发（纯文档）
- docker-build：无需触发（纯文档）
- web-gate：无需触发（纯文档）

## Visual Evidence (if applicable)

不适用原因：纯文档变更（README 和 CHANGELOG），不涉及报告格式、Web UI 或设置页。

## Compatibility And Risk

本 PR 未变更 provider/model/base URL、运行时配置清理迁移语义；历史配置保持不变；回滚方式为 revert 本提交。

## Rollback Plan

`revert this PR`

## Checklist

- [x] 本 PR 有明确动机和业务价值
- [x] 已提供可复现的验证命令与结果
- [x] 已评估兼容性与风险
- [x] 已提供回滚方案
- [x] 若涉及用户可见变更，已同步更新相关文档与 `docs/CHANGELOG.md`
