### PR TITLE
fix: tolerate reasoning wrappers around analysis JSON

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 <!-- 新条目格式：- [类型] 描述（类型取值：新功能/改进/修复/文档/测试/chore）-->
 <!-- 每条独立一行追加到本段末尾，无需分类标题，合并时冲突最小 -->
 - [新功能] 飞书推送新增文件上传能力：`FeishuSender.send_feishu_file(file_path)` 通过 App Bot SDK (`im.v1.file.create`) 上传文件并发送文件消息；Webhook 模式回退为发送文件内容文本；新增 `FEISHU_SEND_AS_FILE=true` 配置开关，开启后飞书以文件形式发送报告而非文字消息。
+- [修复] 个股分析 JSON 提取器会忽略模型输出中的 `<think>` / reasoning 包装，避免单一有效 JSON 被误判为 `ambiguous_json` 并触发补全重试循环。
 
 ## [3.25.0] - 2026-07-03
 

--- a/src/analyzer.py
+++ b/src/analyzer.py
@@ -4334,7 +4334,7 @@ class GeminiAnalyzer:
     ) -> str:
         """Build retry prompt using the previous response as the complement baseline."""
         complement = self._build_integrity_complement_prompt(missing_fields, report_language=report_language)
-        previous_output = previous_response.strip()
+        previous_output = self._strip_analysis_reasoning_blocks(previous_response).strip()
         if normalize_report_language(report_language) in ("en", "ko"):
             prefix = "### The previous output is below. Complete the missing fields based on that output and return the full JSON again. Do not omit existing fields:"
         else:
@@ -4353,6 +4353,40 @@ class GeminiAnalyzer:
     def _extract_analysis_json_object(self, response_text: str) -> Tuple[str, Dict[str, Any]]:
         """Extract the single allowed JSON object from an LLM response."""
 
+        text = response_text or ""
+        try:
+            return self._extract_analysis_json_object_strict(text)
+        except (ValueError, json.JSONDecodeError) as exc:
+            if (
+                not isinstance(exc, json.JSONDecodeError)
+                and str(exc) != "ambiguous_json"
+            ):
+                raise
+            text_without_reasoning = self._strip_analysis_reasoning_blocks(text)
+            if text_without_reasoning == text:
+                raise
+            try:
+                return self._extract_analysis_json_object_strict(text_without_reasoning)
+            except (ValueError, json.JSONDecodeError):
+                raise exc
+
+    @staticmethod
+    def _strip_analysis_reasoning_blocks(response_text: str) -> str:
+        """Remove model reasoning wrappers before selecting the analysis JSON."""
+        text = response_text or ""
+        tag_pattern = re.compile(
+            r"<(?P<tag>think|thinking|reasoning)>\s*.*?\s*</(?P=tag)>",
+            flags=re.IGNORECASE | re.DOTALL,
+        )
+        text = tag_pattern.sub("", text)
+        fence_pattern = re.compile(
+            r"```[ \t]*(?:think|thinking|reasoning|cot|chain[-_ ]?of[-_ ]?thought)[^\n`]*\n?.*?```",
+            flags=re.IGNORECASE | re.DOTALL,
+        )
+        return fence_pattern.sub("", text)
+
+    def _extract_analysis_json_object_strict(self, response_text: str) -> Tuple[str, Dict[str, Any]]:
+        """Extract one JSON object without accepting non-JSON prose."""
         text = response_text or ""
         stripped = text.strip()
         if not stripped:

--- a/src/analyzer.py
+++ b/src/analyzer.py
@@ -4380,7 +4380,7 @@ class GeminiAnalyzer:
         )
         text = tag_pattern.sub("", text)
         fence_pattern = re.compile(
-            r"```[ \t]*(?:think|thinking|reasoning|cot|chain[-_ ]?of[-_ ]?thought)[^\n`]*\n?.*?```",
+            r"```[ \t]*(?:think|thinking|reasoning|cot|chain[-_ ]?of[-_ ]?thought)[ \t]*\r?\n.*?```",
             flags=re.IGNORECASE | re.DOTALL,
         )
         return fence_pattern.sub("", text)

--- a/tests/test_report_integrity.py
+++ b/tests/test_report_integrity.py
@@ -526,3 +526,18 @@ class TestIntegrityRetryPrompt(unittest.TestCase):
         self.assertIn("原始提示", prompt)
         self.assertIn('{"analysis_summary": "已有内容"}', prompt)
         self.assertIn("dashboard.core_conclusion.one_sentence", prompt)
+
+    def test_retry_prompt_strips_reasoning_blocks_from_previous_response(self) -> None:
+        """Retry prompt should not replay model reasoning wrappers."""
+        with patch.object(GeminiAnalyzer, "_init_litellm", return_value=None):
+            analyzer = GeminiAnalyzer()
+        prompt = analyzer._build_integrity_retry_prompt(
+            "base prompt",
+            '<think>private draft</think>\n{"analysis_summary": "kept"}',
+            ["dashboard.core_conclusion.one_sentence"],
+        )
+
+        self.assertNotIn("<think>", prompt)
+        self.assertNotIn("private draft", prompt)
+        self.assertIn('{"analysis_summary": "kept"}', prompt)
+        self.assertIn("dashboard.core_conclusion.one_sentence", prompt)

--- a/tests/test_report_schema.py
+++ b/tests/test_report_schema.py
@@ -327,6 +327,31 @@ private reasoning that is not part of the response contract
 }
 ```""")
 
+    def test_validate_json_response_rejects_unknown_reasoning_fence_labels(self) -> None:
+        analyzer = GeminiAnalyzer.__new__(GeminiAnalyzer)
+        analyzer._config_override = SimpleNamespace(generation_backend="litellm")
+
+        for fence_label in ("cotton", "thinking-notes"):
+            with self.subTest(fence_label=fence_label):
+                with self.assertRaises(Exception) as context:
+                    analyzer._validate_json_response(f"""```{fence_label}
+content outside the supported reasoning wrapper contract
+```
+```json
+{{
+  "stock_name": "TestCo",
+  "sentiment_score": 66,
+  "trend_prediction": "bullish",
+  "operation_advice": "hold",
+  "analysis_summary": "final JSON"
+}}
+```""")
+
+                self.assertEqual(
+                    getattr(context.exception, "details", {}).get("reason"),
+                    "ambiguous_json",
+                )
+
     def test_validate_json_response_rejects_ambiguous_json_before_repair(self) -> None:
         analyzer = GeminiAnalyzer.__new__(GeminiAnalyzer)
         analyzer._config_override = SimpleNamespace(generation_backend="litellm")

--- a/tests/test_report_schema.py
+++ b/tests/test_report_schema.py
@@ -243,6 +243,27 @@ class TestAnalyzerSchemaFallback(unittest.TestCase):
         self.assertEqual(result.name, "贵州茅台")
         self.assertEqual(result.sentiment_score, 67)
 
+    def test_parse_response_accepts_think_block_before_json_fence(self) -> None:
+        analyzer = GeminiAnalyzer()
+        response = """<think>
+draft the report privately
+</think>
+```json
+{
+  "stock_name": "TestCo",
+  "sentiment_score": 71,
+  "trend_prediction": "bullish",
+  "operation_advice": "hold",
+  "analysis_summary": "single valid JSON after reasoning"
+}
+```"""
+
+        result = analyzer._parse_response(response, "AAPL", "Apple")
+
+        self.assertTrue(result.success)
+        self.assertEqual(result.sentiment_score, 71)
+        self.assertEqual(result.analysis_summary, "single valid JSON after reasoning")
+
     def test_parse_response_repairs_nested_single_json_candidate(self) -> None:
         analyzer = GeminiAnalyzer()
         response = """```json
@@ -289,6 +310,23 @@ class TestAnalyzerSchemaFallback(unittest.TestCase):
 }
 ```""")
 
+    def test_validate_json_response_accepts_reasoning_fence_plus_json_fence(self) -> None:
+        analyzer = GeminiAnalyzer.__new__(GeminiAnalyzer)
+        analyzer._config_override = SimpleNamespace(generation_backend="litellm")
+
+        analyzer._validate_json_response("""```thinking
+private reasoning that is not part of the response contract
+```
+```json
+{
+  "stock_name": "TestCo",
+  "sentiment_score": 66,
+  "trend_prediction": "bullish",
+  "operation_advice": "hold",
+  "analysis_summary": "final JSON"
+}
+```""")
+
     def test_validate_json_response_rejects_ambiguous_json_before_repair(self) -> None:
         analyzer = GeminiAnalyzer.__new__(GeminiAnalyzer)
         analyzer._config_override = SimpleNamespace(generation_backend="litellm")
@@ -306,6 +344,19 @@ class TestAnalyzerSchemaFallback(unittest.TestCase):
             analyzer._validate_json_response("""Here is the JSON:
 ```
 {"sentiment_score": 70, "trend_prediction": "看多"}
+```""")
+
+        self.assertEqual(getattr(context.exception, "details", {}).get("reason"), "ambiguous_json")
+
+    def test_validate_json_response_still_rejects_prose_after_stripping_reasoning(self) -> None:
+        analyzer = GeminiAnalyzer.__new__(GeminiAnalyzer)
+        analyzer._config_override = SimpleNamespace(generation_backend="litellm")
+
+        with self.assertRaises(Exception) as context:
+            analyzer._validate_json_response("""<think>private draft</think>
+Here is the JSON:
+```json
+{"sentiment_score": 70, "trend_prediction": "bullish"}
 ```""")
 
         self.assertEqual(getattr(context.exception, "details", {}).get("reason"), "ambiguous_json")


### PR DESCRIPTION
## PR Type

- [x] fix
- [ ] feat
- [ ] refactor
- [ ] docs
- [ ] chore
- [x] test

## Background And Problem

Fixes #1946.

Some LLM responses can include private reasoning wrappers such as `<think>...</think>` or reasoning markdown fences before the single final stock-analysis JSON object. The current extractor keeps the strict "one final JSON only" contract, but it evaluates the raw wrapper text first, so a valid single JSON response can be reported as `ambiguous_json`. That failure can trigger provider fallback and the integrity retry path; the retry prompt previously replayed the same reasoning wrapper, which could keep the completion loop alive.

Root cause: the parser did not distinguish known reasoning-only wrappers from arbitrary prose before selecting the final JSON candidate, and the integrity retry prompt used the previous raw response unchanged.

## Scope Of Change

Files changed: 4 files, 102 insertions, 1 deletion.

```text
docs/CHANGELOG.md              |  1 +
src/analyzer.py                | 36 ++++++++++++++++++++++++++++-
tests/test_report_integrity.py | 15 +++++++++++++
tests/test_report_schema.py    | 51 ++++++++++++++++++++++++++++++++++++++++++
```

File list:

- `src/analyzer.py`: strips known reasoning wrappers only after the existing strict JSON extraction fails with `ambiguous_json` or invalid JSON, then reruns the same strict extractor; also strips reasoning wrappers before building integrity retry prompts.
- `tests/test_report_schema.py`: adds regression coverage for `<think>` plus JSON, reasoning fence plus JSON, and arbitrary prose that must still be rejected.
- `tests/test_report_integrity.py`: adds retry-prompt coverage to ensure reasoning wrappers are not replayed.
- `docs/CHANGELOG.md`: documents the fix under `[Unreleased]`.

Documentation updated: `docs/CHANGELOG.md`.

## Issue Link

Fixes #1946

## Verification Commands And Results

```powershell
.venv\Scripts\python.exe -m py_compile src/analyzer.py
```

Result: pass.

```powershell
.venv\Scripts\python.exe -m pytest tests/test_report_schema.py tests/test_report_integrity.py
```

Result: pass, `51 passed, 1 warning`.

```powershell
git diff --check
```

Result: pass. Git on Windows printed LF-to-CRLF notices only; no whitespace errors were reported for this diff.

Current Head CI: `ai-governance:action_required / backend-gate:action_required / docker-build:action_required / web-gate:action_required`. GitHub created the CI workflow for this fork PR, but the run currently needs maintainer action before jobs execute. Actions run: https://github.com/ZhuLinsen/daily_stock_analysis/actions/runs/28934617563

## Visual Evidence (if applicable)

Not applicable. This PR changes backend JSON parsing and retry prompt handling only; no report rendering, report formatting, or Web UI surface is changed. Reproducible evidence is provided by the parser and integrity prompt regression tests above.

## Compatibility And Risk

This PR does not change provider/model/base URL, runtime config cleanup or migration semantics; historical configuration remains unchanged; rollback is to revert this PR.

Risk is low and scoped to analysis JSON extraction. The parser still rejects arbitrary prose and multiple final JSON candidates; only known reasoning wrappers are removed before retrying the same strict extraction path. If a provider emits an unsupported wrapper spelling, the previous strict behavior remains in effect.

No third-party API request parameters, routing prefixes, or provider fallback order are changed.

## Rollback Plan

Revert this PR. No data migration, cache cleanup, or runtime configuration rollback is required.

## EXTRACT_PROMPT Change (if applicable)

Not applicable. This PR does not change `src/services/image_stock_extractor.py` or `EXTRACT_PROMPT`.

<details>
<summary>Expand: Full EXTRACT_PROMPT</summary>

```text
Not changed.
```

</details>

## Checklist

- [x] This PR has a clear motivation and value
- [x] Reproducible verification commands and results are included
- [x] Compatibility and risk have been assessed
- [x] A rollback plan is provided
- [x] If report formatting or Web UI changed, affected report/page screenshots are linked in the PR body/comments and one-off acceptance screenshots are not committed as repository files
- [x] If Web settings fields changed, screenshots of the settings page are required; if unavailable, provide alternative visual evidence with command + artifact path that points to the changed item.
- [x] If user-visible changes are included, relevant docs and `docs/CHANGELOG.md` are updated; `README.md` is updated only for homepage-level changes, with details kept in `docs/*.md`
