### PR TITLE
docs: fix broken relative links in CONTRIBUTING.md and bot-command.md

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -100,7 +100,7 @@ npm run build
 
 ## 📋 优先贡献方向
 
-查看 [Roadmap](README.md#-roadmap) 了解当前需要的功能：
+查看 [Roadmap](../README.md) 了解当前需要的功能：
 
 - 🔔 新通知渠道（钉钉、飞书、Telegram）
 - 🤖 新 AI 模型支持（GPT-4、Claude）

--- a/docs/bot-command.md
+++ b/docs/bot-command.md
@@ -236,7 +236,7 @@ class CommandDispatcher:
 
 ## 配置
 
-在 [config.py](../config.py) 中新增机器人配置：
+在 [config.py](../src/config.py) 中新增机器人配置：
 
 ```python
 # === 机器人配置 ===
@@ -282,7 +282,7 @@ telegram_webhook_secret: str           # 新增：Webhook 密钥
 - 支持命令频率限制（防刷）
 - 敏感操作（如批量分析）可设置权限白名单
 
-在 [config.py](../config.py) 中新增机器人安全配置：
+在 [config.py](../src/config.py) 中新增机器人安全配置：
 
 ```python
     bot_rate_limit_requests: int = 10     # 频率限制：窗口内最大请求数


### PR DESCRIPTION
## Summary

Fixes three broken relative links in the docs:

- **docs/CONTRIBUTING.md**: the Roadmap link pointed to `README.md` relative to `docs/`, which resolves to a non-existent `docs/README.md`. Changed it to `../README.md`. The `#-roadmap` anchor was dropped as the README no longer has a Roadmap section.
- **docs/bot-command.md**: two links pointed to `../config.py`, but the config file lives at `src/config.py` (the referenced bot options are at `src/config.py` around line 1096). Changed both to `../src/config.py`.

Verified with a script that checks every relative markdown link in the repo against the file tree — these were the only three broken links, and all resolve after this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)