### PR TITLE
feat: add opt-in intelligence auto fetch (#1913)

### DIFF
--- a/.agents/skills/analyze-issue/SKILL.md
+++ b/.agents/skills/analyze-issue/SKILL.md
@@ -1,0 +1,143 @@
+# Analyze Issue
+
+分析 GitHub Issue，判断其真实性、优先级、仓库责任边界与建议动作。
+
+**Repository**: https://github.com/ZhuLinsen/daily_stock_analysis/issues
+
+## Usage
+
+```text
+/analyze-issue <issue_number>
+```
+
+## Instructions
+
+分析时使用简洁中文，优先遵循仓库根目录 `AGENTS.md`。
+
+### Step 1: 同步最新代码基线
+
+分析 issue 前必须先刷新远端状态，并尽量把本地安全推进到最新基线：
+
+```bash
+git status --short
+git fetch --all --prune
+# 仅当工作区干净且当前分支可 fast-forward 时执行：
+git pull --ff-only
+```
+
+- 只有在工作区干净、当前分支有可 fast-forward 的上游时，才执行并接受 `git pull --ff-only` 的结果。
+- 如存在本地改动、冲突状态、未跟踪风险文件、无上游分支或无法 fast-forward，不要执行 `stash`、`reset`、强制切分支或覆盖本地状态；改用已 fetch 的 `origin/main` 或相关远端 refs 做分析。
+- 在输出文档的 `Evidence` 中记录同步结果：本地 HEAD、使用的远端基线，以及未更新本地工作树的原因（如有）。
+
+### Step 2: 拉取 Issue 信息
+
+```bash
+gh issue view <issue_number> --repo ZhuLinsen/daily_stock_analysis
+gh issue view <issue_number> --repo ZhuLinsen/daily_stock_analysis --comments
+```
+
+如为 bug，优先核对 issue 模板中是否提供了以下信息：
+
+- 是否已同步到最新版本
+- commit hash / 版本基线
+- 运行环境与复现步骤
+- 日志或报错信息
+
+### Step 3: 回答 4 个核心问题
+
+1. 版本是否明确
+2. 问题是否真实且可验证
+3. 是否属于仓库责任边界
+4. 是否值得立即处理
+
+### Step 4: 结合仓库现状做证据检查
+
+- 阅读相关代码、配置、测试、脚本、工作流与文档
+- 如果问题涉及 API、数据源 fallback、报告生成、通知发送、认证、桌面端、发布流程，明确写出影响面
+- 判断是实际 bug、环境配置问题、使用方式问题、还是外部依赖问题
+- 如怀疑已被修复，检查当前代码而不是只看 issue 描述
+
+### Step 5: 形成结论
+
+至少给出以下字段：
+
+- `版本基线`：最新 / 非最新 / 未提供
+- `是否合理`：是/否 + 理由
+- `是否是 issue`：是/否 + 理由
+- `是否好解决`：是/否 + 难点
+- `结论`：`成立 / 部分成立 / 不成立`
+- `分类`：`bug / feature / docs / question / external`
+- `优先级`：`P0 / P1 / P2 / P3`
+- `难度`：`easy / medium / hard`
+- `建议动作`：`立即修复 / 排期修复 / 文档澄清 / 关闭`
+
+### Step 6: 生成分析文档
+
+保存到 `.Codex/reviews/issues/issue-<number>.md`
+
+## Output Document Format
+
+```markdown
+# Issue #<number> Analysis
+
+**Date**: YYYY-MM-DD
+**Status**: Pending Review
+
+## Summary
+
+- 版本基线：
+- 是否合理：
+- 是否是 issue：
+- 是否好解决：
+- 结论：
+- 分类：
+- 优先级：
+- 难度：
+- 建议动作：
+
+## Evidence
+
+- 代码同步基线：
+- 关键 issue 信息：
+- 关键代码/脚本/工作流证据：
+
+## Impact Scope
+
+- 受影响模块：
+- 受影响运行路径（本地 / Docker / GitHub Actions / API / Web / Desktop）：
+
+## Root Cause / Main Reasoning
+
+<根因或主要判断依据>
+
+## Proposed Handling
+
+<建议修复、澄清或关闭方式>
+
+若建议后续创建 PR，给出的 PR title 建议符合 `AGENTS.md`：使用 `<类型>: <修改内容>`，不添加 `[codex]`、`codex`、`autocode`、`copilot` 或其他工具/agent 来源前缀；该约定仅用于协作一致性提醒，不应单独作为 review process blocker。
+
+## Risks And Rollback
+
+- 风险点：
+- 若修复，回滚方式：
+
+## Draft Reply
+
+<建议回复内容>
+```
+
+## Allowed Auto-Actions (No Confirmation Needed)
+
+- 拉取 issue 详情与评论
+- 执行 `git fetch --all --prune`，并在工作区干净且可 fast-forward 时执行 `git pull --ff-only`
+- 阅读相关代码、配置、脚本、工作流和文档
+- 生成分析文档
+
+## Actions Requiring Confirmation
+
+执行以下动作前，先询问用户：
+
+1. 添加或修改标签
+2. 在 issue 下评论
+3. 关闭 issue
+4. 开始修复 issue

--- a/.agents/skills/analyze-pr/SKILL.md
+++ b/.agents/skills/analyze-pr/SKILL.md
@@ -1,0 +1,161 @@
+# Analyze PR
+
+分析 GitHub Pull Request，评估必要性、描述完整性、验证证据、主要风险与是否可直接合入。
+
+**Repository**: https://github.com/ZhuLinsen/daily_stock_analysis/pulls
+
+## Usage
+
+```text
+/analyze-pr <pr_number>
+```
+
+## Instructions
+
+分析时使用简洁中文，优先遵循仓库根目录 `AGENTS.md` 和 `.github/PULL_REQUEST_TEMPLATE.md`。
+
+### Step 1: 同步最新代码基线
+
+分析 PR 前必须先刷新远端状态，并尽量把本地安全推进到最新基线：
+
+```bash
+git status --short
+git fetch --all --prune
+# 仅当工作区干净且当前分支可 fast-forward 时执行：
+git pull --ff-only
+```
+
+- 只有在工作区干净、当前分支有可 fast-forward 的上游时，才执行并接受 `git pull --ff-only` 的结果。
+- 如存在本地改动、冲突状态、未跟踪风险文件、无上游分支或无法 fast-forward，不要执行 `stash`、`reset`、强制切分支或覆盖本地状态；改用已 fetch 的 `origin/main`、PR head 或 GitHub diff 做分析。
+- 在输出文档的 `Validation Evidence` 中记录同步结果：本地 HEAD、使用的远端基线，以及未更新本地工作树的原因（如有）。
+
+### Step 2: 拉取 PR 基本信息
+
+```bash
+gh pr view <pr_number> --repo ZhuLinsen/daily_stock_analysis
+gh pr view <pr_number> --repo ZhuLinsen/daily_stock_analysis --comments
+gh pr checks <pr_number> --repo ZhuLinsen/daily_stock_analysis
+gh pr diff <pr_number> --repo ZhuLinsen/daily_stock_analysis
+```
+
+如有失败的 CI，优先查看失败日志，而不是立刻在本地重跑全部检查：
+
+```bash
+gh run view <run_id> --log-failed
+```
+
+### Step 3: 检查标题与描述完整性
+
+先检查 PR title 是否符合 `AGENTS.md` 的非阻断建议：
+
+- 格式应为 `<类型>: <修改内容>`，例如 `fix: 修复大盘分析历史记录丢失`
+- 类型优先为 `fix`/`feat`/`refactor`/`docs`/`chore`/`test`/`ci`
+- 不应包含 `[codex]`、`codex`、`autocode`、`copilot` 或其他工具/agent 来源前缀
+- 标题应描述实际变更；若标题与 diff 不符，在描述完整性中指出，但不应单独作为 review process blocker。
+
+对照 `.github/PULL_REQUEST_TEMPLATE.md`，确认是否覆盖：
+
+- `PR Type`
+- `Background And Problem`
+- `Scope Of Change`
+- `Issue Link`
+- `Verification Commands And Results`
+- `Visual Evidence`（仅当 PR 修改报告格式、报告渲染效果或 Web UI 界面时要求截图或替代可视证据）
+- `Compatibility And Risk`
+- `Rollback Plan`
+
+若 PR 涉及第三方模型 / API 兼容语义、请求参数固定值、OpenAI-compatible 路由、YAML alias、fallback 行为或运行时配置保存 / 清理 / 迁移逻辑，还要额外检查描述里是否明确写出：
+
+- 官方来源链接或公告
+- 当前锁定依赖 / 运行时兼容范围（例如 LiteLLM 版本窗口）
+- 已验证的调用链路覆盖面
+- 旧配置是否会被静默改写、清空、迁移或保持不变
+- 最小回滚路径（通常是 revert 本 PR）
+
+若 PR 修改报告格式、报告渲染效果或 Web UI 界面，还要检查 `Visual Evidence` 是否附受影响报告 / 页面截图；涉及前后差异时优先检查前后对比。若无法截图，描述中应说明原因与替代可视证据。
+
+### Step 4: 优先使用 CI / Diff 证据
+
+- 先根据 `gh pr checks`、PR diff、现有测试与工作流日志判断问题
+- 仅当 CI 未覆盖改动面、CI 结果不足以定性问题、或需要验证关键回归风险时，再补充本地最小验证
+- 不要默认切换当前分支或执行 `gh pr checkout`
+
+如果必须补本地验证，按改动面选择最接近的检查，例如：
+
+- 后端：`./scripts/ci_gate.sh` 或 `python -m py_compile <changed_python_files>`
+- 前端：`cd apps/dsa-web && npm ci && npm run lint && npm run build`
+- 桌面端：先构建 Web，再构建 Electron
+
+### Step 5: 评估正确性与风险
+
+重点检查：
+
+- 是否解决了明确问题，且没有夹带无关改动
+- 是否破坏 API / Schema / Web / Desktop 兼容性
+- 是否破坏 fallback、降级路径、通知链路或发布流程
+- 是否存在明显逻辑错误、异常吞没、安全问题、配置语义变化未同步文档
+
+### Step 6: 生成评审文档
+
+保存到 `.Codex/reviews/prs/pr-<number>.md`
+
+## Output Document Format
+
+```markdown
+# PR #<number> Analysis
+
+**Date**: YYYY-MM-DD
+**Status**: Pending Review
+
+## Findings
+
+- [严重级别] file:line - 问题描述
+
+## Summary
+
+- 必要性：
+- 是否有对应 issue：
+- PR 类型：
+- PR title：
+- description 完整性：
+- 验证情况：
+- 主要风险：
+- 是否可直接合入：
+
+## Validation Evidence
+
+- 代码同步基线：
+- CI 结论：
+- 本地补充验证（如有）：
+
+## Compatibility And Risk
+
+- API / Web / Desktop：
+- 配置 / Docker / GitHub Actions：
+- fallback / 通知 / 报告结构：
+- 第三方依赖 / 官方约束来源：
+- 运行时兼容窗口 / 已覆盖链路：
+- 旧配置迁移或静默改写风险：
+
+## Draft Review Comment
+
+<建议评论内容>
+```
+
+## Allowed Auto-Actions (No Confirmation Needed)
+
+- 拉取 PR 元数据、diff、评论和 CI 状态
+- 执行 `git fetch --all --prune`，并在工作区干净且可 fast-forward 时执行 `git pull --ff-only`
+- 阅读相关代码、模板、工作流与文档
+- 在必要时执行最小化本地验证
+- 生成评审文档
+
+## Actions Requiring Confirmation
+
+执行以下动作前，先询问用户：
+
+1. 发布评论
+2. Approve PR
+3. Request changes
+4. Merge PR
+5. 关闭 PR

--- a/.agents/skills/fix-issue/SKILL.md
+++ b/.agents/skills/fix-issue/SKILL.md
@@ -1,0 +1,120 @@
+# Fix Issue
+
+基于 issue 分析结果实现修复，并按仓库规则补齐验证、风险与回滚说明。
+
+**Repository**: https://github.com/ZhuLinsen/daily_stock_analysis
+
+## Usage
+
+```text
+/fix-issue <issue_number>
+```
+
+## Prerequisites
+
+优先先完成 `/analyze-issue <issue_number>`，确保问题成立且边界清晰。
+
+## Instructions
+
+### Step 1: 确认分析基线
+
+检查 `.Codex/reviews/issues/issue-<number>.md` 是否存在；如果不存在，先补做 issue 分析或在本次修复中补齐最小分析结论。
+
+### Step 2: 同步最新代码基线并选择安全的工作方式
+
+开始修复或准备创建 / 更新 PR 前，先按 `AGENTS.md` 拉新：
+
+```bash
+git status --short
+git fetch --all --prune
+# 仅当工作区干净且当前分支可 fast-forward 时执行：
+git pull --ff-only
+```
+
+- 默认基于当前工作树做最小相关改动
+- 只有在工作区干净、当前分支有可 fast-forward 的上游时，才执行并接受 `git pull --ff-only` 的结果
+- 如存在本地改动、冲突状态、未跟踪风险文件、无上游分支或无法 fast-forward，不要执行 `stash`、`reset`、强制切分支或覆盖本地状态；先记录本地 HEAD、使用的远端基线与无法更新本地工作树的原因
+- 若后续要创建 / 更新 PR，先说明当前分支与目标基线差异；必要时请求用户确认 rebase、merge 或继续基于当前分支推进
+- 不要默认切换分支或改写用户当前工作状态
+- 如果用户明确要求建分支，再执行最小必要的分支操作
+
+### Step 3: 实施修复
+
+- 根据 issue 结论定位相关文件
+- 优先复用现有模块、配置入口、脚本和测试
+- 保持默认行为向后兼容，避免破坏 fallback / fail-open
+- 如果修复涉及用户可见行为、配置语义、CLI/API、部署、通知、报告结构，要同步更新相关文档、`docs/CHANGELOG.md`、`.env.example`
+- 向 `docs/CHANGELOG.md` 写入条目时，在 `[Unreleased]` 段追加一行，格式为 `- [类型] 描述`，其中 `[类型]` 从 `[新功能]/[改进]/[修复]/[文档]/[测试]/[chore]` 中按本次变更内容选择；只有修复 bug 时才使用 `[修复]`；**不要**在 `[Unreleased]` 内新增 `### 类目标题`
+- `README.md` 只承载项目定位、核心能力、快速开始、主要入口、赞助/合作等首页级信息；非必要不更新 README，避免持续膨胀
+- 更细的模块行为、页面交互、专题配置、排障说明、字段契约、实现语义和边界条件，优先更新对应 `docs/*.md`
+
+### Step 4: 按改动面验证
+
+按 `AGENTS.md` 的验证矩阵执行最接近的检查：
+
+- 后端优先：`./scripts/ci_gate.sh`
+- 最低后端要求：`python -m py_compile <changed_python_files>`
+- 前端：`cd apps/dsa-web && npm ci && npm run lint && npm run build`
+- 桌面端：先构建 Web，再构建桌面端
+
+如无法完成完整验证，必须记录缺口、原因与潜在风险。
+
+### Step 5: 更新 issue 分析文档
+
+在 `.Codex/reviews/issues/issue-<number>.md` 中补充：
+
+```markdown
+## Fix Implementation
+
+**Date**: YYYY-MM-DD
+
+### Changes Made
+
+- 文件与改动点：
+
+### Validation
+
+- 已执行：
+- 未执行：
+
+### Risks
+
+- 风险点：
+
+### Rollback
+
+- 回滚方式：
+```
+
+### Step 6: 需要确认的后续动作
+
+如用户要求创建 PR、生成 PR 标题或整理 PR 描述，PR title 建议遵循 `AGENTS.md`：
+
+- 使用 `<类型>: <修改内容>` 格式，例如 `fix: 修复大盘分析历史记录丢失`
+- 类型优先使用 `fix`/`feat`/`refactor`/`docs`/`chore`/`test`/`ci`
+- 标题只描述实际改动，建议不添加 `[codex]`、`codex`、`autocode`、`copilot` 或其他工具/agent 来源前缀
+- 该约定仅用于协作一致性，不应被单独当作 process blocker
+
+只有在用户明确确认后，才执行：
+
+- 建分支
+- `git commit`
+- `git push`
+- 创建 PR
+- 在 issue 下回复或关闭 issue
+
+## Allowed Auto-Actions (No Confirmation Needed)
+
+- 阅读和分析代码
+- 执行 `git fetch --all --prune`，并在工作区干净且可 fast-forward 时执行 `git pull --ff-only`
+- 应用与当前任务直接相关的最小修复
+- 运行非破坏性的本地验证
+- 更新本地 issue 分析文档
+
+## Actions Requiring Confirmation
+
+1. 切换或创建分支
+2. `git commit`
+3. `git push`
+4. 创建 PR
+5. 回复或关闭 issue

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,6 +4,194 @@
 
 如果本文件与仓库中的脚本、工作流、代码现状不一致，以实际可执行内容为准，并在相关改动中顺手修正文档，避免规则继续漂移。
 
+## 项目名称
+
+ashare-research-os
+
+## 项目定位
+
+本项目基于 daily_stock_analysis 扩展，目标不是重新做一个股票前端，也不是做实盘交易机器人，而是构建一个 A股 AI 投研决策流水线。
+
+核心链路为：
+
+Raw Data
+→ Fact Pack
+→ Scorecard
+→ Investment Decision
+→ Structured Report
+→ Paper Trading
+→ Review / Evaluation
+
+## 最重要原则
+
+Codex 必须优先保持 daily_stock_analysis 原项目稳定。
+
+新增功能优先放入：
+
+`private_ext/`
+
+新增命令行脚本放入：
+
+`scripts/`
+
+新增数据和报告放入：
+
+`storage/`
+
+除非明确要求，不要大规模重构 daily_stock_analysis 原有代码。
+
+## 第一阶段目标
+
+第一阶段只做 Mock MVP 闭环：
+
+1. 输入股票池
+2. 生成 Mock Raw Data
+3. Raw Data 转成 Fact Pack
+4. Fact Pack 转成 Scorecard
+5. Scorecard 转成 Investment Decision
+6. 生成结构化 Markdown 报告
+7. 写入 SQLite
+8. 可选接入模拟交易
+9. 生成日志
+
+第一阶段不接真实行情、不接真实 LLM、不接 TradingAgents-astock、不接实盘交易、不做前端。
+
+## MVP 唯一验收命令
+
+```bash
+python scripts/run_stock_report.py \
+  --stocks 600519,000001,300750 \
+  --date 2026-07-03 \
+  --raw-data mock \
+  --research-adapter mock \
+  --paper-trading on
+```
+
+运行成功后必须生成：
+
+```text
+storage/research.sqlite
+
+storage/fact_packs/600519_2026-07-03.json
+storage/fact_packs/000001_2026-07-03.json
+storage/fact_packs/300750_2026-07-03.json
+
+storage/scorecards/600519_2026-07-03.json
+storage/scorecards/000001_2026-07-03.json
+storage/scorecards/300750_2026-07-03.json
+
+storage/reports/stock_report_600519_2026-07-03.md
+storage/reports/stock_report_000001_2026-07-03.md
+storage/reports/stock_report_300750_2026-07-03.md
+
+storage/logs/run_stock_report_2026-07-03.log
+```
+
+SQLite 中至少包含：
+
+```text
+research_runs: 3
+raw_data_snapshots: 3
+fact_packs: 3
+scorecards: 3
+research_decisions: 3
+paper_trade_signals: 3
+paper_nav: 1
+```
+
+## 最高优先级
+
+1. 跑通命令行主流程
+2. Mock 数据闭环
+3. SQLite 初始化和写入
+4. Fact Pack Builder
+5. Score Engine
+6. Decision Engine
+7. Risk Gate
+8. Markdown Report Renderer
+9. Paper Trading
+10. 基础测试
+11. 日志和错误处理
+12. 后续才允许接真实数据、LLM、TradingAgents、推送和前端
+
+## 严禁事项
+
+在 MVP 验收命令跑通之前，禁止：
+
+- 禁止开发前端页面
+- 禁止修改 Web UI
+- 禁止引入 React、Vue、Next.js、Streamlit、Gradio
+- 禁止开发桌面端
+- 禁止接入真实券商下单
+- 禁止保存真实券商账号、密码、验证码、Cookie
+- 禁止实现自动实盘交易
+- 禁止全市场批量跑 LLM Agent
+- 禁止一开始引入 PostgreSQL、Redis、Celery、Kafka、Airflow
+- 禁止跳过 Fact Pack 直接让 LLM 给 Buy/Sell
+- 禁止跳过 Scorecard 直接生成交易建议
+- 禁止只保存最终结论而不保存原始数据和原始输出
+- 禁止为了代码优雅大规模重构原项目
+- 禁止把所有逻辑塞进一个大文件
+
+## 核心架构约束
+
+必须按以下层级实现：
+
+```text
+Raw Data Collector
+  ↓
+Fact Pack Builder
+  ↓
+Score Engine
+  ↓
+Research Adapter
+  ↓
+Decision Engine
+  ↓
+Risk Gate
+  ↓
+Structured Report
+  ↓
+Paper Trading
+  ↓
+Evaluation
+```
+
+其中：
+
+- Raw Data 只负责采集原始数据，不做判断。
+- Fact Pack 只负责把原始数据压缩成结构化事实。
+- Scorecard 只负责分项评分。
+- Decision Engine 才能给出投资观点。
+- Risk Gate 决定观点是否能进入模拟交易。
+- Report 必须写清楚事实、评分、判断、风险、失效条件。
+- Paper Trading 只能模拟，不能实盘。
+- Evaluation 后续用于复盘 AI 判断质量。
+
+## 推荐技术选择
+
+第一阶段使用：
+
+```text
+Python 3.10+
+SQLite
+Pydantic
+Markdown
+pytest
+```
+
+第一阶段不使用：
+
+```text
+PostgreSQL
+Redis
+Celery
+Kafka
+Airflow
+复杂 Web 框架
+真实券商接口
+```
+
 ## 1. 硬规则
 
 - 遵循现有目录边界：

--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -1,0 +1,132 @@
+# A股 AI 投研决策流水线最终实施计划
+
+## 0. 项目目标
+
+本项目目标是构建一个稳定、可扩展、可审计、可复盘的 A股 AI 投研决策流水线。
+
+核心链路：
+
+```text
+Raw Data
+  ↓
+Fact Pack
+  ↓
+Scorecard
+  ↓
+Investment Decision
+  ↓
+Risk Gate
+  ↓
+Structured Report
+  ↓
+Paper Trading
+  ↓
+Review / Evaluation
+```
+
+第一阶段目标不是追求真实数据和真实 LLM，而是先跑通 Mock 闭环。
+
+## 1. 总体设计
+
+### 1.1 为什么不是直接让 LLM 分析？
+
+本项目禁止跳过 Fact Pack 和 Scorecard 直接让 LLM 给出买卖建议。
+
+正确流程是：
+
+```text
+原始数据先结构化
+结构化数据再形成 Fact Pack
+Fact Pack 再生成分项评分
+评分和事实一起进入 Decision Engine
+Decision 经过 Risk Gate
+最终才进入报告和模拟交易
+```
+
+原因：
+
+1. 提高稳定性
+2. 降低幻觉
+3. 方便复盘
+4. 方便替换数据源和模型
+5. 方便验证评分和决策是否有效
+
+## 2. 第一阶段 MVP
+
+### 2.1 MVP 验收命令
+
+```bash
+python scripts/run_stock_report.py \
+  --stocks 600519,000001,300750 \
+  --date 2026-07-03 \
+  --raw-data mock \
+  --research-adapter mock \
+  --paper-trading on
+```
+
+### 2.2 MVP 输出文件
+
+必须生成：
+
+```text
+storage/research.sqlite
+
+storage/fact_packs/600519_2026-07-03.json
+storage/fact_packs/000001_2026-07-03.json
+storage/fact_packs/300750_2026-07-03.json
+
+storage/scorecards/600519_2026-07-03.json
+storage/scorecards/000001_2026-07-03.json
+storage/scorecards/300750_2026-07-03.json
+
+storage/reports/stock_report_600519_2026-07-03.md
+storage/reports/stock_report_000001_2026-07-03.md
+storage/reports/stock_report_300750_2026-07-03.md
+
+storage/logs/run_stock_report_2026-07-03.log
+```
+
+### 2.3 MVP 数据库要求
+
+SQLite 至少包含：
+
+```text
+research_runs
+raw_data_snapshots
+fact_packs
+scorecards
+research_decisions
+paper_trade_signals
+paper_orders
+paper_positions
+paper_nav
+```
+
+## 3. 目录结构
+
+第一阶段必须实现 `private_ext/` 扩展层、`scripts/run_stock_report.py`、`scripts/inspect_db.py` 和对应测试。`daily_stock_analysis` 原有代码只作为稳定外壳，MVP 不改 Web、桌面端、真实行情、真实 LLM、推送或实盘交易。
+
+## 4. Phase 0/1 验收清单
+
+```text
+[ ] AGENTS.md 存在
+[ ] IMPLEMENTATION_PLAN.md 存在
+[ ] private_ext 目录存在
+[ ] scripts/run_stock_report.py 存在
+[ ] scripts/inspect_db.py 存在
+[ ] python -m pytest tests 成功
+[ ] Mock MVP 命令成功
+[ ] storage/research.sqlite 存在
+[ ] storage/fact_packs 至少 3 个 JSON
+[ ] storage/scorecards 至少 3 个 JSON
+[ ] storage/reports 至少 3 个 Markdown 报告
+[ ] SQLite 中 research_runs 至少 3 条
+[ ] SQLite 中 fact_packs 至少 3 条
+[ ] SQLite 中 scorecards 至少 3 条
+[ ] SQLite 中 research_decisions 至少 3 条
+[ ] SQLite 中 paper_nav 至少 1 条
+[ ] 没有新增前端
+[ ] 没有接入实盘
+[ ] 没有破坏 daily_stock_analysis 原有结构
+```
+

--- a/private_ext/__init__.py
+++ b/private_ext/__init__.py
@@ -1,0 +1,2 @@
+"""Private A-share research pipeline extensions."""
+

--- a/private_ext/config.py
+++ b/private_ext/config.py
@@ -1,0 +1,29 @@
+from pathlib import Path
+
+from pydantic import BaseModel
+
+
+class Settings(BaseModel):
+    storage_dir: Path = Path("storage")
+    db_path: Path = Path("storage/research.sqlite")
+    raw_dir: Path = Path("storage/raw")
+    fact_pack_dir: Path = Path("storage/fact_packs")
+    scorecard_dir: Path = Path("storage/scorecards")
+    reports_dir: Path = Path("storage/reports")
+    logs_dir: Path = Path("storage/logs")
+    evidence_dir: Path = Path("storage/evidence")
+
+    initial_cash: float = 1_000_000.0
+    max_position_per_stock: float = 0.05
+    max_positions: int = 10
+
+    commission_rate: float = 0.0003
+    stamp_tax_rate: float = 0.0005
+    slippage_rate: float = 0.001
+
+    default_raw_data: str = "mock"
+    default_research_adapter: str = "mock"
+
+
+settings = Settings()
+

--- a/private_ext/database/__init__.py
+++ b/private_ext/database/__init__.py
@@ -1,0 +1,2 @@
+"""SQLite storage for the private research MVP."""
+

--- a/private_ext/database/init_db.py
+++ b/private_ext/database/init_db.py
@@ -1,0 +1,13 @@
+import sqlite3
+from pathlib import Path
+
+from private_ext.config import Settings, settings
+
+
+def init_db(config: Settings = settings) -> Path:
+    config.db_path.parent.mkdir(parents=True, exist_ok=True)
+    schema_path = Path(__file__).with_name("schema.sql")
+    with sqlite3.connect(config.db_path) as conn:
+        conn.executescript(schema_path.read_text(encoding="utf-8"))
+    return config.db_path
+

--- a/private_ext/database/repo.py
+++ b/private_ext/database/repo.py
@@ -1,0 +1,231 @@
+import json
+import sqlite3
+from pathlib import Path
+from typing import Any
+
+from private_ext.decisions.models import InvestmentDecision
+from private_ext.fact_pack.models import StockFactPack
+from private_ext.raw_data.models import RawStockData
+from private_ext.research.models import ResearchOutput
+from private_ext.scoring.models import StockScorecard
+from private_ext.utils.dates import utc_now_iso
+
+
+class ResearchRepository:
+    def __init__(self, db_path: Path):
+        self.db_path = db_path
+
+    def create_run(self, run_date: str, symbol: str, raw_data_provider: str, research_adapter: str) -> int:
+        with self._connect() as conn:
+            cursor = conn.execute(
+                """
+                INSERT INTO research_runs (run_date, symbol, raw_data_provider, research_adapter, status, started_at)
+                VALUES (?, ?, ?, ?, ?, ?)
+                """,
+                (run_date, symbol, raw_data_provider, research_adapter, "running", utc_now_iso()),
+            )
+            return int(cursor.lastrowid)
+
+    def finish_run(self, run_id: int, status: str = "completed", error_message: str | None = None) -> None:
+        with self._connect() as conn:
+            conn.execute(
+                "UPDATE research_runs SET status = ?, finished_at = ?, error_message = ? WHERE id = ?",
+                (status, utc_now_iso(), error_message, run_id),
+            )
+
+    def save_raw_data(self, run_id: int, raw: RawStockData, provider: str) -> int:
+        with self._connect() as conn:
+            cursor = conn.execute(
+                """
+                INSERT INTO raw_data_snapshots (run_id, symbol, trade_date, provider, raw_json)
+                VALUES (?, ?, ?, ?, ?)
+                """,
+                (run_id, raw.symbol, raw.trade_date, provider, _json(raw.model_dump())),
+            )
+            return int(cursor.lastrowid)
+
+    def save_fact_pack(self, run_id: int, fact_pack: StockFactPack) -> int:
+        with self._connect() as conn:
+            cursor = conn.execute(
+                """
+                INSERT INTO fact_packs (
+                    run_id, symbol, trade_date, fact_pack_json, missing_fields_json, data_quality_warnings_json
+                )
+                VALUES (?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    run_id,
+                    fact_pack.symbol,
+                    fact_pack.trade_date,
+                    _json(fact_pack.model_dump()),
+                    _json(fact_pack.missing_fields),
+                    _json(fact_pack.data_quality_warnings),
+                ),
+            )
+            return int(cursor.lastrowid)
+
+    def save_scorecard(self, run_id: int, scorecard: StockScorecard) -> int:
+        with self._connect() as conn:
+            cursor = conn.execute(
+                """
+                INSERT INTO scorecards (
+                    run_id, symbol, trade_date, total_score, rating_band, scorecard_json, penalty_reasons_json
+                )
+                VALUES (?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    run_id,
+                    scorecard.symbol,
+                    scorecard.trade_date,
+                    scorecard.total_score,
+                    scorecard.rating_band,
+                    _json(scorecard.model_dump()),
+                    _json(scorecard.penalty_reasons),
+                ),
+            )
+            return int(cursor.lastrowid)
+
+    def save_research_output(self, run_id: int, output: ResearchOutput) -> int:
+        with self._connect() as conn:
+            cursor = conn.execute(
+                """
+                INSERT INTO research_outputs (run_id, symbol, adapter, raw_output)
+                VALUES (?, ?, ?, ?)
+                """,
+                (run_id, output.symbol, output.adapter, output.raw_output),
+            )
+            return int(cursor.lastrowid)
+
+    def save_research_decision(self, run_id: int, decision: InvestmentDecision) -> int:
+        with self._connect() as conn:
+            cursor = conn.execute(
+                """
+                INSERT INTO research_decisions (
+                    run_id, symbol, trade_date, rating, action, confidence, target_position, horizon,
+                    thesis, bullish_points_json, bearish_points_json, catalysts_json, risks_json,
+                    invalidation_conditions_json, decision_json
+                )
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    run_id,
+                    decision.symbol,
+                    decision.trade_date,
+                    decision.rating,
+                    decision.action,
+                    decision.confidence,
+                    decision.target_position,
+                    decision.horizon,
+                    decision.thesis,
+                    _json(decision.bullish_points),
+                    _json(decision.bearish_points),
+                    _json(decision.catalysts),
+                    _json(decision.risks),
+                    _json(decision.invalidation_conditions),
+                    _json(decision.model_dump()),
+                ),
+            )
+            return int(cursor.lastrowid)
+
+    def save_paper_signal(self, decision_id: int, decision: InvestmentDecision) -> int:
+        with self._connect() as conn:
+            cursor = conn.execute(
+                """
+                INSERT INTO paper_trade_signals (
+                    decision_id, trade_date, symbol, action, confidence, target_position, risk_gate_passed, risk_gate_reason
+                )
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    decision_id,
+                    decision.trade_date,
+                    decision.symbol,
+                    decision.action,
+                    decision.confidence,
+                    decision.target_position,
+                    1 if decision.risk_gate_passed else 0,
+                    decision.risk_gate_reason,
+                ),
+            )
+            return int(cursor.lastrowid)
+
+    def save_paper_order(
+        self,
+        signal_id: int | None,
+        trade_date: str,
+        symbol: str,
+        action: str,
+        price: float,
+        quantity: int,
+        amount: float,
+        fee: float,
+        reason: str,
+    ) -> int:
+        with self._connect() as conn:
+            cursor = conn.execute(
+                """
+                INSERT INTO paper_orders (signal_id, trade_date, symbol, action, price, quantity, amount, fee, reason)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (signal_id, trade_date, symbol, action, price, quantity, amount, fee, reason),
+            )
+            return int(cursor.lastrowid)
+
+    def upsert_position(self, trade_date: str, symbol: str, quantity: int, cost_price: float, last_price: float) -> int:
+        market_value = quantity * last_price
+        unrealized_pnl = (last_price - cost_price) * quantity
+        with self._connect() as conn:
+            conn.execute("DELETE FROM paper_positions WHERE trade_date = ? AND symbol = ?", (trade_date, symbol))
+            cursor = conn.execute(
+                """
+                INSERT INTO paper_positions (trade_date, symbol, quantity, cost_price, last_price, market_value, unrealized_pnl)
+                VALUES (?, ?, ?, ?, ?, ?, ?)
+                """,
+                (trade_date, symbol, quantity, cost_price, last_price, market_value, unrealized_pnl),
+            )
+            return int(cursor.lastrowid)
+
+    def save_nav(self, trade_date: str, cash: float, market_value: float, daily_return: float | None = None) -> int:
+        with self._connect() as conn:
+            cursor = conn.execute(
+                """
+                INSERT INTO paper_nav (trade_date, cash, market_value, total_nav, daily_return)
+                VALUES (?, ?, ?, ?, ?)
+                """,
+                (trade_date, cash, market_value, cash + market_value, daily_return),
+            )
+            return int(cursor.lastrowid)
+
+    def table_counts(self) -> dict[str, int]:
+        tables = [
+            "research_runs",
+            "raw_data_snapshots",
+            "fact_packs",
+            "scorecards",
+            "research_outputs",
+            "research_decisions",
+            "paper_trade_signals",
+            "paper_orders",
+            "paper_positions",
+            "paper_nav",
+            "decision_outcomes",
+        ]
+        with self._connect() as conn:
+            return {table: int(conn.execute(f"SELECT COUNT(*) FROM {table}").fetchone()[0]) for table in tables}
+
+    def latest_nav(self) -> dict[str, Any] | None:
+        with self._connect() as conn:
+            conn.row_factory = sqlite3.Row
+            row = conn.execute(
+                "SELECT trade_date, cash, market_value, total_nav, daily_return FROM paper_nav ORDER BY id DESC LIMIT 1"
+            ).fetchone()
+            return dict(row) if row else None
+
+    def _connect(self) -> sqlite3.Connection:
+        self.db_path.parent.mkdir(parents=True, exist_ok=True)
+        return sqlite3.connect(self.db_path)
+
+
+def _json(value: Any) -> str:
+    return json.dumps(value, ensure_ascii=False, sort_keys=True)
+

--- a/private_ext/database/schema.sql
+++ b/private_ext/database/schema.sql
@@ -1,0 +1,144 @@
+CREATE TABLE IF NOT EXISTS research_runs (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    run_date TEXT NOT NULL,
+    symbol TEXT NOT NULL,
+    raw_data_provider TEXT NOT NULL,
+    research_adapter TEXT NOT NULL,
+    status TEXT NOT NULL,
+    started_at TEXT,
+    finished_at TEXT,
+    error_message TEXT
+);
+
+CREATE TABLE IF NOT EXISTS raw_data_snapshots (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    run_id INTEGER NOT NULL,
+    symbol TEXT NOT NULL,
+    trade_date TEXT NOT NULL,
+    provider TEXT NOT NULL,
+    raw_json TEXT NOT NULL,
+    created_at TEXT DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY(run_id) REFERENCES research_runs(id)
+);
+
+CREATE TABLE IF NOT EXISTS fact_packs (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    run_id INTEGER NOT NULL,
+    symbol TEXT NOT NULL,
+    trade_date TEXT NOT NULL,
+    fact_pack_json TEXT NOT NULL,
+    missing_fields_json TEXT,
+    data_quality_warnings_json TEXT,
+    created_at TEXT DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY(run_id) REFERENCES research_runs(id)
+);
+
+CREATE TABLE IF NOT EXISTS scorecards (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    run_id INTEGER NOT NULL,
+    symbol TEXT NOT NULL,
+    trade_date TEXT NOT NULL,
+    total_score REAL NOT NULL,
+    rating_band TEXT,
+    scorecard_json TEXT NOT NULL,
+    penalty_reasons_json TEXT,
+    created_at TEXT DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY(run_id) REFERENCES research_runs(id)
+);
+
+CREATE TABLE IF NOT EXISTS research_outputs (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    run_id INTEGER NOT NULL,
+    symbol TEXT NOT NULL,
+    adapter TEXT NOT NULL,
+    raw_output TEXT NOT NULL,
+    created_at TEXT DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY(run_id) REFERENCES research_runs(id)
+);
+
+CREATE TABLE IF NOT EXISTS research_decisions (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    run_id INTEGER NOT NULL,
+    symbol TEXT NOT NULL,
+    trade_date TEXT NOT NULL,
+    rating TEXT NOT NULL,
+    action TEXT NOT NULL,
+    confidence REAL NOT NULL,
+    target_position REAL NOT NULL,
+    horizon TEXT,
+    thesis TEXT,
+    bullish_points_json TEXT,
+    bearish_points_json TEXT,
+    catalysts_json TEXT,
+    risks_json TEXT,
+    invalidation_conditions_json TEXT,
+    decision_json TEXT NOT NULL,
+    created_at TEXT DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY(run_id) REFERENCES research_runs(id)
+);
+
+CREATE TABLE IF NOT EXISTS paper_trade_signals (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    decision_id INTEGER NOT NULL,
+    trade_date TEXT NOT NULL,
+    symbol TEXT NOT NULL,
+    action TEXT NOT NULL,
+    confidence REAL NOT NULL,
+    target_position REAL NOT NULL,
+    risk_gate_passed INTEGER NOT NULL,
+    risk_gate_reason TEXT,
+    created_at TEXT DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY(decision_id) REFERENCES research_decisions(id)
+);
+
+CREATE TABLE IF NOT EXISTS paper_orders (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    signal_id INTEGER,
+    trade_date TEXT NOT NULL,
+    symbol TEXT NOT NULL,
+    action TEXT NOT NULL,
+    price REAL NOT NULL,
+    quantity INTEGER NOT NULL,
+    amount REAL NOT NULL,
+    fee REAL DEFAULT 0,
+    reason TEXT,
+    created_at TEXT DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS paper_positions (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    trade_date TEXT NOT NULL,
+    symbol TEXT NOT NULL,
+    quantity INTEGER NOT NULL,
+    cost_price REAL NOT NULL,
+    last_price REAL,
+    market_value REAL,
+    unrealized_pnl REAL
+);
+
+CREATE TABLE IF NOT EXISTS paper_nav (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    trade_date TEXT NOT NULL,
+    cash REAL NOT NULL,
+    market_value REAL NOT NULL,
+    total_nav REAL NOT NULL,
+    daily_return REAL,
+    created_at TEXT DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS decision_outcomes (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    decision_id INTEGER NOT NULL,
+    horizon_days INTEGER NOT NULL,
+    start_price REAL,
+    end_price REAL,
+    return_pct REAL,
+    benchmark_return_pct REAL,
+    max_up_pct REAL,
+    max_down_pct REAL,
+    direction_correct INTEGER,
+    review_notes TEXT,
+    evaluated_at TEXT DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY(decision_id) REFERENCES research_decisions(id)
+);
+

--- a/private_ext/decisions/__init__.py
+++ b/private_ext/decisions/__init__.py
@@ -1,0 +1,2 @@
+"""Decision engine and risk gate for the private research MVP."""
+

--- a/private_ext/decisions/decision_engine.py
+++ b/private_ext/decisions/decision_engine.py
@@ -1,0 +1,57 @@
+from private_ext.decisions.models import InvestmentDecision
+from private_ext.decisions.normalizer import normalize_action
+from private_ext.research.models import ResearchOutput
+from private_ext.scoring.models import StockScorecard
+
+
+class DecisionEngine:
+    def build(self, scorecard: StockScorecard, research_output: ResearchOutput) -> InvestmentDecision:
+        if scorecard.total_score >= 80:
+            rating, action, confidence, target_position = "bullish", "buy", 0.78, 0.05
+        elif scorecard.total_score >= 65:
+            rating, action, confidence, target_position = "neutral-bullish", "watch", 0.68, 0.02
+        elif scorecard.total_score >= 50:
+            rating, action, confidence, target_position = "neutral", "hold", 0.55, 0.0
+        else:
+            rating, action, confidence, target_position = "bearish", "reduce", 0.65, 0.0
+        return InvestmentDecision(
+            symbol=scorecard.symbol,
+            trade_date=scorecard.trade_date,
+            rating=rating,
+            action=normalize_action(action),
+            confidence=confidence,
+            target_position=target_position,
+            horizon="20d",
+            thesis=research_output.summary,
+            bullish_points=_bullish_points(scorecard),
+            bearish_points=_bearish_points(scorecard),
+            catalysts=["等待业绩、行业景气和资金面进一步验证"],
+            risks=scorecard.penalty_reasons or ["评分或事实链变化导致观点失效"],
+            invalidation_conditions=["总分跌破 60", "出现重大减持、问询函或业绩雷", "核心事实链无法验证"],
+            aggressive_plan="若风险门通过，按目标仓位上限执行模拟买入。",
+            balanced_plan="等待价格和资金面确认后再分批模拟。",
+            conservative_plan="只观察，不产生真实交易行为。",
+        )
+
+
+def _bullish_points(scorecard: StockScorecard) -> list[str]:
+    points = []
+    if scorecard.profitability_score >= 70:
+        points.append("盈利质量较强")
+    if scorecard.growth_score >= 70:
+        points.append("成长评分较高")
+    if scorecard.capital_flow_score >= 65:
+        points.append("资金面偏积极")
+    return points or ["暂无显著看多项"]
+
+
+def _bearish_points(scorecard: StockScorecard) -> list[str]:
+    points = []
+    if scorecard.valuation_score < 55:
+        points.append("估值压力偏高")
+    if scorecard.risk_score < 65:
+        points.append("风险评分偏弱")
+    if scorecard.technical_score < 55:
+        points.append("技术趋势未确认")
+    return points or ["暂无显著看空项"]
+

--- a/private_ext/decisions/models.py
+++ b/private_ext/decisions/models.py
@@ -1,0 +1,27 @@
+from pydantic import BaseModel, Field
+
+
+class InvestmentDecision(BaseModel):
+    symbol: str
+    trade_date: str
+
+    rating: str
+    action: str
+    confidence: float
+    target_position: float
+    horizon: str
+
+    thesis: str
+    bullish_points: list[str]
+    bearish_points: list[str]
+    catalysts: list[str]
+    risks: list[str]
+    invalidation_conditions: list[str]
+
+    aggressive_plan: str
+    balanced_plan: str
+    conservative_plan: str
+
+    risk_gate_passed: bool = False
+    risk_gate_reason: str | None = None
+

--- a/private_ext/decisions/normalizer.py
+++ b/private_ext/decisions/normalizer.py
@@ -1,0 +1,4 @@
+def normalize_action(action: str) -> str:
+    action = action.lower().strip()
+    return action if action in {"buy", "watch", "hold", "reduce"} else "hold"
+

--- a/private_ext/decisions/risk_gate.py
+++ b/private_ext/decisions/risk_gate.py
@@ -1,0 +1,50 @@
+from private_ext.config import Settings, settings
+from private_ext.decisions.models import InvestmentDecision
+from private_ext.fact_pack.models import StockFactPack
+from private_ext.scoring.models import StockScorecard
+
+
+class RiskGate:
+    def __init__(self, config: Settings = settings):
+        self.config = config
+
+    def apply(
+        self,
+        decision: InvestmentDecision,
+        scorecard: StockScorecard,
+        fact_pack: StockFactPack,
+        current_positions: int = 0,
+    ) -> InvestmentDecision:
+        gated = decision.model_copy(deep=True)
+        reasons = []
+        if gated.target_position > self.config.max_position_per_stock:
+            gated.target_position = self.config.max_position_per_stock
+            reasons.append("target_position_capped")
+        if gated.action == "buy" and gated.confidence < 0.70:
+            gated.action = "watch"
+            gated.target_position = 0
+            reasons.append("confidence_below_buy_threshold")
+        if scorecard.risk_score < 50:
+            gated.action = "watch" if gated.action == "buy" else gated.action
+            gated.target_position = 0
+            reasons.append("risk_score_below_threshold")
+        if scorecard.penalty_reasons:
+            gated.action = "watch" if gated.action == "buy" else gated.action
+            gated.target_position = 0
+            reasons.append("penalty_risks_present")
+        if len(fact_pack.data_quality_warnings) > 2 and gated.action == "buy":
+            gated.action = "watch"
+            gated.target_position = 0
+            reasons.append("data_quality_warnings_too_many")
+        if not fact_pack.announcement_facts and gated.action == "buy":
+            gated.action = "watch"
+            gated.target_position = 0
+            reasons.append("announcement_evidence_missing")
+        if current_positions >= self.config.max_positions and gated.action == "buy":
+            gated.action = "watch"
+            gated.target_position = 0
+            reasons.append("max_positions_reached")
+        gated.risk_gate_passed = not reasons
+        gated.risk_gate_reason = "passed" if not reasons else ",".join(reasons)
+        return gated
+

--- a/private_ext/evaluation/__init__.py
+++ b/private_ext/evaluation/__init__.py
@@ -1,0 +1,2 @@
+"""Evaluation hooks for later phases."""
+

--- a/private_ext/evaluation/outcome_checker.py
+++ b/private_ext/evaluation/outcome_checker.py
@@ -1,0 +1,3 @@
+def placeholder() -> str:
+    return "evaluation_not_implemented_in_mock_mvp"
+

--- a/private_ext/fact_pack/__init__.py
+++ b/private_ext/fact_pack/__init__.py
@@ -1,0 +1,2 @@
+"""Fact pack builder for the private research MVP."""
+

--- a/private_ext/fact_pack/builder.py
+++ b/private_ext/fact_pack/builder.py
@@ -1,0 +1,53 @@
+from private_ext.fact_pack.models import StockFactPack
+from private_ext.fact_pack.validators import missing_keys
+from private_ext.raw_data.models import RawStockData
+
+
+class FactPackBuilder:
+    def build(self, raw: RawStockData) -> StockFactPack:
+        missing = []
+        missing.extend(missing_keys(raw.basic_info, ["name", "industry"], "basic_info"))
+        missing.extend(missing_keys(raw.market_snapshot, ["close"], "market_snapshot"))
+        missing.extend(missing_keys(raw.valuation_raw, ["pe", "pb"], "valuation_raw"))
+
+        warnings = []
+        if not raw.announcements_raw:
+            warnings.append("announcement_evidence_missing")
+        if len(missing) >= 3:
+            warnings.append("core_fields_missing")
+
+        risk_facts = [{"risk": item, "severity": "medium"} for item in raw.metadata.get("risk_events", [])]
+        if raw.valuation_raw.get("pe", 0) >= 35:
+            risk_facts.append({"risk": "高估值", "severity": "medium"})
+
+        return StockFactPack(
+            symbol=raw.symbol,
+            trade_date=raw.trade_date,
+            identity={**raw.basic_info},
+            price_facts={**raw.market_snapshot},
+            valuation_facts={**raw.valuation_raw},
+            growth_facts={
+                "revenue_growth": raw.financial_raw.get("revenue_growth"),
+                "profit_growth": raw.financial_raw.get("profit_growth"),
+                "industry_prosperity": raw.industry_raw.get("prosperity"),
+            },
+            profitability_facts={
+                "roe": raw.financial_raw.get("roe"),
+                "gross_margin": raw.financial_raw.get("gross_margin"),
+                "net_margin": raw.financial_raw.get("net_margin"),
+            },
+            balance_sheet_facts={"debt_ratio": raw.financial_raw.get("debt_ratio")},
+            cashflow_facts={"operating_cashflow_quality": raw.financial_raw.get("operating_cashflow_quality")},
+            capital_flow_facts={
+                "main_net_inflow": raw.capital_flow_raw.get("main_net_inflow"),
+                "northbound_net_inflow": raw.northbound_raw.get("net_inflow"),
+                "dragon_tiger": raw.dragon_tiger_raw,
+            },
+            technical_facts={**raw.kline_summary},
+            announcement_facts=raw.announcements_raw,
+            news_facts=raw.news_raw,
+            risk_facts=risk_facts,
+            missing_fields=missing,
+            data_quality_warnings=warnings,
+        )
+

--- a/private_ext/fact_pack/models.py
+++ b/private_ext/fact_pack/models.py
@@ -1,0 +1,25 @@
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+
+class StockFactPack(BaseModel):
+    symbol: str
+    trade_date: str
+
+    identity: dict[str, Any]
+    price_facts: dict[str, Any]
+    valuation_facts: dict[str, Any]
+    growth_facts: dict[str, Any]
+    profitability_facts: dict[str, Any]
+    balance_sheet_facts: dict[str, Any]
+    cashflow_facts: dict[str, Any]
+    capital_flow_facts: dict[str, Any]
+    technical_facts: dict[str, Any]
+    announcement_facts: list[dict[str, Any]]
+    news_facts: list[dict[str, Any]]
+    risk_facts: list[dict[str, Any]]
+
+    missing_fields: list[str] = Field(default_factory=list)
+    data_quality_warnings: list[str] = Field(default_factory=list)
+

--- a/private_ext/fact_pack/validators.py
+++ b/private_ext/fact_pack/validators.py
@@ -1,0 +1,6 @@
+from typing import Any
+
+
+def missing_keys(payload: dict[str, Any], keys: list[str], prefix: str) -> list[str]:
+    return [f"{prefix}.{key}" for key in keys if payload.get(key) in (None, "", [])]
+

--- a/private_ext/paper_trading/__init__.py
+++ b/private_ext/paper_trading/__init__.py
@@ -1,0 +1,2 @@
+"""Paper trading for the private research MVP."""
+

--- a/private_ext/paper_trading/broker.py
+++ b/private_ext/paper_trading/broker.py
@@ -1,0 +1,59 @@
+from private_ext.config import Settings, settings
+from private_ext.database.repo import ResearchRepository
+from private_ext.decisions.models import InvestmentDecision
+from private_ext.paper_trading.models import PaperTradeExecution
+
+
+MOCK_PRICES = {"600519": 1500.0, "000001": 10.0, "300750": 200.0}
+
+
+class PaperBroker:
+    def __init__(self, config: Settings = settings, repo: ResearchRepository | None = None):
+        self.config = config
+        self.repo = repo
+        self.cash = config.initial_cash
+        self.positions: dict[str, tuple[int, float]] = {}
+
+    def apply(self, decision_id: int, decision: InvestmentDecision) -> PaperTradeExecution:
+        price = MOCK_PRICES.get(decision.symbol, 100.0)
+        signal_id = self.repo.save_paper_signal(decision_id, decision) if self.repo else None
+
+        if decision.action == "buy" and decision.risk_gate_passed and decision.target_position > 0:
+            budget = self.config.initial_cash * min(decision.target_position, self.config.max_position_per_stock)
+            effective_price = price * (1 + self.config.slippage_rate)
+            quantity = int(budget // (effective_price * 100)) * 100
+            amount = round(quantity * effective_price, 2)
+            fee = round(amount * self.config.commission_rate, 2)
+            if quantity > 0 and amount + fee <= self.cash:
+                self.cash -= amount + fee
+                self.positions[decision.symbol] = (quantity, effective_price)
+                if self.repo:
+                    self.repo.save_paper_order(signal_id, decision.trade_date, decision.symbol, "buy", effective_price, quantity, amount, fee, "risk gate passed")
+                    self.repo.upsert_position(decision.trade_date, decision.symbol, quantity, effective_price, price)
+                    self.mark_to_market(decision.trade_date)
+                return PaperTradeExecution(action="buy", price=effective_price, quantity=quantity, amount=amount, fee=fee, executed=True, reason="risk gate passed")
+            return PaperTradeExecution(action="buy", price=price, quantity=0, amount=0, fee=0, executed=False, reason="insufficient budget or lot size")
+
+        if decision.action == "reduce" and decision.symbol in self.positions:
+            quantity, cost_price = self.positions.pop(decision.symbol)
+            effective_price = price * (1 - self.config.slippage_rate)
+            amount = round(quantity * effective_price, 2)
+            fee = round(amount * (self.config.commission_rate + self.config.stamp_tax_rate), 2)
+            self.cash += amount - fee
+            if self.repo:
+                self.repo.save_paper_order(signal_id, decision.trade_date, decision.symbol, "sell", effective_price, quantity, amount, fee, "reduce signal")
+                self.repo.upsert_position(decision.trade_date, decision.symbol, 0, cost_price, price)
+                self.mark_to_market(decision.trade_date)
+            return PaperTradeExecution(action="reduce", price=effective_price, quantity=quantity, amount=amount, fee=fee, executed=True, reason="reduce signal")
+
+        return PaperTradeExecution(action=decision.action, price=price, quantity=0, amount=0, fee=0, executed=False, reason=f"{decision.action} only")
+
+    def mark_to_market(self, trade_date: str) -> int | None:
+        market_value = 0.0
+        if self.repo:
+            for symbol, (quantity, cost_price) in self.positions.items():
+                price = MOCK_PRICES.get(symbol, 100.0)
+                market_value += quantity * price
+                self.repo.upsert_position(trade_date, symbol, quantity, cost_price, price)
+            return self.repo.save_nav(trade_date, round(self.cash, 2), round(market_value, 2))
+        return None

--- a/private_ext/paper_trading/models.py
+++ b/private_ext/paper_trading/models.py
@@ -1,0 +1,12 @@
+from pydantic import BaseModel
+
+
+class PaperTradeExecution(BaseModel):
+    action: str
+    price: float
+    quantity: int
+    amount: float
+    fee: float
+    executed: bool
+    reason: str
+

--- a/private_ext/raw_data/__init__.py
+++ b/private_ext/raw_data/__init__.py
@@ -1,0 +1,2 @@
+"""Raw data collectors for the private research MVP."""
+

--- a/private_ext/raw_data/base.py
+++ b/private_ext/raw_data/base.py
@@ -1,0 +1,12 @@
+from abc import ABC, abstractmethod
+
+from private_ext.raw_data.models import RawStockData
+
+
+class RawDataCollector(ABC):
+    provider = "base"
+
+    @abstractmethod
+    def collect(self, symbol: str, trade_date: str) -> RawStockData:
+        raise NotImplementedError
+

--- a/private_ext/raw_data/mock_collector.py
+++ b/private_ext/raw_data/mock_collector.py
@@ -1,0 +1,131 @@
+from __future__ import annotations
+
+from copy import deepcopy
+
+from private_ext.raw_data.base import RawDataCollector
+from private_ext.raw_data.models import RawStockData
+
+
+_MOCKS: dict[str, dict] = {
+    "600519": {
+        "name": "贵州茅台",
+        "industry": "白酒",
+        "close": 1500.0,
+        "pe": 28.0,
+        "pb": 9.5,
+        "dividend_yield": 2.1,
+        "revenue_growth": 8.0,
+        "profit_growth": 12.0,
+        "roe": 29.0,
+        "gross_margin": 91.0,
+        "net_margin": 52.0,
+        "debt_ratio": 18.0,
+        "cashflow_quality": "strong",
+        "main_net_inflow": 0.8,
+        "northbound_net_inflow": 1.5,
+        "trend": "up",
+        "volatility": 18.0,
+        "sentiment": "positive",
+        "risk_events": [],
+    },
+    "000001": {
+        "name": "平安银行",
+        "industry": "银行",
+        "close": 10.0,
+        "pe": 5.5,
+        "pb": 0.55,
+        "dividend_yield": 4.2,
+        "revenue_growth": 3.0,
+        "profit_growth": 4.0,
+        "roe": 10.5,
+        "gross_margin": 45.0,
+        "net_margin": 26.0,
+        "debt_ratio": 65.0,
+        "cashflow_quality": "stable",
+        "main_net_inflow": 0.2,
+        "northbound_net_inflow": 0.1,
+        "trend": "sideways",
+        "volatility": 12.0,
+        "sentiment": "neutral",
+        "risk_events": ["净息差承压"],
+    },
+    "300750": {
+        "name": "宁德时代",
+        "industry": "新能源电池",
+        "close": 200.0,
+        "pe": 36.0,
+        "pb": 5.8,
+        "dividend_yield": 0.8,
+        "revenue_growth": 24.0,
+        "profit_growth": 28.0,
+        "roe": 22.0,
+        "gross_margin": 24.0,
+        "net_margin": 12.0,
+        "debt_ratio": 42.0,
+        "cashflow_quality": "improving",
+        "main_net_inflow": 1.8,
+        "northbound_net_inflow": 2.4,
+        "trend": "up",
+        "volatility": 34.0,
+        "sentiment": "positive",
+        "risk_events": ["高估值", "行业竞争加剧"],
+    },
+}
+
+
+class MockRawDataCollector(RawDataCollector):
+    provider = "mock"
+
+    def collect(self, symbol: str, trade_date: str) -> RawStockData:
+        data = deepcopy(_MOCKS.get(symbol, _neutral_profile(symbol)))
+        return RawStockData(
+            symbol=symbol,
+            trade_date=trade_date,
+            basic_info={"name": data["name"], "industry": data["industry"], "market": "cn"},
+            market_snapshot={"close": data["close"], "currency": "CNY"},
+            kline_summary={"trend": data["trend"], "volatility": data["volatility"], "ma5_above_ma20": data["trend"] == "up"},
+            valuation_raw={"pe": data["pe"], "pb": data["pb"], "dividend_yield": data["dividend_yield"]},
+            financial_raw={
+                "revenue_growth": data["revenue_growth"],
+                "profit_growth": data["profit_growth"],
+                "roe": data["roe"],
+                "gross_margin": data["gross_margin"],
+                "net_margin": data["net_margin"],
+                "debt_ratio": data["debt_ratio"],
+                "operating_cashflow_quality": data["cashflow_quality"],
+            },
+            capital_flow_raw={"main_net_inflow": data["main_net_inflow"]},
+            northbound_raw={"net_inflow": data["northbound_net_inflow"]},
+            dragon_tiger_raw={"listed": False, "reason": ""},
+            announcements_raw=[
+                {"title": f"{data['name']} 经营情况公告", "date": trade_date, "sentiment": data["sentiment"], "summary": "Mock 公告证据"}
+            ],
+            news_raw=[{"title": f"{data['industry']} 行业跟踪", "date": trade_date, "sentiment": data["sentiment"]}],
+            analyst_raw=[{"rating": "neutral", "target_price": round(data["close"] * 1.08, 2)}],
+            industry_raw={"industry": data["industry"], "cycle": "stable", "prosperity": data["sentiment"]},
+            metadata={"provider": self.provider, "mock": True, "risk_events": data["risk_events"]},
+        )
+
+
+def _neutral_profile(symbol: str) -> dict:
+    return {
+        "name": f"股票{symbol}",
+        "industry": "通用行业",
+        "close": 100.0,
+        "pe": 18.0,
+        "pb": 2.0,
+        "dividend_yield": 1.5,
+        "revenue_growth": 8.0,
+        "profit_growth": 8.0,
+        "roe": 12.0,
+        "gross_margin": 35.0,
+        "net_margin": 10.0,
+        "debt_ratio": 45.0,
+        "cashflow_quality": "stable",
+        "main_net_inflow": 0.0,
+        "northbound_net_inflow": 0.0,
+        "trend": "sideways",
+        "volatility": 20.0,
+        "sentiment": "neutral",
+        "risk_events": [],
+    }

--- a/private_ext/raw_data/models.py
+++ b/private_ext/raw_data/models.py
@@ -1,0 +1,24 @@
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+
+class RawStockData(BaseModel):
+    symbol: str
+    trade_date: str
+
+    basic_info: dict[str, Any]
+    market_snapshot: dict[str, Any]
+    kline_summary: dict[str, Any]
+    valuation_raw: dict[str, Any]
+    financial_raw: dict[str, Any]
+    capital_flow_raw: dict[str, Any]
+    northbound_raw: dict[str, Any]
+    dragon_tiger_raw: dict[str, Any]
+    announcements_raw: list[dict[str, Any]]
+    news_raw: list[dict[str, Any]]
+    analyst_raw: list[dict[str, Any]]
+    industry_raw: dict[str, Any]
+
+    metadata: dict[str, Any] = Field(default_factory=dict)
+

--- a/private_ext/research/__init__.py
+++ b/private_ext/research/__init__.py
@@ -1,0 +1,2 @@
+"""Research adapters for the private research MVP."""
+

--- a/private_ext/research/base.py
+++ b/private_ext/research/base.py
@@ -1,0 +1,14 @@
+from abc import ABC, abstractmethod
+
+from private_ext.fact_pack.models import StockFactPack
+from private_ext.research.models import ResearchOutput
+from private_ext.scoring.models import StockScorecard
+
+
+class ResearchAdapter(ABC):
+    adapter = "base"
+
+    @abstractmethod
+    def analyze(self, fact_pack: StockFactPack, scorecard: StockScorecard) -> ResearchOutput:
+        raise NotImplementedError
+

--- a/private_ext/research/mock_adapter.py
+++ b/private_ext/research/mock_adapter.py
@@ -1,0 +1,34 @@
+import json
+
+from private_ext.fact_pack.models import StockFactPack
+from private_ext.research.base import ResearchAdapter
+from private_ext.research.models import ResearchOutput
+from private_ext.scoring.models import StockScorecard
+
+
+class MockResearchAdapter(ResearchAdapter):
+    adapter = "mock"
+
+    def analyze(self, fact_pack: StockFactPack, scorecard: StockScorecard) -> ResearchOutput:
+        if scorecard.total_score >= 80:
+            rating, action, confidence = "bullish", "buy", 0.78
+        elif scorecard.total_score >= 65:
+            rating, action, confidence = "neutral-bullish", "watch", 0.68
+        elif scorecard.total_score >= 50:
+            rating, action, confidence = "neutral", "hold", 0.55
+        else:
+            rating, action, confidence = "bearish", "reduce", 0.65
+        payload = {
+            "rating": rating,
+            "action": action,
+            "confidence": confidence,
+            "summary": f"{fact_pack.identity.get('name', fact_pack.symbol)} mock research score {scorecard.total_score}",
+        }
+        return ResearchOutput(
+            symbol=fact_pack.symbol,
+            trade_date=fact_pack.trade_date,
+            adapter=self.adapter,
+            raw_output=json.dumps(payload, ensure_ascii=False),
+            summary=payload["summary"],
+        )
+

--- a/private_ext/research/models.py
+++ b/private_ext/research/models.py
@@ -1,0 +1,10 @@
+from pydantic import BaseModel
+
+
+class ResearchOutput(BaseModel):
+    symbol: str
+    trade_date: str
+    adapter: str
+    raw_output: str
+    summary: str
+

--- a/private_ext/scoring/__init__.py
+++ b/private_ext/scoring/__init__.py
@@ -1,0 +1,2 @@
+"""Scorecard engines for the private research MVP."""
+

--- a/private_ext/scoring/capital_flow.py
+++ b/private_ext/scoring/capital_flow.py
@@ -1,0 +1,13 @@
+from private_ext.fact_pack.models import StockFactPack
+
+
+def score_capital_flow(fact_pack: StockFactPack) -> tuple[float, str]:
+    main = float(fact_pack.capital_flow_facts.get("main_net_inflow") or 0)
+    northbound = float(fact_pack.capital_flow_facts.get("northbound_net_inflow") or 0)
+    score = 55 + main * 8 + northbound * 6
+    return _clamp(score), f"main_net_inflow={main}, northbound_net_inflow={northbound}"
+
+
+def _clamp(value: float) -> float:
+    return max(0, min(100, round(value, 2)))
+

--- a/private_ext/scoring/financial_health.py
+++ b/private_ext/scoring/financial_health.py
@@ -1,0 +1,17 @@
+from private_ext.fact_pack.models import StockFactPack
+
+
+def score_financial_health(fact_pack: StockFactPack) -> tuple[float, str]:
+    debt_ratio = float(fact_pack.balance_sheet_facts.get("debt_ratio") or 0)
+    cashflow_quality = fact_pack.cashflow_facts.get("operating_cashflow_quality")
+    score = 80 - max(0, debt_ratio - 35) * 0.6
+    if cashflow_quality == "strong":
+        score += 10
+    elif cashflow_quality == "improving":
+        score += 5
+    return _clamp(score), f"debt_ratio={debt_ratio}%, cashflow={cashflow_quality}"
+
+
+def _clamp(value: float) -> float:
+    return max(0, min(100, round(value, 2)))
+

--- a/private_ext/scoring/growth.py
+++ b/private_ext/scoring/growth.py
@@ -1,0 +1,13 @@
+from private_ext.fact_pack.models import StockFactPack
+
+
+def score_growth(fact_pack: StockFactPack) -> tuple[float, str]:
+    revenue = float(fact_pack.growth_facts.get("revenue_growth") or 0)
+    profit = float(fact_pack.growth_facts.get("profit_growth") or 0)
+    score = 50 + revenue * 0.8 + profit * 0.8
+    return _clamp(score), f"revenue_growth={revenue}%, profit_growth={profit}%"
+
+
+def _clamp(value: float) -> float:
+    return max(0, min(100, round(value, 2)))
+

--- a/private_ext/scoring/models.py
+++ b/private_ext/scoring/models.py
@@ -1,0 +1,22 @@
+from pydantic import BaseModel, Field
+
+
+class StockScorecard(BaseModel):
+    symbol: str
+    trade_date: str
+
+    valuation_score: float
+    growth_score: float
+    profitability_score: float
+    financial_health_score: float
+    capital_flow_score: float
+    technical_score: float
+    sentiment_score: float
+    risk_score: float
+
+    total_score: float
+    rating_band: str
+
+    score_explanations: dict[str, str]
+    penalty_reasons: list[str] = Field(default_factory=list)
+

--- a/private_ext/scoring/profitability.py
+++ b/private_ext/scoring/profitability.py
@@ -1,0 +1,13 @@
+from private_ext.fact_pack.models import StockFactPack
+
+
+def score_profitability(fact_pack: StockFactPack) -> tuple[float, str]:
+    roe = float(fact_pack.profitability_facts.get("roe") or 0)
+    net_margin = float(fact_pack.profitability_facts.get("net_margin") or 0)
+    score = 45 + roe * 1.2 + net_margin * 0.35
+    return _clamp(score), f"ROE={roe}%, net_margin={net_margin}%"
+
+
+def _clamp(value: float) -> float:
+    return max(0, min(100, round(value, 2)))
+

--- a/private_ext/scoring/risk.py
+++ b/private_ext/scoring/risk.py
@@ -1,0 +1,22 @@
+from private_ext.fact_pack.models import StockFactPack
+
+
+MAJOR_RISK_KEYWORDS = ("重大减持", "解禁", "问询函", "业绩雷")
+
+
+def score_risk(fact_pack: StockFactPack) -> tuple[float, str, list[str]]:
+    risks = [str(item.get("risk", "")) for item in fact_pack.risk_facts]
+    score = 88 - len(risks) * 8
+    penalties = []
+    for risk in risks:
+        if any(keyword in risk for keyword in MAJOR_RISK_KEYWORDS):
+            score -= 25
+            penalties.append(risk)
+        elif risk:
+            penalties.append(risk)
+    return _clamp(score), f"risk_events={len(risks)}", penalties
+
+
+def _clamp(value: float) -> float:
+    return max(0, min(100, round(value, 2)))
+

--- a/private_ext/scoring/sentiment.py
+++ b/private_ext/scoring/sentiment.py
@@ -1,0 +1,20 @@
+from private_ext.fact_pack.models import StockFactPack
+
+
+def score_sentiment(fact_pack: StockFactPack) -> tuple[float, str]:
+    sentiments = [
+        item.get("sentiment")
+        for item in [*fact_pack.announcement_facts, *fact_pack.news_facts]
+        if item.get("sentiment")
+    ]
+    score = 60
+    if sentiments.count("positive") > sentiments.count("negative"):
+        score += 12
+    elif sentiments.count("negative") > 0:
+        score -= 12
+    return _clamp(score), f"sentiments={','.join(sentiments) or 'missing'}"
+
+
+def _clamp(value: float) -> float:
+    return max(0, min(100, round(value, 2)))
+

--- a/private_ext/scoring/technical.py
+++ b/private_ext/scoring/technical.py
@@ -1,0 +1,21 @@
+from private_ext.fact_pack.models import StockFactPack
+
+
+def score_technical(fact_pack: StockFactPack) -> tuple[float, str]:
+    trend = fact_pack.technical_facts.get("trend")
+    volatility = float(fact_pack.technical_facts.get("volatility") or 0)
+    score = 60
+    if trend == "up":
+        score += 18
+    elif trend == "down":
+        score -= 18
+    if volatility > 30:
+        score -= 8
+    elif volatility < 15:
+        score += 6
+    return _clamp(score), f"trend={trend}, volatility={volatility}%"
+
+
+def _clamp(value: float) -> float:
+    return max(0, min(100, round(value, 2)))
+

--- a/private_ext/scoring/total.py
+++ b/private_ext/scoring/total.py
@@ -1,0 +1,70 @@
+from private_ext.fact_pack.models import StockFactPack
+from private_ext.scoring.capital_flow import score_capital_flow
+from private_ext.scoring.financial_health import score_financial_health
+from private_ext.scoring.growth import score_growth
+from private_ext.scoring.models import StockScorecard
+from private_ext.scoring.profitability import score_profitability
+from private_ext.scoring.risk import score_risk
+from private_ext.scoring.sentiment import score_sentiment
+from private_ext.scoring.technical import score_technical
+from private_ext.scoring.valuation import score_valuation
+
+
+class ScoreEngine:
+    def score(self, fact_pack: StockFactPack) -> StockScorecard:
+        valuation_score, valuation_explain = score_valuation(fact_pack)
+        growth_score, growth_explain = score_growth(fact_pack)
+        profitability_score, profitability_explain = score_profitability(fact_pack)
+        financial_health_score, financial_health_explain = score_financial_health(fact_pack)
+        capital_flow_score, capital_flow_explain = score_capital_flow(fact_pack)
+        technical_score, technical_explain = score_technical(fact_pack)
+        sentiment_score, sentiment_explain = score_sentiment(fact_pack)
+        risk_score, risk_explain, penalty_reasons = score_risk(fact_pack)
+
+        total = (
+            valuation_score * 0.15
+            + growth_score * 0.15
+            + profitability_score * 0.15
+            + financial_health_score * 0.15
+            + capital_flow_score * 0.10
+            + technical_score * 0.10
+            + sentiment_score * 0.10
+            + risk_score * 0.10
+        )
+        total_score = round(total, 2)
+        return StockScorecard(
+            symbol=fact_pack.symbol,
+            trade_date=fact_pack.trade_date,
+            valuation_score=valuation_score,
+            growth_score=growth_score,
+            profitability_score=profitability_score,
+            financial_health_score=financial_health_score,
+            capital_flow_score=capital_flow_score,
+            technical_score=technical_score,
+            sentiment_score=sentiment_score,
+            risk_score=risk_score,
+            total_score=total_score,
+            rating_band=_rating_band(total_score),
+            score_explanations={
+                "valuation": valuation_explain,
+                "growth": growth_explain,
+                "profitability": profitability_explain,
+                "financial_health": financial_health_explain,
+                "capital_flow": capital_flow_explain,
+                "technical": technical_explain,
+                "sentiment": sentiment_explain,
+                "risk": risk_explain,
+            },
+            penalty_reasons=penalty_reasons,
+        )
+
+
+def _rating_band(total_score: float) -> str:
+    if total_score >= 80:
+        return "strong"
+    if total_score >= 65:
+        return "positive"
+    if total_score >= 50:
+        return "neutral"
+    return "weak"
+

--- a/private_ext/scoring/valuation.py
+++ b/private_ext/scoring/valuation.py
@@ -1,0 +1,24 @@
+from private_ext.fact_pack.models import StockFactPack
+
+
+def score_valuation(fact_pack: StockFactPack) -> tuple[float, str]:
+    pe = float(fact_pack.valuation_facts.get("pe") or 0)
+    pb = float(fact_pack.valuation_facts.get("pb") or 0)
+    dividend = float(fact_pack.valuation_facts.get("dividend_yield") or 0)
+    score = 70
+    if pe <= 8:
+        score += 14
+    elif pe >= 35:
+        score -= 18
+    if pb <= 1:
+        score += 8
+    elif pb >= 6:
+        score -= 10
+    if dividend >= 3:
+        score += 8
+    return _clamp(score), f"PE={pe}, PB={pb}, dividend={dividend}%"
+
+
+def _clamp(value: float) -> float:
+    return max(0, min(100, round(value, 2)))
+

--- a/private_ext/utils/__init__.py
+++ b/private_ext/utils/__init__.py
@@ -1,0 +1,2 @@
+"""Utility helpers for the private research MVP."""
+

--- a/private_ext/utils/dates.py
+++ b/private_ext/utils/dates.py
@@ -1,0 +1,6 @@
+from datetime import datetime, timezone
+
+
+def utc_now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="seconds")
+

--- a/private_ext/utils/logger.py
+++ b/private_ext/utils/logger.py
@@ -1,0 +1,20 @@
+import logging
+from pathlib import Path
+
+
+def setup_run_logger(logs_dir: Path, trade_date: str) -> logging.Logger:
+    logs_dir.mkdir(parents=True, exist_ok=True)
+    logger = logging.getLogger("private_ext.run_stock_report")
+    logger.setLevel(logging.INFO)
+    logger.handlers.clear()
+
+    formatter = logging.Formatter("%(asctime)s %(levelname)s %(message)s")
+    file_handler = logging.FileHandler(logs_dir / f"run_stock_report_{trade_date}.log", encoding="utf-8")
+    file_handler.setFormatter(formatter)
+    logger.addHandler(file_handler)
+
+    stream_handler = logging.StreamHandler()
+    stream_handler.setFormatter(formatter)
+    logger.addHandler(stream_handler)
+    return logger
+

--- a/scripts/inspect_db.py
+++ b/scripts/inspect_db.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from private_ext.config import settings
+from private_ext.database.repo import ResearchRepository
+
+
+def main() -> int:
+    repo = ResearchRepository(settings.db_path)
+    print(f"Database: {settings.db_path}")
+    print()
+    for table, count in repo.table_counts().items():
+        print(f"{table}: {count}")
+    latest_nav = repo.latest_nav()
+    if latest_nav:
+        print()
+        print("Latest NAV:")
+        print(f"cash: {latest_nav['cash']}")
+        print(f"market_value: {latest_nav['market_value']}")
+        print(f"total_nav: {latest_nav['total_nav']}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/run_stock_report.py
+++ b/scripts/run_stock_report.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from private_ext.config import settings
+from private_ext.database.init_db import init_db
+from private_ext.database.repo import ResearchRepository
+from private_ext.decisions.decision_engine import DecisionEngine
+from private_ext.decisions.risk_gate import RiskGate
+from private_ext.fact_pack.builder import FactPackBuilder
+from private_ext.paper_trading.broker import PaperBroker
+from private_ext.paper_trading.models import PaperTradeExecution
+from private_ext.raw_data.mock_collector import MockRawDataCollector
+from private_ext.reports.stock_report import render_stock_report
+from private_ext.research.mock_adapter import MockResearchAdapter
+from private_ext.scoring.total import ScoreEngine
+from private_ext.utils.logger import setup_run_logger
+
+
+def main() -> int:
+    args = _parse_args()
+    if args.raw_data != "mock":
+        raise SystemExit("Phase 1 only supports --raw-data mock")
+    if args.research_adapter != "mock":
+        raise SystemExit("Phase 1 only supports --research-adapter mock")
+
+    _ensure_dirs()
+    init_db(settings)
+    repo = ResearchRepository(settings.db_path)
+    logger = setup_run_logger(settings.logs_dir, args.trade_date)
+
+    collector = MockRawDataCollector()
+    fact_builder = FactPackBuilder()
+    score_engine = ScoreEngine()
+    research_adapter = MockResearchAdapter()
+    decision_engine = DecisionEngine()
+    risk_gate = RiskGate(settings)
+    paper_broker = PaperBroker(settings, repo)
+
+    stocks = [stock.strip() for stock in args.stocks.split(",") if stock.strip()]
+    reports = []
+    for symbol in stocks:
+        run_id = repo.create_run(args.trade_date, symbol, collector.provider, research_adapter.adapter)
+        logger.info("start symbol=%s run_id=%s", symbol, run_id)
+        try:
+            raw = collector.collect(symbol, args.trade_date)
+            repo.save_raw_data(run_id, raw, collector.provider)
+            _write_json(settings.raw_dir / f"{symbol}_{args.trade_date}.json", raw.model_dump())
+
+            fact_pack = fact_builder.build(raw)
+            repo.save_fact_pack(run_id, fact_pack)
+            _write_json(settings.fact_pack_dir / f"{symbol}_{args.trade_date}.json", fact_pack.model_dump())
+
+            scorecard = score_engine.score(fact_pack)
+            repo.save_scorecard(run_id, scorecard)
+            _write_json(settings.scorecard_dir / f"{symbol}_{args.trade_date}.json", scorecard.model_dump())
+
+            research_output = research_adapter.analyze(fact_pack, scorecard)
+            repo.save_research_output(run_id, research_output)
+
+            decision = decision_engine.build(scorecard, research_output)
+            decision = risk_gate.apply(decision, scorecard, fact_pack, current_positions=len(paper_broker.positions))
+            decision_id = repo.save_research_decision(run_id, decision)
+
+            if args.paper_trading == "on":
+                execution = paper_broker.apply(decision_id, decision)
+            else:
+                execution = PaperTradeExecution(
+                    action=decision.action,
+                    price=0,
+                    quantity=0,
+                    amount=0,
+                    fee=0,
+                    executed=False,
+                    reason="paper trading off",
+                )
+            report_path = render_stock_report(fact_pack, scorecard, decision, execution, settings.reports_dir)
+            reports.append(report_path)
+            repo.finish_run(run_id)
+            logger.info("completed symbol=%s report=%s", symbol, report_path)
+        except Exception as exc:
+            repo.finish_run(run_id, status="failed", error_message=str(exc))
+            logger.exception("failed symbol=%s", symbol)
+            raise
+
+    if args.paper_trading == "on":
+        paper_broker.mark_to_market(args.trade_date)
+
+    print("Stock report MVP completed.")
+    print(f"Date: {args.trade_date}")
+    print(f"Stocks: {','.join(stocks)}")
+    print(f"Reports: {settings.reports_dir}/")
+    print(f"Database: {settings.db_path}")
+    return 0
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run Mock A-share research report MVP.")
+    parser.add_argument("--stocks", required=True)
+    parser.add_argument("--date", dest="trade_date", required=True)
+    parser.add_argument("--raw-data", default=settings.default_raw_data)
+    parser.add_argument("--research-adapter", default=settings.default_research_adapter)
+    parser.add_argument("--paper-trading", choices=["on", "off"], default="on")
+    return parser.parse_args()
+
+
+def _ensure_dirs() -> None:
+    for path in (
+        settings.storage_dir,
+        settings.raw_dir,
+        settings.fact_pack_dir,
+        settings.scorecard_dir,
+        settings.reports_dir,
+        settings.logs_dir,
+        settings.evidence_dir,
+    ):
+        path.mkdir(parents=True, exist_ok=True)
+
+
+def _write_json(path: Path, payload: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True), encoding="utf-8")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+

--- a/tests/test_decision_engine.py
+++ b/tests/test_decision_engine.py
@@ -1,0 +1,48 @@
+from private_ext.decisions.decision_engine import DecisionEngine
+from private_ext.research.models import ResearchOutput
+from private_ext.scoring.models import StockScorecard
+
+
+def _scorecard(total_score: float) -> StockScorecard:
+    return StockScorecard(
+        symbol="600519",
+        trade_date="2026-07-03",
+        valuation_score=80,
+        growth_score=80,
+        profitability_score=80,
+        financial_health_score=80,
+        capital_flow_score=80,
+        technical_score=80,
+        sentiment_score=80,
+        risk_score=80,
+        total_score=total_score,
+        rating_band="strong",
+        score_explanations={
+            "valuation": "ok",
+            "growth": "ok",
+            "profitability": "ok",
+            "financial_health": "ok",
+            "capital_flow": "ok",
+            "technical": "ok",
+            "sentiment": "ok",
+            "risk": "ok",
+        },
+    )
+
+
+def test_decision_engine_maps_high_score_to_buy_decision():
+    research_output = ResearchOutput(
+        symbol="600519",
+        trade_date="2026-07-03",
+        adapter="mock",
+        raw_output="mock",
+        summary="high quality opportunity",
+    )
+
+    decision = DecisionEngine().build(_scorecard(82), research_output)
+
+    assert decision.action == "buy"
+    assert decision.target_position == 0.05
+    assert decision.confidence >= 0.70
+    assert decision.thesis
+

--- a/tests/test_fact_pack_builder.py
+++ b/tests/test_fact_pack_builder.py
@@ -1,0 +1,16 @@
+from private_ext.fact_pack.builder import FactPackBuilder
+from private_ext.raw_data.mock_collector import MockRawDataCollector
+
+
+def test_fact_pack_builder_generates_structured_facts_from_mock_raw_data():
+    raw = MockRawDataCollector().collect("600519", "2026-07-03")
+
+    fact_pack = FactPackBuilder().build(raw)
+
+    assert fact_pack.symbol == "600519"
+    assert fact_pack.trade_date == "2026-07-03"
+    assert fact_pack.identity["name"] == "贵州茅台"
+    assert fact_pack.valuation_facts["pe"] > 0
+    assert fact_pack.profitability_facts["roe"] > 0
+    assert fact_pack.missing_fields == []
+

--- a/tests/test_paper_broker.py
+++ b/tests/test_paper_broker.py
@@ -1,0 +1,54 @@
+import sqlite3
+from pathlib import Path
+
+from private_ext.config import Settings
+from private_ext.database.init_db import init_db
+from private_ext.database.repo import ResearchRepository
+from private_ext.decisions.models import InvestmentDecision
+from private_ext.paper_trading.broker import PaperBroker
+
+
+def test_paper_broker_records_buy_signal_order_position_and_nav(tmp_path: Path):
+    settings = Settings(
+        storage_dir=tmp_path,
+        db_path=tmp_path / "research.sqlite",
+        raw_dir=tmp_path / "raw",
+        fact_pack_dir=tmp_path / "fact_packs",
+        scorecard_dir=tmp_path / "scorecards",
+        reports_dir=tmp_path / "reports",
+        logs_dir=tmp_path / "logs",
+        evidence_dir=tmp_path / "evidence",
+    )
+    init_db(settings)
+    repo = ResearchRepository(settings.db_path)
+    decision = InvestmentDecision(
+        symbol="300750",
+        trade_date="2026-07-03",
+        rating="bullish",
+        action="buy",
+        confidence=0.78,
+        target_position=0.05,
+        horizon="20d",
+        thesis="candidate",
+        bullish_points=["profitability"],
+        bearish_points=[],
+        catalysts=[],
+        risks=[],
+        invalidation_conditions=["score below 60"],
+        aggressive_plan="buy",
+        balanced_plan="buy small",
+        conservative_plan="watch",
+        risk_gate_passed=True,
+        risk_gate_reason="passed",
+    )
+    decision_id = repo.save_research_decision(1, decision)
+
+    execution = PaperBroker(settings, repo).apply(decision_id, decision)
+
+    assert execution.executed is True
+    assert execution.quantity % 100 == 0
+    with sqlite3.connect(settings.db_path) as conn:
+        assert conn.execute("SELECT COUNT(*) FROM paper_trade_signals").fetchone()[0] == 1
+        assert conn.execute("SELECT COUNT(*) FROM paper_orders").fetchone()[0] == 1
+        assert conn.execute("SELECT COUNT(*) FROM paper_positions").fetchone()[0] == 1
+        assert conn.execute("SELECT COUNT(*) FROM paper_nav").fetchone()[0] == 1

--- a/tests/test_private_ext_report_renderer.py
+++ b/tests/test_private_ext_report_renderer.py
@@ -1,0 +1,86 @@
+from pathlib import Path
+
+from private_ext.decisions.models import InvestmentDecision
+from private_ext.fact_pack.models import StockFactPack
+from private_ext.paper_trading.models import PaperTradeExecution
+from private_ext.reports.stock_report import render_stock_report
+from private_ext.scoring.models import StockScorecard
+
+
+def test_private_ext_report_renderer_writes_required_markdown_sections(tmp_path: Path):
+    fact_pack = StockFactPack(
+        symbol="600519",
+        trade_date="2026-07-03",
+        identity={"name": "贵州茅台", "industry": "白酒"},
+        price_facts={"close": 1500.0},
+        valuation_facts={"pe": 28.0},
+        growth_facts={"revenue_growth": 8.0},
+        profitability_facts={"roe": 28.0},
+        balance_sheet_facts={"debt_ratio": 20.0},
+        cashflow_facts={"operating_cashflow_quality": "strong"},
+        capital_flow_facts={"main_net_inflow": 1.2},
+        technical_facts={"trend": "up"},
+        announcement_facts=[],
+        news_facts=[],
+        risk_facts=[],
+    )
+    scorecard = StockScorecard(
+        symbol="600519",
+        trade_date="2026-07-03",
+        valuation_score=70,
+        growth_score=60,
+        profitability_score=90,
+        financial_health_score=80,
+        capital_flow_score=70,
+        technical_score=70,
+        sentiment_score=65,
+        risk_score=85,
+        total_score=75,
+        rating_band="positive",
+        score_explanations={key: "ok" for key in (
+            "valuation",
+            "growth",
+            "profitability",
+            "financial_health",
+            "capital_flow",
+            "technical",
+            "sentiment",
+            "risk",
+        )},
+    )
+    decision = InvestmentDecision(
+        symbol="600519",
+        trade_date="2026-07-03",
+        rating="neutral-bullish",
+        action="watch",
+        confidence=0.68,
+        target_position=0.02,
+        horizon="20d",
+        thesis="watch for confirmation",
+        bullish_points=["profitability"],
+        bearish_points=["valuation"],
+        catalysts=["demand recovery"],
+        risks=["valuation compression"],
+        invalidation_conditions=["growth slows"],
+        aggressive_plan="small position",
+        balanced_plan="watch",
+        conservative_plan="wait",
+    )
+    execution = PaperTradeExecution(
+        action="watch",
+        price=1500.0,
+        quantity=0,
+        amount=0,
+        fee=0,
+        executed=False,
+        reason="watch only",
+    )
+
+    path = render_stock_report(fact_pack, scorecard, decision, execution, tmp_path)
+
+    report = path.read_text(encoding="utf-8")
+    assert path.name == "stock_report_600519_2026-07-03.md"
+    assert "# A股AI投研报告" in report
+    assert "## 1. 结论摘要" in report
+    assert "## 9. 风险提示" in report
+    assert "不构成投资建议" in report

--- a/tests/test_risk_gate.py
+++ b/tests/test_risk_gate.py
@@ -1,0 +1,73 @@
+from private_ext.decisions.models import InvestmentDecision
+from private_ext.decisions.risk_gate import RiskGate
+from private_ext.fact_pack.models import StockFactPack
+from private_ext.scoring.models import StockScorecard
+
+
+def test_risk_gate_downgrades_low_confidence_buy_to_watch():
+    decision = InvestmentDecision(
+        symbol="600519",
+        trade_date="2026-07-03",
+        rating="bullish",
+        action="buy",
+        confidence=0.60,
+        target_position=0.05,
+        horizon="20d",
+        thesis="candidate",
+        bullish_points=["profitability"],
+        bearish_points=[],
+        catalysts=[],
+        risks=[],
+        invalidation_conditions=["score below 60"],
+        aggressive_plan="buy",
+        balanced_plan="watch",
+        conservative_plan="wait",
+    )
+    scorecard = StockScorecard(
+        symbol="600519",
+        trade_date="2026-07-03",
+        valuation_score=80,
+        growth_score=80,
+        profitability_score=80,
+        financial_health_score=80,
+        capital_flow_score=80,
+        technical_score=80,
+        sentiment_score=80,
+        risk_score=80,
+        total_score=82,
+        rating_band="strong",
+        score_explanations={key: "ok" for key in (
+            "valuation",
+            "growth",
+            "profitability",
+            "financial_health",
+            "capital_flow",
+            "technical",
+            "sentiment",
+            "risk",
+        )},
+    )
+    fact_pack = StockFactPack(
+        symbol="600519",
+        trade_date="2026-07-03",
+        identity={"name": "贵州茅台"},
+        price_facts={},
+        valuation_facts={},
+        growth_facts={},
+        profitability_facts={},
+        balance_sheet_facts={},
+        cashflow_facts={},
+        capital_flow_facts={},
+        technical_facts={},
+        announcement_facts=[],
+        news_facts=[],
+        risk_facts=[],
+    )
+
+    gated = RiskGate().apply(decision, scorecard, fact_pack)
+
+    assert gated.action == "watch"
+    assert gated.target_position == 0
+    assert gated.risk_gate_passed is False
+    assert "confidence" in (gated.risk_gate_reason or "")
+

--- a/tests/test_score_engine.py
+++ b/tests/test_score_engine.py
@@ -1,0 +1,25 @@
+from private_ext.fact_pack.builder import FactPackBuilder
+from private_ext.raw_data.mock_collector import MockRawDataCollector
+from private_ext.scoring.total import ScoreEngine
+
+
+def test_score_engine_generates_explained_scores_between_zero_and_one_hundred():
+    raw = MockRawDataCollector().collect("300750", "2026-07-03")
+    fact_pack = FactPackBuilder().build(raw)
+
+    scorecard = ScoreEngine().score(fact_pack)
+
+    assert scorecard.symbol == "300750"
+    assert 0 <= scorecard.total_score <= 100
+    assert scorecard.rating_band in {"strong", "positive", "neutral", "weak"}
+    assert set(scorecard.score_explanations) == {
+        "valuation",
+        "growth",
+        "profitability",
+        "financial_health",
+        "capital_flow",
+        "technical",
+        "sentiment",
+        "risk",
+    }
+


### PR DESCRIPTION
* feat: add opt-in intelligence auto fetch

* fix(review-feedback-1913): waiting for or sharing the in-flight refresh result instead of

* fix(review-feedback-1913): 补齐 workflow 显式映射，或在文档/PR scope 中明确该开关暂不适用于仓库自带默认 workflow

* docs: clarify intelligence auto fetch workflow scope

* fix(review-feedback-1913): 修复自动刷新读取全局配置而非当前分析配置的问题

<!--
For Chinese contributors: 请直接用中文填写。
For English contributors: please fill in English. All fields marked (EN) accept English.
-->

## PR Type

- [ ] fix
- [ ] feat
- [ ] refactor
- [ ] docs
- [ ] chore
- [ ] test

## Background And Problem

请描述当前问题、影响范围与触发场景。  
*(EN) Describe the problem, its impact, and what triggers it.*

## Scope Of Change

请列出本 PR 修改的模块和文件范围。  
*(EN) List the modules and files changed in this PR.*

> 注意：请按实际 `git diff` 全量列出文件范围（建议注明文件总数），避免遗漏文档/后端/API/前端文件导致描述不一致。

> 若本 PR 修改了 `.github/PULL_REQUEST_TEMPLATE.md`、`.github/copilot-instructions.md`、`AGENTS.md`、`.github/instructions/*` 或 `.claude/skills/**` 等协作与治理文件，请补充“变更原因 + 影响面 + 回滚方式（默认 revert）”到 Summary / Compatibility / Rollback，避免 Scope 与描述不一致。

> 建议先执行并粘贴以下命令输出，避免与实际 diff 不一致：

```bash
BASE_REF=$(git merge-base HEAD origin/main)
git diff --stat "$BASE_REF"..HEAD
git diff --name-only "$BASE_REF"..HEAD
```

- 文件总数 / 变更行数（建议粘贴 `git diff --stat "$BASE_REF"..HEAD`）：
- 文件清单（按实际 diff 全量，逐项列出）：
- 文档更新文件（`docs/*`）：

## Issue Link

必须填写以下之一 / Fill in one of:
- `Fixes #<issue_number>`
- `Refs #<issue_number>`
- 无 Issue 时说明原因与验收标准 / If no issue, explain the motivation and acceptance criteria

## Verification Commands And Results

请填写你实际执行过的命令和关键结果（不要只写"已测试"）。  
*(EN) Paste the commands you actually ran and their key output (don't just write "tested"):*

```bash
# example
./scripts/ci_gate.sh
python -m pytest -m "not network"
```

> `Full-suite note` 必须与当次 PR 的当前 Head CI 结果保持一致；若本地复现存在环境相关失败，请明确标注“本地环境差异”并给出 GitHub CI 的结论与链接。  
> 请避免保留与本 PR 无关的历史失败措辞，按本次实际结果填报。
> 如历史描述中仍保留 `./scripts/ci_gate.sh` 失败记录，请先改为当前 Head CI 状态或说明与 Head CI 的差异来源。
> 若 `Full-suite note` 与当前 Head CI 不一致，PR 文本不完整，请先更新 PR 描述后再提交。

- 请在下面按实际结果填写并与 `Full-suite note` 保持一致（任一未填视为信息缺失）：
  - ai-governance：`pass` / `fail`，附链接
  - backend-gate：`pass` / `fail`，附链接
  - docker-build：`pass` / `fail`，附链接
  - web-gate：`pass` / `fail`，附链接
  - 若本 PR 修改 `.github/PULL_REQUEST_TEMPLATE.md` 等流程模板协作文件，请先说明变更必要性、影响边界，并明确回滚方式（默认 `revert this PR`）；否则请在下一版中拆为单独 chore PR。

关键输出/结论 / Key output & conclusion:

- 【必填】当前 Head CI：`ai-governance:pass / backend-gate:pass / docker-build:pass / web-gate:pass`（按实际结果替换）并附对应链接。  
- 若需保留本地失败现象，请在同段写明“本地环境差异 + 当前 CI 通过/失败结果 + CI 链接”。  
- 若全部通过，需补充一句：`当前状态：全部通过（pass）`，并明确 Head CI 全部为 pass。  

- 建议将本行直接粘贴到 PR 描述正文首段：`当前 Head CI：ai-governance:pass / backend-gate:pass / docker-build:pass / web-gate:pass`（仅示例，按实际结果替换）。

> 若上述核验项与 PR 文本冲突，建议先更新 PR 描述再提交，避免审查因状态不一致被阻塞。

## Visual Evidence (if applicable)

【必填】若本 PR 修改报告格式、报告渲染效果或 Web UI 界面，请在此处附受影响报告 / 页面截图；涉及前后差异时，优先附前后对比。Issue / PR 过程截图、审查截图、一次性验收截图和临时可视证据请放在 PR 描述、PR 评论、GitHub 附件、Actions artifact 或外部可访问链接中，不要作为仓库文件合入。
*(EN) If this PR changes report formatting, report rendering, or Web UI, attach screenshots of the affected report/page here; before/after screenshots are preferred when relevant. Issue/PR process screenshots, review screenshots, one-off acceptance screenshots, and temporary visual evidence should be linked from the PR body/comments, GitHub attachments, Actions artifacts, or external accessible evidence; do not commit them as repository files.)*

> 如截图无法获取，请在“原因”中明确写明替代证据（如 Playwright/e2e 产物路径、审查链接）及其可追溯命令，不得留空。涉及 Web 设置/报告渲染变更时，需确保截图或替代证据明确指向变更项。
>
> 若本 PR 修改 Web UI，建议至少补一条可复现路径，例如（优先 settings page）：
>
> - Playwright 截图产物：`apps/dsa-web/e2e/smoke.spec.ts`（`cd apps/dsa-web && npx playwright test e2e/smoke.spec.ts --grep "settings page renders title and save actions after login"`）
> - 审查证据链接：可直接使用 Actions 产物、GitHub 评论附件或外部可访问链接。

> 替代证据模板（设置页变更建议）：
> - 命令：`cd apps/dsa-web && npx playwright test e2e/smoke.spec.ts --grep "settings page"`
> - 产物路径：`apps/dsa-web/test-results/**/smoke-settings-page-*.png`
> - 说明：截图中应可见本次修改的系统设置项（字段、标签、帮助文案）

- 截图链接 / Screenshot links（Web UI/报告改动项必填，未提供请在下方“不适用原因”给出替代证据）：
- settings 页建议命名：`smoke-settings-page-zh` / `smoke-settings-page-en`
- 前后对比 / Before & After（如有）：
- settings 字段变更说明：截图或产物应明确包含 `MARKET_REVIEW_REGION` 字段与帮助文案区块（中文/英文）。
- 不适用原因 / Reason if not applicable（若未附截图，此项务必填写，且包含可复现证据与命令）：
  - Playwright 命令（无截图时）：`cd apps/dsa-web && npx playwright test e2e/smoke.spec.ts --grep "settings page"`
  - 产物路径（无截图时）：`apps/dsa-web/test-results/**/smoke-settings-page-*.png`
  - 说明：截图（或产物）必须可见本次修改的设置字段文案与帮助信息。

> 若本 PR 修改 Web 设置字段（字段、文案或帮助文案），截图或替代证据必须可定位到对应设置项区域并可追溯至变更项；该项为必填。

> 若本 PR 修改 Web UI 或报告展示且无法获取截图，原因栏必须给出可复现替代证据（例如 Playwright 截图产物路径 + 命令），且不得留空。

## Compatibility And Risk

请说明兼容性影响、潜在风险（如无请写 `None`）。  
*(EN) Describe compatibility impact and potential risks (write `None` if not applicable).*

- 若本 PR 修改第三方模型 / API 的兼容语义、请求参数、路由前缀或 provider fallback，请提供**官方来源链接或公告**，并说明这是长期约束、当前运行时约束还是临时兼容处理。  
  请在下方补充所影响外部 API/服务、回归范围与回退方式。  
  *(EN) If this PR changes third-party model/API compatibility, request parameters, routing prefixes, or provider fallback behavior, include an **official source link or announcement** and clarify whether the rule is permanent, runtime-specific, or a temporary compatibility workaround.)*
- 若本 PR 未触及第三方模型/API、provider/model/base URL 或运行时配置保存/清理/迁移逻辑，请在此段直接按以下文案确认（无须再次展开）：  
  `本 PR 未变更 provider/model/base URL、运行时配置清理迁移语义；历史配置保持不变；回滚方式为 revert 本提交。`
- 若本 PR 修改 `.github/PULL_REQUEST_TEMPLATE.md` / PR 流程模板类文件，请在此明确：仅影响协作流程与模板维护，不改 runtime 行为；回退方式为 revert；并补充是否影响自动化提交流程。  
  *(EN) If this PR changes `.github/PULL_REQUEST_TEMPLATE.md` or other PR workflow files, state that it only affects contribution governance templates (no runtime behavior), provide rollback by revert, and note any CI/checklist impact.)*
- 若本 PR 依赖特定运行时 / 锁定依赖窗口（例如 LiteLLM 版本范围、OpenAI-compatible 路由、YAML alias 行为），请写明当前验证过的兼容范围与覆盖路径。  
  *(EN) If this PR depends on a specific runtime or pinned dependency window (for example a LiteLLM version range, OpenAI-compatible routing, or YAML alias behavior), state the compatibility window you verified and which code paths were covered.)*
- 若本 PR 触及运行时配置保存、清理、迁移或回填逻辑，请明确说明旧配置是否会被自动改写、清空、迁移或保持不变，以及用户如何恢复原行为。  
  *(EN) If this PR touches runtime config save/cleanup/migration/backfill logic, explicitly describe whether existing config is rewritten, cleared, migrated, or left intact, and how users can restore the previous behavior.)*
- 若本 PR **未触及** provider/model/base URL 或运行时配置保存/清理/迁移逻辑（本条仅作为声明），请明确写：`本 PR 未变更 provider/model/base URL、运行时配置清理迁移语义；历史配置保持不变；回滚方式为 revert 本提交。`

## Rollback Plan

请至少写一句可执行的回滚方案（必填）。  
*(EN) Provide at least one actionable rollback step (required).*

- 如果是兼容性修复，默认应写出**最小回滚方式**（例如 `revert this PR`），并说明是否需要额外回滚配置或数据迁移。  
  *(EN) For compatibility fixes, include the **minimal rollback path** (for example `revert this PR`) and whether any additional config or data rollback is required.)*

## EXTRACT_PROMPT Change (if applicable)

若本 PR 修改了 `src/services/image_stock_extractor.py` 中的 `EXTRACT_PROMPT`，请在此处粘贴完整变更后的 prompt。  
*If this PR changes `EXTRACT_PROMPT` in `src/services/image_stock_extractor.py`, paste the full updated prompt here:*

<details>
<summary>展开 / Expand: Full EXTRACT_PROMPT</summary>

```
(paste full prompt here)
```

</details>

## Checklist

- [ ] 本 PR 有明确动机和业务价值 / This PR has a clear motivation and value
- [ ] 已提供可复现的验证命令与结果 / Reproducible verification commands and results are included
- [ ] 已评估兼容性与风险 / Compatibility and risk have been assessed
- [ ] 已提供回滚方案 / A rollback plan is provided
- [ ] 若修改报告格式或 Web UI 界面，已在 PR 描述/评论附受影响报告 / 页面截图，且未把一次性验收截图作为仓库文件合入 / If report formatting or Web UI changed, affected report/page screenshots are linked in the PR body/comments and one-off acceptance screenshots are not committed as repository files
- [ ] 若本 PR 修改 Web 设置字段（字段、文案或帮助文本），请补充设置页截图；无法截图时需提供替代可视证据（命令 + 产物路径），并指向对应变更项 / If Web settings fields changed (labels or help text), screenshots of the settings page are required; if unavailable, provide alternative visual evidence with command + artifact path that points to the changed item.
- [ ] 若涉及用户可见变更，已同步更新相关文档与 `docs/CHANGELOG.md`；`README.md` 仅在首页级信息变化时更新，细节优先写入 `docs/*.md` / If user-visible changes are included, relevant docs and `docs/CHANGELOG.md` are updated; `README.md` is updated only for homepage-level changes, with details kept in `docs/*.md`
