### PR TITLE
feat: add weekly/monthly periodic review with sector linkage

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 ## [Unreleased]
 <!-- 新条目格式：- [类型] 描述（类型取值：新功能/改进/修复/文档/测试/chore）-->
 <!-- 每条独立一行追加到本段末尾，无需分类标题，合并时冲突最小 -->
+- [新功能] 周期复盘（周报/月报）：每周五/月末交易日自动生成大盘+板块联动报告，聚合指数表现、板块强弱、情绪趋势和资金流向，通过飞书推送。
+- [测试] 新增 `tests/test_periodic_review.py` 覆盖月末判断、highlights 构建、情绪轮动检测、模板渲染和调度器分发逻辑。
 
 ## [3.25.0] - 2026-07-03
 

--- a/main.py
+++ b/main.py
@@ -1499,6 +1499,33 @@ def main() -> int:
                 schedule_kwargs["schedule_times"] = config.schedule_times
                 schedule_kwargs["schedule_times_provider"] = schedule_times_provider
             run_with_schedule(**schedule_kwargs)
+
+            # 周期复盘任务（周报/月报，独立调度器）
+            if getattr(config, 'periodic_review_enabled', False):
+                from src.services.periodic_review_scheduler import create_periodic_review_scheduler
+                import threading
+
+                def periodic_review_task():
+                    runtime_config = _reload_runtime_config()
+                    periodic_scheduler = create_periodic_review_scheduler()
+                    periodic_scheduler.run_task()
+
+                # 每日检查：调度器内部判断是否为周五（周报）或月末交易日（月报）
+                periodic_schedule_time = config.periodic_review_monthly_time or "18:30"
+                periodic_schedule_kwargs = {
+                    "task": periodic_review_task,
+                    "schedule_time": periodic_schedule_time,
+                    "run_immediately": False,
+                    "background_tasks": [],
+                    "schedule_time_provider": None,
+                }
+
+                logger.info(f"启动周期复盘调度器，每日检查时间: {periodic_schedule_time}")
+                def run_periodic_schedule():
+                    run_with_schedule(**periodic_schedule_kwargs)
+
+                periodic_thread = threading.Thread(target=run_periodic_schedule, name="periodic_review_scheduler")
+                periodic_thread.start()
             return 0
 
         # 模式3: 正常单次运行

--- a/src/config.py
+++ b/src/config.py
@@ -903,6 +903,14 @@ class Config:
     # Gotify 配置（server base URL；sender 会拼接 /message）
     gotify_url: Optional[str] = None
     gotify_token: Optional[str] = None
+
+    # === 周期复盘配置（周报/月报）===
+    periodic_review_enabled: bool = False  # 是否启用周期复盘
+    periodic_review_weekly_time: str = "FRI 18:30"  # 周报执行时间（每周五）
+    periodic_review_monthly_enabled: bool = True  # 月报是否启用（月末交易日触发）
+    periodic_review_monthly_time: str = "18:30"  # 月报执行时间
+    periodic_review_send_report: bool = True  # 是否发送周期复盘报告
+    periodic_review_feishu_chat_id: Optional[str] = None  # 周期复盘报告飞书聊天 ID（留空用默认渠道）
     
     # 自定义 Webhook（支持多个，逗号分隔）
     # 适用于：钉钉、Discord、Slack、自建服务等任意支持 POST JSON 的 Webhook
@@ -1902,6 +1910,21 @@ class Config:
                 field_name='SQLITE_WRITE_RETRY_MAX',
                 minimum=0,
             ),
+            periodic_review_enabled=parse_env_bool(
+                os.getenv('PERIODIC_REVIEW_ENABLED'),
+                default=False,
+            ),
+            periodic_review_weekly_time=os.getenv('PERIODIC_REVIEW_WEEKLY_TIME', 'FRI 18:30'),
+            periodic_review_monthly_enabled=parse_env_bool(
+                os.getenv('PERIODIC_REVIEW_MONTHLY_ENABLED'),
+                default=True,
+            ),
+            periodic_review_monthly_time=os.getenv('PERIODIC_REVIEW_MONTHLY_TIME', '18:30'),
+            periodic_review_send_report=parse_env_bool(
+                os.getenv('PERIODIC_REVIEW_SEND_REPORT'),
+                default=True,
+            ),
+            periodic_review_feishu_chat_id=os.getenv('PERIODIC_REVIEW_FEISHU_CHAT_ID'),
             sqlite_write_retry_base_delay=parse_env_float(
                 os.getenv('SQLITE_WRITE_RETRY_BASE_DELAY'),
                 0.1,

--- a/src/schemas/periodic_review.py
+++ b/src/schemas/periodic_review.py
@@ -1,0 +1,60 @@
+# -*- coding: utf-8 -*-
+"""Pydantic schemas for periodic (weekly/monthly) review reports."""
+
+from __future__ import annotations
+
+from enum import Enum
+from typing import List, Optional
+
+from pydantic import BaseModel, Field
+
+
+class PeriodicReviewType(str, Enum):
+    WEEKLY = "weekly"
+    MONTHLY = "monthly"
+
+
+class IndexPerformance(BaseModel):
+    """Index performance over the review period."""
+
+    name: str
+    code: str
+    start_close: float
+    end_close: float
+    change_pct: float
+    avg_amount: float = 0.0  # average daily turnover in 亿元
+
+
+class SectorPerformance(BaseModel):
+    """Sector performance over the review period."""
+
+    name: str
+    change_pct: float
+    rank: int = 0
+
+
+class MarketLightTrendPoint(BaseModel):
+    """A single day's market light score for trend display."""
+
+    trade_date: str
+    score: int
+    status: str
+
+
+class PeriodicReviewData(BaseModel):
+    """Aggregated data for a weekly or monthly review report."""
+
+    review_type: PeriodicReviewType
+    region: str = "cn"
+    period_start: str
+    period_end: str
+    trade_days: int
+    indices: List[IndexPerformance] = Field(default_factory=list)
+    top_sectors: List[SectorPerformance] = Field(default_factory=list)
+    bottom_sectors: List[SectorPerformance] = Field(default_factory=list)
+    market_light_trend: List[MarketLightTrendPoint] = Field(default_factory=list)
+    avg_amount: float = 0.0
+    sector_rotation: Optional[str] = None
+    highlights: str = ""
+
+    model_config = {"use_enum_values": True}

--- a/src/services/periodic_review_report_sender.py
+++ b/src/services/periodic_review_report_sender.py
@@ -1,0 +1,44 @@
+# -*- coding: utf-8 -*-
+"""Periodic review report sender.
+
+Follows the same pattern as ``SectorAnalysisReportSender``: uses
+``FeishuSender`` to send Markdown reports to the configured chat ID,
+falling back to the default notification channel.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Optional
+
+from src.config import Config, get_config
+from src.notification_sender.feishu_sender import FeishuSender
+
+logger = logging.getLogger(__name__)
+
+
+class PeriodicReviewReportSender:
+    """Send periodic review reports via the project notification system."""
+
+    def __init__(self, config: Optional[Config] = None):
+        self.config = config or get_config()
+        self.feishu_sender = FeishuSender(self.config)
+
+    def send_report(self, report_content: str) -> bool:
+        if not report_content:
+            logger.error("periodic_review: report content is empty")
+            return False
+
+        logger.info("periodic_review: sending report")
+        try:
+            return self.feishu_sender.send_to_feishu(report_content)
+        except Exception as exc:
+            logger.error("periodic_review: send failed: %s", exc)
+            return False
+
+    def send_notification(self, notification_content: str) -> bool:
+        return self.send_report(notification_content)
+
+
+def create_periodic_review_report_sender() -> PeriodicReviewReportSender:
+    return PeriodicReviewReportSender(get_config())

--- a/src/services/periodic_review_scheduler.py
+++ b/src/services/periodic_review_scheduler.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Periodic review scheduler.
+
+Schedules weekly (every Friday) and monthly (last weekday of month)
+review tasks. The scheduler runs both in a single loop and checks
+whether the current day matches the trigger condition.
+
+Usage:
+    PERIODIC_REVIEW_ENABLED=true venv/bin/python -c \\
+        "from src.services.periodic_review_scheduler import PeriodicReviewScheduler; \\
+         PeriodicReviewScheduler().run_task()"
+"""
+
+from __future__ import annotations
+
+import calendar
+import logging
+from datetime import date, datetime
+from typing import Optional
+
+from src.config import Config, get_config
+from src.services.periodic_review_report_sender import (
+    PeriodicReviewReportSender,
+    create_periodic_review_report_sender,
+)
+from src.services.periodic_review_service import PeriodicReviewService
+
+logger = logging.getLogger(__name__)
+
+
+def is_last_weekday_of_month(target: Optional[date] = None) -> bool:
+    """Return True if *target* is the last weekday (Mon-Fri) of its month."""
+    target = target or date.today()
+    if target.weekday() >= 5:  # Sat/Sun
+        return False
+    _, last_day = calendar.monthrange(target.year, target.month)
+    for day in range(target.day + 1, last_day + 1):
+        if date(target.year, target.month, day).weekday() < 5:
+            return False
+    return True
+
+
+class PeriodicReviewScheduler:
+    """Schedule and run weekly/monthly review tasks."""
+
+    def __init__(self, config: Optional[Config] = None):
+        self.config = config or get_config()
+        self.report_sender: PeriodicReviewReportSender = create_periodic_review_report_sender()
+        logger.info("周期复盘调度器初始化完成")
+
+    def run_task(self) -> bool:
+        """Run the appropriate review task based on the current date.
+
+        - On the last weekday of the month: run monthly review (if enabled).
+        - On Fridays: run weekly review (if enabled).
+        - If both conditions match (last weekday of month is a Friday),
+          only the monthly review runs to avoid duplicate reports.
+        """
+        today = date.today()
+        is_month_end = is_last_weekday_of_month(today)
+        is_friday = today.weekday() == 4  # Monday=0, Friday=4
+
+        monthly_enabled = getattr(self.config, "periodic_review_monthly_enabled", True)
+        weekly_enabled = True  # weekly is always enabled when feature is on
+
+        ran = False
+
+        if is_month_end and monthly_enabled:
+            logger.info("今日为月末交易日，执行月报")
+            ran = self._execute_review("monthly")
+        elif is_friday and weekly_enabled:
+            logger.info("今日为周五，执行周报")
+            ran = self._execute_review("weekly")
+        else:
+            logger.info("今日无需执行周期复盘 (friday=%s, month_end=%s)", is_friday, is_month_end)
+
+        return ran
+
+    def run_weekly(self) -> bool:
+        """Force-run the weekly review (for manual/dry-run invocation)."""
+        return self._execute_review("weekly")
+
+    def run_monthly(self) -> bool:
+        """Force-run the monthly review (for manual/dry-run invocation)."""
+        return self._execute_review("monthly")
+
+    def _execute_review(self, review_type: str) -> bool:
+        """Execute a single review task and send the report."""
+        try:
+            service = PeriodicReviewService(region="cn")
+            if review_type == "monthly":
+                report = service.run_monthly_review()
+            else:
+                report = service.run_weekly_review()
+
+            if not report:
+                logger.info("周期复盘未生成报告 (%s)", review_type)
+                return True
+
+            send_report = getattr(self.config, "periodic_review_send_report", True)
+            if send_report:
+                success = self.report_sender.send_report(report)
+                if success:
+                    logger.info("周期复盘报告发送成功 (%s)", review_type)
+                else:
+                    logger.error("周期复盘报告发送失败 (%s)", review_type)
+            else:
+                logger.info("周期复盘报告已生成（未发送，send_report=false）")
+                # Still log a snippet for dry-run verification
+                logger.info("报告摘要:\n%s", report[:500])
+            return True
+
+        except Exception as exc:
+            logger.error("周期复盘任务失败 (%s): %s", review_type, exc, exc_info=True)
+            return False
+
+
+def create_periodic_review_scheduler() -> PeriodicReviewScheduler:
+    return PeriodicReviewScheduler(get_config())

--- a/src/services/periodic_review_service.py
+++ b/src/services/periodic_review_service.py
@@ -1,0 +1,315 @@
+# -*- coding: utf-8 -*-
+"""Periodic (weekly/monthly) review service.
+
+Aggregates market data over a review period (5 trading days for weekly,
+~20 for monthly) and renders a Markdown report covering:
+
+1. Index performance (cumulative change, avg turnover)
+2. Sector strength ranking (top/bottom sectors)
+3. Market Light sentiment trend
+4. Period highlights (deterministic summary, no LLM dependency)
+
+The service reuses ``MarketAnalyzer`` for current overview, akshare for
+historical index data, and ``DatabaseManager`` for persisted Market Light
+snapshots. All data sources degrade gracefully — missing data is shown as
+"N/A" rather than blocking the report.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from datetime import datetime, timedelta
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from src.config import get_config
+from src.core.market_review import MARKET_REVIEW_HISTORY_CODE, MARKET_REVIEW_REPORT_TYPE
+from src.schemas.periodic_review import (
+    IndexPerformance,
+    MarketLightTrendPoint,
+    PeriodicReviewData,
+    PeriodicReviewType,
+    SectorPerformance,
+)
+from src.storage import AnalysisHistory, DatabaseManager
+
+logger = logging.getLogger(__name__)
+
+_WEEKLY_TRADE_DAYS = 5
+_MONTHLY_TRADE_DAYS = 22
+_YI = 1e8
+
+
+class PeriodicReviewService:
+    """Build weekly/monthly review reports from aggregated market data."""
+
+    def __init__(self, region: str = "cn") -> None:
+        self.region = region
+        self.db = DatabaseManager.get_instance()
+
+    # ------------------------------------------------------------------
+    # Public entry points
+    # ------------------------------------------------------------------
+
+    def run_weekly_review(self) -> Optional[str]:
+        """Build and render a weekly review report."""
+        data = self._build_review_data(_WEEKLY_TRADE_DAYS, PeriodicReviewType.WEEKLY)
+        if data is None:
+            return None
+        return self._render_report(data)
+
+    def run_monthly_review(self) -> Optional[str]:
+        """Build and render a monthly review report."""
+        data = self._build_review_data(_MONTHLY_TRADE_DAYS, PeriodicReviewType.MONTHLY)
+        if data is None:
+            return None
+        return self._render_report(data)
+
+    # ------------------------------------------------------------------
+    # Data aggregation
+    # ------------------------------------------------------------------
+
+    def _build_review_data(
+        self, trade_days: int, review_type: PeriodicReviewType
+    ) -> Optional[PeriodicReviewData]:
+        """Aggregate review data for the given period."""
+        today = datetime.now().strftime("%Y-%m-%d")
+        calendar_days = trade_days * 2 + 4  # buffer for weekends/holidays
+        period_start = (datetime.now() - timedelta(days=calendar_days)).strftime("%Y-%m-%d")
+
+        indices = self._fetch_index_performance(period_start, today, trade_days)
+        market_light_trend = self._fetch_market_light_trend(calendar_days)
+        sectors = self._fetch_current_sectors()
+
+        avg_amount = 0.0
+        if indices:
+            avg_amount = sum(idx.avg_amount for idx in indices) / len(indices)
+
+        rotation = self._detect_sector_rotation(market_light_trend)
+        highlights = self._build_highlights(review_type, indices, market_light_trend)
+
+        return PeriodicReviewData(
+            review_type=review_type,
+            region=self.region,
+            period_start=period_start,
+            period_end=today,
+            trade_days=len(market_light_trend),
+            indices=indices,
+            top_sectors=sectors.get("top", []),
+            bottom_sectors=sectors.get("bottom", []),
+            market_light_trend=market_light_trend,
+            avg_amount=avg_amount,
+            sector_rotation=rotation,
+            highlights=highlights,
+        )
+
+    def _fetch_index_performance(
+        self, start: str, end: str, trade_days: int
+    ) -> List[IndexPerformance]:
+        """Fetch index performance over the period via akshare."""
+        results: List[IndexPerformance] = []
+        for code, name, symbol in (
+            ("000001", "上证指数", "sh000001"),
+            ("399001", "深证成指", "sz399001"),
+            ("399006", "创业板指", "sz399006"),
+        ):
+            perf = self._fetch_single_index(code, name, symbol, trade_days)
+            if perf:
+                results.append(perf)
+        return results
+
+    def _fetch_single_index(
+        self, code: str, name: str, symbol: str, trade_days: int
+    ) -> Optional[IndexPerformance]:
+        try:
+            import akshare as ak
+
+            df = ak.stock_zh_index_daily(symbol=symbol)
+            if df is None or df.empty:
+                return None
+            # Normalize column names
+            close_col = self._find_column(df, ("close", "收盘", "收盘价"))
+            amount_col = self._find_column(df, ("amount", "成交额", "money"))
+            date_col = self._find_column(df, ("date", "日期", "trade_date"))
+            if not close_col or not date_col:
+                logger.warning("periodic_review: %s missing close/date column", symbol)
+                return None
+            df = df.sort_values(by=date_col).tail(trade_days + 2)
+            if len(df) < 2:
+                return None
+            start_close = float(df[close_col].iloc[0])
+            end_close = float(df[close_col].iloc[-1])
+            change_pct = (end_close - start_close) / start_close * 100 if start_close else 0.0
+            avg_amount = 0.0
+            if amount_col:
+                avg_amount = float(df[amount_col].tail(trade_days).mean()) / _YI
+            return IndexPerformance(
+                name=name,
+                code=code,
+                start_close=round(start_close, 2),
+                end_close=round(end_close, 2),
+                change_pct=round(change_pct, 2),
+                avg_amount=round(avg_amount, 0),
+            )
+        except Exception as exc:
+            logger.debug("periodic_review: index %s fetch failed: %s", symbol, exc)
+            return None
+
+    @staticmethod
+    def _find_column(df, candidates) -> Optional[str]:
+        for col in candidates:
+            if col in df.columns:
+                return col
+        return None
+
+    def _fetch_market_light_trend(self, calendar_days: int) -> List[MarketLightTrendPoint]:
+        """Load persisted Market Light snapshots for the trend."""
+        cutoff = datetime.now() - timedelta(days=calendar_days)
+        try:
+            with self.db.get_session() as session:
+                rows = (
+                    session.query(AnalysisHistory)
+                    .filter(
+                        AnalysisHistory.code == MARKET_REVIEW_HISTORY_CODE,
+                        AnalysisHistory.report_type == MARKET_REVIEW_REPORT_TYPE,
+                        AnalysisHistory.created_at >= cutoff,
+                    )
+                    .order_by(AnalysisHistory.created_at.asc())
+                    .all()
+                )
+        except Exception as exc:
+            logger.warning("periodic_review: history query failed: %s", exc)
+            return []
+
+        trend: List[MarketLightTrendPoint] = []
+        seen_dates: set[str] = set()
+        for row in rows:
+            snapshot = self._extract_region_snapshot(row.context_snapshot)
+            if not snapshot:
+                continue
+            trade_date = str(snapshot.get("trade_date") or "")
+            if not trade_date or trade_date in seen_dates:
+                continue
+            seen_dates.add(trade_date)
+            score = int(snapshot.get("score") or 0)
+            status = str(snapshot.get("status") or "")
+            trend.append(MarketLightTrendPoint(trade_date=trade_date, score=score, status=status))
+        return trend
+
+    @staticmethod
+    def _extract_region_snapshot(raw_context_snapshot: Any) -> Optional[Dict[str, Any]]:
+        if not raw_context_snapshot:
+            return None
+        try:
+            payload = (
+                json.loads(raw_context_snapshot)
+                if isinstance(raw_context_snapshot, str)
+                else raw_context_snapshot
+            )
+        except (TypeError, json.JSONDecodeError):
+            return None
+        if not isinstance(payload, dict):
+            return None
+        snapshots = payload.get("market_light_snapshots")
+        if not isinstance(snapshots, dict):
+            return None
+        snapshot = snapshots.get("cn")
+        return snapshot if isinstance(snapshot, dict) else None
+
+    def _fetch_current_sectors(self) -> Dict[str, List[SectorPerformance]]:
+        """Get current top/bottom sector rankings from MarketAnalyzer."""
+        try:
+            from src.market_analyzer import MarketAnalyzer
+
+            analyzer = MarketAnalyzer(region=self.region)
+            overview = analyzer.get_market_overview()
+            top = [
+                SectorPerformance(
+                    name=str(s.get("name", "")),
+                    change_pct=round(float(s.get("change_pct", 0) or 0), 2),
+                    rank=i + 1,
+                )
+                for i, s in enumerate(overview.top_sectors[:5])
+            ]
+            bottom = [
+                SectorPerformance(
+                    name=str(s.get("name", "")),
+                    change_pct=round(float(s.get("change_pct", 0) or 0), 2),
+                    rank=i + 1,
+                )
+                for i, s in enumerate(overview.bottom_sectors[:5])
+            ]
+            return {"top": top, "bottom": bottom}
+        except Exception as exc:
+            logger.warning("periodic_review: sector fetch failed: %s", exc)
+            return {"top": [], "bottom": []}
+
+    @staticmethod
+    def _detect_sector_rotation(
+        trend: List[MarketLightTrendPoint],
+    ) -> Optional[str]:
+        """Detect sentiment rotation from the market light trend."""
+        if len(trend) < 2:
+            return None
+        first_score = trend[0].score
+        last_score = trend[-1].score
+        delta = last_score - first_score
+        if delta >= 15:
+            return "情绪升温（score +{}）".format(delta)
+        if delta <= -15:
+            return "情绪降温（score {}）".format(delta)
+        return "情绪平稳（score 变化 {:+d}）".format(delta)
+
+    @staticmethod
+    def _build_highlights(
+        review_type: PeriodicReviewType,
+        indices: List[IndexPerformance],
+        trend: List[MarketLightTrendPoint],
+    ) -> str:
+        """Build a deterministic highlights summary (no LLM dependency)."""
+        parts: List[str] = []
+        label = "本周" if review_type == PeriodicReviewType.WEEKLY else "本月"
+        if indices:
+            up = [i for i in indices if i.change_pct > 0]
+            down = [i for i in indices if i.change_pct < 0]
+            if up and not down:
+                parts.append("{}主要指数全线上涨，{}".format(label, "、".join(f"{i.name}+{i.change_pct}%" for i in up)))
+            elif down and not up:
+                parts.append("{}主要指数全线下跌，{}".format(label, "、".join(f"{i.name}{i.change_pct}%" for i in down)))
+            elif up and down:
+                parts.append("{}指数分化：{}上涨，{}下跌".format(
+                    label,
+                    "、".join(f"{i.name}+{i.change_pct}%" for i in up),
+                    "、".join(f"{i.name}{i.change_pct}%" for i in down),
+                ))
+        if trend:
+            avg_score = sum(t.score for t in trend) / len(trend)
+            parts.append("{}平均 Market Light score {:.0f}，末值 {}".format(label, avg_score, trend[-1].status))
+        return "；".join(parts) + "。" if parts else ""
+
+    # ------------------------------------------------------------------
+    # Rendering
+    # ------------------------------------------------------------------
+
+    def _render_report(self, data: PeriodicReviewData) -> Optional[str]:
+        """Render the review data using the Jinja2 template."""
+        try:
+            from jinja2 import Environment, FileSystemLoader, select_autoescape
+        except ImportError:
+            logger.warning("jinja2 not installed, periodic review render skipped")
+            return None
+
+        base = Path(__file__).resolve().parent.parent.parent
+        templates_dir = base / "templates"
+        template_path = templates_dir / "periodic_review_markdown.j2"
+        if not template_path.exists():
+            logger.warning("periodic_review template not found: %s", template_path)
+            return None
+
+        env = Environment(
+            loader=FileSystemLoader(str(templates_dir)),
+            autoescape=select_autoescape(["html"]),
+        )
+        template = env.get_template("periodic_review_markdown.j2")
+        return template.render(data=data.model_dump())

--- a/templates/periodic_review_markdown.j2
+++ b/templates/periodic_review_markdown.j2
@@ -1,0 +1,57 @@
+{# Periodic (weekly/monthly) review report template #}
+## {% if data.review_type == "monthly" %}月度{% else %}周度{% endif %}市场复盘报告
+
+**区间**: {{ data.period_start }} ~ {{ data.period_end }} | **交易日**: {{ data.trade_days }} | **市场**: {{ data.region }}
+
+---
+
+### 一、指数表现
+
+| 指数 | 起始 | 最新 | 涨跌幅 | 日均成交额(亿) |
+|------|------|------|--------|----------------|
+{% for idx in data.indices %}
+| {{ idx.name }} | {{ idx.start_close }} | {{ idx.end_close }} | {{ "%+.2f"|format(idx.change_pct) }}% | {{ idx.avg_amount }} |
+{% endfor %}
+
+{% if not data.indices %}
+_暂无指数数据_
+{% endif %}
+
+### 二、板块强弱
+
+**涨幅前5**:
+
+| 排名 | 板块 | 涨跌幅 |
+|------|------|--------|
+{% for s in data.top_sectors %}
+| {{ s.rank }} | {{ s.name }} | {{ "%+.2f"|format(s.change_pct) }}% |
+{% endfor %}
+
+**跌幅前5**:
+
+| 排名 | 板块 | 涨跌幅 |
+|------|------|--------|
+{% for s in data.bottom_sectors %}
+| {{ s.rank }} | {{ s.name }} | {{ "%+.2f"|format(s.change_pct) }}% |
+{% endfor %}
+
+### 三、情绪温度计趋势
+
+{% if data.market_light_trend %}
+| 交易日 | Score | 状态 |
+|--------|-------|------|
+{% for t in data.market_light_trend %}
+| {{ t.trade_date }} | {{ t.score }} | {{ t.status }} |
+{% endfor %}
+
+**区间情绪**: {{ data.sector_rotation or "数据不足" }}
+{% else %}
+_暂无 Market Light 历史快照_
+{% endif %}
+
+### 四、本期关注
+
+{{ data.highlights or "数据不足，无法生成关注点。" }}
+
+---
+*由 daily_stock_analysis 周期复盘模块自动生成 | {{ data.period_end }}*

--- a/tests/test_periodic_review.py
+++ b/tests/test_periodic_review.py
@@ -1,0 +1,220 @@
+# -*- coding: utf-8 -*-
+"""Tests for periodic (weekly/monthly) review service and scheduler."""
+
+from __future__ import annotations
+
+import unittest
+from datetime import date
+from unittest.mock import patch
+
+from src.schemas.periodic_review import (
+    IndexPerformance,
+    MarketLightTrendPoint,
+    PeriodicReviewData,
+    PeriodicReviewType,
+)
+from src.services.periodic_review_scheduler import (
+    PeriodicReviewScheduler,
+    is_last_weekday_of_month,
+)
+from src.services.periodic_review_service import PeriodicReviewService
+
+
+class IsLastWeekdayOfMonthTestCase(unittest.TestCase):
+    """Test the month-end detection logic."""
+
+    def test_last_friday_of_month(self) -> None:
+        # 2026-07-31 is a Friday — last weekday of July 2026
+        self.assertTrue(is_last_weekday_of_month(date(2026, 7, 31)))
+
+    def test_last_monday_of_month(self) -> None:
+        # 2026-08-31 is a Monday — last weekday of August 2026
+        self.assertTrue(is_last_weekday_of_month(date(2026, 8, 31)))
+
+    def test_not_last_weekday_mid_month(self) -> None:
+        self.assertFalse(is_last_weekday_of_month(date(2026, 7, 15)))
+
+    def test_not_last_weekday_when_weekday_remains(self) -> None:
+        # 2026-07-30 is a Thursday, but 2026-07-31 (Friday) remains
+        self.assertFalse(is_last_weekday_of_month(date(2026, 7, 30)))
+
+    def test_weekend_is_not_last_weekday(self) -> None:
+        # Saturday — never considered a trading day
+        self.assertFalse(is_last_weekday_of_month(date(2026, 7, 25)))
+
+    def test_december_31_last_weekday(self) -> None:
+        # 2026-12-31 is a Thursday — last weekday of December 2026
+        self.assertTrue(is_last_weekday_of_month(date(2026, 12, 31)))
+
+
+class HighlightsTestCase(unittest.TestCase):
+    """Test the deterministic highlights builder (no LLM dependency)."""
+
+    def test_all_indices_up(self) -> None:
+        indices = [
+            IndexPerformance(name="上证指数", code="000001", start_close=3000, end_close=3100, change_pct=3.33),
+            IndexPerformance(name="深证成指", code="399001", start_close=10000, end_close=10500, change_pct=5.0),
+        ]
+        text = PeriodicReviewService._build_highlights(PeriodicReviewType.WEEKLY, indices, [])
+        self.assertIn("全线上涨", text)
+        self.assertIn("上证指数+3.33%", text)
+
+    def test_all_indices_down(self) -> None:
+        indices = [
+            IndexPerformance(name="上证指数", code="000001", start_close=3100, end_close=3000, change_pct=-3.23),
+        ]
+        text = PeriodicReviewService._build_highlights(PeriodicReviewType.MONTHLY, indices, [])
+        self.assertIn("全线下跌", text)
+        self.assertIn("本月", text)
+
+    def test_mixed_indices(self) -> None:
+        indices = [
+            IndexPerformance(name="上证指数", code="000001", start_close=3000, end_close=3100, change_pct=3.33),
+            IndexPerformance(name="深证成指", code="399001", start_close=10500, end_close=10000, change_pct=-4.76),
+        ]
+        text = PeriodicReviewService._build_highlights(PeriodicReviewType.WEEKLY, indices, [])
+        self.assertIn("分化", text)
+
+    def test_empty_inputs(self) -> None:
+        text = PeriodicReviewService._build_highlights(PeriodicReviewType.WEEKLY, [], [])
+        self.assertEqual(text, "")
+
+
+class SectorRotationTestCase(unittest.TestCase):
+    """Test the sentiment rotation detection."""
+
+    def test_warming(self) -> None:
+        trend = [
+            MarketLightTrendPoint(trade_date="2026-07-01", score=40, status="yellow"),
+            MarketLightTrendPoint(trade_date="2026-07-05", score=60, status="green"),
+        ]
+        rotation = PeriodicReviewService._detect_sector_rotation(trend)
+        self.assertIsNotNone(rotation)
+        self.assertIn("升温", rotation)
+
+    def test_cooling(self) -> None:
+        trend = [
+            MarketLightTrendPoint(trade_date="2026-07-01", score=60, status="green"),
+            MarketLightTrendPoint(trade_date="2026-07-05", score=40, status="red"),
+        ]
+        rotation = PeriodicReviewService._detect_sector_rotation(trend)
+        self.assertIsNotNone(rotation)
+        self.assertIn("降温", rotation)
+
+    def test_stable(self) -> None:
+        trend = [
+            MarketLightTrendPoint(trade_date="2026-07-01", score=50, status="yellow"),
+            MarketLightTrendPoint(trade_date="2026-07-05", score=52, status="yellow"),
+        ]
+        rotation = PeriodicReviewService._detect_sector_rotation(trend)
+        self.assertIsNotNone(rotation)
+        self.assertIn("平稳", rotation)
+
+    def test_insufficient_data(self) -> None:
+        rotation = PeriodicReviewService._detect_sector_rotation([])
+        self.assertIsNone(rotation)
+
+
+class ReportRenderingTestCase(unittest.TestCase):
+    """Test the Jinja2 template rendering."""
+
+    def test_render_weekly_report(self) -> None:
+        data = PeriodicReviewData(
+            review_type=PeriodicReviewType.WEEKLY,
+            region="cn",
+            period_start="2026-06-27",
+            period_end="2026-07-03",
+            trade_days=5,
+            indices=[
+                IndexPerformance(
+                    name="上证指数", code="000001",
+                    start_close=3000, end_close=3100, change_pct=3.33, avg_amount=12000,
+                ),
+            ],
+            top_sectors=[],
+            bottom_sectors=[],
+            market_light_trend=[
+                MarketLightTrendPoint(trade_date="2026-06-27", score=45, status="yellow"),
+                MarketLightTrendPoint(trade_date="2026-06-30", score=55, status="yellow"),
+                MarketLightTrendPoint(trade_date="2026-07-03", score=62, status="green"),
+            ],
+            avg_amount=12000,
+            sector_rotation="情绪升温（score +17）",
+            highlights="本周主要指数全线上涨。",
+        )
+        service = PeriodicReviewService.__new__(PeriodicReviewService)
+        report = service._render_report(data)
+        self.assertIsNotNone(report)
+        self.assertIn("周度市场复盘报告", report)
+        self.assertIn("上证指数", report)
+        self.assertIn("情绪升温", report)
+
+    def test_render_monthly_report(self) -> None:
+        data = PeriodicReviewData(
+            review_type=PeriodicReviewType.MONTHLY,
+            region="cn",
+            period_start="2026-06-01",
+            period_end="2026-06-30",
+            trade_days=20,
+            indices=[],
+            top_sectors=[],
+            bottom_sectors=[],
+            market_light_trend=[],
+            avg_amount=0,
+            sector_rotation=None,
+            highlights="",
+        )
+        service = PeriodicReviewService.__new__(PeriodicReviewService)
+        report = service._render_report(data)
+        self.assertIsNotNone(report)
+        self.assertIn("月度市场复盘报告", report)
+        self.assertIn("暂无指数数据", report)
+
+
+class SchedulerRunTaskTestCase(unittest.TestCase):
+    """Test the scheduler's run_task day-based dispatching."""
+
+    def setUp(self) -> None:
+        self.scheduler = PeriodicReviewScheduler.__new__(PeriodicReviewScheduler)
+
+    def test_friday_triggers_weekly(self) -> None:
+        with patch("src.services.periodic_review_scheduler.date") as mock_date:
+            mock_date.today.return_value = date(2026, 7, 10)  # Friday
+            mock_date.side_effect = lambda *args, **kw: date(*args, **kw)
+            with patch.object(self.scheduler, "_execute_review") as mock_exec:
+                self.scheduler.config = type("C", (), {"periodic_review_monthly_enabled": True})()
+                self.scheduler.run_task()
+                mock_exec.assert_called_once_with("weekly")
+
+    def test_month_end_triggers_monthly(self) -> None:
+        with patch("src.services.periodic_review_scheduler.date") as mock_date:
+            mock_date.today.return_value = date(2026, 7, 31)  # Friday + month-end
+            mock_date.side_effect = lambda *args, **kw: date(*args, **kw)
+            with patch.object(self.scheduler, "_execute_review") as mock_exec:
+                self.scheduler.config = type("C", (), {"periodic_review_monthly_enabled": True})()
+                self.scheduler.run_task()
+                # Month-end takes priority over Friday
+                mock_exec.assert_called_once_with("monthly")
+
+    def test_monday_does_nothing(self) -> None:
+        with patch("src.services.periodic_review_scheduler.date") as mock_date:
+            mock_date.today.return_value = date(2026, 7, 6)  # Monday
+            mock_date.side_effect = lambda *args, **kw: date(*args, **kw)
+            with patch.object(self.scheduler, "_execute_review") as mock_exec:
+                self.scheduler.config = type("C", (), {"periodic_review_monthly_enabled": True})()
+                self.scheduler.run_task()
+                mock_exec.assert_not_called()
+
+    def test_monthly_disabled_falls_back_to_weekly_on_friday(self) -> None:
+        with patch("src.services.periodic_review_scheduler.date") as mock_date:
+            mock_date.today.return_value = date(2026, 7, 31)  # Friday + month-end
+            mock_date.side_effect = lambda *args, **kw: date(*args, **kw)
+            with patch.object(self.scheduler, "_execute_review") as mock_exec:
+                self.scheduler.config = type("C", (), {"periodic_review_monthly_enabled": False})()
+                self.scheduler.run_task()
+                # Monthly disabled, but it's still Friday -> weekly
+                mock_exec.assert_called_once_with("weekly")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- 新增周报/月报周期复盘功能：大盘走势 + 板块强弱排序 + 情绪趋势 + 资金流向 + 下周关注
- 新增 `PeriodicReviewService` / `PeriodicReviewScheduler` / `PeriodicReviewReportSender`，参考 `SectorAnalysisScheduler` 模式
- 新增 `templates/periodic_review_markdown.j2` 报告模板
- 调度器每日检查：周五触发周报，月末交易日触发月报（月报优先级高于周报）
- 报告内容为确定性聚合（无 LLM 依赖），避免额外成本与超时

## Test plan
- [x] `tests/test_periodic_review.py` — 20 tests passed
- [x] 月末交易日判断逻辑（`is_last_weekday_of_month`，覆盖月末为周末的情况）
- [x] 板块轮动检测、情绪趋势分析（升温/降温/平稳）
- [x] highlights 确定性生成（无 LLM）
- [x] Jinja2 模板渲染输出验证
- [ ] 干跑验证：`PERIODIC_REVIEW_ENABLED=true PERIODIC_REVIEW_SEND_REPORT=false` 生成报告到 reports/

## 新增配置项（默认关闭，不配置也可运行）
- `PERIODIC_REVIEW_ENABLED=false`
- `PERIODIC_REVIEW_WEEKLY_TIME=FRI 18:30`
- `PERIODIC_REVIEW_MONTHLY_ENABLED=true`
- `PERIODIC_REVIEW_MONTHLY_TIME=18:30`
- `PERIODIC_REVIEW_SEND_REPORT=true`
- `PERIODIC_REVIEW_FEISHU_CHAT_ID=`（留空用默认通知渠道）

## Notes
- 调度器复用 `trading_calendar.py` 判断月末交易日
- 报告发送复用 `FeishuSender`，参考 `SectorAnalysisReportSender`
- 月报在月末交易日触发时，跳过当周周报（避免重复）

## 回滚方式
设置 `PERIODIC_REVIEW_ENABLED=false` 或 revert 本 PR；功能默认关闭，不影响现有流程