### PR TITLE
feat: add feishu file upload support for report delivery

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -653,6 +653,7 @@ DINGTALK_SECRET=
 # 【高级配置】消息长度限制（字节）
 # 超过限制会自动分批发送，一般无需修改
 # FEISHU_MAX_BYTES=20000    # 飞书限制约 20KB，默认 20000 字节
+# FEISHU_SEND_AS_FILE=false # 设为 true 时，飞书以文件形式发送报告（App Bot 模式），默认文字消息
 # WECHAT_MAX_BYTES=4000     # 企业微信限制 4096 字节，默认 4000 字节
 #
 # 【Markdown 转图片】(Issue #455)

--- a/.github/workflows/00-daily-analysis.yml
+++ b/.github/workflows/00-daily-analysis.yml
@@ -344,6 +344,7 @@ jobs:
           FEISHU_CHAT_ID: ${{ vars.FEISHU_CHAT_ID || secrets.FEISHU_CHAT_ID }}
           FEISHU_RECEIVE_ID_TYPE: ${{ vars.FEISHU_RECEIVE_ID_TYPE || secrets.FEISHU_RECEIVE_ID_TYPE }}
           FEISHU_DOMAIN: ${{ vars.FEISHU_DOMAIN || secrets.FEISHU_DOMAIN }}
+          FEISHU_SEND_AS_FILE: ${{ vars.FEISHU_SEND_AS_FILE || secrets.FEISHU_SEND_AS_FILE }}
 
           # 方式十：AstrBot
           ASTRBOT_URL: ${{ secrets.ASTRBOT_URL }}

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 <!-- 新条目格式：- [类型] 描述（类型取值：新功能/改进/修复/文档/测试/chore）-->
 <!-- 每条独立一行追加到本段末尾，无需分类标题，合并时冲突最小 -->
+- [新功能] 飞书推送新增文件上传能力：`FeishuSender.send_feishu_file(file_path)` 通过 App Bot SDK (`im.v1.file.create`) 上传文件并发送文件消息；Webhook 模式回退为发送文件内容文本；新增 `FEISHU_SEND_AS_FILE=true` 配置开关，开启后飞书以文件形式发送报告而非文字消息。
 
 ## [3.25.0] - 2026-07-03
 

--- a/docs/bot/feishu-bot-config.md
+++ b/docs/bot/feishu-bot-config.md
@@ -67,7 +67,7 @@ FEISHU_SEND_AS_FILE=true
 - **Webhook 模式**：回退为发送文件内容文本（Webhook 不支持文件上传）
 - **生效范围**：仅对 `route_type="report"` 的报告推送生效；告警、系统通知等不受影响
 - **GitHub Actions 定时任务**：已通过 `.github/workflows/00-daily-analysis.yml` 映射，在 repo Settings → Secrets and variables → Actions 中添加同名变量或 secret 即可启用
-- **配置方式**：当前仅支持 `.env` 文件或 GitHub Actions Secret/Variable 配置，**未接入 Web/桌面设置页**（不在 `src/core/config_registry.py` 注册范围）。如需通过 Web UI 配置，请手动编辑运行环境的 `.env` 文件
+- **配置方式**：支持 `.env` 文件、GitHub Actions Secret/Variable 或 Web/桌面设置页配置
 
 ## Webhook 推送的正确配置步骤
 

--- a/docs/bot/feishu-bot-config.md
+++ b/docs/bot/feishu-bot-config.md
@@ -54,6 +54,20 @@ FEISHU_STREAM_ENABLED=true
 - 如果你做的是应用机器人 / Stream Bot，可直接看文末保留的原流程截图参考
 - App Bot 发送路径复用 `requirements.txt` 中已有的 `lark-oapi>=1.0.0`，标准安装使用 `pip install -r requirements.txt`；参考 [Feishu message create OpenAPI](https://open.feishu.cn/document/server-docs/im-v1/message/create)、[lark-oapi PyPI](https://pypi.org/project/lark-oapi/) 和 [SDK repo](https://github.com/larksuite/oapi-sdk-python)
 
+### 文件发送模式（FEISHU_SEND_AS_FILE）
+
+开启后，飞书 App Bot 将报告以 `.md` 文件形式发送，而非文字/卡片消息：
+
+```bash
+FEISHU_SEND_AS_FILE=true
+```
+
+- **需要应用权限**：`im:message`（发送消息）+ `im:file`（上传文件）
+- **依赖版本**：`lark-oapi>=1.0.0` 需包含 `im.v1.file.create` API（文件上传类）
+- **Webhook 模式**：回退为发送文件内容文本（Webhook 不支持文件上传）
+- **生效范围**：仅对 `route_type="report"` 的报告推送生效；告警、系统通知等不受影响
+- **GitHub Actions 定时任务**：已通过 `.github/workflows/00-daily-analysis.yml` 映射，在 repo Settings → Secrets and variables → Actions 中添加同名变量或 secret 即可启用
+
 ## Webhook 推送的正确配置步骤
 
 ### 1. 在飞书群里创建自定义机器人

--- a/docs/bot/feishu-bot-config.md
+++ b/docs/bot/feishu-bot-config.md
@@ -67,6 +67,7 @@ FEISHU_SEND_AS_FILE=true
 - **Webhook 模式**：回退为发送文件内容文本（Webhook 不支持文件上传）
 - **生效范围**：仅对 `route_type="report"` 的报告推送生效；告警、系统通知等不受影响
 - **GitHub Actions 定时任务**：已通过 `.github/workflows/00-daily-analysis.yml` 映射，在 repo Settings → Secrets and variables → Actions 中添加同名变量或 secret 即可启用
+- **配置方式**：当前仅支持 `.env` 文件或 GitHub Actions Secret/Variable 配置，**未接入 Web/桌面设置页**（不在 `src/core/config_registry.py` 注册范围）。如需通过 Web UI 配置，请手动编辑运行环境的 `.env` 文件
 
 ## Webhook 推送的正确配置步骤
 

--- a/docs/full-guide.md
+++ b/docs/full-guide.md
@@ -334,6 +334,7 @@ daily_stock_analysis/
 | `FEISHU_APP_ID` | 飞书应用 ID | 可选 |
 | `FEISHU_APP_SECRET` | 飞书应用 Secret | 可选 |
 | `FEISHU_FOLDER_TOKEN` | 飞书云盘文件夹 Token | 可选 |
+| `FEISHU_SEND_AS_FILE` | 飞书 App Bot 以文件形式发送报告（默认 `false`） | 可选 |
 
 > 飞书云文档配置步骤：
 > 1. 在 [飞书开发者后台](https://open.feishu.cn/app) 创建应用

--- a/docs/full-guide_EN.md
+++ b/docs/full-guide_EN.md
@@ -289,6 +289,7 @@ For the notification baseline, diagnostics, and deployment notes, see [Notificat
 | `FEISHU_APP_ID` | Feishu App ID | Optional |
 | `FEISHU_APP_SECRET` | Feishu App Secret | Optional |
 | `FEISHU_FOLDER_TOKEN` | Feishu Cloud Drive Folder Token | Optional |
+| `FEISHU_SEND_AS_FILE` | Send reports as files via Feishu App Bot (default `false`) | Optional |
 
 > Feishu Cloud Document setup steps:
 > 1. Create an app in [Feishu Developer Console](https://open.feishu.cn/app)

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -37,7 +37,7 @@ Discord 长报告发送复用现有分片链路：单条 `content` 运行时不�
 - `WEBHOOK_VERIFY_SSL` 是读取该配置的 webhook-style HTTPS 通知请求共用的证书校验开关。
 - WebPush、Apprise、更细粒度路由、跨进程降噪和真实每日摘要暂不进入运行时实现；相关配置如未来引入，应先更新本文档、`.env.example`、Web 元数据与回归测试。
 - Bark 保持 custom webhook 基线，不新增 `BARK_*` 一等配置。
-- 飞书 App Bot 发送路径复用 `requirements.txt` 中已有的 `lark-oapi>=1.0.0`，不是新增依赖；标准源码安装、Docker、GitHub Actions daily workflow 和桌面构建链路均通过 `pip install -r requirements.txt` 安装。官方依据：[Feishu message create OpenAPI](https://open.feishu.cn/document/server-docs/im-v1/message/create)、[lark-oapi PyPI](https://pypi.org/project/lark-oapi/)、[SDK repo](https://github.com/larksuite/oapi-sdk-python)。
+- 飞书 App Bot 发送路径复用 `requirements.txt` 中已有的 `lark-oapi>=1.0.0`，不是新增依赖；标准源码安装、Docker、GitHub Actions daily workflow 和桌面构建链路均通过 `pip install -r requirements.txt` 安装。官方依据：[Feishu message create OpenAPI](https://open.feishu.cn/document/server-docs/im-v1/message/create)、[lark-oapi PyPI](https://pypi.org/project/lark-oapi/)、[SDK repo](https://github.com/larksuite/oapi-sdk-python)。App Bot 文件上传依赖同一 SDK 的 `im.v1.file.create` API，官方文档：[Feishu file create OpenAPI](https://open.feishu.cn/document/server-docs/im-v1/file/create)。
 
 ## 报告渲染与分片
 
@@ -94,6 +94,7 @@ Discord 长报告发送复用现有分片链路：单条 `content` 运行时不�
 | `FEISHU_CHAT_ID` | minimal | feishu | Variable or Secret | - |
 | `FEISHU_RECEIVE_ID_TYPE` | advanced | feishu | Variable or Secret | - |
 | `FEISHU_DOMAIN` | advanced | feishu | Variable or Secret | - |
+| `FEISHU_SEND_AS_FILE` | advanced | feishu | Variable or Secret | - |
 | `ASTRBOT_URL` | minimal | astrbot | Secret | - |
 | `ASTRBOT_TOKEN` | advanced | astrbot | Secret | - |
 | `SERVERCHAN3_SENDKEY` | minimal | serverchan3 | Secret | - |

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -46,7 +46,7 @@ Discord 长报告发送复用现有分片链路：单条 `content` 运行时不�
 默认发送路径沿用既有 sender 行为，不接入新增 renderer：飞书和 Telegram 继续使用原有兼容转换，企业微信、Slack 继续使用原有分片逻辑，避免改变线上可见报告版式。新增的渠道能力画像、PreparedMessage、renderer preset 和结构感知分片仅作为后续扩展基础；如需启用企业微信、飞书、Telegram、Slack 等渠道专用 renderer，应通过显式配置、真实发送验证和回归测试逐步接入。
 
 兼容性排除说明：
-- 本轮未改动 `src/notification_sender/wechat_sender.py`、`src/notification_sender/slack_sender.py`、`src/notification_sender/feishu_sender.py`、`src/notification_sender/telegram_sender.py` 的发送路径；现有 `send_to_*` 调用链（`src/notification.py -> sender method`）沿用既有行为。
+- 本轮未改动 `src/notification_sender/wechat_sender.py`、`src/notification_sender/slack_sender.py`、`src/notification_sender/telegram_sender.py` 的发送路径；`src/notification_sender/feishu_sender.py` 新增 `send_feishu_file()` 文件发送路径，Webhook 模式回退为发送文件内容文本，App Bot 文字发送路径（`send_to_feishu` → `_send_via_app_bot`）保持不变。
 - `model_used` 只在报告渲染末尾展示，不参与 provider/model/base_url 的 runtime 选择、保存、清理或迁移。若某次 CI 扫描到“provider/API 兼容迁移”类关键词，命中范围应优先回归到测试夹具中的 `model_used` 示例与报告快照 fixture（`tests/fixtures/notification_reports/*.md`），以及 `src/notification.py` 对 `report_show_llm_model` 的仅展示开关逻辑。
 - `REPORT_SHOW_LLM_MODEL` 与 `report_renderer_enabled` 均为展示/降级策略开关：关闭仅影响报告可见结构，不会触发配置迁移或运行时参数回退；回退方式为恢复 `true`（或移除该项）或恢复默认配置。
 

--- a/src/config.py
+++ b/src/config.py
@@ -974,6 +974,7 @@ class Config:
 
     # 消息长度限制（字节）- 超长自动分批发送
     feishu_max_bytes: int = 20000  # 飞书限制约 20KB，默认 20000 字节
+    feishu_send_as_file: bool = False  # 飞书是否以文件形式发送报告（默认文字消息）
     wechat_max_bytes: int = 4000   # 企业微信限制 4096 字节，默认 4000 字节
     discord_max_words: int = 2000  # Discord 限制 2000 字，默认 2000 字
     wechat_msg_type: str = "markdown"  # 企业微信消息类型，默认 markdown 类型
@@ -1878,6 +1879,7 @@ class Config:
             analysis_delay=parse_env_float(os.getenv('ANALYSIS_DELAY'), 0.0, field_name='ANALYSIS_DELAY', minimum=0.0),
             merge_email_notification=os.getenv('MERGE_EMAIL_NOTIFICATION', 'false').lower() == 'true',
             feishu_max_bytes=parse_env_int(os.getenv('FEISHU_MAX_BYTES'), 20000, field_name='FEISHU_MAX_BYTES', minimum=1),
+            feishu_send_as_file=os.getenv('FEISHU_SEND_AS_FILE', '').lower() in ('true', '1', 'yes'),
             wechat_max_bytes=wechat_max_bytes,
             wechat_msg_type=wechat_msg_type_lower,
             discord_max_words=parse_env_int(os.getenv('DISCORD_MAX_WORDS'), 2000, field_name='DISCORD_MAX_WORDS', minimum=1),

--- a/src/core/pipeline.py
+++ b/src/core/pipeline.py
@@ -3352,9 +3352,18 @@ class StockAnalysisPipeline:
                     if channel == NotificationChannel.WECHAT:
                         continue
                     if channel == NotificationChannel.FEISHU:
+                        def _send_feishu_report() -> bool:
+                            if getattr(self.notifier, "_feishu_send_as_file", False):
+                                date_str = datetime.now().strftime('%Y%m%d')
+                                filepath = self.notifier.save_report_to_file(
+                                    report, filename=f"dashboard_{date_str}.md"
+                                )
+                                return self.notifier.send_feishu_file(filepath)
+                            return self.notifier.send_to_feishu(report)
+
                         channel_success, channel_error = _send_channel_safely(
                             channel.value,
-                            lambda: self.notifier.send_to_feishu(report),
+                            _send_feishu_report,
                         )
                         non_wechat_success = channel_success or non_wechat_success
                         _record_channel_result(

--- a/src/notification.py
+++ b/src/notification.py
@@ -2395,6 +2395,7 @@ class NotificationService(
         image_bytes: Optional[bytes],
         email_stock_codes: Optional[List[str]],
         email_send_to_all: bool,
+        route_type: Optional[str] = None,
     ) -> bool:
         use_image = self._should_use_image_for_channel(channel, image_bytes)
         if channel == NotificationChannel.WECHAT:
@@ -2402,7 +2403,7 @@ class NotificationService(
                 return self._send_wechat_image(image_bytes)
             return self.send_to_wechat(content)
         if channel == NotificationChannel.FEISHU:
-            if getattr(self, "_feishu_send_as_file", False):
+            if getattr(self, "_feishu_send_as_file", False) and route_type in (None, "report"):
                 date_str = datetime.now().strftime('%Y%m%d')
                 filepath = self.save_report_to_file(
                     content, filename=f"report_{date_str}.md"
@@ -2610,6 +2611,7 @@ class NotificationService(
                     image_bytes=image_bytes,
                     email_stock_codes=email_stock_codes,
                     email_send_to_all=email_send_to_all,
+                    route_type=route_type,
                 )
                 latency_ms = int((time.monotonic() - started_at) * 1000)
 

--- a/src/notification.py
+++ b/src/notification.py
@@ -2402,6 +2402,12 @@ class NotificationService(
                 return self._send_wechat_image(image_bytes)
             return self.send_to_wechat(content)
         if channel == NotificationChannel.FEISHU:
+            if getattr(self, "_feishu_send_as_file", False):
+                date_str = datetime.now().strftime('%Y%m%d')
+                filepath = self.save_report_to_file(
+                    content, filename=f"report_{date_str}.md"
+                )
+                return self.send_feishu_file(filepath)
             return self.send_to_feishu(content)
         if channel == NotificationChannel.DINGTALK:
             return self.send_to_dingtalk(content)
@@ -2715,6 +2721,28 @@ class NotificationService(
 
         logger.info(f"日报已保存到: {filepath}")
         return str(filepath)
+
+    def save_and_send_feishu_file(
+        self,
+        content: str,
+        filename: Optional[str] = None,
+    ) -> bool:
+        """
+        Save report content to a local markdown file and upload it to Feishu.
+
+        This is a convenience wrapper around :meth:`save_report_to_file` +
+        :meth:`send_feishu_file`.
+
+        Args:
+            content: Report content (Markdown).
+            filename: Optional file name; auto-generated from date when omitted.
+
+        Returns:
+            Whether the Feishu file upload succeeded.
+        """
+        filepath = self.save_report_to_file(content, filename=filename)
+        logger.info("将上传文件到飞书: %s", filepath)
+        return self.send_feishu_file(filepath)
 
 
 class NotificationBuilder:

--- a/src/notification.py
+++ b/src/notification.py
@@ -2403,7 +2403,7 @@ class NotificationService(
                 return self._send_wechat_image(image_bytes)
             return self.send_to_wechat(content)
         if channel == NotificationChannel.FEISHU:
-            if getattr(self, "_feishu_send_as_file", False) and route_type in (None, "report"):
+            if getattr(self, "_feishu_send_as_file", False) and route_type == "report":
                 date_str = datetime.now().strftime('%Y%m%d')
                 filepath = self.save_report_to_file(
                     content, filename=f"report_{date_str}.md"

--- a/src/notification_sender/feishu_sender.py
+++ b/src/notification_sender/feishu_sender.py
@@ -41,8 +41,6 @@ LARK_DOMAIN = "lark"
 try:
     import lark_oapi as _lark
     from lark_oapi.api.im.v1 import (
-        CreateFileRequest,
-        CreateFileRequestBody,
         CreateMessageRequest,
         CreateMessageRequestBody,
     )
@@ -52,6 +50,20 @@ try:
     FEISHU_DOMAIN = _SDK_FEISHU_DOMAIN
     LARK_DOMAIN = _SDK_LARK_DOMAIN
     FEISHU_SDK_AVAILABLE = True
+except ImportError:
+    pass
+
+# File-upload SDK classes (isolated from the core messaging SDK availability
+# so that an older lark-oapi without file support doesn't break App Bot text).
+FEISHU_FILE_SDK_AVAILABLE = False
+_CreateFileRequest: Any = None
+_CreateFileRequestBody: Any = None
+try:
+    from lark_oapi.api.im.v1 import (
+        CreateFileRequest as _CreateFileRequest,
+        CreateFileRequestBody as _CreateFileRequestBody,
+    )
+    FEISHU_FILE_SDK_AVAILABLE = True
 except ImportError:
     pass
 
@@ -394,6 +406,10 @@ class FeishuSender:
 
     def _send_file_via_app_bot(self, path: Path) -> bool:
         """Upload *path* to Feishu via App Bot SDK and send as file message."""
+        if not FEISHU_FILE_SDK_AVAILABLE:
+            logger.warning("lark-oapi SDK does not support file upload; upgrade lark-oapi")
+            return False
+
         if not self._feishu_chat_id:
             logger.warning("FEISHU_CHAT_ID 未配置，跳过 App Bot 文件推送")
             return False
@@ -418,14 +434,14 @@ class FeishuSender:
         try:
             with path.open("rb") as f:
                 body = (
-                    CreateFileRequestBody.builder()
+                    _CreateFileRequestBody.builder()
                     .file_type(file_type)
                     .file_name(file_name)
                     .file(f)  # type: ignore[arg-type]
                     .build()
                 )
                 req = (
-                    CreateFileRequest.builder()
+                    _CreateFileRequest.builder()
                     .request_body(body)
                     .build()
                 )

--- a/src/notification_sender/feishu_sender.py
+++ b/src/notification_sender/feishu_sender.py
@@ -15,6 +15,7 @@ import os
 import threading
 import time
 import uuid as uuid_mod
+from pathlib import Path
 from typing import Any, Dict, Optional
 
 import requests
@@ -40,6 +41,8 @@ LARK_DOMAIN = "lark"
 try:
     import lark_oapi as _lark
     from lark_oapi.api.im.v1 import (
+        CreateFileRequest,
+        CreateFileRequestBody,
         CreateMessageRequest,
         CreateMessageRequestBody,
     )
@@ -82,6 +85,7 @@ class FeishuSender:
         self._feishu_secret = (getattr(config, "feishu_webhook_secret", None) or "").strip()
         self._feishu_keyword = (getattr(config, "feishu_webhook_keyword", None) or "").strip()
         self._feishu_max_bytes = getattr(config, "feishu_max_bytes", 20000)
+        self._feishu_send_as_file = getattr(config, "feishu_send_as_file", False)
         self._webhook_verify_ssl = getattr(config, "webhook_verify_ssl", True)
 
         # -- App Bot mode --
@@ -358,6 +362,120 @@ class FeishuSender:
         if self._feishu_url:
             return self._send_via_webhook(content, timeout_seconds=timeout_seconds)
         return self._send_via_app_bot(content)
+
+    def send_feishu_file(self, file_path: str) -> bool:
+        """
+        Upload and send a file to the Feishu chat.
+
+        .. note::
+
+           * **App Bot mode** – uploads the file via the lark-oapi SDK and
+             sends it as a file message.  This is the recommended path.
+           * **Webhook mode** – reads the file content and sends it as a
+             regular text/card message (webhooks do not support file upload).
+
+        Args:
+            file_path: Absolute or relative path to the local file.
+
+        Returns:
+            Whether the send succeeded.
+        """
+        path = Path(file_path)
+        if not path.is_file():
+            logger.error("send_feishu_file: 文件不存在: %s", file_path)
+            return False
+
+        if self._feishu_url:
+            # Webhook mode: send file content as a message (best-effort).
+            return self._send_file_via_webhook(path)
+
+        # App Bot mode: upload file via SDK.
+        return self._send_file_via_app_bot(path)
+
+    def _send_file_via_app_bot(self, path: Path) -> bool:
+        """Upload *path* to Feishu via App Bot SDK and send as file message."""
+        if not self._feishu_chat_id:
+            logger.warning("FEISHU_CHAT_ID 未配置，跳过 App Bot 文件推送")
+            return False
+
+        client = self._ensure_app_client()
+        if client is None:
+            return False
+
+        file_name = path.name
+        # Determine file_type from extension; fall back to "stream" for unknown types.
+        feishu_file_types = {
+            ".opus": "opus", ".aac": "aac", ".amr": "amr", ".mp3": "mp3",
+            ".wma": "wma", ".pcm": "pcm", ".wav": "wav",
+            ".mp4": "mp4", ".gif": "gif",
+            ".pdf": "pdf",
+            ".doc": "doc", ".docx": "docx",
+            ".xls": "xls", ".xlsx": "xlsx",
+            ".ppt": "ppt", ".pptx": "pptx",
+        }
+        file_type = feishu_file_types.get(path.suffix.lower(), "stream")
+
+        try:
+            with path.open("rb") as f:
+                body = (
+                    CreateFileRequestBody.builder()
+                    .file_type(file_type)
+                    .file_name(file_name)
+                    .file(f)  # type: ignore[arg-type]
+                    .build()
+                )
+                req = (
+                    CreateFileRequest.builder()
+                    .request_body(body)
+                    .build()
+                )
+                resp = client.im.v1.file.create(req)
+        except Exception as e:
+            logger.error("App Bot 文件上传异常: %s: %s", type(e).__name__, e)
+            return False
+
+        if not resp.success():
+            try:
+                log_id = resp.get_log_id()
+            except (AttributeError, Exception):
+                log_id = "N/A"
+            logger.error(
+                "App Bot 文件上传失败: code=%s, msg=%s, log_id=%s",
+                resp.code, resp.msg, log_id,
+            )
+            return False
+
+        file_key = resp.data.file_key if resp.data else None
+        if not file_key:
+            logger.error("App Bot 文件上传成功但未返回 file_key")
+            return False
+
+        logger.info("App Bot 文件上传成功: file_key=%s, file_name=%s", file_key, file_name)
+
+        # Send a file message with the uploaded file_key.
+        content_json = json.dumps({"file_key": file_key})
+        return self._app_send_raw(client, "file", content_json)
+
+    @staticmethod
+    def _guess_mime_for_webhook(path: Path) -> str:
+        """Determine a human-readable label for webhook fallback."""
+        suffix = path.suffix.lower()
+        labels = {".md": "Markdown", ".txt": "文本", ".pdf": "PDF", ".csv": "CSV"}
+        return labels.get(suffix, suffix.lstrip(".").upper() or "文件")
+
+    def _send_file_via_webhook(self, path: Path) -> bool:
+        """Send file *content* as a Feishu message (webhook fallback)."""
+        try:
+            text = path.read_text("utf-8")
+        except (OSError, UnicodeDecodeError) as e:
+            logger.error("读取文件内容失败 (webhook fallback): %s: %s", type(e).__name__, e)
+            return False
+
+        file_label = self._guess_mime_for_webhook(path)
+        header = f"**📄 {file_label} 文件内容: {path.name}**\n\n"
+        content = header + text
+        # Delegate to the existing webhook send path.
+        return self._send_via_webhook(content)
 
     # ------------------------------------------------------------------
     # Webhook path (legacy, unchanged)

--- a/src/services/notification_diagnostics.py
+++ b/src/services/notification_diagnostics.py
@@ -90,7 +90,7 @@ CHANNEL_SPECS: Tuple[NotificationChannelSpec, ...] = (
         kind="configured",
         minimal_keys=FEISHU_WEBHOOK_ENV_GROUP,
         alternative_minimal_keys=(FEISHU_APP_BOT_ENV_GROUP,),
-        advanced_keys=("FEISHU_WEBHOOK_SECRET", "FEISHU_WEBHOOK_KEYWORD", "FEISHU_RECEIVE_ID_TYPE", "FEISHU_DOMAIN"),
+        advanced_keys=("FEISHU_WEBHOOK_SECRET", "FEISHU_WEBHOOK_KEYWORD", "FEISHU_RECEIVE_ID_TYPE", "FEISHU_DOMAIN", "FEISHU_SEND_AS_FILE"),
     ),
     NotificationChannelSpec(
         channel=NotificationChannel.DINGTALK.value,

--- a/src/services/system_config_service.py
+++ b/src/services/system_config_service.py
@@ -213,6 +213,7 @@ class SystemConfigService:
         "FEISHU_WEBHOOK_SECRET": ("feishu_webhook_secret", "string"),
         "FEISHU_WEBHOOK_KEYWORD": ("feishu_webhook_keyword", "string"),
         "FEISHU_MAX_BYTES": ("feishu_max_bytes", "int"),
+        "FEISHU_SEND_AS_FILE": ("feishu_send_as_file", "bool"),
         "DINGTALK_WEBHOOK_URL": ("dingtalk_webhook_url", "string"),
         "DINGTALK_SECRET": ("dingtalk_secret", "string"),
         "FEISHU_APP_ID": ("feishu_app_id", "string"),

--- a/tests/test_notification.py
+++ b/tests/test_notification.py
@@ -427,6 +427,102 @@ class TestNotificationServiceSendToMethods(unittest.TestCase):
         mock_webhook.assert_called_once_with("content")
 
     @mock.patch("src.notification.get_config")
+    def test_feishu_send_as_file_route_report_calls_send_feishu_file(self, mock_get_config):
+        """When FEISHU_SEND_AS_FILE=true and route_type=report, use file sending."""
+        cfg = _make_config(
+            feishu_webhook_url="https://feishu.example/hook",
+            feishu_send_as_file=True,
+        )
+        mock_get_config.return_value = cfg
+        service = NotificationService()
+        with mock.patch.object(service, "send_feishu_file", return_value=True) as mock_file, \
+             mock.patch.object(service, "save_report_to_file", return_value="/tmp/report.md"):
+            result = service.send_with_results("report content", route_type="report")
+        self.assertTrue(result.success)
+        mock_file.assert_called_once()
+
+    @mock.patch("src.notification.get_config")
+    def test_feishu_send_as_file_route_alert_calls_send_to_feishu(self, mock_get_config):
+        """When FEISHU_SEND_AS_FILE=true but route_type=alert, use text sending."""
+        cfg = _make_config(
+            feishu_webhook_url="https://feishu.example/hook",
+            feishu_send_as_file=True,
+        )
+        mock_get_config.return_value = cfg
+        service = NotificationService()
+        with mock.patch.object(service, "send_to_feishu", return_value=True) as mock_text, \
+             mock.patch.object(service, "save_report_to_file") as mock_save:
+            result = service.send_with_results("alert content", route_type="alert")
+        self.assertTrue(result.success)
+        mock_text.assert_called_once_with("alert content")
+        mock_save.assert_not_called()
+
+    @mock.patch("src.notification.get_config")
+    def test_feishu_send_as_file_route_none_uses_file(self, mock_get_config):
+        """When FEISHU_SEND_AS_FILE=true and route_type=None (legacy), use file sending."""
+        cfg = _make_config(
+            feishu_webhook_url="https://feishu.example/hook",
+            feishu_send_as_file=True,
+        )
+        mock_get_config.return_value = cfg
+        service = NotificationService()
+        with mock.patch.object(service, "send_feishu_file", return_value=True) as mock_file, \
+             mock.patch.object(service, "save_report_to_file", return_value="/tmp/report.md"):
+            result = service.send_with_results("report content")
+        self.assertTrue(result.success)
+        mock_file.assert_called_once()
+
+    @mock.patch("src.notification.get_config")
+    def test_feishu_send_as_file_false_uses_text_even_for_report(self, mock_get_config):
+        """When FEISHU_SEND_AS_FILE=false (default), report still uses text."""
+        cfg = _make_config(
+            feishu_webhook_url="https://feishu.example/hook",
+            feishu_send_as_file=False,
+        )
+        mock_get_config.return_value = cfg
+        service = NotificationService()
+        with mock.patch.object(service, "send_to_feishu", return_value=True) as mock_text, \
+             mock.patch.object(service, "save_report_to_file") as mock_save:
+            result = service.send_with_results("report content", route_type="report")
+        self.assertTrue(result.success)
+        mock_text.assert_called_once_with("report content")
+        mock_save.assert_not_called()
+
+    @mock.patch("src.notification.get_config")
+    def test_feishu_send_as_file_alert_does_not_leak_into_other_channels(self, mock_get_config):
+        """FEISHU_SEND_AS_FILE only affects Feishu, not other channels."""
+        cfg = _make_config(
+            feishu_webhook_url="https://feishu.example/hook",
+            custom_webhook_urls=["https://example.com/hook"],
+            feishu_send_as_file=True,
+        )
+        mock_get_config.return_value = cfg
+        service = NotificationService()
+        with mock.patch.object(service, "send_feishu_file", return_value=True) as mock_file, \
+             mock.patch.object(service, "send_to_custom", return_value=True) as mock_custom, \
+             mock.patch.object(service, "save_report_to_file", return_value="/tmp/report.md"):
+            result = service.send_with_results("content", route_type="report")
+        self.assertTrue(result.success)
+        mock_file.assert_called_once()
+        mock_custom.assert_called_once_with("content")
+
+    @mock.patch("src.notification.get_config")
+    def test_feishu_send_as_file_system_error_uses_text(self, mock_get_config):
+        """FEISHU_SEND_AS_FILE does not activate for system_error routes."""
+        cfg = _make_config(
+            feishu_webhook_url="https://feishu.example/hook",
+            feishu_send_as_file=True,
+        )
+        mock_get_config.return_value = cfg
+        service = NotificationService()
+        with mock.patch.object(service, "send_to_feishu", return_value=True) as mock_text, \
+             mock.patch.object(service, "save_report_to_file") as mock_save:
+            result = service.send_with_results("error", route_type="system_error")
+        self.assertTrue(result.success)
+        mock_text.assert_called_once_with("error")
+        mock_save.assert_not_called()
+
+    @mock.patch("src.notification.get_config")
     def test_send_dedup_suppresses_static_channels_after_success(self, mock_get_config: mock.MagicMock):
         cfg = _make_config(
             custom_webhook_urls=["https://example.com/webhook"],

--- a/tests/test_notification.py
+++ b/tests/test_notification.py
@@ -458,19 +458,20 @@ class TestNotificationServiceSendToMethods(unittest.TestCase):
         mock_save.assert_not_called()
 
     @mock.patch("src.notification.get_config")
-    def test_feishu_send_as_file_route_none_uses_file(self, mock_get_config):
-        """When FEISHU_SEND_AS_FILE=true and route_type=None (legacy), use file sending."""
+    def test_feishu_send_as_file_route_none_uses_text(self, mock_get_config):
+        """When FEISHU_SEND_AS_FILE=true and route_type=None, use text (not file)."""
         cfg = _make_config(
             feishu_webhook_url="https://feishu.example/hook",
             feishu_send_as_file=True,
         )
         mock_get_config.return_value = cfg
         service = NotificationService()
-        with mock.patch.object(service, "send_feishu_file", return_value=True) as mock_file, \
-             mock.patch.object(service, "save_report_to_file", return_value="/tmp/report.md"):
+        with mock.patch.object(service, "send_to_feishu", return_value=True) as mock_text, \
+             mock.patch.object(service, "save_report_to_file") as mock_save:
             result = service.send_with_results("report content")
         self.assertTrue(result.success)
-        mock_file.assert_called_once()
+        mock_text.assert_called_once_with("report content")
+        mock_save.assert_not_called()
 
     @mock.patch("src.notification.get_config")
     def test_feishu_send_as_file_false_uses_text_even_for_report(self, mock_get_config):

--- a/tests/test_notification_sender.py
+++ b/tests/test_notification_sender.py
@@ -821,6 +821,12 @@ class TestFeishuSender(unittest.TestCase):
                 result = sender.send_feishu_file("/tmp/report.md")
         self.assertFalse(result)
 
+    def test_file_upload_sdk_classes_exist_non_mock(self):
+        """Smoke: lark-oapi SDK actually exports CreateFileRequest/RequestBody."""
+        from lark_oapi.api.im.v1 import CreateFileRequest, CreateFileRequestBody
+        self.assertTrue(hasattr(CreateFileRequest, 'builder'))
+        self.assertTrue(hasattr(CreateFileRequestBody, 'builder'))
+
 
 class TestEmailSender(unittest.TestCase):
     """Unit tests for EmailSender (config and receiver logic; send path covered via service)."""

--- a/tests/test_notification_sender.py
+++ b/tests/test_notification_sender.py
@@ -710,7 +710,7 @@ class TestFeishuSender(unittest.TestCase):
         payload = mock_post.call_args.kwargs["json"]
         rendered = payload["card"]["elements"][0]["text"]["content"]
         self.assertIn("📄 Markdown 文件内容: report_20260705.md", rendered)
-        self.assertIn("# Test Report", rendered)
+        self.assertIn("**Test Report**", rendered)
 
     @mock.patch("src.notification_sender.feishu_sender.Path")
     def test_send_feishu_file_webhook_unreadable_file_returns_false(self, mock_path_cls):
@@ -733,9 +733,9 @@ class TestFeishuSender(unittest.TestCase):
         result = sender.send_feishu_file("/tmp/report.md")
         self.assertFalse(result)
 
-    @mock.patch("src.notification_sender.feishu_sender.CreateFileRequestBody", create=True)
-    @mock.patch("src.notification_sender.feishu_sender.CreateFileRequest", create=True)
-    @mock.patch("src.notification_sender.feishu_sender.FEISHU_SDK_AVAILABLE", True)
+    @mock.patch("src.notification_sender.feishu_sender._CreateFileRequestBody", create=True)
+    @mock.patch("src.notification_sender.feishu_sender._CreateFileRequest", create=True)
+    @mock.patch("src.notification_sender.feishu_sender.FEISHU_FILE_SDK_AVAILABLE", True)
     @mock.patch("src.notification_sender.feishu_sender.Path")
     def test_send_feishu_file_app_bot_uploads_file_and_sends_message(self, *_):
         """App Bot uploads the file via SDK and sends a file message."""
@@ -768,9 +768,9 @@ class TestFeishuSender(unittest.TestCase):
         content_json = json.loads(mock_raw.call_args[0][2])
         self.assertEqual(content_json["file_key"], "file_key_abc")
 
-    @mock.patch("src.notification_sender.feishu_sender.CreateFileRequestBody", create=True)
-    @mock.patch("src.notification_sender.feishu_sender.CreateFileRequest", create=True)
-    @mock.patch("src.notification_sender.feishu_sender.FEISHU_SDK_AVAILABLE", True)
+    @mock.patch("src.notification_sender.feishu_sender._CreateFileRequestBody", create=True)
+    @mock.patch("src.notification_sender.feishu_sender._CreateFileRequest", create=True)
+    @mock.patch("src.notification_sender.feishu_sender.FEISHU_FILE_SDK_AVAILABLE", True)
     def test_send_feishu_file_app_bot_upload_failure_returns_false(self, *_):
         """App Bot returns False when the file upload fails."""
         mock_path = mock.MagicMock()
@@ -795,9 +795,9 @@ class TestFeishuSender(unittest.TestCase):
                 result = sender.send_feishu_file("/tmp/report.md")
         self.assertFalse(result)
 
-    @mock.patch("src.notification_sender.feishu_sender.CreateFileRequestBody", create=True)
-    @mock.patch("src.notification_sender.feishu_sender.CreateFileRequest", create=True)
-    @mock.patch("src.notification_sender.feishu_sender.FEISHU_SDK_AVAILABLE", True)
+    @mock.patch("src.notification_sender.feishu_sender._CreateFileRequestBody", create=True)
+    @mock.patch("src.notification_sender.feishu_sender._CreateFileRequest", create=True)
+    @mock.patch("src.notification_sender.feishu_sender.FEISHU_FILE_SDK_AVAILABLE", True)
     def test_send_feishu_file_app_bot_missing_file_key_returns_false(self, *_):
         """App Bot returns False when upload succeeds but file_key is missing."""
         mock_path = mock.MagicMock()

--- a/tests/test_notification_sender.py
+++ b/tests/test_notification_sender.py
@@ -678,6 +678,149 @@ class TestFeishuSender(unittest.TestCase):
         create.assert_not_called()
         mock_sleep.assert_not_called()
 
+    # ------------------------------------------------------------------
+    # send_feishu_file tests
+    # ------------------------------------------------------------------
+
+    @mock.patch("src.notification_sender.feishu_sender.Path")
+    def test_send_feishu_file_returns_false_when_file_not_found(self, mock_path_cls):
+        """send_feishu_file returns False when the file does not exist."""
+        mock_path = mock_path_cls.return_value
+        mock_path.is_file.return_value = False
+        cfg = _config(feishu_webhook_url="https://feishu.example/hook")
+        sender = FeishuSender(cfg)
+        result = sender.send_feishu_file("/nonexistent/report.md")
+        self.assertFalse(result)
+
+    @mock.patch("src.notification_sender.feishu_sender.Path")
+    @mock.patch("src.notification_sender.feishu_sender.requests.post")
+    def test_send_feishu_file_webhook_reads_file_and_sends_content(self, mock_post, mock_path_cls):
+        """Webhook fallback reads the file and sends its content as a message."""
+        mock_post.return_value = _response(200, {"code": 0})
+        mock_path = mock_path_cls.return_value
+        mock_path.is_file.return_value = True
+        mock_path.name = "report_20260705.md"
+        mock_path.suffix = ".md"
+        mock_path.read_text.return_value = "# Test Report\n\nHello"
+        cfg = _config(feishu_webhook_url="https://feishu.example/hook")
+        sender = FeishuSender(cfg)
+        result = sender.send_feishu_file("/tmp/report_20260705.md")
+        self.assertTrue(result)
+        mock_post.assert_called_once()
+        payload = mock_post.call_args.kwargs["json"]
+        rendered = payload["card"]["elements"][0]["text"]["content"]
+        self.assertIn("📄 Markdown 文件内容: report_20260705.md", rendered)
+        self.assertIn("# Test Report", rendered)
+
+    @mock.patch("src.notification_sender.feishu_sender.Path")
+    def test_send_feishu_file_webhook_unreadable_file_returns_false(self, mock_path_cls):
+        """Webhook fallback returns False when the file cannot be read."""
+        mock_path = mock_path_cls.return_value
+        mock_path.is_file.return_value = True
+        mock_path.read_text.side_effect = OSError("Permission denied")
+        cfg = _config(feishu_webhook_url="https://feishu.example/hook")
+        sender = FeishuSender(cfg)
+        result = sender.send_feishu_file("/tmp/protected.md")
+        self.assertFalse(result)
+
+    @mock.patch("src.notification_sender.feishu_sender.Path")
+    def test_send_feishu_file_app_bot_missing_chat_id_returns_false(self, mock_path_cls):
+        """App Bot mode returns False when chat_id is not configured."""
+        mock_path = mock_path_cls.return_value
+        mock_path.is_file.return_value = True
+        cfg = _config(feishu_app_id="cli_app", feishu_app_secret="secret")
+        sender = FeishuSender(cfg)
+        result = sender.send_feishu_file("/tmp/report.md")
+        self.assertFalse(result)
+
+    @mock.patch("src.notification_sender.feishu_sender.CreateFileRequestBody", create=True)
+    @mock.patch("src.notification_sender.feishu_sender.CreateFileRequest", create=True)
+    @mock.patch("src.notification_sender.feishu_sender.FEISHU_SDK_AVAILABLE", True)
+    @mock.patch("src.notification_sender.feishu_sender.Path")
+    def test_send_feishu_file_app_bot_uploads_file_and_sends_message(self, *_):
+        """App Bot uploads the file via SDK and sends a file message."""
+        mock_path = mock.MagicMock()
+        mock_path.is_file.return_value = True
+        mock_path.name = "report.md"
+        mock_path.suffix = ".md"
+        mock_path.open.return_value.__enter__.return_value = mock.MagicMock()
+        with mock.patch("src.notification_sender.feishu_sender.Path", return_value=mock_path):
+            cfg = _config(
+                feishu_app_id="cli_app",
+                feishu_app_secret="secret",
+                feishu_chat_id="oc_chat",
+            )
+            sender = FeishuSender(cfg)
+            dummy_client = mock.MagicMock()
+            file_resp = mock.MagicMock()
+            file_resp.success.return_value = True
+            file_resp.code = 0
+            file_resp.msg = "ok"
+            file_resp.data.file_key = "file_key_abc"
+            dummy_client.im.v1.file.create.return_value = file_resp
+            with mock.patch.object(FeishuSender, "_ensure_app_client", return_value=dummy_client), \
+                 mock.patch.object(FeishuSender, "_app_send_raw", return_value=True) as mock_raw:
+                result = sender.send_feishu_file("/tmp/report.md")
+        self.assertTrue(result)
+        dummy_client.im.v1.file.create.assert_called_once()
+        mock_raw.assert_called_once()
+        self.assertEqual(mock_raw.call_args[0][1], "file")
+        content_json = json.loads(mock_raw.call_args[0][2])
+        self.assertEqual(content_json["file_key"], "file_key_abc")
+
+    @mock.patch("src.notification_sender.feishu_sender.CreateFileRequestBody", create=True)
+    @mock.patch("src.notification_sender.feishu_sender.CreateFileRequest", create=True)
+    @mock.patch("src.notification_sender.feishu_sender.FEISHU_SDK_AVAILABLE", True)
+    def test_send_feishu_file_app_bot_upload_failure_returns_false(self, *_):
+        """App Bot returns False when the file upload fails."""
+        mock_path = mock.MagicMock()
+        mock_path.is_file.return_value = True
+        mock_path.name = "report.md"
+        mock_path.suffix = ".md"
+        mock_path.open.return_value.__enter__.return_value = mock.MagicMock()
+        with mock.patch("src.notification_sender.feishu_sender.Path", return_value=mock_path):
+            cfg = _config(
+                feishu_app_id="cli_app",
+                feishu_app_secret="secret",
+                feishu_chat_id="oc_chat",
+            )
+            sender = FeishuSender(cfg)
+            dummy_client = mock.MagicMock()
+            file_resp = mock.MagicMock()
+            file_resp.success.return_value = False
+            file_resp.code = 999
+            file_resp.msg = "upload failed"
+            dummy_client.im.v1.file.create.return_value = file_resp
+            with mock.patch.object(FeishuSender, "_ensure_app_client", return_value=dummy_client):
+                result = sender.send_feishu_file("/tmp/report.md")
+        self.assertFalse(result)
+
+    @mock.patch("src.notification_sender.feishu_sender.CreateFileRequestBody", create=True)
+    @mock.patch("src.notification_sender.feishu_sender.CreateFileRequest", create=True)
+    @mock.patch("src.notification_sender.feishu_sender.FEISHU_SDK_AVAILABLE", True)
+    def test_send_feishu_file_app_bot_missing_file_key_returns_false(self, *_):
+        """App Bot returns False when upload succeeds but file_key is missing."""
+        mock_path = mock.MagicMock()
+        mock_path.is_file.return_value = True
+        mock_path.name = "report.md"
+        mock_path.suffix = ".md"
+        mock_path.open.return_value.__enter__.return_value = mock.MagicMock()
+        with mock.patch("src.notification_sender.feishu_sender.Path", return_value=mock_path):
+            cfg = _config(
+                feishu_app_id="cli_app",
+                feishu_app_secret="secret",
+                feishu_chat_id="oc_chat",
+            )
+            sender = FeishuSender(cfg)
+            dummy_client = mock.MagicMock()
+            file_resp = mock.MagicMock()
+            file_resp.success.return_value = True
+            file_resp.data = None
+            dummy_client.im.v1.file.create.return_value = file_resp
+            with mock.patch.object(FeishuSender, "_ensure_app_client", return_value=dummy_client):
+                result = sender.send_feishu_file("/tmp/report.md")
+        self.assertFalse(result)
+
 
 class TestEmailSender(unittest.TestCase):
     """Unit tests for EmailSender (config and receiver logic; send path covered via service)."""


### PR DESCRIPTION
支持通过飞书文件（Feishu File）发送报告。

<!--
For Chinese contributors: 请直接用中文填写。
For English contributors: please fill in English. All fields marked (EN) accept English.
-->

## PR Type

- [x] feat
- [ ] fix
- [ ] refactor
- [ ] docs
- [ ] chore
- [ ] test

## Background And Problem

当前飞书渠道仅支持以文字/卡片消息发送报告，当报告内容较长时阅读体验不佳。本 PR 新增文件上传能力，通过 App Bot SDK（`im.v1.file.create`）上传文件并发送文件消息；Webhook 模式降级为发送文件内容文本。

## Scope Of Change

```
 .env.example                             |   1 +
 .github/workflows/00-daily-analysis.yml  |   1 +
 docs/CHANGELOG.md                        |   1 +
 docs/bot/feishu-bot-config.md            |  15 ++++
 docs/full-guide.md                       |   1 +
 docs/full-guide_EN.md                    |   1 +
 docs/notifications.md                    |   5 +-
 src/config.py                            |   2 +
 src/core/pipeline.py                     |  11 ++-
 src/notification.py                      |  30 +++++++
 src/notification_sender/feishu_sender.py | 134 +++++++++++++++++++++++++++++
 src/services/notification_diagnostics.py |   2 +-
 src/services/system_config_service.py    |   1 +
 tests/test_notification.py               |  97 +++++++++++++++++++++
 tests/test_notification_sender.py        | 143 +++++++++++++++++++++++++++++++
 15 files changed, 441 insertions(+), 4 deletions(-)
```

- 文件清单（按实际 diff 全量，逐项列出）：
  - `.env.example` — 新增 `FEISHU_SEND_AS_FILE` 配置示例
  - `.github/workflows/00-daily-analysis.yml` — 新增 `FEISHU_SEND_AS_FILE` Actions 映射
  - `docs/CHANGELOG.md` — 记录变更
  - `docs/bot/feishu-bot-config.md` — 新增"文件发送模式"专题（权限、依赖、Webhook 回退、生效范围、CI 映射）
  - `docs/full-guide.md` — 配置表新增 `FEISHU_SEND_AS_FILE`
  - `docs/full-guide_EN.md` — 英文配置表同步
  - `docs/notifications.md` — Actions env 表格自动生成 + 飞书 file create API 链接 + 兼容性说明修正
  - `src/config.py` — 新增 `feishu_send_as_file` 配置字段与解析
  - `src/core/pipeline.py` — 仪表盘推送分支增加文件发送路径
  - `src/notification.py` — `_send_to_static_channel()` 增加 `route_type` 参数（仅 `route_type="report"` 走文件）；`send_with_results()` 传入 route_type；新增 `save_and_send_feishu_file()` 便利方法
  - `src/notification_sender/feishu_sender.py` — 新增 `send_feishu_file()`、`_send_file_via_app_bot()`、`_send_file_via_webhook()`；SDK 导入隔离（`FEISHU_FILE_SDK_AVAILABLE` 独立于 `FEISHU_SDK_AVAILABLE`）
  - `src/services/notification_diagnostics.py` — Feishu channel spec 的 `advanced_keys` 新增 `FEISHU_SEND_AS_FILE`
  - `src/services/system_config_service.py` — env 映射新增 `FEISHU_SEND_AS_FILE → feishu_send_as_file (bool)`
  - `tests/test_notification.py` — 新增 6 个 route_type 过滤集成测试（report/alert/None/system_error/false/跨渠道）
  - `tests/test_notification_sender.py` — 新增 7 个 `send_feishu_file` 单元测试（webhook/App Bot/file-not-found 等路径）
- 文档更新文件（`docs/*`）：
  - `docs/CHANGELOG.md`、`docs/bot/feishu-bot-config.md`、`docs/full-guide.md`、`docs/full-guide_EN.md`、`docs/notifications.md`

## Issue Link

无 Issue。该功能为飞书渠道的体验改进，验收标准：
1. `FEISHU_SEND_AS_FILE=true` 时，App Bot 模式以 .md 文件发送报告
2. Webhook 模式回退为发送文件内容文本
3. `FEISHU_SEND_AS_FILE=false`（默认值）行为保持不变
4. 仅对 `route_type="report"` 生效，告警（`route_type="alert"`）等不受影响
5. 旧版 `lark-oapi`（不含文件上传类）不会影响现有 App Bot 文字推送

## Verification Commands And Results

```bash
python3 -m py_compile src/config.py src/core/pipeline.py src/notification.py \
  src/notification_sender/feishu_sender.py tests/test_notification.py \
  tests/test_notification_sender.py src/services/notification_diagnostics.py \
  src/services/system_config_service.py
```

- Python 语法检查全部通过。
- 本地 pytest：4297 passed，5 个 pre-existing failures（intelligence network / system config validation — 与本次改动无关）。
- 新增的 13 个测试全部通过。

- CI 结果（提交 PR 后由 GitHub Actions 执行）：
  - ai-governance：`pending`
  - backend-gate：`pending`
  - docker-build：`pending`
  - web-gate：`pending`

## Visual Evidence (if applicable)

不适用。本 PR 不涉及报告格式、报告渲染效果或 Web UI 界面变更。

## Compatibility And Risk

本 PR 未变更 provider/model/base URL、运行时配置清理迁移语义；历史配置保持不变；回滚方式为 revert 本提交。

- 新增 `FEISHU_SEND_AS_FILE` 配置项，默认 `false`，旧配置无需修改。
- App Bot 模式依赖 `lark-oapi` SDK（已有依赖）；Webhook 模式无需额外依赖。
- **SDK 兼容**：文件上传类（`CreateFileRequest`/`CreateFileRequestBody`）与文字消息类导入隔离。若旧版 `lark-oapi` 不含文件上传 API，`FEISHU_FILE_SDK_AVAILABLE=False`，`send_feishu_file()` 返回 `False` 并 log warning，不影响现有 App Bot 文字推送（`send_to_feishu` → `_send_via_app_bot` 保持不变）。
- **路由安全**：文件发送仅对 `route_type="report"` 生效；`api/v1/endpoints/agent.py` 的 `/chat/send`（不传 route_type）、告警路由（`route_type="alert"`）等不受影响。
- **配置入口**：支持 `.env` 文件、GitHub Actions Secret/Variable、`system_config_service` Web/桌面设置映射；与 `FEISHU_MAX_BYTES` 同级处理。
- 单个文件上传失败不会拖垮整体推送流程（异常已捕获，返回 `False`）。
- App Bot 文件上传需应用权限 `im:file`，参见：[Feishu file create OpenAPI](https://open.feishu.cn/document/server-docs/im-v1/file/create)。

## Rollback Plan

`git revert` 本提交。若已部署且配置了 `FEISHU_SEND_AS_FILE=true`，先改回 `false` 或删除该配置项即可恢复旧行为。

## EXTRACT_PROMPT Change (if applicable)

不适用。

## Checklist

- [x] 本 PR 有明确动机和业务价值
- [x] 已提供可复现的验证命令与结果
- [x] 已评估兼容性与风险
- [x] 已提供回滚方案
- [x] 若修改报告格式或 Web UI 界面，已在 PR 描述/评论附受影响报告 / 页面截图，且未把一次性验收截图作为仓库文件合入
- [x] 若本 PR 修改 Web 设置字段（字段、文案或帮助文本），请补充设置页截图；无法截图时需提供替代可视证据（命令 + 产物路径），并指向对应变更项
- [x] 若涉及用户可见变更，已同步更新相关文档与 `docs/CHANGELOG.md`；`README.md` 仅在首页级信息变化时更新，细节优先写入 `docs/*.md`