### PR TITLE
fix: preserve zero sentiment score alignment

### DIFF
--- a/api/v1/endpoints/analysis.py
+++ b/api/v1/endpoints/analysis.py
@@ -1352,10 +1352,10 @@ def _build_analysis_report(
         explicit_action=raw_result_data.get("action") or details_data.get("action") or summary_data.get("action"),
         report_type=meta.report_type,
         report_language=report_language,
-        sentiment_score=(
-            summary_data.get("sentiment_score")
-            or raw_result_data.get("sentiment_score")
-            or details_data.get("sentiment_score")
+        sentiment_score=_first_non_empty_report_value(
+            summary_data.get("sentiment_score"),
+            raw_result_data.get("sentiment_score"),
+            details_data.get("sentiment_score"),
         ),
         guardrail_reason=_extract_guardrail_reason(raw_result_data),
         align_with_score=True,

--- a/api/v1/endpoints/analysis.py
+++ b/api/v1/endpoints/analysis.py
@@ -885,6 +885,16 @@ def _prepare_report_for_task_enrichment(
     return enriched_report
 
 
+def _first_non_empty_report_value(*values: Any) -> Any:
+    for value in values:
+        if value is None:
+            continue
+        if isinstance(value, str) and not value.strip():
+            continue
+        return value
+    return None
+
+
 def _ensure_report_action_fields(report_data: Dict[str, Any]) -> Dict[str, Any]:
     enriched_report = dict(report_data)
     meta = dict(enriched_report.get("meta") or {})
@@ -899,7 +909,10 @@ def _ensure_report_action_fields(report_data: Dict[str, Any]) -> Dict[str, Any]:
         explicit_action=raw_result.get("action") or summary.get("action"),
         report_type=meta.get("report_type"),
         report_language=report_language,
-        sentiment_score=summary.get("sentiment_score") or raw_result.get("sentiment_score"),
+        sentiment_score=_first_non_empty_report_value(
+            summary.get("sentiment_score"),
+            raw_result.get("sentiment_score"),
+        ),
         guardrail_reason=_extract_guardrail_reason(raw_result),
         align_with_score=True,
     )

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,18 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 > For user-friendly release highlights, see the [GitHub Releases](https://github.com/ZhuLinsen/daily_stock_analysis/releases) page.
 
 ## [Unreleased]
-- [修复] 修复 Windows 桌面端启动后端时固定传入 `--host 127.0.0.1` 导致 `.env` 中 `WEBUI_HOST=0.0.0.0` 不生效、局域网无法访问 WebUI 的问题；桌面端仍默认使用 `127.0.0.1`，仅在显式配置 `WEBUI_HOST` 后按配置绑定，并继续使用本机地址完成健康检查和窗口加载。
-- [新功能] 钉钉群机器人通知支持 — 支持通过 `DINGTALK_WEBHOOK_URL` 和 `DINGTALK_SECRET` 配置钉钉推送，并支持长文本自动切片以适配 20KB 限制。
 - [修复] 修复任务状态接口重建报告动作字段时把合法情绪分 `0` 当成空值的问题，确保低分报告能按评分口径纠正为卖出建议。
-
-- [文档] 记录 Agent `/chat/stream` progress event 契约，说明新增 `stage_start`、`stage_done`、`pipeline_timeout`、`pipeline_budget_skipped` 的字段语义、Web 兼容边界、验证方式、回滚方式；其中 `pipeline_budget_skipped` 表示剩余预算不足、未启动下一阶段即跳过的语义；本变更不触及 provider/model/Base URL 或运行时配置迁移语义。
-- [修复] 日股/韩股 `market_phase` 补齐收盘集合竞价识别：JP 15:25-15:30 与 KR 15:20-15:30 现在会进入 `closing_auction`，避免临近收盘阶段仍被标记为普通 `intraday`；仅调整阶段标签和派生 `market_phase_summary`，不改变数据源、配置或交易日 fail-open/fail-closed 语义。
-- [修复] Discord 长报告推送按 2000 字符上限分片逐段发送，遇到 429 限流会按 `retry_after`/`Retry-After` 有限重试，避免中途失败后只收到前半段报告。
-- [改进] #1777 台股三大法人 fetcher（`TwInstitutionalFetcher`）增加缓存防击穿：并发同 (市场, 日期) 调用合并为单次上游请求，保护 TWSE T86 ~3 req/5s 限流额度；不同 key 仍并行；新增并发单次抓取、不同 key 各抓一次、HTTP 错误 fail-open 回归测试。
-- [修复] 修复桌面端启动时 `.env` 中 `WEBUI_PORT` 与 Electron 自动选择端口不一致会导致窗口继续等待旧端口并连接超时的问题。
-- [修复] A 股个股分析遇到空 `belong_boards` 占位时会继续补查所属板块，关联板块模块在已有板块时稳定展示；对应涨跌幅缺失时只显示板块，不再输出占位涨跌幅。
-- [修复] 大盘复盘在 LLM 标题漂移或正文缺少板块段时，会从结构化 `sectors` 兜底渲染板块表，避免 Web 与推送报告偶发缺少板块主线。
-- [改进] AlphaSift 默认依赖 pin 更新到 `9f522747caafd3c0b1ddb7e14d5cf44c8580b6cf`，接入 wrapper 数据源 caller-side timeout、东财直连限速/抖动、策略目录元数据与新增防守策略；选股任务状态轮询遇到可恢复超时时改为提示后台任务仍会自动重试，`.env.example` 补充相关超时调优项，降低外部数据源卡住时触发 Web 30 秒等待超时的概率。
 
 <!-- 新条目格式：- [类型] 描述（类型取值：新功能/改进/修复/文档/测试/chore）-->
 <!-- 每条独立一行追加到本段末尾，无需分类标题，合并时冲突最小 -->

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 > For user-friendly release highlights, see the [GitHub Releases](https://github.com/ZhuLinsen/daily_stock_analysis/releases) page.
 
 ## [Unreleased]
+- [修复] 修复 Windows 桌面端启动后端时固定传入 `--host 127.0.0.1` 导致 `.env` 中 `WEBUI_HOST=0.0.0.0` 不生效、局域网无法访问 WebUI 的问题；桌面端仍默认使用 `127.0.0.1`，仅在显式配置 `WEBUI_HOST` 后按配置绑定，并继续使用本机地址完成健康检查和窗口加载。
+- [新功能] 钉钉群机器人通知支持 — 支持通过 `DINGTALK_WEBHOOK_URL` 和 `DINGTALK_SECRET` 配置钉钉推送，并支持长文本自动切片以适配 20KB 限制。
+- [修复] 修复任务状态接口重建报告动作字段时把合法情绪分 `0` 当成空值的问题，确保低分报告能按评分口径纠正为卖出建议。
+
+- [文档] 记录 Agent `/chat/stream` progress event 契约，说明新增 `stage_start`、`stage_done`、`pipeline_timeout`、`pipeline_budget_skipped` 的字段语义、Web 兼容边界、验证方式、回滚方式；其中 `pipeline_budget_skipped` 表示剩余预算不足、未启动下一阶段即跳过的语义；本变更不触及 provider/model/Base URL 或运行时配置迁移语义。
+- [修复] 日股/韩股 `market_phase` 补齐收盘集合竞价识别：JP 15:25-15:30 与 KR 15:20-15:30 现在会进入 `closing_auction`，避免临近收盘阶段仍被标记为普通 `intraday`；仅调整阶段标签和派生 `market_phase_summary`，不改变数据源、配置或交易日 fail-open/fail-closed 语义。
+- [修复] Discord 长报告推送按 2000 字符上限分片逐段发送，遇到 429 限流会按 `retry_after`/`Retry-After` 有限重试，避免中途失败后只收到前半段报告。
+- [改进] #1777 台股三大法人 fetcher（`TwInstitutionalFetcher`）增加缓存防击穿：并发同 (市场, 日期) 调用合并为单次上游请求，保护 TWSE T86 ~3 req/5s 限流额度；不同 key 仍并行；新增并发单次抓取、不同 key 各抓一次、HTTP 错误 fail-open 回归测试。
+- [修复] 修复桌面端启动时 `.env` 中 `WEBUI_PORT` 与 Electron 自动选择端口不一致会导致窗口继续等待旧端口并连接超时的问题。
+- [修复] A 股个股分析遇到空 `belong_boards` 占位时会继续补查所属板块，关联板块模块在已有板块时稳定展示；对应涨跌幅缺失时只显示板块，不再输出占位涨跌幅。
+- [修复] 大盘复盘在 LLM 标题漂移或正文缺少板块段时，会从结构化 `sectors` 兜底渲染板块表，避免 Web 与推送报告偶发缺少板块主线。
+- [改进] AlphaSift 默认依赖 pin 更新到 `9f522747caafd3c0b1ddb7e14d5cf44c8580b6cf`，接入 wrapper 数据源 caller-side timeout、东财直连限速/抖动、策略目录元数据与新增防守策略；选股任务状态轮询遇到可恢复超时时改为提示后台任务仍会自动重试，`.env.example` 补充相关超时调优项，降低外部数据源卡住时触发 Web 30 秒等待超时的概率。
+
 <!-- 新条目格式：- [类型] 描述（类型取值：新功能/改进/修复/文档/测试/chore）-->
 <!-- 每条独立一行追加到本段末尾，无需分类标题，合并时冲突最小 -->
 

--- a/tests/test_analysis_api_contract.py
+++ b/tests/test_analysis_api_contract.py
@@ -703,6 +703,62 @@ class AnalysisApiContractTestCase(unittest.TestCase):
         self.assertEqual(status.result.report["summary"]["action"], "sell")
         self.assertEqual(status.result.report["summary"]["action_label"], "卖出")
 
+    def test_get_analysis_status_preserves_zero_sentiment_score_when_enriching_report(self) -> None:
+        if get_analysis_status is None or analysis_endpoint_module is None:
+            self.skipTest("analysis endpoint helpers unavailable in this environment")
+
+        created_at = datetime(2026, 5, 21, 17, 40, 0)
+        queue = MagicMock()
+        queue.get_task.return_value = SimpleNamespace(
+            task_id="task-queue-zero-score-enriched",
+            stock_code="600519",
+            stock_name="贵州茅台",
+            status=analysis_endpoint_module.TaskStatusEnum.COMPLETED,
+            progress=100,
+            result={
+                "stock_code": "600519",
+                "stock_name": "贵州茅台",
+                "report": {
+                    "meta": {
+                        "query_id": "task-queue-zero-score-enriched",
+                        "stock_code": "600519",
+                        "report_type": "detailed",
+                        "report_language": "zh",
+                    },
+                    "summary": {
+                        "analysis_summary": "趋势显著恶化",
+                        "operation_advice": "持有",
+                        "sentiment_score": 0,
+                    },
+                    "details": {
+                        "raw_result": {
+                            "operation_advice": "持有",
+                            "report_language": "zh",
+                        },
+                    },
+                },
+            },
+            error=None,
+            original_query=None,
+            selection_source=None,
+            analysis_phase="auto",
+            created_at=created_at,
+            completed_at=datetime(2026, 5, 21, 17, 45, 0),
+        )
+
+        with patch("api.v1.endpoints.analysis.get_task_queue", return_value=queue), \
+             patch(
+                 "api.v1.endpoints.analysis._load_sync_fundamental_sources",
+                 return_value=({}, None),
+             ):
+            status = get_analysis_status("task-queue-zero-score-enriched")
+
+        self.assertEqual(status.status, "completed")
+        self.assertIsNotNone(status.result)
+        self.assertEqual(status.result.report["summary"]["sentiment_score"], 0)
+        self.assertEqual(status.result.report["summary"]["action"], "sell")
+        self.assertEqual(status.result.report["summary"]["action_label"], "卖出")
+
     def test_get_analysis_status_preserves_queue_report_created_at_when_enriching(self) -> None:
         if get_analysis_status is None or analysis_endpoint_module is None:
             self.skipTest("analysis endpoint helpers unavailable in this environment")

--- a/tests/test_analysis_api_contract.py
+++ b/tests/test_analysis_api_contract.py
@@ -651,6 +651,58 @@ class AnalysisApiContractTestCase(unittest.TestCase):
         self.assertEqual(status.result.report["summary"]["action"], "watch")
         self.assertEqual(status.result.report["summary"]["action_label"], "观望")
 
+    def test_get_analysis_status_preserves_zero_sentiment_score_when_aligning_action(self) -> None:
+        if get_analysis_status is None or analysis_endpoint_module is None:
+            self.skipTest("analysis endpoint helpers unavailable in this environment")
+
+        created_at = datetime(2026, 5, 21, 17, 40, 0)
+        queue = MagicMock()
+        queue.get_task.return_value = SimpleNamespace(
+            task_id="task-queue-zero-score",
+            stock_code="600519",
+            stock_name="贵州茅台",
+            status=analysis_endpoint_module.TaskStatusEnum.COMPLETED,
+            progress=100,
+            result={
+                "stock_code": "600519",
+                "stock_name": "贵州茅台",
+                "report": {
+                    "meta": {
+                        "query_id": "task-queue-zero-score",
+                        "stock_code": "600519",
+                        "report_type": "detailed",
+                        "report_language": "zh",
+                    },
+                    "summary": {
+                        "analysis_summary": "趋势显著恶化",
+                        "operation_advice": "持有",
+                        "sentiment_score": 0,
+                    },
+                    "details": {
+                        "raw_result": {
+                            "operation_advice": "持有",
+                            "report_language": "zh",
+                        },
+                    },
+                },
+            },
+            error=None,
+            original_query=None,
+            selection_source=None,
+            analysis_phase="auto",
+            created_at=created_at,
+            completed_at=datetime(2026, 5, 21, 17, 45, 0),
+        )
+
+        with patch("api.v1.endpoints.analysis.get_task_queue", return_value=queue):
+            status = get_analysis_status("task-queue-zero-score")
+
+        self.assertEqual(status.status, "completed")
+        self.assertIsNotNone(status.result)
+        self.assertEqual(status.result.report["summary"]["sentiment_score"], 0)
+        self.assertEqual(status.result.report["summary"]["action"], "sell")
+        self.assertEqual(status.result.report["summary"]["action_label"], "卖出")
+
     def test_get_analysis_status_preserves_queue_report_created_at_when_enriching(self) -> None:
         if get_analysis_status is None or analysis_endpoint_module is None:
             self.skipTest("analysis endpoint helpers unavailable in this environment")


### PR DESCRIPTION
## What changed
- Preserve `0` as a valid `sentiment_score` when rebuilding report action fields for in-memory analysis task results.
- Skip only `None` and blank strings when choosing the score from summary/raw_result.
- Add an API contract regression test for `sentiment_score: 0` with legacy hold advice.
- Update `docs/CHANGELOG.md`.

## Why
The status endpoint used `summary.get("sentiment_score") or raw_result.get("sentiment_score")`, so a valid zero score was treated as missing. That prevented score/action alignment from correcting neutral legacy advice to the canonical sell action while a completed task was still served from memory.

## User impact
Low-score reports returned by task status now keep consistent action labels before and after database/history fallback.

## Validation
- `python -m py_compile api/v1/endpoints/analysis.py tests/test_analysis_api_contract.py`
- `/tmp/dsa-zero-venv/bin/python -m pytest tests/test_analysis_api_contract.py -k "zero_sentiment_score or raw_result_action or normalizes_completed_queue_result_contract"`
- `/tmp/dsa-zero-venv/bin/python -m pytest tests/test_decision_action.py`

## Notes
Local system Python was missing several runtime dependencies, so validation used a temporary venv at `/tmp/dsa-zero-venv`.

## Rollback
Revert this PR to restore the previous score fallback behavior.
