### PR TITLE
fix(data-provider): honour EFINANCE_CACHE_DIR for efinance cache

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -864,10 +864,15 @@ ADMIN_AUTH_ENABLED=false
 #                          # (e.g. search-cache.json).  Upstream efinance ≤0.5.x
 #                          # mkdir()s into its own package directory by default,
 #                          # which fails on read-only filesystems (containers).
-#                          # Leave unset to default to $XDG_CACHE_HOME/efinance
-#                          # (or ~/.cache/efinance when XDG_CACHE_HOME is empty).
-#                          # Set explicitly for containerized deployments, e.g.
-#                          # EFINANCE_CACHE_DIR=/app/data/.efinance-cache.
+#
+#                          # Default resolution: $XDG_CACHE_HOME/efinance, or
+#                          # ~/.cache/efinance when XDG_CACHE_HOME is empty.
+#                          # The official container image injects
+#                          # /app/data/.efinance-cache via docker/entrypoint.sh,
+#                          # so non-rootless deployments get a writable path
+#                          # automatically; only set this explicitly for
+#                          # non-standard layouts (rootless + custom mount,
+#                          # CI, custom compose env_file, etc.).
 #                          # If the resolved path is not creatable, importing the
 #                          # fetcher logs a warning and continues; efinance writes
 #                          # will then fail with a clear OSError, handled by the

--- a/.env.example
+++ b/.env.example
@@ -859,6 +859,13 @@ ADMIN_AUTH_ENABLED=false
 # EFINANCE_PRIORITY=0      # EastMoney (China) - default: 0
 # EFINANCE_CALL_TIMEOUT=30 # Timeout (seconds) for efinance API calls; prevents indefinite hangs
 #                          # when eastmoney hosts are unreachable. Default: 30
+# EFINANCE_CACHE_DIR=/app/data/.efinance-cache
+#                          # Writable directory for efinance's internal cache files
+#                          # (e.g. search-cache.json).  Upstream efinance ≤0.5.x
+#                          # mkdir()s into its own package directory by default,
+#                          # which fails on read-only filesystems (containers).
+#                          # Set this to any writable path; the directory is
+#                          # auto-created if missing.  Default: /app/data/.efinance-cache
 # AKSHARE_PRIORITY=1       # AkShare (China) - default: 1
 # TUSHARE_PRIORITY=2       # Tushare Pro (China) - default: 2
 # TICKFLOW_PRIORITY=2      # TickFlow（A 股）- 默认：2；可选，需配置 TICKFLOW_API_KEY

--- a/.env.example
+++ b/.env.example
@@ -859,13 +859,19 @@ ADMIN_AUTH_ENABLED=false
 # EFINANCE_PRIORITY=0      # EastMoney (China) - default: 0
 # EFINANCE_CALL_TIMEOUT=30 # Timeout (seconds) for efinance API calls; prevents indefinite hangs
 #                          # when eastmoney hosts are unreachable. Default: 30
-# EFINANCE_CACHE_DIR=/app/data/.efinance-cache
+# EFINANCE_CACHE_DIR=
 #                          # Writable directory for efinance's internal cache files
 #                          # (e.g. search-cache.json).  Upstream efinance ≤0.5.x
 #                          # mkdir()s into its own package directory by default,
 #                          # which fails on read-only filesystems (containers).
-#                          # Set this to any writable path; the directory is
-#                          # auto-created if missing.  Default: /app/data/.efinance-cache
+#                          # Leave unset to default to $XDG_CACHE_HOME/efinance
+#                          # (or ~/.cache/efinance when XDG_CACHE_HOME is empty).
+#                          # Set explicitly for containerized deployments, e.g.
+#                          # EFINANCE_CACHE_DIR=/app/data/.efinance-cache.
+#                          # If the resolved path is not creatable, importing the
+#                          # fetcher logs a warning and continues; efinance writes
+#                          # will then fail with a clear OSError, handled by the
+#                          # normal data-source fallback chain.
 # AKSHARE_PRIORITY=1       # AkShare (China) - default: 1
 # TUSHARE_PRIORITY=2       # Tushare Pro (China) - default: 2
 # TICKFLOW_PRIORITY=2      # TickFlow（A 股）- 默认：2；可选，需配置 TICKFLOW_API_KEY

--- a/data_provider/efinance_fetcher.py
+++ b/data_provider/efinance_fetcher.py
@@ -86,23 +86,39 @@ _ef_cfg_stub.MAX_CONNECTIONS = 50
 _ef_cfg_stub.SHOW_TICKFLOW_PROMPT = True
 _ef_cfg_stub.HERE = _Path("/tmp/.efinance-config-marker")
 
-# Inject the stub ONLY if efinance has not been loaded yet.  If upstream
-# code already imported `efinance` (and therefore populated
-# `efinance.config` via its own `__init__.py`), we leave that alone — that
-# path owns its own cache-dir contract and presumably is already running
-# in a writable environment.
+# Inject the stub for the `efinance.config` symbol.  Whether or not
+# efinance has already been imported, this places our stub where
+# downstream `from efinance.config import X` resolves.
+_sys.modules["efinance.config"] = _ef_cfg_stub
+
+# Best-effort: also bind the stub as the parent package's `config`
+# attribute.  efinance 0.5.x's `__init__.py` does not expose `.config`
+# (verified against 0.5.8); without this attribute assignment, callers
+# using `import efinance as ef; ef.config.X` raise AttributeError.
 #
-# Module-level `import efinance as ef` is deliberately omitted.  A
-# previous revision caught only `ImportError` around that import; any
-# `OSError` raised during efinance import (reproducible regression
-# caught in PR review) propagated out of this module and broke
-# `import data_provider` at startup.  The stub in sys.modules is
-# sufficient: the first `from efinance.config import …` (whether
-# triggered by data_provider's fetcher calls or by an external caller)
-# resolves to the stub when efinance hasn't been loaded yet, and to the
-# real module when it has.
-if "efinance" not in _sys.modules:
-    _sys.modules["efinance.config"] = _ef_cfg_stub
+# Wrapped in `except BaseException` because:
+#   * The eager `import efinance` half can raise OSError on cache
+#     probing (reproducible regression caught in PR review).
+#   * The parent-attribute assignment is best-effort against future
+#     upstream changes that may make the package attribute non-
+#     assignable.
+# Both halves MUST NOT propagate, or `import data_provider` breaks at
+# startup — defeating the whole point of this patch.
+try:
+    import efinance as _ef  # noqa: F401
+    setattr(_ef, "config", _ef_cfg_stub)
+except (ImportError, OSError):
+    # efinance not installed (ImportError) or raised OSError during
+    # import (reproducible regression caught in PR review; narrower
+    # catch than `except BaseException` so unrelated dependency
+    # failures surface as before).  Both must NOT propagate as
+    # `import data_provider` failures.
+    pass
+except (AttributeError, TypeError):
+    # Parent-attribute assignment is best-effort: the consumer-side
+    # re-exports via `sys.modules["efinance.config"]` already resolve
+    # correctly even when this half fails.
+    pass
 
 import logging
 import os

--- a/data_provider/efinance_fetcher.py
+++ b/data_provider/efinance_fetcher.py
@@ -20,6 +20,44 @@ EfinanceFetcher - 优先数据源 (Priority 0)
 4. 熔断器机制：连续失败后自动冷却
 """
 
+# Honour EFINANCE_CACHE_DIR so efinance's cache lives outside its package
+# directory.  Upstream efinance (≤0.5.x) hardcodes DATA_DIR to a path
+# inside its own package directory and unconditionally mkdir()s it at
+# import time, which crashes on read-only filesystems (containers,
+# system Python installs).  We pre-register a writable stub for
+# efinance.config in sys.modules BEFORE any `import efinance as ef`
+# triggers upstream's mkdir(), so any later code path sees a writable
+# cache path driven by $EFINANCE_CACHE_DIR (default
+# /app/data/.efinance-cache, which is already a writable Volume in
+# containerized deployments).
+import os as _os
+import sys as _sys
+import types as _types
+from pathlib import Path as _Path
+
+_EFINANCE_CACHE_DIR = _Path(_os.environ.get(
+    "EFINANCE_CACHE_DIR", "/app/data/.efinance-cache"))
+_EFINANCE_CACHE_DIR.mkdir(parents=True, exist_ok=True)
+
+_ef_cfg_stub = _types.ModuleType("efinance.config")
+_ef_cfg_stub.DATA_DIR = _EFINANCE_CACHE_DIR
+_ef_cfg_stub.SEARCH_RESULT_CACHE_PATH = str(
+    _EFINANCE_CACHE_DIR / "search-cache.json")
+_ef_cfg_stub.MAX_CONNECTIONS = 50
+_ef_cfg_stub.SHOW_TICKFLOW_PROMPT = True
+_ef_cfg_stub.HERE = _Path("/tmp/.efinance-config-marker")
+
+_sys.modules.setdefault("efinance.config", _ef_cfg_stub)
+
+try:
+    import efinance as _ef  # noqa: F401  -- triggers efinance/__init__.py + utils with our config stub
+    _ef.config = _ef_cfg_stub  # attribute access (ef.config) hit by downstream callers
+except ImportError:
+    # efinance not installed (test envs, partial installs).  sys.modules
+    # stub stays in place; a later `import efinance as ef` in environments
+    # where efinance IS installed will still pick it up.
+    pass
+
 import logging
 import os
 import random

--- a/data_provider/efinance_fetcher.py
+++ b/data_provider/efinance_fetcher.py
@@ -26,23 +26,62 @@ EfinanceFetcher - 优先数据源 (Priority 0)
 # import time, which crashes on read-only filesystems (containers,
 # system Python installs).  We pre-register a writable stub for
 # efinance.config in sys.modules BEFORE any `import efinance as ef`
-# triggers upstream's mkdir(), so any later code path sees a writable
-# cache path driven by $EFINANCE_CACHE_DIR (default
-# /app/data/.efinance-cache, which is already a writable Volume in
-# containerized deployments).
+# triggers upstream's mkdir().
+#
+# Cache directory resolution (in priority order):
+#   1. $EFINANCE_CACHE_DIR if set (user override)
+#   2. $XDG_CACHE_HOME/efinance  (Linux/macOS convention)
+#   3. ~/.cache/efinance        (fallback when XDG_CACHE_HOME unset)
+#
+# The resolved directory is created lazily and only logged-as-warning on
+# failure; importing this module never raises on an unwritable cache
+# path.  Downstream fetcher calls will surface a clear OSError if the
+# cache file can't be opened, which is handled by the normal data-source
+# fallback chain.
+import logging as _logging
 import os as _os
 import sys as _sys
 import types as _types
 from pathlib import Path as _Path
 
-_EFINANCE_CACHE_DIR = _Path(_os.environ.get(
-    "EFINANCE_CACHE_DIR", "/app/data/.efinance-cache"))
-_EFINANCE_CACHE_DIR.mkdir(parents=True, exist_ok=True)
+_logger = _logging.getLogger(__name__)
+
+
+def _resolve_cache_dir() -> _Path:
+    """Resolve efinance cache directory; never raises."""
+    override = _os.environ.get("EFINANCE_CACHE_DIR", "").strip()
+    if override:
+        return _Path(override).expanduser()
+    xdg = _os.environ.get("XDG_CACHE_HOME", "").strip()
+    if xdg:
+        return _Path(xdg).expanduser() / "efinance"
+    return _Path.home() / ".cache" / "efinance"
+
+
+def _ensure_cache_dir(path: _Path) -> _Path | None:
+    """Best-effort mkdir(); returns path on success, None on failure."""
+    try:
+        path.mkdir(parents=True, exist_ok=True)
+        return path
+    except OSError as e:
+        _logger.warning(
+            "EFINANCE_CACHE_DIR %s not creatable (%s); "
+            "efinance cache disabled, fetcher writes will fail",
+            path, e,
+        )
+        return None
+
+
+_EFINANCE_CACHE_DIR = _resolve_cache_dir()
+_cache_dir = _ensure_cache_dir(_EFINANCE_CACHE_DIR)
+# Even if mkdir failed we still set DATA_DIR/SEARCH_RESULT_CACHE_PATH so
+# the stub is structurally complete; subsequent efinance writes will
+# raise their own OSError which the data-source fallback handles.
+_effective = _cache_dir if _cache_dir is not None else _EFINANCE_CACHE_DIR
 
 _ef_cfg_stub = _types.ModuleType("efinance.config")
-_ef_cfg_stub.DATA_DIR = _EFINANCE_CACHE_DIR
-_ef_cfg_stub.SEARCH_RESULT_CACHE_PATH = str(
-    _EFINANCE_CACHE_DIR / "search-cache.json")
+_ef_cfg_stub.DATA_DIR = _effective
+_ef_cfg_stub.SEARCH_RESULT_CACHE_PATH = str(_effective / "search-cache.json")
 _ef_cfg_stub.MAX_CONNECTIONS = 50
 _ef_cfg_stub.SHOW_TICKFLOW_PROMPT = True
 _ef_cfg_stub.HERE = _Path("/tmp/.efinance-config-marker")

--- a/data_provider/efinance_fetcher.py
+++ b/data_provider/efinance_fetcher.py
@@ -86,16 +86,23 @@ _ef_cfg_stub.MAX_CONNECTIONS = 50
 _ef_cfg_stub.SHOW_TICKFLOW_PROMPT = True
 _ef_cfg_stub.HERE = _Path("/tmp/.efinance-config-marker")
 
-_sys.modules.setdefault("efinance.config", _ef_cfg_stub)
-
-try:
-    import efinance as _ef  # noqa: F401  -- triggers efinance/__init__.py + utils with our config stub
-    _ef.config = _ef_cfg_stub  # attribute access (ef.config) hit by downstream callers
-except ImportError:
-    # efinance not installed (test envs, partial installs).  sys.modules
-    # stub stays in place; a later `import efinance as ef` in environments
-    # where efinance IS installed will still pick it up.
-    pass
+# Inject the stub ONLY if efinance has not been loaded yet.  If upstream
+# code already imported `efinance` (and therefore populated
+# `efinance.config` via its own `__init__.py`), we leave that alone — that
+# path owns its own cache-dir contract and presumably is already running
+# in a writable environment.
+#
+# Module-level `import efinance as ef` is deliberately omitted.  A
+# previous revision caught only `ImportError` around that import; any
+# `OSError` raised during efinance import (reproducible regression
+# caught in PR review) propagated out of this module and broke
+# `import data_provider` at startup.  The stub in sys.modules is
+# sufficient: the first `from efinance.config import …` (whether
+# triggered by data_provider's fetcher calls or by an external caller)
+# resolves to the stub when efinance hasn't been loaded yet, and to the
+# real module when it has.
+if "efinance" not in _sys.modules:
+    _sys.modules["efinance.config"] = _ef_cfg_stub
 
 import logging
 import os

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -7,6 +7,14 @@ APP_UID="1000"
 APP_GID="1000"
 WRITABLE_DIRS="/app/data /app/logs /app/reports /home/dsa/.longbridge"
 DATABASE_FILE="${DATABASE_PATH:-/app/data/stock_analysis.db}"
+# Efinance (≤0.5.x) mkdir()s into its own package directory on import, which
+# fails on this image's read-only rootfs.  Default the cache to a writable
+# volume so the official container works out-of-the-box; non-container users
+# inherit the data_provider XDG / ~/.cache fallback via the efinance_fetcher
+# contract.  Operators can still override via -e EFINANCE_CACHE_DIR=... or an
+# env_file.
+EFINANCE_CACHE_DIR="${EFINANCE_CACHE_DIR:-/app/data/.efinance-cache}"
+export EFINANCE_CACHE_DIR
 
 warn() {
     printf '%s\n' "$*" >&2

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 <!-- 每条独立一行追加到本段末尾，无需分类标题，合并时冲突最小 -->
 - [新功能] 飞书推送新增文件上传能力：`FeishuSender.send_feishu_file(file_path)` 通过 App Bot SDK (`im.v1.file.create`) 上传文件并发送文件消息；Webhook 模式回退为发送文件内容文本；新增 `FEISHU_SEND_AS_FILE=true` 配置开关，开启后飞书以文件形式发送报告而非文字消息。
 - [新功能] 多 Agent 编排 Pipeline 新增子 Agent 独立超时钳位：支持 6 个环境变量为 TechnicalAgent、IntelAgent、RiskAgent、DecisionAgent、PortfolioAgent、SkillAgent 各自配置独立硬上限，互不挤占配额；默认 0 表示关闭钳位。
+- [修复] efinance 数据源支持通过 `EFINANCE_CACHE_DIR` 环境变量指定可写缓存目录；在只读 rootfs（容器化部署、system Python）下使用容器默认路径 `/app/data/.efinance-cache`（已挂载为可写 Volume），避免导入阶段 `Read-only file system` 错误。
 
 ## [3.25.0] - 2026-07-03
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -26,8 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 <!-- 每条独立一行追加到本段末尾，无需分类标题，合并时冲突最小 -->
 - [新功能] 飞书推送新增文件上传能力：`FeishuSender.send_feishu_file(file_path)` 通过 App Bot SDK (`im.v1.file.create`) 上传文件并发送文件消息；Webhook 模式回退为发送文件内容文本；新增 `FEISHU_SEND_AS_FILE=true` 配置开关，开启后飞书以文件形式发送报告而非文字消息。
 - [新功能] 多 Agent 编排 Pipeline 新增子 Agent 独立超时钳位：支持 6 个环境变量为 TechnicalAgent、IntelAgent、RiskAgent、DecisionAgent、PortfolioAgent、SkillAgent 各自配置独立硬上限，互不挤占配额；默认 0 表示关闭钳位。
-- [修复] efinance 数据源支持通过 `EFINANCE_CACHE_DIR` 环境变量指定可写缓存目录；在只读 rootfs（容器化部署、system Python）下使用容器默认路径 `/app/data/.efinance-cache`（已挂载为可写 Volume），避免导入阶段 `Read-only file system` 错误。
-- [修复] efinance 数据源支持通过 `EFINANCE_CACHE_DIR` 环境变量指定可写缓存目录；非容器环境默认 `$XDG_CACHE_HOME/efinance` → `~/.cache/efinance`，官方容器构建由 `docker/entrypoint.sh` 自动注入 `/app/data/.efinance-cache`（已挂载为可写 Volume），避免只读 rootfs（容器化部署、system Python）下导入阶段 `Read-only file system` 错误。
+- [修复] efinance 数据源支持通过 `EFINANCE_CACHE_DIR` 环境变量指定可写缓存目录；非容器环境默认 `$XDG_CACHE_HOME/efinance` → `~/.cache/efinance`，官方容器构建由 `docker/entrypoint.sh` 自动注入 `/app/data/.efinance-cache`（已挂载为可写 Volume），避免只读 rootfs（容器化部署、system Python）下导入阶段 `Read-only file system` 错误；把 efinance 缓存目录移出包路径的兼容性同时要求 `efinance<0.6`（基于实际运行版本 0.5.8 编写 stub，重写整个 `efinance.config` 私有模块在 0.6.x 上不再保证向后兼容）。
 
 ## [3.25.0] - 2026-07-03
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - [新功能] 飞书推送新增文件上传能力：`FeishuSender.send_feishu_file(file_path)` 通过 App Bot SDK (`im.v1.file.create`) 上传文件并发送文件消息；Webhook 模式回退为发送文件内容文本；新增 `FEISHU_SEND_AS_FILE=true` 配置开关，开启后飞书以文件形式发送报告而非文字消息。
 - [新功能] 多 Agent 编排 Pipeline 新增子 Agent 独立超时钳位：支持 6 个环境变量为 TechnicalAgent、IntelAgent、RiskAgent、DecisionAgent、PortfolioAgent、SkillAgent 各自配置独立硬上限，互不挤占配额；默认 0 表示关闭钳位。
 - [修复] efinance 数据源支持通过 `EFINANCE_CACHE_DIR` 环境变量指定可写缓存目录；在只读 rootfs（容器化部署、system Python）下使用容器默认路径 `/app/data/.efinance-cache`（已挂载为可写 Volume），避免导入阶段 `Read-only file system` 错误。
+- [修复] efinance 数据源支持通过 `EFINANCE_CACHE_DIR` 环境变量指定可写缓存目录；非容器环境默认 `$XDG_CACHE_HOME/efinance` → `~/.cache/efinance`，官方容器构建由 `docker/entrypoint.sh` 自动注入 `/app/data/.efinance-cache`（已挂载为可写 Volume），避免只读 rootfs（容器化部署、system Python）下导入阶段 `Read-only file system` 错误。
 
 ## [3.25.0] - 2026-07-03
 

--- a/docs/full-guide.md
+++ b/docs/full-guide.md
@@ -140,7 +140,6 @@ daily_stock_analysis/
 | `MARKDOWN_TO_IMAGE_MAX_CHARS` | 超过此长度不转图片，避免超大图片（默认 15000） | 可选 |
 | `MD2IMG_ENGINE` | 转图引擎：`wkhtmltoimage`（默认，需 wkhtmltopdf）或 `markdown-to-file`（emoji 更好，需 `npm i -g markdown-to-file`） | 可选 |
 | `PREFETCH_REALTIME_QUOTES` | 设为 `false` 可禁用实时行情预取，避免 efinance/akshare_em 全市场拉取（默认 true） | 可选 |
-| `EFINANCE_CACHE_DIR` | efinance 内部缓存目录（如 `search-cache.json`）。上游 efinance ≤0.5.x 默认在自身包目录下 `mkdir()`，在只读 rootfs 上会失败。默认解析为 `$XDG_CACHE_HOME/efinance` → `~/.cache/efinance`；官方容器镜像经 `docker/entrypoint.sh` 默认注入 `/app/data/.efinance-cache`。若解析路径不可创建，仅记 warning 并继续；后续 efinance 写入将抛出清晰 `OSError`，由数据源 fallback 链路处理。 | 可选 |
 
 > 兼容性说明：`REPORT_SHOW_LLM_MODEL` 维持默认 `true` 的原始展示语义，关闭时只影响底部模型文案输出。该配置不会变更 provider/model/Base URL、LiteLLM 路由、模型保存、迁移或清理语义；回退方式为恢复或删除该变量，并设为 `true`。
 
@@ -414,6 +413,7 @@ daily_stock_analysis/
 | `FUNDAMENTAL_RETRY_MAX` | 基本面能力重试次数（含首次） | `1` | 可选 |
 | `FUNDAMENTAL_CACHE_TTL_SECONDS` | 基本面聚合缓存 TTL（秒），短缓存减轻重复拉取 | `120` | 可选 |
 | `FUNDAMENTAL_CACHE_MAX_ENTRIES` | 基本面缓存最大条目数（TTL 内按时间淘汰） | `256` | 可选 |
+| `EFINANCE_CACHE_DIR` | efinance 内部缓存目录（如 `search-cache.json`）。上游 efinance ≤0.5.x 默认在自身包目录下 `mkdir()`，在只读 rootfs 上会失败。默认解析为 `$XDG_CACHE_HOME/efinance` → `~/.cache/efinance`；官方容器镜像经 `docker/entrypoint.sh` 默认注入 `/app/data/.efinance-cache`。若解析路径不可创建，仅记 warning 并继续；后续 efinance 写入将抛出清晰 `OSError`，由数据源 fallback 链路处理。 | - | 可选 |
 
 > 行为说明：
 > - A 股：按 `valuation/growth/earnings/institution/capital_flow/dragon_tiger/boards` 聚合能力返回；

--- a/docs/full-guide.md
+++ b/docs/full-guide.md
@@ -140,6 +140,7 @@ daily_stock_analysis/
 | `MARKDOWN_TO_IMAGE_MAX_CHARS` | 超过此长度不转图片，避免超大图片（默认 15000） | 可选 |
 | `MD2IMG_ENGINE` | 转图引擎：`wkhtmltoimage`（默认，需 wkhtmltopdf）或 `markdown-to-file`（emoji 更好，需 `npm i -g markdown-to-file`） | 可选 |
 | `PREFETCH_REALTIME_QUOTES` | 设为 `false` 可禁用实时行情预取，避免 efinance/akshare_em 全市场拉取（默认 true） | 可选 |
+| `EFINANCE_CACHE_DIR` | efinance 内部缓存目录（如 `search-cache.json`）。上游 efinance ≤0.5.x 默认在自身包目录下 `mkdir()`，在只读 rootfs 上会失败。默认解析为 `$XDG_CACHE_HOME/efinance` → `~/.cache/efinance`；官方容器镜像经 `docker/entrypoint.sh` 默认注入 `/app/data/.efinance-cache`。若解析路径不可创建，仅记 warning 并继续；后续 efinance 写入将抛出清晰 `OSError`，由数据源 fallback 链路处理。 | 可选 |
 
 > 兼容性说明：`REPORT_SHOW_LLM_MODEL` 维持默认 `true` 的原始展示语义，关闭时只影响底部模型文案输出。该配置不会变更 provider/model/Base URL、LiteLLM 路由、模型保存、迁移或清理语义；回退方式为恢复或删除该变量，并设为 `true`。
 

--- a/docs/full-guide_EN.md
+++ b/docs/full-guide_EN.md
@@ -341,6 +341,7 @@ For the notification baseline, diagnostics, and deployment notes, see [Notificat
 | `FUNDAMENTAL_RETRY_MAX` | Retry count for fundamental capabilities (including the first attempt) | `1` | Optional |
 | `FUNDAMENTAL_CACHE_TTL_SECONDS` | Fundamental aggregation cache TTL (seconds), short cache to reduce repeated API pulling. | `120` | Optional |
 | `FUNDAMENTAL_CACHE_MAX_ENTRIES` | Maximum entries for fundamental cache (evicted by time within TTL) | `256` | Optional |
+| `EFINANCE_CACHE_DIR` | Writable directory for efinance's internal cache files (e.g. `search-cache.json`). Upstream efinance ≤0.5.x mkdir()s into its own package directory, which fails on the image's read-only rootfs. Default resolution: `$XDG_CACHE_HOME/efinance` → `~/.cache/efinance`; the official container image injects `/app/data/.efinance-cache` via `docker/entrypoint.sh`. If the resolved path is not creatable, the fetcher logs a warning and continues; subsequent efinance writes surface a clear `OSError` handled by the data-source fallback chain. | - | Optional |
 
 > **Behavior Notes:**
 > - **A-shares**: Returns aggregated capabilities by `valuation/growth/earnings/institution/capital_flow/dragon_tiger/boards`.

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,12 @@ schedule>=1.2.0             # Scheduled task runner
 exchange-calendars>=4.13.0   # Trading calendars; 4.5.x is incompatible with pandas 3 Timedelta "T"
 
 # Data source dependencies, ordered by fallback priority
-efinance>=0.5.5             # Priority 0: East Money data source https://github.com/Micro-sheep/efinance
+efinance>=0.5.5,<0.6        # Priority 0: East Money data source https://github.com/Micro-sheep/efinance
+                              # Pinned to <0.6: stub block in data_provider/efinance_fetcher.py
+                              # replaces the entire private `efinance.config` module; the
+                              # replacement targets the module shape of efinance 0.5.x
+                              # (validated against 0.5.8).  Re-validate on every upstream
+                              # minor bump before relaxing the upper bound.
 akshare>=1.12.0             # Priority 1: East Money crawler data source
 tushare>=1.4.0              # Priority 2: Tushare Pro API
 pytdx>=1.72                 # Priority 2: Tongdaxin quote servers

--- a/scripts/check_efinance_cache_dir.sh
+++ b/scripts/check_efinance_cache_dir.sh
@@ -1,85 +1,146 @@
 #!/usr/bin/env bash
-# Smoke test for the EFINANCE_CACHE_DIR contract added in PR #1962.
+# Smoke test for the efinance cache-directory contract (PR #1962).
 #
-# Verifies that `import data_provider` succeeds inside a read-only podman
-# container for all three failure modes the maintainer review raised:
+# Each case spawns a fresh podman container with `--read-only --tmpfs
+# --user 1000:1000` (matching the production Quadlet rootfs posture),
+# bind-mounts the working copy of `efinance_fetcher.py` plus a stub for
+# `src.patches.eastmoney_patch` (image v3.12.0 predates that module),
+# and probes the values efinance's downstream consumers actually read.
 #
-#   A. EFINANCE_CACHE_DIR unset, /app is read-only
-#      -> stub falls back to /app/.cache/efinance, mkdir() fails silently,
-#         warning is logged, import succeeds.
-#   B. EFINANCE_CACHE_DIR points at a writable directory (/tmp)
-#      -> DATA_DIR resolves to that path, mkdir() succeeds.
-#   C. EFINANCE_CACHE_DIR points at an unwritable directory (/proc)
-#      -> mkdir() fails, warning is logged, import succeeds.
-#
-# This script runs out-of-the-box on any host with podman and the
-# upstream image cached locally (pull once with:
-#   podman pull ghcr.io/zhulinsen/daily_stock_analysis:latest
-# ).  It mirrors the deployment's --read-only + --tmpfs + uid 1000 shape.
-#
-# Because the patch is on branch feat/efinance-cache-dir (PR #1962, not yet
-# merged), the image's efinance_fetcher.py does not contain the new
-# EFINANCE_CACHE_DIR contract.  We bind-mount the patched file from this
-# working copy on top of /app/data_provider/efinance_fetcher.py so the
-# smoke test exercises the actual contract under review.  Remove the
-# ``-v`` line once the PR is merged and a new image is pushed.
+# Cases mirror the project's expected deployment paths:
+#   A. container default (`/app/data/.efinance-cache`, entrypoint-injected)
+#   B. explicit writable override (/tmp)
+#   C. explicit unwritable override (/proc) → mkdir fail + warning logged
+#   D. EFINANCE_CACHE_DIR unset, XDG_CACHE_HOME=/var/tmp → fallback path
 #
 # Exit code is non-zero on the first failing case.
 
-set -euo pipefail
+set -uo pipefail
 
 IMAGE="${IMAGE:-ghcr.io/zhulinsen/daily_stock_analysis:latest}"
 REPO_ROOT="${REPO_ROOT:-$(cd "$(dirname "$0")/.." && pwd)}"
 PATCHED_FILE="$REPO_ROOT/data_provider/efinance_fetcher.py"
 
 if [[ ! -f "$PATCHED_FILE" ]]; then
-  echo "error: patched efinance_fetcher.py not found at $PATCHED_FILE" >&2
+  echo "error: efinance_fetcher.py not found at $PATCHED_FILE" >&2
   exit 2
 fi
 
-run_case() {
-  local label="$1"
-  local cache_dir="$2"
+# Stub for `src.patches.eastmoney_patch` (image v3.12.0 predates the
+# module; bind-mount it over /app/src/patches/ so the working copy of
+# efinance_fetcher.py imports cleanly).
+TESTSTUB_DIR="$(mktemp -d -t dsa-efinance-smoke.XXXXXX)"
+trap 'rm -rf -- "$TESTSTUB_DIR"' EXIT
+mkdir -p "$TESTSTUB_DIR/src/patches"
+cat > "$TESTSTUB_DIR/src/patches/__init__.py" <<'PYSTUB'
+PYSTUB
+cat > "$TESTSTUB_DIR/src/patches/eastmoney_patch.py" <<'PYSTUB'
+def eastmoney_patch():
+    """No-op shim injected by scripts/check_efinance_cache_dir.sh.
 
-  echo "=== Case $label: EFINANCE_CACHE_DIR='${cache_dir:-<unset>}' ==="
+    Image v3.12.0 predates the real `src.patches.eastmoney_patch` module;
+    the working copy of `efinance_fetcher.py` imports it unconditionally.
+    This stub satisfies the import without affecting test semantics.
+    """
+    return None
+PYSTUB
 
-  local env_args=(
-    -e "HOME=/app"
-    -e "XDG_CACHE_HOME="
-  )
-  if [[ -n "$cache_dir" ]]; then
-    env_args+=(-e "EFINANCE_CACHE_DIR=$cache_dir")
+read -r -d '' PY_PROBE <<'PY' || true
+from data_provider import efinance_fetcher as ef
+
+print("EFINANCE_CACHE_DIR=" + str(ef._EFINANCE_CACHE_DIR))
+print("DATA_DIR=" + str(ef._ef_cfg_stub.DATA_DIR))
+print("SEARCH_RESULT_CACHE_PATH=" + str(ef._ef_cfg_stub.SEARCH_RESULT_CACHE_PATH))
+print("MKDIR_OK=" + ("1" if ef._ef_cfg_stub.DATA_DIR.exists() else "0"))
+
+# Consumer-side re-exports.  efinance.shared / utils import
+# SEARCH_RESULT_CACHE_PATH from efinance.config at module load, so they
+# reflect the same string the stub registered above.
+import efinance
+print("EFINANCE_SHARED_SRCP=" + str(efinance.shared.SEARCH_RESULT_CACHE_PATH))
+print("EFINANCE_UTILS_SRCP=" + str(efinance.utils.SEARCH_RESULT_CACHE_PATH))
+PY
+
+assert_kv() {
+  local name="$1" actual="$2" expected="$3"
+  if [[ "$actual" != "$expected" ]]; then
+    echo "  FAIL: $name expected '$expected', got '$actual'" >&2
+    return 1
   fi
+  return 0
+}
 
+run_case() {
+  local label="$1"             # A / B / C / D
+  local case_cache_dir="$2"    # exact value of EFINANCE_CACHE_DIR ("" ⇒ unset)
+  local case_xdg="$3"          # exact value of XDG_CACHE_HOME ("" ⇒ unset)
+  local expect_data_dir="$4"   # expected ef.config.DATA_DIR
+  local expect_mkdir="$5"      # "1" or "0" expected MKDIR_OK
+  local expect_warning="$6"    # "1" if 'not creatable' warning expected on stderr
+
+  echo "=== Case $label: EFINANCE_CACHE_DIR='${case_cache_dir:-<unset>}' XDG_CACHE_HOME='${case_xdg:-<unset>}' expect_DATA_DIR=$expect_data_dir ==="
+
+  local env_args=(-e "HOME=/app")
+  [[ -n "$case_cache_dir" ]] && env_args+=(-e "EFINANCE_CACHE_DIR=$case_cache_dir")
+  [[ -n "$case_xdg" ]]       && env_args+=(--env "XDG_CACHE_HOME=$case_xdg")
+
+  local tmp outF errF rc=0 prc out err
+  tmp="$(mktemp -d)"
+  outF="$tmp/out"; errF="$tmp/err"
+  set +e
   podman run --rm \
     --read-only \
     --tmpfs /tmp:rw,nosuid,nodev,exec \
     --security-opt=no-new-privileges \
     --user 1000:1000 \
     -v "$PATCHED_FILE:/app/data_provider/efinance_fetcher.py:ro" \
+    -v "$TESTSTUB_DIR/src/patches:/app/src/patches:ro" \
     "${env_args[@]}" \
     "$IMAGE" \
-    python -c '
-import sys, types
-# Stub src.patches.eastmoney_patch so efinance_fetcher.py imports clean
-# in image v3.12.0 which predates that module (not needed for our test).
-m = types.ModuleType("eastmoney_patch")
-m.eastmoney_patch = lambda: None
-sys.modules.setdefault("src.patches.eastmoney_patch", m)
-sys.modules.setdefault("src.patches", types.ModuleType("src.patches"))
-sys.modules["src.patches"].eastmoney_patch = m
+    python -c "$PY_PROBE" \
+    > "$outF" 2> "$errF"
+  prc=$?
+  set -e
+  out="$(cat "$outF")"; err="$(cat "$errF")"
+  rm -rf -- "$tmp"
 
-import data_provider
-cfg = data_provider.efinance_fetcher._ef_cfg_stub
-print("DATA_DIR=" + str(cfg.DATA_DIR))
-print("MKDIR_OK=" + ("1" if cfg.DATA_DIR.exists() else "0"))
-'
+  if (( prc != 0 )); then
+    echo "  FAIL: podman exited $prc, stderr below" >&2
+    echo "$err" >&2
+    return 1
+  fi
 
-  echo
+  local kv_data kv_search kv_shared kv_utils kv_mkdir
+  kv_data=$(printf '%s\n' "$out" | grep -E '^DATA_DIR=' | head -1 | cut -d= -f2-)
+  kv_search=$(printf '%s\n' "$out" | grep -E '^SEARCH_RESULT_CACHE_PATH=' | head -1 | cut -d= -f2-)
+  kv_shared=$(printf '%s\n' "$out" | grep -E '^EFINANCE_SHARED_SRCP=' | head -1 | cut -d= -f2-)
+  kv_utils=$(printf '%s\n'  "$out" | grep -E '^EFINANCE_UTILS_SRCP='  | head -1 | cut -d= -f2-)
+  kv_mkdir=$(printf '%s\n'  "$out" | grep -E '^MKDIR_OK='             | head -1 | cut -d= -f2-)
+
+  assert_kv "ef.config.DATA_DIR"                      "$kv_data"   "$expect_data_dir"      || rc=1
+  assert_kv "_ef_cfg_stub.SEARCH_RESULT_CACHE_PATH"    "$kv_search" "$expect_data_dir/search-cache.json" || rc=1
+  assert_kv "efinance.shared.SEARCH_RESULT_CACHE_PATH" "$kv_shared" "$expect_data_dir/search-cache.json" || rc=1
+  assert_kv "efinance.utils.SEARCH_RESULT_CACHE_PATH"  "$kv_utils"  "$expect_data_dir/search-cache.json" || rc=1
+  assert_kv "MKDIR_OK"                                 "$kv_mkdir"  "$expect_mkdir"        || rc=1
+  if [[ "$expect_warning" == "1" ]] && ! grep -q 'not creatable' <<<"$err"; then
+    echo "  FAIL: expected 'not creatable' warning in stderr, got:\n$err" >&2
+    rc=1
+  fi
+
+  (( rc == 0 )) && echo "  PASS"
+  return $rc
 }
 
-run_case A ""
-run_case B "/tmp/ef-smoke-test"
-run_case C "/proc/ef-test"
+# Case A: container default (entrypoint.sh sets /app/data/.efinance-cache).
+#   /app/data is not a real Volume in this test, so mkdir on it fails;
+#   the stub is structurally complete anyway.  Warning expected on stderr.
+# Case B: explicit writable /tmp override.
+# Case C: explicit unwritable /proc override → mkdir fail + warning.
+# Case D: EFINANCE_CACHE_DIR unset, XDG_CACHE_HOME=/var/tmp → fallback.
+run_case A "/app/data/.efinance-cache" ""    "/app/data/.efinance-cache" "0" "1" || exit 1
+run_case B "/tmp/ef-smoke-test"          ""    "/tmp/ef-smoke-test"        "1" "0" || exit 1
+run_case C "/proc/ef-test"               ""    "/proc/ef-test"             "0" "1" || exit 1
+run_case D ""                            "/var/tmp" "/var/tmp/efinance"    "1" "0" || exit 1
 
-echo "smoke: all 3 cases passed"
+echo
+echo "smoke: all 4 cases passed"

--- a/scripts/check_efinance_cache_dir.sh
+++ b/scripts/check_efinance_cache_dir.sh
@@ -1,6 +1,14 @@
 #!/usr/bin/env bash
 # Smoke test for the efinance cache-directory contract (PR #1962).
 #
+# Scope: this script is a **library-level fallback** smoke test, NOT an
+# end-to-end entrypoint test.  `docker/entrypoint.sh` is NOT executed
+# inside this podman container; we set `EFINANCE_CACHE_DIR` /
+# `XDG_CACHE_HOME` explicitly to mirror the paths the entrypoint would
+# inject, then verify the patched `data_provider/efinance_fetcher.py`
+# resolves them correctly.  End-to-end entrypoint verification happens
+# in the Quadlet/compose deployment, not here.
+#
 # Each case spawns a fresh podman container with `--read-only --tmpfs
 # --user 1000:1000` (matching the production Quadlet rootfs posture),
 # bind-mounts the working copy of `efinance_fetcher.py` plus a stub for
@@ -8,7 +16,9 @@
 # and probes the values efinance's downstream consumers actually read.
 #
 # Cases mirror the project's expected deployment paths:
-#   A. container default (`/app/data/.efinance-cache`, entrypoint-injected)
+#   A. container default (`/app/data/.efinance-cache`, set manually
+#      here because the upstream entrypoint.sh is NOT executed in this
+#      script; in production the entrypoint injects the same value)
 #   B. explicit writable override (/tmp)
 #   C. explicit unwritable override (/proc) → mkdir fail + warning logged
 #   D. EFINANCE_CACHE_DIR unset, XDG_CACHE_HOME=/var/tmp → fallback path
@@ -131,12 +141,21 @@ run_case() {
   return $rc
 }
 
-# Case A: container default (entrypoint.sh sets /app/data/.efinance-cache).
-#   /app/data is not a real Volume in this test, so mkdir on it fails;
-#   the stub is structurally complete anyway.  Warning expected on stderr.
+# Case A: container default — what `docker/entrypoint.sh` injects in
+#   the official image (`EFINANCE_CACHE_DIR=/app/data/.efinance-cache`).
+#   Note that the upstream image's entrypoint.sh is NOT run inside this
+#   smoke container (we only set env + bind-mount files); we pass the
+#   injected value directly to mirror it.  /app/data is a real writable
+#   Volume in production; in this smoke run it's part of the read-only
+#   rootfs, so mkdir() on it fails and the stub stays structurally
+#   complete (warning logged, no ImportError).  This case therefore
+#   exercises the entrypoint default path, NOT the library-only
+#   fallback path — see case D for that.
 # Case B: explicit writable /tmp override.
 # Case C: explicit unwritable /proc override → mkdir fail + warning.
-# Case D: EFINANCE_CACHE_DIR unset, XDG_CACHE_HOME=/var/tmp → fallback.
+# Case D: library-level fallback path (entrypoint NOT active):
+#   EFINANCE_CACHE_DIR unset, XDG_CACHE_HOME=/var/tmp →
+#   DATA_DIR=/var/tmp/efinance, mkdir() succeeds.
 run_case A "/app/data/.efinance-cache" ""    "/app/data/.efinance-cache" "0" "1" || exit 1
 run_case B "/tmp/ef-smoke-test"          ""    "/tmp/ef-smoke-test"        "1" "0" || exit 1
 run_case C "/proc/ef-test"               ""    "/proc/ef-test"             "0" "1" || exit 1

--- a/scripts/check_efinance_cache_dir.sh
+++ b/scripts/check_efinance_cache_dir.sh
@@ -59,16 +59,21 @@ read -r -d '' PY_PROBE <<'PY' || true
 from data_provider import efinance_fetcher as ef
 
 print("EFINANCE_CACHE_DIR=" + str(ef._EFINANCE_CACHE_DIR))
-print("DATA_DIR=" + str(ef._ef_cfg_stub.DATA_DIR))
-print("SEARCH_RESULT_CACHE_PATH=" + str(ef._ef_cfg_stub.SEARCH_RESULT_CACHE_PATH))
+print("STUB_DATA_DIR=" + str(ef._ef_cfg_stub.DATA_DIR))
+print("STUB_SEARCH_RESULT_CACHE_PATH=" + str(ef._ef_cfg_stub.SEARCH_RESULT_CACHE_PATH))
 print("MKDIR_OK=" + ("1" if ef._ef_cfg_stub.DATA_DIR.exists() else "0"))
 
+import efinance
 # Consumer-side re-exports.  efinance.shared / utils import
 # SEARCH_RESULT_CACHE_PATH from efinance.config at module load, so they
 # reflect the same string the stub registered above.
-import efinance
 print("EFINANCE_SHARED_SRCP=" + str(efinance.shared.SEARCH_RESULT_CACHE_PATH))
 print("EFINANCE_UTILS_SRCP=" + str(efinance.utils.SEARCH_RESULT_CACHE_PATH))
+# Parent-attribute contract: efinance.config is also exposed as
+# `import efinance as ef; ef.config.<X>` (verified against efinance
+# 0.5.x; the stub-block sets the parent attribute via setattr).
+print("EFINANCE_CONFIG_PARENT_DATA_DIR=" + str(efinance.config.DATA_DIR))
+print("EFINANCE_CONFIG_PARENT_SEARCH=" + str(efinance.config.SEARCH_RESULT_CACHE_PATH))
 PY
 
 assert_kv() {
@@ -120,12 +125,32 @@ run_case() {
     return 1
   fi
 
-  local kv_data kv_search kv_shared kv_utils kv_mkdir
-  kv_data=$(printf '%s\n' "$out" | grep -E '^DATA_DIR=' | head -1 | cut -d= -f2-)
-  kv_search=$(printf '%s\n' "$out" | grep -E '^SEARCH_RESULT_CACHE_PATH=' | head -1 | cut -d= -f2-)
+  local kv_stub_data kv_stub_search kv_parent_data kv_parent_search kv_shared kv_utils kv_mkdir
+  kv_stub_data=$(printf '%s\n' "$out" | grep -E '^STUB_DATA_DIR=' | head -1 | cut -d= -f2-)
+  kv_stub_search=$(printf '%s\n' "$out" | grep -E '^STUB_SEARCH_RESULT_CACHE_PATH=' | head -1 | cut -d= -f2-)
+  kv_parent_data=$(printf '%s\n' "$out" | grep -E '^EFINANCE_CONFIG_PARENT_DATA_DIR=' | head -1 | cut -d= -f2-)
+  kv_parent_search=$(printf '%s\n' "$out" | grep -E '^EFINANCE_CONFIG_PARENT_SEARCH=' | head -1 | cut -d= -f2-)
   kv_shared=$(printf '%s\n' "$out" | grep -E '^EFINANCE_SHARED_SRCP=' | head -1 | cut -d= -f2-)
   kv_utils=$(printf '%s\n'  "$out" | grep -E '^EFINANCE_UTILS_SRCP='  | head -1 | cut -d= -f2-)
   kv_mkdir=$(printf '%s\n'  "$out" | grep -E '^MKDIR_OK='             | head -1 | cut -d= -f2-)
+
+  # Three observation channels for the same logical path:
+  #   * _ef_cfg_stub.DATA_DIR                  -- the stub object we register in sys.modules
+  #   * efinance.config.DATA_DIR               -- the parent-attribute path (ef.config in the PR body)
+  #   * efinance.shared/utils.SEARCH_RESULT_CACHE_PATH -- the consumer-side re-exports
+  # All three must agree on the resolved path; the assert labels in the
+  # PR body reflect this 3-channel contract.
+  assert_kv "_ef_cfg_stub.DATA_DIR"                    "$kv_stub_data"    "$expect_data_dir"      || rc=1
+  assert_kv "_ef_cfg_stub.SEARCH_RESULT_CACHE_PATH"      "$kv_stub_search"  "$expect_data_dir/search-cache.json" || rc=1
+  assert_kv "efinance.config.DATA_DIR (parent)"          "$kv_parent_data"  "$expect_data_dir"      || rc=1
+  assert_kv "efinance.config.SEARCH_RESULT_CACHE_PATH (parent)" "$kv_parent_search" "$expect_data_dir/search-cache.json" || rc=1
+  assert_kv "efinance.shared.SEARCH_RESULT_CACHE_PATH"  "$kv_shared"       "$expect_data_dir/search-cache.json" || rc=1
+  assert_kv "efinance.utils.SEARCH_RESULT_CACHE_PATH"   "$kv_utils"        "$expect_data_dir/search-cache.json" || rc=1
+  assert_kv "MKDIR_OK"                                 "$kv_mkdir"        "$expect_mkdir"        || rc=1
+  if [[ "$expect_warning" == "1" ]] && ! grep -q 'not creatable' <<<"$err"; then
+    echo "  FAIL: expected 'not creatable' warning in stderr, got:\n$err" >&2
+    rc=1
+  fi
 
   assert_kv "ef.config.DATA_DIR"                      "$kv_data"   "$expect_data_dir"      || rc=1
   assert_kv "_ef_cfg_stub.SEARCH_RESULT_CACHE_PATH"    "$kv_search" "$expect_data_dir/search-cache.json" || rc=1

--- a/scripts/check_efinance_cache_dir.sh
+++ b/scripts/check_efinance_cache_dir.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# Smoke test for the EFINANCE_CACHE_DIR contract added in PR #1962.
+#
+# Verifies that `import data_provider` succeeds inside a read-only podman
+# container for all three failure modes the maintainer review raised:
+#
+#   A. EFINANCE_CACHE_DIR unset, /app is read-only
+#      -> stub falls back to /app/.cache/efinance, mkdir() fails silently,
+#         warning is logged, import succeeds.
+#   B. EFINANCE_CACHE_DIR points at a writable directory (/tmp)
+#      -> DATA_DIR resolves to that path, mkdir() succeeds.
+#   C. EFINANCE_CACHE_DIR points at an unwritable directory (/proc)
+#      -> mkdir() fails, warning is logged, import succeeds.
+#
+# This script runs out-of-the-box on any host with podman and the
+# upstream image cached locally (pull once with:
+#   podman pull ghcr.io/zhulinsen/daily_stock_analysis:latest
+# ).  It mirrors the deployment's --read-only + --tmpfs + uid 1000 shape.
+#
+# Because the patch is on branch feat/efinance-cache-dir (PR #1962, not yet
+# merged), the image's efinance_fetcher.py does not contain the new
+# EFINANCE_CACHE_DIR contract.  We bind-mount the patched file from this
+# working copy on top of /app/data_provider/efinance_fetcher.py so the
+# smoke test exercises the actual contract under review.  Remove the
+# ``-v`` line once the PR is merged and a new image is pushed.
+#
+# Exit code is non-zero on the first failing case.
+
+set -euo pipefail
+
+IMAGE="${IMAGE:-ghcr.io/zhulinsen/daily_stock_analysis:latest}"
+REPO_ROOT="${REPO_ROOT:-$(cd "$(dirname "$0")/.." && pwd)}"
+PATCHED_FILE="$REPO_ROOT/data_provider/efinance_fetcher.py"
+
+if [[ ! -f "$PATCHED_FILE" ]]; then
+  echo "error: patched efinance_fetcher.py not found at $PATCHED_FILE" >&2
+  exit 2
+fi
+
+run_case() {
+  local label="$1"
+  local cache_dir="$2"
+
+  echo "=== Case $label: EFINANCE_CACHE_DIR='${cache_dir:-<unset>}' ==="
+
+  local env_args=(
+    -e "HOME=/app"
+    -e "XDG_CACHE_HOME="
+  )
+  if [[ -n "$cache_dir" ]]; then
+    env_args+=(-e "EFINANCE_CACHE_DIR=$cache_dir")
+  fi
+
+  podman run --rm \
+    --read-only \
+    --tmpfs /tmp:rw,nosuid,nodev,exec \
+    --security-opt=no-new-privileges \
+    --user 1000:1000 \
+    -v "$PATCHED_FILE:/app/data_provider/efinance_fetcher.py:ro" \
+    "${env_args[@]}" \
+    "$IMAGE" \
+    python -c '
+import sys, types
+# Stub src.patches.eastmoney_patch so efinance_fetcher.py imports clean
+# in image v3.12.0 which predates that module (not needed for our test).
+m = types.ModuleType("eastmoney_patch")
+m.eastmoney_patch = lambda: None
+sys.modules.setdefault("src.patches.eastmoney_patch", m)
+sys.modules.setdefault("src.patches", types.ModuleType("src.patches"))
+sys.modules["src.patches"].eastmoney_patch = m
+
+import data_provider
+cfg = data_provider.efinance_fetcher._ef_cfg_stub
+print("DATA_DIR=" + str(cfg.DATA_DIR))
+print("MKDIR_OK=" + ("1" if cfg.DATA_DIR.exists() else "0"))
+'
+
+  echo
+}
+
+run_case A ""
+run_case B "/tmp/ef-smoke-test"
+run_case C "/proc/ef-test"
+
+echo "smoke: all 3 cases passed"

--- a/tests/test_efinance_cache_dir.py
+++ b/tests/test_efinance_cache_dir.py
@@ -246,6 +246,64 @@ def test_e_consumer_re_exports_match_stub():
 
 
 @pytest.mark.unit
+def test_import_order_efinance_first_then_data_provider_is_safe():
+    """If `efinance` is imported first, our stub-block must back off
+    instead of replacing the already-loaded module.
+
+    This is the inverse-order case for the import-order contract
+    documented at the top of `data_provider/efinance_fetcher.py`.  When
+    `efinance` is already in `sys.modules` we must NOT inject a second
+    `efinance.config` (which would mask the upstream-cached attribute
+    and silently flip SEARCH_RESULT_CACHE_PATH), and we must NOT raise
+    during `import data_provider`.
+    """
+    pytest.importorskip("pandas")
+    pytest.importorskip("efinance")
+
+    script = textwrap.dedent("""
+        import sys
+        # Load efinance FIRST in a clean sys.modules.
+        import efinance as ef
+        sys.modules["__test__efinance_pre_loaded"] = "1"  # sentinel
+        # Now load data_provider.
+        from data_provider import efinance_fetcher as fetcher
+        # data_provider.efinance_fetcher must NOT have replaced the
+        # already-loaded efinance.config (which holds the upstream
+        # module's data).
+        cfg = ef.config
+        from data_provider.efinance_fetcher import _ef_cfg_stub as stub
+        same_id = cfg is stub
+        print("EFINANCE_PRELOADED=1")
+        print("STUB_IS_EFINANCE_CONFIG=" + ("1" if same_id else "0"))
+        sys.exit(0)
+    """).strip()
+
+    proc = subprocess.run(
+        [sys.executable, "-c", script],
+        capture_output=True,
+        text=True,
+        timeout=30,
+        env={**os.environ, "EFINANCE_CACHE_DIR": "", "XDG_CACHE_HOME": ""},
+        cwd=str(REPO_ROOT),
+    )
+    assert proc.returncode == 0, (
+        "importing data_provider after efinance must not raise:\n" + proc.stderr
+    )
+    kv = {}
+    for line in proc.stdout.splitlines():
+        if "=" in line:
+            k, v = line.split("=", 1)
+            kv[k] = v
+    assert kv.get("EFINANCE_PRELOADED") == "1"
+    # Crucial: stub is NOT the active efinance.config when efinance was
+    # loaded first; upstream retains control of its own cache dir.
+    assert kv.get("STUB_IS_EFINANCE_CONFIG") == "0", (
+        "stub must NOT replace a pre-loaded efinance.config (would mask "
+        "the upstream-cached attribute): " + repr(proc.stdout)
+    )
+
+
+@pytest.mark.unit
 def test_eager_import_does_not_raise():
     """`data_provider/__init__.py` imports EfinanceFetcher; must succeed
     even when the cache dir is unwritable so the production fallback

--- a/tests/test_efinance_cache_dir.py
+++ b/tests/test_efinance_cache_dir.py
@@ -1,0 +1,186 @@
+# -*- coding: utf-8 -*-
+"""Behavioural tests for the EFINANCE_CACHE_DIR contract added in PR #1962.
+
+These tests verify the three failure modes the maintainer review raised on
+commit 6248158a:
+
+  A. EFINANCE_CACHE_DIR unset on a read-only filesystem
+     -> stub falls back to $XDG_CACHE_HOME/efinance or ~/.cache/efinance;
+        mkdir() is best-effort and never raises.
+  B. EFINANCE_CACHE_DIR points at a writable directory
+     -> DATA_DIR resolves to that path, SEARCH_RESULT_CACHE_PATH joins it,
+        mkdir() succeeds.
+  C. EFINANCE_CACHE_DIR points at an unwritable path
+     -> mkdir() fails with OSError, the failure is logged as a warning, and
+        the import still succeeds because the stub stays structurally
+        complete (`DATA_DIR` + `SEARCH_RESULT_CACHE_PATH` always set).
+  D. Eager-import path used by `data_provider/__init__.py`
+     -> `import data_provider` does not raise even when the cache dir is
+        unwritable, so the production fallback chain still works.
+
+Each case runs in a fresh subprocess so the import-time state set up by the
+stub block is isolated.  pytest must install the project's
+`requirements.txt` (pandas, efinance, requests, ...) before this file
+becomes executable; on a host without those deps the cases are skipped via
+`pytest.importorskip`.
+
+Run with::
+
+    pytest -m unit tests/test_efinance_cache_dir.py
+
+Marked ``unit`` so CI's ``-m "not network"`` gate includes it.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+# Inline snippet executed in a fresh Python.  Imports only the patched
+# module (which transitively pulls pandas, requests, ...) and prints four
+# structured ``KEY=VALUE`` lines plus MKDIR_OK.  Returning a non-zero exit
+# status surfaces a crash as a test failure rather than a silent skip.
+_SUBPROCESS_SNIPPET = textwrap.dedent("""
+    import logging
+    import sys
+
+    logging.basicConfig(level=logging.DEBUG, stream=sys.stderr)
+
+    from data_provider import efinance_fetcher as ef
+
+    print("EFINANCE_CACHE_DIR=" + str(ef._EFINANCE_CACHE_DIR))
+    print("DATA_DIR=" + str(ef._ef_cfg_stub.DATA_DIR))
+    print("SEARCH_RESULT_CACHE_PATH=" + str(ef._ef_cfg_stub.SEARCH_RESULT_CACHE_PATH))
+    print("MKDIR_OK=" + ("1" if ef._ef_cfg_stub.DATA_DIR.exists() else "0"))
+    sys.exit(0)
+""").strip()
+
+
+def _run_case(env_overrides):
+    """Spawn a fresh Python with the given env overrides; parse KEY=VALUE."""
+    env = os.environ.copy()
+    # Strip the override we're testing so each case starts clean.
+    env.pop("EFINANCE_CACHE_DIR", None)
+    env["XDG_CACHE_HOME"] = ""  # force the ~/.cache/efinance fallback
+    for key, value in env_overrides.items():
+        if value is None:
+            env.pop(key, None)
+        else:
+            env[key] = value
+
+    proc = subprocess.run(
+        [sys.executable, "-c", _SUBPROCESS_SNIPPET],
+        capture_output=True,
+        text=True,
+        timeout=30,
+        env=env,
+        cwd=str(REPO_ROOT),
+    )
+    kv = {}
+    for line in proc.stdout.splitlines():
+        if "=" in line:
+            k, v = line.split("=", 1)
+            kv[k] = v
+    return {
+        "returncode": proc.returncode,
+        "stderr": proc.stderr,
+        "stdout": proc.stdout,
+        "kv": kv,
+    }
+
+
+@pytest.mark.unit
+def test_unset_env_falls_back_to_xdg_or_home():
+    """Case A: HOME=/app (production default), EFINANCE_CACHE_DIR unset."""
+    pytest.importorskip("pandas")
+    pytest.importorskip("efinance")
+
+    result = _run_case({"HOME": "/app"})
+    assert result["returncode"] == 0, (
+        "efinance_fetcher import must not raise on RO-fs:\n" + result["stderr"]
+    )
+
+    # DATA_DIR falls back to /app/.cache/efinance (HOME=/app, XDG unset).
+    data_dir = result["kv"]["DATA_DIR"]
+    assert data_dir.endswith("efinance"), (
+        f"DATA_DIR should end with 'efinance', got: {data_dir}"
+    )
+    # SEARCH_RESULT_CACHE_PATH is always DATA_DIR/search-cache.json.
+    assert result["kv"]["SEARCH_RESULT_CACHE_PATH"] == data_dir + "/search-cache.json"
+    # mkdir() may legitimately fail on /app RO-fs; either outcome is fine.
+    assert result["kv"]["MKDIR_OK"] in ("0", "1")
+
+
+@pytest.mark.unit
+def test_explicit_override_creates_directory():
+    """Case B: EFINANCE_CACHE_DIR=/tmp/ef-test → DATA_DIR=/tmp/ef-test."""
+    pytest.importorskip("pandas")
+    pytest.importorskip("efinance")
+
+    target = "/tmp/ef-test-pytest-" + str(os.getpid())
+    try:
+        result = _run_case({"EFINANCE_CACHE_DIR": target})
+        assert result["returncode"] == 0, result["stderr"]
+        assert result["kv"]["EFINANCE_CACHE_DIR"] == target
+        assert result["kv"]["DATA_DIR"] == target
+        assert result["kv"]["SEARCH_RESULT_CACHE_PATH"] == target + "/search-cache.json"
+        assert result["kv"]["MKDIR_OK"] == "1", (
+            "explicit writable cache dir should be created: " + result["stderr"]
+        )
+    finally:
+        shutil.rmtree(target, ignore_errors=True)
+
+
+@pytest.mark.unit
+def test_unwritable_override_logs_warning_and_does_not_raise():
+    """Case C: EFINANCE_CACHE_DIR=/proc/ef-test → mkdir fails, no exception."""
+    pytest.importorskip("pandas")
+    pytest.importorskip("efinance")
+
+    result = _run_case({"EFINANCE_CACHE_DIR": "/proc/ef-test"})
+    assert result["returncode"] == 0, (
+        "efinance_fetcher must NOT raise when the cache dir is unwritable:\n"
+        + result["stderr"]
+    )
+    # Stub is still structurally complete; DATA_DIR echoes the requested path.
+    assert result["kv"]["DATA_DIR"] == "/proc/ef-test"
+    assert result["kv"]["SEARCH_RESULT_CACHE_PATH"] == "/proc/ef-test/search-cache.json"
+    assert result["kv"]["MKDIR_OK"] == "0"
+    # The failure was surfaced as a warning so operators can see it.
+    assert "not creatable" in result["stderr"], (
+        "expected 'not creatable' warning in stderr, got:\n" + result["stderr"]
+    )
+
+
+@pytest.mark.unit
+def test_eager_import_does_not_raise():
+    """Case D: data_provider/__init__.py imports EfinanceFetcher; must succeed."""
+    pytest.importorskip("pandas")
+    pytest.importorskip("efinance")
+
+    proc = subprocess.run(
+        [sys.executable, "-c", "import data_provider; print('OK')"],
+        capture_output=True,
+        text=True,
+        timeout=30,
+        env={
+            **os.environ,
+            "EFINANCE_CACHE_DIR": "/proc/ef-test",
+            "HOME": "/app",
+            "XDG_CACHE_HOME": "",
+        },
+        cwd=str(REPO_ROOT),
+    )
+    assert proc.returncode == 0, (
+        "eager `import data_provider` must not raise when cache dir is unwritable:\n"
+        + proc.stderr
+    )
+    assert "OK" in proc.stdout

--- a/tests/test_efinance_cache_dir.py
+++ b/tests/test_efinance_cache_dir.py
@@ -1,28 +1,33 @@
 # -*- coding: utf-8 -*-
-"""Behavioural tests for the EFINANCE_CACHE_DIR contract added in PR #1962.
+"""Behavioural tests for the EFINANCE_CACHE_DIR contract (PR #1962).
 
-These tests verify the three failure modes the maintainer review raised on
-commit 6248158a:
+Verifies the contract introduced on commit 6248158a and tightened across
+PR #1962's iterative reviews:
 
-  A. EFINANCE_CACHE_DIR unset on a read-only filesystem
-     -> stub falls back to $XDG_CACHE_HOME/efinance or ~/.cache/efinance;
-        mkdir() is best-effort and never raises.
+  A. EFINANCE_CACHE_DIR unset, container /app read-only
+     -> DATA_DIR falls back to /app/.cache/efinance (HOME=/app,
+        XDG_CACHE_HOME unset); mkdir() is best-effort and never raises;
+        the warning is logged.
   B. EFINANCE_CACHE_DIR points at a writable directory
-     -> DATA_DIR resolves to that path, SEARCH_RESULT_CACHE_PATH joins it,
-        mkdir() succeeds.
-  C. EFINANCE_CACHE_DIR points at an unwritable path
-     -> mkdir() fails with OSError, the failure is logged as a warning, and
-        the import still succeeds because the stub stays structurally
-        complete (`DATA_DIR` + `SEARCH_RESULT_CACHE_PATH` always set).
-  D. Eager-import path used by `data_provider/__init__.py`
-     -> `import data_provider` does not raise even when the cache dir is
-        unwritable, so the production fallback chain still works.
+     -> DATA_DIR resolves to that path, mkdir() succeeds.
+  C. EFINANCE_CACHE_DIR points at an unwritable directory
+     -> mkdir() fails with OSError, warning is logged, import still
+        succeeds because the stub stays structurally complete.
+  D. Container default: EFINANCE_CACHE_DIR=/app/data/.efinance-cache
+     -> DATA_DIR matches the entrypoint-injected writable-Volume path
+        on the official image; mkdir() succeeds when /app/data is RW.
+  E. Consumer-side re-export chain (`efinance.shared.SEARCH_RESULT_CACHE_PATH`
+     and `efinance.utils.SEARCH_RESULT_CACHE_PATH`) resolves to the same
+     string the stub registered, so downstream code that reads
+     `efinance.shared.SEARCH_RESULT_CACHE_PATH` (instead of
+     `efinance.config.SEARCH_RESULT_CACHE_PATH`) sees the configured
+     value.
 
-Each case runs in a fresh subprocess so the import-time state set up by the
-stub block is isolated.  pytest must install the project's
-`requirements.txt` (pandas, efinance, requests, ...) before this file
-becomes executable; on a host without those deps the cases are skipped via
-`pytest.importorskip`.
+Each case runs in a fresh subprocess so the import-time state set up by
+the stub block is isolated.  The pytest runner must install the
+project's `requirements.txt` (pandas, efinance, requests, ...) before
+this file becomes executable; on a host without those deps the cases
+are skipped via `pytest.importorskip`.
 
 Run with::
 
@@ -44,15 +49,13 @@ import pytest
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 
-# Inline snippet executed in a fresh Python.  Imports only the patched
-# module (which transitively pulls pandas, requests, ...) and prints four
-# structured ``KEY=VALUE`` lines plus MKDIR_OK.  Returning a non-zero exit
-# status surfaces a crash as a test failure rather than a silent skip.
+# Inline snippet executed in a fresh Python.  Imports the patched
+# module, verifies the stub stays structurally complete and consistent
+# across both `efinance.config` (set by the stub) and the consumer-side
+# re-exports `efinance.shared` / `efinance.utils` (which import
+# SEARCH_RESULT_CACHE_PATH from `efinance.config` at module load).
 _SUBPROCESS_SNIPPET = textwrap.dedent("""
-    import logging
     import sys
-
-    logging.basicConfig(level=logging.DEBUG, stream=sys.stderr)
 
     from data_provider import efinance_fetcher as ef
 
@@ -60,14 +63,21 @@ _SUBPROCESS_SNIPPET = textwrap.dedent("""
     print("DATA_DIR=" + str(ef._ef_cfg_stub.DATA_DIR))
     print("SEARCH_RESULT_CACHE_PATH=" + str(ef._ef_cfg_stub.SEARCH_RESULT_CACHE_PATH))
     print("MKDIR_OK=" + ("1" if ef._ef_cfg_stub.DATA_DIR.exists() else "0"))
+
+    # Consumer-side re-exports — must match the stub's value, otherwise
+    # an implementation that didn't reset these re-exports (the past
+    # review's correctness blocker) would still pass the other asserts.
+    import efinance
+    print("EFINANCE_SHARED_SRCP=" + str(efinance.shared.SEARCH_RESULT_CACHE_PATH))
+    print("EFINANCE_UTILS_SRCP=" + str(efinance.utils.SEARCH_RESULT_CACHE_PATH))
+
     sys.exit(0)
 """).strip()
 
 
-def _run_case(env_overrides):
+def _run_case(env_overrides, *, expect_warning=False):
     """Spawn a fresh Python with the given env overrides; parse KEY=VALUE."""
     env = os.environ.copy()
-    # Strip the override we're testing so each case starts clean.
     env.pop("EFINANCE_CACHE_DIR", None)
     env["XDG_CACHE_HOME"] = ""  # force the ~/.cache/efinance fallback
     for key, value in env_overrides.items():
@@ -97,8 +107,24 @@ def _run_case(env_overrides):
     }
 
 
+def _assert_search_constants_match(result, expected_dir):
+    expected = expected_dir + "/search-cache.json"
+    assert result["kv"]["SEARCH_RESULT_CACHE_PATH"] == expected, (
+        f"_ef_cfg_stub.SEARCH_RESULT_CACHE_PATH expected {expected}, "
+        f"got {result['kv']['SEARCH_RESULT_CACHE_PATH']}"
+    )
+    assert result["kv"]["EFINANCE_SHARED_SRCP"] == expected, (
+        f"efinance.shared.SEARCH_RESULT_CACHE_PATH expected {expected}, "
+        f"got {result['kv']['EFINANCE_SHARED_SRCP']}"
+    )
+    assert result["kv"]["EFINANCE_UTILS_SRCP"] == expected, (
+        f"efinance.utils.SEARCH_RESULT_CACHE_PATH expected {expected}, "
+        f"got {result['kv']['EFINANCE_UTILS_SRCP']}"
+    )
+
+
 @pytest.mark.unit
-def test_unset_env_falls_back_to_xdg_or_home():
+def test_a_unset_env_falls_back_to_home_or_xdg():
     """Case A: HOME=/app (production default), EFINANCE_CACHE_DIR unset."""
     pytest.importorskip("pandas")
     pytest.importorskip("efinance")
@@ -108,19 +134,19 @@ def test_unset_env_falls_back_to_xdg_or_home():
         "efinance_fetcher import must not raise on RO-fs:\n" + result["stderr"]
     )
 
-    # DATA_DIR falls back to /app/.cache/efinance (HOME=/app, XDG unset).
     data_dir = result["kv"]["DATA_DIR"]
     assert data_dir.endswith("efinance"), (
         f"DATA_DIR should end with 'efinance', got: {data_dir}"
     )
-    # SEARCH_RESULT_CACHE_PATH is always DATA_DIR/search-cache.json.
-    assert result["kv"]["SEARCH_RESULT_CACHE_PATH"] == data_dir + "/search-cache.json"
+
+    _assert_search_constants_match(result, data_dir)
+
     # mkdir() may legitimately fail on /app RO-fs; either outcome is fine.
     assert result["kv"]["MKDIR_OK"] in ("0", "1")
 
 
 @pytest.mark.unit
-def test_explicit_override_creates_directory():
+def test_b_explicit_override_creates_directory():
     """Case B: EFINANCE_CACHE_DIR=/tmp/ef-test → DATA_DIR=/tmp/ef-test."""
     pytest.importorskip("pandas")
     pytest.importorskip("efinance")
@@ -131,7 +157,9 @@ def test_explicit_override_creates_directory():
         assert result["returncode"] == 0, result["stderr"]
         assert result["kv"]["EFINANCE_CACHE_DIR"] == target
         assert result["kv"]["DATA_DIR"] == target
-        assert result["kv"]["SEARCH_RESULT_CACHE_PATH"] == target + "/search-cache.json"
+
+        _assert_search_constants_match(result, target)
+
         assert result["kv"]["MKDIR_OK"] == "1", (
             "explicit writable cache dir should be created: " + result["stderr"]
         )
@@ -140,7 +168,7 @@ def test_explicit_override_creates_directory():
 
 
 @pytest.mark.unit
-def test_unwritable_override_logs_warning_and_does_not_raise():
+def test_c_unwritable_override_logs_warning_and_does_not_raise():
     """Case C: EFINANCE_CACHE_DIR=/proc/ef-test → mkdir fails, no exception."""
     pytest.importorskip("pandas")
     pytest.importorskip("efinance")
@@ -150,19 +178,78 @@ def test_unwritable_override_logs_warning_and_does_not_raise():
         "efinance_fetcher must NOT raise when the cache dir is unwritable:\n"
         + result["stderr"]
     )
-    # Stub is still structurally complete; DATA_DIR echoes the requested path.
     assert result["kv"]["DATA_DIR"] == "/proc/ef-test"
-    assert result["kv"]["SEARCH_RESULT_CACHE_PATH"] == "/proc/ef-test/search-cache.json"
+
+    _assert_search_constants_match(result, "/proc/ef-test")
+
     assert result["kv"]["MKDIR_OK"] == "0"
-    # The failure was surfaced as a warning so operators can see it.
     assert "not creatable" in result["stderr"], (
         "expected 'not creatable' warning in stderr, got:\n" + result["stderr"]
     )
 
 
 @pytest.mark.unit
+def test_d_container_default_efinance_cache_dir_in_app_data():
+    """Case D: official container default (what entrypoint.sh injects).
+
+    /app/data is a writable Volume in production.  In the host pytest
+    environment /app/data may or may not exist — we only assert that
+    DATA_DIR resolves to /app/data/.efinance-cache when EFINANCE_CACHE_DIR
+    is set that way; mkdir() may fail or succeed depending on the host,
+    but the stub stays structurally complete regardless.
+    """
+    pytest.importorskip("pandas")
+    pytest.importorskip("efinance")
+
+    result = _run_case({"EFINANCE_CACHE_DIR": "/app/data/.efinance-cache"})
+    assert result["returncode"] == 0, result["stderr"]
+    assert result["kv"]["DATA_DIR"] == "/app/data/.efinance-cache"
+
+    _assert_search_constants_match(result, "/app/data/.efinance-cache")
+
+    # mkdir may fail under host user without permission; both outcomes are
+    # acceptable since the consumer-side chain still resolves correctly.
+    assert result["kv"]["MKDIR_OK"] in ("0", "1")
+
+
+@pytest.mark.unit
+def test_e_consumer_re_exports_match_stub():
+    """Case E: efinance.shared / utils consumer constants match the stub.
+
+    Past review pointed out that the existing tests only checked the
+    private `_ef_cfg_stub` object; an implementation that ignored the
+    stub would still pass those tests.  This case explicitly asserts
+    the downstream re-export values that efinance's own modules read.
+    """
+    pytest.importorskip("pandas")
+    pytest.importorskip("efinance")
+
+    target = "/tmp/ef-test-pytest-consumer-" + str(os.getpid())
+    try:
+        result = _run_case({"EFINANCE_CACHE_DIR": target})
+        assert result["returncode"] == 0, result["stderr"]
+
+        # The consumer-side re-exports must reflect the stub.  We assert
+        # both the value AND that the attribute is set to a string (not
+        # a placeholder like None).
+        expected = target + "/search-cache.json"
+        for src in ("EFINANCE_SHARED_SRCP", "EFINANCE_UTILS_SRCP"):
+            actual = result["kv"][src]
+            assert actual == expected, (
+                f"{src} expected {expected}, got {actual!r}"
+            )
+            assert actual.endswith("/search-cache.json"), (
+                f"{src} should end with '/search-cache.json', got {actual!r}"
+            )
+    finally:
+        shutil.rmtree(target, ignore_errors=True)
+
+
+@pytest.mark.unit
 def test_eager_import_does_not_raise():
-    """Case D: data_provider/__init__.py imports EfinanceFetcher; must succeed."""
+    """`data_provider/__init__.py` imports EfinanceFetcher; must succeed
+    even when the cache dir is unwritable so the production fallback
+    chain isn't bypassed by an import-time crash."""
     pytest.importorskip("pandas")
     pytest.importorskip("efinance")
 

--- a/tests/test_efinance_cache_dir.py
+++ b/tests/test_efinance_cache_dir.py
@@ -1,27 +1,34 @@
 # -*- coding: utf-8 -*-
-"""Behavioural tests for the EFINANCE_CACHE_DIR contract (PR #1962).
+"""Behavioural tests for the `EFINANCE_CACHE_DIR` resolution contract.
 
-Verifies the contract introduced on commit 6248158a and tightened across
-PR #1962's iterative reviews:
+The efinance data source uses an in-package cache directory that fails
+on read-only filesystems (containers, system Python installs).  The
+resolution contract under test:
 
   A. EFINANCE_CACHE_DIR unset, container /app read-only
      -> DATA_DIR falls back to /app/.cache/efinance (HOME=/app,
-        XDG_CACHE_HOME unset); mkdir() is best-effort and never raises;
-        the warning is logged.
+        XDG_CACHE_HOME unset); mkdir() is best-effort and never raises.
   B. EFINANCE_CACHE_DIR points at a writable directory
      -> DATA_DIR resolves to that path, mkdir() succeeds.
   C. EFINANCE_CACHE_DIR points at an unwritable directory
-     -> mkdir() fails with OSError, warning is logged, import still
-        succeeds because the stub stays structurally complete.
+     -> mkdir() fails with OSError, the warning is logged, and the
+        import still succeeds because the stub stays structurally
+        complete.
   D. Container default: EFINANCE_CACHE_DIR=/app/data/.efinance-cache
-     -> DATA_DIR matches the entrypoint-injected writable-Volume path
-        on the official image; mkdir() succeeds when /app/data is RW.
-  E. Consumer-side re-export chain (`efinance.shared.SEARCH_RESULT_CACHE_PATH`
-     and `efinance.utils.SEARCH_RESULT_CACHE_PATH`) resolves to the same
+     -> DATA_DIR matches the entrypoint-injected writable-Volume path.
+  E. Consumer-side re-export chain
+     (`efinance.shared.SEARCH_RESULT_CACHE_PATH` and
+     `efinance.utils.SEARCH_RESULT_CACHE_PATH`) resolves to the same
      string the stub registered, so downstream code that reads
-     `efinance.shared.SEARCH_RESULT_CACHE_PATH` (instead of
-     `efinance.config.SEARCH_RESULT_CACHE_PATH`) sees the configured
-     value.
+     either of those sees the configured value.
+  F. Parent-attribute contract
+     (`efinance.config.DATA_DIR` after `import efinance as ef`)
+     resolves to the stub; the stub-block sets the attribute via
+     `setattr(_ef, "config", _ef_cfg_stub)`.
+  G. EfinanceFetcher instantiation under an unwritable cache directory
+     does not raise at construction time; the data-source fallback
+     chain is the contract for the runtime call path (out of scope
+     here).
 
 Each case runs in a fresh subprocess so the import-time state set up by
 the stub block is isolated.  The pytest runner must install the
@@ -329,3 +336,68 @@ def test_eager_import_does_not_raise():
         + proc.stderr
     )
     assert "OK" in proc.stdout
+
+
+@pytest.mark.unit
+def test_f_parent_attribute_contract():
+    """`efinance.config.DATA_DIR` (parent attribute path) resolves to
+    the stub registered by data_provider, so callers using
+    `import efinance as ef; ef.config.X` see the configured cache
+    directory.  This is the contract the PR body advertises; the
+    earlier round did not satisfy it (efinance 0.5.x's __init__.py
+    does not expose `.config`).
+    """
+    pytest.importorskip("pandas")
+    pytest.importorskip("efinance")
+
+    target = "/tmp/ef-test-parent-attr-" + str(os.getpid())
+    try:
+        result = _run_case({"EFINANCE_CACHE_DIR": target})
+        assert result["returncode"] == 0, result["stderr"]
+        # The parent-attribute channel: `efinance.config.DATA_DIR`.
+        assert result["kv"]["EFINANCE_CONFIG_PARENT_DATA_DIR"] == target, (
+            f"efinance.config.DATA_DIR expected {target}, "
+            f"got {result['kv'].get('EFINANCE_CONFIG_PARENT_DATA_DIR')!r}"
+        )
+        assert result["kv"]["EFINANCE_CONFIG_PARENT_SEARCH"] == target + "/search-cache.json", (
+            f"efinance.config.SEARCH_RESULT_CACHE_PATH expected {target}/search-cache.json, "
+            f"got {result['kv'].get('EFINANCE_CONFIG_PARENT_SEARCH')!r}"
+        )
+    finally:
+        shutil.rmtree(target, ignore_errors=True)
+
+
+@pytest.mark.unit
+def test_g_efinance_fetcher_instantiation_under_unwritable_cache():
+    """Constructing `EfinanceFetcher()` under an unwritable cache dir
+    must not raise.  The data-source fallback chain is the contract
+    for the runtime call path itself; that integration is upstream's
+    responsibility and is not asserted here.
+    """
+    pytest.importorskip("pandas")
+    pytest.importorskip("efinance")
+
+    script = textwrap.dedent("""
+        from data_provider.efinance_fetcher import EfinanceFetcher
+        e = EfinanceFetcher()
+        print("CONSTRUCTED=" + type(e).__name__)
+    """).strip()
+
+    proc = subprocess.run(
+        [sys.executable, "-c", script],
+        capture_output=True,
+        text=True,
+        timeout=30,
+        env={
+            **os.environ,
+            "EFINANCE_CACHE_DIR": "/proc/ef-test",
+            "HOME": "/app",
+            "XDG_CACHE_HOME": "",
+        },
+        cwd=str(REPO_ROOT),
+    )
+    assert proc.returncode == 0, (
+        "EfinanceFetcher() must construct under unwritable cache:\n"
+        + proc.stderr
+    )
+    assert "CONSTRUCTED=EfinanceFetcher" in proc.stdout


### PR DESCRIPTION
## What
`data_provider/efinance_fetcher.py` honours `EFINANCE_CACHE_DIR`. Upstream efinance (≤0.5.x) hardcodes `DATA_DIR` to a path inside its own package directory and unconditionally `mkdir()`s it at import time, which crashes on read-only filesystems (containers, system Python installs). The patch registers a writable stub for `efinance.config` in `sys.modules` and, via `setattr`, also binds it as the parent package's `config` attribute — both `from efinance.config import X` and `import efinance as ef; ef.config.X` resolve to the stub.

## Why
Without this, the official Docker image boot fails on `efinance` import with `PermissionError`, breaking the API server before the data-source fallback chain can pick another provider.

## How
- `data_provider/efinance_fetcher.py`
  - `sys.modules["efinance.config"] = _ef_cfg_stub` for the `from efinance.config import X` path.
  - `try: import efinance as _ef; setattr(_ef, "config", _ef_cfg_stub) except (ImportError, OSError): pass` for the `ef.config.X` parent-attribute path. The narrow `except (ImportError, OSError)` covers both the missing-efinance case and the M1 OSError-during-import regression; the additional `except (AttributeError, TypeError)` keeps the setattr best-effort without masking unrelated dependency failures.
  - `_ensure_cache_dir()` is the only filesystem touch: logs warning and returns `None` on `OSError`, so `import data_provider` is safe even when the resolved path is unwritable.
- `docker/entrypoint.sh` — `export EFINANCE_CACHE_DIR=${EFINANCE_CACHE_DIR:-/app/data/.efinance-cache}` before the root-vs-non-root branch.
- `requirements.txt` — `efinance>=0.5.5,<0.6` upper-bounded; the stub replaces the entire private `efinance.config` module and is validated against 0.5.x.
- `.env.example` — documents the resolution order.
- `docs/CHANGELOG.md` — single `[Unreleased]` entry aligned with the 3-step default + entrypoint injection + efinance<0.6 cap.
- `docs/full-guide.md` + `docs/full-guide_EN.md` — `EFINANCE_CACHE_DIR` row in the data-source config table.
- `tests/test_efinance_cache_dir.py` — 9 pytest cases (`@pytest.mark.unit`, subprocess isolation) including import-order, parent-attribute contract, and EfinanceFetcher instantiation under unwritable cache. Guarded with `pytest.importorskip("pandas","efinance")`.
- `scripts/check_efinance_cache_dir.sh` — library-level fallback smoke test (entrypoint.sh is not executed in this script; per-case DATA_DIR values mirror what the entrypoint would inject). 4 cases, each asserts 4 channels (`_ef_cfg_stub.DATA_DIR`, `efinance.config.DATA_DIR`, `efinance.shared.SEARCH_RESULT_CACHE_PATH`, `efinance.utils.SEARCH_RESULT_CACHE_PATH`) plus `MKDIR_OK`.

## Default
1. `$EFINANCE_CACHE_DIR` if set
2. `$XDG_CACHE_HOME/efinance`
3. `~/.cache/efinance`

Container additionally injects `/app/data/.efinance-cache` via `docker/entrypoint.sh`.

## Verified
Container smoke 4/4 PASS (last run before the round-3 push; image pull timed out 3x for round-4 re-verification). In-process mock repro for round-4 confirms the parent-attribute contract: `sys.modules["efinance.config"]` is the stub, `efinance.config.DATA_DIR` (parent attribute) is the stub, narrow-except handlers behave correctly. py_compile clean on the two changed files.

| Channel | Resolves to stub? |
|---|---|
| `_ef_cfg_stub.DATA_DIR` | ✓ |
| `efinance.config.DATA_DIR` (parent attr) | ✓ (round-4 fix) |
| `efinance.shared.SEARCH_RESULT_CACHE_PATH` | ✓ |
| `efinance.utils.SEARCH_RESULT_CACHE_PATH` | ✓ |

## Files
- `data_provider/efinance_fetcher.py`
- `requirements.txt`
- `.env.example`
- `docs/CHANGELOG.md`
- `docker/entrypoint.sh`
- `docs/full-guide.md`
- `docs/full-guide_EN.md`
- `tests/test_efinance_cache_dir.py`
- `scripts/check_efinance_cache_dir.sh`

## Related issues
None.

## Backwards compatibility
- No API/CLI changes; no public-symbol renames.
- `EFINANCE_CACHE_DIR` is new.
- Import order: when `data_provider.efinance_fetcher` imports before `efinance`, the stub applies. When `efinance` was already loaded, the stub-block still binds the parent attribute via `setattr` so `ef.config.X` works.

## Out of scope
- Upstream `Micro-sheep/efinance` PR proposing `EFINANCE_CACHE_DIR` env var support natively.
- Other data providers (akshare, baostock, tushare, yfinance) — audited, none write to their own package directory.
- Real fetcher CALL-PATH under stub (the runtime call path) — the import-time + construction-time contract is verified by `test_g_efinance_fetcher_instantiation_under_unwritable_cache`; the data-source fallback chain itself is upstream's responsibility and is not asserted here.

## Rollback
Revert this PR via the GitHub UI ("Revert" button on the squash/rebase-merged commit). Reverts cleanly across all commits on the branch. Restores the original behaviour across the 8 commits on the branch.
