### PR TITLE
Wip0/dsa after quiet 20260701

### DIFF
--- a/.github/workflows/deploy-oracle.yml
+++ b/.github/workflows/deploy-oracle.yml
@@ -1,0 +1,21 @@
+name: Deploy to Oracle VPS
+
+on:
+  push:
+    branches:
+      - oracle-deploy
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Deploy via SSH
+        uses: appleboy/ssh-action@v1.0.3
+        with:
+          host: ${{ secrets.ORACLE_HOST }}
+          username: ubuntu
+          key: ${{ secrets.ORACLE_SSH_KEY }}
+          port: 22
+          script: |
+            sudo /opt/daily_stock_analysis/deploy.sh

--- a/.gitignore
+++ b/.gitignore
@@ -98,3 +98,14 @@ main.py.backup.*
 apps/dsa-web/src/pages/*.backup_*
 src/**/*.backup_*
 templates/*.backup_*
+
+# DSA local backups and runtime files
+backups/
+logs/*.log
+*.backup_*
+*.broken.*
+crontab.backup*.txt
+main.py.backup.*
+apps/dsa-web/src/pages/*.backup_*
+src/**/*.backup_*
+templates/*.backup_*

--- a/.gitignore
+++ b/.gitignore
@@ -87,3 +87,14 @@ static/
 /apps/dsa-desktop/dist/
 /apps/dsa-desktop/node_modules/
 docs/specs/
+
+# DSA local backups and runtime files
+backups/
+logs/*.log
+*.backup_*
+*.broken.*
+crontab.backup*.txt
+main.py.backup.*
+apps/dsa-web/src/pages/*.backup_*
+src/**/*.backup_*
+templates/*.backup_*

--- a/api/app.py
+++ b/api/app.py
@@ -448,3 +448,4 @@ def create_app(static_dir: Optional[Path] = None) -> FastAPI:
 
 # 默认应用实例（供 uvicorn 直接使用）
 app = create_app()
+

--- a/api/app.py
+++ b/api/app.py
@@ -1,3 +1,5 @@
+from fastapi import Request
+from starlette.responses import Response
 # -*- coding: utf-8 -*-
 """
 ===================================
@@ -227,6 +229,52 @@ def create_app(static_dir: Optional[Path] = None) -> FastAPI:
         version="1.0.0",
         lifespan=app_lifespan,
     )
+
+    @app.middleware("http")
+    async def _block_sensitive_static_paths(request: Request, call_next):
+        raw_path = request.scope.get("path") or request.url.path or ""
+        path = unquote(raw_path).replace("\\", "/")
+        lower_path = path.lower()
+
+        blocked_exact = {
+            "/.env",
+            "/.env.local",
+            "/.env.production",
+            "/.env.development",
+            "/.git/config",
+            "/config.inc.php",
+        }
+        blocked_prefixes = (
+            "/.git",
+            "/.svn",
+            "/.hg",
+            "/.aws",
+            "/.ssh",
+        )
+        blocked_suffixes = (
+            ".bak",
+            ".backup",
+            ".old",
+            ".orig",
+            ".pyc",
+            ".pyo",
+            ".swp",
+        )
+        blocked_fragments = (
+            ".bak_",
+            ".backup_",
+        )
+
+        if (
+            lower_path in blocked_exact
+            or any(lower_path.startswith(prefix) for prefix in blocked_prefixes)
+            or any(lower_path.endswith(suffix) for suffix in blocked_suffixes)
+            or any(fragment in lower_path for fragment in blocked_fragments)
+        ):
+            return Response(status_code=404)
+
+        return await call_next(request)
+
     
     # ============================================================
     # CORS 配置

--- a/api/middlewares/auth.py
+++ b/api/middlewares/auth.py
@@ -20,9 +20,13 @@ EXEMPT_PATHS = frozenset({
     "/api/v1/auth/login",
     "/api/v1/auth/status",
     "/api/health",
+            "/assets",
+            "/favicon.ico",
+            "/vite.svg",
     "/api/v1/health",
     "/health",
-    "/docs",
+    "/",
+            "/docs",
     "/redoc",
     "/openapi.json",
 })
@@ -46,10 +50,12 @@ class AuthMiddleware(BaseHTTPMiddleware):
             return await call_next(request)
 
         path = request.url.path
-        if _path_exempt(path):
+
+        # Only protect API v1 routes. Frontend and static assets must be public.
+        if not path.startswith("/api/v1/"):
             return await call_next(request)
 
-        if not path.startswith("/api/v1/"):
+        if _path_exempt(path):
             return await call_next(request)
 
         cookie_val = request.cookies.get(COOKIE_NAME)

--- a/apps/dsa-web/src/pages/HomePage.tsx
+++ b/apps/dsa-web/src/pages/HomePage.tsx
@@ -24,6 +24,8 @@ import { normalizeReportLanguage } from '../utils/reportLanguage';
 import type { MarketReviewPayload, StockBarItem, TaskInfo } from '../types/analysis';
 import type { RunFlowSnapshotSource } from '../types/runFlow';
 
+const SHOW_MARKET_REVIEW = false;
+
 type MarketReviewNotice = {
   variant: 'success' | 'warning' | 'danger';
   title: string;
@@ -616,6 +618,10 @@ const HomePage: React.FC = () => {
       modelUsed: latestMarketReview.modelUsed,
       marketPhaseSummary: latestMarketReview.marketPhaseSummary,
     };
+
+    if (!SHOW_MARKET_REVIEW) {
+      return stockItems;
+    }
 
     return [marketReviewItem, ...stockItems].sort((left, right) => {
       const leftTime = left.lastAnalysisTime ? Date.parse(left.lastAnalysisTime) : 0;

--- a/apps/dsa-web/src/pages/StockScreeningPage.tsx
+++ b/apps/dsa-web/src/pages/StockScreeningPage.tsx
@@ -40,7 +40,7 @@ import {
 import { formatParsedApiError, getParsedApiError, toApiErrorMessage, type ParsedApiError } from '../api/error';
 import { AppPage, Button, InlineAlert } from '../components/common';
 
-const MARKETS = [{ id: 'cn', label: 'A 股' }];
+const MARKETS = [{ id: 'us', label: '美股' }];
 const SCREEN_TASK_STORAGE_KEY = 'dsa.alphasift.activeScreenTask.v1';
 const SCREEN_TASK_POLL_INTERVAL_MS = 2000;
 
@@ -67,7 +67,7 @@ const readPersistedScreenTask = (): PersistedScreenTask | null => {
     const restoredMaxResults = Number(parsed.maxResults);
     return {
       taskId: parsed.taskId,
-      market: typeof parsed.market === 'string' && parsed.market.trim() ? parsed.market : 'cn',
+      market: typeof parsed.market === 'string' && parsed.market.trim() ? parsed.market : 'us',
       strategy: typeof parsed.strategy === 'string' && parsed.strategy.trim() ? parsed.strategy : 'dual_low',
       maxResults: Number.isFinite(restoredMaxResults) ? Math.min(100, Math.max(1, restoredMaxResults)) : 3,
     };
@@ -438,7 +438,7 @@ const StockScreeningPage: React.FC = () => {
   const [restoredTask] = useState<PersistedScreenTask | null>(() => readPersistedScreenTask());
   const [enabled, setEnabled] = useState(false);
   const [available, setAvailable] = useState(false);
-  const [market, setMarket] = useState(restoredTask?.market || 'cn');
+  const [market, setMarket] = useState('us');
   const [strategy, setStrategy] = useState(restoredTask?.strategy || 'dual_low');
   const [strategies, setStrategies] = useState<AlphaSiftStrategy[]>([]);
   const [maxResults, setMaxResults] = useState(restoredTask?.maxResults || 3);

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -e
+
+cd /opt/daily_stock_analysis
+
+sudo -u ubuntu git fetch origin
+sudo -u ubuntu git reset --hard origin/oracle-deploy
+
+source .venv/bin/activate
+pip install -r requirements.txt
+
+systemctl restart dsa
+systemctl status dsa --no-pager

--- a/deploy/oracle/README.md
+++ b/deploy/oracle/README.md
@@ -1,0 +1,20 @@
+# Oracle DSA Deployment
+
+DSA running path:
+
+/opt/daily_stock_analysis
+
+systemd service:
+
+/etc/systemd/system/dsa.service
+
+Nginx Proxy Manager forward target:
+
+Forward Hostname/IP: 172.23.0.1
+Forward Port: 8080
+
+Common commands:
+
+systemctl status dsa --no-pager
+systemctl restart dsa
+journalctl -u dsa -f

--- a/deploy/oracle/backup_dsa.sh
+++ b/deploy/oracle/backup_dsa.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -e
+tar -czf /root/dsa-backup-$(date +%F).tar.gz \
+  /opt/daily_stock_analysis \
+  /etc/systemd/system/dsa.service
+echo "Backup complete."

--- a/deploy/oracle/dsa.service
+++ b/deploy/oracle/dsa.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=Daily Stock Analysis
+After=network.target docker.service
+Wants=docker.service
+
+[Service]
+Type=simple
+WorkingDirectory=/opt/daily_stock_analysis
+Environment=PYTHONUNBUFFERED=1
+ExecStart=/opt/daily_stock_analysis/.venv/bin/python -m uvicorn api.app:app --host 0.0.0.0 --port 8080
+Restart=always
+RestartSec=5
+User=root
+
+[Install]
+WantedBy=multi-user.target

--- a/scripts/backfill_stock_pool_data.py
+++ b/scripts/backfill_stock_pool_data.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Iterable, List
+
+import pandas as pd
+
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+
+def load_symbols(raw_symbols: str | None = None) -> List[str]:
+    try:
+        from dotenv import load_dotenv
+        load_dotenv(ROOT / ".env", override=False)
+    except Exception:
+        pass
+
+    raw = raw_symbols or os.getenv("STOCK_LIST", "")
+    symbols = []
+    seen = set()
+
+    for item in raw.replace(";", ",").split(","):
+        symbol = item.strip().upper()
+        if not symbol or symbol in seen:
+            continue
+        seen.add(symbol)
+        symbols.append(symbol)
+
+    return symbols
+
+
+def normalize_yfinance_history(raw: pd.DataFrame) -> pd.DataFrame:
+    if raw is None or raw.empty:
+        return pd.DataFrame()
+
+    df = raw.copy()
+
+    if isinstance(df.columns, pd.MultiIndex):
+        df.columns = [str(col[0]).strip() for col in df.columns]
+
+    df = df.reset_index()
+    rename = {
+        "Date": "date",
+        "Datetime": "date",
+        "Open": "open",
+        "High": "high",
+        "Low": "low",
+        "Close": "close",
+        "Adj Close": "adj_close",
+        "Volume": "volume",
+    }
+    df = df.rename(columns=rename)
+
+    keep = [c for c in ["date", "open", "high", "low", "close", "volume"] if c in df.columns]
+    df = df[keep].copy()
+
+    if "date" in df.columns:
+        df["date"] = pd.to_datetime(df["date"]).dt.date.astype(str)
+
+    for col in ["open", "high", "low", "close", "volume"]:
+        if col in df.columns:
+            df[col] = pd.to_numeric(df[col], errors="coerce")
+
+    df = df.dropna(subset=["date", "open", "high", "low", "close"])
+    return df
+
+
+def backfill_history(symbol: str, period: str = "1y") -> int:
+    import yfinance as yf
+    from src.storage import DatabaseManager
+
+    raw = yf.download(
+        symbol,
+        period=period,
+        interval="1d",
+        auto_adjust=False,
+        progress=False,
+        threads=False,
+    )
+    df = normalize_yfinance_history(raw)
+    if df.empty:
+        print(f"[history] {symbol}: no data")
+        return 0
+
+    db = DatabaseManager()
+    saved = db.save_daily_data(df, symbol, "yfinance")
+    print(f"[history] {symbol}: rows={len(df)}, saved={saved}")
+    return int(saved or 0)
+
+
+def backfill_fundamental(symbol: str) -> int:
+    from src.storage import DatabaseManager
+    from src.services.alphasift_service import get_dsa_fundamental_context
+    from src.services.us_valuation_service import enrich_us_valuation_context
+
+    ctx = get_dsa_fundamental_context(symbol)
+    ctx = enrich_us_valuation_context(symbol, ctx)
+
+    db = DatabaseManager()
+    query_id = f"stock_pool_backfill_{datetime.now(timezone.utc).strftime('%Y%m%d')}"
+    saved = db.save_fundamental_snapshot(
+        query_id=query_id,
+        code=symbol,
+        payload=ctx,
+        source_chain=ctx.get("source_chain", []),
+        coverage=ctx.get("coverage", {}),
+    )
+    valuation = (ctx.get("valuation") or {}).get("data") or {}
+    print(
+        f"[fundamental] {symbol}: saved={saved}, "
+        f"PE={valuation.get('trailing_pe') or valuation.get('pe_ratio')}, "
+        f"ForwardPE={valuation.get('forward_pe')}"
+    )
+    return int(saved or 0)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Backfill stock-pool daily bars and fundamental snapshots.")
+    parser.add_argument("--symbols", help="Comma separated symbols. Default: STOCK_LIST from .env")
+    parser.add_argument("--period", default="1y", help="yfinance history period, default: 1y")
+    parser.add_argument("--skip-history", action="store_true")
+    parser.add_argument("--skip-fundamental", action="store_true")
+    parser.add_argument("--sleep", type=float, default=1.0)
+    args = parser.parse_args()
+
+    symbols = load_symbols(args.symbols)
+    if not symbols:
+        print("No symbols found. Set STOCK_LIST or pass --symbols GOOG,AAPL,TSLA")
+        return 2
+
+    print(f"Backfill symbols: {', '.join(symbols)}")
+
+    ok = 0
+    failed = 0
+
+    for symbol in symbols:
+        print(f"\n===== {symbol} =====")
+        try:
+            if not args.skip_history:
+                backfill_history(symbol, args.period)
+                time.sleep(args.sleep)
+            if not args.skip_fundamental:
+                backfill_fundamental(symbol)
+                time.sleep(args.sleep)
+            ok += 1
+        except Exception as exc:
+            failed += 1
+            print(f"[failed] {symbol}: {exc!r}")
+
+    print(f"\nDone. ok={ok}, failed={failed}")
+    return 0 if failed == 0 else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/backfill_us_daily_1y.py
+++ b/scripts/backfill_us_daily_1y.py
@@ -1,0 +1,88 @@
+import sqlite3
+from datetime import datetime
+import pandas as pd
+import yfinance as yf
+
+DB = "data/stock_analysis.db"
+SYMBOLS = ["GOOG", "AAPL"]
+
+def normalize_df(df):
+    if isinstance(df.columns, pd.MultiIndex):
+        df.columns = [c[0] for c in df.columns]
+    df = df.rename(columns={
+        "Open": "open",
+        "High": "high",
+        "Low": "low",
+        "Close": "close",
+        "Volume": "volume",
+    })
+    df = df[["open", "high", "low", "close", "volume"]].dropna()
+    df["ma5"] = df["close"].rolling(5).mean()
+    df["ma10"] = df["close"].rolling(10).mean()
+    df["ma20"] = df["close"].rolling(20).mean()
+    df["pct_chg"] = df["close"].pct_change() * 100
+    df["volume_ratio"] = df["volume"] / df["volume"].rolling(5).mean().shift(1)
+    return df
+
+conn = sqlite3.connect(DB)
+cur = conn.cursor()
+now = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+
+for symbol in SYMBOLS:
+    print(f"Fetching {symbol} 1y daily...")
+    df = yf.download(symbol, period="1y", interval="1d", auto_adjust=False, progress=False)
+    df = normalize_df(df)
+
+    if df.empty:
+        print(f"{symbol}: no data")
+        continue
+
+    start_date = df.index.min().strftime("%Y-%m-%d")
+    end_date = df.index.max().strftime("%Y-%m-%d")
+
+    cur.execute(
+        "delete from stock_daily where code=? and date between ? and ?",
+        (symbol, start_date, end_date),
+    )
+
+    rows = []
+    for idx, row in df.iterrows():
+        rows.append((
+            symbol,
+            idx.strftime("%Y-%m-%d"),
+            float(row["open"]),
+            float(row["high"]),
+            float(row["low"]),
+            float(row["close"]),
+            int(row["volume"]),
+            0,
+            None if pd.isna(row["pct_chg"]) else float(row["pct_chg"]),
+            None if pd.isna(row["ma5"]) else float(row["ma5"]),
+            None if pd.isna(row["ma10"]) else float(row["ma10"]),
+            None if pd.isna(row["ma20"]) else float(row["ma20"]),
+            None if pd.isna(row["volume_ratio"]) else float(row["volume_ratio"]),
+            "yfinance_1y_backfill",
+            now,
+            now,
+        ))
+
+    cur.executemany("""
+        insert into stock_daily
+        (code, date, open, high, low, close, volume, amount, pct_chg,
+         ma5, ma10, ma20, volume_ratio, data_source, created_at, updated_at)
+        values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    """, rows)
+
+    print(f"{symbol}: inserted {len(rows)} rows, {start_date} ~ {end_date}")
+
+conn.commit()
+
+print("\nCurrent stock_daily counts:")
+for symbol in SYMBOLS:
+    count, min_date, max_date = cur.execute(
+        "select count(*), min(date), max(date) from stock_daily where code=?",
+        (symbol,),
+    ).fetchone()
+    print(symbol, count, min_date, max_date)
+
+conn.close()

--- a/scripts/backup_dsa.sh
+++ b/scripts/backup_dsa.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd /opt/daily_stock_analysis
+mkdir -p backups
+
+ts=$(date +%Y%m%d_%H%M%S)
+tar --exclude='.venv' \
+    --exclude='node_modules' \
+    --exclude='apps/dsa-web/node_modules' \
+    --exclude='backups' \
+    --exclude='archive' \
+    -czf "backups/dsa_backup_${ts}.tar.gz" \
+    .env main.py data reports scripts
+
+find backups -name 'dsa_backup_*.tar.gz' -type f -mtime +14 -delete
+
+echo "Backup complete: backups/dsa_backup_${ts}.tar.gz"

--- a/scripts/health_check.sh
+++ b/scripts/health_check.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+set -u
+
+APP_DIR="/opt/daily_stock_analysis"
+
+echo "===== DSA Health Check ====="
+date
+echo
+
+cd "$APP_DIR" || {
+  echo "❌ 无法进入 $APP_DIR"
+  exit 1
+}
+
+echo "【Git】"
+git branch --show-current 2>/dev/null || true
+git status --short 2>/dev/null || true
+git log --oneline -5 2>/dev/null || true
+echo
+
+echo "【Service】"
+systemctl is-active dsa || true
+systemctl status dsa --no-pager -l | head -30 || true
+echo
+
+echo "【Config】"
+if [ -f .env ]; then
+  grep -E '^(STOCK_LIST|MARKET_REVIEW_ENABLED|MARKET_REVIEW_REGION|LITELLM_MODEL|OPENAI_MODEL)=' .env || true
+else
+  echo "⚠️ .env 不存在"
+fi
+echo
+
+echo "【Cron】"
+crontab -l 2>/dev/null | grep -E 'daily_stock_analysis|main.py|analyzer|dsa' || true
+echo
+
+echo "【Port】"
+ss -lntp | grep -E ':8080|:8081|:8000|:5000' || true
+echo
+
+echo "【Latest reports】"
+ls -lt reports 2>/dev/null | head -10 || true
+echo
+
+echo "【Latest logs】"
+ls -lt logs 2>/dev/null | head -10 || true
+echo
+
+echo "【Recent errors】"
+grep -RInE 'ERROR|Traceback|PermissionError|Exception' logs/*.log 2>/dev/null | tail -40 || true
+echo
+
+echo "===== Done ====="

--- a/src/analyzer.py
+++ b/src/analyzer.py
@@ -879,7 +879,7 @@ def fill_chip_structure_if_needed(result: "AnalysisResult", chip_data: Any) -> N
         logger.warning("[chip_structure] Fill failed, skipping: %s", e)
 
 
-_PRICE_POS_KEYS = ("ma5", "ma10", "ma20", "bias_ma5", "bias_status", "current_price", "support_level", "resistance_level")
+_PRICE_POS_KEYS = ("ma5", "ma10", "ma20", "bias_ma5", "bias_status", "current_price", "support_level", "resistance_level", "boll_mid", "boll_upper", "boll_lower", "boll_width", "boll_position_pct", "boll_signal", "boll_buy_zone", "boll_breakout_level", "boll_stop_loss")
 
 
 def fill_price_position_if_needed(
@@ -1825,7 +1825,26 @@ class GeminiAnalyzer:
                 "ideal_buy": "理想买入点：XX元（在MA5附近）",
                 "secondary_buy": "次优买入点：XX元（在MA10附近）",
                 "stop_loss": "止损位：XX元（跌破MA20或X%）",
-                "take_profit": "目标位：XX元（前高/整数关口）"
+                "take_profit": "目标位：XX元（前高/整数关口）",
+                "boll_status": "BOLL状态：接近下轨/中轨下方/站上中轨/接近上轨/突破上轨",
+                "boll_buy_zone": "低吸观察区：XX-XX元（下轨至中轨）",
+                "boll_mid_confirm": "中轨确认位：XX元（站上中轨才算结构修复）",
+                "boll_breakout": "突破确认位：XX元（放量突破上轨才确认）",
+                "boll_stop_loss": "BOLL止损位：XX元（跌破下轨需谨慎）",
+                "chase_advice": "是否适合追涨：不适合/谨慎/可小仓位，说明理由",
+                "rsi_status": "RSI状态：超卖/弱势/中性/强势/超买",
+                "rsi_signal": "RSI信号：结合RSI(6/12/24)判断反弹、趋势延续或追高风险",
+                "rsi_buy_condition": "RSI买点条件：例如RSI从30下方回升、RSI(6)上穿RSI(12)、或RSI站回40以上",
+                "rsi_risk": "RSI风险：例如RSI>70追高风险，或RSI持续低于40说明弱势未改",
+                "macd_status": "MACD状态：金叉/死叉/零轴上方/零轴下方/柱体收敛或扩张",
+                "macd_signal": "MACD信号：结合DIF、DEA、MACD柱判断趋势修复或转弱",
+                "macd_buy_condition": "MACD买点条件：例如DIF上穿DEA、MACD柱由负转正、或负柱连续缩短",
+                "macd_risk": "MACD风险：例如死叉、DIF/DEA在零轴下方、负柱扩大说明弱势延续",
+                "composite_signal": "综合信号：观望/低吸观察/趋势确认/突破买点/减仓风控",
+                "buy_point_type": "买点类型：暂无买点/低吸观察/趋势确认/突破买点",
+                "trigger_conditions": "触发条件：例如站上BOLL中轨 + RSI>40 + MACD负柱缩短或金叉",
+                "risk_level": "风险级别：低/中/中高/高，并说明原因",
+                "composite_conclusion": "综合结论：一句话说明当前是否可买、应等什么信号、关键止损位在哪里"
             },
             "position_strategy": {
                 "suggested_position": "建议仓位：X成",
@@ -1995,7 +2014,26 @@ class GeminiAnalyzer:
                 "ideal_buy": "理想入场位：XX元（满足主要技能触发条件）",
                 "secondary_buy": "次优入场位：XX元（更保守或确认后执行）",
                 "stop_loss": "止损位：XX元（失效条件或X%风险）",
-                "take_profit": "目标位：XX元（按阻力位/风险回报比制定）"
+                "take_profit": "目标位：XX元（按阻力位/风险回报比制定）",
+                "boll_status": "BOLL状态：接近下轨/中轨下方/站上中轨/接近上轨/突破上轨",
+                "boll_buy_zone": "低吸观察区：XX-XX元（下轨至中轨）",
+                "boll_mid_confirm": "中轨确认位：XX元（站上中轨才算结构修复）",
+                "boll_breakout": "突破确认位：XX元（放量突破上轨才确认）",
+                "boll_stop_loss": "BOLL止损位：XX元（跌破下轨需谨慎）",
+                "chase_advice": "是否适合追涨：不适合/谨慎/可小仓位，说明理由",
+                "rsi_status": "RSI状态：超卖/弱势/中性/强势/超买",
+                "rsi_signal": "RSI信号：结合RSI(6/12/24)判断反弹、趋势延续或追高风险",
+                "rsi_buy_condition": "RSI买点条件：例如RSI从30下方回升、RSI(6)上穿RSI(12)、或RSI站回40以上",
+                "rsi_risk": "RSI风险：例如RSI>70追高风险，或RSI持续低于40说明弱势未改",
+                "macd_status": "MACD状态：金叉/死叉/零轴上方/零轴下方/柱体收敛或扩张",
+                "macd_signal": "MACD信号：结合DIF、DEA、MACD柱判断趋势修复或转弱",
+                "macd_buy_condition": "MACD买点条件：例如DIF上穿DEA、MACD柱由负转正、或负柱连续缩短",
+                "macd_risk": "MACD风险：例如死叉、DIF/DEA在零轴下方、负柱扩大说明弱势延续",
+                "composite_signal": "综合信号：观望/低吸观察/趋势确认/突破买点/减仓风控",
+                "buy_point_type": "买点类型：暂无买点/低吸观察/趋势确认/突破买点",
+                "trigger_conditions": "触发条件：例如站上BOLL中轨 + RSI>40 + MACD负柱缩短或金叉",
+                "risk_level": "风险级别：低/中/中高/高，并说明原因",
+                "composite_conclusion": "综合结论：一句话说明当前是否可买、应等什么信号、关键止损位在哪里"
             },
             "position_strategy": {
                 "suggested_position": "建议仓位：X成",
@@ -3272,6 +3310,11 @@ class GeminiAnalyzer:
 | 趋势强度 | {trend.get('trend_strength', 0)}/100 | |
 | **乖离率(MA5)** | **{trend.get('bias_ma5', 0):+.2f}%** | {bias_warning} |
 | 乖离率(MA10) | {trend.get('bias_ma10', 0):+.2f}% | |
+| BOLL状态 | {trend.get('boll_signal', unknown_text)} | 低吸/突破/止损辅助 |
+| BOLL位置 | {trend.get('boll_position_pct', 0)}% | 0%接近下轨，100%接近上轨 |
+| BOLL低吸区 | {trend.get('boll_buy_zone', unknown_text)} | 下轨至中轨 |
+| BOLL突破位 | {trend.get('boll_breakout_level', unknown_text)} | 放量突破上轨才确认 |
+| BOLL止损位 | {trend.get('boll_stop_loss', unknown_text)} | 跌破下轨需谨慎 |
 | 量能状态 | {trend.get('volume_status', unknown_text)} | {trend.get('volume_trend', '')} |
 | 系统信号 | {trend.get('buy_signal', unknown_text)} | |
 | 系统评分 | {trend.get('signal_score', 0)}/100 | |

--- a/src/analyzer.py
+++ b/src/analyzer.py
@@ -1856,7 +1856,7 @@ class GeminiAnalyzer:
                 "✅/⚠️/❌ 检查项2：乖离率合理（强势趋势可放宽）",
                 "✅/⚠️/❌ 检查项3：量能配合",
                 "✅/⚠️/❌ 检查项4：无重大利空",
-                "✅/⚠️/❌ 检查项5：筹码健康",
+                "✅/⚠️/❌/⚪ 检查项5：A股筹码健康；美股使用成交量成本区估算，严禁因“无真实筹码分布”直接判为负面",
                 "✅/⚠️/❌/⚪ 检查项6：Forward PE估值（forward_pe < 30 为合理；30及以上为偏高；缺失则写“Forward PE缺失，暂不判断”；严禁写“PE估值合理（数据缺失）”）"
             ]
         },
@@ -3062,7 +3062,7 @@ class GeminiAnalyzer:
         """
         格式化分析提示词（决策仪表盘 v2.0）
         
-        包含：技术指标、实时行情（量比/换手率）、筹码分布、趋势分析、新闻
+        包含：技术指标、实时行情（量比/换手率）、A股筹码分布或美股成交量成本区估算、趋势分析、新闻
         
         Args:
             context: 技术面数据上下文（包含增强数据）
@@ -3221,7 +3221,7 @@ class GeminiAnalyzer:
 | 估算换手率 | {estimated_turnover_text} |
 | 估值判断 | {valuation_data.get('valuation_judgement') or 'N/A'} |
 
-估值检查规则：Forward PE < 30 为合理；30及以上为偏高；50及以上为明显偏高；Forward PE缺失时写“Forward PE缺失，暂不判断”。严禁写“PE估值合理（数据缺失）”。
+估值检查规则：Forward PE < 30 为合理；30及以上为偏高；50及以上为明显偏高；Forward PE缺失时写“Forward PE缺失，暂不判断”。严禁写“PE估值合理（数据缺失）”。\n美股筹码规则：美股没有A股式真实筹码分布；应参考成交量成本区估算，不得把“筹码未知/筹码缺失”作为主要风险。
 换手率规则：若实时换手率缺失，但估算换手率存在，请在 volume_analysis.turnover_rate 中使用估算换手率数值，并在量能含义中注明“按流通股本估算”或“按总股本估算”；若估算换手率也缺失，写“换手率数据缺失，暂不判断”，严禁写“数据缺失，无法判断%”。
 """
 
@@ -3341,7 +3341,7 @@ class GeminiAnalyzer:
                 "Do not fabricate profit ratio, average cost, or concentration. Mention chip data "
                 "unavailability only once in the report; do not repeat per-field no-data text in `chip_structure`."
                 if report_language == "en"
-                else "请勿编造获利比例、平均成本或集中度；报告中只说明一次筹码数据不可用，不要把“数据缺失，无法判断”逐字段重复写入 `chip_structure`。"
+                else "请勿编造获利比例、平均成本或集中度；A股筹码数据不可用时只说明一次。若市场为美股，请使用“成交量成本区估算”表述，不要把“无真实筹码分布”作为核心负面风险。"
             )
             prompt += f"""
 ### 筹码分布数据（效率指标）
@@ -3483,7 +3483,7 @@ class GeminiAnalyzer:
             prompt += """
 ⚠️ **数据缺失警告**
 由于接口限制，当前无法获取完整的实时行情和技术指标数据。
-请 **忽略上述表格中的 N/A 数据**。若 fundamental_context.valuation.data 中存在 forward_pe，请优先按 Forward PE 判断估值：forward_pe < 30 为合理，30及以上为偏高，50及以上为明显偏高；若 forward_pe 缺失，必须写“Forward PE缺失，暂不判断”，严禁写“PE估值合理（数据缺失）”。同时结合 **【📰 舆情情报】** 进行基本面和情绪面分析。
+请 **忽略上述表格中的 N/A 数据**。若 fundamental_context.valuation.data 中存在 forward_pe，请优先按 Forward PE 判断估值：forward_pe < 30 为合理，30及以上为偏高，50及以上为明显偏高；若 forward_pe 缺失，必须写“Forward PE缺失，暂不判断”，严禁写“PE估值合理（数据缺失）”。\n美股筹码规则：美股没有A股式真实筹码分布；应参考成交量成本区估算，不得把“筹码未知/筹码缺失”作为主要风险。同时结合 **【📰 舆情情报】** 进行基本面和情绪面分析。
 在回答技术面问题（如均线、乖离率）时，请直接说明“数据缺失，无法判断”，**严禁编造数据**。
 """
 

--- a/src/analyzer.py
+++ b/src/analyzer.py
@@ -840,6 +840,37 @@ def _mark_chip_structure_unavailable(result: "AnalysisResult", language: str) ->
     data_perspective["chip_unavailable_reason"] = get_chip_unavailable_text(language)
 
 
+def normalize_us_chip_checklist_text(result: "AnalysisResult") -> None:
+    """For US stocks, replace A-share chip no-data checklist wording with volume-cost wording."""
+    try:
+        market = ""
+        ctx = getattr(result, "fundamental_context", None)
+        if isinstance(ctx, dict):
+            market = str(ctx.get("market") or "").lower()
+        code = str(getattr(result, "code", "") or "").upper()
+        is_us = market == "us" or (code and code.isascii() and code.replace(".", "").replace("-", "").isalnum())
+        if not is_us:
+            return
+
+        dashboard = getattr(result, "dashboard", None)
+        if not isinstance(dashboard, dict):
+            return
+        checklist = dashboard.get("checklist")
+        if not isinstance(checklist, list):
+            return
+
+        cleaned = []
+        for item in checklist:
+            text = str(item)
+            if "筹码" in text and ("数据缺失" in text or "无法判断" in text or "未知" in text):
+                cleaned.append("⚪ 检查项5：使用成交量成本区估算")
+            else:
+                cleaned.append(item)
+        dashboard["checklist"] = cleaned
+    except Exception:
+        return
+
+
 def normalize_chip_structure_availability(result: "AnalysisResult", chip_data: Any) -> None:
     """Fill valid chip metrics or collapse placeholder-only chip fields to one fallback line."""
     if not result:
@@ -2991,6 +3022,7 @@ class GeminiAnalyzer:
                 result.model_used = model_used
                 result.report_language = report_language
                 normalize_chip_structure_availability(result, context.get("chip"))
+                normalize_us_chip_checklist_text(result)
 
                 # 内容完整性校验（可选）
                 if not config.report_integrity_enabled:

--- a/src/analyzer.py
+++ b/src/analyzer.py
@@ -3257,6 +3257,58 @@ class GeminiAnalyzer:
 换手率规则：若实时换手率缺失，但估算换手率存在，请在 volume_analysis.turnover_rate 中使用估算换手率数值，并在量能含义中注明“按流通股本估算”或“按总股本估算”；若估算换手率也缺失，写“换手率数据缺失，暂不判断”，严禁写“数据缺失，无法判断%”。
 """
 
+        daily_turnover = (
+            fundamental_context.get("daily_turnover", {})
+            if isinstance(fundamental_context, dict)
+            else {}
+        )
+        if isinstance(daily_turnover, dict) and daily_turnover.get("status") in {"ok", "partial"}:
+            prompt += f"""
+### 每日换手率
+| 指标 | 数值 |
+|------|------|
+| 最新交易日 | {daily_turnover.get('latest_trade_date') or 'N/A'} |
+| 最新换手率 | {daily_turnover.get('latest_turnover_rate') or 'N/A'}% |
+| 5日均值 | {daily_turnover.get('avg_5d_turnover_rate') or 'N/A'}% |
+| 20日均值 | {daily_turnover.get('avg_20d_turnover_rate') or 'N/A'}% |
+| 相对20日 | {daily_turnover.get('latest_vs_20d_ratio') or 'N/A'} |
+| 状态 | {daily_turnover.get('activity_status') or 'N/A'} |
+| 计算口径 | {daily_turnover.get('calculation_method') or 'N/A'} |
+
+每日换手率规则：必须说明最新换手率相对5日和20日均值是放大、缩小还是正常；若为估算口径，必须注明估算基础。
+"""
+
+        sector_valuation = (
+            fundamental_context.get("sector_valuation_comparison", {})
+            if isinstance(fundamental_context, dict)
+            else {}
+        )
+        if isinstance(sector_valuation, dict) and sector_valuation.get("status") == "ok":
+            current = sector_valuation.get("current") if isinstance(sector_valuation.get("current"), dict) else {}
+            medians = sector_valuation.get("peer_medians") if isinstance(sector_valuation.get("peer_medians"), dict) else {}
+            relative = sector_valuation.get("relative") if isinstance(sector_valuation.get("relative"), dict) else {}
+
+            def _rel_text(*keys):
+                for key in keys:
+                    item = relative.get(key) if isinstance(relative.get(key), dict) else {}
+                    text = item.get("text")
+                    if text and text != "数据不足":
+                        return text
+                return "数据不足"
+
+            prompt += f"""
+### 同板块估值比较
+| 项目 | 当前股票 | 板块/同行中位数 | 相对位置 |
+|------|----------|----------------|----------|
+| PE(TTM) | {current.get('trailing_pe') or current.get('pe_ratio') or 'N/A'} | {medians.get('trailing_pe') or medians.get('pe_ratio') or 'N/A'} | {_rel_text('trailing_pe', 'pe_ratio')} |
+| Forward PE | {current.get('forward_pe') or 'N/A'} | {medians.get('forward_pe') or 'N/A'} | {_rel_text('forward_pe')} |
+| PB | {current.get('pb_ratio') or 'N/A'} | {medians.get('pb_ratio') or 'N/A'} | {_rel_text('pb_ratio')} |
+| PS | {current.get('ps_ratio') or 'N/A'} | {medians.get('ps_ratio') or 'N/A'} | {_rel_text('ps_ratio')} |
+
+所属板块/行业：{sector_valuation.get('sector') or 'N/A'} / {sector_valuation.get('industry') or 'N/A'}；样本数：{sector_valuation.get('peer_count') or 'N/A'}。
+同板块估值规则：必须把当前股票与板块中位数比较；数据缺失时写“同板块估值数据不足”，不得强行得出低估或高估结论。
+"""
+
         earnings_block = (
             fundamental_context.get("earnings", {})
             if isinstance(fundamental_context, dict)

--- a/src/analyzer.py
+++ b/src/analyzer.py
@@ -3177,6 +3177,37 @@ class GeminiAnalyzer:
                     valuation_data = raw_valuation
 
         if valuation_data:
+            estimated_turnover_rate = None
+            estimated_turnover_base = None
+            try:
+                latest_volume = None
+                if isinstance(context, dict):
+                    latest_bar = context.get("latest_bar") or context.get("today") or {}
+                    if isinstance(latest_bar, dict):
+                        latest_volume = latest_bar.get("volume")
+                    if latest_volume is None:
+                        daily_data = context.get("daily_data") or context.get("daily_bars")
+                        if isinstance(daily_data, list) and daily_data:
+                            last_daily = daily_data[-1]
+                            if isinstance(last_daily, dict):
+                                latest_volume = last_daily.get("volume")
+                        elif hasattr(daily_data, "iloc") and len(daily_data) > 0:
+                            latest_volume = daily_data.iloc[-1].get("volume")
+
+                share_base = valuation_data.get("float_shares") or valuation_data.get("shares_outstanding")
+                estimated_turnover_base = "流通股本" if valuation_data.get("float_shares") else "总股本"
+                if latest_volume is not None and share_base:
+                    estimated_turnover_rate = float(latest_volume) / float(share_base) * 100
+            except Exception:
+                estimated_turnover_rate = None
+                estimated_turnover_base = None
+
+            estimated_turnover_text = (
+                f"{estimated_turnover_rate:.2f}%（按{estimated_turnover_base}估算）"
+                if estimated_turnover_rate is not None
+                else "N/A"
+            )
+
             prompt += f"""
 
 ### 估值数据（Forward PE规则）
@@ -3187,9 +3218,11 @@ class GeminiAnalyzer:
 | 市值 | {valuation_data.get('market_cap') or valuation_data.get('total_mv') or 'N/A'} |
 | 总股本 | {valuation_data.get('shares_outstanding') or 'N/A'} |
 | 流通股本 | {valuation_data.get('float_shares') or 'N/A'} |
+| 估算换手率 | {estimated_turnover_text} |
 | 估值判断 | {valuation_data.get('valuation_judgement') or 'N/A'} |
 
 估值检查规则：Forward PE < 30 为合理；30及以上为偏高；50及以上为明显偏高；Forward PE缺失时写“Forward PE缺失，暂不判断”。严禁写“PE估值合理（数据缺失）”。
+换手率规则：若实时换手率缺失，但估算换手率存在，请在 volume_analysis.turnover_rate 中使用估算换手率数值，并在量能含义中注明“按流通股本估算”或“按总股本估算”；若估算换手率也缺失，写“换手率数据缺失，暂不判断”，严禁写“数据缺失，无法判断%”。
 """
 
         earnings_block = (

--- a/src/analyzer.py
+++ b/src/analyzer.py
@@ -1857,7 +1857,7 @@ class GeminiAnalyzer:
                 "✅/⚠️/❌ 检查项3：量能配合",
                 "✅/⚠️/❌ 检查项4：无重大利空",
                 "✅/⚠️/❌ 检查项5：筹码健康",
-                "✅/⚠️/❌ 检查项6：PE估值合理"
+                "✅/⚠️/❌/⚪ 检查项6：Forward PE估值（forward_pe < 30 为合理；30及以上为偏高；缺失则写“Forward PE缺失，暂不判断”；严禁写“PE估值合理（数据缺失）”）"
             ]
         },
 
@@ -3168,6 +3168,30 @@ class GeminiAnalyzer:
 
         # 添加财报与分红（价值投资口径）
         fundamental_context = context.get("fundamental_context") if isinstance(context, dict) else None
+        valuation_data = {}
+        if isinstance(fundamental_context, dict):
+            valuation_block = fundamental_context.get("valuation")
+            if isinstance(valuation_block, dict):
+                raw_valuation = valuation_block.get("data")
+                if isinstance(raw_valuation, dict):
+                    valuation_data = raw_valuation
+
+        if valuation_data:
+            prompt += f"""
+
+### 估值数据（Forward PE规则）
+| 指标 | 数值 |
+|------|------|
+| PE(TTM) | {valuation_data.get('trailing_pe') or valuation_data.get('pe_ratio') or 'N/A'} |
+| Forward PE | {valuation_data.get('forward_pe') or 'N/A'} |
+| 市值 | {valuation_data.get('market_cap') or valuation_data.get('total_mv') or 'N/A'} |
+| 总股本 | {valuation_data.get('shares_outstanding') or 'N/A'} |
+| 流通股本 | {valuation_data.get('float_shares') or 'N/A'} |
+| 估值判断 | {valuation_data.get('valuation_judgement') or 'N/A'} |
+
+估值检查规则：Forward PE < 30 为合理；30及以上为偏高；50及以上为明显偏高；Forward PE缺失时写“Forward PE缺失，暂不判断”。严禁写“PE估值合理（数据缺失）”。
+"""
+
         earnings_block = (
             fundamental_context.get("earnings", {})
             if isinstance(fundamental_context, dict)
@@ -3426,7 +3450,7 @@ class GeminiAnalyzer:
             prompt += """
 ⚠️ **数据缺失警告**
 由于接口限制，当前无法获取完整的实时行情和技术指标数据。
-请 **忽略上述表格中的 N/A 数据**，重点依据 **【📰 舆情情报】** 中的新闻进行基本面和情绪面分析。
+请 **忽略上述表格中的 N/A 数据**。若 fundamental_context.valuation.data 中存在 forward_pe，请优先按 Forward PE 判断估值：forward_pe < 30 为合理，30及以上为偏高，50及以上为明显偏高；若 forward_pe 缺失，必须写“Forward PE缺失，暂不判断”，严禁写“PE估值合理（数据缺失）”。同时结合 **【📰 舆情情报】** 进行基本面和情绪面分析。
 在回答技术面问题（如均线、乖离率）时，请直接说明“数据缺失，无法判断”，**严禁编造数据**。
 """
 

--- a/src/core/pipeline.py
+++ b/src/core/pipeline.py
@@ -160,6 +160,31 @@ def _symbol_scope_lookup_values(code: str, market: str) -> List[str]:
     return values
 
 
+
+def _append_boll_summary_for_prompt(summary, trend_analysis):
+    """Append BOLL buy/sell helper text to the analysis context summary."""
+    if not isinstance(trend_analysis, dict):
+        return summary
+
+    boll_signal = trend_analysis.get("boll_signal")
+    if not boll_signal:
+        return summary
+
+    lines = [
+        "",
+        "### BOLL 布林线买卖点辅助",
+        f"- BOLL状态：{boll_signal}",
+        f"- BOLL位置：{trend_analysis.get('boll_position_pct', 'N/A')}%（0%接近下轨，100%接近上轨）",
+        f"- 低吸观察区：{trend_analysis.get('boll_buy_zone', 'N/A')}",
+        f"- 突破确认位：{trend_analysis.get('boll_breakout_level', 'N/A')}",
+        f"- 风险止损位：{trend_analysis.get('boll_stop_loss', 'N/A')}",
+        "- 使用约束：BOLL只作为辅助指标；买点需结合均线、量能、RSI/MACD和市场阶段确认。",
+    ]
+
+    base = summary if isinstance(summary, str) else ""
+    return base.rstrip() + "\n" + "\n".join(lines) + "\n"
+
+
 class StockAnalysisPipeline:
     """
     股票分析主流程调度器
@@ -551,7 +576,7 @@ class StockAnalysisPipeline:
             )
             news_result_count: Optional[int] = None
             self._emit_progress(46, f"{stock_name}：正在检索新闻与舆情")
-            if self.search_service is not None and self.search_service.is_available:
+            if False and self.search_service is not None and self.search_service.is_available:
                 logger.info(f"{stock_name}({code}) 开始多维度情报搜索...")
 
                 # 使用多维度搜索（最多5次搜索）
@@ -696,7 +721,14 @@ class StockAnalysisPipeline:
                     news_context=news_context,
                     progress_callback=self._emit_progress,
                     stream_progress_callback=_on_llm_stream,
-                    analysis_context_pack_summary=analysis_context_pack_summary,
+                    analysis_context_pack_summary=_append_boll_summary_for_prompt(
+                    analysis_context_pack_summary,
+                    (
+                        (locals().get('trend_analysis') or locals().get('trend_result') or locals().get('trend')).to_dict()
+                        if hasattr((locals().get('trend_analysis') or locals().get('trend_result') or locals().get('trend')), 'to_dict')
+                        else (locals().get('trend_analysis') or locals().get('trend_result') or locals().get('trend'))
+                    ),
+                ),
                 )
                 llm_duration_ms = int((time.monotonic() - llm_started_at) * 1000)
                 record_llm_run(
@@ -1349,7 +1381,7 @@ class StockAnalysisPipeline:
 
             # 保存新闻情报到数据库（Agent 工具结果仅用于 LLM 上下文，未持久化，Fixes #396）
             # 使用 search_stock_news（与 Agent 工具调用逻辑一致），仅 1 次 API 调用，无额外延迟
-            if self.search_service is not None and self.search_service.is_available:
+            if False and self.search_service is not None and self.search_service.is_available:
                 try:
                     news_response = self.search_service.search_stock_news(
                         stock_code=code,

--- a/src/core/pipeline.py
+++ b/src/core/pipeline.py
@@ -181,6 +181,8 @@ def _append_boll_summary_for_prompt(summary, trend_analysis):
         f"- BOLL点位：低吸观察区={v('boll_buy_zone')}；突破确认位={v('boll_breakout_level')}；止损参考位={v('boll_stop_loss')}。",
         f"- 均线：现价={v('current_price')}；MA5={v('ma5')}，MA10={v('ma10')}，MA20={v('ma20')}，MA60={v('ma60')}；MA5乖离={v('bias_ma5')}%。",
         f"- 量能：状态={v('volume_status')}；5日量比={v('volume_ratio_5d')}；说明={v('volume_trend')}。",
+        "- 若 fundamental_context.daily_turnover 存在，必须增加“每日换手率”解读：最新值、5日均值、20日均值、相对20日状态。",
+        "- 若 fundamental_context.sector_valuation_comparison 存在，必须增加“同板块估值比较”：PE/Forward PE/PB/PS 与板块中位数对比，并说明偏低/接近/偏高。",
         "- 写作要求：说明上述指标如何支持或限制当前操作建议；如果指标互相矛盾，要说明以趋势、风险还是估值为主。",
     ]
 
@@ -524,6 +526,20 @@ class StockAnalysisPipeline:
                 fundamental_context = enrich_us_valuation_context(code, fundamental_context)
             except Exception as e:
                 logger.debug(f"{stock_name}({code}) yfinance估值数据补齐失败: {e}")
+
+            try:
+                from src.services.valuation_turnover_enrichment import (
+                    enrich_daily_turnover_context,
+                    enrich_sector_valuation_comparison,
+                )
+                fundamental_context = enrich_daily_turnover_context(
+                    code,
+                    fundamental_context,
+                    self.fetcher_manager,
+                )
+                fundamental_context = enrich_sector_valuation_comparison(code, fundamental_context)
+            except Exception as e:
+                logger.debug(f"{stock_name}({code}) 换手率/同板块估值增强失败: {e}")
 
             # P0: write-only snapshot, fail-open, no read dependency on this table.
             try:

--- a/src/core/pipeline.py
+++ b/src/core/pipeline.py
@@ -162,28 +162,30 @@ def _symbol_scope_lookup_values(code: str, market: str) -> List[str]:
 
 
 def _append_boll_summary_for_prompt(summary, trend_analysis):
-    """Append BOLL buy/sell helper text to the analysis context summary."""
+    """Append technical and valuation indicator hints to the analysis context summary."""
     if not isinstance(trend_analysis, dict):
         return summary
 
-    boll_signal = trend_analysis.get("boll_signal")
-    if not boll_signal:
-        return summary
+    def v(key, default="N/A"):
+        value = trend_analysis.get(key, default)
+        return default if value in (None, "") else value
 
     lines = [
         "",
-        "### BOLL 布林线买卖点辅助",
-        f"- BOLL状态：{boll_signal}",
-        f"- BOLL位置：{trend_analysis.get('boll_position_pct', 'N/A')}%（0%接近下轨，100%接近上轨）",
-        f"- 低吸观察区：{trend_analysis.get('boll_buy_zone', 'N/A')}",
-        f"- 突破确认位：{trend_analysis.get('boll_breakout_level', 'N/A')}",
-        f"- 风险止损位：{trend_analysis.get('boll_stop_loss', 'N/A')}",
-        "- 使用约束：BOLL只作为辅助指标；买点需结合均线、量能、RSI/MACD和市场阶段确认。",
+        "### 技术与估值指标解读要求",
+        "- 最终个股分析正文必须并入 RSI、MACD、BOLL、均线乖离、量能和 PE/Forward PE 解读。",
+        "- 如果 PE/Forward PE 数据缺失，必须明确写“估值数据缺失，暂不判断”，不得写成估值合理。",
+        f"- RSI：RSI(6)={v('rsi_6')}，RSI(12)={v('rsi_12')}，RSI(24)={v('rsi_24')}；状态={v('rsi_status')}；信号={v('rsi_signal')}。",
+        f"- MACD：DIF={v('macd_dif')}，DEA={v('macd_dea')}，柱={v('macd_bar')}；状态={v('macd_status')}；信号={v('macd_signal')}。",
+        f"- BOLL：中轨={v('boll_mid')}，上轨={v('boll_upper')}，下轨={v('boll_lower')}，位置={v('boll_position_pct')}%；状态={v('boll_signal')}。",
+        f"- BOLL点位：低吸观察区={v('boll_buy_zone')}；突破确认位={v('boll_breakout_level')}；止损参考位={v('boll_stop_loss')}。",
+        f"- 均线：现价={v('current_price')}；MA5={v('ma5')}，MA10={v('ma10')}，MA20={v('ma20')}，MA60={v('ma60')}；MA5乖离={v('bias_ma5')}%。",
+        f"- 量能：状态={v('volume_status')}；5日量比={v('volume_ratio_5d')}；说明={v('volume_trend')}。",
+        "- 写作要求：说明上述指标如何支持或限制当前操作建议；如果指标互相矛盾，要说明以趋势、风险还是估值为主。",
     ]
 
     base = summary if isinstance(summary, str) else ""
     return base.rstrip() + "\n" + "\n".join(lines) + "\n"
-
 
 class StockAnalysisPipeline:
     """

--- a/src/core/pipeline.py
+++ b/src/core/pipeline.py
@@ -517,6 +517,12 @@ class StockAnalysisPipeline:
                 fundamental_context,
             )
 
+            try:
+                from src.services.us_valuation_service import enrich_us_valuation_context
+                fundamental_context = enrich_us_valuation_context(code, fundamental_context)
+            except Exception as e:
+                logger.debug(f"{stock_name}({code}) yfinance估值数据补齐失败: {e}")
+
             # P0: write-only snapshot, fail-open, no read dependency on this table.
             try:
                 self.db.save_fundamental_snapshot(

--- a/src/notification.py
+++ b/src/notification.py
@@ -2116,6 +2116,43 @@ class NotificationService(
             "",
         ])
 
+    def _append_volume_cost_zone_summary(self, lines: List[str], result: AnalysisResult) -> None:
+        code = getattr(result, "code", "") or getattr(result, "stock_code", "")
+        try:
+            from src.services.volume_cost_zone_service import build_volume_cost_zone_from_db
+            zone = build_volume_cost_zone_from_db(code)
+        except Exception:
+            return
+
+        if not isinstance(zone, dict) or zone.get("status") != "ok":
+            return
+
+        support = (
+            f"{zone['support_low']:.2f}-{zone['support_high']:.2f}"
+            if zone.get("support_low") is not None and zone.get("support_high") is not None
+            else "N/A"
+        )
+        resistance = (
+            f"{zone['resistance_low']:.2f}-{zone['resistance_high']:.2f}"
+            if zone.get("resistance_low") is not None and zone.get("resistance_high") is not None
+            else "N/A"
+        )
+
+        lines.extend([
+            "### 📊 成交量成本区估算",
+            "",
+            "| 样本 | 成交均价 | 主要成本区 | 当前价位置 | 支撑参考 | 压力参考 |",
+            "|-----:|---------:|-----------:|----------|---------:|---------:|",
+            (
+                f"| {zone.get('sample_days', 'N/A')}日 | {zone.get('avg_cost', 'N/A')} | "
+                f"{zone.get('main_cost_low', 'N/A')}-{zone.get('main_cost_high', 'N/A')} | "
+                f"{zone.get('position', 'N/A')} | {support} | {resistance} |"
+            ),
+            "",
+            f"> {zone.get('note', '这是成交量成本区估算，不等同于A股筹码分布。')}",
+            "",
+        ])
+
     def _append_financial_summary(
         self,
         lines: List[str],

--- a/src/notification.py
+++ b/src/notification.py
@@ -2036,6 +2036,7 @@ class NotificationService(
         labels = get_report_labels(report_language)
 
         self._append_valuation_summary(lines, blocks, labels)
+        self._append_weekly_rsi_summary(lines, result)
         self._append_volume_cost_zone_summary(lines, result)
         self._append_financial_summary(lines, blocks, labels)
         self._append_shareholder_return(lines, blocks, labels)
@@ -2113,6 +2114,35 @@ class NotificationService(
                 f"| {cells['pe_ttm']} | {cells['forward_pe']} | {cells['market_cap']} | "
                 f"{cells['shares']} | {cells['float_shares']} | {cells['judgement']} |"
             ),
+            "",
+        ])
+
+    def _append_weekly_rsi_summary(self, lines: List[str], result: AnalysisResult) -> None:
+        code = getattr(result, "code", "") or getattr(result, "stock_code", "")
+        try:
+            from src.services.weekly_rsi_service import build_weekly_rsi_from_db
+            weekly = build_weekly_rsi_from_db(code)
+        except Exception:
+            return
+
+        if not isinstance(weekly, dict) or weekly.get("status") != "ok":
+            return
+
+        previous = weekly.get("previous_rsi")
+        previous_text = f"{previous:.2f}" if isinstance(previous, (int, float)) else "N/A"
+
+        lines.extend([
+            "### 📈 周线 RSI(14)",
+            "",
+            "| 周线日期 | 当前RSI | 上周RSI | 趋势 | 对比30 | 对比50 | 对比70 |",
+            "|:------:|-------:|-------:|:----:|-------|-------|-------|",
+            (
+                f"| {weekly.get('week_date', 'N/A')} | {weekly.get('current_rsi', 'N/A')} | "
+                f"{previous_text} | {weekly.get('trend', 'N/A')} | "
+                f"{weekly.get('vs_30', 'N/A')} | {weekly.get('vs_50', 'N/A')} | {weekly.get('vs_70', 'N/A')} |"
+            ),
+            "",
+            f"> {weekly.get('interpretation', '')}",
             "",
         ])
 

--- a/src/notification.py
+++ b/src/notification.py
@@ -996,7 +996,7 @@ class NotificationService(
             f"*{labels['generated_at_label']}：{datetime.now().strftime('%Y-%m-%d %H:%M:%S')}*",
         ])
         
-        return "\n".join(report_lines)
+        return _normalize_us_chip_markdown_text("\n".join(report_lines))
     
     @staticmethod
     def _escape_md(name: str) -> str:
@@ -1425,7 +1425,7 @@ class NotificationService(
         if models:
             report_lines.append(f"*{labels['analysis_model_label']}：{', '.join(models)}*")
         
-        return "\n".join(report_lines)
+        return _normalize_us_chip_markdown_text("\n".join(report_lines))
     
     def generate_wechat_dashboard(self, results: List[AnalysisResult]) -> str:
         """
@@ -2801,3 +2801,21 @@ if __name__ == "__main__":
         print(f"推送结果: {'成功' if success else '失败'}")
     else:
         print("\n通知渠道未配置，跳过推送测试")
+
+
+def _normalize_us_chip_markdown_text(markdown: str) -> str:
+    """Final markdown guard: US reports with volume-cost zones should not show chip no-data as a defect."""
+    if not isinstance(markdown, str) or "成交量成本区估算" not in markdown:
+        return markdown
+
+    cleaned = []
+    bad_tokens = ("数据缺失", "无法判断", "缺失", "未知")
+    for line in markdown.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("-") and "筹码" in stripped and any(token in stripped for token in bad_tokens):
+            indent = line[: len(line) - len(line.lstrip())]
+            cleaned.append(f"{indent}- ⚪ 检查项5：使用成交量成本区估算")
+        else:
+            cleaned.append(line)
+    return "\n".join(cleaned)
+

--- a/src/notification.py
+++ b/src/notification.py
@@ -2036,6 +2036,7 @@ class NotificationService(
         labels = get_report_labels(report_language)
 
         self._append_valuation_summary(lines, blocks, labels)
+        self._append_volume_cost_zone_summary(lines, result)
         self._append_financial_summary(lines, blocks, labels)
         self._append_shareholder_return(lines, blocks, labels)
         self._append_related_boards(lines, blocks, labels)

--- a/src/notification.py
+++ b/src/notification.py
@@ -1233,7 +1233,7 @@ class NotificationService(
                     if vol_data:
                         report_lines.extend([
                             f"**{labels['volume_label']}**: {labels['volume_ratio_label']} {vol_data.get('volume_ratio', 'N/A')} ({vol_data.get('volume_status', '')}) | "
-                            f"{labels['turnover_rate_label']} {vol_data.get('turnover_rate', 'N/A')}%",
+                            f"{labels['turnover_rate_label']} {self._format_turnover_rate_text(vol_data.get('turnover_rate', 'N/A'))}",
                             f"💡 *{vol_data.get('volume_meaning', '')}*",
                             "",
                         ])
@@ -2039,6 +2039,19 @@ class NotificationService(
         self._append_financial_summary(lines, blocks, labels)
         self._append_shareholder_return(lines, blocks, labels)
         self._append_related_boards(lines, blocks, labels)
+
+    def _format_turnover_rate_text(self, value: Any) -> str:
+        if value is None:
+            return "数据缺失，暂不判断"
+        text = str(value).strip()
+        if not text or text.upper() in {"N/A", "NONE", "NULL"}:
+            return "数据缺失，暂不判断"
+        if "%" in text or "缺失" in text or "判断" in text or "估算" in text:
+            return text
+        try:
+            return f"{float(text):.2f}%"
+        except Exception:
+            return text
 
     def _append_valuation_summary(
         self,

--- a/src/notification.py
+++ b/src/notification.py
@@ -1987,6 +1987,7 @@ class NotificationService(
         ctx = getattr(result, "fundamental_context", None)
         if not isinstance(ctx, dict):
             return {
+                "valuation": {},
                 "financial_report": {},
                 "growth": {},
                 "dividend": {},
@@ -2010,7 +2011,11 @@ class NotificationService(
 
         belong_boards = ctx.get("belong_boards") if isinstance(ctx.get("belong_boards"), list) else []
 
+        valuation_block = ctx.get("valuation") if isinstance(ctx.get("valuation"), dict) else {}
+        valuation_data = valuation_block.get("data") if isinstance(valuation_block.get("data"), dict) else {}
+
         return {
+            "valuation": valuation_data,
             "financial_report": financial_report,
             "growth": growth_data,
             "dividend": dividend,
@@ -2030,9 +2035,72 @@ class NotificationService(
         report_language = self._get_report_language(result)
         labels = get_report_labels(report_language)
 
+        self._append_valuation_summary(lines, blocks, labels)
         self._append_financial_summary(lines, blocks, labels)
         self._append_shareholder_return(lines, blocks, labels)
         self._append_related_boards(lines, blocks, labels)
+
+    def _append_valuation_summary(
+        self,
+        lines: List[str],
+        blocks: Dict[str, Any],
+        labels: Dict[str, str],
+    ) -> None:
+        valuation = blocks.get("valuation") or {}
+
+        def fmt_number(value: Any) -> str:
+            try:
+                if value is None:
+                    return "N/A"
+                return f"{float(value):.2f}"
+            except Exception:
+                return "N/A"
+
+        def fmt_usd_amount(value: Any) -> str:
+            try:
+                number = float(value)
+            except Exception:
+                return "N/A"
+            if number >= 1e12:
+                return f"{number / 1e12:.2f} 万亿美元"
+            if number >= 1e8:
+                return f"{number / 1e8:.2f} 亿美元"
+            return f"{number:.0f} 美元"
+
+        def fmt_shares(value: Any) -> str:
+            try:
+                number = float(value)
+            except Exception:
+                return "N/A"
+            if number >= 1e8:
+                return f"{number / 1e8:.2f} 亿股"
+            if number >= 1e4:
+                return f"{number / 1e4:.2f} 万股"
+            return f"{number:.0f} 股"
+
+        cells = {
+            "pe_ttm": fmt_number(valuation.get("trailing_pe") or valuation.get("pe_ratio")),
+            "forward_pe": fmt_number(valuation.get("forward_pe")),
+            "market_cap": fmt_usd_amount(valuation.get("market_cap") or valuation.get("total_mv")),
+            "shares": fmt_shares(valuation.get("shares_outstanding")),
+            "float_shares": fmt_shares(valuation.get("float_shares")),
+            "judgement": self._format_text(valuation.get("valuation_judgement")),
+        }
+
+        if all(v == "N/A" for v in cells.values()):
+            return
+
+        lines.extend([
+            "### 📏 估值与股本",
+            "",
+            "| PE(TTM) | Forward PE | 市值 | 总股本 | 流通股本 | 估值判断 |",
+            "|-------:|-----------:|-----:|-------:|---------:|---------|",
+            (
+                f"| {cells['pe_ttm']} | {cells['forward_pe']} | {cells['market_cap']} | "
+                f"{cells['shares']} | {cells['float_shares']} | {cells['judgement']} |"
+            ),
+            "",
+        ])
 
     def _append_financial_summary(
         self,

--- a/src/notification.py
+++ b/src/notification.py
@@ -1280,6 +1280,81 @@ class NotificationService(
                             f"| 🎊 {labels['take_profit_label']} | {self._clean_sniper_value(sniper.get('take_profit', 'N/A'))} |",
                             "",
                         ])
+
+                        composite_rows = [
+                            ("综合信号", sniper.get('composite_signal')),
+                            ("买点类型", sniper.get('buy_point_type')),
+                            ("触发条件", sniper.get('trigger_conditions')),
+                            ("风险级别", sniper.get('risk_level')),
+                            ("综合结论", sniper.get('composite_conclusion')),
+                        ]
+                        composite_rows = [(label, value) for label, value in composite_rows if value]
+                        if composite_rows:
+                            report_lines.extend([
+                                "**🧭 综合买卖点判断**",
+                                "",
+                                "| 项目 | 判断 |",
+                                "|------|------|",
+                            ])
+                            for label, value in composite_rows:
+                                report_lines.append(f"| {label} | {self._clean_sniper_value(value)} |")
+                            report_lines.append("")
+
+                        boll_rows = [
+                            ("BOLL状态", sniper.get('boll_status')),
+                            ("低吸观察区", sniper.get('boll_buy_zone')),
+                            ("中轨确认位", sniper.get('boll_mid_confirm')),
+                            ("突破确认位", sniper.get('boll_breakout')),
+                            ("风险止损位", sniper.get('boll_stop_loss')),
+                            ("是否适合追涨", sniper.get('chase_advice')),
+                        ]
+                        boll_rows = [(label, value) for label, value in boll_rows if value]
+                        if boll_rows:
+                            report_lines.extend([
+                                "**📌 BOLL辅助判断**",
+                                "",
+                                "| 项目 | 判断 |",
+                                "|------|------|",
+                            ])
+                            for label, value in boll_rows:
+                                report_lines.append(f"| {label} | {self._clean_sniper_value(value)} |")
+                            report_lines.append("")
+
+                        rsi_rows = [
+                            ("RSI状态", sniper.get('rsi_status')),
+                            ("RSI信号", sniper.get('rsi_signal')),
+                            ("RSI买点条件", sniper.get('rsi_buy_condition')),
+                            ("RSI风险", sniper.get('rsi_risk')),
+                        ]
+                        rsi_rows = [(label, value) for label, value in rsi_rows if value]
+                        if rsi_rows:
+                            report_lines.extend([
+                                "**📈 RSI动能辅助**",
+                                "",
+                                "| 项目 | 判断 |",
+                                "|------|------|",
+                            ])
+                            for label, value in rsi_rows:
+                                report_lines.append(f"| {label} | {self._clean_sniper_value(value)} |")
+                            report_lines.append("")
+
+                        macd_rows = [
+                            ("MACD状态", sniper.get('macd_status')),
+                            ("MACD信号", sniper.get('macd_signal')),
+                            ("MACD买点条件", sniper.get('macd_buy_condition')),
+                            ("MACD风险", sniper.get('macd_risk')),
+                        ]
+                        macd_rows = [(label, value) for label, value in macd_rows if value]
+                        if macd_rows:
+                            report_lines.extend([
+                                "**📉 MACD趋势辅助**",
+                                "",
+                                "| 项目 | 判断 |",
+                                "|------|------|",
+                            ])
+                            for label, value in macd_rows:
+                                report_lines.append(f"| {label} | {self._clean_sniper_value(value)} |")
+                            report_lines.append("")
                     # 仓位策略
                     position = battle.get('position_strategy', {})
                     if position:

--- a/src/services/alphasift_service.py
+++ b/src/services/alphasift_service.py
@@ -11,6 +11,7 @@ import logging
 import math
 import os
 import re
+import sqlite3
 import subprocess
 import sys
 import threading
@@ -44,6 +45,27 @@ DSA_ALPHASIFT_SNAPSHOT_SOURCE_PRIORITY = "sina,efinance,akshare_em,em_datacenter
 DSA_ALPHASIFT_SNAPSHOT_SOURCE_PRIORITY_WITH_TUSHARE = "tushare,sina,efinance,akshare_em,em_datacenter"
 DSA_ALPHASIFT_CANDIDATE_CONTEXT_PROVIDERS = "news,fund_flow,announcement,quote"
 DSA_ALPHASIFT_DATA_DIR = Path("data") / "alphasift"
+DSA_US_SCREEN_DEFAULT_UNIVERSE = (
+    "AAPL", "MSFT", "GOOG", "GOOGL", "AMZN", "META", "NVDA", "TSLA",
+    "BRK-B", "V", "VOO", "VTI", "TLT", "SGOV", "BIL",
+)
+DSA_US_SCREEN_NAME_MAP = {
+    "AAPL": "苹果",
+    "MSFT": "微软",
+    "GOOG": "谷歌C",
+    "GOOGL": "谷歌A",
+    "AMZN": "亚马逊",
+    "META": "Meta",
+    "NVDA": "英伟达",
+    "TSLA": "特斯拉",
+    "BRK-B": "伯克希尔B",
+    "V": "Visa",
+    "VOO": "Vanguard S&P 500 ETF",
+    "VTI": "Vanguard Total Stock Market ETF",
+    "TLT": "20年期以上美债ETF",
+    "SGOV": "短期美债ETF",
+    "BIL": "1-3月短债ETF",
+}
 DSA_ALPHASIFT_HOTSPOT_CACHE_PATH = DSA_ALPHASIFT_DATA_DIR / "hotspots.json"
 DSA_ALPHASIFT_HOTSPOT_HISTORY_PATH = DSA_ALPHASIFT_DATA_DIR / "hotspot.history.jsonl"
 DSA_ALPHASIFT_MIN_HOTSPOT_CACHE_COUNT = 3
@@ -806,6 +828,89 @@ class AlphaSiftStrategyResponse(BaseModel):
     market: str = ""
 
 
+
+def _screen_us_candidates_from_dsa(
+    *,
+    config: Config,
+    strategy: str,
+    market: str,
+    max_results: int,
+) -> Dict[str, Any]:
+    """Build a lightweight US-market screen result from the DSA default universe.
+
+    This keeps the AlphaSift screen endpoint usable for US stocks even when the
+    upstream AlphaSift adapter only supports CN market snapshots.
+    """
+    _ = config
+    strategy_text = _env_text(strategy) or "dual_low"
+    market_text = _env_text(market) or "us"
+
+    try:
+        limit = int(max_results)
+    except (TypeError, ValueError):
+        limit = 3
+    limit = max(1, min(100, limit))
+
+    symbols = list(DSA_US_SCREEN_DEFAULT_UNIVERSE)
+    # A conservative order for the existing DSA watch universe. The final
+    # candidate details are enriched later by _enrich_candidates_with_dsa().
+    if strategy_text in {"dual_low", "low", "value", "defensive"}:
+        preferred = ["SGOV", "BIL", "TLT", "VOO", "VTI", "BRK-B", "V", "AAPL", "MSFT", "GOOG", "GOOGL", "AMZN", "META", "NVDA", "TSLA"]
+        symbols = [s for s in preferred if s in symbols] + [s for s in symbols if s not in preferred]
+    elif strategy_text in {"growth", "momentum", "trend"}:
+        preferred = ["NVDA", "MSFT", "AAPL", "AMZN", "META", "GOOG", "GOOGL", "TSLA", "V", "VOO", "VTI", "BRK-B", "TLT", "SGOV", "BIL"]
+        symbols = [s for s in preferred if s in symbols] + [s for s in symbols if s not in preferred]
+
+    raw_candidates: List[Dict[str, Any]] = []
+    for idx, symbol in enumerate(symbols[:limit], start=1):
+        name = DSA_US_SCREEN_NAME_MAP.get(symbol, symbol)
+        raw_candidates.append(
+            {
+                "code": symbol,
+                "symbol": symbol,
+                "name": name,
+                "market": market_text,
+                "rank": idx,
+                "score": max(1, 100 - idx),
+                "reason": "来自 DSA 默认美股观察池，已按策略偏好排序；后续由 DSA 数据补充行情、估值和新闻摘要。",
+                "source": "dsa_us_default_universe",
+            }
+        )
+
+    selected, dsa_enrichment = _enrich_candidates_with_dsa(raw_candidates)
+
+    return {
+        "enabled": True,
+        "candidates": selected,
+        "candidate_count": len(selected),
+        "run_id": None,
+        "strategy": strategy_text,
+        "market": market_text,
+        "snapshot_count": len(symbols),
+        "snapshot_source": "dsa_us_default_universe",
+        "after_filter_count": len(raw_candidates),
+        "llm_ranked": False,
+        "llm_market_view": "美股筛选当前使用 DSA 默认观察池。排序用于生成候选清单，不等同于完整 AlphaSift 全市场扫描。",
+        "llm_selection_logic": "根据策略偏好从默认美股观察池排序，并复用 DSA enrichment 补充行情、估值、新闻与分析摘要。",
+        "llm_portfolio_risk": "",
+        "llm_coverage": None,
+        "llm_parse_errors": [],
+        "warnings": [
+            "当前美股筛选为 DSA 默认观察池模式，非全市场扫描。",
+            "候选结果需要结合个股深度分析后再判断操作。",
+        ],
+        "source_errors": [],
+        "dsa_enrichment": dsa_enrichment,
+        "deep_analysis_requested": False,
+        "post_analyzers": [],
+        "daily_enriched": True,
+        "daily_enrich_count": dsa_enrichment.get("enriched_count") if isinstance(dsa_enrichment, dict) else None,
+        "risk_enabled": False,
+        "portfolio_diversity_enabled": False,
+        "portfolio_concentration_notes": [],
+    }
+
+
 class AlphaSiftService:
     """Coordinate AlphaSift calls with DSA-owned runtime capabilities."""
 
@@ -1068,6 +1173,14 @@ class AlphaSiftService:
     def screen(self, *, strategy: str, market: str, max_results: int) -> Dict[str, Any]:
         _ensure_alphasift_enabled(self.config)
         _ensure_alphasift_available_for_use()
+        market_text = _env_text(market).lower()
+        if market_text in {"us", "usa", "美股"}:
+            return _screen_us_candidates_from_dsa(
+                config=self.config,
+                strategy=strategy,
+                market="us",
+                max_results=max_results,
+            )
         _ensure_supported_market(market)
         _ensure_supported_strategy(strategy)
 

--- a/src/services/alphasift_service.py
+++ b/src/services/alphasift_service.py
@@ -877,7 +877,15 @@ def _screen_us_candidates_from_dsa(
             }
         )
 
-    selected, dsa_enrichment = _enrich_candidates_with_dsa(raw_candidates)
+    selected = raw_candidates
+    dsa_enrichment = {
+        "enabled": False,
+        "max_candidates": 0,
+        "requested_count": 0,
+        "enriched_count": 0,
+        "warnings": ["us_screen_fast_mode_skip_dsa_enrichment"],
+        "news_included": False,
+    }
 
     return {
         "enabled": True,
@@ -3368,7 +3376,7 @@ def get_dsa_candidate_context(
     return context.get("dsa_context", {})
 
 
-def _enrich_candidates_with_dsa(candidates: List[Dict[str, Any]]) -> Tuple[List[Dict[str, Any]], Dict[str, Any]]:
+def _enrich_candidates_with_dsa(candidates: List[Dict[str, Any]], *, include_news: bool = True) -> Tuple[List[Dict[str, Any]], Dict[str, Any]]:
     enriched_count = 0
     warnings: List[str] = []
     limit = min(len(candidates), DSA_ENRICHMENT_MAX_CANDIDATES)
@@ -3392,7 +3400,7 @@ def _enrich_candidates_with_dsa(candidates: List[Dict[str, Any]]) -> Tuple[List[
         try:
             enriched = _build_dsa_candidate_context(
                 candidate,
-                include_news=True,
+                include_news=include_news,
                 include_fundamentals=True,
                 profile="post_rank_full",
             )

--- a/src/services/history_service.py
+++ b/src/services/history_service.py
@@ -801,7 +801,26 @@ class HistoryService:
 
         # Generate Markdown report
         try:
-            return self._generate_single_stock_markdown(result, record)
+            markdown_report = self._generate_single_stock_markdown(result, record)
+            try:
+                from src.services.report_metric_sections import append_metric_sections_to_report
+                context_snapshot = (parse_json_field(getattr(record, "context_snapshot", None)) or {})
+                enhanced_context = (
+                    context_snapshot.get("enhanced_context", {})
+                    if isinstance(context_snapshot, dict)
+                    else {}
+                )
+                fundamental_context = (
+                    enhanced_context.get("fundamental_context")
+                    or context_snapshot.get("fundamental_context")
+                    or raw_result.get("fundamental_context")
+                    or getattr(result, "fundamental_context", None)
+                    or {}
+                )
+                markdown_report = append_metric_sections_to_report(markdown_report, fundamental_context)
+            except Exception as metric_exc:
+                logger.debug(f"append metric sections failed for history report {record_id}: {metric_exc}")
+            return markdown_report
         except Exception as e:
             logger.error(f"get_markdown_report: failed to generate markdown for {record_id}: {e}", exc_info=True)
             raise MarkdownReportGenerationError(

--- a/src/services/report_metric_sections.py
+++ b/src/services/report_metric_sections.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+
+
+def _fmt(value: Any, suffix: str = "") -> str:
+    if value is None or value == "":
+        return "N/A"
+    return f"{value}{suffix}"
+
+
+def _dict(value: Any) -> Dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def _relative_text(relative: Dict[str, Any], *keys: str) -> str:
+    for key in keys:
+        item = relative.get(key)
+        if isinstance(item, dict):
+            text = item.get("text")
+            if text and text != "数据不足":
+                ratio = item.get("ratio")
+                return f"{text}（{ratio}x）" if ratio else str(text)
+    return "数据不足"
+
+
+def render_daily_turnover_section(fundamental_context: Optional[Dict[str, Any]]) -> str:
+    block = _dict(_dict(fundamental_context).get("daily_turnover"))
+    if block.get("status") not in {"ok", "partial"}:
+        return ""
+
+    return f"""
+### 📊 每日换手率
+
+| 指标 | 数值 |
+|------|------|
+| 最新交易日 | {_fmt(block.get('latest_trade_date'))} |
+| 最新换手率 | {_fmt(block.get('latest_turnover_rate'), '%')} |
+| 5日均值 | {_fmt(block.get('avg_5d_turnover_rate'), '%')} |
+| 20日均值 | {_fmt(block.get('avg_20d_turnover_rate'), '%')} |
+| 相对20日 | {_fmt(block.get('latest_vs_20d_ratio'))} |
+| 状态 | {_fmt(block.get('activity_status'))} |
+| 计算口径 | {_fmt(block.get('calculation_method'))} |
+""".strip()
+
+
+def render_sector_valuation_section(fundamental_context: Optional[Dict[str, Any]]) -> str:
+    block = _dict(_dict(fundamental_context).get("sector_valuation_comparison"))
+    if block.get("status") != "ok":
+        return ""
+
+    current = _dict(block.get("current"))
+    medians = _dict(block.get("peer_medians"))
+    relative = _dict(block.get("relative"))
+
+    return f"""
+### 🏷️ 同板块估值比较
+
+所属板块/行业：{_fmt(block.get('sector'))} / {_fmt(block.get('industry'))}；样本数：{_fmt(block.get('peer_count'))}
+
+| 指标 | 当前股票 | 板块/同行中位数 | 相对位置 |
+|------|----------|----------------|----------|
+| PE(TTM) | {_fmt(current.get('trailing_pe') or current.get('pe_ratio'))} | {_fmt(medians.get('trailing_pe') or medians.get('pe_ratio'))} | {_relative_text(relative, 'trailing_pe', 'pe_ratio')} |
+| Forward PE | {_fmt(current.get('forward_pe'))} | {_fmt(medians.get('forward_pe'))} | {_relative_text(relative, 'forward_pe')} |
+| PB | {_fmt(current.get('pb_ratio'))} | {_fmt(medians.get('pb_ratio'))} | {_relative_text(relative, 'pb_ratio')} |
+| PS | {_fmt(current.get('ps_ratio'))} | {_fmt(medians.get('ps_ratio'))} | {_relative_text(relative, 'ps_ratio')} |
+""".strip()
+
+
+def append_metric_sections_to_report(report: Any, fundamental_context: Optional[Dict[str, Any]]) -> Any:
+    if not isinstance(report, str) or not report.strip():
+        return report
+
+    sections = [
+        render_daily_turnover_section(fundamental_context),
+        render_sector_valuation_section(fundamental_context),
+    ]
+    sections = [section for section in sections if section]
+
+    if not sections:
+        return report
+
+    existing = report
+    sections = [section for section in sections if section.splitlines()[0].strip() not in existing]
+    if not sections:
+        return report
+
+    return existing.rstrip() + "\n\n" + "\n\n".join(sections) + "\n"

--- a/src/services/us_valuation_service.py
+++ b/src/services/us_valuation_service.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+import math
+import re
+from datetime import datetime, timezone
+from typing import Any, Dict, Optional, Tuple
+
+
+_US_SYMBOL_RE = re.compile(r"^[A-Z][A-Z0-9.\-]{0,9}$")
+
+
+def _num(value: Any) -> Optional[float]:
+    try:
+        if value is None:
+            return None
+        number = float(value)
+        if math.isfinite(number):
+            return number
+    except Exception:
+        pass
+    return None
+
+
+def _valuation_judgement(forward_pe: Any) -> Tuple[str, str]:
+    pe = _num(forward_pe)
+    if pe is None or pe <= 0:
+        return "unknown", "Forward PE数据缺失，暂不判断"
+
+    if pe < 30:
+        return "reasonable", "Forward PE < 30，估值合理"
+    if pe < 50:
+        return "slightly_high", "Forward PE >= 30，估值偏高"
+    return "high", "Forward PE >= 50，估值明显偏高"
+
+
+def _looks_like_us_symbol(code: str, context: Dict[str, Any]) -> bool:
+    market = str(context.get("market") or "").lower()
+    if market == "us":
+        return True
+    return bool(_US_SYMBOL_RE.match(str(code or "").strip().upper()))
+
+
+def fetch_yfinance_valuation(code: str) -> Dict[str, Any]:
+    import yfinance as yf
+
+    symbol = str(code or "").strip().upper()
+    ticker = yf.Ticker(symbol)
+    info = ticker.get_info() or {}
+
+    trailing_pe = _num(info.get("trailingPE"))
+    forward_pe = _num(info.get("forwardPE"))
+    market_cap = _num(info.get("marketCap"))
+    shares_outstanding = _num(info.get("sharesOutstanding"))
+    float_shares = _num(info.get("floatShares"))
+    level, judgement = _valuation_judgement(forward_pe)
+
+    return {
+        "pe_ratio": trailing_pe,
+        "trailing_pe": trailing_pe,
+        "forward_pe": forward_pe,
+        "market_cap": market_cap,
+        "total_mv": market_cap,
+        "shares_outstanding": shares_outstanding,
+        "float_shares": float_shares,
+        "currency": "USD",
+        "valuation_level": level,
+        "valuation_judgement": judgement,
+        "source": "yfinance",
+        "fetched_at": datetime.now(timezone.utc).isoformat(),
+    }
+
+
+def enrich_us_valuation_context(code: str, fundamental_context: Optional[Dict[str, Any]]) -> Dict[str, Any]:
+    ctx: Dict[str, Any] = dict(fundamental_context or {})
+    if not _looks_like_us_symbol(code, ctx):
+        return ctx
+
+    valuation_data = fetch_yfinance_valuation(code)
+
+    valuation_block = ctx.get("valuation") if isinstance(ctx.get("valuation"), dict) else {}
+    old_data = valuation_block.get("data") if isinstance(valuation_block.get("data"), dict) else {}
+
+    merged_data = dict(old_data)
+    merged_data.update({k: v for k, v in valuation_data.items() if v is not None})
+
+    ctx["valuation"] = {
+        **valuation_block,
+        "status": "ok",
+        "data": merged_data,
+    }
+
+    coverage = ctx.get("coverage") if isinstance(ctx.get("coverage"), dict) else {}
+    coverage = dict(coverage)
+    coverage["valuation"] = "ok"
+    ctx["coverage"] = coverage
+
+    source_chain = ctx.get("source_chain")
+    if isinstance(source_chain, list):
+        if "yfinance" not in source_chain:
+            source_chain.append("yfinance")
+        ctx["source_chain"] = source_chain
+    else:
+        ctx["source_chain"] = ["yfinance"]
+
+    if not ctx.get("market"):
+        ctx["market"] = "us"
+
+    return ctx

--- a/src/services/us_valuation_service.py
+++ b/src/services/us_valuation_service.py
@@ -50,6 +50,8 @@ def fetch_yfinance_valuation(code: str) -> Dict[str, Any]:
     trailing_pe = _num(info.get("trailingPE"))
     forward_pe = _num(info.get("forwardPE"))
     market_cap = _num(info.get("marketCap"))
+    pb_ratio = _num(info.get("priceToBook"))
+    ps_ratio = _num(info.get("priceToSalesTrailing12Months"))
     shares_outstanding = _num(info.get("sharesOutstanding"))
     float_shares = _num(info.get("floatShares"))
     level, judgement = _valuation_judgement(forward_pe)
@@ -59,6 +61,13 @@ def fetch_yfinance_valuation(code: str) -> Dict[str, Any]:
         "trailing_pe": trailing_pe,
         "forward_pe": forward_pe,
         "market_cap": market_cap,
+        "pb_ratio": pb_ratio,
+        "price_to_book": pb_ratio,
+        "ps_ratio": ps_ratio,
+        "price_to_sales": ps_ratio,
+        "sector": info.get("sector"),
+        "industry": info.get("industry"),
+        "short_name": info.get("shortName") or info.get("longName"),
         "total_mv": market_cap,
         "shares_outstanding": shares_outstanding,
         "float_shares": float_shares,

--- a/src/services/valuation_turnover_enrichment.py
+++ b/src/services/valuation_turnover_enrichment.py
@@ -1,0 +1,331 @@
+from __future__ import annotations
+
+import math
+import re
+from datetime import datetime, timezone
+from statistics import median
+from typing import Any, Dict, Iterable, List, Optional, Tuple
+
+
+_US_SYMBOL_RE = re.compile(r"^[A-Z][A-Z0-9.\-]{0,9}$")
+
+_TURNOVER_KEYS = ("turnover_rate", "turnoverRate", "turnover", "换手率")
+_VOLUME_KEYS = ("volume", "Volume", "成交量")
+_DATE_KEYS = ("date", "Date", "日期")
+
+_US_SECTOR_PEERS: Dict[str, List[str]] = {
+    "Technology": ["AAPL", "MSFT", "NVDA", "AVGO", "ORCL", "CRM", "AMD", "QCOM", "CSCO"],
+    "Communication Services": ["META", "GOOGL", "GOOG", "NFLX", "DIS", "CMCSA", "T", "VZ"],
+    "Consumer Cyclical": ["AMZN", "TSLA", "HD", "MCD", "NKE", "SBUX", "BKNG"],
+    "Financial Services": ["BRK-B", "JPM", "BAC", "WFC", "GS", "MS", "V", "MA"],
+    "Healthcare": ["LLY", "UNH", "JNJ", "ABBV", "MRK", "PFE", "TMO", "ABT"],
+    "Energy": ["XOM", "CVX", "COP", "SLB", "EOG"],
+    "Consumer Defensive": ["WMT", "COST", "PG", "KO", "PEP", "PM"],
+    "Industrials": ["GE", "CAT", "BA", "HON", "UPS", "RTX"],
+    "Utilities": ["NEE", "SO", "DUK", "AEP", "SRE"],
+    "Real Estate": ["PLD", "AMT", "EQIX", "SPG", "O"],
+    "Basic Materials": ["LIN", "APD", "SHW", "FCX", "NEM"],
+}
+
+
+def _num(value: Any) -> Optional[float]:
+    try:
+        if value is None:
+            return None
+        if isinstance(value, str):
+            value = value.replace("%", "").replace(",", "").strip()
+            if not value or value.upper() in {"N/A", "NONE", "NULL", "-"}:
+                return None
+        number = float(value)
+        return number if math.isfinite(number) else None
+    except Exception:
+        return None
+
+
+def _round(value: Any, digits: int = 2) -> Optional[float]:
+    number = _num(value)
+    return round(number, digits) if number is not None else None
+
+
+def _first(mapping: Dict[str, Any], keys: Iterable[str]) -> Any:
+    for key in keys:
+        if key in mapping and mapping.get(key) not in (None, ""):
+            return mapping.get(key)
+    return None
+
+
+def _records(df: Any) -> List[Dict[str, Any]]:
+    if df is None:
+        return []
+    if hasattr(df, "to_dict"):
+        try:
+            return [dict(row) for row in df.to_dict("records")]
+        except Exception:
+            return []
+    if isinstance(df, list):
+        return [dict(row) for row in df if isinstance(row, dict)]
+    return []
+
+
+def _valuation_data(ctx: Dict[str, Any]) -> Dict[str, Any]:
+    block = ctx.get("valuation") if isinstance(ctx.get("valuation"), dict) else {}
+    data = block.get("data") if isinstance(block.get("data"), dict) else {}
+    return dict(data)
+
+
+def _share_base(ctx: Dict[str, Any]) -> Tuple[Optional[float], Optional[str]]:
+    data = _valuation_data(ctx)
+    float_shares = _num(data.get("float_shares"))
+    if float_shares and float_shares > 0:
+        return float_shares, "流通股本"
+    shares = _num(data.get("shares_outstanding"))
+    if shares and shares > 0:
+        return shares, "总股本"
+    return None, None
+
+
+def _append_source(ctx: Dict[str, Any], source: str) -> None:
+    chain = ctx.get("source_chain")
+    if isinstance(chain, list):
+        if source not in chain:
+            chain.append(source)
+    else:
+        ctx["source_chain"] = [source]
+
+
+def enrich_daily_turnover_context(code: str, fundamental_context: Optional[Dict[str, Any]], fetcher_manager: Any, *, days: int = 60) -> Dict[str, Any]:
+    ctx = dict(fundamental_context or {})
+    warnings: List[str] = []
+    rows: List[Dict[str, Any]] = []
+    source = "unknown"
+
+    try:
+        result = fetcher_manager.get_daily_data(code, days=days)
+        if isinstance(result, tuple):
+            df, source = result
+        else:
+            df = result
+        rows = _records(df)
+    except Exception as exc:
+        warnings.append(f"daily_data_failed: {exc}")
+
+    share_base, share_base_name = _share_base(ctx)
+    values: List[Dict[str, Any]] = []
+
+    for row in rows:
+        rate = _num(_first(row, _TURNOVER_KEYS))
+        method = "provider_turnover_rate"
+        if rate is None:
+            volume = _num(_first(row, _VOLUME_KEYS))
+            if volume is not None and share_base:
+                rate = volume / share_base * 100
+                method = f"estimated_by_{share_base_name}"
+        if rate is None:
+            continue
+        values.append({
+            "date": str(_first(row, _DATE_KEYS) or ""),
+            "turnover_rate": round(rate, 4),
+            "method": method,
+        })
+
+    latest = values[-1] if values else {}
+    rates = [item["turnover_rate"] for item in values]
+    avg_5 = sum(rates[-5:]) / min(len(rates), 5) if rates else None
+    avg_20 = sum(rates[-20:]) / min(len(rates), 20) if rates else None
+    ratio = (latest.get("turnover_rate") / avg_20) if latest and avg_20 else None
+
+    if ratio is None:
+        activity = "数据不足"
+    elif ratio >= 1.5:
+        activity = "放量换手"
+    elif ratio <= 0.7:
+        activity = "缩量换手"
+    else:
+        activity = "正常换手"
+
+    status = "ok" if values else "unavailable"
+    ctx["daily_turnover"] = {
+        "status": status,
+        "source": source,
+        "latest_trade_date": latest.get("date"),
+        "latest_turnover_rate": _round(latest.get("turnover_rate")),
+        "avg_5d_turnover_rate": _round(avg_5),
+        "avg_20d_turnover_rate": _round(avg_20),
+        "latest_vs_20d_ratio": _round(ratio),
+        "activity_status": activity,
+        "calculation_method": latest.get("method"),
+        "sample_count": len(values),
+        "series_tail": values[-5:],
+        "warnings": warnings,
+        "fetched_at": datetime.now(timezone.utc).isoformat(),
+    }
+
+    coverage = dict(ctx.get("coverage") or {})
+    coverage["daily_turnover"] = status
+    ctx["coverage"] = coverage
+    _append_source(ctx, f"daily_turnover:{source}")
+    return ctx
+
+
+def _market_for(code: str, ctx: Dict[str, Any]) -> str:
+    market = str(ctx.get("market") or "").lower()
+    if market:
+        return market
+    return "us" if _US_SYMBOL_RE.match(str(code or "").strip().upper()) else "cn"
+
+
+def _compare(current: Any, benchmark: Any) -> Dict[str, Any]:
+    cur = _num(current)
+    mid = _num(benchmark)
+    if cur is None or mid is None or cur <= 0 or mid <= 0:
+        return {"level": "unknown", "text": "数据不足"}
+    ratio = cur / mid
+    if ratio <= 0.85:
+        level, text = "below", "低于板块中位数"
+    elif ratio >= 1.15:
+        level, text = "above", "高于板块中位数"
+    else:
+        level, text = "near", "接近板块中位数"
+    return {"level": level, "text": text, "ratio": round(ratio, 2)}
+
+
+def _median(values: Iterable[Any]) -> Optional[float]:
+    nums = [_num(v) for v in values]
+    nums = [v for v in nums if v is not None and v > 0]
+    return round(median(nums), 2) if nums else None
+
+
+def _primary_board(ctx: Dict[str, Any]) -> Optional[str]:
+    boards = ctx.get("belong_boards")
+    if not isinstance(boards, list):
+        return None
+    for item in boards:
+        if isinstance(item, dict):
+            name = item.get("name") or item.get("board_name") or item.get("板块名称")
+            if name:
+                return str(name)
+        elif item:
+            return str(item)
+    return None
+
+
+def _enrich_cn_sector_comparison(code: str, ctx: Dict[str, Any]) -> Dict[str, Any]:
+    board = _primary_board(ctx)
+    if not board:
+        return {"status": "unavailable", "reason": "belong_boards_missing"}
+
+    import akshare as ak
+
+    last_error = None
+    df = None
+    for fetch_name in ("stock_board_industry_cons_em", "stock_board_concept_cons_em"):
+        try:
+            df = getattr(ak, fetch_name)(symbol=board)
+            if df is not None and len(df) > 0:
+                break
+        except Exception as exc:
+            last_error = exc
+            df = None
+
+    rows = _records(df)
+    if not rows:
+        return {"status": "unavailable", "sector": board, "reason": f"sector_constituents_missing: {last_error}"}
+
+    pe_values = [_first(row, ("市盈率-动态", "市盈率", "pe_ratio", "PE")) for row in rows]
+    pb_values = [_first(row, ("市净率", "pb_ratio", "PB")) for row in rows]
+    data = _valuation_data(ctx)
+    current_pe = data.get("pe_ratio") or data.get("trailing_pe")
+    current_pb = data.get("pb_ratio") or data.get("price_to_book")
+
+    for row in rows:
+        row_code = str(_first(row, ("代码", "code", "symbol")) or "").zfill(6)
+        if row_code == str(code).strip()[-6:]:
+            current_pe = current_pe or _first(row, ("市盈率-动态", "市盈率", "pe_ratio", "PE"))
+            current_pb = current_pb or _first(row, ("市净率", "pb_ratio", "PB"))
+            break
+
+    medians = {"pe_ratio": _median(pe_values), "pb_ratio": _median(pb_values)}
+    return {
+        "status": "ok",
+        "market": "cn",
+        "sector": board,
+        "source": "akshare_board_constituents",
+        "peer_count": len(rows),
+        "current": {"pe_ratio": _round(current_pe), "pb_ratio": _round(current_pb)},
+        "peer_medians": medians,
+        "relative": {
+            "pe_ratio": _compare(current_pe, medians.get("pe_ratio")),
+            "pb_ratio": _compare(current_pb, medians.get("pb_ratio")),
+        },
+    }
+
+
+def _enrich_us_sector_comparison(code: str, ctx: Dict[str, Any], *, max_peers: int = 8) -> Dict[str, Any]:
+    import yfinance as yf
+
+    symbol = str(code or "").strip().upper()
+    info = yf.Ticker(symbol).get_info() or {}
+    sector = info.get("sector") or _valuation_data(ctx).get("sector")
+    industry = info.get("industry") or _valuation_data(ctx).get("industry")
+    if not sector:
+        return {"status": "unavailable", "market": "us", "reason": "sector_missing"}
+
+    peers = [p for p in _US_SECTOR_PEERS.get(str(sector), []) if p.upper() != symbol][:max_peers]
+    if not peers:
+        return {"status": "unavailable", "market": "us", "sector": sector, "industry": industry, "reason": "peer_universe_missing"}
+
+    peer_rows: List[Dict[str, Any]] = []
+    for peer in peers:
+        try:
+            pinfo = yf.Ticker(peer).get_info() or {}
+            peer_rows.append({
+                "symbol": peer,
+                "name": pinfo.get("shortName") or pinfo.get("longName") or peer,
+                "trailing_pe": _round(pinfo.get("trailingPE")),
+                "forward_pe": _round(pinfo.get("forwardPE")),
+                "pb_ratio": _round(pinfo.get("priceToBook")),
+                "ps_ratio": _round(pinfo.get("priceToSalesTrailing12Months")),
+            })
+        except Exception:
+            continue
+
+    data = _valuation_data(ctx)
+    current = {
+        "trailing_pe": _round(data.get("trailing_pe") or data.get("pe_ratio") or info.get("trailingPE")),
+        "forward_pe": _round(data.get("forward_pe") or info.get("forwardPE")),
+        "pb_ratio": _round(data.get("pb_ratio") or data.get("price_to_book") or info.get("priceToBook")),
+        "ps_ratio": _round(data.get("ps_ratio") or data.get("price_to_sales") or info.get("priceToSalesTrailing12Months")),
+    }
+    medians = {
+        key: _median(row.get(key) for row in peer_rows)
+        for key in ("trailing_pe", "forward_pe", "pb_ratio", "ps_ratio")
+    }
+
+    return {
+        "status": "ok" if peer_rows else "unavailable",
+        "market": "us",
+        "sector": sector,
+        "industry": industry,
+        "source": "yfinance_static_sector_peers",
+        "peer_count": len(peer_rows),
+        "current": current,
+        "peer_medians": medians,
+        "relative": {key: _compare(current.get(key), medians.get(key)) for key in medians},
+        "peers": peer_rows[:6],
+    }
+
+
+def enrich_sector_valuation_comparison(code: str, fundamental_context: Optional[Dict[str, Any]]) -> Dict[str, Any]:
+    ctx = dict(fundamental_context or {})
+    market = _market_for(code, ctx)
+    try:
+        comparison = _enrich_us_sector_comparison(code, ctx) if market == "us" else _enrich_cn_sector_comparison(code, ctx)
+    except Exception as exc:
+        comparison = {"status": "unavailable", "market": market, "reason": str(exc)}
+
+    ctx["sector_valuation_comparison"] = comparison
+    coverage = dict(ctx.get("coverage") or {})
+    coverage["sector_valuation_comparison"] = comparison.get("status") or "unavailable"
+    ctx["coverage"] = coverage
+    _append_source(ctx, str(comparison.get("source") or "sector_valuation_comparison"))
+    return ctx

--- a/src/services/volume_cost_zone_service.py
+++ b/src/services/volume_cost_zone_service.py
@@ -1,0 +1,139 @@
+from __future__ import annotations
+
+import math
+import sqlite3
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+
+def _safe_float(value: Any) -> Optional[float]:
+    try:
+        if value is None:
+            return None
+        number = float(value)
+        if math.isfinite(number):
+            return number
+    except Exception:
+        pass
+    return None
+
+
+def build_volume_cost_zone_from_db(
+    code: str,
+    db_path: str | Path = "data/stock_analysis.db",
+    lookback: int = 252,
+    bins: int = 12,
+) -> Dict[str, Any]:
+    symbol = str(code or "").strip().upper()
+    if not symbol:
+        return {"status": "missing", "reason": "empty_symbol"}
+
+    path = Path(db_path)
+    if not path.exists():
+        return {"status": "missing", "reason": "database_not_found"}
+
+    with sqlite3.connect(str(path)) as conn:
+        rows = conn.execute(
+            """
+            select date, close, volume
+            from stock_daily
+            where upper(code) = ?
+            order by date desc
+            limit ?
+            """,
+            (symbol, lookback),
+        ).fetchall()
+
+    bars: List[Dict[str, float]] = []
+    for date_value, close_value, volume_value in rows:
+        close = _safe_float(close_value)
+        volume = _safe_float(volume_value)
+        if close is None or volume is None or close <= 0 or volume <= 0:
+            continue
+        bars.append({"date": str(date_value), "close": close, "volume": volume})
+
+    if len(bars) < 60:
+        return {
+            "status": "insufficient",
+            "reason": f"历史成交数据不足，仅{len(bars)}条",
+            "sample_days": len(bars),
+        }
+
+    bars = list(reversed(bars))
+    current_price = bars[-1]["close"]
+    min_price = min(item["close"] for item in bars)
+    max_price = max(item["close"] for item in bars)
+    total_volume = sum(item["volume"] for item in bars)
+
+    if max_price <= min_price or total_volume <= 0:
+        return {"status": "insufficient", "reason": "价格或成交量数据不足", "sample_days": len(bars)}
+
+    bin_width = (max_price - min_price) / bins
+    bucket_volume = [0.0 for _ in range(bins)]
+
+    weighted_sum = 0.0
+    for item in bars:
+        idx = int((item["close"] - min_price) / bin_width)
+        idx = max(0, min(bins - 1, idx))
+        bucket_volume[idx] += item["volume"]
+        weighted_sum += item["close"] * item["volume"]
+
+    avg_cost = weighted_sum / total_volume
+    ranked = sorted(range(bins), key=lambda i: bucket_volume[i], reverse=True)
+
+    selected = []
+    acc = 0.0
+    for idx in ranked:
+        selected.append(idx)
+        acc += bucket_volume[idx]
+        if acc / total_volume >= 0.70:
+            break
+
+    low_idx = min(selected)
+    high_idx = max(selected)
+    main_low = min_price + low_idx * bin_width
+    main_high = min_price + (high_idx + 1) * bin_width
+
+    support_candidates = [
+        (i, bucket_volume[i])
+        for i in range(bins)
+        if min_price + (i + 1) * bin_width < current_price
+    ]
+    resistance_candidates = [
+        (i, bucket_volume[i])
+        for i in range(bins)
+        if min_price + i * bin_width > current_price
+    ]
+
+    support = None
+    if support_candidates:
+        i = max(support_candidates, key=lambda x: x[1])[0]
+        support = (min_price + i * bin_width, min_price + (i + 1) * bin_width)
+
+    resistance = None
+    if resistance_candidates:
+        i = max(resistance_candidates, key=lambda x: x[1])[0]
+        resistance = (min_price + i * bin_width, min_price + (i + 1) * bin_width)
+
+    if current_price < main_low:
+        position = "低于主要成交成本区，偏弱"
+    elif current_price > main_high:
+        position = "高于主要成交成本区，偏强但需防回落"
+    else:
+        position = "位于主要成交成本区内，震荡消化"
+
+    return {
+        "status": "ok",
+        "method": "近一年日线成交量按价格区间加权估算",
+        "sample_days": len(bars),
+        "current_price": round(current_price, 2),
+        "avg_cost": round(avg_cost, 2),
+        "main_cost_low": round(main_low, 2),
+        "main_cost_high": round(main_high, 2),
+        "support_low": round(support[0], 2) if support else None,
+        "support_high": round(support[1], 2) if support else None,
+        "resistance_low": round(resistance[0], 2) if resistance else None,
+        "resistance_high": round(resistance[1], 2) if resistance else None,
+        "position": position,
+        "note": "这是成交量成本区估算，不等同于A股筹码分布。",
+    }

--- a/src/services/weekly_rsi_service.py
+++ b/src/services/weekly_rsi_service.py
@@ -1,0 +1,129 @@
+from __future__ import annotations
+
+import math
+import sqlite3
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+import pandas as pd
+
+
+def _safe_float(value: Any) -> Optional[float]:
+    try:
+        if value is None:
+            return None
+        number = float(value)
+        if math.isfinite(number):
+            return number
+    except Exception:
+        pass
+    return None
+
+
+def _relation(value: float, threshold: float) -> str:
+    diff = value - threshold
+    if abs(diff) < 0.05:
+        return f"接近 {threshold:.0f}"
+    if diff > 0:
+        return f"高于 {threshold:.0f}（+{diff:.2f}）"
+    return f"低于 {threshold:.0f}（{diff:.2f}）"
+
+
+def _interpret_rsi(value: float) -> str:
+    if value < 30:
+        return "周线RSI低于30，处于超卖区，反弹观察价值上升，但仍需价格止跌确认"
+    if value < 50:
+        return "周线RSI位于30-50之间，中期动能偏弱，属于弱势修复区"
+    if value < 70:
+        return "周线RSI位于50-70之间，中期动能中性偏强"
+    return "周线RSI高于70，处于超买区，需防止高位回落"
+
+
+def build_weekly_rsi_from_db(
+    code: str,
+    db_path: str | Path = "data/stock_analysis.db",
+    period: int = 14,
+    lookback_daily_rows: int = 520,
+) -> Dict[str, Any]:
+    symbol = str(code or "").strip().upper()
+    if not symbol:
+        return {"status": "missing", "reason": "empty_symbol"}
+
+    path = Path(db_path)
+    if not path.exists():
+        return {"status": "missing", "reason": "database_not_found"}
+
+    with sqlite3.connect(str(path)) as conn:
+        rows = conn.execute(
+            """
+            select date, close
+            from stock_daily
+            where upper(code) = ?
+            order by date desc
+            limit ?
+            """,
+            (symbol, lookback_daily_rows),
+        ).fetchall()
+
+    data = []
+    for date_value, close_value in rows:
+        close = _safe_float(close_value)
+        if close is None or close <= 0:
+            continue
+        data.append({"date": str(date_value), "close": close})
+
+    if len(data) < period * 5:
+        return {
+            "status": "insufficient",
+            "reason": f"日线数据不足，仅{len(data)}条",
+            "daily_rows": len(data),
+        }
+
+    df = pd.DataFrame(data)
+    df["date"] = pd.to_datetime(df["date"])
+    df = df.sort_values("date").set_index("date")
+
+    weekly_close = df["close"].resample("W-FRI").last().dropna()
+    if len(weekly_close) < period + 2:
+        return {
+            "status": "insufficient",
+            "reason": f"周线数据不足，仅{len(weekly_close)}条",
+            "weekly_bars": len(weekly_close),
+        }
+
+    delta = weekly_close.diff()
+    gain = delta.clip(lower=0)
+    loss = -delta.clip(upper=0)
+
+    avg_gain = gain.ewm(alpha=1 / period, adjust=False, min_periods=period).mean()
+    avg_loss = loss.ewm(alpha=1 / period, adjust=False, min_periods=period).mean()
+
+    rs = avg_gain / avg_loss.replace(0, pd.NA)
+    rsi = 100 - (100 / (1 + rs))
+    rsi = rsi.dropna()
+
+    if rsi.empty:
+        return {"status": "insufficient", "reason": "RSI计算结果为空"}
+
+    current = float(rsi.iloc[-1])
+    previous = float(rsi.iloc[-2]) if len(rsi) >= 2 else None
+    trend = "持平"
+    if previous is not None:
+        if current > previous + 0.2:
+            trend = "回升"
+        elif current < previous - 0.2:
+            trend = "回落"
+
+    return {
+        "status": "ok",
+        "period": period,
+        "week_date": weekly_close.index[-1].date().isoformat(),
+        "weekly_bars": int(len(weekly_close)),
+        "current_rsi": round(current, 2),
+        "previous_rsi": round(previous, 2) if previous is not None else None,
+        "trend": trend,
+        "vs_30": _relation(current, 30),
+        "vs_50": _relation(current, 50),
+        "vs_70": _relation(current, 70),
+        "interpretation": _interpret_rsi(current),
+    }

--- a/src/stock_analyzer.py
+++ b/src/stock_analyzer.py
@@ -143,6 +143,15 @@ class TrendAnalysisResult:
             'ma20': self.ma20,
             'ma60': self.ma60,
             'current_price': self.current_price,
+            'boll_mid': self.boll_mid,
+            'boll_upper': self.boll_upper,
+            'boll_lower': self.boll_lower,
+            'boll_width': self.boll_width,
+            'boll_position_pct': self.boll_position_pct,
+            'boll_signal': self.boll_signal,
+            'boll_buy_zone': self.boll_buy_zone,
+            'boll_breakout_level': self.boll_breakout_level,
+            'boll_stop_loss': self.boll_stop_loss,
             'bias_ma5': self.bias_ma5,
             'bias_ma10': self.bias_ma10,
             'bias_ma20': self.bias_ma20,
@@ -226,9 +235,10 @@ class StockTrendAnalyzer:
         # 计算均线
         df = self._calculate_mas(df)
 
-        # 计算 MACD 和 RSI
+        # 计算 MACD、RSI 和 BOLL
         df = self._calculate_macd(df)
         df = self._calculate_rsi(df)
+        df = self._calculate_boll(df)
 
         # 获取最新数据
         latest = df.iloc[-1]
@@ -237,6 +247,11 @@ class StockTrendAnalyzer:
         result.ma10 = float(latest['MA10'])
         result.ma20 = float(latest['MA20'])
         result.ma60 = float(latest.get('MA60', 0))
+        result.boll_mid = float(latest.get('BOLL_MID', 0) or 0)
+        result.boll_upper = float(latest.get('BOLL_UPPER', 0) or 0)
+        result.boll_lower = float(latest.get('BOLL_LOWER', 0) or 0)
+        result.boll_width = float(latest.get('BOLL_WIDTH', 0) or 0)
+        result.boll_position_pct = float(latest.get('BOLL_POSITION_PCT', 0) or 0)
 
         # 1. 趋势判断
         self._analyze_trend(df, result)
@@ -244,7 +259,10 @@ class StockTrendAnalyzer:
         # 2. 乖离率计算
         self._calculate_bias(result)
 
-        # 3. 量能分析
+        # 3. BOLL 布林线分析
+        self._analyze_boll(df, result)
+
+        # 4. 量能分析
         self._analyze_volume(df, result)
 
         # 4. 支撑压力分析
@@ -271,6 +289,19 @@ class StockTrendAnalyzer:
             df['MA60'] = df['close'].rolling(window=60).mean()
         else:
             df['MA60'] = df['MA20']  # 数据不足时使用 MA20 替代
+        return df
+
+    def _calculate_boll(self, df: pd.DataFrame) -> pd.DataFrame:
+        """计算 BOLL 布林线指标。"""
+        df = df.copy()
+        mid = df['close'].rolling(window=20).mean()
+        std = df['close'].rolling(window=20).std(ddof=0)
+        df['BOLL_MID'] = mid
+        df['BOLL_UPPER'] = mid + 2 * std
+        df['BOLL_LOWER'] = mid - 2 * std
+        df['BOLL_WIDTH'] = ((df['BOLL_UPPER'] - df['BOLL_LOWER']) / mid * 100).where(mid > 0, 0)
+        band = df['BOLL_UPPER'] - df['BOLL_LOWER']
+        df['BOLL_POSITION_PCT'] = ((df['close'] - df['BOLL_LOWER']) / band * 100).where(band > 0, 50)
         return df
 
     def _calculate_macd(self, df: pd.DataFrame) -> pd.DataFrame:
@@ -407,6 +438,48 @@ class StockTrendAnalyzer:
         if result.ma20 > 0:
             result.bias_ma20 = (price - result.ma20) / result.ma20 * 100
     
+    def _analyze_boll(self, df: pd.DataFrame, result: TrendAnalysisResult) -> None:
+        """分析 BOLL 位置，用于低吸、突破和止损判断。"""
+        price = result.current_price
+        mid = result.boll_mid
+        upper = result.boll_upper
+        lower = result.boll_lower
+
+        if not price or not mid or not upper or not lower or upper <= lower:
+            result.boll_signal = "BOLL数据不足"
+            return
+
+        result.boll_buy_zone = f"{lower:.2f} - {mid:.2f}"
+        result.boll_breakout_level = f"{upper:.2f}"
+        result.boll_stop_loss = f"{lower:.2f}"
+
+        is_near_lower = price <= lower * 1.03
+        is_near_upper = price >= upper * 0.97
+        is_breakout_upper = price > upper
+        is_narrow_band = 0 < result.boll_width < 8
+
+        if price < lower:
+            result.boll_signal = "跌破下轨，弱势风险释放，等待重新站回下轨确认"
+            result.risk_factors.append("BOLL跌破下轨，止损纪律优先")
+        elif is_breakout_upper and is_narrow_band:
+            result.boll_signal = "布林带收窄后突破上轨，趋势突破确认信号"
+            result.signal_reasons.append("BOLL收窄后突破上轨，若量能配合可视为突破买点")
+        elif is_breakout_upper:
+            result.boll_signal = "突破上轨，趋势强但需防冲高回落"
+            result.risk_factors.append("价格位于BOLL上轨外，追高需控制仓位")
+        elif is_near_upper:
+            result.boll_signal = "接近上轨，偏高位，观察是否冲高回落"
+            result.risk_factors.append("价格接近BOLL上轨，短线追涨性价比下降")
+        elif price > mid:
+            result.boll_signal = "站上中轨，趋势修复中，关注能否继续向上轨推进"
+            result.signal_reasons.append("价格站上BOLL中轨，结构改善")
+        elif is_near_lower:
+            result.boll_signal = "接近下轨，进入低吸观察区，但需等待止跌确认"
+            result.signal_reasons.append("价格接近BOLL下轨，可关注低吸观察位")
+        else:
+            result.boll_signal = "中轨下方震荡，趋势确认不足"
+            result.risk_factors.append("价格仍在BOLL中轨下方，趋势确认不足")
+
     def _analyze_volume(self, df: pd.DataFrame, result: TrendAnalysisResult) -> None:
         """
         分析量能

--- a/templates/report_markdown.j2
+++ b/templates/report_markdown.j2
@@ -159,6 +159,21 @@
 | 🎊 {{ labels.take_profit_label }} | {{ clean_sniper(sniper.get('take_profit')) }} |
 {% endif %}
 
+{% set has_boll = sniper.get('boll_status') or sniper.get('boll_buy_zone') or sniper.get('boll_mid_confirm') or sniper.get('boll_breakout') or sniper.get('boll_stop_loss') or sniper.get('chase_advice') %}
+{% if has_boll %}
+**📌 BOLL辅助判断**
+
+| 项目 | 判断 |
+|------|------|
+{% if sniper.get('boll_status') %}| BOLL状态 | {{ clean_sniper(sniper.get('boll_status')) }} |
+{% endif %}{% if sniper.get('boll_buy_zone') %}| 低吸观察区 | {{ clean_sniper(sniper.get('boll_buy_zone')) }} |
+{% endif %}{% if sniper.get('boll_mid_confirm') %}| 中轨确认位 | {{ clean_sniper(sniper.get('boll_mid_confirm')) }} |
+{% endif %}{% if sniper.get('boll_breakout') %}| 突破确认位 | {{ clean_sniper(sniper.get('boll_breakout')) }} |
+{% endif %}{% if sniper.get('boll_stop_loss') %}| 风险止损位 | {{ clean_sniper(sniper.get('boll_stop_loss')) }} |
+{% endif %}{% if sniper.get('chase_advice') %}| 是否适合追涨 | {{ clean_sniper(sniper.get('chase_advice')) }} |
+{% endif %}
+{% endif %}
+
 {% set position = battle.get('position_strategy', {}) %}
 {% if position %}
 **💰 {{ labels.suggested_position_label }}**: {{ position.get('suggested_position', 'N/A') }}


### PR DESCRIPTION
<!--
For Chinese contributors: 请直接用中文填写。
For English contributors: please fill in English. All fields marked (EN) accept English.
-->

## PR Type

- [ ] fix
- [ ] feat
- [ ] refactor
- [ ] docs
- [ ] chore
- [ ] test

## Background And Problem

请描述当前问题、影响范围与触发场景。  
*(EN) Describe the problem, its impact, and what triggers it.*

## Scope Of Change

请列出本 PR 修改的模块和文件范围。  
*(EN) List the modules and files changed in this PR.*

> 注意：请按实际 `git diff` 全量列出文件范围（建议注明文件总数），避免遗漏文档/后端/API/前端文件导致描述不一致。

> 若本 PR 修改了 `.github/PULL_REQUEST_TEMPLATE.md`、`.github/copilot-instructions.md`、`AGENTS.md`、`.github/instructions/*` 或 `.claude/skills/**` 等协作与治理文件，请补充“变更原因 + 影响面 + 回滚方式（默认 revert）”到 Summary / Compatibility / Rollback，避免 Scope 与描述不一致。

> 建议先执行并粘贴以下命令输出，避免与实际 diff 不一致：

```bash
BASE_REF=$(git merge-base HEAD origin/main)
git diff --stat "$BASE_REF"..HEAD
git diff --name-only "$BASE_REF"..HEAD
```

- 文件总数 / 变更行数（建议粘贴 `git diff --stat "$BASE_REF"..HEAD`）：
- 文件清单（按实际 diff 全量，逐项列出）：
- 文档更新文件（`docs/*`）：

## Issue Link

必须填写以下之一 / Fill in one of:
- `Fixes #<issue_number>`
- `Refs #<issue_number>`
- 无 Issue 时说明原因与验收标准 / If no issue, explain the motivation and acceptance criteria

## Verification Commands And Results

请填写你实际执行过的命令和关键结果（不要只写"已测试"）。  
*(EN) Paste the commands you actually ran and their key output (don't just write "tested"):*

```bash
# example
./scripts/ci_gate.sh
python -m pytest -m "not network"
```

> `Full-suite note` 必须与当次 PR 的当前 Head CI 结果保持一致；若本地复现存在环境相关失败，请明确标注“本地环境差异”并给出 GitHub CI 的结论与链接。  
> 请避免保留与本 PR 无关的历史失败措辞，按本次实际结果填报。
> 如历史描述中仍保留 `./scripts/ci_gate.sh` 失败记录，请先改为当前 Head CI 状态或说明与 Head CI 的差异来源。
> 若 `Full-suite note` 与当前 Head CI 不一致，PR 文本不完整，请先更新 PR 描述后再提交。

- 请在下面按实际结果填写并与 `Full-suite note` 保持一致（任一未填视为信息缺失）：
  - ai-governance：`pass` / `fail`，附链接
  - backend-gate：`pass` / `fail`，附链接
  - docker-build：`pass` / `fail`，附链接
  - web-gate：`pass` / `fail`，附链接
  - 若本 PR 修改 `.github/PULL_REQUEST_TEMPLATE.md` 等流程模板协作文件，请先说明变更必要性、影响边界，并明确回滚方式（默认 `revert this PR`）；否则请在下一版中拆为单独 chore PR。

关键输出/结论 / Key output & conclusion:

- 【必填】当前 Head CI：`ai-governance:pass / backend-gate:pass / docker-build:pass / web-gate:pass`（按实际结果替换）并附对应链接。  
- 若需保留本地失败现象，请在同段写明“本地环境差异 + 当前 CI 通过/失败结果 + CI 链接”。  
- 若全部通过，需补充一句：`当前状态：全部通过（pass）`，并明确 Head CI 全部为 pass。  

- 建议将本行直接粘贴到 PR 描述正文首段：`当前 Head CI：ai-governance:pass / backend-gate:pass / docker-build:pass / web-gate:pass`（仅示例，按实际结果替换）。

> 若上述核验项与 PR 文本冲突，建议先更新 PR 描述再提交，避免审查因状态不一致被阻塞。

## Visual Evidence (if applicable)

【必填】若本 PR 修改报告格式、报告渲染效果或 Web UI 界面，请在此处附受影响报告 / 页面截图；涉及前后差异时，优先附前后对比。Issue / PR 过程截图、审查截图、一次性验收截图和临时可视证据请放在 PR 描述、PR 评论、GitHub 附件、Actions artifact 或外部可访问链接中，不要作为仓库文件合入。
*(EN) If this PR changes report formatting, report rendering, or Web UI, attach screenshots of the affected report/page here; before/after screenshots are preferred when relevant. Issue/PR process screenshots, review screenshots, one-off acceptance screenshots, and temporary visual evidence should be linked from the PR body/comments, GitHub attachments, Actions artifacts, or external accessible evidence; do not commit them as repository files.)*

> 如截图无法获取，请在“原因”中明确写明替代证据（如 Playwright/e2e 产物路径、审查链接）及其可追溯命令，不得留空。涉及 Web 设置/报告渲染变更时，需确保截图或替代证据明确指向变更项。
>
> 若本 PR 修改 Web UI，建议至少补一条可复现路径，例如（优先 settings page）：
>
> - Playwright 截图产物：`apps/dsa-web/e2e/smoke.spec.ts`（`cd apps/dsa-web && npx playwright test e2e/smoke.spec.ts --grep "settings page renders title and save actions after login"`）
> - 审查证据链接：可直接使用 Actions 产物、GitHub 评论附件或外部可访问链接。

> 替代证据模板（设置页变更建议）：
> - 命令：`cd apps/dsa-web && npx playwright test e2e/smoke.spec.ts --grep "settings page"`
> - 产物路径：`apps/dsa-web/test-results/**/smoke-settings-page-*.png`
> - 说明：截图中应可见本次修改的系统设置项（字段、标签、帮助文案）

- 截图链接 / Screenshot links（Web UI/报告改动项必填，未提供请在下方“不适用原因”给出替代证据）：
- settings 页建议命名：`smoke-settings-page-zh` / `smoke-settings-page-en`
- 前后对比 / Before & After（如有）：
- settings 字段变更说明：截图或产物应明确包含 `MARKET_REVIEW_REGION` 字段与帮助文案区块（中文/英文）。
- 不适用原因 / Reason if not applicable（若未附截图，此项务必填写，且包含可复现证据与命令）：
  - Playwright 命令（无截图时）：`cd apps/dsa-web && npx playwright test e2e/smoke.spec.ts --grep "settings page"`
  - 产物路径（无截图时）：`apps/dsa-web/test-results/**/smoke-settings-page-*.png`
  - 说明：截图（或产物）必须可见本次修改的设置字段文案与帮助信息。

> 若本 PR 修改 Web 设置字段（字段、文案或帮助文案），截图或替代证据必须可定位到对应设置项区域并可追溯至变更项；该项为必填。

> 若本 PR 修改 Web UI 或报告展示且无法获取截图，原因栏必须给出可复现替代证据（例如 Playwright 截图产物路径 + 命令），且不得留空。

## Compatibility And Risk

请说明兼容性影响、潜在风险（如无请写 `None`）。  
*(EN) Describe compatibility impact and potential risks (write `None` if not applicable).*

- 若本 PR 修改第三方模型 / API 的兼容语义、请求参数、路由前缀或 provider fallback，请提供**官方来源链接或公告**，并说明这是长期约束、当前运行时约束还是临时兼容处理。  
  请在下方补充所影响外部 API/服务、回归范围与回退方式。  
  *(EN) If this PR changes third-party model/API compatibility, request parameters, routing prefixes, or provider fallback behavior, include an **official source link or announcement** and clarify whether the rule is permanent, runtime-specific, or a temporary compatibility workaround.)*
- 若本 PR 未触及第三方模型/API、provider/model/base URL 或运行时配置保存/清理/迁移逻辑，请在此段直接按以下文案确认（无须再次展开）：  
  `本 PR 未变更 provider/model/base URL、运行时配置清理迁移语义；历史配置保持不变；回滚方式为 revert 本提交。`
- 若本 PR 修改 `.github/PULL_REQUEST_TEMPLATE.md` / PR 流程模板类文件，请在此明确：仅影响协作流程与模板维护，不改 runtime 行为；回退方式为 revert；并补充是否影响自动化提交流程。  
  *(EN) If this PR changes `.github/PULL_REQUEST_TEMPLATE.md` or other PR workflow files, state that it only affects contribution governance templates (no runtime behavior), provide rollback by revert, and note any CI/checklist impact.)*
- 若本 PR 依赖特定运行时 / 锁定依赖窗口（例如 LiteLLM 版本范围、OpenAI-compatible 路由、YAML alias 行为），请写明当前验证过的兼容范围与覆盖路径。  
  *(EN) If this PR depends on a specific runtime or pinned dependency window (for example a LiteLLM version range, OpenAI-compatible routing, or YAML alias behavior), state the compatibility window you verified and which code paths were covered.)*
- 若本 PR 触及运行时配置保存、清理、迁移或回填逻辑，请明确说明旧配置是否会被自动改写、清空、迁移或保持不变，以及用户如何恢复原行为。  
  *(EN) If this PR touches runtime config save/cleanup/migration/backfill logic, explicitly describe whether existing config is rewritten, cleared, migrated, or left intact, and how users can restore the previous behavior.)*
- 若本 PR **未触及** provider/model/base URL 或运行时配置保存/清理/迁移逻辑（本条仅作为声明），请明确写：`本 PR 未变更 provider/model/base URL、运行时配置清理迁移语义；历史配置保持不变；回滚方式为 revert 本提交。`

## Rollback Plan

请至少写一句可执行的回滚方案（必填）。  
*(EN) Provide at least one actionable rollback step (required).*

- 如果是兼容性修复，默认应写出**最小回滚方式**（例如 `revert this PR`），并说明是否需要额外回滚配置或数据迁移。  
  *(EN) For compatibility fixes, include the **minimal rollback path** (for example `revert this PR`) and whether any additional config or data rollback is required.)*

## EXTRACT_PROMPT Change (if applicable)

若本 PR 修改了 `src/services/image_stock_extractor.py` 中的 `EXTRACT_PROMPT`，请在此处粘贴完整变更后的 prompt。  
*If this PR changes `EXTRACT_PROMPT` in `src/services/image_stock_extractor.py`, paste the full updated prompt here:*

<details>
<summary>展开 / Expand: Full EXTRACT_PROMPT</summary>

```
(paste full prompt here)
```

</details>

## Checklist

- [ ] 本 PR 有明确动机和业务价值 / This PR has a clear motivation and value
- [ ] 已提供可复现的验证命令与结果 / Reproducible verification commands and results are included
- [ ] 已评估兼容性与风险 / Compatibility and risk have been assessed
- [ ] 已提供回滚方案 / A rollback plan is provided
- [ ] 若修改报告格式或 Web UI 界面，已在 PR 描述/评论附受影响报告 / 页面截图，且未把一次性验收截图作为仓库文件合入 / If report formatting or Web UI changed, affected report/page screenshots are linked in the PR body/comments and one-off acceptance screenshots are not committed as repository files
- [ ] 若本 PR 修改 Web 设置字段（字段、文案或帮助文本），请补充设置页截图；无法截图时需提供替代可视证据（命令 + 产物路径），并指向对应变更项 / If Web settings fields changed (labels or help text), screenshots of the settings page are required; if unavailable, provide alternative visual evidence with command + artifact path that points to the changed item.
- [ ] 若涉及用户可见变更，已同步更新相关文档与 `docs/CHANGELOG.md`；`README.md` 仅在首页级信息变化时更新，细节优先写入 `docs/*.md` / If user-visible changes are included, relevant docs and `docs/CHANGELOG.md` are updated; `README.md` is updated only for homepage-level changes, with details kept in `docs/*.md`
