### PR TITLE
feat: extend Market Light with 5 sentiment dimensions

### DIFF
--- a/data_provider/margin_flow_fetcher.py
+++ b/data_provider/margin_flow_fetcher.py
@@ -1,0 +1,258 @@
+# -*- coding: utf-8 -*-
+"""Fetcher for extended Market Light dimension data.
+
+Provides market-level inputs that feed the five extended Market Light
+dimensions (margin_balance, northbound_flow, turnover_quantile,
+limit_ratio, continuous_board).
+
+Every function degrades gracefully: on any failure it returns ``None``,
+so ``MarketAnalyzer._build_market_light_scores`` marks the corresponding
+dimension as ``available=False`` and the snapshot remains valid.
+
+Data sources (all via akshare, no token required):
+- 融资融券余额: ``ak.stock_margin_sse`` + ``ak.stock_margin_szse``
+- 北向资金净流入: ``ak.stock_hsgt_hist_em`` (T+1, may be NaN since 2024 reform)
+- 成交额历史: ``ak.stock_zh_index_daily`` (上证 + 深证)
+- 连板高度: ``ak.stock_zt_pool_strong_em``
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timedelta
+from typing import List, Optional
+
+logger = logging.getLogger(__name__)
+
+_MARGIN_LOOKBACK_DAYS = 12  # calendar days, to ensure >= 5 trading days
+_NORTHBOUND_LOOKBACK_DAYS = 12
+_TURNOVER_HISTORY_DAYS = 90  # calendar days, to ensure >= 60 trading days
+_YI = 1e8  # 元 -> 亿元
+
+
+def _to_date_str(dt: datetime, fmt: str = "%Y%m%d") -> str:
+    return dt.strftime(fmt)
+
+
+def fetch_margin_balance_recent(trading_days: int = 5) -> Optional[List[float]]:
+    """Return total A-share margin balance for the recent N trading days.
+
+    Each value is the combined SSE+SZSE 融资融券余额 in 亿元. Returns ``None``
+    when both exchanges fail or fewer than 2 valid rows are available.
+    """
+    try:
+        import akshare as ak
+    except Exception as exc:  # pragma: no cover - import guard
+        logger.debug("margin_balance: akshare import failed: %s", exc)
+        return None
+
+    end = datetime.now()
+    start = end - timedelta(days=_MARGIN_LOOKBACK_DAYS)
+    sse_values = _fetch_margin_sse(start, end)
+    szse_values = _fetch_margin_szse(start, end)
+    if sse_values is None and szse_values is None:
+        logger.info("margin_balance: both exchanges returned no data")
+        return None
+
+    # Align by date (both lists are ordered oldest->newest with date+value tuples)
+    merged = _merge_margin_by_date(sse_values, szse_values)
+    if len(merged) < 2:
+        logger.info("margin_balance: only %d aligned days, need >= 2", len(merged))
+        return None
+    return merged[-trading_days:]
+
+
+def _fetch_margin_sse(start: datetime, end: datetime) -> Optional[List[tuple]]:
+    try:
+        import akshare as ak
+
+        df = ak.stock_margin_sse(
+            start_date=_to_date_str(start), end_date=_to_date_str(end)
+        )
+        if df is None or df.empty:
+            return None
+        col_date = "信用交易日期"
+        col_balance = "融资融券余额"
+        if col_date not in df.columns or col_balance not in df.columns:
+            logger.warning("margin_sse: unexpected columns %s", list(df.columns))
+            return None
+        df = df[[col_date, col_balance]].dropna()
+        result = [
+            (str(row[col_date]), float(row[col_balance]) / _YI)
+            for _, row in df.iterrows()
+        ]
+        result.sort(key=lambda x: x[0])
+        return result
+    except Exception as exc:
+        logger.debug("margin_sse fetch failed: %s", exc)
+        return None
+
+
+def _fetch_margin_szse(start: datetime, end: datetime) -> Optional[List[tuple]]:
+    try:
+        import akshare as ak
+
+        df = ak.stock_margin_szse(
+            start_date=_to_date_str(start, "%Y-%m-%d"),
+            end_date=_to_date_str(end, "%Y-%m-%d"),
+        )
+        if df is None or df.empty:
+            return None
+        # 深交所 columns: 信用交易日期, 融资余额, 融券余额, 融资融券余额
+        col_date = "信用交易日期"
+        col_balance = "融资融券余额"
+        if col_date not in df.columns or col_balance not in df.columns:
+            # fallback: 融资余额 + 融券余额
+            if "融资余额" in df.columns and "融券余额" in df.columns:
+                df = df[[col_date, "融资余额", "融券余额"]].dropna() if col_date in df.columns else None
+                if df is None:
+                    return None
+                result = [
+                    (str(row[col_date]), (float(row["融资余额"]) + float(row["融券余额"])) / _YI)
+                    for _, row in df.iterrows()
+                ]
+                result.sort(key=lambda x: x[0])
+                return result
+            logger.warning("margin_szse: unexpected columns %s", list(df.columns))
+            return None
+        df = df[[col_date, col_balance]].dropna()
+        result = [
+            (str(row[col_date]), float(row[col_balance]) / _YI)
+            for _, row in df.iterrows()
+        ]
+        result.sort(key=lambda x: x[0])
+        return result
+    except Exception as exc:
+        logger.debug("margin_szse fetch failed: %s", exc)
+        return None
+
+
+def _merge_margin_by_date(
+    sse: Optional[List[tuple]], szse: Optional[List[tuple]]
+) -> List[float]:
+    """Merge SSE + SZSE margin by aligned date, returning total balance list."""
+    if sse is None and szse is None:
+        return []
+    if sse is None:
+        return [v for _, v in szse]
+    if szse is None:
+        return [v for _, v in sse]
+    szse_map = {d: v for d, v in szse}
+    merged: List[float] = []
+    for date, sse_val in sse:
+        szse_val = szse_map.get(date)
+        if szse_val is not None:
+            merged.append(sse_val + szse_val)
+    if not merged:
+        # dates don't align; fall back to whichever is longer
+        return [v for _, v in sse] if len(sse) >= len(szse) else [v for _, v in szse]
+    return merged
+
+
+def fetch_northbound_flow_recent(trading_days: int = 5) -> Optional[List[float]]:
+    """Return recent N days of northbound net inflow (亿元).
+
+    Returns ``None`` when the API fails or all recent values are NaN
+    (northbound real-time data was restricted in 2024; only T+1 historical
+    data is available, and even that may be NaN for recent days).
+    """
+    try:
+        import akshare as ak
+
+        df = ak.stock_hsgt_hist_em(symbol="北向资金")
+        if df is None or df.empty:
+            return None
+        col_flow = "当日成交净买额"
+        if col_flow not in df.columns:
+            logger.warning("northbound: unexpected columns %s", list(df.columns))
+            return None
+        df = df[["日期", col_flow]].dropna()
+        if df.empty:
+            return None
+        values = [float(v) / _YI for v in df[col_flow].tolist()]
+        if len(values) < 2:
+            return None
+        return values[-trading_days:]
+    except Exception as exc:
+        logger.debug("northbound fetch failed: %s", exc)
+        return None
+
+
+def fetch_turnover_history(trading_days: int = 60) -> Optional[List[float]]:
+    """Return recent N trading days of total A-share turnover (亿元).
+
+    Combines Shanghai (sh000001) and Shenzhen (sz399001) index turnover.
+    """
+    try:
+        import akshare as ak
+
+        sh = _fetch_index_turnover("sh000001")
+        sz = _fetch_index_turnover("sz399001")
+        if sh is None and sz is None:
+            return None
+        if sh is None:
+            return sz[-trading_days:] if sz else None
+        if sz is None:
+            return sh[-trading_days:] if sh else None
+        # align by length (both are oldest->newest)
+        min_len = min(len(sh), len(sz))
+        combined = [sh[-(min_len - i)] + sz[-(min_len - i)] for i in range(min_len)]
+        return combined[-trading_days:]
+    except Exception as exc:
+        logger.debug("turnover_history fetch failed: %s", exc)
+        return None
+
+
+def _fetch_index_turnover(symbol: str) -> Optional[List[float]]:
+    try:
+        import akshare as ak
+
+        df = ak.stock_zh_index_daily(symbol=symbol)
+        if df is None or df.empty:
+            return None
+        # column name varies; prefer 成交额 then amount then volume
+        col = None
+        for candidate in ("成交额", "amount", "money"):
+            if candidate in df.columns:
+                col = candidate
+                break
+        if col is None:
+            logger.warning("turnover %s: no amount column in %s", symbol, list(df.columns))
+            return None
+        df = df[[col]].dropna()
+        values = [float(v) / _YI for v in df[col].tolist()]
+        return values
+    except Exception as exc:
+        logger.debug("turnover %s fetch failed: %s", symbol, exc)
+        return None
+
+
+def fetch_continuous_board_height() -> Optional[int]:
+    """Return today's max consecutive limit-up board height (连板高度).
+
+    Parses the 涨停统计 column (e.g. ``"3/3"``) from the strong-stock pool
+    and returns the maximum first number. Returns ``None`` on any failure.
+    """
+    try:
+        import akshare as ak
+
+        today = _to_date_str(datetime.now())
+        df = ak.stock_zt_pool_strong_em(date=today)
+        if df is None or df.empty:
+            return None
+        col = "涨停统计"
+        if col not in df.columns:
+            logger.warning("continuous_board: column %s missing in %s", col, list(df.columns))
+            return None
+        max_height = 0
+        for raw in df[col].dropna():
+            try:
+                height = int(str(raw).split("/")[0])
+                if height > max_height:
+                    max_height = height
+            except (ValueError, IndexError):
+                continue
+        return max_height if max_height > 0 else None
+    except Exception as exc:
+        logger.debug("continuous_board fetch failed: %s", exc)
+        return None

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 ## [Unreleased]
 <!-- 新条目格式：- [类型] 描述（类型取值：新功能/改进/修复/文档/测试/chore）-->
 <!-- 每条独立一行追加到本段末尾，无需分类标题，合并时冲突最小 -->
+- [新功能] MarketLight 情绪温度计扩展 5 个维度：融资融券余额变化、北向资金方向、换手率分位、涨停跌停比、连板高度；新增维度可选，旧快照向后兼容。
+- [测试] 新增 `tests/test_market_light_extended_dimensions.py` 覆盖扩展维度评分与向后兼容。
 
 ## [3.25.0] - 2026-07-03
 

--- a/docs/alerts.md
+++ b/docs/alerts.md
@@ -375,6 +375,16 @@ scope/type 校验是双向约束：`target_scope=market` 只能使用两类 Mark
 | `index` | `indices` 非空且至少一个 `change_pct != None` | `50` |
 | `limit` | `has_market_stats && (limit_up_count + limit_down_count) > 0` | `50` |
 
+扩展维度（可选，仅 A 股填充，数据源缺失时 `available=false`，不影响 `data_quality` 和 aggregate `score`）：
+
+| 扩展 dimension | 数据源 | `available=true` 条件 |
+| --- | --- | --- |
+| `margin_balance` | `ak.stock_margin_sse` + `ak.stock_margin_szse` | 最近 2 日融资融券余额可得 |
+| `northbound_flow` | `ak.stock_hsgt_hist_em` | 最近 2 日北向净流入非 NaN（2024 年后可能不可得） |
+| `turnover_quantile` | `ak.stock_zh_index_daily` (sh000001 + sz399001) | 20 日以上历史成交额 + 当日成交额 > 0 |
+| `limit_ratio` | 复用 `MarketOverview` | `limit_up_count + limit_down_count > 0` |
+| `continuous_board` | `ak.stock_zt_pool_strong_em` | 当日最高连板数 > 0 |
+
 `data_quality=unavailable` 表示 `index.available=false`，两类 market rule 都返回 `skipped` 且不触发通知；`partial` 表示至少一个维度 fallback，`ok` 表示三项均 available。`market_light_status` 在 `ok/partial` 下可触发；`partial` 触发时 diagnostics 必含 `missing_dimensions`。`market_light_score_drop` 直接比较 canonical aggregate score；任一侧 `partial` 仍允许比较，但 diagnostics 必含 `partial_comparison=true` 和 `missing_dimensions`。
 
 ### 基线、交易日与去重

--- a/src/market_analyzer.py
+++ b/src/market_analyzer.py
@@ -103,6 +103,10 @@ class MarketOverview:
     bottom_sectors: List[Dict] = field(default_factory=list)  # 跌幅前5板块
     top_concepts: List[Dict] = field(default_factory=list)    # 涨幅前5概念
     bottom_concepts: List[Dict] = field(default_factory=list) # 跌幅前5概念
+    # Extended dimension inputs for Market Light (populated when data sources
+    # are available; keys: margin_balance_recent, northbound_flow_recent,
+    # turnover_history, continuous_board_height).
+    extended_inputs: Dict[str, Any] = field(default_factory=dict)
 
 
 @dataclass
@@ -445,8 +449,49 @@ Focus on index trend, liquidity, and sector rotation to shape the next-session t
         
         # 4. 获取北向资金（可选）
         # self._get_north_flow(overview)
-        
+
+        # 5. 获取扩展维度数据（仅 A 股；其他市场数据源不同，跳过）
+        if self.region == "cn":
+            self._fetch_extended_inputs(overview)
+
         return overview
+
+    def _fetch_extended_inputs(self, overview: MarketOverview) -> None:
+        """Fetch extended Market Light dimension data (best-effort).
+
+        Each fetcher degrades gracefully to None, so missing data sources
+        only mark the corresponding dimension as unavailable without
+        affecting the core market overview flow.
+        """
+        try:
+            from data_provider.margin_flow_fetcher import (
+                fetch_continuous_board_height,
+                fetch_margin_balance_recent,
+                fetch_northbound_flow_recent,
+                fetch_turnover_history,
+            )
+        except Exception as exc:
+            logger.debug("[大盘] %s action=extended_inputs status=import_failed error=%s", self._log_context(), exc)
+            return
+
+        for key, fetcher in (
+            ("margin_balance_recent", fetch_margin_balance_recent),
+            ("northbound_flow_recent", fetch_northbound_flow_recent),
+            ("turnover_history", fetch_turnover_history),
+            ("continuous_board_height", fetch_continuous_board_height),
+        ):
+            try:
+                value = fetcher()
+                if value:
+                    overview.extended_inputs[key] = value
+            except Exception as exc:
+                logger.debug(
+                    "[大盘] %s action=extended_inputs key=%s status=failed error=%s",
+                    self._log_context(),
+                    key,
+                    exc,
+                )
+
 
     
     def _get_main_indices(self) -> List[MarketIndex]:
@@ -1273,9 +1318,15 @@ Focus on index trend, liquidity, and sector rotation to shape the next-session t
             "limit": {"score": limit_score, "available": limit_available},
         }
 
+        # Extended dimensions (optional; available=False when data is missing).
+        # These do not affect the core score or data_quality, preserving
+        # backward compatibility for persisted snapshots and alert thresholds.
+        extended = self._compute_extended_dimensions(overview)
+        dimensions.update(extended)
+
         if not index_available:
             data_quality = "unavailable"
-        elif all(dimension["available"] for dimension in dimensions.values()):
+        elif all(dimension["available"] for dimension in dimensions.values() if dimension is not None):
             data_quality = "ok"
         else:
             data_quality = "partial"
@@ -1305,6 +1356,103 @@ Focus on index trend, liquidity, and sector rotation to shape the next-session t
             "dimensions": dimensions,
             "data_quality": data_quality,
         }
+
+    @staticmethod
+    def _clamp_score(value: float) -> int:
+        return int(max(0, min(100, round(value))))
+
+    def _compute_extended_dimensions(self, overview: MarketOverview) -> Dict[str, Dict[str, Any]]:
+        """Compute the five extended Market Light dimensions.
+
+        Each dimension is returned as ``{"score": int, "available": bool}``.
+        When the underlying data is missing, ``available`` is False and the
+        score defaults to 50 (neutral).
+        """
+        inputs = overview.extended_inputs or {}
+
+        margin_balance = self._dimension_margin_balance(inputs.get("margin_balance_recent"))
+        northbound_flow = self._dimension_northbound_flow(inputs.get("northbound_flow_recent"))
+        turnover_quantile = self._dimension_turnover_quantile(
+            inputs.get("turnover_history"), overview.total_amount
+        )
+        limit_ratio = self._dimension_limit_ratio(
+            overview.limit_up_count, overview.limit_down_count
+        )
+        continuous_board = self._dimension_continuous_board(
+            inputs.get("continuous_board_height")
+        )
+        return {
+            "margin_balance": margin_balance,
+            "northbound_flow": northbound_flow,
+            "turnover_quantile": turnover_quantile,
+            "limit_ratio": limit_ratio,
+            "continuous_board": continuous_board,
+        }
+
+    def _dimension_margin_balance(self, recent: Optional[List[float]]) -> Dict[str, Any]:
+        """融资融券余额变化: 5日余额变化率映射到 0-100。"""
+        if not recent or len(recent) < 2:
+            return {"score": 50, "available": False}
+        try:
+            oldest = float(recent[0])
+            latest = float(recent[-1])
+            if oldest <= 0:
+                return {"score": 50, "available": False}
+            change_rate = (latest - oldest) / oldest  # e.g. +0.02 = +2%
+            # +2% -> 66, 0% -> 50, -2% -> 34
+            score = self._clamp_score(50 + change_rate * 800)
+            return {"score": score, "available": True}
+        except (TypeError, ValueError):
+            return {"score": 50, "available": False}
+
+    def _dimension_northbound_flow(self, recent: Optional[List[float]]) -> Dict[str, Any]:
+        """北向资金方向: 5日累计净流入映射到 0-100。"""
+        if not recent:
+            return {"score": 50, "available": False}
+        try:
+            values = [float(v) for v in recent if v is not None]
+            if len(values) < 2:
+                return {"score": 50, "available": False}
+            cumulative = sum(values)
+            # +50亿 -> 70, 0 -> 50, -50亿 -> 30
+            score = self._clamp_score(50 + cumulative * 0.4)
+            return {"score": score, "available": True}
+        except (TypeError, ValueError):
+            return {"score": 50, "available": False}
+
+    def _dimension_turnover_quantile(
+        self, history: Optional[List[float]], today_amount: float
+    ) -> Dict[str, Any]:
+        """换手率分位: 今日成交额在 60日历史中的百分位。"""
+        if not history or len(history) < 20 or not today_amount or today_amount <= 0:
+            return {"score": 50, "available": False}
+        try:
+            values = [float(v) for v in history if v is not None and v > 0]
+            if len(values) < 20:
+                return {"score": 50, "available": False}
+            below = sum(1 for v in values if v <= today_amount)
+            percentile = below / len(values)
+            return {"score": self._clamp_score(percentile * 100), "available": True}
+        except (TypeError, ValueError):
+            return {"score": 50, "available": False}
+
+    def _dimension_limit_ratio(self, limit_up: int, limit_down: int) -> Dict[str, Any]:
+        """涨停跌停比: 涨停家数 / (涨停 + 跌停)。"""
+        total = limit_up + limit_down
+        if total <= 0:
+            return {"score": 50, "available": False}
+        ratio = limit_up / total
+        return {"score": self._clamp_score(ratio * 100), "available": True}
+
+    def _dimension_continuous_board(self, height: Optional[int]) -> Dict[str, Any]:
+        """连板高度: 当日最高连板数映射到 0-100。"""
+        if not height or height <= 0:
+            return {"score": 50, "available": False}
+        # 1板=30, 2板=45, 3板=58, 4板=68, 5板=76, 6板=82, 7板=86, 8+=90
+        mapping = {1: 30, 2: 45, 3: 58, 4: 68, 5: 76, 6: 82, 7: 86}
+        score = mapping.get(height, 90) if height < 8 else 90
+        return {"score": score, "available": True}
+
 
     def _build_market_temperature(self, overview: MarketOverview) -> tuple[int, str]:
         scores = self._build_market_light_scores(overview)

--- a/src/schemas/market_light.py
+++ b/src/schemas/market_light.py
@@ -3,7 +3,7 @@
 
 from __future__ import annotations
 
-from typing import Literal
+from typing import Literal, Optional
 
 from pydantic import BaseModel, Field
 
@@ -22,11 +22,23 @@ class MarketLightDimension(BaseModel):
 
 
 class MarketLightDimensions(BaseModel):
-    """Canonical Market Light dimension scores."""
+    """Canonical Market Light dimension scores.
+
+    The three core dimensions (breadth/index/limit) are always present. The
+    five extended dimensions are optional so that snapshots persisted before
+    the extension still validate; they default to ``None`` and should be
+    treated as "unavailable" by consumers.
+    """
 
     breadth: MarketLightDimension
     index: MarketLightDimension
     limit: MarketLightDimension
+    # Extended dimensions (optional for backward compatibility with old snapshots)
+    margin_balance: Optional[MarketLightDimension] = None
+    northbound_flow: Optional[MarketLightDimension] = None
+    turnover_quantile: Optional[MarketLightDimension] = None
+    limit_ratio: Optional[MarketLightDimension] = None
+    continuous_board: Optional[MarketLightDimension] = None
 
 
 class MarketLightSnapshot(BaseModel):

--- a/src/services/market_light_alerts.py
+++ b/src/services/market_light_alerts.py
@@ -349,9 +349,24 @@ def _base_diagnostics(snapshot: MarketLightSnapshot) -> Dict[str, Any]:
     }
 
 
+_CORE_DIMENSION_NAMES = ("breadth", "index", "limit")
+
+
 def _missing_dimensions(snapshot: MarketLightSnapshot) -> list[str]:
+    """Return the core dimensions that are unavailable in the snapshot.
+
+    Only the three core dimensions (breadth/index/limit) are checked, matching
+    the ``data_quality`` semantics. Extended dimensions are optional context
+    and are not reported as missing to avoid noisy diagnostics.
+    """
     dimensions = snapshot.dimensions.model_dump()
-    return sorted(name for name, item in dimensions.items() if not item.get("available"))
+    return sorted(
+        name
+        for name in _CORE_DIMENSION_NAMES
+        if name in dimensions
+        and isinstance(dimensions[name], dict)
+        and not dimensions[name].get("available")
+    )
 
 
 def _positive_float(value: Any, field_name: str) -> float:

--- a/tests/test_market_light_extended_dimensions.py
+++ b/tests/test_market_light_extended_dimensions.py
@@ -1,0 +1,235 @@
+# -*- coding: utf-8 -*-
+"""Tests for extended Market Light dimensions (margin_balance, northbound_flow,
+turnover_quantile, limit_ratio, continuous_board).
+
+These tests verify the scoring logic and backward compatibility without
+requiring network access to akshare.
+"""
+
+from __future__ import annotations
+
+import unittest
+
+from src.config import get_config
+from src.core.market_profile import get_profile
+from src.market_analyzer import MarketAnalyzer, MarketIndex, MarketOverview
+from src.schemas.market_light import MarketLightSnapshot
+
+
+def _make_overview(**kwargs) -> MarketOverview:
+    """Build a MarketOverview with sensible defaults for dimension tests."""
+    defaults = {
+        "date": "2026-07-03",
+        "indices": [MarketIndex(code="000001", name="上证指数", current=3200, change_pct=0.5)],
+        "up_count": 2500,
+        "down_count": 2500,
+        "limit_up_count": 40,
+        "limit_down_count": 10,
+        "total_amount": 12000.0,
+    }
+    defaults.update(kwargs)
+    return MarketOverview(**defaults)
+
+
+class ExtendedDimensionsTestCase(unittest.TestCase):
+    """Test the five extended Market Light dimension scoring methods."""
+
+    def setUp(self) -> None:
+        # MarketAnalyzer only needs region/profile/config for these scoring
+        # methods; the data_manager and analyzer deps are not invoked in
+        # _build_market_light_scores.
+        self.analyzer = MarketAnalyzer.__new__(MarketAnalyzer)
+        self.analyzer.region = "cn"
+        self.analyzer.profile = get_profile("cn")
+        self.analyzer.config = get_config()
+
+    def test_margin_balance_available_when_two_values(self) -> None:
+        overview = _make_overview(
+            extended_inputs={"margin_balance_recent": [15000.0, 15300.0]}
+        )
+        scores = self.analyzer._build_market_light_scores(overview)
+        dim = scores["dimensions"]["margin_balance"]
+        self.assertTrue(dim["available"])
+        # +2% change -> 50 + 0.02*800 = 66
+        self.assertEqual(dim["score"], 66)
+
+    def test_margin_balance_unavailable_when_single_value(self) -> None:
+        overview = _make_overview(
+            extended_inputs={"margin_balance_recent": [15000.0]}
+        )
+        scores = self.analyzer._build_market_light_scores(overview)
+        dim = scores["dimensions"]["margin_balance"]
+        self.assertFalse(dim["available"])
+        self.assertEqual(dim["score"], 50)
+
+    def test_margin_balance_negative_change_scores_below_50(self) -> None:
+        overview = _make_overview(
+            extended_inputs={"margin_balance_recent": [15300.0, 15000.0]}
+        )
+        scores = self.analyzer._build_market_light_scores(overview)
+        dim = scores["dimensions"]["margin_balance"]
+        self.assertTrue(dim["available"])
+        self.assertLess(dim["score"], 50)
+
+    def test_northbound_flow_cumulative_positive(self) -> None:
+        overview = _make_overview(
+            extended_inputs={"northbound_flow_recent": [10.0, 20.0, 30.0]}
+        )
+        scores = self.analyzer._build_market_light_scores(overview)
+        dim = scores["dimensions"]["northbound_flow"]
+        self.assertTrue(dim["available"])
+        # cumulative = 60 -> 50 + 60*0.4 = 74
+        self.assertEqual(dim["score"], 74)
+
+    def test_northbound_flow_empty_returns_unavailable(self) -> None:
+        overview = _make_overview(extended_inputs={})
+        scores = self.analyzer._build_market_light_scores(overview)
+        dim = scores["dimensions"]["northbound_flow"]
+        self.assertFalse(dim["available"])
+
+    def test_turnover_quantile_percentile(self) -> None:
+        history = [float(i) for i in range(30, 90)]  # 60 values: 30..89
+        overview = _make_overview(
+            total_amount=59.0,
+            extended_inputs={"turnover_history": history},
+        )
+        scores = self.analyzer._build_market_light_scores(overview)
+        dim = scores["dimensions"]["turnover_quantile"]
+        self.assertTrue(dim["available"])
+        # values <= 59.0 are 30..59 = 30 out of 60 -> percentile 0.5 -> score 50
+        self.assertEqual(dim["score"], 50)
+
+    def test_turnover_quantile_high_percentile(self) -> None:
+        history = [float(i) for i in range(30, 90)]
+        overview = _make_overview(
+            total_amount=88.0,
+            extended_inputs={"turnover_history": history},
+        )
+        scores = self.analyzer._build_market_light_scores(overview)
+        dim = scores["dimensions"]["turnover_quantile"]
+        self.assertTrue(dim["available"])
+        self.assertGreater(dim["score"], 90)
+
+    def test_turnover_quantile_insufficient_history(self) -> None:
+        overview = _make_overview(
+            total_amount=100.0,
+            extended_inputs={"turnover_history": [10.0, 20.0, 30.0]},
+        )
+        scores = self.analyzer._build_market_light_scores(overview)
+        dim = scores["dimensions"]["turnover_quantile"]
+        self.assertFalse(dim["available"])
+
+    def test_limit_ratio_available(self) -> None:
+        overview = _make_overview(limit_up_count=60, limit_down_count=40)
+        scores = self.analyzer._build_market_light_scores(overview)
+        dim = scores["dimensions"]["limit_ratio"]
+        self.assertTrue(dim["available"])
+        self.assertEqual(dim["score"], 60)
+
+    def test_limit_ratio_no_limits_unavailable(self) -> None:
+        overview = _make_overview(limit_up_count=0, limit_down_count=0)
+        scores = self.analyzer._build_market_light_scores(overview)
+        dim = scores["dimensions"]["limit_ratio"]
+        self.assertFalse(dim["available"])
+
+    def test_continuous_board_height_mapping(self) -> None:
+        for height, expected in [(1, 30), (2, 45), (3, 58), (4, 68), (5, 76), (6, 82), (7, 86), (10, 90)]:
+            with self.subTest(height=height):
+                overview = _make_overview(
+                    extended_inputs={"continuous_board_height": height}
+                )
+                scores = self.analyzer._build_market_light_scores(overview)
+                dim = scores["dimensions"]["continuous_board"]
+                self.assertTrue(dim["available"])
+                self.assertEqual(dim["score"], expected)
+
+    def test_continuous_board_none_unavailable(self) -> None:
+        overview = _make_overview(extended_inputs={})
+        scores = self.analyzer._build_market_light_scores(overview)
+        dim = scores["dimensions"]["continuous_board"]
+        self.assertFalse(dim["available"])
+
+    def test_extended_dimensions_do_not_affect_core_score(self) -> None:
+        """The overall score must stay based on the 3 core dimensions."""
+        overview_core_only = _make_overview(extended_inputs={})
+        overview_full = _make_overview(
+            extended_inputs={
+                "margin_balance_recent": [15000.0, 15300.0],
+                "northbound_flow_recent": [10.0, 20.0, 30.0],
+                "turnover_history": [float(i) for i in range(30, 90)],
+                "continuous_board_height": 5,
+            }
+        )
+        scores_core = self.analyzer._build_market_light_scores(overview_core_only)
+        scores_full = self.analyzer._build_market_light_scores(overview_full)
+        self.assertEqual(scores_core["score"], scores_full["score"])
+        self.assertEqual(scores_core["temperature_label"], scores_full["temperature_label"])
+
+    def test_all_extended_unavailable_when_no_inputs(self) -> None:
+        overview = _make_overview(extended_inputs={})
+        scores = self.analyzer._build_market_light_scores(overview)
+        for key in ("margin_balance", "northbound_flow", "turnover_quantile", "limit_ratio", "continuous_board"):
+            # limit_ratio is derived from overview, not extended_inputs
+            dim = scores["dimensions"][key]
+            self.assertIn("available", dim)
+            self.assertIn("score", dim)
+            self.assertIsInstance(dim["score"], int)
+            self.assertTrue(0 <= dim["score"] <= 100)
+
+
+class BackwardCompatTestCase(unittest.TestCase):
+    """Old snapshots persisted with only 3 dimensions must still validate."""
+
+    def test_old_snapshot_with_three_dimensions_validates(self) -> None:
+        old_snapshot = {
+            "region": "cn",
+            "trade_date": "2026-06-01",
+            "status": "yellow",
+            "score": 50,
+            "label": "需观察",
+            "temperature_label": "震荡",
+            "reasons": ["test"],
+            "guidance": "test",
+            "dimensions": {
+                "breadth": {"score": 50, "available": True},
+                "index": {"score": 50, "available": True},
+                "limit": {"score": 50, "available": True},
+            },
+            "data_quality": "ok",
+        }
+        snapshot = MarketLightSnapshot.model_validate(old_snapshot)
+        self.assertIsNone(snapshot.dimensions.margin_balance)
+        self.assertIsNone(snapshot.dimensions.northbound_flow)
+        self.assertIsNone(snapshot.dimensions.turnover_quantile)
+        self.assertIsNone(snapshot.dimensions.limit_ratio)
+        self.assertIsNone(snapshot.dimensions.continuous_board)
+
+    def test_new_snapshot_with_all_dimensions_validates(self) -> None:
+        new_snapshot = {
+            "region": "cn",
+            "trade_date": "2026-07-03",
+            "status": "green",
+            "score": 72,
+            "label": "可进攻",
+            "temperature_label": "偏暖",
+            "reasons": ["test"],
+            "guidance": "test",
+            "dimensions": {
+                "breadth": {"score": 72, "available": True},
+                "index": {"score": 70, "available": True},
+                "limit": {"score": 80, "available": True},
+                "margin_balance": {"score": 66, "available": True},
+                "northbound_flow": {"score": 74, "available": True},
+                "turnover_quantile": {"score": 50, "available": True},
+                "limit_ratio": {"score": 80, "available": True},
+                "continuous_board": {"score": 58, "available": True},
+            },
+            "data_quality": "ok",
+        }
+        snapshot = MarketLightSnapshot.model_validate(new_snapshot)
+        self.assertEqual(snapshot.dimensions.margin_balance.score, 66)
+        self.assertEqual(snapshot.dimensions.continuous_board.score, 58)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- 扩展 `MarketLightDimensions` 新增 5 个可选情绪维度：融资融券余额变化(`margin_balance`)、北向资金方向(`northbound_flow`)、换手率分位(`turnover_quantile`)、涨停跌停比(`limit_ratio`)、连板高度(`continuous_board`)
- 新增 `data_provider/margin_flow_fetcher.py`（基于 akshare，失败优雅降级返回 None）
- 扩展维度为 `Optional`，不影响核心 score/status/data_quality，向后兼容旧 3 维度快照
- 修复 `market_light_alerts._missing_dimensions` 在 Optional 维度为 None 时的崩溃

## Test plan
- [x] `tests/test_market_light_extended_dimensions.py` — 16 tests passed
- [x] 向后兼容：3 维度旧快照可正常反序列化为 8 维度（后 5 个为 None）
- [x] 扩展维度数据不可用时 `available=False`，不影响核心评分与告警
- [x] 各维度独立计算，互不干扰
- [ ] 在线验证：`build_current_snapshot('cn')` 返回 8 维度（需网络环境）

## Notes
- 扩展维度为 Optional，旧消费方无需改动
- 数据源（akshare）失败返回 None，graceful degradation，不拖垮主流程
- 评分公式：margin=50+change_rate*800；northbound=50+cumulative*0.4；turnover=percentile*100；continuous_board 按 连板数 1-8+ 映射 30-90

## 回滚方式
revert 本 PR 即可；新增字段均为 Optional，无数据迁移风险