### PR TITLE
feat: 子Agent 独立超时配置(#1929)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -475,6 +475,14 @@ AGENT_SKILLS=
 # Agent 执行超时预算（秒，0 表示关闭；single-agent 用作整体循环预算，multi-agent 用作协作编排预算；默认 600）
 # AGENT_ORCHESTRATOR_TIMEOUT_S=600
 
+# 子 Agent 独立超时钳位（秒，0=关闭钳位且回退到 Pipeline 剩余预算；设为正值如 180 可为该 Agent 启用独立硬上限）
+# AGENT_TECHNICAL_AGENT_TIMEOUT_S=0
+# AGENT_INTEL_AGENT_TIMEOUT_S=0
+# AGENT_RISK_AGENT_TIMEOUT_S=0
+# AGENT_DECISION_AGENT_TIMEOUT_S=0
+# AGENT_PORTFOLIO_AGENT_TIMEOUT_S=0
+# AGENT_SKILL_AGENT_TIMEOUT_S=0
+
 # 风控 Agent 是否可以否决买入信号（默认开启）
 # AGENT_RISK_OVERRIDE=true
 

--- a/.env.example
+++ b/.env.example
@@ -475,7 +475,11 @@ AGENT_SKILLS=
 # Agent 执行超时预算（秒，0 表示关闭；single-agent 用作整体循环预算，multi-agent 用作协作编排预算；默认 600）
 # AGENT_ORCHESTRATOR_TIMEOUT_S=600
 
-# 子 Agent 独立超时钳位（秒，0=关闭钳位且回退到 Pipeline 剩余预算；设为正值如 180 可为该 Agent 启用独立硬上限）
+# 子 Agent 独立超时上限（秒，0=关闭；设为正值如 180 可为该 Agent 启用独立硬上限）
+# 生效规则：
+#   - Pipeline 总预算关闭（AGENT_ORCHESTRATOR_TIMEOUT_S=0）时：子 Agent 上限独立生效，作为该 Agent 的绝对超时
+#   - Pipeline 总预算开启时：实际上限 = min(Pipeline 剩余预算, 子 Agent 上限)，取两者中较小值
+#   - 未配置（默认 0）时：无独立上限，仅受 Pipeline 剩余预算约束
 # AGENT_TECHNICAL_AGENT_TIMEOUT_S=0
 # AGENT_INTEL_AGENT_TIMEOUT_S=0
 # AGENT_RISK_AGENT_TIMEOUT_S=0

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 <!-- 新条目格式：- [类型] 描述（类型取值：新功能/改进/修复/文档/测试/chore）-->
 <!-- 每条独立一行追加到本段末尾，无需分类标题，合并时冲突最小 -->
 - [新功能] 飞书推送新增文件上传能力：`FeishuSender.send_feishu_file(file_path)` 通过 App Bot SDK (`im.v1.file.create`) 上传文件并发送文件消息；Webhook 模式回退为发送文件内容文本；新增 `FEISHU_SEND_AS_FILE=true` 配置开关，开启后飞书以文件形式发送报告而非文字消息。
+- [新功能] 多 Agent 编排 Pipeline 新增子 Agent 独立超时钳位：支持 6 个环境变量为 TechnicalAgent、IntelAgent、RiskAgent、DecisionAgent、PortfolioAgent、SkillAgent 各自配置独立硬上限，互不挤占配额；默认 0 表示关闭钳位。
 
 ## [3.25.0] - 2026-07-03
 

--- a/src/agent/orchestrator.py
+++ b/src/agent/orchestrator.py
@@ -281,14 +281,19 @@ class AgentOrchestrator:
         timeout_seconds: Optional[float] = None,
     ) -> StageResult:
         """Run a stage agent while preserving compatibility with older call signatures."""
-        # Clamp by per-agent limit when configured
+        # Clamp by per-agent limit when configured.
+        # When pipeline budget is disabled (timeout_seconds is None),
+        # the sub-agent's own limit still applies as a standalone cap.
         sub_agent_timeout_map = self._get_sub_agent_timeout_map()
-        if timeout_seconds is not None and sub_agent_timeout_map:
+        if sub_agent_timeout_map:
             agent_limit = sub_agent_timeout_map.get(agent.agent_name)
             if agent_limit is None and agent.agent_name in getattr(self, "_skill_agent_names", set()):
                 agent_limit = sub_agent_timeout_map.get("skill")
             if agent_limit is not None:
-                timeout_seconds = min(timeout_seconds, agent_limit)
+                if timeout_seconds is not None:
+                    timeout_seconds = min(timeout_seconds, agent_limit)
+                else:
+                    timeout_seconds = agent_limit
         run_kwargs = {"progress_callback": progress_callback}
         if (
             timeout_seconds is not None

--- a/src/agent/orchestrator.py
+++ b/src/agent/orchestrator.py
@@ -114,6 +114,25 @@ class AgentOrchestrator:
         except (TypeError, ValueError):
             return 0
 
+    def _get_sub_agent_timeout_map(self) -> Dict[str, float]:
+        """Return per-agent timeout clamps from config, skipping disabled (0) entries."""
+        config = self.config
+        if config is None:
+            return {}
+        entries = [
+            ("technical", "agent_technical_agent_timeout_s"),
+            ("intel", "agent_intel_agent_timeout_s"),
+            ("risk", "agent_risk_agent_timeout_s"),
+            ("decision", "agent_decision_agent_timeout_s"),
+            ("portfolio", "agent_portfolio_agent_timeout_s"),
+            ("skill", "agent_skill_agent_timeout_s"),
+        ]
+        return {
+            key: float(val)
+            for key, attr in entries
+            if (val := getattr(config, attr, None)) is not None and val > 0
+        }
+
     def _build_timeout_result(
         self,
         stats: AgentRunStats,
@@ -262,6 +281,14 @@ class AgentOrchestrator:
         timeout_seconds: Optional[float] = None,
     ) -> StageResult:
         """Run a stage agent while preserving compatibility with older call signatures."""
+        # Clamp by per-agent limit when configured
+        sub_agent_timeout_map = self._get_sub_agent_timeout_map()
+        if timeout_seconds is not None and sub_agent_timeout_map:
+            agent_limit = sub_agent_timeout_map.get(agent.agent_name)
+            if agent_limit is None and agent.agent_name in getattr(self, "_skill_agent_names", set()):
+                agent_limit = sub_agent_timeout_map.get("skill")
+            if agent_limit is not None:
+                timeout_seconds = min(timeout_seconds, agent_limit)
         run_kwargs = {"progress_callback": progress_callback}
         if (
             timeout_seconds is not None

--- a/src/config.py
+++ b/src/config.py
@@ -848,6 +848,12 @@ class Config:
     agent_arch: str = "single"     # Agent architecture: 'single' (legacy) or 'multi' (orchestrator)
     agent_orchestrator_mode: str = "standard"  # Orchestrator mode: quick/standard/full/specialist
     agent_orchestrator_timeout_s: int = 600  # Cooperative timeout budget for the whole multi-agent pipeline
+    agent_technical_agent_timeout_s: float = 0
+    agent_intel_agent_timeout_s: float = 0
+    agent_risk_agent_timeout_s: float = 0
+    agent_decision_agent_timeout_s: float = 0
+    agent_portfolio_agent_timeout_s: float = 0
+    agent_skill_agent_timeout_s: float = 0
     agent_risk_override: bool = True  # Allow risk agent to veto buy signals
     agent_deep_research_budget: int = 30000  # Max token budget for deep research
     agent_deep_research_timeout: int = 180  # Max seconds for /research command before returning timeout
@@ -1753,6 +1759,30 @@ class Config:
                 600,
                 field_name='AGENT_ORCHESTRATOR_TIMEOUT_S',
                 minimum=0,
+            ),
+            agent_technical_agent_timeout_s=parse_env_float(
+                os.getenv('AGENT_TECHNICAL_AGENT_TIMEOUT_S'), 0,
+                field_name='AGENT_TECHNICAL_AGENT_TIMEOUT_S', minimum=0,
+            ),
+            agent_intel_agent_timeout_s=parse_env_float(
+                os.getenv('AGENT_INTEL_AGENT_TIMEOUT_S'), 0,
+                field_name='AGENT_INTEL_AGENT_TIMEOUT_S', minimum=0,
+            ),
+            agent_risk_agent_timeout_s=parse_env_float(
+                os.getenv('AGENT_RISK_AGENT_TIMEOUT_S'), 0,
+                field_name='AGENT_RISK_AGENT_TIMEOUT_S', minimum=0,
+            ),
+            agent_decision_agent_timeout_s=parse_env_float(
+                os.getenv('AGENT_DECISION_AGENT_TIMEOUT_S'), 0,
+                field_name='AGENT_DECISION_AGENT_TIMEOUT_S', minimum=0,
+            ),
+            agent_portfolio_agent_timeout_s=parse_env_float(
+                os.getenv('AGENT_PORTFOLIO_AGENT_TIMEOUT_S'), 0,
+                field_name='AGENT_PORTFOLIO_AGENT_TIMEOUT_S', minimum=0,
+            ),
+            agent_skill_agent_timeout_s=parse_env_float(
+                os.getenv('AGENT_SKILL_AGENT_TIMEOUT_S'), 0,
+                field_name='AGENT_SKILL_AGENT_TIMEOUT_S', minimum=0,
             ),
             agent_risk_override=os.getenv('AGENT_RISK_OVERRIDE', 'true').lower() == 'true',
             agent_deep_research_budget=parse_env_int(

--- a/tests/test_multi_agent.py
+++ b/tests/test_multi_agent.py
@@ -1137,6 +1137,121 @@ class TestOrchestratorExecution(unittest.TestCase):
             295.0,
         )
 
+    # --- Sub-agent timeout clamp regression (AGENT_*_TIMEOUT_S) ---
+
+    def _make_config_with_sub_agent_timeouts(self, **kwargs):
+        """Return a SimpleNamespace config with sub-agent timeout fields."""
+        defaults = {
+            "agent_orchestrator_timeout_s": 0,
+            "agent_technical_agent_timeout_s": 0,
+            "agent_intel_agent_timeout_s": 0,
+            "agent_risk_agent_timeout_s": 0,
+            "agent_decision_agent_timeout_s": 0,
+            "agent_portfolio_agent_timeout_s": 0,
+            "agent_skill_agent_timeout_s": 0,
+            "agent_risk_override": True,
+        }
+        defaults.update(kwargs)
+        return SimpleNamespace(**defaults)
+
+    def test_run_stage_agent_no_pipeline_budget_uses_sub_agent_limit(self):
+        """When pipeline budget is 0 (timeout_seconds=None), sub-agent limit applies standalone."""
+        orch = self._make_orchestrator(
+            config=self._make_config_with_sub_agent_timeouts(
+                agent_technical_agent_timeout_s=180,
+            )
+        )
+        agent = MagicMock(agent_name="technical")
+        result = self._stage_result("technical")
+        agent.run.return_value = result
+
+        orch._run_stage_agent(agent, AgentContext(query="test"), timeout_seconds=None)
+
+        call_kwargs = agent.run.call_args.kwargs
+        self.assertEqual(call_kwargs["timeout_seconds"], 180)
+
+    def test_run_stage_agent_pipeline_budget_larger_than_agent_limit_clamps_to_agent(self):
+        """Pipeline remaining > sub-agent limit → use smaller agent limit."""
+        orch = self._make_orchestrator(
+            config=self._make_config_with_sub_agent_timeouts(
+                agent_technical_agent_timeout_s=120,
+            )
+        )
+        agent = MagicMock(agent_name="technical")
+        result = self._stage_result("technical")
+        agent.run.return_value = result
+
+        orch._run_stage_agent(agent, AgentContext(query="test"), timeout_seconds=300)
+
+        call_kwargs = agent.run.call_args.kwargs
+        self.assertEqual(call_kwargs["timeout_seconds"], 120)
+
+    def test_run_stage_agent_pipeline_budget_smaller_than_agent_limit_uses_pipeline(self):
+        """Pipeline remaining < sub-agent limit → use smaller pipeline remaining."""
+        orch = self._make_orchestrator(
+            config=self._make_config_with_sub_agent_timeouts(
+                agent_technical_agent_timeout_s=300,
+            )
+        )
+        agent = MagicMock(agent_name="technical")
+        result = self._stage_result("technical")
+        agent.run.return_value = result
+
+        orch._run_stage_agent(agent, AgentContext(query="test"), timeout_seconds=60)
+
+        call_kwargs = agent.run.call_args.kwargs
+        self.assertEqual(call_kwargs["timeout_seconds"], 60)
+
+    def test_run_stage_agent_no_sub_agent_limit_passes_pipeline_budget_through(self):
+        """No sub-agent limit configured (all 0) → pipeline budget passed through unchanged."""
+        orch = self._make_orchestrator(
+            config=self._make_config_with_sub_agent_timeouts(),
+        )
+        agent = MagicMock(agent_name="technical")
+        result = self._stage_result("technical")
+        agent.run.return_value = result
+
+        orch._run_stage_agent(agent, AgentContext(query="test"), timeout_seconds=300)
+
+        call_kwargs = agent.run.call_args.kwargs
+        self.assertEqual(call_kwargs["timeout_seconds"], 300)
+
+    def test_run_stage_agent_skill_agent_fallback_applies_skill_clamp(self):
+        """Skill agents (in _skill_agent_names) use the 'skill' clamp key as fallback."""
+        orch = self._make_orchestrator(
+            config=self._make_config_with_sub_agent_timeouts(
+                agent_skill_agent_timeout_s=90,
+            )
+        )
+        orch._skill_agent_names = {"bull_trend_specialist", "volume_breakout_specialist"}
+        agent = MagicMock(agent_name="bull_trend_specialist")
+        result = self._stage_result("bull_trend_specialist")
+        agent.run.return_value = result
+
+        orch._run_stage_agent(agent, AgentContext(query="test"), timeout_seconds=300)
+
+        call_kwargs = agent.run.call_args.kwargs
+        self.assertEqual(call_kwargs["timeout_seconds"], 90)
+
+    def test_run_stage_agent_skill_agent_exact_name_match_wins_over_skill_fallback(self):
+        """Exact agent_name match takes priority over _skill_agent_names fallback."""
+        orch = self._make_orchestrator(
+            config=self._make_config_with_sub_agent_timeouts(
+                agent_skill_agent_timeout_s=90,
+                agent_decision_agent_timeout_s=150,
+            )
+        )
+        orch._skill_agent_names = {"decision"}
+        agent = MagicMock(agent_name="decision")
+        result = self._stage_result("decision")
+        agent.run.return_value = result
+
+        orch._run_stage_agent(agent, AgentContext(query="test"), timeout_seconds=300)
+
+        call_kwargs = agent.run.call_args.kwargs
+        # Exact name "decision" → 150, not skill fallback 90
+        self.assertEqual(call_kwargs["timeout_seconds"], 150)
+
     def test_run_wraps_orchestrator_result(self):
         from src.agent.orchestrator import OrchestratorResult
 


### PR DESCRIPTION
## PR Type

- [ ] fix
- [x] feat
- [ ] refactor
- [ ] docs
- [ ] chore
- [ ] test

## Background And Problem

当前多 Agent 编排 Pipeline 中，所有子 Agent 共享 Pipeline 总预算。如果 TechnicalAgent 或 IntelAgent 跑满全部剩余时间，下游 Agent（RiskAgent、DecisionAgent 等）将无预算可用，导致分析流程被截断或跳过关键阶段。

触发场景：当某个 Agent 因模型响应慢、网络波动或 prompt 过长而耗尽 Pipeline 剩余时间时，后续阶段（尤其是 DecisionAgent 的最终综合判断）会被跳过，影响分析报告完整性。

PR实现：每个子 Agent 的 max_timeout 默认值均为 0（0 表示钳位关闭，行为退化为 remaining_budget 透传），确保本次改动对现有 Pipeline 零影响。
后续若要开启钳位，需另行讨论各子 Agent 合理的默认超时值。

（未显示在web端，后续PR可将其同步至网页端，让用户可在网页端配置默认值。）

## Scope Of Change

- 文件总数 / 变更行数：5 files, 190 insertions(+)
- 文件清单：
  - `src/config.py` — 新增 6 个 `float` 数据类字段 + 6 个 `parse_env_float` 调用
  - `src/agent/orchestrator.py` — 新增 `_get_sub_agent_timeout_map` 方法 + `_run_stage_agent` 钳位逻辑
  - `.env.example` — 追加 6 个注释掉的子 Agent 超时环境变量 + 生效规则注释
  - `docs/CHANGELOG.md` — 追加 1 条 `[Unreleased]` 新功能条目
  - `tests/test_multi_agent.py` — 新增 6 个 `_run_stage_agent` 钳位回归测试

```bash
$ git diff --stat origin/main..HEAD
 .env.example              |  12 +++++
 docs/CHANGELOG.md         |   1 +
 src/agent/orchestrator.py |  32 +++++++++++++
 src/config.py             |  30 ++++++++++++
 tests/test_multi_agent.py | 115 ++++++++++++++++++++++++++++++++++++++
 5 files changed, 190 insertions(+)
 4 files changed, 66 insertions(+)
```

## Issue Link

Fixes #1929

## Verification Commands And Results

```bash
# 语法检查
python -m py_compile src/config.py
python -m py_compile src/agent/orchestrator.py

# 配置加载测试（默认值）
python -c "
from src.config import get_config
config = get_config()
print('technical:', config.agent_technical_agent_timeout_s)
print('intel:', config.agent_intel_agent_timeout_s)
print('risk:', config.agent_risk_agent_timeout_s)
print('decision:', config.agent_decision_agent_timeout_s)
print('portfolio:', config.agent_portfolio_agent_timeout_s)
print('skill:', config.agent_skill_agent_timeout_s)
"

# 配置加载测试（环境变量）
AGENT_TECHNICAL_AGENT_TIMEOUT_S=180 python -c "
from src.config import get_config
config = get_config()
assert config.agent_technical_agent_timeout_s == 180
assert config.agent_intel_agent_timeout_s == 0
print('OK: per-agent timeout loaded correctly')
"

# _run_stage_agent 钳位回归测试（6 个场景）
python -m pytest tests/test_multi_agent.py -k "test_run_stage_agent" -v
```

关键输出/结论：
- 语法检查通过，无 import 错误
- 默认值全部为 0（关闭钳位），保持向后兼容
- 环境变量正确加载并解析
- 本 PR 未修改 Web UI / 报告格式，无需 Playwright 截图

> 当前状态：本地验证通过。CI 结果待 GitHub Actions 运行后补充。

## Visual Evidence (if applicable)

不适用原因：本 PR 仅涉及后端配置与环境变量，不修改 Web UI 或报告渲染效果，无需截图。

## Compatibility And Risk

本 PR 未变更 provider/model/base URL、运行时配置清理迁移语义；历史配置保持不变；回滚方式为 revert 本提交。

**关于自动化扫描"外部模型/API 或运行时配置迁移风险"的排除说明**：
本次仅新增 6 个 `AGENT_*_TIMEOUT_S` 环境变量及其读取、传递和钳位逻辑，具体变更范围：
- `src/config.py`：仅在 dataclass 新增 6 个 `float` 默认字段 + `_load_from_env` 新增 6 个 `parse_env_float` 调用，未修改任何 LLM provider/model/base URL 字段或默认值
- `src/agent/orchestrator.py`：仅新增 `_get_sub_agent_timeout_map` 方法和 `_run_stage_agent` 内 `min()` 钳位，未修改 `_execute_pipeline` 的调用链或超时语义
- 未修改 `requirements.txt`、`litellm` 版本约束、provider fallback 逻辑或配置迁移/清理代码
- 未修改 Web 设置页字段注册（`config_registry.py`）、i18n 标签或 display_order

因此自动化扫描若命中，属于对 `src/config.py` 新增 env 字段的泛化误报，并非真实的外部 API/依赖/迁移风险。

兼容性说明：
- 默认值为 0（关闭钳位），不配置任何环境变量时行为与原来完全一致
- 仅当用户显式设置 `AGENT_*_TIMEOUT_S > 0` 时才会激活对应 Agent 的独立超时上限
- Pipeline 预算关闭时子 Agent 上限独立生效；Pipeline 预算开启时取 min(剩余预算, Agent 上限)

## Rollback Plan

`git revert <commit>` 即可回滚，无需额外配置或数据迁移。

## Checklist

- [x] 本 PR 有明确动机和业务价值
- [x] 已提供可复现的验证命令与结果
- [x] 已评估兼容性与风险
- [x] 已提供回滚方案
- [x] 若修改报告格式或 Web UI 界面，已在 PR 描述/评论附受影响报告 / 页面截图（不适用）
- [x] 若本 PR 修改 Web 设置字段（不适用）
- [x] 若涉及用户可见变更，已同步更新相关文档与 `docs/CHANGELOG.md`
