### PR TITLE
fix: 改进报告诊断原因展示

### DIFF
--- a/apps/dsa-web/src/components/report/AnalysisContextSummary.tsx
+++ b/apps/dsa-web/src/components/report/AnalysisContextSummary.tsx
@@ -72,7 +72,6 @@ const TEXT = {
     warnings: '告警',
     missingReasons: '缺失原因',
     diagnosticCodes: '诊断码',
-    actionHint: '处理建议',
     inputScope: '本次分析输入',
     evidenceScope: '仅代表进入本次 LLM 的输入，不等同于数据源运行成功',
     qualityScore: '质量分',
@@ -95,17 +94,6 @@ const TEXT = {
       partial: '部分可用',
       fetch_failed: '抓取失败',
     },
-    guidance: {
-      newsMissingWithResults: '上方相关资讯可能来自报告页补充检索或历史持久化；本次 LLM 输入没有使用新闻上下文。若需要新闻参与分析，请检查搜索服务配置、网络或接口限流后重新分析。',
-      newsMissing: '本次没有可用新闻上下文进入 LLM。请检查搜索服务配置、网络或接口限流，也可以稍后重新分析。',
-      missing: '该数据块没有进入本次 LLM 输入。请检查对应数据源配置、网络或接口限流后重新分析。',
-      fetch_failed: '数据源抓取失败。请检查对应 provider 配置、网络和接口限流后重新分析。',
-      partial: '只有部分字段进入本次 LLM 输入，结论需要结合其他数据块复核。',
-      fallback: '本次使用降级数据源，结论可靠性可能低于主数据源。',
-      stale: '本次使用过期数据，建议等数据源更新后重新分析。',
-      estimated: '本次包含估算字段，盘中结论建议结合实时行情复核。',
-      not_supported: '当前市场或标的不支持该数据块，通常无需处理。',
-    },
   },
   en: {
     eyebrow: 'DATA CONTEXT',
@@ -116,7 +104,6 @@ const TEXT = {
     warnings: 'Warnings',
     missingReasons: 'Missing Reasons',
     diagnosticCodes: 'Diagnostic Codes',
-    actionHint: 'Suggested Action',
     inputScope: 'Analysis Input',
     evidenceScope: 'Shows inputs included in this LLM run, not provider run success',
     qualityScore: 'Quality',
@@ -139,17 +126,6 @@ const TEXT = {
       partial: 'Partial',
       fetch_failed: 'Fetch failed',
     },
-    guidance: {
-      newsMissingWithResults: 'Related news above may come from supplemental report-page retrieval or persisted history; this LLM run did not use news context. To include news in analysis, check search configuration, network, or rate limits and reanalyze.',
-      newsMissing: 'No usable news context entered this LLM run. Check search configuration, network, or rate limits, or reanalyze later.',
-      missing: 'This block was not included in this LLM run. Check the matching data source configuration, network, or rate limits and reanalyze.',
-      fetch_failed: 'The data source fetch failed. Check provider configuration, network, and rate limits before reanalyzing.',
-      partial: 'Only part of this block entered the LLM input. Cross-check the conclusion with other data blocks.',
-      fallback: 'A fallback data source was used, so confidence may be lower than with the primary source.',
-      stale: 'Stale data was used. Reanalyze after the data source updates.',
-      estimated: 'Estimated fields were included. Cross-check intraday conclusions against real-time quotes.',
-      not_supported: 'This market or symbol does not support this block; usually no action is required.',
-    },
   },
   ko: {
     eyebrow: '데이터 컨텍스트',
@@ -160,7 +136,6 @@ const TEXT = {
     warnings: '경고',
     missingReasons: '누락 사유',
     diagnosticCodes: '진단 코드',
-    actionHint: '권장 조치',
     inputScope: '이번 분석 입력',
     evidenceScope: '이번 LLM 입력에 포함된 항목만 표시하며, 데이터 소스 실행 성공과는 다릅니다',
     qualityScore: '품질 점수',
@@ -183,51 +158,49 @@ const TEXT = {
       partial: '부분 사용',
       fetch_failed: '수집 실패',
     },
-    guidance: {
-      newsMissingWithResults: '위 관련 뉴스는 리포트 페이지 보충 검색 또는 저장된 이력에서 온 것일 수 있으며, 이번 LLM 입력에는 뉴스 컨텍스트가 포함되지 않았습니다. 뉴스까지 분석에 반영하려면 검색 설정, 네트워크, 제한 상태를 확인한 뒤 다시 분석하세요.',
-      newsMissing: '이번 LLM 입력에 사용할 뉴스 컨텍스트가 없습니다. 검색 설정, 네트워크, 제한 상태를 확인하거나 잠시 후 다시 분석하세요.',
-      missing: '이 데이터 블록은 이번 LLM 입력에 포함되지 않았습니다. 해당 데이터 소스 설정, 네트워크, 제한 상태를 확인한 뒤 다시 분석하세요.',
-      fetch_failed: '데이터 소스 수집에 실패했습니다. provider 설정, 네트워크, 제한 상태를 확인한 뒤 다시 분석하세요.',
-      partial: '일부 필드만 이번 LLM 입력에 포함되었습니다. 다른 데이터 블록과 함께 결론을 확인하세요.',
-      fallback: '대체 데이터 소스를 사용했습니다. 기본 데이터 소스보다 신뢰도가 낮을 수 있습니다.',
-      stale: '만료된 데이터를 사용했습니다. 데이터 소스가 갱신된 뒤 다시 분석하는 것을 권장합니다.',
-      estimated: '추정 필드가 포함되었습니다. 장중 결론은 실시간 시세와 함께 확인하세요.',
-      not_supported: '현재 시장 또는 종목은 이 데이터 블록을 지원하지 않으며, 보통 별도 조치가 필요하지 않습니다.',
-    },
   },
 } as const;
 
 const MISSING_REASON_LABELS: Record<ReportLanguage, Record<string, string>> = {
   zh: {
-    daily_bars_missing: '未进入分析输入',
-    news_context_missing: '未进入分析输入',
-    realtime_quote_missing: '未进入分析输入',
-    trend_result_missing: '未进入分析输入',
-    fundamental_context_missing: '未进入分析输入',
-    chip_distribution_missing: '未进入分析输入',
-    today_missing: '今日数据未进入分析输入',
-    yesterday_missing: '昨日数据未进入分析输入',
+    daily_bars_missing: '日线未进入本次分析输入；请检查日线数据源配置、网络或接口限流后重新分析。',
+    news_context_missing: '新闻未进入本次分析输入；请检查搜索服务配置、网络或接口限流，也可以稍后重新分析。',
+    realtime_quote_missing: '实时行情未进入本次分析输入；请检查行情数据源配置、网络或接口限流后重新分析。',
+    trend_result_missing: '技术分析结果未进入本次分析输入；请检查日线数据完整性后重新分析。',
+    fundamental_context_missing: '基本面未进入本次分析输入；请检查基本面数据源配置、网络或接口限流后重新分析。',
+    fundamental_pipeline_failed: '基本面抓取失败；请检查对应 provider 配置、网络或接口限流后重新分析。',
+    chip_distribution_missing: '筹码数据未进入本次分析输入；请检查筹码数据源是否支持该市场或标的，或稍后重新分析。',
+    today_missing: '今日数据未进入本次分析输入；盘中结论建议结合实时行情复核后重新分析。',
+    yesterday_missing: '昨日数据未进入本次分析输入；请检查日线数据源是否更新后重新分析。',
   },
   en: {
-    daily_bars_missing: 'Not included in analysis input',
-    news_context_missing: 'Not included in analysis input',
-    realtime_quote_missing: 'Not included in analysis input',
-    trend_result_missing: 'Not included in analysis input',
-    fundamental_context_missing: 'Not included in analysis input',
-    chip_distribution_missing: 'Not included in analysis input',
-    today_missing: 'Today data not included in analysis input',
-    yesterday_missing: 'Yesterday data not included in analysis input',
+    daily_bars_missing: 'Daily bars were not included in this LLM input; check the daily data source configuration, network, or rate limits and reanalyze.',
+    news_context_missing: 'News was not included in this LLM input; check search configuration, network, or rate limits, or reanalyze later.',
+    realtime_quote_missing: 'Real-time quote was not included in this LLM input; check the quote data source configuration, network, or rate limits and reanalyze.',
+    trend_result_missing: 'Technical analysis result was not included in this LLM input; check daily bar completeness and reanalyze.',
+    fundamental_context_missing: 'Fundamentals were not included in this LLM input; check fundamental data source configuration, network, or rate limits and reanalyze.',
+    fundamental_pipeline_failed: 'Fundamental fetch failed; check the provider configuration, network, or rate limits and reanalyze.',
+    chip_distribution_missing: 'Chip distribution was not included in this LLM input; check whether the chip data source supports this market or symbol, or reanalyze later.',
+    today_missing: 'Today data was not included in this LLM input; cross-check intraday conclusions with real-time quotes and reanalyze.',
+    yesterday_missing: 'Yesterday data was not included in this LLM input; check whether the daily data source has updated and reanalyze.',
   },
   ko: {
-    daily_bars_missing: '분석 입력에 포함되지 않음',
-    news_context_missing: '분석 입력에 포함되지 않음',
-    realtime_quote_missing: '분석 입력에 포함되지 않음',
-    trend_result_missing: '분석 입력에 포함되지 않음',
-    fundamental_context_missing: '분석 입력에 포함되지 않음',
-    chip_distribution_missing: '분석 입력에 포함되지 않음',
-    today_missing: '당일 데이터가 분석 입력에 포함되지 않음',
-    yesterday_missing: '전일 데이터가 분석 입력에 포함되지 않음',
+    daily_bars_missing: '일봉이 이번 LLM 입력에 포함되지 않았습니다. 일봉 데이터 소스 설정, 네트워크 또는 제한 상태를 확인한 뒤 다시 분석하세요.',
+    news_context_missing: '뉴스가 이번 LLM 입력에 포함되지 않았습니다. 검색 설정, 네트워크 또는 제한 상태를 확인하거나 잠시 후 다시 분석하세요.',
+    realtime_quote_missing: '실시간 시세가 이번 LLM 입력에 포함되지 않았습니다. 시세 데이터 소스 설정, 네트워크 또는 제한 상태를 확인한 뒤 다시 분석하세요.',
+    trend_result_missing: '기술 분석 결과가 이번 LLM 입력에 포함되지 않았습니다. 일봉 데이터 완전성을 확인한 뒤 다시 분석하세요.',
+    fundamental_context_missing: '펀더멘털이 이번 LLM 입력에 포함되지 않았습니다. 펀더멘털 데이터 소스 설정, 네트워크 또는 제한 상태를 확인한 뒤 다시 분석하세요.',
+    fundamental_pipeline_failed: '펀더멘털 수집에 실패했습니다. provider 설정, 네트워크 또는 제한 상태를 확인한 뒤 다시 분석하세요.',
+    chip_distribution_missing: '매물대 데이터가 이번 LLM 입력에 포함되지 않았습니다. 해당 시장 또는 종목을 데이터 소스가 지원하는지 확인하거나 잠시 후 다시 분석하세요.',
+    today_missing: '당일 데이터가 이번 LLM 입력에 포함되지 않았습니다. 장중 결론은 실시간 시세와 함께 확인한 뒤 다시 분석하세요.',
+    yesterday_missing: '전일 데이터가 이번 LLM 입력에 포함되지 않았습니다. 일봉 데이터 소스가 갱신되었는지 확인한 뒤 다시 분석하세요.',
   },
+};
+
+const NEWS_MISSING_WITH_RESULTS_LABELS: Record<ReportLanguage, string> = {
+  zh: '新闻未进入本次分析输入；上方相关资讯通常来自报告页补充检索或历史持久化，不代表新闻已参与本次 LLM 分析。若需要新闻参与分析，请检查搜索服务配置、网络或接口限流后重新分析。',
+  en: 'News was not included in this LLM input; related news above usually comes from supplemental report-page retrieval or persisted history, and does not mean news participated in this LLM analysis. To include news, check search configuration, network, or rate limits and reanalyze.',
+  ko: '뉴스가 이번 LLM 입력에 포함되지 않았습니다. 위 관련 뉴스는 보통 리포트 페이지 보충 검색 또는 저장된 이력에서 온 것이며, 이번 LLM 분석에 뉴스가 반영되었다는 뜻은 아닙니다. 뉴스까지 반영하려면 검색 설정, 네트워크 또는 제한 상태를 확인한 뒤 다시 분석하세요.',
 };
 
 const UNKNOWN_MISSING_REASON_LABELS: Record<ReportLanguage, string> = {
@@ -281,35 +254,17 @@ const formatLimitation = (
   return language === 'zh' ? `${label}：${statusLabel}` : `${label}: ${statusLabel}`;
 };
 
-const formatMissingReason = (reason: string, language: ReportLanguage): string => {
-  const label = MISSING_REASON_LABELS[language][reason];
-  return label || UNKNOWN_MISSING_REASON_LABELS[language];
-};
-
-const guidanceClassName = (status: AnalysisContextPackBlockStatus): string => {
-  if (status === 'missing' || status === 'fetch_failed') {
-    return 'border-danger/25 bg-danger/10 text-danger';
-  }
-  if (status === 'not_supported') {
-    return 'border-border/60 bg-muted/20 text-muted-text';
-  }
-  return 'border-warning/25 bg-warning/10 text-warning';
-};
-
-const getBlockGuidance = (
+const formatMissingReason = (
+  reason: string,
   block: AnalysisContextPackOverview['blocks'][number],
   overview: AnalysisContextPackOverview,
-  text: (typeof TEXT)[ReportLanguage],
-): string | null => {
-  if (block.status === 'available') {
-    return null;
+  language: ReportLanguage,
+): string => {
+  if (reason === 'news_context_missing' && block.key === 'news' && (overview.metadata?.newsResultCount || 0) > 0) {
+    return NEWS_MISSING_WITH_RESULTS_LABELS[language];
   }
-  if (block.key === 'news' && block.status === 'missing') {
-    return (overview.metadata?.newsResultCount || 0) > 0
-      ? text.guidance.newsMissingWithResults
-      : text.guidance.newsMissing;
-  }
-  return text.guidance[block.status] || null;
+  const label = MISSING_REASON_LABELS[language][reason];
+  return label || UNKNOWN_MISSING_REASON_LABELS[language];
 };
 
 export const AnalysisContextSummary: React.FC<AnalysisContextSummaryProps> = ({
@@ -447,7 +402,6 @@ export const AnalysisContextSummary: React.FC<AnalysisContextSummaryProps> = ({
           <div className="grid grid-cols-1 gap-2 md:grid-cols-2">
             {overview.blocks.map((block) => {
               const style = STATUS_STYLE[block.status] || STATUS_STYLE.missing;
-              const guidance = getBlockGuidance(block, overview, text);
               return (
                 <div key={block.key} className="home-subpanel p-3">
                   <div className="flex items-start justify-between gap-3">
@@ -477,19 +431,13 @@ export const AnalysisContextSummary: React.FC<AnalysisContextSummaryProps> = ({
                   {block.missingReasons?.length ? (
                     <p className="mt-2 text-xs leading-5 text-muted-text">
                       {text.missingReasons}: {block.missingReasons
-                        .map((reason) => formatMissingReason(reason, reportLanguage))
+                        .map((reason) => formatMissingReason(reason, block, overview, reportLanguage))
                         .join(', ')}
                     </p>
                   ) : null}
                   {block.missingReasons?.length ? (
                     <p className="mt-1 text-[11px] leading-5 text-muted-text">
                       {text.diagnosticCodes}: {block.missingReasons.join(', ')}
-                    </p>
-                  ) : null}
-                  {guidance ? (
-                    <p className={`mt-2 rounded-lg border px-3 py-2 text-xs leading-5 ${guidanceClassName(block.status)}`}>
-                      <span className="font-medium">{text.actionHint}: </span>
-                      {guidance}
                     </p>
                   ) : null}
                 </div>

--- a/apps/dsa-web/src/components/report/AnalysisContextSummary.tsx
+++ b/apps/dsa-web/src/components/report/AnalysisContextSummary.tsx
@@ -68,8 +68,11 @@ const TEXT = {
     title: '输入数据块',
     counts: '状态计数',
     source: '来源',
+    sourceUnavailable: '未记录输入来源',
     warnings: '告警',
     missingReasons: '缺失原因',
+    diagnosticCodes: '诊断码',
+    actionHint: '处理建议',
     inputScope: '本次分析输入',
     evidenceScope: '仅代表进入本次 LLM 的输入，不等同于数据源运行成功',
     qualityScore: '质量分',
@@ -92,14 +95,28 @@ const TEXT = {
       partial: '部分可用',
       fetch_failed: '抓取失败',
     },
+    guidance: {
+      newsMissingWithResults: '上方相关资讯可能来自报告页补充检索或历史持久化；本次 LLM 输入没有使用新闻上下文。若需要新闻参与分析，请检查搜索服务配置、网络或接口限流后重新分析。',
+      newsMissing: '本次没有可用新闻上下文进入 LLM。请检查搜索服务配置、网络或接口限流，也可以稍后重新分析。',
+      missing: '该数据块没有进入本次 LLM 输入。请检查对应数据源配置、网络或接口限流后重新分析。',
+      fetch_failed: '数据源抓取失败。请检查对应 provider 配置、网络和接口限流后重新分析。',
+      partial: '只有部分字段进入本次 LLM 输入，结论需要结合其他数据块复核。',
+      fallback: '本次使用降级数据源，结论可靠性可能低于主数据源。',
+      stale: '本次使用过期数据，建议等数据源更新后重新分析。',
+      estimated: '本次包含估算字段，盘中结论建议结合实时行情复核。',
+      not_supported: '当前市场或标的不支持该数据块，通常无需处理。',
+    },
   },
   en: {
     eyebrow: 'DATA CONTEXT',
     title: 'Input Blocks',
     counts: 'Status Counts',
     source: 'Source',
+    sourceUnavailable: 'Input source not recorded',
     warnings: 'Warnings',
     missingReasons: 'Missing Reasons',
+    diagnosticCodes: 'Diagnostic Codes',
+    actionHint: 'Suggested Action',
     inputScope: 'Analysis Input',
     evidenceScope: 'Shows inputs included in this LLM run, not provider run success',
     qualityScore: 'Quality',
@@ -122,14 +139,28 @@ const TEXT = {
       partial: 'Partial',
       fetch_failed: 'Fetch failed',
     },
+    guidance: {
+      newsMissingWithResults: 'Related news above may come from supplemental report-page retrieval or persisted history; this LLM run did not use news context. To include news in analysis, check search configuration, network, or rate limits and reanalyze.',
+      newsMissing: 'No usable news context entered this LLM run. Check search configuration, network, or rate limits, or reanalyze later.',
+      missing: 'This block was not included in this LLM run. Check the matching data source configuration, network, or rate limits and reanalyze.',
+      fetch_failed: 'The data source fetch failed. Check provider configuration, network, and rate limits before reanalyzing.',
+      partial: 'Only part of this block entered the LLM input. Cross-check the conclusion with other data blocks.',
+      fallback: 'A fallback data source was used, so confidence may be lower than with the primary source.',
+      stale: 'Stale data was used. Reanalyze after the data source updates.',
+      estimated: 'Estimated fields were included. Cross-check intraday conclusions against real-time quotes.',
+      not_supported: 'This market or symbol does not support this block; usually no action is required.',
+    },
   },
   ko: {
     eyebrow: '데이터 컨텍스트',
     title: '입력 데이터 블록',
     counts: '상태 카운트',
     source: '출처',
+    sourceUnavailable: '입력 출처 기록 없음',
     warnings: '경고',
     missingReasons: '누락 사유',
+    diagnosticCodes: '진단 코드',
+    actionHint: '권장 조치',
     inputScope: '이번 분석 입력',
     evidenceScope: '이번 LLM 입력에 포함된 항목만 표시하며, 데이터 소스 실행 성공과는 다릅니다',
     qualityScore: '품질 점수',
@@ -151,6 +182,17 @@ const TEXT = {
       estimated: '추정',
       partial: '부분 사용',
       fetch_failed: '수집 실패',
+    },
+    guidance: {
+      newsMissingWithResults: '위 관련 뉴스는 리포트 페이지 보충 검색 또는 저장된 이력에서 온 것일 수 있으며, 이번 LLM 입력에는 뉴스 컨텍스트가 포함되지 않았습니다. 뉴스까지 분석에 반영하려면 검색 설정, 네트워크, 제한 상태를 확인한 뒤 다시 분석하세요.',
+      newsMissing: '이번 LLM 입력에 사용할 뉴스 컨텍스트가 없습니다. 검색 설정, 네트워크, 제한 상태를 확인하거나 잠시 후 다시 분석하세요.',
+      missing: '이 데이터 블록은 이번 LLM 입력에 포함되지 않았습니다. 해당 데이터 소스 설정, 네트워크, 제한 상태를 확인한 뒤 다시 분석하세요.',
+      fetch_failed: '데이터 소스 수집에 실패했습니다. provider 설정, 네트워크, 제한 상태를 확인한 뒤 다시 분석하세요.',
+      partial: '일부 필드만 이번 LLM 입력에 포함되었습니다. 다른 데이터 블록과 함께 결론을 확인하세요.',
+      fallback: '대체 데이터 소스를 사용했습니다. 기본 데이터 소스보다 신뢰도가 낮을 수 있습니다.',
+      stale: '만료된 데이터를 사용했습니다. 데이터 소스가 갱신된 뒤 다시 분석하는 것을 권장합니다.',
+      estimated: '추정 필드가 포함되었습니다. 장중 결론은 실시간 시세와 함께 확인하세요.',
+      not_supported: '현재 시장 또는 종목은 이 데이터 블록을 지원하지 않으며, 보통 별도 조치가 필요하지 않습니다.',
     },
   },
 } as const;
@@ -235,7 +277,33 @@ const formatLimitation = (
 
 const formatMissingReason = (reason: string, language: ReportLanguage): string => {
   const label = MISSING_REASON_LABELS[language][reason];
-  return label ? `${label} (${reason})` : reason;
+  return label || reason;
+};
+
+const guidanceClassName = (status: AnalysisContextPackBlockStatus): string => {
+  if (status === 'missing' || status === 'fetch_failed') {
+    return 'border-danger/25 bg-danger/10 text-danger';
+  }
+  if (status === 'not_supported') {
+    return 'border-border/60 bg-muted/20 text-muted-text';
+  }
+  return 'border-warning/25 bg-warning/10 text-warning';
+};
+
+const getBlockGuidance = (
+  block: AnalysisContextPackOverview['blocks'][number],
+  overview: AnalysisContextPackOverview,
+  text: (typeof TEXT)[ReportLanguage],
+): string | null => {
+  if (block.status === 'available') {
+    return null;
+  }
+  if (block.key === 'news' && block.status === 'missing') {
+    return (overview.metadata?.newsResultCount || 0) > 0
+      ? text.guidance.newsMissingWithResults
+      : text.guidance.newsMissing;
+  }
+  return text.guidance[block.status] || null;
 };
 
 export const AnalysisContextSummary: React.FC<AnalysisContextSummaryProps> = ({
@@ -373,6 +441,7 @@ export const AnalysisContextSummary: React.FC<AnalysisContextSummaryProps> = ({
           <div className="grid grid-cols-1 gap-2 md:grid-cols-2">
             {overview.blocks.map((block) => {
               const style = STATUS_STYLE[block.status] || STATUS_STYLE.missing;
+              const guidance = getBlockGuidance(block, overview, text);
               return (
                 <div key={block.key} className="home-subpanel p-3">
                   <div className="flex items-start justify-between gap-3">
@@ -381,6 +450,10 @@ export const AnalysisContextSummary: React.FC<AnalysisContextSummaryProps> = ({
                       {block.source ? (
                         <p className="mt-1 truncate text-xs text-secondary-text">
                           {text.source}: {block.source}
+                        </p>
+                      ) : block.status !== 'available' ? (
+                        <p className="mt-1 truncate text-xs text-secondary-text">
+                          {text.source}: {text.sourceUnavailable}
                         </p>
                       ) : null}
                     </div>
@@ -400,6 +473,17 @@ export const AnalysisContextSummary: React.FC<AnalysisContextSummaryProps> = ({
                       {text.missingReasons}: {block.missingReasons
                         .map((reason) => formatMissingReason(reason, reportLanguage))
                         .join(', ')}
+                    </p>
+                  ) : null}
+                  {block.missingReasons?.length ? (
+                    <p className="mt-1 text-[11px] leading-5 text-muted-text">
+                      {text.diagnosticCodes}: {block.missingReasons.join(', ')}
+                    </p>
+                  ) : null}
+                  {guidance ? (
+                    <p className={`mt-2 rounded-lg border px-3 py-2 text-xs leading-5 ${guidanceClassName(block.status)}`}>
+                      <span className="font-medium">{text.actionHint}: </span>
+                      {guidance}
                     </p>
                   ) : null}
                 </div>

--- a/apps/dsa-web/src/components/report/AnalysisContextSummary.tsx
+++ b/apps/dsa-web/src/components/report/AnalysisContextSummary.tsx
@@ -71,6 +71,7 @@ const TEXT = {
     sourceUnavailable: '未记录输入来源',
     warnings: '告警',
     missingReasons: '缺失原因',
+    statusGuidance: '状态说明',
     diagnosticCodes: '诊断码',
     action: '处理',
     scope: '范围',
@@ -105,6 +106,7 @@ const TEXT = {
     sourceUnavailable: 'Input source not recorded',
     warnings: 'Warnings',
     missingReasons: 'Missing Reasons',
+    statusGuidance: 'Status Note',
     diagnosticCodes: 'Diagnostic Codes',
     action: 'Action',
     scope: 'Scope',
@@ -139,6 +141,7 @@ const TEXT = {
     sourceUnavailable: '입력 출처 기록 없음',
     warnings: '경고',
     missingReasons: '누락 사유',
+    statusGuidance: '상태 안내',
     diagnosticCodes: '진단 코드',
     action: '조치',
     scope: '범위',
@@ -249,6 +252,72 @@ const UNKNOWN_MISSING_REASON_LABELS: Record<ReportLanguage, string> = {
   zh: '未记录明确缺失原因',
   en: 'Missing reason was not recorded',
   ko: '명확한 누락 사유 기록 없음',
+};
+
+const STATUS_FALLBACK_GUIDANCE: Record<
+  ReportLanguage,
+  Partial<Record<AnalysisContextPackBlockStatus, string>>
+> = {
+  zh: {
+    missing: '数据未进入本次分析输入',
+    fetch_failed: '数据抓取失败，本次分析未使用该数据',
+    not_supported: '当前市场或标的不支持该数据',
+    fallback: '本次分析使用了降级数据路径',
+    stale: '本次分析使用了非最新数据',
+    estimated: '本次分析使用了估算数据',
+    partial: '仅部分数据进入本次分析输入',
+  },
+  en: {
+    missing: 'Data was not included in this analysis input',
+    fetch_failed: 'Data retrieval failed and this analysis did not use the data',
+    not_supported: 'This data is not supported for the current market or symbol',
+    fallback: 'This analysis used a fallback data path',
+    stale: 'This analysis used data that may not be current',
+    estimated: 'This analysis used estimated data',
+    partial: 'Only part of the data was included in this analysis input',
+  },
+  ko: {
+    missing: '데이터가 이번 분석 입력에 포함되지 않았습니다',
+    fetch_failed: '데이터 수집에 실패해 이번 분석에서 사용되지 않았습니다',
+    not_supported: '현재 시장 또는 종목은 이 데이터를 지원하지 않습니다',
+    fallback: '이번 분석은 강등 데이터 경로를 사용했습니다',
+    stale: '이번 분석은 최신이 아닐 수 있는 데이터를 사용했습니다',
+    estimated: '이번 분석은 추정 데이터를 사용했습니다',
+    partial: '데이터의 일부만 이번 분석 입력에 포함되었습니다',
+  },
+};
+
+const STATUS_FALLBACK_ACTIONS: Record<
+  ReportLanguage,
+  Partial<Record<AnalysisContextPackBlockStatus, string>>
+> = {
+  zh: {
+    missing: '检查数据源/配置/网络后重跑',
+    fetch_failed: '检查数据源/网络/限流后重跑',
+    not_supported: '更换受支持的数据源或结合其他指标',
+    fallback: '结合数据来源和告警复核降级结果',
+    stale: '检查数据更新时间后按需重跑',
+    estimated: '结合原始数据复核估算结果',
+    partial: '检查告警和数据源后重跑',
+  },
+  en: {
+    missing: 'Check the data source, configuration, and network, then rerun',
+    fetch_failed: 'Check the data source, network, and rate limits, then rerun',
+    not_supported: 'Use a supported data source or cross-check other indicators',
+    fallback: 'Review the fallback result against its source and warnings',
+    stale: 'Check the data timestamp and rerun if needed',
+    estimated: 'Cross-check the estimate against the source data',
+    partial: 'Check the warnings and data source, then rerun',
+  },
+  ko: {
+    missing: '데이터 소스/설정/네트워크 확인 후 다시 실행',
+    fetch_failed: '데이터 소스/네트워크/제한 확인 후 다시 실행',
+    not_supported: '지원되는 데이터 소스를 사용하거나 다른 지표와 교차 확인',
+    fallback: '데이터 출처와 경고를 기준으로 강등 결과 확인',
+    stale: '데이터 갱신 시각 확인 후 필요하면 다시 실행',
+    estimated: '원본 데이터와 추정 결과를 교차 확인',
+    partial: '경고와 데이터 소스 확인 후 다시 실행',
+  },
 };
 
 const STATUS_ORDER: AnalysisContextPackBlockStatus[] = [
@@ -464,9 +533,17 @@ export const AnalysisContextSummary: React.FC<AnalysisContextSummaryProps> = ({
           <div className="grid grid-cols-1 gap-2 md:grid-cols-2">
             {overview.blocks.map((block) => {
               const style = STATUS_STYLE[block.status] || STATUS_STYLE.missing;
-              const missingReasonChips = block.missingReasons?.length
+              const hasMissingReasons = Boolean(block.missingReasons?.length);
+              const guidanceSummary = hasMissingReasons
+                ? block.missingReasons
+                  ?.map((reason) => getMissingReasonSummary(reason, reportLanguage))
+                  .join(', ')
+                : STATUS_FALLBACK_GUIDANCE[reportLanguage][block.status];
+              const guidanceChips = hasMissingReasons
                 ? getMissingReasonChips(block, overview, reportLanguage, text)
-                : [];
+                : STATUS_FALLBACK_ACTIONS[reportLanguage][block.status]
+                  ? [`${text.action}: ${STATUS_FALLBACK_ACTIONS[reportLanguage][block.status]}`]
+                  : [];
               return (
                 <div key={block.key} className="home-subpanel p-3">
                   <div className="flex items-start justify-between gap-3">
@@ -493,16 +570,14 @@ export const AnalysisContextSummary: React.FC<AnalysisContextSummaryProps> = ({
                       {text.warnings}: {block.warnings.join(', ')}
                     </p>
                   ) : null}
-                  {block.missingReasons?.length ? (
+                  {guidanceSummary ? (
                     <p className="mt-2 text-xs leading-5 text-muted-text">
-                      {text.missingReasons}: {block.missingReasons
-                        .map((reason) => getMissingReasonSummary(reason, reportLanguage))
-                        .join(', ')}
+                      {hasMissingReasons ? text.missingReasons : text.statusGuidance}: {guidanceSummary}
                     </p>
                   ) : null}
-                  {missingReasonChips.length ? (
+                  {guidanceChips.length ? (
                     <div className="mt-2 flex flex-wrap gap-1.5 text-[11px] leading-5">
-                      {missingReasonChips.map((chip) => (
+                      {guidanceChips.map((chip) => (
                         <span key={chip} className="home-accent-chip max-w-full px-2 py-0.5 text-muted-text">
                           {chip}
                         </span>

--- a/apps/dsa-web/src/components/report/AnalysisContextSummary.tsx
+++ b/apps/dsa-web/src/components/report/AnalysisContextSummary.tsx
@@ -72,6 +72,8 @@ const TEXT = {
     warnings: '告警',
     missingReasons: '缺失原因',
     diagnosticCodes: '诊断码',
+    action: '处理',
+    scope: '范围',
     inputScope: '本次分析输入',
     evidenceScope: '仅代表进入本次 LLM 的输入，不等同于数据源运行成功',
     qualityScore: '质量分',
@@ -104,6 +106,8 @@ const TEXT = {
     warnings: 'Warnings',
     missingReasons: 'Missing Reasons',
     diagnosticCodes: 'Diagnostic Codes',
+    action: 'Action',
+    scope: 'Scope',
     inputScope: 'Analysis Input',
     evidenceScope: 'Shows inputs included in this LLM run, not provider run success',
     qualityScore: 'Quality',
@@ -136,6 +140,8 @@ const TEXT = {
     warnings: '경고',
     missingReasons: '누락 사유',
     diagnosticCodes: '진단 코드',
+    action: '조치',
+    scope: '범위',
     inputScope: '이번 분석 입력',
     evidenceScope: '이번 LLM 입력에 포함된 항목만 표시하며, 데이터 소스 실행 성공과는 다릅니다',
     qualityScore: '품질 점수',
@@ -163,44 +169,80 @@ const TEXT = {
 
 const MISSING_REASON_LABELS: Record<ReportLanguage, Record<string, string>> = {
   zh: {
-    daily_bars_missing: '日线未进入本次分析输入；请检查日线数据源配置、网络或接口限流后重新分析。',
-    news_context_missing: '新闻未进入本次分析输入；请检查搜索服务配置、网络或接口限流，也可以稍后重新分析。',
-    realtime_quote_missing: '实时行情未进入本次分析输入；请检查行情数据源配置、网络或接口限流后重新分析。',
-    trend_result_missing: '技术分析结果未进入本次分析输入；请检查日线数据完整性后重新分析。',
-    fundamental_context_missing: '基本面未进入本次分析输入；请检查基本面数据源配置、网络或接口限流后重新分析。',
-    fundamental_pipeline_failed: '基本面抓取失败；请检查对应 provider 配置、网络或接口限流后重新分析。',
-    chip_distribution_missing: '筹码数据未进入本次分析输入；请检查筹码数据源是否支持该市场或标的，或稍后重新分析。',
-    today_missing: '今日数据未进入本次分析输入；盘中结论建议结合实时行情复核后重新分析。',
-    yesterday_missing: '昨日数据未进入本次分析输入；请检查日线数据源是否更新后重新分析。',
+    daily_bars_missing: '日线未进入本次分析输入',
+    news_context_missing: '新闻未进入本次分析输入',
+    realtime_quote_missing: '实时行情未进入本次分析输入',
+    trend_result_missing: '技术分析结果未进入本次分析输入',
+    fundamental_context_missing: '基本面未进入本次分析输入',
+    fundamental_pipeline_failed: '基本面抓取失败',
+    chip_distribution_missing: '筹码数据未进入本次分析输入',
+    today_missing: '今日数据未进入本次分析输入',
+    yesterday_missing: '昨日数据未进入本次分析输入',
   },
   en: {
-    daily_bars_missing: 'Daily bars were not included in this LLM input; check the daily data source configuration, network, or rate limits and reanalyze.',
-    news_context_missing: 'News was not included in this LLM input; check search configuration, network, or rate limits, or reanalyze later.',
-    realtime_quote_missing: 'Real-time quote was not included in this LLM input; check the quote data source configuration, network, or rate limits and reanalyze.',
-    trend_result_missing: 'Technical analysis result was not included in this LLM input; check daily bar completeness and reanalyze.',
-    fundamental_context_missing: 'Fundamentals were not included in this LLM input; check fundamental data source configuration, network, or rate limits and reanalyze.',
-    fundamental_pipeline_failed: 'Fundamental fetch failed; check the provider configuration, network, or rate limits and reanalyze.',
-    chip_distribution_missing: 'Chip distribution was not included in this LLM input; check whether the chip data source supports this market or symbol, or reanalyze later.',
-    today_missing: 'Today data was not included in this LLM input; cross-check intraday conclusions with real-time quotes and reanalyze.',
-    yesterday_missing: 'Yesterday data was not included in this LLM input; check whether the daily data source has updated and reanalyze.',
+    daily_bars_missing: 'Daily bars were not included in this LLM input',
+    news_context_missing: 'News was not included in this LLM input',
+    realtime_quote_missing: 'Real-time quote was not included in this LLM input',
+    trend_result_missing: 'Technical analysis result was not included in this LLM input',
+    fundamental_context_missing: 'Fundamentals were not included in this LLM input',
+    fundamental_pipeline_failed: 'Fundamental fetch failed',
+    chip_distribution_missing: 'Chip distribution was not included in this LLM input',
+    today_missing: 'Today data was not included in this LLM input',
+    yesterday_missing: 'Yesterday data was not included in this LLM input',
   },
   ko: {
-    daily_bars_missing: '일봉이 이번 LLM 입력에 포함되지 않았습니다. 일봉 데이터 소스 설정, 네트워크 또는 제한 상태를 확인한 뒤 다시 분석하세요.',
-    news_context_missing: '뉴스가 이번 LLM 입력에 포함되지 않았습니다. 검색 설정, 네트워크 또는 제한 상태를 확인하거나 잠시 후 다시 분석하세요.',
-    realtime_quote_missing: '실시간 시세가 이번 LLM 입력에 포함되지 않았습니다. 시세 데이터 소스 설정, 네트워크 또는 제한 상태를 확인한 뒤 다시 분석하세요.',
-    trend_result_missing: '기술 분석 결과가 이번 LLM 입력에 포함되지 않았습니다. 일봉 데이터 완전성을 확인한 뒤 다시 분석하세요.',
-    fundamental_context_missing: '펀더멘털이 이번 LLM 입력에 포함되지 않았습니다. 펀더멘털 데이터 소스 설정, 네트워크 또는 제한 상태를 확인한 뒤 다시 분석하세요.',
-    fundamental_pipeline_failed: '펀더멘털 수집에 실패했습니다. provider 설정, 네트워크 또는 제한 상태를 확인한 뒤 다시 분석하세요.',
-    chip_distribution_missing: '매물대 데이터가 이번 LLM 입력에 포함되지 않았습니다. 해당 시장 또는 종목을 데이터 소스가 지원하는지 확인하거나 잠시 후 다시 분석하세요.',
-    today_missing: '당일 데이터가 이번 LLM 입력에 포함되지 않았습니다. 장중 결론은 실시간 시세와 함께 확인한 뒤 다시 분석하세요.',
-    yesterday_missing: '전일 데이터가 이번 LLM 입력에 포함되지 않았습니다. 일봉 데이터 소스가 갱신되었는지 확인한 뒤 다시 분석하세요.',
+    daily_bars_missing: '일봉이 이번 LLM 입력에 포함되지 않았습니다',
+    news_context_missing: '뉴스가 이번 LLM 입력에 포함되지 않았습니다',
+    realtime_quote_missing: '실시간 시세가 이번 LLM 입력에 포함되지 않았습니다',
+    trend_result_missing: '기술 분석 결과가 이번 LLM 입력에 포함되지 않았습니다',
+    fundamental_context_missing: '펀더멘털이 이번 LLM 입력에 포함되지 않았습니다',
+    fundamental_pipeline_failed: '펀더멘털 수집에 실패했습니다',
+    chip_distribution_missing: '매물대 데이터가 이번 LLM 입력에 포함되지 않았습니다',
+    today_missing: '당일 데이터가 이번 LLM 입력에 포함되지 않았습니다',
+    yesterday_missing: '전일 데이터가 이번 LLM 입력에 포함되지 않았습니다',
   },
 };
 
-const NEWS_MISSING_WITH_RESULTS_LABELS: Record<ReportLanguage, string> = {
-  zh: '新闻未进入本次分析输入；上方相关资讯通常来自报告页补充检索或历史持久化，不代表新闻已参与本次 LLM 分析。若需要新闻参与分析，请检查搜索服务配置、网络或接口限流后重新分析。',
-  en: 'News was not included in this LLM input; related news above usually comes from supplemental report-page retrieval or persisted history, and does not mean news participated in this LLM analysis. To include news, check search configuration, network, or rate limits and reanalyze.',
-  ko: '뉴스가 이번 LLM 입력에 포함되지 않았습니다. 위 관련 뉴스는 보통 리포트 페이지 보충 검색 또는 저장된 이력에서 온 것이며, 이번 LLM 분석에 뉴스가 반영되었다는 뜻은 아닙니다. 뉴스까지 반영하려면 검색 설정, 네트워크 또는 제한 상태를 확인한 뒤 다시 분석하세요.',
+const MISSING_REASON_ACTIONS: Record<ReportLanguage, Record<string, string>> = {
+  zh: {
+    daily_bars_missing: '检查日线数据源/网络/限流后重跑',
+    news_context_missing: '检查搜索配置/网络/限流后重跑',
+    realtime_quote_missing: '检查行情数据源/网络/限流后重跑',
+    trend_result_missing: '检查日线完整性后重跑',
+    fundamental_context_missing: '检查基本面数据源/网络/限流后重跑',
+    fundamental_pipeline_failed: '检查 provider 配置/网络/限流后重跑',
+    chip_distribution_missing: '确认市场或标的支持筹码数据',
+    today_missing: '结合实时行情复核后重跑',
+    yesterday_missing: '等待日线数据源更新后重跑',
+  },
+  en: {
+    daily_bars_missing: 'Check daily source/network/rate limits and rerun',
+    news_context_missing: 'Check search config/network/rate limits and rerun',
+    realtime_quote_missing: 'Check quote source/network/rate limits and rerun',
+    trend_result_missing: 'Check daily bar completeness and rerun',
+    fundamental_context_missing: 'Check fundamental source/network/rate limits and rerun',
+    fundamental_pipeline_failed: 'Check provider config/network/rate limits and rerun',
+    chip_distribution_missing: 'Confirm chip data supports this market or symbol',
+    today_missing: 'Cross-check real-time quotes and rerun',
+    yesterday_missing: 'Wait for daily source update and rerun',
+  },
+  ko: {
+    daily_bars_missing: '일봉 소스/네트워크/제한 확인 후 재실행',
+    news_context_missing: '검색 설정/네트워크/제한 확인 후 재실행',
+    realtime_quote_missing: '시세 소스/네트워크/제한 확인 후 재실행',
+    trend_result_missing: '일봉 완전성 확인 후 재실행',
+    fundamental_context_missing: '펀더멘털 소스/네트워크/제한 확인 후 재실행',
+    fundamental_pipeline_failed: 'provider 설정/네트워크/제한 확인 후 재실행',
+    chip_distribution_missing: '시장 또는 종목의 매물대 지원 여부 확인',
+    today_missing: '실시간 시세와 대조 후 재실행',
+    yesterday_missing: '일봉 소스 갱신 후 재실행',
+  },
+};
+
+const NEWS_SUPPLEMENTAL_SCOPE_LABELS: Record<ReportLanguage, string> = {
+  zh: '相关资讯来自报告页补充/历史',
+  en: 'Related news is supplemental/history',
+  ko: '관련 뉴스는 보충/이력 출처',
 };
 
 const UNKNOWN_MISSING_REASON_LABELS: Record<ReportLanguage, string> = {
@@ -254,17 +296,37 @@ const formatLimitation = (
   return language === 'zh' ? `${label}：${statusLabel}` : `${label}: ${statusLabel}`;
 };
 
-const formatMissingReason = (
+const getMissingReasonSummary = (
   reason: string,
+  language: ReportLanguage,
+): string => {
+  const label = MISSING_REASON_LABELS[language][reason];
+  return label || UNKNOWN_MISSING_REASON_LABELS[language];
+};
+
+const getMissingReasonChips = (
   block: AnalysisContextPackOverview['blocks'][number],
   overview: AnalysisContextPackOverview,
   language: ReportLanguage,
-): string => {
-  if (reason === 'news_context_missing' && block.key === 'news' && (overview.metadata?.newsResultCount || 0) > 0) {
-    return NEWS_MISSING_WITH_RESULTS_LABELS[language];
+  text: (typeof TEXT)[ReportLanguage],
+): string[] => {
+  const chips = (block.missingReasons || []).flatMap((reason) => {
+    const action = MISSING_REASON_ACTIONS[language][reason];
+    return [
+      `${text.diagnosticCodes}: ${reason}`,
+      action ? `${text.action}: ${action}` : null,
+    ];
+  }).filter((chip): chip is string => Boolean(chip));
+
+  if (
+    block.key === 'news'
+    && block.missingReasons?.includes('news_context_missing')
+    && (overview.metadata?.newsResultCount || 0) > 0
+  ) {
+    chips.push(`${text.scope}: ${NEWS_SUPPLEMENTAL_SCOPE_LABELS[language]}`);
   }
-  const label = MISSING_REASON_LABELS[language][reason];
-  return label || UNKNOWN_MISSING_REASON_LABELS[language];
+
+  return Array.from(new Set(chips));
 };
 
 export const AnalysisContextSummary: React.FC<AnalysisContextSummaryProps> = ({
@@ -402,6 +464,9 @@ export const AnalysisContextSummary: React.FC<AnalysisContextSummaryProps> = ({
           <div className="grid grid-cols-1 gap-2 md:grid-cols-2">
             {overview.blocks.map((block) => {
               const style = STATUS_STYLE[block.status] || STATUS_STYLE.missing;
+              const missingReasonChips = block.missingReasons?.length
+                ? getMissingReasonChips(block, overview, reportLanguage, text)
+                : [];
               return (
                 <div key={block.key} className="home-subpanel p-3">
                   <div className="flex items-start justify-between gap-3">
@@ -431,14 +496,18 @@ export const AnalysisContextSummary: React.FC<AnalysisContextSummaryProps> = ({
                   {block.missingReasons?.length ? (
                     <p className="mt-2 text-xs leading-5 text-muted-text">
                       {text.missingReasons}: {block.missingReasons
-                        .map((reason) => formatMissingReason(reason, block, overview, reportLanguage))
+                        .map((reason) => getMissingReasonSummary(reason, reportLanguage))
                         .join(', ')}
                     </p>
                   ) : null}
-                  {block.missingReasons?.length ? (
-                    <p className="mt-1 text-[11px] leading-5 text-muted-text">
-                      {text.diagnosticCodes}: {block.missingReasons.join(', ')}
-                    </p>
+                  {missingReasonChips.length ? (
+                    <div className="mt-2 flex flex-wrap gap-1.5 text-[11px] leading-5">
+                      {missingReasonChips.map((chip) => (
+                        <span key={chip} className="home-accent-chip max-w-full px-2 py-0.5 text-muted-text">
+                          {chip}
+                        </span>
+                      ))}
+                    </div>
                   ) : null}
                 </div>
               );

--- a/apps/dsa-web/src/components/report/AnalysisContextSummary.tsx
+++ b/apps/dsa-web/src/components/report/AnalysisContextSummary.tsx
@@ -178,7 +178,11 @@ const MISSING_REASON_LABELS: Record<ReportLanguage, Record<string, string>> = {
     trend_result_missing: '技术分析结果未进入本次分析输入',
     fundamental_context_missing: '基本面未进入本次分析输入',
     fundamental_pipeline_failed: '基本面抓取失败',
+    fundamentals_not_supported: '当前市场或标的不支持基本面数据',
+    fundamental_coverage_missing: '基本面覆盖数据未进入本次分析输入',
+    fundamental_source_chain_missing: '基本面来源链未进入本次分析输入',
     chip_distribution_missing: '筹码数据未进入本次分析输入',
+    chip_not_supported: '当前市场或标的不支持筹码数据',
     today_missing: '今日数据未进入本次分析输入',
     yesterday_missing: '昨日数据未进入本次分析输入',
   },
@@ -189,7 +193,11 @@ const MISSING_REASON_LABELS: Record<ReportLanguage, Record<string, string>> = {
     trend_result_missing: 'Technical analysis result was not included in this LLM input',
     fundamental_context_missing: 'Fundamentals were not included in this LLM input',
     fundamental_pipeline_failed: 'Fundamental fetch failed',
+    fundamentals_not_supported: 'Fundamental data is not supported for this market or symbol',
+    fundamental_coverage_missing: 'Fundamental coverage was not included in this LLM input',
+    fundamental_source_chain_missing: 'Fundamental sources were not included in this LLM input',
     chip_distribution_missing: 'Chip distribution was not included in this LLM input',
+    chip_not_supported: 'Chip data is not supported for this market or symbol',
     today_missing: 'Today data was not included in this LLM input',
     yesterday_missing: 'Yesterday data was not included in this LLM input',
   },
@@ -200,7 +208,11 @@ const MISSING_REASON_LABELS: Record<ReportLanguage, Record<string, string>> = {
     trend_result_missing: '기술 분석 결과가 이번 LLM 입력에 포함되지 않았습니다',
     fundamental_context_missing: '펀더멘털이 이번 LLM 입력에 포함되지 않았습니다',
     fundamental_pipeline_failed: '펀더멘털 수집에 실패했습니다',
+    fundamentals_not_supported: '현재 시장 또는 종목은 펀더멘털 데이터를 지원하지 않습니다',
+    fundamental_coverage_missing: '펀더멘털 커버리지가 이번 LLM 입력에 포함되지 않았습니다',
+    fundamental_source_chain_missing: '펀더멘털 출처가 이번 LLM 입력에 포함되지 않았습니다',
     chip_distribution_missing: '매물대 데이터가 이번 LLM 입력에 포함되지 않았습니다',
+    chip_not_supported: '현재 시장 또는 종목은 매물대 데이터를 지원하지 않습니다',
     today_missing: '당일 데이터가 이번 LLM 입력에 포함되지 않았습니다',
     yesterday_missing: '전일 데이터가 이번 LLM 입력에 포함되지 않았습니다',
   },
@@ -214,7 +226,11 @@ const MISSING_REASON_ACTIONS: Record<ReportLanguage, Record<string, string>> = {
     trend_result_missing: '检查日线完整性后重跑',
     fundamental_context_missing: '检查基本面数据源/网络/限流后重跑',
     fundamental_pipeline_failed: '检查 provider 配置/网络/限流后重跑',
+    fundamentals_not_supported: '确认当前市场或标的的基本面数据支持情况',
+    fundamental_coverage_missing: '检查基本面数据源覆盖范围后重跑',
+    fundamental_source_chain_missing: '检查基本面 provider 配置后重跑',
     chip_distribution_missing: '确认市场或标的支持筹码数据',
+    chip_not_supported: '更换受支持的数据源或结合其他指标',
     today_missing: '结合实时行情复核后重跑',
     yesterday_missing: '等待日线数据源更新后重跑',
   },
@@ -225,7 +241,11 @@ const MISSING_REASON_ACTIONS: Record<ReportLanguage, Record<string, string>> = {
     trend_result_missing: 'Check daily bar completeness and rerun',
     fundamental_context_missing: 'Check fundamental source/network/rate limits and rerun',
     fundamental_pipeline_failed: 'Check provider config/network/rate limits and rerun',
+    fundamentals_not_supported: 'Confirm fundamental data support for this market or symbol',
+    fundamental_coverage_missing: 'Check fundamental source coverage and rerun',
+    fundamental_source_chain_missing: 'Check fundamental provider configuration and rerun',
     chip_distribution_missing: 'Confirm chip data supports this market or symbol',
+    chip_not_supported: 'Use a supported data source or cross-check other indicators',
     today_missing: 'Cross-check real-time quotes and rerun',
     yesterday_missing: 'Wait for daily source update and rerun',
   },
@@ -236,7 +256,11 @@ const MISSING_REASON_ACTIONS: Record<ReportLanguage, Record<string, string>> = {
     trend_result_missing: '일봉 완전성 확인 후 재실행',
     fundamental_context_missing: '펀더멘털 소스/네트워크/제한 확인 후 재실행',
     fundamental_pipeline_failed: 'provider 설정/네트워크/제한 확인 후 재실행',
+    fundamentals_not_supported: '현재 시장 또는 종목의 펀더멘털 데이터 지원 여부 확인',
+    fundamental_coverage_missing: '펀더멘털 데이터 소스 범위 확인 후 재실행',
+    fundamental_source_chain_missing: '펀더멘털 provider 설정 확인 후 재실행',
     chip_distribution_missing: '시장 또는 종목의 매물대 지원 여부 확인',
+    chip_not_supported: '지원되는 데이터 소스를 사용하거나 다른 지표와 교차 확인',
     today_missing: '실시간 시세와 대조 후 재실행',
     yesterday_missing: '일봉 소스 갱신 후 재실행',
   },
@@ -368,9 +392,10 @@ const formatLimitation = (
 const getMissingReasonSummary = (
   reason: string,
   language: ReportLanguage,
+  status: AnalysisContextPackBlockStatus,
 ): string => {
   const label = MISSING_REASON_LABELS[language][reason];
-  return label || UNKNOWN_MISSING_REASON_LABELS[language];
+  return label || STATUS_FALLBACK_GUIDANCE[language][status] || UNKNOWN_MISSING_REASON_LABELS[language];
 };
 
 const getMissingReasonChips = (
@@ -380,7 +405,8 @@ const getMissingReasonChips = (
   text: (typeof TEXT)[ReportLanguage],
 ): string[] => {
   const chips = (block.missingReasons || []).flatMap((reason) => {
-    const action = MISSING_REASON_ACTIONS[language][reason];
+    const action = MISSING_REASON_ACTIONS[language][reason]
+      || STATUS_FALLBACK_ACTIONS[language][block.status];
     return [
       `${text.diagnosticCodes}: ${reason}`,
       action ? `${text.action}: ${action}` : null,
@@ -536,7 +562,7 @@ export const AnalysisContextSummary: React.FC<AnalysisContextSummaryProps> = ({
               const hasMissingReasons = Boolean(block.missingReasons?.length);
               const guidanceSummary = hasMissingReasons
                 ? block.missingReasons
-                  ?.map((reason) => getMissingReasonSummary(reason, reportLanguage))
+                  ?.map((reason) => getMissingReasonSummary(reason, reportLanguage, block.status))
                   .join(', ')
                 : STATUS_FALLBACK_GUIDANCE[reportLanguage][block.status];
               const guidanceChips = hasMissingReasons

--- a/apps/dsa-web/src/components/report/AnalysisContextSummary.tsx
+++ b/apps/dsa-web/src/components/report/AnalysisContextSummary.tsx
@@ -230,6 +230,12 @@ const MISSING_REASON_LABELS: Record<ReportLanguage, Record<string, string>> = {
   },
 };
 
+const UNKNOWN_MISSING_REASON_LABELS: Record<ReportLanguage, string> = {
+  zh: '未记录明确缺失原因',
+  en: 'Missing reason was not recorded',
+  ko: '명확한 누락 사유 기록 없음',
+};
+
 const STATUS_ORDER: AnalysisContextPackBlockStatus[] = [
   'available',
   'missing',
@@ -277,7 +283,7 @@ const formatLimitation = (
 
 const formatMissingReason = (reason: string, language: ReportLanguage): string => {
   const label = MISSING_REASON_LABELS[language][reason];
-  return label || reason;
+  return label || UNKNOWN_MISSING_REASON_LABELS[language];
 };
 
 const guidanceClassName = (status: AnalysisContextPackBlockStatus): string => {

--- a/apps/dsa-web/src/components/report/ReportDiagnostics.tsx
+++ b/apps/dsa-web/src/components/report/ReportDiagnostics.tsx
@@ -40,6 +40,7 @@ const TEXT = {
     unavailable: '运行诊断暂不可用',
     noComponents: '暂无组件诊断',
     components: '关键链路',
+    primaryReason: '主要原因',
     advanced: '高级字段',
     copy: '复制排障信息',
     copied: '已复制',
@@ -70,6 +71,7 @@ const TEXT = {
     unavailable: 'Diagnostics unavailable',
     noComponents: 'No component diagnostics',
     components: 'Key Path',
+    primaryReason: 'Primary Reason',
     advanced: 'Advanced Fields',
     copy: 'Copy diagnostics',
     copied: 'Copied',
@@ -100,6 +102,7 @@ const TEXT = {
     unavailable: '실행 진단을 사용할 수 없음',
     noComponents: '컴포넌트 진단 없음',
     components: '핵심 경로',
+    primaryReason: '주요 사유',
     advanced: '고급 필드',
     copy: '진단 정보 복사',
     copied: '복사됨',
@@ -141,6 +144,111 @@ const COMPONENT_STATUS_STYLE: Record<RunDiagnosticComponentStatus, { variant: Ba
   skipped: { variant: 'default', tone: 'neutral' },
 };
 
+const DETAIL_ORDER = [
+  'error_type',
+  'provider',
+  'fallback_to',
+  'record_count',
+  'attempts',
+  'analysis_input_status',
+  'analysis_input_missing_reasons',
+  'evidence_scope',
+  'analysis_input_source',
+  'model',
+  'fallback_model',
+  'tokens',
+  'duration_ms',
+  'channels',
+  'failed',
+  'analysis_history_id',
+];
+
+const DETAIL_LABELS: Record<ReportLanguage, Record<string, string>> = {
+  zh: {
+    provider: '数据源',
+    attempts: '尝试',
+    record_count: '记录数',
+    fallback_to: '降级到',
+    error_type: '错误类型',
+    model: '模型',
+    tokens: 'Tokens',
+    duration_ms: '耗时',
+    fallback_model: '切换模型',
+    channels: '渠道',
+    failed: '失败渠道',
+    analysis_history_id: '历史 ID',
+    analysis_input_block: '输入块',
+    analysis_input_status: '输入状态',
+    analysis_input_source: '输入来源',
+    analysis_input_missing_reasons: '真实原因',
+    evidence_scope: '证据范围',
+  },
+  en: {
+    provider: 'Provider',
+    attempts: 'Attempts',
+    record_count: 'Records',
+    fallback_to: 'Fallback To',
+    error_type: 'Error Type',
+    model: 'Model',
+    tokens: 'Tokens',
+    duration_ms: 'Duration',
+    fallback_model: 'Fallback Model',
+    channels: 'Channels',
+    failed: 'Failed',
+    analysis_history_id: 'History ID',
+    analysis_input_block: 'Input Block',
+    analysis_input_status: 'Input Status',
+    analysis_input_source: 'Input Source',
+    analysis_input_missing_reasons: 'Raw Reason',
+    evidence_scope: 'Evidence Scope',
+  },
+  ko: {
+    provider: '데이터 소스',
+    attempts: '시도',
+    record_count: '레코드',
+    fallback_to: '강등 대상',
+    error_type: '오류 유형',
+    model: '모델',
+    tokens: 'Tokens',
+    duration_ms: '소요 시간',
+    fallback_model: '전환 모델',
+    channels: '채널',
+    failed: '실패 채널',
+    analysis_history_id: '이력 ID',
+    analysis_input_block: '입력 블록',
+    analysis_input_status: '입력 상태',
+    analysis_input_source: '입력 출처',
+    analysis_input_missing_reasons: '원인 코드',
+    evidence_scope: '증거 범위',
+  },
+};
+
+const DETAIL_VALUE_LABELS: Record<ReportLanguage, Record<string, string>> = {
+  zh: {
+    provider_run_vs_analysis_input: '数据源成功但未进分析输入',
+    retrieval_vs_analysis_input: '检索结果未进分析输入',
+    analysis_input_only: '仅记录分析输入状态',
+  },
+  en: {
+    provider_run_vs_analysis_input: 'Provider succeeded but input excluded',
+    retrieval_vs_analysis_input: 'Retrieved results excluded from input',
+    analysis_input_only: 'Analysis input status only',
+  },
+  ko: {
+    provider_run_vs_analysis_input: '소스 성공, 분석 입력 제외',
+    retrieval_vs_analysis_input: '검색 결과가 입력에서 제외됨',
+    analysis_input_only: '분석 입력 상태만 기록',
+  },
+};
+
+const compactText = (value: string, maxLength = 92): string => {
+  const text = value.trim();
+  if (text.length <= maxLength) {
+    return text;
+  }
+  return `${text.slice(0, Math.max(0, maxLength - 3))}...`;
+};
+
 const compactId = (value?: string): string | null => {
   const text = (value || '').trim();
   if (!text) return null;
@@ -157,6 +265,57 @@ const getOrderedComponents = (
     .filter((component): component is RunDiagnosticComponent => Boolean(component));
   const remaining = items.filter((component) => !COMPONENT_ORDER.includes(component.key));
   return [...ordered, ...remaining];
+};
+
+const formatDetailValue = (
+  key: string,
+  value: unknown,
+  language: ReportLanguage,
+): string | null => {
+  if (value === null || value === undefined || value === '') {
+    return null;
+  }
+  if (Array.isArray(value)) {
+    const items = value
+      .map((item) => String(item).trim())
+      .filter(Boolean)
+      .slice(0, 3);
+    if (!items.length) {
+      return null;
+    }
+    return items.join(', ');
+  }
+  if (typeof value === 'object') {
+    return null;
+  }
+  if (key === 'duration_ms' && typeof value === 'number') {
+    return `${value}ms`;
+  }
+  const raw = String(value).trim();
+  return DETAIL_VALUE_LABELS[language][raw] || raw;
+};
+
+const getComponentDetailChips = (
+  component: RunDiagnosticComponent,
+  language: ReportLanguage,
+): string[] => {
+  const details = component.details || {};
+  const orderedKeys = [
+    ...DETAIL_ORDER.filter((key) => Object.prototype.hasOwnProperty.call(details, key)),
+    ...Object.keys(details).filter((key) => !DETAIL_ORDER.includes(key)).sort(),
+  ];
+
+  return orderedKeys
+    .map((key) => {
+      const value = formatDetailValue(key, details[key], language);
+      if (!value) {
+        return null;
+      }
+      const label = DETAIL_LABELS[language][key] || key;
+      return `${label}: ${compactText(value, 52)}`;
+    })
+    .filter((chip): chip is string => Boolean(chip))
+    .slice(0, 6);
 };
 
 /**
@@ -333,9 +492,12 @@ export const ReportDiagnostics: React.FC<ReportDiagnosticsProps> = ({
         <div className="home-divider space-y-4 border-t px-4 pb-4 pt-3">
           <div className="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
             <div className="min-w-0 space-y-2">
-              <p className="text-sm leading-6 text-foreground">
-                {visibleSummary.reason}
-              </p>
+              <div className="home-subpanel flex max-w-full flex-wrap items-center gap-2 px-3 py-2">
+                <span className="label-uppercase">{text.primaryReason}</span>
+                <span className="min-w-0 text-sm leading-5 text-foreground" title={visibleSummary.reason}>
+                  {compactText(visibleSummary.reason)}
+                </span>
+              </div>
               <div className="flex flex-wrap items-center gap-2 text-xs text-muted-text">
                 {traceId ? (
                   <span className="home-accent-chip px-2 py-0.5 font-mono">
@@ -391,6 +553,7 @@ export const ReportDiagnostics: React.FC<ReportDiagnosticsProps> = ({
               {components.length > 0 ? components.map((component) => {
                 const componentStyle = COMPONENT_STATUS_STYLE[component.status] || COMPONENT_STATUS_STYLE.unknown;
                 const componentLabel = text.component[component.status] || component.status;
+                const detailChips = getComponentDetailChips(component, reportLanguage);
                 return (
                   <div key={component.key} className="home-subpanel p-3">
                     <div className="flex items-start justify-between gap-3">
@@ -398,8 +561,8 @@ export const ReportDiagnostics: React.FC<ReportDiagnosticsProps> = ({
                         <p className="text-sm font-medium text-foreground">
                           {component.label}
                         </p>
-                        <p className="mt-1 text-xs leading-5 text-secondary-text">
-                          {component.message}
+                        <p className="mt-1 text-xs leading-5 text-secondary-text" title={component.message}>
+                          {compactText(component.message, 82)}
                         </p>
                       </div>
                       <Badge variant={componentStyle.variant} className="shrink-0 gap-1.5 shadow-none">
@@ -407,6 +570,15 @@ export const ReportDiagnostics: React.FC<ReportDiagnosticsProps> = ({
                         {componentLabel}
                       </Badge>
                     </div>
+                    {detailChips.length ? (
+                      <div className="mt-2 flex flex-wrap gap-1.5 text-[11px] leading-5">
+                        {detailChips.map((chip) => (
+                          <span key={chip} className="home-accent-chip max-w-full px-2 py-0.5 text-muted-text">
+                            {chip}
+                          </span>
+                        ))}
+                      </div>
+                    ) : null}
                   </div>
                 );
               }) : (

--- a/apps/dsa-web/src/components/report/ReportDiagnostics.tsx
+++ b/apps/dsa-web/src/components/report/ReportDiagnostics.tsx
@@ -150,6 +150,7 @@ const DETAIL_ORDER = [
   'fallback_to',
   'record_count',
   'attempts',
+  'analysis_input_block',
   'analysis_input_status',
   'analysis_input_missing_reasons',
   'evidence_scope',
@@ -295,19 +296,38 @@ const formatDetailValue = (
   return DETAIL_VALUE_LABELS[language][raw] || raw;
 };
 
+const normalizeDetailKey = (key: string): string => (
+  key
+    .replace(/([a-z0-9])([A-Z])/g, '$1_$2')
+    .toLowerCase()
+);
+
 const getComponentDetailChips = (
   component: RunDiagnosticComponent,
   language: ReportLanguage,
 ): string[] => {
   const details = component.details || {};
+  const normalizedDetails = Object.entries(details).reduce<Record<string, unknown>>(
+    (result, [key, value]) => {
+      const normalizedKey = normalizeDetailKey(key);
+      if (
+        !Object.prototype.hasOwnProperty.call(result, normalizedKey)
+        || key === normalizedKey
+      ) {
+        result[normalizedKey] = value;
+      }
+      return result;
+    },
+    {},
+  );
   const orderedKeys = [
-    ...DETAIL_ORDER.filter((key) => Object.prototype.hasOwnProperty.call(details, key)),
-    ...Object.keys(details).filter((key) => !DETAIL_ORDER.includes(key)).sort(),
+    ...DETAIL_ORDER.filter((key) => Object.prototype.hasOwnProperty.call(normalizedDetails, key)),
+    ...Object.keys(normalizedDetails).filter((key) => !DETAIL_ORDER.includes(key)).sort(),
   ];
 
   return orderedKeys
     .map((key) => {
-      const value = formatDetailValue(key, details[key], language);
+      const value = formatDetailValue(key, normalizedDetails[key], language);
       if (!value) {
         return null;
       }
@@ -494,7 +514,7 @@ export const ReportDiagnostics: React.FC<ReportDiagnosticsProps> = ({
             <div className="min-w-0 space-y-2">
               <div className="home-subpanel flex max-w-full flex-wrap items-center gap-2 px-3 py-2">
                 <span className="label-uppercase">{text.primaryReason}</span>
-                <span className="min-w-0 text-sm leading-5 text-foreground" title={visibleSummary.reason}>
+                <span className="min-w-0 text-sm leading-5 text-foreground" aria-label={visibleSummary.reason}>
                   {compactText(visibleSummary.reason)}
                 </span>
               </div>
@@ -561,7 +581,7 @@ export const ReportDiagnostics: React.FC<ReportDiagnosticsProps> = ({
                         <p className="text-sm font-medium text-foreground">
                           {component.label}
                         </p>
-                        <p className="mt-1 text-xs leading-5 text-secondary-text" title={component.message}>
+                        <p className="mt-1 text-xs leading-5 text-secondary-text" aria-label={component.message}>
                           {compactText(component.message, 82)}
                         </p>
                       </div>

--- a/apps/dsa-web/src/components/report/ReportDiagnostics.tsx
+++ b/apps/dsa-web/src/components/report/ReportDiagnostics.tsx
@@ -164,6 +164,14 @@ const DETAIL_ORDER = [
   'analysis_history_id',
 ];
 
+const ANALYSIS_INPUT_DETAIL_ORDER = [
+  'analysis_input_missing_reasons',
+  'evidence_scope',
+  'analysis_input_status',
+  'analysis_input_block',
+  'analysis_input_source',
+];
+
 const DETAIL_LABELS: Record<ReportLanguage, Record<string, string>> = {
   zh: {
     provider: '数据源',
@@ -321,7 +329,13 @@ const getComponentDetailChips = (
     {},
   );
   const orderedKeys = [
-    ...DETAIL_ORDER.filter((key) => Object.prototype.hasOwnProperty.call(normalizedDetails, key)),
+    ...ANALYSIS_INPUT_DETAIL_ORDER.filter(
+      (key) => Object.prototype.hasOwnProperty.call(normalizedDetails, key),
+    ),
+    ...DETAIL_ORDER.filter(
+      (key) => !ANALYSIS_INPUT_DETAIL_ORDER.includes(key)
+        && Object.prototype.hasOwnProperty.call(normalizedDetails, key),
+    ),
     ...Object.keys(normalizedDetails).filter((key) => !DETAIL_ORDER.includes(key)).sort(),
   ];
 

--- a/apps/dsa-web/src/components/report/__tests__/AnalysisContextSummary.test.tsx
+++ b/apps/dsa-web/src/components/report/__tests__/AnalysisContextSummary.test.tsx
@@ -104,15 +104,17 @@ describe('AnalysisContextSummary', () => {
     expect(screen.getByText('数据限制:')).toBeInTheDocument();
     expect(screen.getByText(/基本面：抓取失败/)).toBeInTheDocument();
     expect(screen.getByText(/news_provider_timeout/)).toBeInTheDocument();
-    expect(screen.getByText(/缺失原因: 未进入分析输入/)).toBeInTheDocument();
+    expect(screen.getByText(/缺失原因: 新闻未进入本次分析输入/)).toBeInTheDocument();
+    expect(screen.getByText(/上方相关资讯通常来自报告页补充检索或历史持久化/)).toBeInTheDocument();
+    expect(screen.getByText(/若需要新闻参与分析，请检查搜索服务配置、网络或接口限流后重新分析/)).toBeInTheDocument();
     expect(screen.getByText(/诊断码: news_context_missing/)).toBeInTheDocument();
     expect(screen.getByText('来源: 未记录输入来源')).toBeInTheDocument();
-    expect(screen.getByText(/上方相关资讯可能来自报告页补充检索或历史持久化/)).toBeInTheDocument();
-    expect(screen.getByText(/若需要新闻参与分析，请检查搜索服务配置、网络或接口限流后重新分析/)).toBeInTheDocument();
+    expect(screen.queryByText(/处理建议:/)).not.toBeInTheDocument();
     const fundamentalsBlock = screen.getByText('基本面').closest('.home-subpanel');
     expect(fundamentalsBlock).not.toBeNull();
     const fundamentals = within(fundamentalsBlock as HTMLElement);
-    expect(fundamentals.getByText(/缺失原因: 未记录明确缺失原因/)).toBeInTheDocument();
+    expect(fundamentals.getByText(/缺失原因: 基本面抓取失败/)).toBeInTheDocument();
+    expect(fundamentals.getByText(/请检查对应 provider 配置、网络或接口限流后重新分析/)).toBeInTheDocument();
     expect(fundamentals.queryByText(/缺失原因:.*fundamental_pipeline_failed/)).not.toBeInTheDocument();
     expect(fundamentals.getByText(/诊断码: fundamental_pipeline_failed/)).toBeInTheDocument();
     expect(screen.getAllByText('新闻结果数: 3').some((item) => item.textContent === '新闻结果数: 3')).toBe(true);
@@ -136,7 +138,9 @@ describe('AnalysisContextSummary', () => {
 
     expect(screen.getByText('Data Limitations:')).toBeInTheDocument();
     expect(screen.getByText(/fundamentals: Fetch failed/)).toBeInTheDocument();
-    expect(screen.getByText(/Related news above may come from supplemental report-page retrieval/)).toBeInTheDocument();
+    expect(screen.getByText(/Missing Reasons: News was not included in this LLM input/)).toBeInTheDocument();
+    expect(screen.getByText(/related news above usually comes from supplemental report-page retrieval/)).toBeInTheDocument();
+    expect(screen.queryByText(/Suggested Action:/)).not.toBeInTheDocument();
   });
 
   it('surfaces degraded non-zero states in the collapsed summary', () => {

--- a/apps/dsa-web/src/components/report/__tests__/AnalysisContextSummary.test.tsx
+++ b/apps/dsa-web/src/components/report/__tests__/AnalysisContextSummary.test.tsx
@@ -144,6 +144,38 @@ describe('AnalysisContextSummary', () => {
     expect(screen.queryByText(/Suggested Action:/)).not.toBeInTheDocument();
   });
 
+  it('keeps unknown missing reason codes out of user-facing explanations', () => {
+    const unknownReasonOverview: AnalysisContextPackOverview = {
+      ...overview,
+      blocks: [{
+        key: 'fundamentals',
+        label: '基本面',
+        status: 'fetch_failed',
+        source: 'fundamental_pipeline',
+        warnings: [],
+        missingReasons: ['brand_new_internal_code'],
+      }],
+      counts: {
+        available: 0,
+        missing: 0,
+        notSupported: 0,
+        fallback: 0,
+        stale: 0,
+        estimated: 0,
+        partial: 0,
+        fetchFailed: 1,
+      },
+    };
+
+    render(<AnalysisContextSummary overview={unknownReasonOverview} />);
+
+    fireEvent.click(screen.getAllByText('输入数据块')[0]);
+
+    expect(screen.getByText('缺失原因: 未记录明确缺失原因')).toBeInTheDocument();
+    expect(screen.queryByText(/缺失原因:.*brand_new_internal_code/)).not.toBeInTheDocument();
+    expect(screen.getByText('诊断码: brand_new_internal_code')).toBeInTheDocument();
+  });
+
   it('surfaces degraded non-zero states in the collapsed summary', () => {
     const degradedOverview: AnalysisContextPackOverview = {
       ...overview,
@@ -164,15 +196,39 @@ describe('AnalysisContextSummary', () => {
           warnings: ['stale_fundamental'],
           missingReasons: [],
         },
+        {
+          key: 'technical',
+          label: '技术',
+          status: 'partial',
+          source: 'technical_pipeline',
+          warnings: ['technical_partial'],
+          missingReasons: [],
+        },
+        {
+          key: 'chip',
+          label: '筹码',
+          status: 'estimated',
+          source: 'estimated_chip',
+          warnings: [],
+          missingReasons: [],
+        },
+        {
+          key: 'daily_bars',
+          label: '日线',
+          status: 'not_supported',
+          source: null,
+          warnings: [],
+          missingReasons: [],
+        },
       ],
       counts: {
         available: 0,
         missing: 0,
-        notSupported: 0,
+        notSupported: 1,
         fallback: 1,
         stale: 1,
-        estimated: 0,
-        partial: 0,
+        estimated: 1,
+        partial: 1,
         fetchFailed: 0,
       },
     };
@@ -185,6 +241,22 @@ describe('AnalysisContextSummary', () => {
     expect(within(panel).getByText('缺失 0')).toBeVisible();
     expect(within(panel).getAllByText('降级 1')[0]).toBeVisible();
     expect(within(panel).getAllByText('过期 1')[0]).toBeVisible();
+    expect(within(panel).getAllByText('估算 1')[0]).toBeVisible();
+    expect(within(panel).getAllByText('部分可用 1')[0]).toBeVisible();
+    expect(within(panel).getAllByText('不支持 1')[0]).toBeVisible();
+
+    fireEvent.click(within(panel).getAllByText('输入数据块')[0]);
+
+    const quoteBlock = screen.getByText('行情').closest('.home-subpanel');
+    expect(quoteBlock).not.toBeNull();
+    expect(within(quoteBlock as HTMLElement).getByText('状态说明: 本次分析使用了降级数据路径')).toBeInTheDocument();
+    expect(within(quoteBlock as HTMLElement).getByText('处理: 结合数据来源和告警复核降级结果')).toBeInTheDocument();
+    expect(within(quoteBlock as HTMLElement).queryByText(/诊断码:/)).not.toBeInTheDocument();
+
+    expect(screen.getByText('状态说明: 本次分析使用了非最新数据')).toBeInTheDocument();
+    expect(screen.getByText('状态说明: 仅部分数据进入本次分析输入')).toBeInTheDocument();
+    expect(screen.getByText('状态说明: 本次分析使用了估算数据')).toBeInTheDocument();
+    expect(screen.getByText('状态说明: 当前市场或标的不支持该数据')).toBeInTheDocument();
   });
 
   it('does not render without an overview', () => {

--- a/apps/dsa-web/src/components/report/__tests__/AnalysisContextSummary.test.tsx
+++ b/apps/dsa-web/src/components/report/__tests__/AnalysisContextSummary.test.tsx
@@ -171,9 +171,42 @@ describe('AnalysisContextSummary', () => {
 
     fireEvent.click(screen.getAllByText('输入数据块')[0]);
 
-    expect(screen.getByText('缺失原因: 未记录明确缺失原因')).toBeInTheDocument();
+    expect(screen.getByText('缺失原因: 数据抓取失败，本次分析未使用该数据')).toBeInTheDocument();
     expect(screen.queryByText(/缺失原因:.*brand_new_internal_code/)).not.toBeInTheDocument();
     expect(screen.getByText('诊断码: brand_new_internal_code')).toBeInTheDocument();
+    expect(screen.getByText('处理: 检查数据源/网络/限流后重跑')).toBeInTheDocument();
+  });
+
+  it('explains the real chip_not_supported reason with actionable guidance', () => {
+    const unsupportedChipOverview: AnalysisContextPackOverview = {
+      ...overview,
+      blocks: [{
+        key: 'chip',
+        label: '筹码',
+        status: 'not_supported',
+        source: null,
+        warnings: [],
+        missingReasons: ['chip_not_supported'],
+      }],
+      counts: {
+        available: 0,
+        missing: 0,
+        notSupported: 1,
+        fallback: 0,
+        stale: 0,
+        estimated: 0,
+        partial: 0,
+        fetchFailed: 0,
+      },
+    };
+
+    render(<AnalysisContextSummary overview={unsupportedChipOverview} />);
+
+    fireEvent.click(screen.getAllByText('输入数据块')[0]);
+
+    expect(screen.getByText('缺失原因: 当前市场或标的不支持筹码数据')).toBeInTheDocument();
+    expect(screen.getByText('处理: 更换受支持的数据源或结合其他指标')).toBeInTheDocument();
+    expect(screen.getByText('诊断码: chip_not_supported')).toBeInTheDocument();
   });
 
   it('surfaces degraded non-zero states in the collapsed summary', () => {

--- a/apps/dsa-web/src/components/report/__tests__/AnalysisContextSummary.test.tsx
+++ b/apps/dsa-web/src/components/report/__tests__/AnalysisContextSummary.test.tsx
@@ -105,16 +105,16 @@ describe('AnalysisContextSummary', () => {
     expect(screen.getByText(/基本面：抓取失败/)).toBeInTheDocument();
     expect(screen.getByText(/news_provider_timeout/)).toBeInTheDocument();
     expect(screen.getByText(/缺失原因: 新闻未进入本次分析输入/)).toBeInTheDocument();
-    expect(screen.getByText(/上方相关资讯通常来自报告页补充检索或历史持久化/)).toBeInTheDocument();
-    expect(screen.getByText(/若需要新闻参与分析，请检查搜索服务配置、网络或接口限流后重新分析/)).toBeInTheDocument();
     expect(screen.getByText(/诊断码: news_context_missing/)).toBeInTheDocument();
+    expect(screen.getByText(/范围: 相关资讯来自报告页补充\/历史/)).toBeInTheDocument();
+    expect(screen.getByText(/处理: 检查搜索配置\/网络\/限流后重跑/)).toBeInTheDocument();
     expect(screen.getByText('来源: 未记录输入来源')).toBeInTheDocument();
     expect(screen.queryByText(/处理建议:/)).not.toBeInTheDocument();
     const fundamentalsBlock = screen.getByText('基本面').closest('.home-subpanel');
     expect(fundamentalsBlock).not.toBeNull();
     const fundamentals = within(fundamentalsBlock as HTMLElement);
     expect(fundamentals.getByText(/缺失原因: 基本面抓取失败/)).toBeInTheDocument();
-    expect(fundamentals.getByText(/请检查对应 provider 配置、网络或接口限流后重新分析/)).toBeInTheDocument();
+    expect(fundamentals.getByText(/处理: 检查 provider 配置\/网络\/限流后重跑/)).toBeInTheDocument();
     expect(fundamentals.queryByText(/缺失原因:.*fundamental_pipeline_failed/)).not.toBeInTheDocument();
     expect(fundamentals.getByText(/诊断码: fundamental_pipeline_failed/)).toBeInTheDocument();
     expect(screen.getAllByText('新闻结果数: 3').some((item) => item.textContent === '新闻结果数: 3')).toBe(true);
@@ -139,7 +139,8 @@ describe('AnalysisContextSummary', () => {
     expect(screen.getByText('Data Limitations:')).toBeInTheDocument();
     expect(screen.getByText(/fundamentals: Fetch failed/)).toBeInTheDocument();
     expect(screen.getByText(/Missing Reasons: News was not included in this LLM input/)).toBeInTheDocument();
-    expect(screen.getByText(/related news above usually comes from supplemental report-page retrieval/)).toBeInTheDocument();
+    expect(screen.getByText(/Scope: Related news is supplemental\/history/)).toBeInTheDocument();
+    expect(screen.getByText(/Action: Check search config\/network\/rate limits and rerun/)).toBeInTheDocument();
     expect(screen.queryByText(/Suggested Action:/)).not.toBeInTheDocument();
   });
 

--- a/apps/dsa-web/src/components/report/__tests__/AnalysisContextSummary.test.tsx
+++ b/apps/dsa-web/src/components/report/__tests__/AnalysisContextSummary.test.tsx
@@ -104,8 +104,12 @@ describe('AnalysisContextSummary', () => {
     expect(screen.getByText('数据限制:')).toBeInTheDocument();
     expect(screen.getByText(/基本面：抓取失败/)).toBeInTheDocument();
     expect(screen.getByText(/news_provider_timeout/)).toBeInTheDocument();
-    expect(screen.getByText(/未进入分析输入 \(news_context_missing\)/)).toBeInTheDocument();
-    expect(screen.getByText(/fundamental_pipeline_failed/)).toBeInTheDocument();
+    expect(screen.getByText(/缺失原因: 未进入分析输入/)).toBeInTheDocument();
+    expect(screen.getByText(/诊断码: news_context_missing/)).toBeInTheDocument();
+    expect(screen.getByText('来源: 未记录输入来源')).toBeInTheDocument();
+    expect(screen.getByText(/上方相关资讯可能来自报告页补充检索或历史持久化/)).toBeInTheDocument();
+    expect(screen.getByText(/若需要新闻参与分析，请检查搜索服务配置、网络或接口限流后重新分析/)).toBeInTheDocument();
+    expect(screen.getAllByText(/fundamental_pipeline_failed/).length).toBeGreaterThanOrEqual(1);
     expect(screen.getAllByText('新闻结果数: 3').some((item) => item.textContent === '新闻结果数: 3')).toBe(true);
     expect(screen.getAllByText('本次分析输入')[0]).toBeVisible();
   });
@@ -127,6 +131,7 @@ describe('AnalysisContextSummary', () => {
 
     expect(screen.getByText('Data Limitations:')).toBeInTheDocument();
     expect(screen.getByText(/fundamentals: Fetch failed/)).toBeInTheDocument();
+    expect(screen.getByText(/Related news above may come from supplemental report-page retrieval/)).toBeInTheDocument();
   });
 
   it('surfaces degraded non-zero states in the collapsed summary', () => {

--- a/apps/dsa-web/src/components/report/__tests__/AnalysisContextSummary.test.tsx
+++ b/apps/dsa-web/src/components/report/__tests__/AnalysisContextSummary.test.tsx
@@ -109,7 +109,12 @@ describe('AnalysisContextSummary', () => {
     expect(screen.getByText('来源: 未记录输入来源')).toBeInTheDocument();
     expect(screen.getByText(/上方相关资讯可能来自报告页补充检索或历史持久化/)).toBeInTheDocument();
     expect(screen.getByText(/若需要新闻参与分析，请检查搜索服务配置、网络或接口限流后重新分析/)).toBeInTheDocument();
-    expect(screen.getAllByText(/fundamental_pipeline_failed/).length).toBeGreaterThanOrEqual(1);
+    const fundamentalsBlock = screen.getByText('基本面').closest('.home-subpanel');
+    expect(fundamentalsBlock).not.toBeNull();
+    const fundamentals = within(fundamentalsBlock as HTMLElement);
+    expect(fundamentals.getByText(/缺失原因: 未记录明确缺失原因/)).toBeInTheDocument();
+    expect(fundamentals.queryByText(/缺失原因:.*fundamental_pipeline_failed/)).not.toBeInTheDocument();
+    expect(fundamentals.getByText(/诊断码: fundamental_pipeline_failed/)).toBeInTheDocument();
     expect(screen.getAllByText('新闻结果数: 3').some((item) => item.textContent === '新闻结果数: 3')).toBe(true);
     expect(screen.getAllByText('本次分析输入')[0]).toBeVisible();
   });

--- a/apps/dsa-web/src/components/report/__tests__/ReportDiagnostics.test.tsx
+++ b/apps/dsa-web/src/components/report/__tests__/ReportDiagnostics.test.tsx
@@ -30,6 +30,19 @@ const diagnosticSummary: RunDiagnosticSummary = {
       details: {
         provider: 'baostock',
         attempts: 2,
+        error_type: 'TimeoutError',
+      },
+    },
+    news: {
+      key: 'news',
+      label: '新闻搜索',
+      status: 'degraded',
+      message: '新闻检索返回 3 条结果，但新闻未进入本次分析输入；报告页相关资讯可能来自后续检索或历史持久化',
+      details: {
+        record_count: 3,
+        analysis_input_status: 'missing',
+        analysis_input_missing_reasons: ['news_context_missing'],
+        evidence_scope: 'retrieval_vs_analysis_input',
       },
     },
     notification: {
@@ -66,7 +79,13 @@ describe('ReportDiagnostics', () => {
     fireEvent.click(screen.getByText('运行状态'));
 
     expect(panel).toHaveAttribute('open');
-    expect(screen.getByText('最近失败后已降级')).toBeInTheDocument();
+    expect(screen.getByText('主要原因')).toBeInTheDocument();
+    expect(screen.getAllByText('最近失败后已降级').length).toBeGreaterThan(0);
+    expect(screen.getByText('数据源: baostock')).toBeInTheDocument();
+    expect(screen.getByText('错误类型: TimeoutError')).toBeInTheDocument();
+    expect(screen.getByText('尝试: 2')).toBeInTheDocument();
+    expect(screen.getByText('真实原因: news_context_missing')).toBeInTheDocument();
+    expect(screen.getByText('证据范围: 检索结果未进分析输入')).toBeInTheDocument();
     expect(screen.getByText('未配置')).toBeInTheDocument();
 
     fireEvent.click(screen.getByRole('button', { name: '复制排障信息' }));

--- a/apps/dsa-web/src/components/report/__tests__/ReportDiagnostics.test.tsx
+++ b/apps/dsa-web/src/components/report/__tests__/ReportDiagnostics.test.tsx
@@ -137,6 +137,44 @@ describe('ReportDiagnostics', () => {
     expect(screen.getByText('证据范围: 仅记录分析输入状态')).toBeInTheDocument();
   });
 
+  it('keeps analysis-input reasons and evidence ahead of the six-chip limit', () => {
+    const crowdedDetailsSummary: RunDiagnosticSummary = {
+      ...diagnosticSummary,
+      components: {
+        dailyData: {
+          key: 'daily_data',
+          label: '日线数据',
+          status: 'degraded',
+          message: '日线数据源成功，但未进入分析输入',
+          details: {
+            provider: 'baostock',
+            fallbackTo: 'SuccessfulDailyFetcher',
+            recordCount: 30,
+            attempts: 2,
+            providerRunStatus: 'degraded',
+            analysisInputBlock: 'daily_bars',
+            analysisInputStatus: 'missing',
+            analysisInputSource: 'storage.get_analysis_context',
+            analysisInputMissingReasons: ['daily_bars_missing'],
+            evidenceScope: 'provider_run_vs_analysis_input',
+          },
+        },
+      },
+    };
+
+    render(<ReportDiagnostics summary={crowdedDetailsSummary} />);
+
+    fireEvent.click(screen.getByText('运行状态'));
+
+    expect(screen.getByText('真实原因: daily_bars_missing')).toBeInTheDocument();
+    expect(screen.getByText('证据范围: 数据源成功但未进分析输入')).toBeInTheDocument();
+    expect(screen.getByText('输入状态: missing')).toBeInTheDocument();
+    expect(screen.getByText('输入块: daily_bars')).toBeInTheDocument();
+    expect(screen.getByText('输入来源: storage.get_analysis_context')).toBeInTheDocument();
+    expect(screen.getByText('数据源: baostock')).toBeInTheDocument();
+    expect(screen.queryByText('记录数: 30')).not.toBeInTheDocument();
+  });
+
   it('opens historical run flow from the diagnostics body', async () => {
     const onOpenRunFlow = vi.fn();
     vi.mocked(historyApi.getDiagnostics).mockResolvedValue(diagnosticSummary);

--- a/apps/dsa-web/src/components/report/__tests__/ReportDiagnostics.test.tsx
+++ b/apps/dsa-web/src/components/report/__tests__/ReportDiagnostics.test.tsx
@@ -30,7 +30,7 @@ const diagnosticSummary: RunDiagnosticSummary = {
       details: {
         provider: 'baostock',
         attempts: 2,
-        error_type: 'TimeoutError',
+        errorType: 'TimeoutError',
       },
     },
     news: {
@@ -39,10 +39,11 @@ const diagnosticSummary: RunDiagnosticSummary = {
       status: 'degraded',
       message: '新闻检索返回 3 条结果，但新闻未进入本次分析输入；报告页相关资讯可能来自后续检索或历史持久化',
       details: {
-        record_count: 3,
-        analysis_input_status: 'missing',
-        analysis_input_missing_reasons: ['news_context_missing'],
-        evidence_scope: 'retrieval_vs_analysis_input',
+        recordCount: 3,
+        analysisInputBlock: 'news',
+        analysisInputStatus: 'missing',
+        analysisInputMissingReasons: ['news_context_missing'],
+        evidenceScope: 'retrieval_vs_analysis_input',
       },
     },
     notification: {
@@ -84,6 +85,9 @@ describe('ReportDiagnostics', () => {
     expect(screen.getByText('数据源: baostock')).toBeInTheDocument();
     expect(screen.getByText('错误类型: TimeoutError')).toBeInTheDocument();
     expect(screen.getByText('尝试: 2')).toBeInTheDocument();
+    expect(screen.getByText('记录数: 3')).toBeInTheDocument();
+    expect(screen.getByText('输入块: news')).toBeInTheDocument();
+    expect(screen.getByText('输入状态: missing')).toBeInTheDocument();
     expect(screen.getByText('真实原因: news_context_missing')).toBeInTheDocument();
     expect(screen.getByText('证据范围: 检索结果未进分析输入')).toBeInTheDocument();
     expect(screen.getByText('未配置')).toBeInTheDocument();
@@ -105,6 +109,32 @@ describe('ReportDiagnostics', () => {
     expect(screen.getByText('Run Status')).toBeInTheDocument();
     expect(screen.getByText('Degraded')).toBeInTheDocument();
     expect(screen.getByText('Fetch / LLM / save / notification path')).toBeInTheDocument();
+  });
+
+  it('keeps snake_case diagnostic detail keys compatible', () => {
+    const snakeCaseSummary: RunDiagnosticSummary = {
+      ...diagnosticSummary,
+      components: {
+        news: {
+          ...diagnosticSummary.components.news,
+          details: {
+            record_count: 4,
+            analysis_input_status: 'partial',
+            analysis_input_missing_reasons: ['news_context_missing'],
+            evidence_scope: 'analysis_input_only',
+          },
+        },
+      },
+    };
+
+    render(<ReportDiagnostics summary={snakeCaseSummary} />);
+
+    fireEvent.click(screen.getByText('运行状态'));
+
+    expect(screen.getByText('记录数: 4')).toBeInTheDocument();
+    expect(screen.getByText('输入状态: partial')).toBeInTheDocument();
+    expect(screen.getByText('真实原因: news_context_missing')).toBeInTheDocument();
+    expect(screen.getByText('证据范围: 仅记录分析输入状态')).toBeInTheDocument();
   });
 
   it('opens historical run flow from the diagnostics body', async () => {

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 ## [Unreleased]
 - [改进] GitHub Actions 每日分析工作流补齐 TickFlow 数据源环境变量映射，并收敛 README 数据源稳定性说明到完整指南。
 - [改进] Web 报告页输入数据块在数据缺失、抓取失败或新闻上下文未进入 LLM 输入时显示可操作处理建议，并区分报告页补充资讯与本次分析输入。
+- [改进] Web 报告页输入数据块在原缺失原因字段展示可操作说明，并区分报告页补充资讯与本次分析输入。
 - [修复] WebUI 启动时显式 `--host` / `--port` 不再被 `.env` 中的 `WEBUI_HOST` / `WEBUI_PORT` 覆盖，未传 CLI 参数时统一使用解析后的运行时配置。
 - [改进] GitHub Actions: 每日分析工作流（`00-daily-analysis.yml`）新增钉钉通知环境变量映射，支持在云端定时任务中直接使用钉钉机器人。
 - [修复] Web 持仓页首屏快照改用 `include_realtime=false` 快速估值，跳过逐票实时行情预取后先展示持仓列表，避免外部实时行情源变慢时长时间空白等待。

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,8 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 - [改进] GitHub Actions 每日分析工作流补齐 TickFlow 数据源环境变量映射，并收敛 README 数据源稳定性说明到完整指南。
-- [改进] Web 报告页输入数据块在数据缺失、抓取失败或新闻上下文未进入 LLM 输入时显示可操作处理建议，并区分报告页补充资讯与本次分析输入。
-- [改进] Web 报告页输入数据块在原缺失原因字段展示可操作说明，并区分报告页补充资讯与本次分析输入。
+- [改进] Web 报告页输入数据块和运行诊断改为短原因 + 诊断标签展示，暴露真实原因、证据范围和处理动作，并区分报告页补充资讯与本次分析输入。
 - [修复] WebUI 启动时显式 `--host` / `--port` 不再被 `.env` 中的 `WEBUI_HOST` / `WEBUI_PORT` 覆盖，未传 CLI 参数时统一使用解析后的运行时配置。
 - [改进] GitHub Actions: 每日分析工作流（`00-daily-analysis.yml`）新增钉钉通知环境变量映射，支持在云端定时任务中直接使用钉钉机器人。
 - [修复] Web 持仓页首屏快照改用 `include_realtime=false` 快速估值，跳过逐票实时行情预取后先展示持仓列表，避免外部实时行情源变慢时长时间空白等待。

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 - [改进] GitHub Actions 每日分析工作流补齐 TickFlow 数据源环境变量映射，并收敛 README 数据源稳定性说明到完整指南。
+- [改进] Web 报告页输入数据块在数据缺失、抓取失败或新闻上下文未进入 LLM 输入时显示可操作处理建议，并区分报告页补充资讯与本次分析输入。
 - [修复] WebUI 启动时显式 `--host` / `--port` 不再被 `.env` 中的 `WEBUI_HOST` / `WEBUI_PORT` 覆盖，未传 CLI 参数时统一使用解析后的运行时配置。
 - [改进] GitHub Actions: 每日分析工作流（`00-daily-analysis.yml`）新增钉钉通知环境变量映射，支持在云端定时任务中直接使用钉钉机器人。
 - [修复] Web 持仓页首屏快照改用 `include_realtime=false` 快速估值，跳过逐票实时行情预取后先展示持仓列表，避免外部实时行情源变慢时长时间空白等待。


### PR DESCRIPTION
Closes #1933

## 改了什么

- Web 报告页 `AnalysisContextSummary` 将输入数据块的缺失原因改为“短原因 + 诊断标签”，补齐 builder 当前会生成的筹码/基本面 reason code 本地化解释与处理动作，未知 code 仅保留在诊断码区域。
- `fallback`、`stale`、`partial`、`estimated`、`not_supported` 等异常状态即使未携带 `missingReasons`，也会显示本地化状态说明和处理建议。
- `ReportDiagnostics` 将运行诊断的 `details` 关键字段提升为标签展示，兼容真实 API 深度转换后的 camelCase 和旧 snake_case；分析输入真实原因、证据范围、状态、块和来源优先占用可见 chip 名额，完整 JSON 仍保留在高级字段折叠区。
- 新闻结果存在但新闻上下文未进入本次 LLM 输入时，明确区分“报告页补充/历史资讯”和“本次分析输入”。
- 来源为空时显示“未记录输入来源”，避免用户把空来源理解成数据源成功。
- 移除诊断文案的原生 `title` tooltip，改用可访问标签，满足 Web UI governance。
- 补充前端回归测试和 `docs/CHANGELOG.md` 记录。

## 为什么这么改

报告页“相关资讯”、输入数据块和运行诊断代表不同数据面。此前界面会让用户看到页面有新闻、但输入数据块新闻缺失，又不知道真实原因和下一步怎么处理。现在把用户可理解的状态说明、原始诊断码和证据范围分层展示，并确保真实 API 字段形态不会导致关键标签丢失。

`provider`、`model`、`fallback_model` 等仅为诊断展示字段；本 PR 没有修改模型名、provider 默认值、Base URL、SDK 依赖或运行时配置。

## 截图对比

截图使用同一份 mock 报告详情数据生成，不包含真实用户数据。左侧为 `origin/main`，右侧为本 PR。

![PR 1934 before after](https://litter.catbox.moe/r85zp2.png)

## 验证情况

- `npm ci`
- `npm run test -- tests/ui_governance.test.ts src/components/report/__tests__/AnalysisContextSummary.test.tsx src/components/report/__tests__/ReportNews.test.tsx src/components/report/__tests__/ReportDiagnostics.test.tsx` → 20 passed
- `npm run lint` → passed
- `npm run build` → passed
- `npm run test` → 934 passed, 2 skipped, 1 failed；唯一失败为未改动的 `AlertRuleForm.test.tsx` 期待日股/韩股选项，当前 PR head 的 `AlertRuleForm` 仅有 cn/hk/us，与本 PR diff 无关。
- GitHub Actions（head `2c3cb98c9`）：`ai-governance` / `backend-gate` / `docker-build` / `web-gate` / PR Review 全部通过。

## 未验证项

- 未进行真实后端报告详情联调；已通过 camelCase API 形态回归测试覆盖字段转换路径。
- 未覆盖桌面端打包；本次改动限于 Web 报告页展示组件。

## 风险点

- 极窄屏下状态说明与诊断标签可能换行并增加展开面板高度，但不会改变 API 契约、分析流程或报告内容。
- camelCase/snake_case 归一化仅用于可视标签生成，高级诊断 JSON 保持原始内容。

## 回滚方式

- 回滚本 PR 即可恢复原有输入数据块和运行诊断展示。
