### PR TITLE
fix: repair AlphaSift local daily bars bridge and add dev script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -87,3 +87,5 @@ static/
 /apps/dsa-desktop/dist/
 /apps/dsa-desktop/node_modules/
 docs/specs/
+
+.cursor

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+- [改进] 新增 `scripts/run-dev-with-alphasift.sh`，本地开发时可在 bundled 与 editable 本地 AlphaSift 间切换并启动 DSA。
 - [改进] 通知报告的分析结果摘要不再展开 AI 决策信号明细，完整信号保留在个股详情和单股报告中。
 - [新功能] #1595 P1.5 新增 Provider Cache Capability Registry，按 provider、api surface、gateway 和 verification status 建模 prompt cache 能力，未知 OpenAI-compatible route 默认 telemetry only。
 - [改进] #1595 P1 新增 prompt cache telemetry / analysis-path hints / diagnostics 最小配置，默认不改变 provider 请求 shape，并复用 LLM usage HMAC secret 做 domain-separated cache hint 派生。

--- a/docs/alphasift-integration.md
+++ b/docs/alphasift-integration.md
@@ -193,6 +193,42 @@ AlphaSift 侧已在 `ZhuLinsen/alphasift@377049857cc04175dc3cca62121ee41adec6cdb
 - 结果页展示运行 ID、样本数量、过滤后数量、LLM 是否重排、LLM 覆盖率和 DSA 增强计数；如果 AlphaSift 返回 warning/source error/LLM parse error 或 `llm_ranked=false`，页面会明确显示降级原因，避免把本地因子结果误展示成正常 LLM 判断；重复的快照源 fallback warning/source error 会在前端合并展示为一条“数据源降级”提示。
 - 展开候选时展示 AlphaSift 摘要、因子和 LLM 判断；若 DSA 已增强，还会展示 `DSA 增强摘要`、`DSA 新闻` 和 `DSA 增强提示`。
 
+## 本地开发（editable AlphaSift）
+
+本地联调时，DSA 直接从当前 Python 环境导入 `alphasift.dsa_adapter`；`ALPHASIFT_INSTALL_SPEC` 不能指向本地目录，也不应在 Web 设置页点击「修复安装」，否则会重装回 `requirements.txt` 固定 pin。
+
+推荐使用仓库脚本在 bundled / 本地 editable 间切换并启动后端：
+
+```bash
+# 交互式选择 AlphaSift 来源，默认以 --serve-only 启动
+./scripts/run-dev-with-alphasift.sh
+
+# 明确使用本地 editable（默认路径：<repo>/../alphasift）
+./scripts/run-dev-with-alphasift.sh --local
+
+# 自定义本地仓库路径
+ALPHASIFT_LOCAL_PATH=/path/to/alphasift ./scripts/run-dev-with-alphasift.sh --local
+
+# 仅切换依赖，不启动服务
+./scripts/run-dev-with-alphasift.sh --local --install-only
+
+# 切回 requirements.txt pin 版本
+./scripts/run-dev-with-alphasift.sh --bundled --install-only
+
+# 查看当前环境中的 AlphaSift 来源
+./scripts/run-dev-with-alphasift.sh --status
+
+# 透传 main.py 参数
+./scripts/run-dev-with-alphasift.sh --local -- --serve-only --port 8000
+```
+
+脚本行为说明：
+
+- `--local`：执行 `pip install -e <ALPHASIFT_LOCAL_PATH>`，本地代码改动后重启 DSA 即可生效。
+- `--bundled`：按 `requirements.txt` 中的 git pin 强制重装 AlphaSift。
+- 未指定模式时会提示 `local / bundled / skip` 三选一；`skip` 保留当前环境已安装版本。
+- 启动前会校验 `alphasift.dsa_adapter` 可导入，并打印当前包路径与 `get_status()` 摘要。
+
 ## 桌面端说明
 
 源码运行的桌面端复用同一个 Python 后端环境，并设置 `DSA_DESKTOP_MODE=true`；通过设置页开启时如缺少适配层，会提示更新依赖或重建后端产物。

--- a/scripts/run-dev-with-alphasift.sh
+++ b/scripts/run-dev-with-alphasift.sh
@@ -1,0 +1,283 @@
+#!/usr/bin/env bash
+# ===================================
+# DSA 本地开发启动脚本（可选 AlphaSift 来源）
+# ===================================
+#
+# 用法：
+#   ./scripts/run-dev-with-alphasift.sh [--local|--bundled] [--install-only|--status] [--] [main.py 参数...]
+#
+# 未指定 --local / --bundled 时会交互式选择 AlphaSift 来源。
+# 默认启动参数为：--serve-only
+#
+# 环境变量：
+#   ALPHASIFT_LOCAL_PATH  本地 alphasift 仓库路径（默认：<repo>/../alphasift）
+#   PYTHON_BIN            Python 解释器（默认：python3）
+#
+# 示例：
+#   ./scripts/run-dev-with-alphasift.sh --local
+#   ./scripts/run-dev-with-alphasift.sh --bundled -- --serve-only --port 8000
+#   ALPHASIFT_LOCAL_PATH=/path/to/alphasift ./scripts/run-dev-with-alphasift.sh --local --install-only
+#
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m'
+
+info() { echo -e "${BLUE}[INFO]${NC} $1"; }
+success() { echo -e "${GREEN}[SUCCESS]${NC} $1"; }
+warn() { echo -e "${YELLOW}[WARN]${NC} $1"; }
+error() { echo -e "${RED}[ERROR]${NC} $1"; }
+
+PYTHON_BIN="${PYTHON_BIN:-}"
+if [[ -z "${PYTHON_BIN}" ]]; then
+  if command -v python3 >/dev/null 2>&1; then
+    PYTHON_BIN="python3"
+  else
+    PYTHON_BIN="python"
+  fi
+fi
+
+if ! command -v "${PYTHON_BIN}" >/dev/null 2>&1; then
+  error "未找到 Python。请安装 Python 3.10+ 后重试。"
+  exit 1
+fi
+
+DEFAULT_LOCAL_PATH="$(cd "${REPO_ROOT}/.." && pwd)/alphasift"
+ALPHASIFT_LOCAL_PATH="${ALPHASIFT_LOCAL_PATH:-${DEFAULT_LOCAL_PATH}}"
+
+MODE=""
+INSTALL_ONLY=0
+SHOW_STATUS=0
+MAIN_ARGS=()
+
+usage() {
+  cat <<'EOF'
+用法: ./scripts/run-dev-with-alphasift.sh [选项] [-- main.py 参数...]
+
+选项:
+  --local, -l         使用本地 editable 安装（pip install -e <path>）
+  --bundled, -b       使用 requirements.txt 中 pin 的 AlphaSift 版本
+  --install-only      仅安装/切换 AlphaSift，不启动 DSA
+  --status, -s        显示当前 Python 环境中的 AlphaSift 来源
+  -h, --help          显示本帮助
+
+未指定 --local / --bundled 时会交互式选择。
+默认 main.py 参数：--serve-only
+
+环境变量:
+  ALPHASIFT_LOCAL_PATH  本地 alphasift 仓库路径
+  PYTHON_BIN            Python 解释器
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --local|-l)
+      MODE="local"
+      shift
+      ;;
+    --bundled|-b)
+      MODE="bundled"
+      shift
+      ;;
+    --install-only)
+      INSTALL_ONLY=1
+      shift
+      ;;
+    --status|-s)
+      SHOW_STATUS=1
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    --)
+      shift
+      MAIN_ARGS+=("$@")
+      break
+      ;;
+    *)
+      MAIN_ARGS+=("$1")
+      shift
+      ;;
+  esac
+done
+
+resolve_bundled_spec() {
+  local spec
+  spec="$(grep -E '^git\+.*alphasift' "${REPO_ROOT}/requirements.txt" | head -n 1 || true)"
+  if [[ -z "${spec}" ]]; then
+    error "requirements.txt 中未找到 AlphaSift git pin。"
+    exit 1
+  fi
+  printf '%s' "${spec}"
+}
+
+validate_local_path() {
+  if [[ ! -d "${ALPHASIFT_LOCAL_PATH}" ]]; then
+    error "本地 AlphaSift 路径不存在：${ALPHASIFT_LOCAL_PATH}"
+    error "请设置 ALPHASIFT_LOCAL_PATH 或把仓库放在 ${DEFAULT_LOCAL_PATH}"
+    exit 1
+  fi
+  if [[ ! -f "${ALPHASIFT_LOCAL_PATH}/alphasift/dsa_adapter.py" ]]; then
+    error "本地路径缺少 alphasift/dsa_adapter.py：${ALPHASIFT_LOCAL_PATH}"
+    exit 1
+  fi
+}
+
+show_alphasift_status() {
+  "${PYTHON_BIN}" - <<'PY'
+import importlib.util
+import pathlib
+import sys
+
+try:
+    import alphasift
+    import alphasift.dsa_adapter as adapter
+except Exception as exc:
+    print(f"alphasift: unavailable ({exc})")
+    sys.exit(1)
+
+adapter_path = pathlib.Path(adapter.__file__).resolve()
+print(f"alphasift package: {pathlib.Path(alphasift.__file__).resolve()}")
+print(f"dsa_adapter:       {adapter_path}")
+
+spec = importlib.util.find_spec("alphasift")
+origin = getattr(spec, "origin", None) if spec else None
+submodule_locations = getattr(spec, "submodule_search_locations", None) if spec else None
+if submodule_locations:
+    locations = [str(pathlib.Path(item).resolve()) for item in submodule_locations]
+    print(f"package locations: {', '.join(locations)}")
+
+try:
+    import importlib.metadata as metadata
+except ImportError:
+    import importlib_metadata as metadata  # type: ignore
+
+try:
+    dist = metadata.distribution("alphasift")
+    editable = (dist.read_text("direct_url.json") or "").strip()
+    if editable:
+        print("install mode:      editable (direct_url.json present)")
+    else:
+        print("install mode:      site-packages")
+except Exception:
+    print("install mode:      unknown")
+
+try:
+    status = adapter.get_status()
+    if isinstance(status, dict):
+        version = status.get("version") or "unknown"
+        available = status.get("available")
+        print(f"adapter status:    available={available}, version={version}")
+except Exception as exc:
+    print(f"adapter status:    get_status() failed ({exc})")
+PY
+}
+
+install_local_alphasift() {
+  validate_local_path
+  info "安装本地 editable AlphaSift：${ALPHASIFT_LOCAL_PATH}"
+  "${PYTHON_BIN}" -m pip install -e "${ALPHASIFT_LOCAL_PATH}"
+}
+
+install_bundled_alphasift() {
+  local bundled_spec
+  bundled_spec="$(resolve_bundled_spec)"
+  info "安装 requirements.txt pin 的 AlphaSift：${bundled_spec}"
+  "${PYTHON_BIN}" -m pip install --upgrade --force-reinstall "${bundled_spec}"
+}
+
+verify_alphasift_adapter() {
+  info "校验 alphasift.dsa_adapter ..."
+  if ! "${PYTHON_BIN}" -c "import alphasift.dsa_adapter" >/dev/null 2>&1; then
+    error "当前 Python 环境无法导入 alphasift.dsa_adapter。"
+    exit 1
+  fi
+  success "AlphaSift 适配层可导入。"
+  echo ""
+  show_alphasift_status
+  echo ""
+}
+
+prompt_mode() {
+  echo ""
+  echo "请选择 AlphaSift 来源："
+  echo "  1) local   - 本地 editable（${ALPHASIFT_LOCAL_PATH}）"
+  echo "  2) bundled - requirements.txt 固定版本"
+  echo "  3) skip    - 不切换，使用当前 Python 环境已安装版本"
+  echo ""
+  read -r -p "输入 1/2/3 [默认 1]: " choice
+  case "${choice:-1}" in
+    1|local|l|L)
+      MODE="local"
+      ;;
+    2|bundled|b|B)
+      MODE="bundled"
+      ;;
+    3|skip|s|S)
+      MODE="skip"
+      ;;
+    *)
+      error "无效选择：${choice}"
+      exit 1
+      ;;
+  esac
+}
+
+apply_mode() {
+  case "${MODE}" in
+    local)
+      install_local_alphasift
+      ;;
+    bundled)
+      install_bundled_alphasift
+      ;;
+    skip)
+      info "跳过 AlphaSift 安装切换。"
+      ;;
+    "")
+      prompt_mode
+      apply_mode
+      return
+      ;;
+    *)
+      error "未知模式：${MODE}"
+      exit 1
+      ;;
+  esac
+}
+
+cd "${REPO_ROOT}"
+
+if [[ "${SHOW_STATUS}" -eq 1 ]]; then
+  show_alphasift_status
+  exit 0
+fi
+
+if [[ -z "${MODE}" ]]; then
+  prompt_mode
+fi
+
+apply_mode
+verify_alphasift_adapter
+
+if [[ "${INSTALL_ONLY}" -eq 1 ]]; then
+  success "AlphaSift 已就绪。未启动 DSA。"
+  exit 0
+fi
+
+if [[ "${#MAIN_ARGS[@]}" -eq 0 ]]; then
+  MAIN_ARGS=(--serve-only)
+fi
+
+info "启动 DSA：${PYTHON_BIN} main.py ${MAIN_ARGS[*]}"
+warn "请勿在 Web 设置页点击 AlphaSift「修复安装」，否则会覆盖当前选择的版本。"
+exec "${PYTHON_BIN}" "${REPO_ROOT}/main.py" "${MAIN_ARGS[@]}"

--- a/src/services/alphasift_service.py
+++ b/src/services/alphasift_service.py
@@ -1820,7 +1820,25 @@ def _alphasift_dsa_daily_history_provider() -> Iterator[None]:
         lookback_days: int = 120,
         source: str = "akshare",
         retries: int = 2,
+        cache_dir: str | Path | None = None,
+        cache_ttl_seconds: float | None = None,
+        daily_bars_dir: str | Path | None = None,
+        end_date: str | None = None,
+        daily_local_fallback_live: bool = False,
     ) -> Any:
+        fetch_kwargs = {
+            "lookback_days": lookback_days,
+            "source": source,
+            "retries": retries,
+            "cache_dir": cache_dir,
+            "cache_ttl_seconds": cache_ttl_seconds,
+            "daily_bars_dir": daily_bars_dir,
+            "end_date": end_date,
+            "daily_local_fallback_live": daily_local_fallback_live,
+        }
+        # Local Parquet daily bars must not be routed through DSA online/DB fetchers.
+        if _env_text(source).lower() == "local":
+            return original_fetch(code, **fetch_kwargs)
         try:
             dsa_df, dsa_source = get_dsa_daily_history(code, lookback_days=lookback_days)
             normalized = _normalize_dsa_daily_history(dsa_df)
@@ -1834,7 +1852,7 @@ def _alphasift_dsa_daily_history_provider() -> Iterator[None]:
                 source,
                 exc,
             )
-        return original_fetch(code, lookback_days=lookback_days, source=source, retries=retries)
+        return original_fetch(code, **fetch_kwargs)
 
     with _ALPHASIFT_RUNTIME_ENV_LOCK:
         setattr(daily_module, "fetch_daily_history", fetch_daily_history_with_dsa)

--- a/tests/test_alphasift_api.py
+++ b/tests/test_alphasift_api.py
@@ -1919,6 +1919,62 @@ class AlphaSiftOpportunitiesApiTestCase(unittest.TestCase):
         original_daily_fetch.assert_not_called()
         self.assertIs(daily_module.fetch_daily_history, original_daily_fetch)
 
+    def test_screen_local_daily_source_bypasses_dsa_daily_history_provider(self) -> None:
+        config = self._config(enabled=True)
+        parent_module = ModuleType("alphasift")
+        daily_module = ModuleType("alphasift.daily")
+        original_daily_fetch = MagicMock(
+            return_value=SimpleNamespace(
+                empty=False,
+                attrs={"daily_source": "local"},
+            )
+        )
+        daily_module.fetch_daily_history = original_daily_fetch
+        parent_module.daily = daily_module
+        captured: Dict[str, Any] = {}
+
+        def screen_with_local_daily_fetch(strategy: str, **kwargs: Any) -> Dict[str, Any]:
+            daily_module.fetch_daily_history(
+                "000002",
+                lookback_days=120,
+                source="local",
+                retries=1,
+                daily_bars_dir="/tmp/daily_bars",
+                end_date="20260703",
+            )
+            captured["context"] = kwargs.get("context")
+            return {
+                "strategy": strategy,
+                "candidates": [{"code": "000002", "score": 80.0}],
+            }
+
+        fake_module = _make_adapter_module(screen=MagicMock(side_effect=screen_with_local_daily_fetch))
+
+        with (
+            patch.dict(sys.modules, {"alphasift": parent_module, "alphasift.daily": daily_module}),
+            patch("src.services.alphasift_service._import_alphasift", return_value=fake_module),
+            patch(
+                "src.services.alphasift_service.get_dsa_daily_history",
+                side_effect=AssertionError("local daily source should bypass DSA history"),
+            ) as dsa_history_mock,
+        ):
+            payload = self._screen(config, market="cn", strategy="dual_low", max_results=5)
+
+        original_daily_fetch.assert_called_once_with(
+            "000002",
+            lookback_days=120,
+            source="local",
+            retries=1,
+            cache_dir=None,
+            cache_ttl_seconds=None,
+            daily_bars_dir="/tmp/daily_bars",
+            end_date="20260703",
+            daily_local_fallback_live=False,
+        )
+        dsa_history_mock.assert_not_called()
+        self.assertEqual(payload["candidate_count"], 1)
+        self.assertIs(daily_module.fetch_daily_history, original_daily_fetch)
+
     def test_screen_enriches_top_candidates_with_dsa_context(self) -> None:
         config = self._config(enabled=True)
         fake_manager = SimpleNamespace(get_stock_name=MagicMock(return_value="贵州茅台"))


### PR DESCRIPTION
Forward daily_bars_dir and related kwargs through the DSA daily history patch, and bypass online fetchers when DAILY_SOURCE=local so full-pool screening can read local Parquet stores. Add run-dev-with-alphasift.sh and integration docs for editable local AlphaSift workflows.

<!--
For Chinese contributors: 请直接用中文填写。
For English contributors: please fill in English. All fields marked (EN) accept English.
-->

## PR Type

- [ ] fix
- [ ] feat
- [ ] refactor
- [ ] docs
- [ ] chore
- [ ] test

## Background And Problem

请描述当前问题、影响范围与触发场景。  
*(EN) Describe the problem, its impact, and what triggers it.*

## Scope Of Change

请列出本 PR 修改的模块和文件范围。  
*(EN) List the modules and files changed in this PR.*

> 注意：请按实际 `git diff` 全量列出文件范围（建议注明文件总数），避免遗漏文档/后端/API/前端文件导致描述不一致。

> 若本 PR 修改了 `.github/PULL_REQUEST_TEMPLATE.md`、`.github/copilot-instructions.md`、`AGENTS.md`、`.github/instructions/*` 或 `.claude/skills/**` 等协作与治理文件，请补充“变更原因 + 影响面 + 回滚方式（默认 revert）”到 Summary / Compatibility / Rollback，避免 Scope 与描述不一致。

> 建议先执行并粘贴以下命令输出，避免与实际 diff 不一致：

```bash
BASE_REF=$(git merge-base HEAD origin/main)
git diff --stat "$BASE_REF"..HEAD
git diff --name-only "$BASE_REF"..HEAD
```

- 文件总数 / 变更行数（建议粘贴 `git diff --stat "$BASE_REF"..HEAD`）：
- 文件清单（按实际 diff 全量，逐项列出）：
- 文档更新文件（`docs/*`）：

## Issue Link

必须填写以下之一 / Fill in one of:
- `Fixes #<issue_number>`
- `Refs #<issue_number>`
- 无 Issue 时说明原因与验收标准 / If no issue, explain the motivation and acceptance criteria

## Verification Commands And Results

请填写你实际执行过的命令和关键结果（不要只写"已测试"）。  
*(EN) Paste the commands you actually ran and their key output (don't just write "tested"):*

```bash
# example
./scripts/ci_gate.sh
python -m pytest -m "not network"
```

> `Full-suite note` 必须与当次 PR 的当前 Head CI 结果保持一致；若本地复现存在环境相关失败，请明确标注“本地环境差异”并给出 GitHub CI 的结论与链接。  
> 请避免保留与本 PR 无关的历史失败措辞，按本次实际结果填报。
> 如历史描述中仍保留 `./scripts/ci_gate.sh` 失败记录，请先改为当前 Head CI 状态或说明与 Head CI 的差异来源。
> 若 `Full-suite note` 与当前 Head CI 不一致，PR 文本不完整，请先更新 PR 描述后再提交。

- 请在下面按实际结果填写并与 `Full-suite note` 保持一致（任一未填视为信息缺失）：
  - ai-governance：`pass` / `fail`，附链接
  - backend-gate：`pass` / `fail`，附链接
  - docker-build：`pass` / `fail`，附链接
  - web-gate：`pass` / `fail`，附链接
  - 若本 PR 修改 `.github/PULL_REQUEST_TEMPLATE.md` 等流程模板协作文件，请先说明变更必要性、影响边界，并明确回滚方式（默认 `revert this PR`）；否则请在下一版中拆为单独 chore PR。

关键输出/结论 / Key output & conclusion:

- 【必填】当前 Head CI：`ai-governance:pass / backend-gate:pass / docker-build:pass / web-gate:pass`（按实际结果替换）并附对应链接。  
- 若需保留本地失败现象，请在同段写明“本地环境差异 + 当前 CI 通过/失败结果 + CI 链接”。  
- 若全部通过，需补充一句：`当前状态：全部通过（pass）`，并明确 Head CI 全部为 pass。  

- 建议将本行直接粘贴到 PR 描述正文首段：`当前 Head CI：ai-governance:pass / backend-gate:pass / docker-build:pass / web-gate:pass`（仅示例，按实际结果替换）。

> 若上述核验项与 PR 文本冲突，建议先更新 PR 描述再提交，避免审查因状态不一致被阻塞。

## Visual Evidence (if applicable)

【必填】若本 PR 修改报告格式、报告渲染效果或 Web UI 界面，请在此处附受影响报告 / 页面截图；涉及前后差异时，优先附前后对比。Issue / PR 过程截图、审查截图、一次性验收截图和临时可视证据请放在 PR 描述、PR 评论、GitHub 附件、Actions artifact 或外部可访问链接中，不要作为仓库文件合入。
*(EN) If this PR changes report formatting, report rendering, or Web UI, attach screenshots of the affected report/page here; before/after screenshots are preferred when relevant. Issue/PR process screenshots, review screenshots, one-off acceptance screenshots, and temporary visual evidence should be linked from the PR body/comments, GitHub attachments, Actions artifacts, or external accessible evidence; do not commit them as repository files.)*

> 如截图无法获取，请在“原因”中明确写明替代证据（如 Playwright/e2e 产物路径、审查链接）及其可追溯命令，不得留空。涉及 Web 设置/报告渲染变更时，需确保截图或替代证据明确指向变更项。
>
> 若本 PR 修改 Web UI，建议至少补一条可复现路径，例如（优先 settings page）：
>
> - Playwright 截图产物：`apps/dsa-web/e2e/smoke.spec.ts`（`cd apps/dsa-web && npx playwright test e2e/smoke.spec.ts --grep "settings page renders title and save actions after login"`）
> - 审查证据链接：可直接使用 Actions 产物、GitHub 评论附件或外部可访问链接。

> 替代证据模板（设置页变更建议）：
> - 命令：`cd apps/dsa-web && npx playwright test e2e/smoke.spec.ts --grep "settings page"`
> - 产物路径：`apps/dsa-web/test-results/**/smoke-settings-page-*.png`
> - 说明：截图中应可见本次修改的系统设置项（字段、标签、帮助文案）

- 截图链接 / Screenshot links（Web UI/报告改动项必填，未提供请在下方“不适用原因”给出替代证据）：
- settings 页建议命名：`smoke-settings-page-zh` / `smoke-settings-page-en`
- 前后对比 / Before & After（如有）：
- settings 字段变更说明：截图或产物应明确包含 `MARKET_REVIEW_REGION` 字段与帮助文案区块（中文/英文）。
- 不适用原因 / Reason if not applicable（若未附截图，此项务必填写，且包含可复现证据与命令）：
  - Playwright 命令（无截图时）：`cd apps/dsa-web && npx playwright test e2e/smoke.spec.ts --grep "settings page"`
  - 产物路径（无截图时）：`apps/dsa-web/test-results/**/smoke-settings-page-*.png`
  - 说明：截图（或产物）必须可见本次修改的设置字段文案与帮助信息。

> 若本 PR 修改 Web 设置字段（字段、文案或帮助文案），截图或替代证据必须可定位到对应设置项区域并可追溯至变更项；该项为必填。

> 若本 PR 修改 Web UI 或报告展示且无法获取截图，原因栏必须给出可复现替代证据（例如 Playwright 截图产物路径 + 命令），且不得留空。

## Compatibility And Risk

请说明兼容性影响、潜在风险（如无请写 `None`）。  
*(EN) Describe compatibility impact and potential risks (write `None` if not applicable).*

- 若本 PR 修改第三方模型 / API 的兼容语义、请求参数、路由前缀或 provider fallback，请提供**官方来源链接或公告**，并说明这是长期约束、当前运行时约束还是临时兼容处理。  
  请在下方补充所影响外部 API/服务、回归范围与回退方式。  
  *(EN) If this PR changes third-party model/API compatibility, request parameters, routing prefixes, or provider fallback behavior, include an **official source link or announcement** and clarify whether the rule is permanent, runtime-specific, or a temporary compatibility workaround.)*
- 若本 PR 未触及第三方模型/API、provider/model/base URL 或运行时配置保存/清理/迁移逻辑，请在此段直接按以下文案确认（无须再次展开）：  
  `本 PR 未变更 provider/model/base URL、运行时配置清理迁移语义；历史配置保持不变；回滚方式为 revert 本提交。`
- 若本 PR 修改 `.github/PULL_REQUEST_TEMPLATE.md` / PR 流程模板类文件，请在此明确：仅影响协作流程与模板维护，不改 runtime 行为；回退方式为 revert；并补充是否影响自动化提交流程。  
  *(EN) If this PR changes `.github/PULL_REQUEST_TEMPLATE.md` or other PR workflow files, state that it only affects contribution governance templates (no runtime behavior), provide rollback by revert, and note any CI/checklist impact.)*
- 若本 PR 依赖特定运行时 / 锁定依赖窗口（例如 LiteLLM 版本范围、OpenAI-compatible 路由、YAML alias 行为），请写明当前验证过的兼容范围与覆盖路径。  
  *(EN) If this PR depends on a specific runtime or pinned dependency window (for example a LiteLLM version range, OpenAI-compatible routing, or YAML alias behavior), state the compatibility window you verified and which code paths were covered.)*
- 若本 PR 触及运行时配置保存、清理、迁移或回填逻辑，请明确说明旧配置是否会被自动改写、清空、迁移或保持不变，以及用户如何恢复原行为。  
  *(EN) If this PR touches runtime config save/cleanup/migration/backfill logic, explicitly describe whether existing config is rewritten, cleared, migrated, or left intact, and how users can restore the previous behavior.)*
- 若本 PR **未触及** provider/model/base URL 或运行时配置保存/清理/迁移逻辑（本条仅作为声明），请明确写：`本 PR 未变更 provider/model/base URL、运行时配置清理迁移语义；历史配置保持不变；回滚方式为 revert 本提交。`

## Rollback Plan

请至少写一句可执行的回滚方案（必填）。  
*(EN) Provide at least one actionable rollback step (required).*

- 如果是兼容性修复，默认应写出**最小回滚方式**（例如 `revert this PR`），并说明是否需要额外回滚配置或数据迁移。  
  *(EN) For compatibility fixes, include the **minimal rollback path** (for example `revert this PR`) and whether any additional config or data rollback is required.)*

## EXTRACT_PROMPT Change (if applicable)

若本 PR 修改了 `src/services/image_stock_extractor.py` 中的 `EXTRACT_PROMPT`，请在此处粘贴完整变更后的 prompt。  
*If this PR changes `EXTRACT_PROMPT` in `src/services/image_stock_extractor.py`, paste the full updated prompt here:*

<details>
<summary>展开 / Expand: Full EXTRACT_PROMPT</summary>

```
(paste full prompt here)
```

</details>

## Checklist

- [ ] 本 PR 有明确动机和业务价值 / This PR has a clear motivation and value
- [ ] 已提供可复现的验证命令与结果 / Reproducible verification commands and results are included
- [ ] 已评估兼容性与风险 / Compatibility and risk have been assessed
- [ ] 已提供回滚方案 / A rollback plan is provided
- [ ] 若修改报告格式或 Web UI 界面，已在 PR 描述/评论附受影响报告 / 页面截图，且未把一次性验收截图作为仓库文件合入 / If report formatting or Web UI changed, affected report/page screenshots are linked in the PR body/comments and one-off acceptance screenshots are not committed as repository files
- [ ] 若本 PR 修改 Web 设置字段（字段、文案或帮助文本），请补充设置页截图；无法截图时需提供替代可视证据（命令 + 产物路径），并指向对应变更项 / If Web settings fields changed (labels or help text), screenshots of the settings page are required; if unavailable, provide alternative visual evidence with command + artifact path that points to the changed item.
- [ ] 若涉及用户可见变更，已同步更新相关文档与 `docs/CHANGELOG.md`；`README.md` 仅在首页级信息变化时更新，细节优先写入 `docs/*.md` / If user-visible changes are included, relevant docs and `docs/CHANGELOG.md` are updated; `README.md` is updated only for homepage-level changes, with details kept in `docs/*.md`
