### PR TITLE
fix: align report action display with score

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -34,7 +34,7 @@ git diff --stat "$BASE_REF"..HEAD
 git diff --name-only "$BASE_REF"..HEAD
 ```
 
-- 文件总数 / 变更行数（建议粘贴 `git diff --stat "$BASE_REF"..HEAD`）：
+- 文件总数 / 变更行数（建议粘贴 `git diff --stat "$BASE_REF"..HEAD`，并注明与 PR 正文一致）：
 - 文件清单（按实际 diff 全量，逐项列出）：
 - 文档更新文件（`docs/*`）：
 
@@ -60,6 +60,7 @@ python -m pytest -m "not network"
 > 请避免保留与本 PR 无关的历史失败措辞，按本次实际结果填报。
 > 如历史描述中仍保留 `./scripts/ci_gate.sh` 失败记录，请先改为当前 Head CI 状态或说明与 Head CI 的差异来源。
 > 若 `Full-suite note` 与当前 Head CI 不一致，PR 文本不完整，请先更新 PR 描述后再提交。
+> ⚠️ PR 描述中的 CI 状态字段不得保留 `pending`；请务必替换为 `pass / fail` 并附对应链接，或补充说明本地环境差异与 CI 结论。
 
 - 请在下面按实际结果填写并与 `Full-suite note` 保持一致（任一未填视为信息缺失）：
   - ai-governance：`pass` / `fail`，附链接

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -60,7 +60,6 @@ python -m pytest -m "not network"
 > 请避免保留与本 PR 无关的历史失败措辞，按本次实际结果填报。
 > 如历史描述中仍保留 `./scripts/ci_gate.sh` 失败记录，请先改为当前 Head CI 状态或说明与 Head CI 的差异来源。
 > 若 `Full-suite note` 与当前 Head CI 不一致，PR 文本不完整，请先更新 PR 描述后再提交。
-> ⚠️ PR 描述中的 CI 状态字段不得保留 `pending`；请务必替换为 `pass / fail` 并附对应链接，或补充说明本地环境差异与 CI 结论。
 
 - 请在下面按实际结果填写并与 `Full-suite note` 保持一致（任一未填视为信息缺失）：
   - ai-governance：`pass` / `fail`，附链接

--- a/api/v1/endpoints/analysis.py
+++ b/api/v1/endpoints/analysis.py
@@ -76,7 +76,8 @@ from src.market_phase_summary import (
 )
 from src.services.stock_code_utils import is_code_like, resolve_index_stock_code_for_analysis
 from src.report_language import get_localized_stock_name, normalize_report_language
-from src.schemas.decision_action import build_action_fields
+from src.schemas.decision_action import display_action_fields
+from src.schemas.decision_scale import extract_decision_guardrail_reason
 from src.services.name_to_code_resolver import resolve_name_to_code
 from src.services.task_queue import (
     get_task_queue,
@@ -180,28 +181,6 @@ def _coalesce_text(*values: Any) -> Optional[str]:
         text = str(value).strip()
         if text:
             return text
-    return None
-
-
-def _extract_guardrail_reason(raw_result: Any) -> Optional[str]:
-    if not isinstance(raw_result, dict):
-        return None
-    for reason in (
-        raw_result.get("guardrail_reason"),
-        raw_result.get("downgrade_reason"),
-        raw_result.get("decision_score_guardrail_reason"),
-    ):
-        if reason is not None:
-            text = str(reason).strip()
-            if text:
-                return text
-    metadata = raw_result.get("metadata")
-    if isinstance(metadata, dict):
-        metadata_reason = metadata.get("guardrail_reason") or metadata.get("downgrade_reason")
-        if metadata_reason is not None:
-            text = str(metadata_reason).strip()
-            if text:
-                return text
     return None
 
 
@@ -904,17 +883,17 @@ def _ensure_report_action_fields(report_data: Dict[str, Any]) -> Dict[str, Any]:
     report_language = normalize_report_language(
         meta.get("report_language") or raw_result.get("report_language")
     )
-    action_fields = build_action_fields(
+    action_fields = display_action_fields(
         operation_advice=raw_result.get("operation_advice") or summary.get("operation_advice"),
         explicit_action=raw_result.get("action") or summary.get("action"),
+        action_label=raw_result.get("action_label") or summary.get("action_label"),
         report_type=meta.get("report_type"),
         report_language=report_language,
         sentiment_score=_first_non_empty_report_value(
             summary.get("sentiment_score"),
             raw_result.get("sentiment_score"),
         ),
-        guardrail_reason=_extract_guardrail_reason(raw_result),
-        align_with_score=True,
+        guardrail_reason=extract_decision_guardrail_reason(raw_result),
     )
     summary["action"] = action_fields["action"]
     summary["action_label"] = action_fields["action_label"]
@@ -1159,14 +1138,14 @@ def get_analysis_status(task_id: str) -> TaskStatus:
                 )
 
             raw_dict = raw_result if isinstance(raw_result, dict) else {}
-            action_fields = build_action_fields(
+            action_fields = display_action_fields(
                 operation_advice=raw_dict.get("operation_advice") or record.operation_advice,
                 explicit_action=raw_dict.get("action"),
+                action_label=raw_dict.get("action_label"),
                 report_type=getattr(record, 'report_type', None),
                 report_language=report_language,
                 sentiment_score=record.sentiment_score if record.sentiment_score is not None else raw_dict.get("sentiment_score"),
-                guardrail_reason=_extract_guardrail_reason(raw_dict),
-                align_with_score=True,
+                guardrail_reason=extract_decision_guardrail_reason(raw_dict),
             )
 
             # Build report from DB record so completed tasks return real data
@@ -1343,13 +1322,16 @@ def _build_analysis_report(
     )
 
     raw_result_data = details_data.get("raw_result") if isinstance(details_data.get("raw_result"), dict) else {}
-    action_fields = build_action_fields(
+    action_fields = display_action_fields(
         operation_advice=(
             raw_result_data.get("operation_advice")
             or details_data.get("operation_advice")
             or summary_data.get("operation_advice")
         ),
         explicit_action=raw_result_data.get("action") or details_data.get("action") or summary_data.get("action"),
+        action_label=raw_result_data.get("action_label")
+        or details_data.get("action_label")
+        or summary_data.get("action_label"),
         report_type=meta.report_type,
         report_language=report_language,
         sentiment_score=_first_non_empty_report_value(
@@ -1357,8 +1339,7 @@ def _build_analysis_report(
             raw_result_data.get("sentiment_score"),
             details_data.get("sentiment_score"),
         ),
-        guardrail_reason=_extract_guardrail_reason(raw_result_data),
-        align_with_score=True,
+        guardrail_reason=extract_decision_guardrail_reason(raw_result_data),
     )
 
     summary = ReportSummary(

--- a/api/v1/endpoints/analysis.py
+++ b/api/v1/endpoints/analysis.py
@@ -874,6 +874,24 @@ def _first_non_empty_report_value(*values: Any) -> Any:
     return None
 
 
+def _raw_result_value(raw_result: Any, key: str) -> Any:
+    if not isinstance(raw_result, dict):
+        return None
+
+    value = raw_result.get(key)
+    if value is not None and value != "":
+        return value
+
+    for container_key in ("summary", "dashboard"):
+        container = raw_result.get(container_key)
+        if isinstance(container, dict):
+            nested_value = container.get(key)
+            if nested_value is not None and nested_value != "":
+                return nested_value
+
+    return None
+
+
 def _ensure_report_action_fields(report_data: Dict[str, Any]) -> Dict[str, Any]:
     enriched_report = dict(report_data)
     meta = dict(enriched_report.get("meta") or {})
@@ -884,9 +902,10 @@ def _ensure_report_action_fields(report_data: Dict[str, Any]) -> Dict[str, Any]:
         meta.get("report_language") or raw_result.get("report_language")
     )
     action_fields = display_action_fields(
-        operation_advice=raw_result.get("operation_advice") or summary.get("operation_advice"),
-        explicit_action=raw_result.get("action") or summary.get("action"),
-        action_label=raw_result.get("action_label") or summary.get("action_label"),
+        operation_advice=_raw_result_value(raw_result, "operation_advice") or summary.get("operation_advice"),
+        explicit_action=_raw_result_value(raw_result, "action") or summary.get("action"),
+        action_label=_raw_result_value(raw_result, "action_label") or summary.get("action_label"),
+        legacy_decision_type=_raw_result_value(raw_result, "decision_type") or summary.get("decision_type"),
         report_type=meta.get("report_type"),
         report_language=report_language,
         sentiment_score=_first_non_empty_report_value(
@@ -1139,9 +1158,10 @@ def get_analysis_status(task_id: str) -> TaskStatus:
 
             raw_dict = raw_result if isinstance(raw_result, dict) else {}
             action_fields = display_action_fields(
-                operation_advice=raw_dict.get("operation_advice") or record.operation_advice,
-                explicit_action=raw_dict.get("action"),
-                action_label=raw_dict.get("action_label"),
+                operation_advice=_raw_result_value(raw_dict, "operation_advice") or record.operation_advice,
+                explicit_action=_raw_result_value(raw_dict, "action"),
+                action_label=_raw_result_value(raw_dict, "action_label"),
+                legacy_decision_type=_raw_result_value(raw_dict, "decision_type"),
                 report_type=getattr(record, 'report_type', None),
                 report_language=report_language,
                 sentiment_score=record.sentiment_score if record.sentiment_score is not None else raw_dict.get("sentiment_score"),
@@ -1324,14 +1344,25 @@ def _build_analysis_report(
     raw_result_data = details_data.get("raw_result") if isinstance(details_data.get("raw_result"), dict) else {}
     action_fields = display_action_fields(
         operation_advice=(
-            raw_result_data.get("operation_advice")
-            or details_data.get("operation_advice")
+            _raw_result_value(raw_result_data, "operation_advice")
+            or _raw_result_value(details_data, "operation_advice")
             or summary_data.get("operation_advice")
         ),
-        explicit_action=raw_result_data.get("action") or details_data.get("action") or summary_data.get("action"),
-        action_label=raw_result_data.get("action_label")
-        or details_data.get("action_label")
-        or summary_data.get("action_label"),
+        explicit_action=(
+            _raw_result_value(raw_result_data, "action")
+            or _raw_result_value(details_data, "action")
+            or summary_data.get("action")
+        ),
+        action_label=(
+            _raw_result_value(raw_result_data, "action_label")
+            or _raw_result_value(details_data, "action_label")
+            or summary_data.get("action_label")
+        ),
+        legacy_decision_type=(
+            _raw_result_value(raw_result_data, "decision_type")
+            or _raw_result_value(details_data, "decision_type")
+            or summary_data.get("decision_type")
+        ),
         report_type=meta.report_type,
         report_language=report_language,
         sentiment_score=_first_non_empty_report_value(

--- a/api/v1/endpoints/history.py
+++ b/api/v1/endpoints/history.py
@@ -43,7 +43,8 @@ from src.report_language import (
     normalize_report_language,
 )
 from src.services.history_service import HistoryService, MarkdownReportGenerationError
-from src.schemas.decision_action import build_action_fields
+from src.schemas.decision_action import display_action_fields
+from src.schemas.decision_scale import extract_decision_guardrail_reason
 from src.utils.data_processing import (
     normalize_model_used,
     extract_fundamental_detail_fields,
@@ -109,29 +110,6 @@ def _coalesce_int(*values: Any) -> Optional[int]:
             return int(float(value))
         except (TypeError, ValueError):
             continue
-    return None
-
-
-def _extract_guardrail_reason(raw_result: Any) -> Optional[str]:
-    if not isinstance(raw_result, dict):
-        return None
-    for reason in (
-        raw_result.get("guardrail_reason"),
-        raw_result.get("downgrade_reason"),
-        raw_result.get("decision_score_guardrail_reason"),
-    ):
-        if reason is not None:
-            text = str(reason).strip()
-            if text:
-                return text
-
-    metadata = raw_result.get("metadata")
-    if isinstance(metadata, dict):
-        metadata_reason = metadata.get("guardrail_reason") or metadata.get("downgrade_reason")
-        if metadata_reason is not None:
-            text = str(metadata_reason).strip()
-            if text:
-                return text
     return None
 
 
@@ -357,16 +335,16 @@ def get_stock_bar(
                 record.operation_advice,
                 _raw_result_value(raw_result, "operation_advice"),
             )
-            action_fields = build_action_fields(
+            action_fields = display_action_fields(
                 operation_advice=operation_advice,
                 explicit_action=_raw_result_value(raw_result, "action"),
+                action_label=_raw_result_value(raw_result, "action_label"),
                 report_type=record.report_type,
                 report_language=normalize_report_language(
                     _raw_result_value(raw_result, "report_language")
                 ),
                 sentiment_score=sentiment_score,
-                guardrail_reason=_extract_guardrail_reason(raw_result),
-                align_with_score=True,
+                guardrail_reason=extract_decision_guardrail_reason(raw_result),
             )
 
             display_stock_code = service._display_stock_code(record.code)

--- a/api/v1/endpoints/history.py
+++ b/api/v1/endpoints/history.py
@@ -339,6 +339,7 @@ def get_stock_bar(
                 operation_advice=operation_advice,
                 explicit_action=_raw_result_value(raw_result, "action"),
                 action_label=_raw_result_value(raw_result, "action_label"),
+                legacy_decision_type=_raw_result_value(raw_result, "decision_type"),
                 report_type=record.report_type,
                 report_language=normalize_report_language(
                     _raw_result_value(raw_result, "report_language")

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 - [改进] 为 multi-agent DecisionAgent 增加内部低敏分歧摘要输入管线，作为 #1904 P1 解释输出的前置 plumbing；不改变 public API、dashboard schema 或最终解释字段。
+- [修复] 推送报告、Jinja 报告与历史 Markdown 导出复用 Web/API 的评分-action 口径：高分但旧 `operation_advice` 仍为持有且无降级原因时，建议文案与三类统计展示为买入；有明确 guardrail reason 时继续保留持有/观望。
 - [改进] GitHub Actions 每日分析工作流补齐 TickFlow 数据源环境变量映射，并收敛 README 数据源稳定性说明到完整指南。
 - [修复] WebUI 启动时显式 `--host` / `--port` 不再被 `.env` 中的 `WEBUI_HOST` / `WEBUI_PORT` 覆盖，未传 CLI 参数时统一使用解析后的运行时配置。
 - [改进] GitHub Actions: 每日分析工作流（`00-daily-analysis.yml`）新增钉钉通知环境变量映射，支持在云端定时任务中直接使用钉钉机器人。

--- a/src/notification.py
+++ b/src/notification.py
@@ -45,9 +45,12 @@ from src.report_language import (
     get_chip_unavailable_reason,
     is_chip_structure_unavailable,
     localize_chip_health,
-    localize_operation_advice,
     localize_trend_prediction,
     normalize_report_language,
+)
+from src.schemas.decision_action import (
+    display_decision_type_for_result,
+    display_operation_advice_for_result,
 )
 from bot.models import BotMessage
 from src.utils.sanitize import sanitize_diagnostic_text
@@ -230,7 +233,7 @@ class NotificationService(
         # 仅分析结果摘要（Issue #262）：true 时只推送汇总，不含个股详情
         self._report_summary_only = getattr(config, 'report_summary_only', False)
         self._report_show_llm_model = getattr(config, 'report_show_llm_model', True)
-        self._history_compare_cache: Dict[Tuple[int, Tuple[Tuple[str, str], ...]], Dict[str, List[Dict[str, Any]]]] = {}
+        self._history_compare_cache: Dict[Tuple[int, str, Tuple[Tuple[str, str], ...]], Dict[str, List[Dict[str, Any]]]] = {}
 
         # 初始化各渠道
         AstrbotSender.__init__(self, config)
@@ -298,8 +301,11 @@ class NotificationService(
         if history_compare_n <= 0 or not results:
             return {"history_by_code": {}}
 
+        report_language = self._get_report_language(results)
+
         cache_key = (
             history_compare_n,
+            report_language,
             tuple(sorted((r.code, getattr(r, 'query_id', '') or '') for r in results)),
         )
         if cache_key in self._history_compare_cache:
@@ -318,6 +324,7 @@ class NotificationService(
                 codes,
                 limit=history_compare_n,
                 exclude_query_ids=exclude_ids,
+                report_language=report_language,
             )
         except Exception as e:
             logger.debug("History comparison skipped: %s", e)
@@ -830,10 +837,7 @@ class NotificationService(
             reverse=True
         )
 
-        # 统计信息 - 使用 decision_type 字段准确统计
-        buy_count = sum(1 for r in results if getattr(r, 'decision_type', '') == 'buy')
-        sell_count = sum(1 for r in results if getattr(r, 'decision_type', '') == 'sell')
-        hold_count = sum(1 for r in results if getattr(r, 'decision_type', '') in ('hold', ''))
+        buy_count, sell_count, hold_count = self._count_display_decisions(results, report_language)
         avg_score = sum(r.sentiment_score for r in results) / len(results) if results else 0
 
         report_lines.extend([
@@ -854,10 +858,10 @@ class NotificationService(
         if self._report_summary_only:
             report_lines.extend([f"## 📊 {labels['summary_heading']}", ""])
             for r in sorted_results:
-                _, emoji, _ = self._get_signal_level(r)
+                signal_text, emoji, _ = self._get_signal_level(r)
                 report_lines.append(
                     f"{emoji} **{self._get_display_name(r, report_language)}({r.code})**: "
-                    f"{localize_operation_advice(r.operation_advice, report_language)} | "
+                    f"{signal_text} | "
                     f"{labels['score_label']} {r.sentiment_score} | "
                     f"{localize_trend_prediction(r.trend_prediction, report_language)}"
                 )
@@ -865,13 +869,13 @@ class NotificationService(
             report_lines.extend([f"## 📈 {labels['report_title']}", ""])
             # 逐个股票的详细分析
             for result in sorted_results:
-                _, emoji, _ = self._get_signal_level(result)
+                signal_text, emoji, _ = self._get_signal_level(result)
                 confidence_stars = result.get_confidence_stars() if hasattr(result, 'get_confidence_stars') else '⭐⭐'
 
                 report_lines.extend([
                     f"### {emoji} {self._get_display_name(result, report_language)} ({result.code})",
                     "",
-                    f"**{labels['action_advice_label']}：{localize_operation_advice(result.operation_advice, report_language)}** | "
+                    f"**{labels['action_advice_label']}：{signal_text}** | "
                     f"**{labels['score_label']}：{result.sentiment_score}** | "
                     f"**{labels['trend_label']}：{localize_trend_prediction(result.trend_prediction, report_language)}** | "
                     f"**Confidence：{confidence_stars}**",
@@ -1096,12 +1100,38 @@ class NotificationService(
                 report_lines.append(f"- {limitation}")
             report_lines.append("")
 
+    def _get_display_operation_advice(
+        self,
+        result: AnalysisResult,
+        report_language: Optional[str] = None,
+    ) -> str:
+        return display_operation_advice_for_result(
+            result,
+            report_language=report_language or self._get_report_language(result),
+        )
+
+    def _count_display_decisions(
+        self,
+        results: List[AnalysisResult],
+        report_language: Optional[str] = None,
+    ) -> Tuple[int, int, int]:
+        language = report_language or self._get_report_language(results)
+        buckets = [
+            display_decision_type_for_result(result, report_language=language)
+            for result in results
+        ]
+        buy_count = sum(1 for bucket in buckets if bucket == "buy")
+        sell_count = sum(1 for bucket in buckets if bucket == "sell")
+        hold_count = len(buckets) - buy_count - sell_count
+        return buy_count, sell_count, hold_count
+
     def _get_signal_level(self, result: AnalysisResult) -> tuple:
         """Get localized signal level and color based on operation advice."""
+        report_language = self._get_report_language(result)
         return get_signal_level(
-            result.operation_advice,
+            self._get_display_operation_advice(result, report_language),
             result.sentiment_score,
-            self._get_report_language(result),
+            report_language,
         )
 
     def generate_dashboard_report(
@@ -1159,10 +1189,7 @@ class NotificationService(
         # 按评分排序（高分在前）
         sorted_results = sorted(results, key=lambda x: x.sentiment_score, reverse=True)
 
-        # 统计信息 - 使用 decision_type 字段准确统计
-        buy_count = sum(1 for r in results if getattr(r, 'decision_type', '') == 'buy')
-        sell_count = sum(1 for r in results if getattr(r, 'decision_type', '') == 'sell')
-        hold_count = sum(1 for r in results if getattr(r, 'decision_type', '') in ('hold', ''))
+        buy_count, sell_count, hold_count = self._count_display_decisions(results, report_language)
 
         report_lines = [
             f"# 🎯 {report_date} {labels['dashboard_title']}",
@@ -1179,11 +1206,11 @@ class NotificationService(
                 "",
             ])
             for r in sorted_results:
-                _, signal_emoji, _ = self._get_signal_level(r)
+                signal_text, signal_emoji, _ = self._get_signal_level(r)
                 display_name = self._get_display_name(r, report_language)
                 report_lines.append(
                     f"{signal_emoji} **{display_name}({r.code})**: "
-                    f"{localize_operation_advice(r.operation_advice, report_language)} | "
+                    f"{signal_text} | "
                     f"{labels['score_label']} {r.sentiment_score} | "
                     f"{localize_trend_prediction(r.trend_prediction, report_language)}"
                 )
@@ -1264,7 +1291,7 @@ class NotificationService(
                     report_lines.extend([
                         f"| {labels['position_status_label']} | {labels['action_advice_label']} |",
                         "|---------|---------|",
-                        f"| 🆕 **{labels['no_position_label']}** | {pos_advice.get('no_position', localize_operation_advice(result.operation_advice, report_language))} |",
+                        f"| 🆕 **{labels['no_position_label']}** | {pos_advice.get('no_position', self._get_display_operation_advice(result, report_language))} |",
                         f"| 💼 **{labels['has_position_label']}** | {pos_advice.get('has_position', labels['continue_holding'])} |",
                         "",
                     ])
@@ -1496,10 +1523,7 @@ class NotificationService(
         # 按评分排序
         sorted_results = sorted(results, key=lambda x: x.sentiment_score, reverse=True)
 
-        # 统计 - 使用 decision_type 字段准确统计
-        buy_count = sum(1 for r in results if getattr(r, 'decision_type', '') == 'buy')
-        sell_count = sum(1 for r in results if getattr(r, 'decision_type', '') == 'sell')
-        hold_count = sum(1 for r in results if getattr(r, 'decision_type', '') in ('hold', ''))
+        buy_count, sell_count, hold_count = self._count_display_decisions(results, report_language)
 
         lines = [
             f"## 🎯 {report_date} {labels['dashboard_title']}",
@@ -1514,11 +1538,11 @@ class NotificationService(
             lines.append(f"**📊 {labels['summary_heading']}**")
             lines.append("")
             for r in sorted_results:
-                _, signal_emoji, _ = self._get_signal_level(r)
+                signal_text, signal_emoji, _ = self._get_signal_level(r)
                 stock_name = self._get_display_name(r, report_language)
                 lines.append(
                     f"{signal_emoji} **{stock_name}({r.code})**: "
-                    f"{localize_operation_advice(r.operation_advice, report_language)} | "
+                    f"{signal_text} | "
                     f"{labels['score_label']} {r.sentiment_score} | "
                     f"{localize_trend_prediction(r.trend_prediction, report_language)}"
                 )
@@ -1650,10 +1674,7 @@ class NotificationService(
         # 按评分排序
         sorted_results = sorted(results, key=lambda x: x.sentiment_score, reverse=True)
 
-        # 统计 - 使用 decision_type 字段准确统计
-        buy_count = sum(1 for r in results if getattr(r, 'decision_type', '') == 'buy')
-        sell_count = sum(1 for r in results if getattr(r, 'decision_type', '') == 'sell')
-        hold_count = sum(1 for r in results if getattr(r, 'decision_type', '') in ('hold', ''))
+        buy_count, sell_count, hold_count = self._count_display_decisions(results, report_language)
         avg_score = sum(r.sentiment_score for r in results) / len(results) if results else 0
 
         lines = [
@@ -1667,12 +1688,12 @@ class NotificationService(
 
         # 每只股票精简信息（控制长度）
         for result in sorted_results:
-            _, emoji, _ = self._get_signal_level(result)
+            signal_text, emoji, _ = self._get_signal_level(result)
 
             # 核心信息行
             lines.append(f"### {emoji} {self._get_display_name(result, report_language)}({result.code})")
             lines.append(
-                f"**{localize_operation_advice(result.operation_advice, report_language)}** | "
+                f"**{signal_text}** | "
                 f"{labels['score_label']}:{result.sentiment_score} | "
                 f"{localize_trend_prediction(result.trend_prediction, report_language)}"
             )
@@ -1743,9 +1764,7 @@ class NotificationService(
         if not results:
             return f"# {report_date} {labels['brief_title']}\n\n{labels['no_results']}"
         sorted_results = sorted(results, key=lambda x: x.sentiment_score, reverse=True)
-        buy_count = sum(1 for r in results if getattr(r, 'decision_type', '') == 'buy')
-        sell_count = sum(1 for r in results if getattr(r, 'decision_type', '') == 'sell')
-        hold_count = sum(1 for r in results if getattr(r, 'decision_type', '') in ('hold', ''))
+        buy_count, sell_count, hold_count = self._count_display_decisions(results, report_language)
         lines = [
             f"# {report_date} {labels['brief_title']}",
             "",
@@ -1753,14 +1772,14 @@ class NotificationService(
         ]
         self._append_market_status_line(lines, results, report_language)
         for r in sorted_results:
-            _, emoji, _ = self._get_signal_level(r)
+            signal_text, emoji, _ = self._get_signal_level(r)
             name = self._get_display_name(r, report_language)
             dash = r.dashboard or {}
             core = dash.get('core_conclusion', {}) or {}
             one = (core.get('one_sentence') or r.analysis_summary or '')[:60]
             lines.append(
                 f"**{name}({r.code})** {emoji} "
-                f"{localize_operation_advice(r.operation_advice, report_language)} | "
+                f"{signal_text} | "
                 f"{labels['score_label']} {r.sentiment_score} | {one}"
             )
         lines.append("")
@@ -1913,7 +1932,7 @@ class NotificationService(
             lines.extend([
                 f"### 💼 {labels['position_advice_heading']}",
                 "",
-                f"- 🆕 **{labels['no_position_label']}**: {pos_advice.get('no_position', localize_operation_advice(result.operation_advice, report_language))}",
+                f"- 🆕 **{labels['no_position_label']}**: {pos_advice.get('no_position', self._get_display_operation_advice(result, report_language))}",
                 f"- 💼 **{labels['has_position_label']}**: {pos_advice.get('has_position', labels['continue_holding'])}",
                 "",
             ])
@@ -2792,10 +2811,14 @@ class NotificationBuilder:
         lines = [f"📊 **{labels['summary_heading']}**", ""]
 
         for r in sorted(results, key=lambda x: x.sentiment_score, reverse=True):
-            _, emoji, _ = get_signal_level(r.operation_advice, r.sentiment_score, report_language)
+            display_advice = display_operation_advice_for_result(
+                r,
+                report_language=report_language,
+            )
+            signal_text, emoji, _ = get_signal_level(display_advice, r.sentiment_score, report_language)
             name = get_localized_stock_name(r.name, r.code, report_language)
             lines.append(
-                f"{emoji} {name}({r.code}): {localize_operation_advice(r.operation_advice, report_language)} | "
+                f"{emoji} {name}({r.code}): {signal_text} | "
                 f"{labels['score_label']} {r.sentiment_score}"
             )
 

--- a/src/report_language.py
+++ b/src/report_language.py
@@ -1023,6 +1023,8 @@ def get_signal_level(advice: Any, score: Any, language: Optional[str]) -> tuple[
 
     if canonical == "strong_buy":
         return (_OPERATION_ADVICE_TRANSLATIONS["strong_buy"][normalized_language], "💚", "strong_buy")
+    if canonical == "strong_sell":
+        return (_OPERATION_ADVICE_TRANSLATIONS["strong_sell"][normalized_language], "🔴", "strong_sell")
     if canonical == "buy":
         if score_signal == "strong_buy":
             return (_OPERATION_ADVICE_TRANSLATIONS["strong_buy"][normalized_language], "💚", "strong_buy")

--- a/src/report_language.py
+++ b/src/report_language.py
@@ -55,6 +55,12 @@ _OPERATION_ADVICE_CANONICAL_MAP = {
     "强烈卖出": "strong_sell",
     "strong sell": "strong_sell",
     "strong_sell": "strong_sell",
+    "回避": "avoid",
+    "avoid": "avoid",
+    "规避": "avoid",
+    "预警": "alert",
+    "风险预警": "alert",
+    "alert": "alert",
     "적극 매수": "strong_buy",
     "매수": "buy",
     "보유": "hold",
@@ -63,6 +69,8 @@ _OPERATION_ADVICE_CANONICAL_MAP = {
     "비중축소": "reduce",
     "매도": "sell",
     "적극 매도": "strong_sell",
+    "회피": "avoid",
+    "경고": "alert",
 }
 
 _OPERATION_ADVICE_TRANSLATIONS = {
@@ -73,6 +81,8 @@ _OPERATION_ADVICE_TRANSLATIONS = {
     "reduce": {"zh": "减仓", "en": "Reduce", "ko": "비중축소"},
     "sell": {"zh": "卖出", "en": "Sell", "ko": "매도"},
     "strong_sell": {"zh": "强烈卖出", "en": "Strong Sell", "ko": "적극 매도"},
+    "avoid": {"zh": "回避", "en": "Avoid", "ko": "회피"},
+    "alert": {"zh": "预警", "en": "Alert", "ko": "경고"},
 }
 
 _TREND_PREDICTION_CANONICAL_MAP = {
@@ -919,12 +929,27 @@ def get_bias_status_emoji(value: Any) -> str:
 
 def infer_decision_type_from_advice(value: Any, default: str = "hold") -> str:
     """Infer buy/hold/sell from human-readable operation advice."""
+
+    try:
+        from src.schemas.decision_action import normalize_decision_action
+    except Exception:  # pragma: no cover
+        normalize_decision_action = None
+
+    if normalize_decision_action is not None:
+        action = normalize_decision_action(value)
+        if action == "buy" or action == "add":
+            return "buy"
+        if action in {"reduce", "sell"}:
+            return "sell"
+        if action in {"hold", "watch", "avoid", "alert"}:
+            return "hold"
+
     canonical = _canonicalize_lookup_value(value, _OPERATION_ADVICE_CANONICAL_MAP)
     if canonical in {"strong_buy", "buy"}:
         return "buy"
     if canonical in {"reduce", "sell", "strong_sell"}:
         return "sell"
-    if canonical in {"hold", "watch"}:
+    if canonical in {"hold", "watch", "avoid", "alert"}:
         return "hold"
 
     normalized_text = _normalize_lookup_key(value)
@@ -943,7 +968,7 @@ def infer_decision_type_from_advice(value: Any, default: str = "hold") -> str:
         return "buy"
     if best_canonical in {"reduce", "sell", "strong_sell"}:
         return "sell"
-    if best_canonical in {"hold", "watch"}:
+    if best_canonical in {"hold", "watch", "avoid", "alert"}:
         return "hold"
 
     return default
@@ -952,10 +977,34 @@ def infer_decision_type_from_advice(value: Any, default: str = "hold") -> str:
 def get_signal_level(advice: Any, score: Any, language: Optional[str]) -> tuple[str, str, str]:
     """Return localized signal text, emoji, and stable color tag."""
     normalized_language = normalize_report_language(language)
-    canonical = _canonicalize_lookup_value(advice, _OPERATION_ADVICE_CANONICAL_MAP)
+    canonical: Optional[str]
+    try:
+        from src.schemas.decision_action import normalize_decision_action
+    except Exception:  # pragma: no cover
+        normalize_decision_action = None
+
+    if normalize_decision_action is not None:
+        action = normalize_decision_action(advice)
+        if action == "add":
+            canonical = "buy"
+        elif action in {"hold", "watch", "reduce", "sell", "avoid", "alert", "buy"}:
+            canonical = action
+        else:
+            canonical = _canonicalize_lookup_value(advice, _OPERATION_ADVICE_CANONICAL_MAP)
+    else:
+        canonical = _canonicalize_lookup_value(advice, _OPERATION_ADVICE_CANONICAL_MAP)
+
+    try:
+        numeric_score = int(float(score))
+    except (TypeError, ValueError):
+        numeric_score = 50
+    score_signal = signal_key_for_score(numeric_score)
+
     if canonical == "strong_buy":
         return (_OPERATION_ADVICE_TRANSLATIONS["strong_buy"][normalized_language], "💚", "strong_buy")
     if canonical == "buy":
+        if score_signal == "strong_buy":
+            return (_OPERATION_ADVICE_TRANSLATIONS["strong_buy"][normalized_language], "💚", "strong_buy")
         return (_OPERATION_ADVICE_TRANSLATIONS["buy"][normalized_language], "🟢", "buy")
     if canonical == "hold":
         return (_OPERATION_ADVICE_TRANSLATIONS["hold"][normalized_language], "🟡", "hold")
@@ -965,13 +1014,9 @@ def get_signal_level(advice: Any, score: Any, language: Optional[str]) -> tuple[
         return (_OPERATION_ADVICE_TRANSLATIONS["reduce"][normalized_language], "🟠", "reduce")
     if canonical in {"sell", "strong_sell"}:
         return (_OPERATION_ADVICE_TRANSLATIONS["sell"][normalized_language], "🔴", "sell")
+    if canonical in {"avoid", "alert"}:
+        return (_OPERATION_ADVICE_TRANSLATIONS[canonical][normalized_language], "🟡", "hold")
 
-    try:
-        numeric_score = int(float(score))
-    except (TypeError, ValueError):
-        numeric_score = 50
-
-    score_signal = signal_key_for_score(numeric_score)
     if score_signal == "strong_buy":
         return (_OPERATION_ADVICE_TRANSLATIONS["strong_buy"][normalized_language], "💚", "strong_buy")
     if score_signal == "buy":

--- a/src/report_language.py
+++ b/src/report_language.py
@@ -76,6 +76,7 @@ _OPERATION_ADVICE_CANONICAL_MAP = {
 _OPERATION_ADVICE_TRANSLATIONS = {
     "strong_buy": {"zh": "强烈买入", "en": "Strong Buy", "ko": "적극 매수"},
     "buy": {"zh": "买入", "en": "Buy", "ko": "매수"},
+    "add": {"zh": "加仓", "en": "Add", "ko": "추가 매수"},
     "hold": {"zh": "持有", "en": "Hold", "ko": "보유"},
     "watch": {"zh": "观望", "en": "Watch", "ko": "관망"},
     "reduce": {"zh": "减仓", "en": "Reduce", "ko": "비중축소"},
@@ -985,9 +986,7 @@ def get_signal_level(advice: Any, score: Any, language: Optional[str]) -> tuple[
 
     if normalize_decision_action is not None:
         action = normalize_decision_action(advice)
-        if action == "add":
-            canonical = "buy"
-        elif action in {"hold", "watch", "reduce", "sell", "avoid", "alert", "buy"}:
+        if action in {"add", "hold", "watch", "reduce", "sell", "avoid", "alert", "buy"}:
             canonical = action
         else:
             canonical = _canonicalize_lookup_value(advice, _OPERATION_ADVICE_CANONICAL_MAP)
@@ -1006,6 +1005,8 @@ def get_signal_level(advice: Any, score: Any, language: Optional[str]) -> tuple[
         if score_signal == "strong_buy":
             return (_OPERATION_ADVICE_TRANSLATIONS["strong_buy"][normalized_language], "💚", "strong_buy")
         return (_OPERATION_ADVICE_TRANSLATIONS["buy"][normalized_language], "🟢", "buy")
+    if canonical == "add":
+        return (_OPERATION_ADVICE_TRANSLATIONS["add"][normalized_language], "🟢", "buy")
     if canonical == "hold":
         return (_OPERATION_ADVICE_TRANSLATIONS["hold"][normalized_language], "🟡", "hold")
     if canonical == "watch":

--- a/src/report_language.py
+++ b/src/report_language.py
@@ -986,8 +986,30 @@ def get_signal_level(advice: Any, score: Any, language: Optional[str]) -> tuple[
 
     if normalize_decision_action is not None:
         action = normalize_decision_action(advice)
-        if action in {"add", "hold", "watch", "reduce", "sell", "avoid", "alert", "buy"}:
-            canonical = action
+        canonical_from_text = _canonicalize_lookup_value(
+            advice,
+            _OPERATION_ADVICE_CANONICAL_MAP,
+        )
+        if action in {
+            "add",
+            "hold",
+            "watch",
+            "reduce",
+            "sell",
+            "avoid",
+            "alert",
+            "buy",
+            "strong_buy",
+            "strong_sell",
+        }:
+            if action == "buy" and canonical_from_text == "strong_buy":
+                canonical = "strong_buy"
+            elif action == "sell" and canonical_from_text == "strong_sell":
+                canonical = "strong_sell"
+            else:
+                canonical = action
+        elif canonical_from_text is not None:
+            canonical = canonical_from_text
         else:
             canonical = _canonicalize_lookup_value(advice, _OPERATION_ADVICE_CANONICAL_MAP)
     else:

--- a/src/schemas/decision_action.py
+++ b/src/schemas/decision_action.py
@@ -239,7 +239,14 @@ _NEGATED_ACTION_PHRASES: Dict[DecisionAction, tuple[str, ...]] = {
 
 _GUARD_ACTIONS: tuple[DecisionAction, ...] = ("avoid", "alert")
 _COMPOUND_GUARD_ACTION_PHRASES: Dict[DecisionAction, tuple[str, ...]] = {
-    "avoid": ("回避买入", "规避买入"),
+    "avoid": (
+        "回避买入",
+        "规避买入",
+        "回避减仓",
+        "规避减仓",
+        "回避卖出",
+        "规避卖出",
+    ),
 }
 _ENGLISH_NEGATED_ACTION_TERMS: Dict[DecisionAction, tuple[str, ...]] = {
     "avoid": ("buy",),

--- a/src/schemas/decision_action.py
+++ b/src/schemas/decision_action.py
@@ -528,6 +528,7 @@ def build_action_fields(
         score=sentiment_score,
         action=action,
         guardrail_reason=guardrail_reason,
+        allow_negated_hold_conflict=not operation_action_is_negated_hold,
     ):
         score_action = action_for_score(sentiment_score)
         if score_action in _ACTION_VALUES:

--- a/src/schemas/decision_action.py
+++ b/src/schemas/decision_action.py
@@ -236,6 +236,9 @@ _NEGATED_ACTION_PHRASES: Dict[DecisionAction, tuple[str, ...]] = {
 }
 
 _GUARD_ACTIONS: tuple[DecisionAction, ...] = ("avoid", "alert")
+_COMPOUND_GUARD_ACTION_PHRASES: Dict[DecisionAction, tuple[str, ...]] = {
+    "avoid": ("回避买入", "规避买入"),
+}
 _ENGLISH_NEGATED_ACTION_TERMS: Dict[DecisionAction, tuple[str, ...]] = {
     "avoid": ("buy",),
     "hold": ("add", "accumulate", "sell", "reduce", "trim"),
@@ -305,6 +308,15 @@ def _has_english_deferred_action(text: str) -> bool:
     )
 
 
+def _resolve_compound_guard_action(text: str) -> Optional[DecisionAction]:
+    """Resolve no-delimiter guard phrases that should stay as guard actions."""
+
+    for action, phrases in _COMPOUND_GUARD_ACTION_PHRASES.items():
+        if any(_word_or_substring_match(text, phrase) for phrase in phrases):
+            return action
+    return None
+
+
 def _explicit_action(value: Any) -> Optional[DecisionAction]:
     normalized = _normalize_key(value)
     if not normalized:
@@ -343,6 +355,10 @@ def normalize_decision_action(value: Any) -> Optional[DecisionAction]:
 
     if _has_english_deferred_action(text):
         return None
+
+    compound_guard_action = _resolve_compound_guard_action(text)
+    if compound_guard_action is not None:
+        return compound_guard_action
 
     segmented_actions = _explicit_segment_actions(value)
     segmented_guard_actions = segmented_actions & set(_GUARD_ACTIONS)

--- a/src/schemas/decision_action.py
+++ b/src/schemas/decision_action.py
@@ -41,6 +41,7 @@ _ACTION_LABELS: Dict[str, Dict[str, str]] = {
 }
 
 _STRONG_BUY_LABELS = {"zh": "强烈买入", "en": "Strong Buy", "ko": "적극 매수"}
+_STRONG_SELL_LABELS = {"zh": "强烈卖出", "en": "Strong Sell", "ko": "적극 매도"}
 
 _LOCALIZED_EXPLICIT_ALIASES: Dict[str, DecisionAction] = {
     label: action
@@ -52,6 +53,8 @@ _EXPLICIT_ALIASES: Dict[str, DecisionAction] = {
     **_LOCALIZED_EXPLICIT_ALIASES,
     "strong buy": "buy",
     "적극 매수": "buy",
+    "적극 매도": "sell",
+    "강력 매도": "sell",
     "accumulate": "add",
     "trim": "reduce",
     "strong sell": "sell",
@@ -112,6 +115,8 @@ _ACTION_PHRASES: Dict[DecisionAction, tuple[str, ...]] = {
         "强烈卖出",
         "strong_sell",
         "strong sell",
+        "적극 매도",
+        "강력 매도",
         "卖出",
         "清仓",
         "sell",
@@ -270,6 +275,15 @@ _STRONG_BUY_TEXT_MARKERS = frozenset(
         "적극 매수",
     }
 )
+_STRONG_SELL_TEXT_MARKERS = frozenset(
+    {
+        "强烈卖出",
+        "strong_sell",
+        "strong sell",
+        "적극 매도",
+        "강력 매도",
+    }
+)
 
 
 def _normalize_key(value: Any) -> str:
@@ -377,6 +391,13 @@ def _has_strong_buy_marker(value: Any) -> bool:
     if not normalized:
         return False
     return any(marker in normalized for marker in _STRONG_BUY_TEXT_MARKERS)
+
+
+def _has_strong_sell_marker(value: Any) -> bool:
+    normalized = _normalize_key(value)
+    if not normalized:
+        return False
+    return any(marker in normalized for marker in _STRONG_SELL_TEXT_MARKERS)
 
 
 def _is_negated_hold_advice(value: Any) -> bool:
@@ -611,6 +632,12 @@ def display_action_fields(
         or _has_strong_buy_marker(action_label)
     ):
         fields["action_label"] = _STRONG_BUY_LABELS[normalize_report_language(report_language)]
+    if fields["action"] == "sell" and (
+        _has_strong_sell_marker(action_source)
+        or _has_strong_sell_marker(operation_advice)
+        or _has_strong_sell_marker(action_label)
+    ):
+        fields["action_label"] = _STRONG_SELL_LABELS[normalize_report_language(report_language)]
     return fields
 
 

--- a/src/schemas/decision_action.py
+++ b/src/schemas/decision_action.py
@@ -11,8 +11,12 @@ from __future__ import annotations
 import re
 from typing import Any, Dict, Literal, Optional, TypedDict, get_args
 
-from src.report_language import normalize_report_language
-from src.schemas.decision_scale import action_for_score, score_action_conflicts_without_guardrail
+from src.report_language import localize_operation_advice, normalize_report_language
+from src.schemas.decision_scale import (
+    action_for_score,
+    extract_decision_guardrail_reason,
+    score_action_conflicts_without_guardrail,
+)
 
 DecisionAction = Literal["buy", "add", "hold", "reduce", "sell", "watch", "avoid", "alert"]
 
@@ -26,17 +30,24 @@ _ACTION_VALUES = set(get_args(DecisionAction))
 _NON_STOCK_REPORT_TYPES = {"market_review"}
 
 _ACTION_LABELS: Dict[str, Dict[str, str]] = {
-    "buy": {"zh": "买入", "en": "Buy"},
-    "add": {"zh": "加仓", "en": "Add"},
-    "hold": {"zh": "持有", "en": "Hold"},
-    "reduce": {"zh": "减仓", "en": "Reduce"},
-    "sell": {"zh": "卖出", "en": "Sell"},
-    "watch": {"zh": "观望", "en": "Watch"},
-    "avoid": {"zh": "回避", "en": "Avoid"},
-    "alert": {"zh": "预警", "en": "Alert"},
+    "buy": {"zh": "买入", "en": "Buy", "ko": "매수"},
+    "add": {"zh": "加仓", "en": "Add", "ko": "추가 매수"},
+    "hold": {"zh": "持有", "en": "Hold", "ko": "보유"},
+    "reduce": {"zh": "减仓", "en": "Reduce", "ko": "비중축소"},
+    "sell": {"zh": "卖出", "en": "Sell", "ko": "매도"},
+    "watch": {"zh": "观望", "en": "Watch", "ko": "관망"},
+    "avoid": {"zh": "回避", "en": "Avoid", "ko": "회피"},
+    "alert": {"zh": "预警", "en": "Alert", "ko": "경고"},
+}
+
+_LOCALIZED_EXPLICIT_ALIASES: Dict[str, DecisionAction] = {
+    label: action
+    for action, labels in _ACTION_LABELS.items()
+    for label in labels.values()
 }
 
 _EXPLICIT_ALIASES: Dict[str, DecisionAction] = {
+    **_LOCALIZED_EXPLICIT_ALIASES,
     "strong buy": "buy",
     "accumulate": "add",
     "trim": "reduce",
@@ -107,6 +118,8 @@ _ACTION_PHRASES: Dict[DecisionAction, tuple[str, ...]] = {
 _NEGATED_ACTION_PHRASES: Dict[DecisionAction, tuple[str, ...]] = {
     "avoid": (
         "暂不买入",
+        "不建议买入",
+        "避免买入",
         "不要买入",
         "不宜买入",
         "先不买入",
@@ -229,6 +242,7 @@ _ENGLISH_NEGATED_ACTION_TERMS: Dict[DecisionAction, tuple[str, ...]] = {
 _ENGLISH_AVOIDED_HOLD_ACTION_TERMS = ("adding", "accumulating", "selling", "reducing", "trimming")
 _ENGLISH_DEFERRED_ACTION_TERMS = ("buy", "add", "accumulate", "sell", "reduce", "trim")
 _FINANCIAL_COMPOUND_SENTINEL = "financialcompound"
+_ACTION_SEGMENT_SPLIT_RE = re.compile(r"[/,，;；、|]+")
 
 
 def _normalize_key(value: Any) -> str:
@@ -299,6 +313,18 @@ def _explicit_action(value: Any) -> Optional[DecisionAction]:
     return _EXPLICIT_ALIASES.get(normalized)
 
 
+def _explicit_segment_actions(value: Any) -> set[DecisionAction]:
+    text = str(value or "").strip()
+    if not text:
+        return set()
+    actions: set[DecisionAction] = set()
+    for segment in _ACTION_SEGMENT_SPLIT_RE.split(text):
+        action = _explicit_action(segment)
+        if action:
+            actions.add(action)
+    return actions
+
+
 def normalize_decision_action(value: Any) -> Optional[DecisionAction]:
     """Return a unique eight-state action for explicit values or clear text.
 
@@ -317,6 +343,17 @@ def normalize_decision_action(value: Any) -> Optional[DecisionAction]:
     if _has_english_deferred_action(text):
         return None
 
+    segmented_actions = _explicit_segment_actions(value)
+    segmented_guard_actions = segmented_actions & set(_GUARD_ACTIONS)
+    segmented_trade_actions = segmented_actions - set(_GUARD_ACTIONS)
+    if segmented_guard_actions:
+        if len(segmented_trade_actions) == 1:
+            return next(iter(segmented_trade_actions))
+        if len(segmented_trade_actions) > 1:
+            if segmented_trade_actions <= {"hold", "watch"}:
+                return "watch" if "watch" in segmented_trade_actions else "hold"
+            return None
+
     negated_matches: set[DecisionAction] = set()
     if _has_english_avoided_hold_action(text):
         negated_matches.add("hold")
@@ -324,19 +361,11 @@ def normalize_decision_action(value: Any) -> Optional[DecisionAction]:
     for action, phrases in _NEGATED_ACTION_PHRASES.items():
         if any(_word_or_substring_match(text, phrase) for phrase in phrases):
             negated_matches.add(action)
-    if len(negated_matches) == 1:
-        return next(iter(negated_matches))
-    if len(negated_matches) > 1:
-        return None
 
     guard_matches: set[DecisionAction] = set()
     for action in _GUARD_ACTIONS:
         if any(_word_or_substring_match(text, phrase) for phrase in _ACTION_PHRASES[action]):
             guard_matches.add(action)
-    if len(guard_matches) == 1:
-        return next(iter(guard_matches))
-    if len(guard_matches) > 1:
-        return None
 
     matches: set[DecisionAction] = set()
     for action, phrases in _ACTION_PHRASES.items():
@@ -345,10 +374,19 @@ def normalize_decision_action(value: Any) -> Optional[DecisionAction]:
         if any(_word_or_substring_match(text, phrase) for phrase in phrases):
             matches.add(action)
 
+    if len(negated_matches) == 1:
+        return None if "alert" in guard_matches else next(iter(negated_matches))
+    if len(negated_matches) > 1:
+        return None
+
     if len(matches) == 1:
         return next(iter(matches))
     if matches and matches <= {"hold", "watch"}:
         return "watch" if "watch" in matches else "hold"
+    if len(guard_matches) == 1:
+        return next(iter(guard_matches))
+    if len(guard_matches) > 1:
+        return None
     return None
 
 
@@ -395,3 +433,157 @@ def build_action_fields(
         "action": action,
         "action_label": localize_action_label(action, report_language) if action else None,
     }
+
+
+def _result_guardrail_reason(result: Any) -> Optional[str]:
+    return extract_decision_guardrail_reason(
+        {
+            "guardrail_reason": getattr(result, "guardrail_reason", None),
+            "downgrade_reason": getattr(result, "downgrade_reason", None),
+            "dashboard": getattr(result, "dashboard", None),
+            "metadata": getattr(result, "metadata", None),
+        }
+    )
+
+
+def display_action_fields(
+    *,
+    operation_advice: Any = None,
+    explicit_action: Any = None,
+    action_label: Any = None,
+    report_type: Any = None,
+    report_language: Optional[str] = "zh",
+    sentiment_score: Any = None,
+    guardrail_reason: Any = None,
+) -> DecisionActionFields:
+    """Return action fields aligned to the canonical score/action display contract."""
+
+    action_source = explicit_action
+    if normalize_decision_action(action_source) is None and str(action_label or "").strip():
+        action_source = action_label
+
+    return build_action_fields(
+        operation_advice=operation_advice,
+        explicit_action=action_source,
+        report_type=report_type,
+        report_language=report_language,
+        sentiment_score=sentiment_score,
+        guardrail_reason=guardrail_reason,
+        align_with_score=True,
+    )
+
+
+def display_operation_advice(
+    *,
+    operation_advice: Any = None,
+    explicit_action: Any = None,
+    action_label: Any = None,
+    report_type: Any = None,
+    report_language: Optional[str] = "zh",
+    sentiment_score: Any = None,
+    guardrail_reason: Any = None,
+) -> str:
+    """Return the public display advice using the canonical score/action scale."""
+
+    fields = display_action_fields(
+        operation_advice=operation_advice,
+        explicit_action=explicit_action,
+        action_label=action_label,
+        report_type=report_type,
+        report_language=report_language,
+        sentiment_score=sentiment_score,
+        guardrail_reason=guardrail_reason,
+    )
+    if fields["action_label"]:
+        return fields["action_label"]
+    return localize_operation_advice(operation_advice, report_language)
+
+
+def _display_result_kwargs(
+    result: Any,
+    *,
+    report_language: Optional[str] = None,
+    report_type: Any = None,
+) -> dict[str, Any]:
+    language = report_language or getattr(result, "report_language", "zh")
+    return {
+        "operation_advice": getattr(result, "operation_advice", None),
+        "explicit_action": getattr(result, "action", None),
+        "action_label": getattr(result, "action_label", None),
+        "report_type": report_type or getattr(result, "report_type", None),
+        "report_language": language,
+        "sentiment_score": getattr(result, "sentiment_score", None),
+        "guardrail_reason": _result_guardrail_reason(result),
+    }
+
+
+def display_operation_advice_for_result(
+    result: Any,
+    *,
+    report_language: Optional[str] = None,
+    report_type: Any = None,
+) -> str:
+    """Return the report-facing operation advice for an AnalysisResult-like object."""
+
+    return display_operation_advice(
+        **_display_result_kwargs(
+            result,
+            report_language=report_language,
+            report_type=report_type,
+        )
+    )
+
+
+def display_action_fields_for_result(
+    result: Any,
+    *,
+    report_language: Optional[str] = None,
+    report_type: Any = None,
+) -> DecisionActionFields:
+    """Return display action fields for an AnalysisResult-like object."""
+
+    return display_action_fields(
+        **_display_result_kwargs(
+            result,
+            report_language=report_language,
+            report_type=report_type,
+        )
+    )
+
+
+def decision_type_for_action(action: Any) -> str:
+    normalized = _explicit_action(action)
+    if normalized in {"buy", "add"}:
+        return "buy"
+    if normalized in {"reduce", "sell"}:
+        return "sell"
+    return "hold"
+
+
+def _legacy_decision_type_for_result(result: Any) -> Optional[str]:
+    normalized = str(getattr(result, "decision_type", "") or "").strip().lower()
+    if normalized in {"buy", "hold", "sell"}:
+        return normalized
+    if normalized == "strong_buy":
+        return "buy"
+    if normalized == "strong_sell":
+        return "sell"
+    return None
+
+
+def display_decision_type_for_result(
+    result: Any,
+    *,
+    report_language: Optional[str] = None,
+    report_type: Any = None,
+) -> str:
+    """Return the three-bucket display decision type used by report summaries."""
+
+    fields = display_action_fields_for_result(
+        result,
+        report_language=report_language,
+        report_type=report_type,
+    )
+    if fields["action"] is not None:
+        return decision_type_for_action(fields["action"])
+    return _legacy_decision_type_for_result(result) or "hold"

--- a/src/schemas/decision_action.py
+++ b/src/schemas/decision_action.py
@@ -343,6 +343,22 @@ def _has_strong_buy_marker(value: Any) -> bool:
     return any(marker in normalized for marker in _STRONG_BUY_TEXT_MARKERS)
 
 
+def _is_negated_hold_advice(value: Any) -> bool:
+    normalized = _normalize_key(value)
+    if not normalized:
+        return False
+
+    text = _mask_english_financial_compounds(normalized)
+    if _has_english_avoided_hold_action(text):
+        return True
+
+    for phrase in _NEGATED_ACTION_PHRASES.get("hold", ()):
+        if _word_or_substring_match(text, phrase):
+            return True
+
+    return False
+
+
 def _explicit_segment_actions(value: Any) -> set[DecisionAction]:
     text = str(value or "").strip()
     if not text:
@@ -460,6 +476,7 @@ def build_action_fields(
     action = normalize_decision_action(explicit_action)
     action_from_legacy = False
     operation_action = normalize_decision_action(operation_advice)
+    operation_action_is_negated_hold = _is_negated_hold_advice(operation_advice)
     legacy_action = normalize_decision_action(legacy_decision_type)
     action_from_legacy = False
 
@@ -470,11 +487,12 @@ def build_action_fields(
         action = legacy_action
         action_from_legacy = True
 
-    if action in {"hold", "watch"} and operation_action in {"hold", "watch"} and legacy_action in {
-        "buy",
-        "reduce",
-        "sell",
-    }:
+    if (
+        action in {"hold", "watch"}
+        and operation_action in {"hold", "watch"}
+        and not operation_action_is_negated_hold
+        and legacy_action in {"buy", "reduce", "sell"}
+    ):
         action = legacy_action
         action_from_legacy = True
 
@@ -539,6 +557,7 @@ def display_action_fields(
     if fields["action"] == "buy" and (
         _has_strong_buy_marker(action_source)
         or _has_strong_buy_marker(operation_advice)
+        or _has_strong_buy_marker(action_label)
     ):
         fields["action_label"] = _STRONG_BUY_LABELS[normalize_report_language(report_language)]
     return fields

--- a/src/schemas/decision_action.py
+++ b/src/schemas/decision_action.py
@@ -40,6 +40,8 @@ _ACTION_LABELS: Dict[str, Dict[str, str]] = {
     "alert": {"zh": "预警", "en": "Alert", "ko": "경고"},
 }
 
+_STRONG_BUY_LABELS = {"zh": "强烈买入", "en": "Strong Buy", "ko": "적극 매수"}
+
 _LOCALIZED_EXPLICIT_ALIASES: Dict[str, DecisionAction] = {
     label: action
     for action, labels in _ACTION_LABELS.items()
@@ -247,6 +249,14 @@ _ENGLISH_AVOIDED_HOLD_ACTION_TERMS = ("adding", "accumulating", "selling", "redu
 _ENGLISH_DEFERRED_ACTION_TERMS = ("buy", "add", "accumulate", "sell", "reduce", "trim")
 _FINANCIAL_COMPOUND_SENTINEL = "financialcompound"
 _ACTION_SEGMENT_SPLIT_RE = re.compile(r"[/,，;；、|]+")
+_STRONG_BUY_TEXT_MARKERS = frozenset(
+    {
+        "强烈买入",
+        "strong_buy",
+        "strong buy",
+        "적극 매수",
+    }
+)
 
 
 def _normalize_key(value: Any) -> str:
@@ -324,6 +334,13 @@ def _explicit_action(value: Any) -> Optional[DecisionAction]:
     if normalized in _ACTION_VALUES:
         return normalized  # type: ignore[return-value]
     return _EXPLICIT_ALIASES.get(normalized)
+
+
+def _has_strong_buy_marker(value: Any) -> bool:
+    normalized = _normalize_key(value)
+    if not normalized:
+        return False
+    return any(marker in normalized for marker in _STRONG_BUY_TEXT_MARKERS)
 
 
 def _explicit_segment_actions(value: Any) -> set[DecisionAction]:
@@ -509,7 +526,7 @@ def display_action_fields(
     if normalize_decision_action(action_source) is None and str(action_label or "").strip():
         action_source = action_label
 
-    return build_action_fields(
+    fields = build_action_fields(
         operation_advice=operation_advice,
         explicit_action=action_source,
         legacy_decision_type=legacy_decision_type,
@@ -519,6 +536,12 @@ def display_action_fields(
         guardrail_reason=guardrail_reason,
         align_with_score=True,
     )
+    if fields["action"] == "buy" and (
+        _has_strong_buy_marker(action_source)
+        or _has_strong_buy_marker(operation_advice)
+    ):
+        fields["action_label"] = _STRONG_BUY_LABELS[normalize_report_language(report_language)]
+    return fields
 
 
 def display_operation_advice(

--- a/src/schemas/decision_action.py
+++ b/src/schemas/decision_action.py
@@ -146,6 +146,7 @@ _NEGATED_ACTION_PHRASES: Dict[DecisionAction, tuple[str, ...]] = {
         "no buy",
         "no need to buy",
         "need not buy",
+        "avoid buying",
         "cannot buy",
         "can't buy",
         "cant buy",
@@ -403,6 +404,7 @@ def build_action_fields(
     *,
     operation_advice: Any = None,
     explicit_action: Any = None,
+    legacy_decision_type: Any = None,
     report_type: Any = None,
     report_language: Optional[str] = "zh",
     sentiment_score: Any = None,
@@ -415,12 +417,32 @@ def build_action_fields(
         return {"action": None, "action_label": None}
 
     action = normalize_decision_action(explicit_action)
+    action_from_legacy = False
+    operation_action = normalize_decision_action(operation_advice)
+    legacy_action = normalize_decision_action(legacy_decision_type)
+    action_from_legacy = False
+
+    if action is None:
+        action = operation_action
+
+    if action is None and legacy_action is not None:
+        action = legacy_action
+        action_from_legacy = True
+
+    if action in {"hold", "watch"} and operation_action in {"hold", "watch"} and legacy_action in {
+        "buy",
+        "reduce",
+        "sell",
+    }:
+        action = legacy_action
+        action_from_legacy = True
+
     if action is None:
         advice_text = str(operation_advice or "").strip()
         if advice_text:
             action = normalize_decision_action(advice_text)
 
-    if align_with_score and score_action_conflicts_without_guardrail(
+    if align_with_score and not action_from_legacy and score_action_conflicts_without_guardrail(
         score=sentiment_score,
         action=action,
         guardrail_reason=guardrail_reason,
@@ -451,6 +473,7 @@ def display_action_fields(
     operation_advice: Any = None,
     explicit_action: Any = None,
     action_label: Any = None,
+    legacy_decision_type: Any = None,
     report_type: Any = None,
     report_language: Optional[str] = "zh",
     sentiment_score: Any = None,
@@ -465,6 +488,7 @@ def display_action_fields(
     return build_action_fields(
         operation_advice=operation_advice,
         explicit_action=action_source,
+        legacy_decision_type=legacy_decision_type,
         report_type=report_type,
         report_language=report_language,
         sentiment_score=sentiment_score,
@@ -541,15 +565,19 @@ def display_action_fields_for_result(
     *,
     report_language: Optional[str] = None,
     report_type: Any = None,
+    legacy_decision_type: Any = None,
 ) -> DecisionActionFields:
     """Return display action fields for an AnalysisResult-like object."""
+    if legacy_decision_type is None:
+        legacy_decision_type = getattr(result, "decision_type", None)
 
     fields = display_action_fields(
         **_display_result_kwargs(
             result,
             report_language=report_language,
             report_type=report_type,
-        )
+        ),
+        legacy_decision_type=legacy_decision_type,
     )
     resolved_report_type = report_type or getattr(result, "report_type", None)
     if fields["action"] is None and str(resolved_report_type or "").strip().lower() not in _NON_STOCK_REPORT_TYPES:

--- a/src/schemas/decision_action.py
+++ b/src/schemas/decision_action.py
@@ -364,6 +364,10 @@ def normalize_decision_action(value: Any) -> Optional[DecisionAction]:
     segmented_guard_actions = segmented_actions & set(_GUARD_ACTIONS)
     segmented_trade_actions = segmented_actions - set(_GUARD_ACTIONS)
     if segmented_guard_actions:
+        if segmented_trade_actions <= {"hold", "watch"}:
+            if len(segmented_guard_actions) == 1:
+                return next(iter(segmented_guard_actions))
+            return None
         if len(segmented_trade_actions) == 1:
             return next(iter(segmented_trade_actions))
         if len(segmented_trade_actions) > 1:
@@ -396,10 +400,14 @@ def normalize_decision_action(value: Any) -> Optional[DecisionAction]:
     if len(negated_matches) > 1:
         return None
 
+    if matches and matches <= {"hold", "watch"}:
+        if guard_matches:
+            if len(guard_matches) == 1:
+                return next(iter(guard_matches))
+            return None
+        return "watch" if "watch" in matches else "hold"
     if len(matches) == 1:
         return next(iter(matches))
-    if matches and matches <= {"hold", "watch"}:
-        return "watch" if "watch" in matches else "hold"
     if len(guard_matches) == 1:
         return next(iter(guard_matches))
     if len(guard_matches) > 1:

--- a/src/schemas/decision_action.py
+++ b/src/schemas/decision_action.py
@@ -393,6 +393,19 @@ def normalize_decision_action(value: Any) -> Optional[DecisionAction]:
     if compound_guard_action is not None:
         return compound_guard_action
 
+    negated_matches: set[DecisionAction] = set()
+    if _has_english_avoided_hold_action(text):
+        negated_matches.add("hold")
+    negated_matches.update(_english_negated_action_matches(text))
+    for action, phrases in _NEGATED_ACTION_PHRASES.items():
+        if any(_word_or_substring_match(text, phrase) for phrase in phrases):
+            negated_matches.add(action)
+
+    if len(negated_matches) == 1:
+        return next(iter(negated_matches))
+    if len(negated_matches) > 1:
+        return None
+
     segmented_actions = _explicit_segment_actions(value)
     segmented_guard_actions = segmented_actions & set(_GUARD_ACTIONS)
     segmented_trade_actions = segmented_actions - set(_GUARD_ACTIONS)
@@ -408,14 +421,6 @@ def normalize_decision_action(value: Any) -> Optional[DecisionAction]:
                 return "watch" if "watch" in segmented_trade_actions else "hold"
             return None
 
-    negated_matches: set[DecisionAction] = set()
-    if _has_english_avoided_hold_action(text):
-        negated_matches.add("hold")
-    negated_matches.update(_english_negated_action_matches(text))
-    for action, phrases in _NEGATED_ACTION_PHRASES.items():
-        if any(_word_or_substring_match(text, phrase) for phrase in phrases):
-            negated_matches.add(action)
-
     guard_matches: set[DecisionAction] = set()
     for action in _GUARD_ACTIONS:
         if any(_word_or_substring_match(text, phrase) for phrase in _ACTION_PHRASES[action]):
@@ -427,11 +432,6 @@ def normalize_decision_action(value: Any) -> Optional[DecisionAction]:
             continue
         if any(_word_or_substring_match(text, phrase) for phrase in phrases):
             matches.add(action)
-
-    if len(negated_matches) == 1:
-        return next(iter(negated_matches))
-    if len(negated_matches) > 1:
-        return None
 
     if matches and matches <= {"hold", "watch"}:
         if guard_matches:

--- a/src/schemas/decision_action.py
+++ b/src/schemas/decision_action.py
@@ -423,6 +423,8 @@ def normalize_decision_action(value: Any) -> Optional[DecisionAction]:
     if len(negated_matches) == 1:
         return next(iter(negated_matches))
     if len(negated_matches) > 1:
+        if "avoid" in negated_matches:
+            return "avoid"
         return None
 
     segmented_actions = _explicit_segment_actions(value)

--- a/src/schemas/decision_action.py
+++ b/src/schemas/decision_action.py
@@ -375,7 +375,7 @@ def normalize_decision_action(value: Any) -> Optional[DecisionAction]:
             matches.add(action)
 
     if len(negated_matches) == 1:
-        return None if "alert" in guard_matches else next(iter(negated_matches))
+        return next(iter(negated_matches))
     if len(negated_matches) > 1:
         return None
 

--- a/src/schemas/decision_action.py
+++ b/src/schemas/decision_action.py
@@ -427,13 +427,16 @@ def _is_negated_hold_advice(value: Any) -> bool:
     return False
 
 
-def _explicit_segment_actions(value: Any) -> set[DecisionAction]:
+def _segment_actions(value: Any) -> set[DecisionAction]:
     text = str(value or "").strip()
     if not text:
         return set()
+    segments = _ACTION_SEGMENT_SPLIT_RE.split(text)
+    if len(segments) == 1:
+        return set()
     actions: set[DecisionAction] = set()
-    for segment in _ACTION_SEGMENT_SPLIT_RE.split(text):
-        action = _explicit_action(segment)
+    for segment in segments:
+        action = normalize_decision_action(segment)
         if action:
             actions.add(action)
     return actions
@@ -464,6 +467,23 @@ def normalize_decision_action(value: Any) -> Optional[DecisionAction]:
     if compound_guard_action is not None:
         return compound_guard_action
 
+    segmented_actions = _segment_actions(value)
+    segmented_guard_actions = segmented_actions & set(_GUARD_ACTIONS)
+    segmented_trade_actions = segmented_actions - set(_GUARD_ACTIONS)
+    if segmented_guard_actions:
+        if segmented_trade_actions <= {"hold", "watch"}:
+            if "avoid" in segmented_guard_actions:
+                return "avoid"
+            if len(segmented_guard_actions) == 1:
+                return next(iter(segmented_guard_actions))
+            return None
+        if len(segmented_trade_actions) == 1:
+            return next(iter(segmented_trade_actions))
+        if len(segmented_trade_actions) > 1:
+            if segmented_trade_actions <= {"hold", "watch"}:
+                return "watch" if "watch" in segmented_trade_actions else "hold"
+            return None
+
     negated_matches: set[DecisionAction] = set()
     if _has_english_avoided_hold_action(text):
         negated_matches.add("hold")
@@ -478,21 +498,6 @@ def normalize_decision_action(value: Any) -> Optional[DecisionAction]:
         if "avoid" in negated_matches:
             return "avoid"
         return None
-
-    segmented_actions = _explicit_segment_actions(value)
-    segmented_guard_actions = segmented_actions & set(_GUARD_ACTIONS)
-    segmented_trade_actions = segmented_actions - set(_GUARD_ACTIONS)
-    if segmented_guard_actions:
-        if segmented_trade_actions <= {"hold", "watch"}:
-            if len(segmented_guard_actions) == 1:
-                return next(iter(segmented_guard_actions))
-            return None
-        if len(segmented_trade_actions) == 1:
-            return next(iter(segmented_trade_actions))
-        if len(segmented_trade_actions) > 1:
-            if segmented_trade_actions <= {"hold", "watch"}:
-                return "watch" if "watch" in segmented_trade_actions else "hold"
-            return None
 
     guard_matches: set[DecisionAction] = set()
     for action in _GUARD_ACTIONS:

--- a/src/schemas/decision_action.py
+++ b/src/schemas/decision_action.py
@@ -328,8 +328,21 @@ def _resolve_compound_guard_action(text: str) -> Optional[DecisionAction]:
 
     if not any(prefix in text for prefix in _COMPOUND_GUARD_PREFIXES):
         return None
-    if any(_word_or_substring_match(text, phrase) for phrase in _COMPOUND_GUARD_ACTION_PHRASES):
-        return "avoid"
+    for prefix in _COMPOUND_GUARD_PREFIXES:
+        if prefix not in text:
+            continue
+        start = 0
+        while True:
+            idx = text.find(prefix, start)
+            if idx == -1:
+                break
+            after_prefix = idx + len(prefix)
+            for phrase in _COMPOUND_GUARD_ACTION_PHRASES:
+                if not phrase:
+                    continue
+                if text.startswith(phrase, after_prefix):
+                    return "avoid"
+            start = after_prefix
     return None
 
 
@@ -479,12 +492,13 @@ def build_action_fields(
     if str(report_type or "").strip().lower() in _NON_STOCK_REPORT_TYPES:
         return {"action": None, "action_label": None}
 
-    action = normalize_decision_action(explicit_action)
-    action_from_legacy = False
     operation_action = normalize_decision_action(operation_advice)
-    operation_action_is_negated_hold = _is_negated_hold_advice(operation_advice)
     legacy_action = normalize_decision_action(legacy_decision_type)
     action_from_legacy = False
+    action = normalize_decision_action(explicit_action)
+
+    explicit_action_is_valid = action is not None
+    operation_action_is_negated_hold = _is_negated_hold_advice(operation_advice)
 
     if action is None:
         action = operation_action
@@ -494,7 +508,8 @@ def build_action_fields(
         action_from_legacy = True
 
     if (
-        action in {"hold", "watch"}
+        not explicit_action_is_valid
+        and action in {"hold", "watch"}
         and operation_action in {"hold", "watch"}
         and not operation_action_is_negated_hold
         and legacy_action in {"buy", "reduce", "sell"}

--- a/src/schemas/decision_action.py
+++ b/src/schemas/decision_action.py
@@ -263,7 +263,16 @@ _ENGLISH_NEGATED_ACTION_TERMS: Dict[DecisionAction, tuple[str, ...]] = {
     "hold": ("add", "accumulate", "sell", "strong sell", "reduce", "trim"),
 }
 _ENGLISH_AVOIDED_HOLD_ACTION_TERMS = ("adding", "accumulating", "selling", "reducing", "trimming")
-_ENGLISH_AVOID_GUARD_ACTION_TERMS = ("buy", "strong buy", "add", "accumulate", "sell", "strong sell")
+_ENGLISH_AVOID_GUARD_ACTION_TERMS = (
+    "buy",
+    "strong buy",
+    "add",
+    "accumulate",
+    "sell",
+    "strong sell",
+    "reduce",
+    "trim",
+)
 _ENGLISH_DEFERRED_ACTION_TERMS = ("buy", "add", "accumulate", "sell", "reduce", "trim")
 _FINANCIAL_COMPOUND_SENTINEL = "financialcompound"
 _ACTION_SEGMENT_SPLIT_RE = re.compile(r"[/,，;；、|]+")

--- a/src/schemas/decision_action.py
+++ b/src/schemas/decision_action.py
@@ -258,6 +258,7 @@ _ENGLISH_NEGATED_ACTION_TERMS: Dict[DecisionAction, tuple[str, ...]] = {
     "hold": ("add", "accumulate", "sell", "strong sell", "reduce", "trim"),
 }
 _ENGLISH_AVOIDED_HOLD_ACTION_TERMS = ("adding", "accumulating", "selling", "reducing", "trimming")
+_ENGLISH_AVOID_GUARD_ACTION_TERMS = ("buy", "strong buy", "add", "accumulate", "sell", "strong sell")
 _ENGLISH_DEFERRED_ACTION_TERMS = ("buy", "add", "accumulate", "sell", "reduce", "trim")
 _FINANCIAL_COMPOUND_SENTINEL = "financialcompound"
 _ACTION_SEGMENT_SPLIT_RE = re.compile(r"[/,，;；、|]+")
@@ -319,6 +320,11 @@ def _english_negated_action_matches(text: str) -> set[DecisionAction]:
 
 def _has_english_avoided_hold_action(text: str) -> bool:
     terms = "|".join(re.escape(term) for term in _ENGLISH_AVOIDED_HOLD_ACTION_TERMS)
+    return bool(re.search(rf"(?<![a-z0-9_])avoid\s+(?:{terms})(?![a-z0-9_])", text))
+
+
+def _has_english_avoid_guard_action(text: str) -> bool:
+    terms = "|".join(re.escape(term) for term in _ENGLISH_AVOID_GUARD_ACTION_TERMS)
     return bool(re.search(rf"(?<![a-z0-9_])avoid\s+(?:{terms})(?![a-z0-9_])", text))
 
 
@@ -420,6 +426,9 @@ def normalize_decision_action(value: Any) -> Optional[DecisionAction]:
 
     if _has_english_deferred_action(text):
         return None
+
+    if _has_english_avoid_guard_action(text):
+        return "avoid"
 
     compound_guard_action = _resolve_compound_guard_action(text)
     if compound_guard_action is not None:

--- a/src/schemas/decision_action.py
+++ b/src/schemas/decision_action.py
@@ -525,13 +525,15 @@ def display_operation_advice_for_result(
 ) -> str:
     """Return the report-facing operation advice for an AnalysisResult-like object."""
 
-    return display_operation_advice(
-        **_display_result_kwargs(
-            result,
-            report_language=report_language,
-            report_type=report_type,
-        )
+    language = report_language or getattr(result, "report_language", "zh")
+    fields = display_action_fields_for_result(
+        result,
+        report_language=language,
+        report_type=report_type,
     )
+    if fields["action_label"]:
+        return fields["action_label"]
+    return localize_operation_advice(getattr(result, "operation_advice", None), language)
 
 
 def display_action_fields_for_result(
@@ -542,13 +544,23 @@ def display_action_fields_for_result(
 ) -> DecisionActionFields:
     """Return display action fields for an AnalysisResult-like object."""
 
-    return display_action_fields(
+    fields = display_action_fields(
         **_display_result_kwargs(
             result,
             report_language=report_language,
             report_type=report_type,
         )
     )
+    resolved_report_type = report_type or getattr(result, "report_type", None)
+    if fields["action"] is None and str(resolved_report_type or "").strip().lower() not in _NON_STOCK_REPORT_TYPES:
+        legacy_action = _legacy_decision_type_for_result(result)
+        if legacy_action:
+            language = report_language or getattr(result, "report_language", "zh")
+            return {
+                "action": legacy_action,
+                "action_label": localize_action_label(legacy_action, language),
+            }
+    return fields
 
 
 def decision_type_for_action(action: Any) -> str:

--- a/src/schemas/decision_action.py
+++ b/src/schemas/decision_action.py
@@ -51,6 +51,7 @@ _LOCALIZED_EXPLICIT_ALIASES: Dict[str, DecisionAction] = {
 _EXPLICIT_ALIASES: Dict[str, DecisionAction] = {
     **_LOCALIZED_EXPLICIT_ALIASES,
     "strong buy": "buy",
+    "적극 매수": "buy",
     "accumulate": "add",
     "trim": "reduce",
     "strong sell": "sell",

--- a/src/schemas/decision_action.py
+++ b/src/schemas/decision_action.py
@@ -238,16 +238,14 @@ _NEGATED_ACTION_PHRASES: Dict[DecisionAction, tuple[str, ...]] = {
 }
 
 _GUARD_ACTIONS: tuple[DecisionAction, ...] = ("avoid", "alert")
-_COMPOUND_GUARD_ACTION_PHRASES: Dict[DecisionAction, tuple[str, ...]] = {
-    "avoid": (
-        "回避买入",
-        "规避买入",
-        "回避减仓",
-        "规避减仓",
-        "回避卖出",
-        "规避卖出",
-    ),
-}
+_COMPOUND_GUARD_PREFIXES = ("回避", "规避", "避免")
+_COMPOUND_GUARD_ACTION_PHRASES: tuple[str, ...] = tuple(
+    {
+        phrase
+        for action in ("buy", "add", "reduce", "sell", "hold", "watch")
+        for phrase in _ACTION_PHRASES[action]
+    }
+)
 _ENGLISH_NEGATED_ACTION_TERMS: Dict[DecisionAction, tuple[str, ...]] = {
     "avoid": ("buy",),
     "hold": ("add", "accumulate", "sell", "reduce", "trim"),
@@ -328,9 +326,10 @@ def _has_english_deferred_action(text: str) -> bool:
 def _resolve_compound_guard_action(text: str) -> Optional[DecisionAction]:
     """Resolve no-delimiter guard phrases that should stay as guard actions."""
 
-    for action, phrases in _COMPOUND_GUARD_ACTION_PHRASES.items():
-        if any(_word_or_substring_match(text, phrase) for phrase in phrases):
-            return action
+    if not any(prefix in text for prefix in _COMPOUND_GUARD_PREFIXES):
+        return None
+    if any(_word_or_substring_match(text, phrase) for phrase in _COMPOUND_GUARD_ACTION_PHRASES):
+        return "avoid"
     return None
 
 

--- a/src/schemas/decision_action.py
+++ b/src/schemas/decision_action.py
@@ -525,11 +525,16 @@ def build_action_fields(
         if advice_text:
             action = normalize_decision_action(advice_text)
 
-    if align_with_score and not action_from_legacy and score_action_conflicts_without_guardrail(
-        score=sentiment_score,
-        action=action,
-        guardrail_reason=guardrail_reason,
-        allow_negated_hold_conflict=not operation_action_is_negated_hold,
+    if (
+        align_with_score
+        and not (explicit_action_is_valid and action == "watch")
+        and not action_from_legacy
+        and score_action_conflicts_without_guardrail(
+            score=sentiment_score,
+            action=action,
+            guardrail_reason=guardrail_reason,
+            allow_negated_hold_conflict=not operation_action_is_negated_hold,
+        )
     ):
         score_action = action_for_score(sentiment_score)
         if score_action in _ACTION_VALUES:

--- a/src/schemas/decision_action.py
+++ b/src/schemas/decision_action.py
@@ -124,6 +124,9 @@ _NEGATED_ACTION_PHRASES: Dict[DecisionAction, tuple[str, ...]] = {
         "不建议买入",
         "避免买入",
         "不要买入",
+        "不建议强烈买入",
+        "避免强烈买入",
+        "不要强烈买入",
         "不宜买入",
         "先不买入",
         "不建议建仓",
@@ -168,6 +171,9 @@ _NEGATED_ACTION_PHRASES: Dict[DecisionAction, tuple[str, ...]] = {
         "暂不增持",
         "无须增持",
         "不建议卖出",
+        "不建议强烈卖出",
+        "避免强烈卖出",
+        "不要强烈卖出",
         "无需卖出",
         "不要卖出",
         "不宜卖出",
@@ -248,8 +254,8 @@ _COMPOUND_GUARD_ACTION_PHRASES: tuple[str, ...] = tuple(
     }
 )
 _ENGLISH_NEGATED_ACTION_TERMS: Dict[DecisionAction, tuple[str, ...]] = {
-    "avoid": ("buy",),
-    "hold": ("add", "accumulate", "sell", "reduce", "trim"),
+    "avoid": ("buy", "strong buy"),
+    "hold": ("add", "accumulate", "sell", "strong sell", "reduce", "trim"),
 }
 _ENGLISH_AVOIDED_HOLD_ACTION_TERMS = ("adding", "accumulating", "selling", "reducing", "trimming")
 _ENGLISH_DEFERRED_ACTION_TERMS = ("buy", "add", "accumulate", "sell", "reduce", "trim")
@@ -300,9 +306,13 @@ def _english_negated_action_matches(text: str) -> set[DecisionAction]:
         r"cannot\s+|can't\s+|cant\s+|"
         r"do\s+not\s+|don't\s+|dont\s+)"
     )
+    negation_strength = r"(?:strong\s+|strongly\s+|very\s+strong\s+)?"
     for action, terms in _ENGLISH_NEGATED_ACTION_TERMS.items():
         for term in terms:
-            if re.search(rf"(?<![a-z0-9_]){negation_prefix}{re.escape(term)}(?![a-z0-9_])", text):
+            if re.search(
+                rf"(?<![a-z0-9_]){negation_prefix}{negation_strength}{re.escape(term)}(?![a-z0-9_])",
+                text,
+            ):
                 matches.add(action)
     return matches
 
@@ -370,6 +380,8 @@ def _is_negated_hold_advice(value: Any) -> bool:
 
     text = _mask_english_financial_compounds(normalized)
     if _has_english_avoided_hold_action(text):
+        return True
+    if "hold" in _english_negated_action_matches(text):
         return True
 
     for phrase in _NEGATED_ACTION_PHRASES.get("hold", ()):

--- a/src/schemas/decision_scale.py
+++ b/src/schemas/decision_scale.py
@@ -157,6 +157,7 @@ def score_action_conflicts_without_guardrail(
     score: Any,
     action: Any,
     guardrail_reason: Any = None,
+    allow_negated_hold_conflict: bool = True,
 ) -> bool:
     """Return True when a neutral action conflicts with a directional score."""
 
@@ -164,6 +165,8 @@ def score_action_conflicts_without_guardrail(
         return False
     normalized_action = str(action or "").strip().lower()
     if normalized_action not in {"hold", "watch"}:
+        return False
+    if not allow_negated_hold_conflict and normalized_action == "hold":
         return False
     score_action = action_for_score(score)
     return score_action in {"buy", "reduce", "sell"}

--- a/src/schemas/decision_scale.py
+++ b/src/schemas/decision_scale.py
@@ -126,9 +126,11 @@ def extract_decision_guardrail_reason(payload: Any) -> Optional[str]:
     calibration = _mapping_or_empty(dashboard.get("decision_score_calibration"))
     stability = _mapping_or_empty(dashboard.get("decision_stability"))
     metadata = _mapping_or_empty(data.get("metadata"))
+    stability_guardrail_reason = stability.get("guardrail_reason")
     stability_reason = stability.get("reason")
     stability_downgrade_reason = stability.get("downgrade_reason")
     if _is_falsey(stability.get("applied")):
+        stability_guardrail_reason = None
         stability_reason = None
         stability_downgrade_reason = None
 
@@ -140,7 +142,7 @@ def extract_decision_guardrail_reason(payload: Any) -> Optional[str]:
         metadata.get("downgrade_reason"),
         calibration.get("guardrail_reason"),
         calibration.get("downgrade_reason"),
-        stability.get("guardrail_reason"),
+        stability_guardrail_reason,
         stability_downgrade_reason,
         stability_reason,
     ):

--- a/src/schemas/decision_scale.py
+++ b/src/schemas/decision_scale.py
@@ -4,7 +4,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any, Optional
+from typing import Any, Mapping, Optional
 
 
 CANONICAL_DECISION_SCALE_VERSION = "decision-scale-v1"
@@ -96,6 +96,58 @@ def score_band_metadata(value: Any) -> dict[str, Any]:
         "canonical_action": band.action,
         "canonical_decision_type": band.decision_type,
     }
+
+
+def _text_or_none(value: Any) -> Optional[str]:
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text or None
+
+
+def _mapping_or_empty(value: Any) -> Mapping[str, Any]:
+    return value if isinstance(value, Mapping) else {}
+
+
+def _is_falsey(value: Any) -> bool:
+    if value is False:
+        return True
+    text = _text_or_none(value)
+    if text is None:
+        return False
+    return text.lower() in {"0", "false", "f", "off", "no", "否"}
+
+
+def extract_decision_guardrail_reason(payload: Any) -> Optional[str]:
+    """Return the first explicit score/action guardrail reason in a report payload."""
+
+    data = _mapping_or_empty(payload)
+    dashboard = _mapping_or_empty(data.get("dashboard"))
+    calibration = _mapping_or_empty(dashboard.get("decision_score_calibration"))
+    stability = _mapping_or_empty(dashboard.get("decision_stability"))
+    metadata = _mapping_or_empty(data.get("metadata"))
+    stability_reason = stability.get("reason")
+    stability_downgrade_reason = stability.get("downgrade_reason")
+    if _is_falsey(stability.get("applied")):
+        stability_reason = None
+        stability_downgrade_reason = None
+
+    for candidate in (
+        data.get("guardrail_reason"),
+        data.get("downgrade_reason"),
+        data.get("decision_score_guardrail_reason"),
+        metadata.get("guardrail_reason"),
+        metadata.get("downgrade_reason"),
+        calibration.get("guardrail_reason"),
+        calibration.get("downgrade_reason"),
+        stability.get("guardrail_reason"),
+        stability_downgrade_reason,
+        stability_reason,
+    ):
+        text = _text_or_none(candidate)
+        if text:
+            return text
+    return None
 
 
 def score_action_conflicts_without_guardrail(

--- a/src/services/history_comparison_service.py
+++ b/src/services/history_comparison_service.py
@@ -12,18 +12,50 @@ import logging
 from typing import Any, Dict, List, Optional
 
 from src.storage import DatabaseManager
+from src.report_language import normalize_report_language
+from src.schemas.decision_action import display_action_fields
+from src.schemas.decision_scale import extract_decision_guardrail_reason
+from src.utils.data_processing import parse_json_field
 
 logger = logging.getLogger(__name__)
 
 
-def _record_to_signal(record: Any) -> Optional[Dict[str, Any]]:
+def _record_to_signal(
+    record: Any,
+    *,
+    report_language: Optional[str] = None,
+) -> Optional[Dict[str, Any]]:
     """Convert AnalysisHistory record to signal dict. Skip on parse error."""
+    raw_result = parse_json_field(getattr(record, "raw_result", None))
+    if not isinstance(raw_result, dict):
+        raw_result = {}
+
+    operation_advice = raw_result.get("operation_advice") or getattr(record, "operation_advice", None)
+    explicit_action = raw_result.get("action")
+    action_label = raw_result.get("action_label")
+    resolved_report_language = normalize_report_language(
+        report_language
+        or raw_result.get("report_language")
+        or getattr(record, "report_language", None)
+    )
+    action_fields = display_action_fields(
+        operation_advice=operation_advice,
+        explicit_action=explicit_action,
+        action_label=action_label,
+        report_type=getattr(record, "report_type", None),
+        report_language=resolved_report_language,
+        sentiment_score=getattr(record, "sentiment_score", None),
+        guardrail_reason=extract_decision_guardrail_reason(raw_result),
+    )
+
     try:
         return {
             "created_at": record.created_at.isoformat() if record.created_at else None,
             "query_id": record.query_id,
             "sentiment_score": record.sentiment_score,
             "operation_advice": record.operation_advice,
+            "action": action_fields["action"],
+            "action_label": action_fields["action_label"],
             "trend_prediction": record.trend_prediction,
         }
     except Exception as e:
@@ -35,6 +67,8 @@ def get_signal_changes(
     code: str,
     limit: int = 5,
     exclude_query_id: Optional[str] = None,
+    *,
+    report_language: Optional[str] = None,
 ) -> List[Dict[str, Any]]:
     """
     Get recent signal changes for a single stock.
@@ -56,7 +90,7 @@ def get_signal_changes(
     )
     out = []
     for r in records:
-        sig = _record_to_signal(r)
+        sig = _record_to_signal(r, report_language=report_language)
         if sig:
             out.append(sig)
     return out
@@ -66,6 +100,8 @@ def get_signal_changes_batch(
     codes: List[str],
     limit: int = 5,
     exclude_query_ids: Optional[Dict[str, str]] = None,
+    *,
+    report_language: Optional[str] = None,
 ) -> Dict[str, List[Dict[str, Any]]]:
     """
     Get recent signal changes for multiple stocks.
@@ -90,7 +126,7 @@ def get_signal_changes_batch(
             exclude_query_id=exclude,
         )
         for r in records:
-            sig = _record_to_signal(r)
+            sig = _record_to_signal(r, report_language=report_language)
             if sig:
                 result[code].append(sig)
     return result

--- a/src/services/history_comparison_service.py
+++ b/src/services/history_comparison_service.py
@@ -20,6 +20,24 @@ from src.utils.data_processing import parse_json_field
 logger = logging.getLogger(__name__)
 
 
+def _raw_result_value(raw_result: Any, key: str) -> Any:
+    if not isinstance(raw_result, dict):
+        return None
+
+    value = raw_result.get(key)
+    if value is not None and value != "":
+        return value
+
+    for container_key in ("summary", "dashboard"):
+        container = raw_result.get(container_key)
+        if isinstance(container, dict):
+            nested_value = container.get(key)
+            if nested_value is not None and nested_value != "":
+                return nested_value
+
+    return None
+
+
 def _record_to_signal(
     record: Any,
     *,
@@ -30,9 +48,9 @@ def _record_to_signal(
     if not isinstance(raw_result, dict):
         raw_result = {}
 
-    operation_advice = raw_result.get("operation_advice") or getattr(record, "operation_advice", None)
-    explicit_action = raw_result.get("action")
-    action_label = raw_result.get("action_label")
+    operation_advice = _raw_result_value(raw_result, "operation_advice") or getattr(record, "operation_advice", None)
+    explicit_action = _raw_result_value(raw_result, "action")
+    action_label = _raw_result_value(raw_result, "action_label")
     resolved_report_language = normalize_report_language(
         report_language
         or raw_result.get("report_language")
@@ -41,6 +59,7 @@ def _record_to_signal(
     action_fields = display_action_fields(
         operation_advice=operation_advice,
         explicit_action=explicit_action,
+        legacy_decision_type=_raw_result_value(raw_result, "decision_type"),
         action_label=action_label,
         report_type=getattr(record, "report_type", None),
         report_language=resolved_report_language,

--- a/src/services/history_service.py
+++ b/src/services/history_service.py
@@ -26,7 +26,6 @@ from src.report_language import (
     is_chip_structure_unavailable,
     localize_bias_status,
     localize_chip_health,
-    localize_operation_advice,
     localize_trend_prediction,
     normalize_report_language,
 )
@@ -36,7 +35,8 @@ from src.market_phase_summary import (
     extract_market_phase_summary,
     rebuild_market_phase_summary_for_stock_code,
 )
-from src.schemas.decision_action import build_action_fields
+from src.schemas.decision_action import display_action_fields, display_operation_advice_for_result
+from src.schemas.decision_scale import extract_decision_guardrail_reason
 from src.utils.sniper_points import find_sniper_points
 from src.utils.data_processing import (
     extract_realtime_detail_fields,
@@ -587,14 +587,14 @@ class HistoryService:
 
     def _decision_action_fields_for_record(self, record, raw_result: Any) -> Dict[str, Any]:
         raw = raw_result if isinstance(raw_result, dict) else {}
-        return build_action_fields(
+        return display_action_fields(
             operation_advice=raw.get("operation_advice") or getattr(record, "operation_advice", None),
             explicit_action=raw.get("action"),
+            action_label=raw.get("action_label"),
             report_type=getattr(record, "report_type", None),
             report_language=normalize_report_language(raw.get("report_language")),
             sentiment_score=getattr(record, "sentiment_score", None),
-            guardrail_reason=raw.get("guardrail_reason") or raw.get("downgrade_reason"),
-            align_with_score=True,
+            guardrail_reason=extract_decision_guardrail_reason(raw),
         )
 
     def delete_history_records(self, record_ids: List[int]) -> int:
@@ -835,7 +835,7 @@ class HistoryService:
             dashboard = raw_result.get("dashboard", {})
 
             # Build AnalysisResult with available data
-            return AnalysisResult(
+            result = AnalysisResult(
                 code=raw_result.get("code", record.code),
                 name=raw_result.get("name", record.name),
                 sentiment_score=raw_result.get("sentiment_score", record.sentiment_score or 50),
@@ -873,6 +873,10 @@ class HistoryService:
                 change_pct=raw_result.get("change_pct"),
                 model_used=raw_result.get("model_used"),
             )
+            guardrail_reason = extract_decision_guardrail_reason(raw_result)
+            if guardrail_reason:
+                setattr(result, "guardrail_reason", guardrail_reason)
+            return result
         except Exception as e:
             logger.error(f"Failed to rebuild AnalysisResult: {e}", exc_info=True)
             return None
@@ -988,7 +992,7 @@ class HistoryService:
             report_lines.extend([
                 f"| {labels['position_status_label']} | {labels['action_advice_label']} |",
                 "|---------|---------|",
-                f"| 🆕 **{labels['no_position_label']}** | {pos_advice.get('no_position', localize_operation_advice(result.operation_advice, report_language))} |",
+                f"| 🆕 **{labels['no_position_label']}** | {pos_advice.get('no_position', self._get_display_operation_advice(result, report_language))} |",
                 f"| 💼 **{labels['has_position_label']}** | {pos_advice.get('has_position', labels['continue_holding'])} |",
                 "",
             ])
@@ -1204,12 +1208,23 @@ class HistoryService:
             return "N/A"
         return text
 
+    def _get_display_operation_advice(
+        self,
+        result: AnalysisResult,
+        report_language: Optional[str] = None,
+    ) -> str:
+        return display_operation_advice_for_result(
+            result,
+            report_language=report_language or getattr(result, "report_language", "zh"),
+        )
+
     def _get_signal_level(self, result: AnalysisResult) -> Tuple[str, str, str]:
         """Get signal level based on sentiment score and decision type."""
+        report_language = getattr(result, "report_language", "zh")
         return get_signal_level(
-            result.operation_advice,
+            self._get_display_operation_advice(result, report_language),
             result.sentiment_score,
-            getattr(result, "report_language", "zh"),
+            report_language,
         )
 
     @staticmethod

--- a/src/services/history_service.py
+++ b/src/services/history_service.py
@@ -152,6 +152,24 @@ class HistoryService:
                     add(f"SS{normalized}")
 
         return candidates
+
+    @staticmethod
+    def _raw_result_value(raw_result: Any, key: str) -> Any:
+        if not isinstance(raw_result, dict):
+            return None
+
+        value = raw_result.get(key)
+        if value is not None and value != "":
+            return value
+
+        for container_key in ("summary", "dashboard"):
+            container = raw_result.get(container_key)
+            if isinstance(container, dict):
+                nested_value = container.get(key)
+                if nested_value is not None and nested_value != "":
+                    return nested_value
+
+        return None
     
     def get_history_list(
         self,
@@ -587,10 +605,12 @@ class HistoryService:
 
     def _decision_action_fields_for_record(self, record, raw_result: Any) -> Dict[str, Any]:
         raw = raw_result if isinstance(raw_result, dict) else {}
+        raw_decision_type = self._raw_result_value(raw, "decision_type")
         return display_action_fields(
-            operation_advice=raw.get("operation_advice") or getattr(record, "operation_advice", None),
-            explicit_action=raw.get("action"),
-            action_label=raw.get("action_label"),
+            operation_advice=self._raw_result_value(raw, "operation_advice") or getattr(record, "operation_advice", None),
+            explicit_action=self._raw_result_value(raw, "action"),
+            legacy_decision_type=raw_decision_type,
+            action_label=self._raw_result_value(raw, "action_label"),
             report_type=getattr(record, "report_type", None),
             report_language=normalize_report_language(raw.get("report_language")),
             sentiment_score=getattr(record, "sentiment_score", None),

--- a/src/services/history_service.py
+++ b/src/services/history_service.py
@@ -851,6 +851,27 @@ class HistoryService:
         """
         try:
             from src.analyzer import AnalysisResult
+            resolved_report_language = normalize_report_language(
+                self._raw_result_value(raw_result, "report_language")
+                or getattr(record, "report_language", None)
+            )
+            raw_action = self._raw_result_value(raw_result, "action")
+            raw_action_label = self._raw_result_value(raw_result, "action_label")
+            raw_decision_type = self._raw_result_value(raw_result, "decision_type")
+            operation_advice = (
+                self._raw_result_value(raw_result, "operation_advice")
+                or getattr(record, "operation_advice", "")
+            )
+            action_fields = display_action_fields(
+                operation_advice=operation_advice,
+                explicit_action=raw_action,
+                legacy_decision_type=raw_decision_type,
+                action_label=raw_action_label,
+                report_type=getattr(record, "report_type", None),
+                report_language=resolved_report_language,
+                sentiment_score=raw_result.get("sentiment_score", record.sentiment_score or 50),
+                guardrail_reason=extract_decision_guardrail_reason(raw_result),
+            )
             # Extract dashboard data if available
             dashboard = raw_result.get("dashboard", {})
 
@@ -860,12 +881,12 @@ class HistoryService:
                 name=raw_result.get("name", record.name),
                 sentiment_score=raw_result.get("sentiment_score", record.sentiment_score or 50),
                 trend_prediction=raw_result.get("trend_prediction", record.trend_prediction or ""),
-                operation_advice=raw_result.get("operation_advice", record.operation_advice or ""),
-                decision_type=raw_result.get("decision_type", "hold"),
+                operation_advice=operation_advice,
+                decision_type=raw_decision_type or "hold",
                 confidence_level=raw_result.get("confidence_level", "中"),
-                report_language=normalize_report_language(raw_result.get("report_language")),
-                action=raw_result.get("action"),
-                action_label=raw_result.get("action_label"),
+                report_language=resolved_report_language,
+                action=action_fields["action"],
+                action_label=action_fields["action_label"],
                 dashboard=dashboard,
                 trend_analysis=raw_result.get("trend_analysis", ""),
                 short_term_outlook=raw_result.get("short_term_outlook", ""),

--- a/src/services/report_renderer.py
+++ b/src/services/report_renderer.py
@@ -28,6 +28,11 @@ from src.report_language import (
     localize_trend_prediction,
     normalize_report_language,
 )
+from src.schemas.decision_action import (
+    display_decision_type_for_result,
+    display_operation_advice_for_result,
+    localize_action_label,
+)
 from src.utils.data_processing import (
     normalize_model_used,
     signal_attribution_has_content,
@@ -126,20 +131,28 @@ def render(
     sorted_results = sorted(results, key=lambda x: x.sentiment_score, reverse=True)
     sorted_enriched = []
     for r in sorted_results:
-        st, se, _ = get_signal_level(r.operation_advice, r.sentiment_score, report_language)
+        display_advice = display_operation_advice_for_result(
+            r,
+            report_language=report_language,
+        )
+        st, se, _ = get_signal_level(display_advice, r.sentiment_score, report_language)
         rn = get_localized_stock_name(r.name, r.code, report_language)
         sorted_enriched.append({
             "result": r,
             "signal_text": st,
             "signal_emoji": se,
             "stock_name": _escape_md(rn),
-            "localized_operation_advice": localize_operation_advice(r.operation_advice, report_language),
+            "localized_operation_advice": display_advice,
             "localized_trend_prediction": localize_trend_prediction(r.trend_prediction, report_language),
         })
 
-    buy_count = sum(1 for r in results if getattr(r, "decision_type", "") == "buy")
-    sell_count = sum(1 for r in results if getattr(r, "decision_type", "") == "sell")
-    hold_count = sum(1 for r in results if getattr(r, "decision_type", "") in ("hold", ""))
+    display_buckets = [
+        display_decision_type_for_result(r, report_language=report_language)
+        for r in results
+    ]
+    buy_count = sum(1 for bucket in display_buckets if bucket == "buy")
+    sell_count = sum(1 for bucket in display_buckets if bucket == "sell")
+    hold_count = len(display_buckets) - buy_count - sell_count
     show_llm_model = bool(getattr(get_config(), "report_show_llm_model", True))
     models_used: List[str] = []
     if show_llm_model:
@@ -202,6 +215,7 @@ def render(
         "get_chip_unavailable_reason": get_chip_unavailable_reason,
         "is_chip_structure_unavailable": is_chip_structure_unavailable,
         "localize_operation_advice": localize_operation_advice,
+        "localize_action_label": localize_action_label,
         "localize_trend_prediction": localize_trend_prediction,
         "localize_chip_health": localize_chip_health,
         "signal_attribution_has_content": signal_attribution_has_content,

--- a/src/services/report_renderer.py
+++ b/src/services/report_renderer.py
@@ -216,6 +216,7 @@ def render(
         "is_chip_structure_unavailable": is_chip_structure_unavailable,
         "localize_operation_advice": localize_operation_advice,
         "localize_action_label": localize_action_label,
+        "get_signal_level": get_signal_level,
         "localize_trend_prediction": localize_trend_prediction,
         "localize_chip_health": localize_chip_health,
         "signal_attribution_has_content": signal_attribution_has_content,

--- a/templates/report_brief.j2
+++ b/templates/report_brief.j2
@@ -9,7 +9,7 @@
 {% set dash = e.result.dashboard or {} %}
 {% set core = (dash.get('core_conclusion') or {}) if dash else {} %}
 {% set one = (core.get('one_sentence') or e.result.analysis_summary or '')[:60] %}
-**{{ e.stock_name }}({{ e.result.code }})** {{ e.signal_emoji }} {{ e.localized_operation_advice }} | {{ labels.score_label }} {{ e.result.sentiment_score }} | {{ one }}
+**{{ e.stock_name }}({{ e.result.code }})** {{ e.signal_emoji }} {{ e.signal_text }} | {{ labels.score_label }} {{ e.result.sentiment_score }} | {{ one }}
 {% endfor %}
 
 *{{ report_timestamp }}*

--- a/templates/report_markdown.j2
+++ b/templates/report_markdown.j2
@@ -215,7 +215,7 @@
 | {{ labels.time_label }} | {{ labels.score_label }} | {{ labels.advice_label }} | {{ labels.trend_label }} |
 |------|------|------|------|
 {% for h in hist %}
-| {{ h.created_at[:16] if h.created_at else 'N/A' }} | {{ h.sentiment_score or 'N/A' }} | {{ localize_action_label(h.action, report_language) or localize_action_label(h.action_label, report_language) or localize_operation_advice(h.operation_advice or 'N/A', report_language) }} | {{ localize_trend_prediction(h.trend_prediction or 'N/A', report_language) }} |
+| {{ h.created_at[:16] if h.created_at else 'N/A' }} | {{ h.sentiment_score or 'N/A' }} | {{ get_signal_level(localize_action_label(h.action, report_language) or localize_action_label(h.action_label, report_language) or localize_operation_advice(h.operation_advice or 'N/A', report_language), h.sentiment_score, report_language)[0] }} | {{ localize_trend_prediction(h.trend_prediction or 'N/A', report_language) }} |
 {% endfor %}
 {% endif %}
 

--- a/templates/report_markdown.j2
+++ b/templates/report_markdown.j2
@@ -9,7 +9,7 @@
 ## 📊 {{ labels.summary_heading }}
 
 {% for e in enriched %}
-{{ e.signal_emoji }} **{{ e.stock_name }}({{ e.result.code }})**: {{ e.localized_operation_advice }} | {{ labels.score_label }} {{ e.result.sentiment_score }} | {{ e.localized_trend_prediction }}
+{{ e.signal_emoji }} **{{ e.stock_name }}({{ e.result.code }})**: {{ e.signal_text }} | {{ labels.score_label }} {{ e.result.sentiment_score }} | {{ e.localized_trend_prediction }}
 {% endfor %}
 
 ---
@@ -71,7 +71,7 @@
 {% if pos_advice %}
 | {{ labels.position_status_label }} | {{ labels.action_advice_label }} |
 |---------|---------|
-| 🆕 **{{ labels.no_position_label }}** | {{ pos_advice.get('no_position', localize_operation_advice(result.operation_advice, report_language)) }} |
+| 🆕 **{{ labels.no_position_label }}** | {{ pos_advice.get('no_position', e.localized_operation_advice) }} |
 | 💼 **{{ labels.has_position_label }}** | {{ pos_advice.get('has_position', labels.continue_holding) }} |
 {% endif %}
 
@@ -215,7 +215,7 @@
 | {{ labels.time_label }} | {{ labels.score_label }} | {{ labels.advice_label }} | {{ labels.trend_label }} |
 |------|------|------|------|
 {% for h in hist %}
-| {{ h.created_at[:16] if h.created_at else 'N/A' }} | {{ h.sentiment_score or 'N/A' }} | {{ localize_operation_advice(h.operation_advice or 'N/A', report_language) }} | {{ localize_trend_prediction(h.trend_prediction or 'N/A', report_language) }} |
+| {{ h.created_at[:16] if h.created_at else 'N/A' }} | {{ h.sentiment_score or 'N/A' }} | {{ localize_action_label(h.action, report_language) or localize_action_label(h.action_label, report_language) or localize_operation_advice(h.operation_advice or 'N/A', report_language) }} | {{ localize_trend_prediction(h.trend_prediction or 'N/A', report_language) }} |
 {% endfor %}
 {% endif %}
 

--- a/templates/report_markdown.j2
+++ b/templates/report_markdown.j2
@@ -215,7 +215,19 @@
 | {{ labels.time_label }} | {{ labels.score_label }} | {{ labels.advice_label }} | {{ labels.trend_label }} |
 |------|------|------|------|
 {% for h in hist %}
-| {{ h.created_at[:16] if h.created_at else 'N/A' }} | {{ h.sentiment_score or 'N/A' }} | {{ get_signal_level(localize_action_label(h.action, report_language) or localize_action_label(h.action_label, report_language) or localize_operation_advice(h.operation_advice or 'N/A', report_language), h.sentiment_score, report_language)[0] }} | {{ localize_trend_prediction(h.trend_prediction or 'N/A', report_language) }} |
+{% set signal_from_action_label = None %}
+{% if h.action_label %}
+{% set signal_from_action_label = get_signal_level(h.action_label, h.sentiment_score, report_language) %}
+{% endif %}
+{% set signal_advice = signal_from_action_label[2] in ["strong_buy", "strong_sell"] if signal_from_action_label else None %}
+{% if h.action and signal_advice %}
+{% set signal_source = h.action_label %}
+{% elif h.action %}
+{% set signal_source = localize_action_label(h.action, report_language) %}
+{% else %}
+{% set signal_source = h.action_label %}
+{% endif %}
+| {{ h.created_at[:16] if h.created_at else 'N/A' }} | {{ h.sentiment_score or 'N/A' }} | {{ get_signal_level(signal_source or localize_action_label(h.action, report_language) or localize_operation_advice(h.operation_advice or 'N/A', report_language), h.sentiment_score, report_language)[0] }} | {{ localize_trend_prediction(h.trend_prediction or 'N/A', report_language) }} |
 {% endfor %}
 {% endif %}
 

--- a/templates/report_wechat.j2
+++ b/templates/report_wechat.j2
@@ -8,7 +8,7 @@
 {% if summary_only %}
 **📊 {{ labels.summary_heading }}**
 {% for e in enriched %}
-{{ e.signal_emoji }} **{{ e.stock_name }}({{ e.result.code }})**: {{ e.localized_operation_advice }} | {{ labels.score_label }} {{ e.result.sentiment_score }} | {{ e.localized_trend_prediction }}
+{{ e.signal_emoji }} **{{ e.stock_name }}({{ e.result.code }})**: {{ e.signal_text }} | {{ labels.score_label }} {{ e.result.sentiment_score }} | {{ e.localized_trend_prediction }}
 {% endfor %}
 {% else %}
 {% for e in enriched %}

--- a/tests/test_analysis_api_contract.py
+++ b/tests/test_analysis_api_contract.py
@@ -1527,6 +1527,32 @@ class AnalysisApiContractTestCase(unittest.TestCase):
         self.assertEqual(report.summary.action, "buy")
         self.assertEqual(report.summary.action_label, "买入")
 
+    def test_build_analysis_report_prefers_negated_hold_over_legacy_decision_type(self) -> None:
+        if _build_analysis_report is None:
+            self.skipTest("analysis endpoint helpers unavailable in this environment")
+
+        report = _build_analysis_report(
+            report_data={
+                "meta": {"report_type": "detailed", "report_language": "zh"},
+                "summary": {
+                    "analysis_summary": "等待确认",
+                    "operation_advice": "不建议卖出",
+                    "sentiment_score": 50,
+                },
+                "strategy": {},
+                "details": {"decision_type": "sell"},
+            },
+            query_id="q4",
+            stock_code="600519",
+            stock_name="贵州茅台",
+            context_snapshot=None,
+            fallback_fundamental_payload=None,
+        )
+
+        self.assertEqual(report.summary.operation_advice, "不建议卖出")
+        self.assertEqual(report.summary.action, "hold")
+        self.assertEqual(report.summary.action_label, "持有")
+
     def test_build_analysis_report_preserves_legacy_action_with_dashboard_guardrail_reason(self) -> None:
         if _build_analysis_report is None:
             self.skipTest("analysis endpoint helpers unavailable in this environment")

--- a/tests/test_analysis_api_contract.py
+++ b/tests/test_analysis_api_contract.py
@@ -1553,6 +1553,58 @@ class AnalysisApiContractTestCase(unittest.TestCase):
         self.assertEqual(report.summary.action, "hold")
         self.assertEqual(report.summary.action_label, "持有")
 
+    def test_build_analysis_report_keeps_negated_hold_with_high_directional_score(self) -> None:
+        if _build_analysis_report is None:
+            self.skipTest("analysis endpoint helpers unavailable in this environment")
+
+        report = _build_analysis_report(
+            report_data={
+                "meta": {"report_type": "detailed", "report_language": "zh"},
+                "summary": {
+                    "analysis_summary": "等待确认",
+                    "operation_advice": "不建议加仓",
+                    "sentiment_score": 72,
+                },
+                "strategy": {},
+                "details": {},
+            },
+            query_id="q3",
+            stock_code="600519",
+            stock_name="贵州茅台",
+            context_snapshot=None,
+            fallback_fundamental_payload=None,
+        )
+
+        self.assertEqual(report.summary.operation_advice, "不建议加仓")
+        self.assertEqual(report.summary.action, "hold")
+        self.assertEqual(report.summary.action_label, "持有")
+
+    def test_build_analysis_report_keeps_negated_hold_with_low_directional_score(self) -> None:
+        if _build_analysis_report is None:
+            self.skipTest("analysis endpoint helpers unavailable in this environment")
+
+        report = _build_analysis_report(
+            report_data={
+                "meta": {"report_type": "detailed", "report_language": "zh"},
+                "summary": {
+                    "analysis_summary": "等待确认",
+                    "operation_advice": "do not sell",
+                    "sentiment_score": 28,
+                },
+                "strategy": {},
+                "details": {},
+            },
+            query_id="q4",
+            stock_code="600519",
+            stock_name="贵州茅台",
+            context_snapshot=None,
+            fallback_fundamental_payload=None,
+        )
+
+        self.assertEqual(report.summary.operation_advice, "do not sell")
+        self.assertEqual(report.summary.action, "hold")
+        self.assertEqual(report.summary.action_label, "持有")
+
     def test_build_analysis_report_preserves_legacy_action_with_dashboard_guardrail_reason(self) -> None:
         if _build_analysis_report is None:
             self.skipTest("analysis endpoint helpers unavailable in this environment")

--- a/tests/test_analysis_api_contract.py
+++ b/tests/test_analysis_api_contract.py
@@ -651,6 +651,121 @@ class AnalysisApiContractTestCase(unittest.TestCase):
         self.assertEqual(status.result.report["summary"]["action"], "watch")
         self.assertEqual(status.result.report["summary"]["action_label"], "观望")
 
+    def test_get_analysis_status_prefers_action_label_when_raw_action_is_invalid(self) -> None:
+        if get_analysis_status is None or analysis_endpoint_module is None:
+            self.skipTest("analysis endpoint helpers unavailable in this environment")
+
+        created_at = datetime(2026, 5, 21, 17, 40, 0)
+        queue = MagicMock()
+        queue.get_task.return_value = SimpleNamespace(
+            task_id="task-queue-invalid-action-label",
+            stock_code="600519",
+            stock_name="贵州茅台",
+            status=analysis_endpoint_module.TaskStatusEnum.COMPLETED,
+            progress=100,
+            result={
+                "stock_code": "600519",
+                "stock_name": "贵州茅台",
+                "report": {
+                    "meta": {
+                        "query_id": "task-queue-invalid-action-label",
+                        "stock_code": "600519",
+                        "report_type": "detailed",
+                        "report_language": "zh",
+                    },
+                    "summary": {
+                        "analysis_summary": "summary",
+                        "sentiment_score": 72,
+                        "action_label": "回避",
+                    },
+                    "details": {
+                        "raw_result": {
+                            "action": "invalid_action",
+                            "action_label": "回避",
+                        },
+                    },
+                },
+            },
+            error=None,
+            original_query=None,
+            selection_source=None,
+            analysis_phase="auto",
+            created_at=created_at,
+            completed_at=datetime(2026, 5, 21, 17, 45, 0),
+        )
+
+        with patch("api.v1.endpoints.analysis.get_task_queue", return_value=queue), \
+             patch(
+                 "api.v1.endpoints.analysis._load_sync_fundamental_sources",
+                 return_value=({}, None),
+             ):
+            status = get_analysis_status("task-queue-invalid-action-label")
+
+        self.assertEqual(status.status, "completed")
+        self.assertIsNotNone(status.result)
+        self.assertEqual(status.result.report["summary"]["action"], "avoid")
+        self.assertEqual(status.result.report["summary"]["action_label"], "回避")
+
+    def test_get_analysis_status_prefers_legacy_action_when_dashboard_guardrail_reason_exists(self) -> None:
+        if get_analysis_status is None or analysis_endpoint_module is None:
+            self.skipTest("analysis endpoint helpers unavailable in this environment")
+
+        created_at = datetime(2026, 5, 21, 17, 40, 0)
+        queue = MagicMock()
+        queue.get_task.return_value = SimpleNamespace(
+            task_id="task-queue-dashboard-guardrail",
+            stock_code="600519",
+            stock_name="贵州茅台",
+            status=analysis_endpoint_module.TaskStatusEnum.COMPLETED,
+            progress=100,
+            result={
+                "stock_code": "600519",
+                "stock_name": "贵州茅台",
+                "report": {
+                    "meta": {
+                        "query_id": "task-queue-dashboard-guardrail",
+                        "stock_code": "600519",
+                        "report_type": "detailed",
+                        "report_language": "zh",
+                    },
+                    "summary": {
+                        "analysis_summary": "summary",
+                        "operation_advice": "持有",
+                        "sentiment_score": 72,
+                    },
+                    "details": {
+                        "raw_result": {
+                            "operation_advice": "持有",
+                            "dashboard": {
+                                "decision_stability": {
+                                    "applied": True,
+                                    "reason": "宏观事件干扰",
+                                }
+                            },
+                        },
+                    },
+                },
+            },
+            error=None,
+            original_query=None,
+            selection_source=None,
+            analysis_phase="auto",
+            created_at=created_at,
+            completed_at=datetime(2026, 5, 21, 17, 45, 0),
+        )
+
+        with patch("api.v1.endpoints.analysis.get_task_queue", return_value=queue), \
+             patch(
+                 "api.v1.endpoints.analysis._load_sync_fundamental_sources",
+                 return_value=({}, None),
+             ):
+            status = get_analysis_status("task-queue-dashboard-guardrail")
+
+        self.assertEqual(status.status, "completed")
+        self.assertIsNotNone(status.result)
+        self.assertEqual(status.result.report["summary"]["action"], "hold")
+        self.assertEqual(status.result.report["summary"]["action_label"], "持有")
+
     def test_get_analysis_status_preserves_zero_sentiment_score_when_aligning_action(self) -> None:
         if get_analysis_status is None or analysis_endpoint_module is None:
             self.skipTest("analysis endpoint helpers unavailable in this environment")
@@ -1411,6 +1526,40 @@ class AnalysisApiContractTestCase(unittest.TestCase):
 
         self.assertEqual(report.summary.action, "buy")
         self.assertEqual(report.summary.action_label, "买入")
+
+    def test_build_analysis_report_preserves_legacy_action_with_dashboard_guardrail_reason(self) -> None:
+        if _build_analysis_report is None:
+            self.skipTest("analysis endpoint helpers unavailable in this environment")
+
+        report = _build_analysis_report(
+            report_data={
+                "meta": {"report_type": "detailed", "report_language": "zh"},
+                "summary": {
+                    "analysis_summary": "等待确认",
+                    "operation_advice": "持有",
+                    "sentiment_score": 72,
+                },
+                "strategy": {},
+                "details": {
+                    "raw_result": {
+                        "operation_advice": "持有",
+                        "dashboard": {
+                            "decision_score_calibration": {
+                                "guardrail_reason": "短线风险上升",
+                            }
+                        },
+                    },
+                },
+            },
+            query_id="q3",
+            stock_code="600519",
+            stock_name="贵州茅台",
+            context_snapshot=None,
+            fallback_fundamental_payload=None,
+        )
+
+        self.assertEqual(report.summary.action, "hold")
+        self.assertEqual(report.summary.action_label, "持有")
 
     def test_build_analysis_report_reads_decision_action_from_raw_result(self) -> None:
         if _build_analysis_report is None:

--- a/tests/test_analysis_api_contract.py
+++ b/tests/test_analysis_api_contract.py
@@ -1673,6 +1673,39 @@ class AnalysisApiContractTestCase(unittest.TestCase):
         self.assertEqual(report.summary.action, "watch")
         self.assertEqual(report.summary.action_label, "观望")
 
+    def test_build_analysis_report_reads_explicit_watch_action_without_directional_score_alignment(self) -> None:
+        if _build_analysis_report is None:
+            self.skipTest("analysis endpoint helpers unavailable in this environment")
+
+        report = _build_analysis_report(
+            report_data={
+                "meta": {"report_type": "detailed", "report_language": "zh"},
+                "summary": {
+                    "analysis_summary": "等待确认",
+                    "operation_advice": "持有",
+                    "sentiment_score": 72,
+                    "trend_prediction": "震荡",
+                    "action": "watch",
+                },
+                "strategy": {},
+                "details": {
+                    "raw_result": {
+                        "operation_advice": "持有",
+                        "action": "watch",
+                        "report_language": "zh",
+                    },
+                },
+            },
+            query_id="q-explicit-watch",
+            stock_code="600519",
+            stock_name="贵州茅台",
+            context_snapshot=None,
+            fallback_fundamental_payload=None,
+        )
+
+        self.assertEqual(report.summary.action, "watch")
+        self.assertEqual(report.summary.action_label, "观望")
+
     def test_build_analysis_report_stringifies_strategy_price_fields(self) -> None:
         if _build_analysis_report is None:
             self.skipTest("analysis endpoint helpers unavailable in this environment")

--- a/tests/test_analysis_history.py
+++ b/tests/test_analysis_history.py
@@ -825,6 +825,133 @@ class AnalysisHistoryTestCase(unittest.TestCase):
         self.assertEqual(response.items[0].action, "buy")
         self.assertEqual(response.items[0].action_label, "Buy")
 
+    def test_stock_bar_item_prefers_raw_action_label_over_score_alignment(self) -> None:
+        if get_stock_bar is None:
+            self.skipTest("fastapi is not installed in this test environment")
+
+        result = self._build_result()
+        result.operation_advice = "持有"
+        result.action = None
+        result.action_label = "回避"
+        result.sentiment_score = 84
+
+        saved = self.db.save_analysis_history(
+            result=result,
+            query_id="query_stock_bar_action_label",
+            report_type="detailed",
+            news_content="个股正文",
+            context_snapshot=None,
+            save_snapshot=False,
+        )
+        self.assertGreater(saved, 0)
+
+        response = get_stock_bar(
+            start_date=None,
+            end_date=None,
+            limit=10,
+            db_manager=self.db,
+        )
+
+        self.assertEqual(len(response.items), 1)
+        self.assertEqual(response.items[0].action, "avoid")
+        self.assertEqual(response.items[0].action_label, "回避")
+
+    def test_stock_bar_item_prefers_action_label_when_raw_action_is_invalid(self) -> None:
+        if get_stock_bar is None:
+            self.skipTest("fastapi is not installed in this test environment")
+
+        result = self._build_result()
+        result.operation_advice = "持有"
+        result.action = "unknown"
+        result.action_label = "回避"
+        result.sentiment_score = 84
+
+        saved = self.db.save_analysis_history(
+            result=result,
+            query_id="query_stock_bar_invalid_action",
+            report_type="detailed",
+            news_content="个股正文",
+            context_snapshot=None,
+            save_snapshot=False,
+        )
+        self.assertGreater(saved, 0)
+
+        response = get_stock_bar(
+            start_date=None,
+            end_date=None,
+            limit=10,
+            db_manager=self.db,
+        )
+
+        self.assertEqual(len(response.items), 1)
+        self.assertEqual(response.items[0].action, "avoid")
+        self.assertEqual(response.items[0].action_label, "回避")
+
+    def test_history_list_and_detail_use_raw_label_when_action_is_invalid(self) -> None:
+        result = self._build_result()
+        result.operation_advice = "持有"
+        result.action = "unknown"
+        result.action_label = "回避"
+        result.sentiment_score = 84
+
+        saved = self.db.save_analysis_history(
+            result=result,
+            query_id="query_history_invalid_action_label",
+            report_type="detailed",
+            news_content="个股正文",
+            context_snapshot=None,
+            save_snapshot=False,
+        )
+        self.assertGreater(saved, 0)
+
+        service = HistoryService(self.db)
+        listing = service.get_history_list(page=1, limit=10)
+        detail = service.resolve_and_get_detail("query_history_invalid_action_label")
+
+        self.assertEqual(listing["items"][0]["action"], "avoid")
+        self.assertEqual(listing["items"][0]["action_label"], "回避")
+        self.assertIsNotNone(detail)
+        self.assertEqual(detail["action"], "avoid")
+        self.assertEqual(detail["action_label"], "回避")
+
+    def test_stock_bar_item_keeps_guardrailed_advice_from_dashboard_when_aligning(self) -> None:
+        if get_stock_bar is None:
+            self.skipTest("fastapi is not installed in this test environment")
+
+        result = self._build_result()
+        result.operation_advice = "持有"
+        result.sentiment_score = 84
+        result.dashboard = {
+            "decision_stability": {
+                "applied": True,
+                "reason": "资金流不稳定，暂缓进场",
+            }
+        }
+
+        saved = self.db.save_analysis_history(
+            result=result,
+            query_id="query_stock_bar_guardrail",
+            report_type="detailed",
+            news_content="个股正文",
+            context_snapshot={
+                "market_phase_summary": {"market": "cn", "phase": "intraday"},
+            },
+            save_snapshot=False,
+        )
+        self.assertGreater(saved, 0)
+
+        response = get_stock_bar(
+            start_date=None,
+            end_date=None,
+            limit=10,
+            db_manager=self.db,
+        )
+
+        self.assertEqual(len(response.items), 1)
+        self.assertEqual(response.items[0].sentiment_score, 84)
+        self.assertEqual(response.items[0].action, "hold")
+        self.assertEqual(response.items[0].action_label, "持有")
+
     def test_history_detail_uses_service_resolved_action_fields(self) -> None:
         if get_history_detail is None:
             self.skipTest("fastapi is not installed in this test environment")
@@ -1674,6 +1801,120 @@ class AnalysisHistoryTestCase(unittest.TestCase):
         self.assertIsNotNone(markdown)
         self.assertIn("**筹码**: 筹码分布未启用或数据源暂不可用，未纳入筹码判断。", markdown)
         self.assertEqual(markdown.count("数据缺失，无法判断"), 0)
+
+    def test_history_markdown_aligns_display_advice_with_score(self) -> None:
+        result = AnalysisResult(
+            code="301308.SZ",
+            name="江波龙",
+            sentiment_score=70,
+            trend_prediction="看多",
+            operation_advice="持有",
+            analysis_summary="高分但旧建议仍为持有",
+            dashboard={
+                "core_conclusion": {"one_sentence": "高分但旧建议仍为持有"},
+            },
+        )
+
+        saved = self.db.save_analysis_history(
+            result=result,
+            query_id="query_display_advice_score_aligned_001",
+            report_type="full",
+            news_content="news",
+            context_snapshot=None,
+            save_snapshot=False,
+        )
+        self.assertGreater(saved, 0)
+
+        with self.db.get_session() as session:
+            row = session.query(AnalysisHistory).filter(
+                AnalysisHistory.query_id == "query_display_advice_score_aligned_001"
+            ).first()
+            if row is None:
+                self.fail("未找到保存的历史记录")
+            record_id = row.id
+
+        markdown = HistoryService(self.db).get_markdown_report(str(record_id))
+
+        self.assertIsNotNone(markdown)
+        self.assertIn("**🟢 买入** | 看多", markdown)
+        self.assertNotIn("**🟡 持有** | 看多", markdown)
+
+    def test_history_markdown_preserves_top_level_guardrail_reason(self) -> None:
+        result = AnalysisResult(
+            code="301308.SZ",
+            name="江波龙",
+            sentiment_score=70,
+            trend_prediction="看多",
+            operation_advice="持有",
+            analysis_summary="高分但有顶层降级原因",
+            dashboard={
+                "core_conclusion": {"one_sentence": "高分但有顶层降级原因"},
+            },
+        )
+
+        saved = self.db.save_analysis_history(
+            result=result,
+            query_id="query_display_advice_root_guardrail_001",
+            report_type="full",
+            news_content="news",
+            context_snapshot=None,
+            save_snapshot=False,
+        )
+        self.assertGreater(saved, 0)
+
+        with self.db.session_scope() as session:
+            row = session.query(AnalysisHistory).filter(
+                AnalysisHistory.query_id == "query_display_advice_root_guardrail_001"
+            ).first()
+            if row is None:
+                self.fail("未找到保存的历史记录")
+            raw_result = json.loads(row.raw_result)
+            raw_result["guardrail_reason"] = "等待回踩确认"
+            row.raw_result = json.dumps(raw_result, ensure_ascii=False)
+            record_id = row.id
+
+        markdown = HistoryService(self.db).get_markdown_report(str(record_id))
+
+        self.assertIsNotNone(markdown)
+        self.assertIn("**🟡 持有** | 看多", markdown)
+        self.assertNotIn("**🟢 买入** | 看多", markdown)
+
+    def test_history_markdown_aligns_high_score_legacy_advice_to_strong_buy(self) -> None:
+        result = AnalysisResult(
+            code="301308.SZ",
+            name="江波龙",
+            sentiment_score=85,
+            trend_prediction="看多",
+            operation_advice="持有",
+            analysis_summary="高分但旧建议仍为持有",
+            dashboard={
+                "core_conclusion": {"one_sentence": "高分但旧建议仍为持有"},
+            },
+        )
+
+        saved = self.db.save_analysis_history(
+            result=result,
+            query_id="query_display_advice_score_strong_001",
+            report_type="full",
+            news_content="news",
+            context_snapshot=None,
+            save_snapshot=False,
+        )
+        self.assertGreater(saved, 0)
+
+        with self.db.get_session() as session:
+            row = session.query(AnalysisHistory).filter(
+                AnalysisHistory.query_id == "query_display_advice_score_strong_001"
+            ).first()
+            if row is None:
+                self.fail("未找到保存的历史记录")
+            record_id = row.id
+
+        markdown = HistoryService(self.db).get_markdown_report(str(record_id))
+
+        self.assertIsNotNone(markdown)
+        self.assertIn("**💚 强烈买入** | 看多", markdown)
+        self.assertNotIn("**🟢 买入** | 看多", markdown)
 
     def test_history_detail_returns_persisted_market_review_report(self) -> None:
         """Market review detail should surface the saved recap content for Web history clicks."""

--- a/tests/test_analysis_history.py
+++ b/tests/test_analysis_history.py
@@ -1002,6 +1002,33 @@ class AnalysisHistoryTestCase(unittest.TestCase):
         self.assertEqual(detail["action"], "sell")
         self.assertEqual(detail["action_label"], "卖出")
 
+    def test_history_list_and_detail_preserves_negated_hold_over_legacy_decision_type(self) -> None:
+        result = self._build_result()
+        result.operation_advice = "不建议卖出"
+        result.action = "unknown"
+        result.decision_type = "sell"
+        result.sentiment_score = 50
+
+        saved = self.db.save_analysis_history(
+            result=result,
+            query_id="query_history_negated_legacy_decision_type",
+            report_type="detailed",
+            news_content="个股正文",
+            context_snapshot=None,
+            save_snapshot=False,
+        )
+        self.assertGreater(saved, 0)
+
+        service = HistoryService(self.db)
+        listing = service.get_history_list(page=1, limit=10)
+        detail = service.resolve_and_get_detail("query_history_negated_legacy_decision_type")
+
+        self.assertEqual(listing["items"][0]["action"], "hold")
+        self.assertEqual(listing["items"][0]["action_label"], "持有")
+        self.assertIsNotNone(detail)
+        self.assertEqual(detail["action"], "hold")
+        self.assertEqual(detail["action_label"], "持有")
+
     def test_stock_bar_item_keeps_guardrailed_advice_from_dashboard_when_aligning(self) -> None:
         if get_stock_bar is None:
             self.skipTest("fastapi is not installed in this test environment")

--- a/tests/test_analysis_history.py
+++ b/tests/test_analysis_history.py
@@ -755,6 +755,36 @@ class AnalysisHistoryTestCase(unittest.TestCase):
         self.assertEqual(response.items[0].action, "avoid")
         self.assertEqual(response.items[0].action_label, "回避")
 
+    def test_stock_bar_item_keeps_compound_no_separator_avoid_phrase_with_high_score(self) -> None:
+        if get_stock_bar is None:
+            self.skipTest("fastapi is not installed in this test environment")
+
+        result = self._build_result()
+        result.operation_advice = "回避买入"
+        result.sentiment_score = 88
+
+        saved = self.db.save_analysis_history(
+            result=result,
+            query_id="query_stock_bar_compound_avoid",
+            report_type="detailed",
+            news_content="个股正文",
+            context_snapshot=None,
+            save_snapshot=False,
+        )
+        self.assertGreater(saved, 0)
+
+        response = get_stock_bar(
+            start_date=None,
+            end_date=None,
+            limit=10,
+            db_manager=self.db,
+        )
+
+        self.assertEqual(len(response.items), 1)
+        self.assertEqual(response.items[0].operation_advice, "回避买入")
+        self.assertEqual(response.items[0].action, "avoid")
+        self.assertEqual(response.items[0].action_label, "回避")
+
     def test_stock_bar_item_aligns_score_and_legacy_advice(self) -> None:
         if get_stock_bar is None:
             self.skipTest("fastapi is not installed in this test environment")

--- a/tests/test_analysis_history.py
+++ b/tests/test_analysis_history.py
@@ -887,6 +887,37 @@ class AnalysisHistoryTestCase(unittest.TestCase):
         self.assertEqual(response.items[0].action, "avoid")
         self.assertEqual(response.items[0].action_label, "回避")
 
+    def test_stock_bar_item_prefers_legacy_decision_type_when_action_invalid(self) -> None:
+        if get_stock_bar is None:
+            self.skipTest("fastapi is not installed in this test environment")
+
+        result = self._build_result()
+        result.operation_advice = "持有"
+        result.action = "unknown"
+        result.decision_type = "sell"
+        result.sentiment_score = 88
+
+        saved = self.db.save_analysis_history(
+            result=result,
+            query_id="query_stock_bar_legacy_decision_type",
+            report_type="detailed",
+            news_content="个股正文",
+            context_snapshot=None,
+            save_snapshot=False,
+        )
+        self.assertGreater(saved, 0)
+
+        response = get_stock_bar(
+            start_date=None,
+            end_date=None,
+            limit=10,
+            db_manager=self.db,
+        )
+
+        self.assertEqual(len(response.items), 1)
+        self.assertEqual(response.items[0].action, "sell")
+        self.assertEqual(response.items[0].action_label, "卖出")
+
     def test_history_list_and_detail_use_raw_label_when_action_is_invalid(self) -> None:
         result = self._build_result()
         result.operation_advice = "持有"
@@ -913,6 +944,33 @@ class AnalysisHistoryTestCase(unittest.TestCase):
         self.assertIsNotNone(detail)
         self.assertEqual(detail["action"], "avoid")
         self.assertEqual(detail["action_label"], "回避")
+
+    def test_history_list_and_detail_use_legacy_decision_type_on_persisted_score_mismatch(self) -> None:
+        result = self._build_result()
+        result.operation_advice = "持有"
+        result.action = "unknown"
+        result.decision_type = "sell"
+        result.sentiment_score = 88
+
+        saved = self.db.save_analysis_history(
+            result=result,
+            query_id="query_history_legacy_decision_type",
+            report_type="detailed",
+            news_content="个股正文",
+            context_snapshot=None,
+            save_snapshot=False,
+        )
+        self.assertGreater(saved, 0)
+
+        service = HistoryService(self.db)
+        listing = service.get_history_list(page=1, limit=10)
+        detail = service.resolve_and_get_detail("query_history_legacy_decision_type")
+
+        self.assertEqual(listing["items"][0]["action"], "sell")
+        self.assertEqual(listing["items"][0]["action_label"], "卖出")
+        self.assertIsNotNone(detail)
+        self.assertEqual(detail["action"], "sell")
+        self.assertEqual(detail["action_label"], "卖出")
 
     def test_stock_bar_item_keeps_guardrailed_advice_from_dashboard_when_aligning(self) -> None:
         if get_stock_bar is None:

--- a/tests/test_analysis_history.py
+++ b/tests/test_analysis_history.py
@@ -1954,6 +1954,49 @@ class AnalysisHistoryTestCase(unittest.TestCase):
         self.assertIn("**🟢 买入** | 看多", markdown)
         self.assertNotIn("**🟡 持有** | 看多", markdown)
 
+    def test_history_markdown_reads_nested_dashboard_action_fields(self) -> None:
+        result = AnalysisResult(
+            code="301308.SZ",
+            name="江波龙",
+            sentiment_score=88,
+            trend_prediction="看多",
+            operation_advice="持有",
+            analysis_summary="高分但旧建议仍为持有",
+            dashboard={
+                "core_conclusion": {"one_sentence": "高分但旧建议仍为持有"},
+            },
+        )
+
+        saved = self.db.save_analysis_history(
+            result=result,
+            query_id="query_display_advice_nested_dashboard_action_001",
+            report_type="full",
+            news_content="news",
+            context_snapshot=None,
+            save_snapshot=False,
+        )
+        self.assertGreater(saved, 0)
+
+        with self.db.session_scope() as session:
+            row = session.query(AnalysisHistory).filter(
+                AnalysisHistory.query_id == "query_display_advice_nested_dashboard_action_001"
+            ).first()
+            if row is None:
+                self.fail("未找到保存的历史记录")
+            raw_result = json.loads(row.raw_result)
+            raw_result.setdefault("dashboard", {})
+            raw_result["dashboard"]["action"] = "sell"
+            raw_result["dashboard"]["action_label"] = "卖出"
+            raw_result["dashboard"]["decision_type"] = "hold"
+            row.raw_result = json.dumps(raw_result, ensure_ascii=False)
+            record_id = row.id
+
+        markdown = HistoryService(self.db).get_markdown_report(str(record_id))
+
+        self.assertIsNotNone(markdown)
+        self.assertIn("**🔴 卖出** | 看多", markdown)
+        self.assertNotIn("**🟢 买入** | 看多", markdown)
+
     def test_history_markdown_preserves_top_level_guardrail_reason(self) -> None:
         result = AnalysisResult(
             code="301308.SZ",

--- a/tests/test_decision_action.py
+++ b/tests/test_decision_action.py
@@ -722,6 +722,35 @@ def test_display_action_fields_preserves_strong_buy_label_for_explicit_advice() 
     }
 
 
+def test_display_action_fields_preserves_strong_sell_label_for_explicit_advice() -> None:
+    assert display_action_fields(
+        operation_advice="强烈卖出",
+        sentiment_score=72,
+        report_language="zh",
+    ) == {
+        "action": "sell",
+        "action_label": "强烈卖出",
+    }
+
+    assert display_action_fields(
+        operation_advice="strong sell",
+        sentiment_score=72,
+        report_language="en",
+    ) == {
+        "action": "sell",
+        "action_label": "Strong Sell",
+    }
+
+    assert display_action_fields(
+        operation_advice="적극 매도",
+        sentiment_score=72,
+        report_language="ko",
+    ) == {
+        "action": "sell",
+        "action_label": "적극 매도",
+    }
+
+
 def test_display_action_fields_prefers_strong_buy_action_label_when_explicit_label_supplied() -> None:
     assert display_action_fields(
         operation_advice="持有",
@@ -740,6 +769,19 @@ def test_display_action_fields_prefers_strong_buy_action_label_when_explicit_lab
     ) == {
         "action": "buy",
         "action_label": "적극 매수",
+    }
+
+
+def test_display_action_fields_prefers_strong_sell_action_label_when_explicit_action_is_set() -> None:
+    assert display_action_fields(
+        operation_advice="持有",
+        explicit_action="sell",
+        action_label="强烈卖出",
+        sentiment_score=72,
+        report_language="zh",
+    ) == {
+        "action": "sell",
+        "action_label": "强烈卖出",
     }
 
 

--- a/tests/test_decision_action.py
+++ b/tests/test_decision_action.py
@@ -60,6 +60,8 @@ from src.schemas.decision_scale import (
         ("避免买入", "avoid"),
         ("回避买入", "avoid"),
         ("规避买入", "avoid"),
+        ("规避卖出", "avoid"),
+        ("回避减仓", "avoid"),
         ("do not buy", "avoid"),
         ("회피", "avoid"),
         ("alert", "alert"),

--- a/tests/test_decision_action.py
+++ b/tests/test_decision_action.py
@@ -619,6 +619,33 @@ def test_display_action_fields_prefers_strong_buy_action_label_when_explicit_lab
     }
 
 
+def test_display_action_fields_prefers_strong_buy_action_label_when_explicit_action_is_set() -> None:
+    assert display_action_fields(
+        operation_advice="持有",
+        explicit_action="buy",
+        action_label="强烈买入",
+        sentiment_score=72,
+        report_language="zh",
+    ) == {
+        "action": "buy",
+        "action_label": "强烈买入",
+    }
+
+
+@pytest.mark.parametrize("operation_advice", ["不建议卖出", "不建议加仓"])
+def test_build_action_fields_keeps_negated_hold_over_legacy_decision_type(
+    operation_advice: str,
+) -> None:
+    assert build_action_fields(
+        operation_advice=operation_advice,
+        legacy_decision_type="sell",
+        sentiment_score=50,
+    ) == {
+        "action": "hold",
+        "action_label": "持有",
+    }
+
+
 def test_display_action_fields_for_result_falls_back_when_result_action_is_blank() -> None:
     class Result:
         operation_advice = "持有"

--- a/tests/test_decision_action.py
+++ b/tests/test_decision_action.py
@@ -58,6 +58,8 @@ from src.schemas.decision_scale import (
         ("规避", "avoid"),
         ("不建议买入", "avoid"),
         ("避免买入", "avoid"),
+        ("回避买入", "avoid"),
+        ("规避买入", "avoid"),
         ("do not buy", "avoid"),
         ("회피", "avoid"),
         ("alert", "alert"),
@@ -106,6 +108,11 @@ def test_normalize_decision_action_matrix(value: str, expected: str) -> None:
 )
 def test_normalize_decision_action_unknown_or_ambiguous_returns_none(value: str | None) -> None:
     assert normalize_decision_action(value) is None
+
+
+def test_normalize_decision_action_keeps_no_separator_avoid_buyings_as_avoid() -> None:
+    assert normalize_decision_action("回避买入") == "avoid"
+    assert normalize_decision_action("规避买入") == "avoid"
 
 
 @pytest.mark.parametrize(
@@ -191,6 +198,17 @@ def test_normalize_decision_action_handles_negated_trade_actions(value: str, exp
 )
 def test_build_action_fields_prioritizes_negated_buy_advice_over_embedded_buy_phrase(advice: str) -> None:
     assert build_action_fields(operation_advice=advice) == {
+        "action": "avoid",
+        "action_label": "回避",
+    }
+
+
+def test_build_action_fields_keeps_compound_no_separator_avoid_buy_with_score_alignment() -> None:
+    assert build_action_fields(
+        operation_advice="回避买入",
+        sentiment_score=90,
+        align_with_score=True,
+    ) == {
         "action": "avoid",
         "action_label": "回避",
     }

--- a/tests/test_decision_action.py
+++ b/tests/test_decision_action.py
@@ -5,10 +5,19 @@ import pytest
 
 from src.schemas.decision_action import (
     build_action_fields,
+    display_action_fields,
+    display_action_fields_for_result,
+    display_decision_type_for_result,
+    display_operation_advice,
     localize_action_label,
     normalize_decision_action,
 )
-from src.schemas.decision_scale import action_for_score, decision_type_for_score, signal_key_for_score
+from src.schemas.decision_scale import (
+    action_for_score,
+    decision_type_for_score,
+    extract_decision_guardrail_reason,
+    signal_key_for_score,
+)
 
 
 @pytest.mark.parametrize(
@@ -19,6 +28,8 @@ from src.schemas.decision_scale import action_for_score, decision_type_for_score
         ("买入", "buy"),
         ("布局", "buy"),
         ("建仓", "buy"),
+        ("매수", "buy"),
+        ("추가 매수", "add"),
         ("add", "add"),
         ("加仓", "add"),
         ("增持", "add"),
@@ -27,6 +38,8 @@ from src.schemas.decision_scale import action_for_score, decision_type_for_score
         ("持有", "hold"),
         ("持有观察", "hold"),
         ("洗盘观察", "hold"),
+        ("보유", "hold"),
+        ("관망", "watch"),
         ("watch", "watch"),
         ("观望", "watch"),
         ("等待", "watch"),
@@ -39,17 +52,26 @@ from src.schemas.decision_scale import action_for_score, decision_type_for_score
         ("清仓", "sell"),
         ("strong_sell", "sell"),
         ("强烈卖出", "sell"),
+        ("매도", "sell"),
         ("avoid", "avoid"),
         ("回避", "avoid"),
         ("规避", "avoid"),
         ("不建议买入", "avoid"),
         ("避免买入", "avoid"),
         ("do not buy", "avoid"),
+        ("회피", "avoid"),
         ("alert", "alert"),
         ("风险预警", "alert"),
         ("警惕", "alert"),
         ("触发告警", "alert"),
         ("risk alert", "alert"),
+        ("경고", "alert"),
+        ("风险预警，建议卖出", "sell"),
+        ("风险预警，建议减仓", "reduce"),
+        ("Alert, sell", "sell"),
+        ("경고, 매도", "sell"),
+        ("경고, 비중축소", "reduce"),
+        ("경고, 매수", "buy"),
     ],
 )
 def test_normalize_decision_action_matrix(value: str, expected: str) -> None:
@@ -221,6 +243,43 @@ def test_build_action_fields_keeps_multi_guard_advice_empty(advice: str) -> None
     }
 
 
+def test_build_action_fields_prefers_trade_term_over_alert_prefix() -> None:
+    assert build_action_fields(
+        operation_advice="风险预警，建议卖出",
+        align_with_score=True,
+    ) == {
+        "action": "sell",
+        "action_label": "卖出",
+    }
+
+    assert build_action_fields(
+        operation_advice="Alert, sell",
+        report_language="en",
+        align_with_score=True,
+    ) == {
+        "action": "sell",
+        "action_label": "Sell",
+    }
+
+    assert build_action_fields(
+        operation_advice="경고, 매도",
+        report_language="ko",
+        align_with_score=True,
+    ) == {
+        "action": "sell",
+        "action_label": "매도",
+    }
+
+    assert build_action_fields(
+        operation_advice="경고, 비중축소",
+        report_language="ko",
+        align_with_score=True,
+    ) == {
+        "action": "reduce",
+        "action_label": "비중축소",
+    }
+
+
 @pytest.mark.parametrize(
     "advice",
     [
@@ -366,3 +425,149 @@ def test_build_action_fields_keeps_neutral_score_conflict_when_guardrail_is_expl
         guardrail_reason="等待回踩确认",
         align_with_score=True,
     ) == {"action": "watch", "action_label": "观望"}
+
+
+def test_display_operation_advice_aligns_with_score_without_guardrail() -> None:
+    assert display_operation_advice(
+        operation_advice="持有",
+        sentiment_score=72,
+        report_language="zh",
+    ) == "买入"
+
+
+def test_display_operation_advice_keeps_guardrailed_neutral_advice() -> None:
+    assert display_operation_advice(
+        operation_advice="持有",
+        sentiment_score=72,
+        guardrail_reason="等待回踩确认",
+        report_language="zh",
+    ) == "持有"
+
+
+def test_display_decision_type_for_result_uses_display_action_bucket() -> None:
+    class Result:
+        operation_advice = "持有"
+        sentiment_score = 72
+        report_language = "zh"
+        action = None
+        action_label = None
+        dashboard = None
+
+    assert display_decision_type_for_result(Result()) == "buy"
+
+
+@pytest.mark.parametrize("decision_type, expected", [("buy", "buy"), ("sell", "sell")])
+def test_display_decision_type_for_result_falls_back_to_decision_type(
+    decision_type: str,
+    expected: str,
+) -> None:
+    class Result:
+        operation_advice = "未知波动信号"
+        sentiment_score = 72
+        report_language = "zh"
+        action = None
+        action_label = None
+        dashboard = None
+
+    setattr(Result, "decision_type", decision_type)
+
+    assert display_decision_type_for_result(Result()) == expected
+
+
+def test_display_action_fields_falls_back_to_action_label_when_explicit_action_is_blank() -> None:
+    assert display_action_fields(
+        operation_advice="持有",
+        explicit_action="",
+        action_label="回避",
+        sentiment_score=72,
+        report_language="zh",
+    ) == {
+        "action": "avoid",
+        "action_label": "回避",
+    }
+
+
+@pytest.mark.parametrize("explicit_action", ["unknown", "N/A"])
+def test_display_action_fields_falls_back_to_action_label_when_explicit_action_is_invalid(
+    explicit_action: str,
+) -> None:
+    assert display_action_fields(
+        operation_advice="持有",
+        explicit_action=explicit_action,
+        action_label="回避",
+        sentiment_score=72,
+        report_language="zh",
+    ) == {
+        "action": "avoid",
+        "action_label": "回避",
+    }
+
+
+def test_display_action_fields_for_result_falls_back_when_result_action_is_blank() -> None:
+    class Result:
+        operation_advice = "持有"
+        action = ""
+        action_label = "回避"
+        decision_type = "hold"
+        report_language = "zh"
+        report_type = None
+        sentiment_score = 72
+        dashboard = None
+        guardrail_reason = None
+
+    assert display_action_fields_for_result(Result(), report_language="zh") == {
+        "action": "avoid",
+        "action_label": "回避",
+    }
+
+
+def test_extract_decision_guardrail_reason_reads_dashboard_sources() -> None:
+    assert extract_decision_guardrail_reason(
+        {
+            "dashboard": {
+                "decision_score_calibration": {
+                    "guardrail_reason": "wait for support confirmation",
+                }
+            }
+        }
+    ) == "wait for support confirmation"
+
+    assert extract_decision_guardrail_reason(
+        {
+            "dashboard": {
+                "decision_stability": {
+                    "applied": True,
+                    "reason": "capital flow is unavailable",
+                }
+            }
+        }
+    ) == "capital flow is unavailable"
+
+
+def test_extract_decision_guardrail_reason_ignores_unapplied_stability_reason() -> None:
+    assert (
+        extract_decision_guardrail_reason(
+            {
+                "dashboard": {
+                    "decision_stability": {
+                        "applied": False,
+                        "reason": "资金流不可用，未使用资金流校准",
+                    }
+                }
+            }
+        )
+        is None
+    )
+    assert (
+        extract_decision_guardrail_reason(
+            {
+                "dashboard": {
+                    "decision_stability": {
+                        "applied": False,
+                        "downgrade_reason": "资金流仍偏弱，暂按观望处理",
+                    }
+                }
+            }
+        )
+        is None
+    )

--- a/tests/test_decision_action.py
+++ b/tests/test_decision_action.py
@@ -691,26 +691,16 @@ def test_extract_decision_guardrail_reason_reads_dashboard_sources() -> None:
     ) == "capital flow is unavailable"
 
 
-def test_extract_decision_guardrail_reason_ignores_unapplied_stability_reason() -> None:
+@pytest.mark.parametrize("applied", [False, "off", "no"])
+def test_extract_decision_guardrail_reason_ignores_unapplied_stability_reason(applied) -> None:
     assert (
         extract_decision_guardrail_reason(
             {
                 "dashboard": {
                     "decision_stability": {
-                        "applied": False,
+                        "applied": applied,
+                        "guardrail_reason": "评分虽高，但暂按观望处理",
                         "reason": "资金流不可用，未使用资金流校准",
-                    }
-                }
-            }
-        )
-        is None
-    )
-    assert (
-        extract_decision_guardrail_reason(
-            {
-                "dashboard": {
-                    "decision_stability": {
-                        "applied": False,
                         "downgrade_reason": "资金流仍偏弱，暂按观望处理",
                     }
                 }

--- a/tests/test_decision_action.py
+++ b/tests/test_decision_action.py
@@ -520,6 +520,30 @@ def test_build_action_fields_can_align_neutral_action_with_directional_score() -
     ) == {"action": "reduce", "action_label": "减仓"}
 
 
+@pytest.mark.parametrize(
+    ("advice", "sentiment_score", "expected"),
+    [
+        ("不建议加仓", 72, "hold"),
+        ("do not sell", 28, "hold"),
+        ("不建议卖出", 72, "hold"),
+    ],
+)
+def test_build_action_fields_keeps_negated_hold_over_directional_score_alignment(
+    advice: str,
+    sentiment_score: int,
+    expected: str,
+) -> None:
+    assert build_action_fields(
+        operation_advice=advice,
+        sentiment_score=sentiment_score,
+        align_with_score=True,
+        report_language="zh",
+    ) == {
+        "action": expected,
+        "action_label": "持有",
+    }
+
+
 def test_build_action_fields_keeps_neutral_score_conflict_when_guardrail_is_explicit() -> None:
     assert build_action_fields(
         operation_advice="持有/观望待回踩",

--- a/tests/test_decision_action.py
+++ b/tests/test_decision_action.py
@@ -91,6 +91,10 @@ def test_normalize_decision_action_matrix(value: str, expected: str) -> None:
     assert normalize_decision_action(value) == expected
 
 
+def test_normalize_decision_action_prefers_avoid_for_dual_negation_no_buy_no_sell() -> None:
+    assert normalize_decision_action("不建议买入，也不建议卖出") == "avoid"
+
+
 @pytest.mark.parametrize(
     "value",
     [
@@ -677,6 +681,24 @@ def test_build_action_fields_keeps_negated_hold_over_legacy_decision_type(
     ) == {
         "action": "hold",
         "action_label": "持有",
+    }
+
+
+def test_display_action_fields_for_result_keeps_avoid_with_directional_legacy() -> None:
+    class Result:
+        operation_advice = "不建议买入，也不建议卖出"
+        action = None
+        action_label = None
+        decision_type = "buy"
+        report_language = "zh"
+        report_type = None
+        sentiment_score = 90
+        dashboard = None
+        guardrail_reason = None
+
+    assert display_action_fields_for_result(Result(), report_language="zh") == {
+        "action": "avoid",
+        "action_label": "回避",
     }
 
 

--- a/tests/test_decision_action.py
+++ b/tests/test_decision_action.py
@@ -70,9 +70,14 @@ from src.schemas.decision_scale import (
         ("경고", "alert"),
         ("风险预警，建议卖出", "sell"),
         ("风险预警，建议减仓", "reduce"),
+        ("风险预警，持有", "alert"),
+        ("风险预警，观望", "alert"),
         ("Alert, sell", "sell"),
+        ("alert, hold", "alert"),
+        ("alert, watch", "alert"),
         ("경고, 매도", "sell"),
         ("경고, 비중축소", "reduce"),
+        ("경고, 보유", "alert"),
         ("경고, 매수", "buy"),
         ("risk alert, avoid buying", "avoid"),
     ],
@@ -307,6 +312,38 @@ def test_build_action_fields_prefers_trade_term_over_alert_prefix() -> None:
     }
 
 
+
+def test_build_action_fields_keeps_guard_with_neutral_advice_before_score_fallback() -> None:
+    assert build_action_fields(
+        operation_advice="风险预警，持有",
+        sentiment_score=90,
+        align_with_score=True,
+    ) == {
+        "action": "alert",
+        "action_label": "预警",
+    }
+
+    assert build_action_fields(
+        operation_advice="alert, watch",
+        sentiment_score=85,
+        report_language="en",
+        align_with_score=True,
+    ) == {
+        "action": "alert",
+        "action_label": "Alert",
+    }
+
+    assert build_action_fields(
+        operation_advice="경고, 보유",
+        sentiment_score=88,
+        report_language="ko",
+        align_with_score=True,
+    ) == {
+        "action": "alert",
+        "action_label": "경고",
+    }
+
+
 @pytest.mark.parametrize(
     "advice",
     [
@@ -469,6 +506,26 @@ def test_display_operation_advice_keeps_guardrailed_neutral_advice() -> None:
         guardrail_reason="等待回踩确认",
         report_language="zh",
     ) == "持有"
+
+
+@pytest.mark.parametrize(
+    ("advice", "language", "expected"),
+    [
+        ("风险预警，观望", "zh", "预警"),
+        ("alert, watch", "en", "Alert"),
+        ("경고, 보유", "ko", "경고"),
+    ],
+)
+def test_display_operation_advice_keeps_guard_with_neutral_advice(
+    advice: str,
+    language: str,
+    expected: str,
+) -> None:
+    assert display_operation_advice(
+        operation_advice=advice,
+        sentiment_score=90,
+        report_language=language,
+    ) == expected
 
 
 def test_display_decision_type_for_result_uses_display_action_bucket() -> None:

--- a/tests/test_decision_action.py
+++ b/tests/test_decision_action.py
@@ -587,6 +587,38 @@ def test_display_action_fields_falls_back_to_action_label_when_explicit_action_i
     }
 
 
+def test_display_action_fields_preserves_strong_buy_label_for_explicit_advice() -> None:
+    assert display_action_fields(
+        operation_advice="强烈买入",
+        sentiment_score=72,
+        report_language="zh",
+    ) == {
+        "action": "buy",
+        "action_label": "强烈买入",
+    }
+
+    assert display_action_fields(
+        operation_advice="strong buy",
+        sentiment_score=72,
+        report_language="en",
+    ) == {
+        "action": "buy",
+        "action_label": "Strong Buy",
+    }
+
+
+def test_display_action_fields_prefers_strong_buy_action_label_when_explicit_label_supplied() -> None:
+    assert display_action_fields(
+        operation_advice="持有",
+        action_label="强烈买入",
+        sentiment_score=72,
+        report_language="zh",
+    ) == {
+        "action": "buy",
+        "action_label": "强烈买入",
+    }
+
+
 def test_display_action_fields_for_result_falls_back_when_result_action_is_blank() -> None:
     class Result:
         operation_advice = "持有"

--- a/tests/test_decision_action.py
+++ b/tests/test_decision_action.py
@@ -72,6 +72,7 @@ from src.schemas.decision_scale import (
         ("경고, 매도", "sell"),
         ("경고, 비중축소", "reduce"),
         ("경고, 매수", "buy"),
+        ("risk alert, avoid buying", "avoid"),
     ],
 )
 def test_normalize_decision_action_matrix(value: str, expected: str) -> None:
@@ -100,7 +101,6 @@ def test_normalize_decision_action_matrix(value: str, expected: str) -> None:
         "sell-off risk remains low",
         "sell off risk remains low",
         "no sell-off pressure",
-        "risk alert, avoid buying",
         "普通复盘说明",
     ],
 )
@@ -233,6 +233,7 @@ def test_build_action_fields_prioritizes_negated_hold_advice_over_embedded_trade
     [
         "风险预警，避免买入",
         "risk alert, do not buy",
+        "risk alert, avoid buying",
         "风险预警，不建议买入",
     ],
 )

--- a/tests/test_decision_action.py
+++ b/tests/test_decision_action.py
@@ -254,6 +254,8 @@ def test_build_action_fields_prioritizes_negated_hold_advice_over_embedded_trade
 @pytest.mark.parametrize(
     "advice",
     [
+        "预警，不建议买入",
+        "alert, do not buy",
         "风险预警，避免买入",
         "risk alert, do not buy",
         "risk alert, avoid buying",

--- a/tests/test_decision_action.py
+++ b/tests/test_decision_action.py
@@ -125,6 +125,12 @@ def test_normalize_decision_action_keeps_no_separator_avoid_buyings_as_avoid() -
     assert normalize_decision_action("规避买入") == "avoid"
 
 
+def test_normalize_decision_action_keeps_trading_terms_with_separated_compound_guard_phrase() -> None:
+    assert normalize_decision_action("回避,买入") == "buy"
+    assert normalize_decision_action("规避；减仓") == "reduce"
+    assert normalize_decision_action("回避风险，建议卖出") == "sell"
+
+
 @pytest.mark.parametrize(
     ("value", "expected"),
     [
@@ -447,6 +453,18 @@ def test_build_action_fields_prefers_explicit_action_over_advice() -> None:
         operation_advice="买入",
         explicit_action="watch",
         report_language="zh",
+    )
+
+    assert fields == {"action": "watch", "action_label": "观望"}
+
+
+def test_build_action_fields_keeps_explicit_directional_action_over_legacy() -> None:
+    fields = build_action_fields(
+        operation_advice="持有",
+        explicit_action="watch",
+        legacy_decision_type="buy",
+        report_language="zh",
+        align_with_score=False,
     )
 
     assert fields == {"action": "watch", "action_label": "观望"}

--- a/tests/test_decision_action.py
+++ b/tests/test_decision_action.py
@@ -101,7 +101,6 @@ def test_normalize_decision_action_matrix(value: str, expected: str) -> None:
         "sell off risk remains low",
         "no sell-off pressure",
         "risk alert, avoid buying",
-        "风险预警，避免买入",
         "普通复盘说明",
     ],
 )
@@ -232,15 +231,24 @@ def test_build_action_fields_prioritizes_negated_hold_advice_over_embedded_trade
 @pytest.mark.parametrize(
     "advice",
     [
-        "risk alert, avoid buying",
         "风险预警，避免买入",
+        "risk alert, do not buy",
+        "风险预警，不建议买入",
     ],
 )
-def test_build_action_fields_keeps_multi_guard_advice_empty(advice: str) -> None:
-    assert build_action_fields(operation_advice=advice) == {
-        "action": None,
-        "action_label": None,
+def test_build_action_fields_preserves_negated_warning_advice_before_score_fallback(advice: str) -> None:
+    assert build_action_fields(
+        operation_advice=advice,
+        sentiment_score=90,
+        align_with_score=True,
+    ) == {
+        "action": "avoid",
+        "action_label": "回避",
     }
+    assert display_operation_advice(
+        operation_advice=advice,
+        sentiment_score=90,
+    ) == "回避"
 
 
 def test_build_action_fields_prefers_trade_term_over_alert_prefix() -> None:

--- a/tests/test_decision_action.py
+++ b/tests/test_decision_action.py
@@ -107,6 +107,20 @@ def test_normalize_decision_action_prefers_avoid_for_dual_negation_no_buy_no_sel
 
 
 @pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        ("不建议买入，建议卖出", "sell"),
+        ("不建议买入，建议减仓", "reduce"),
+    ],
+)
+def test_normalize_decision_action_prefers_later_directional_clause(
+    value: str,
+    expected: str,
+) -> None:
+    assert normalize_decision_action(value) == expected
+
+
+@pytest.mark.parametrize(
     "value",
     [
         "",

--- a/tests/test_decision_action.py
+++ b/tests/test_decision_action.py
@@ -92,6 +92,8 @@ from src.schemas.decision_scale import (
         ("avoid buy", "avoid"),
         ("avoid sell", "avoid"),
         ("avoid add", "avoid"),
+        ("avoid reduce", "avoid"),
+        ("avoid trim", "avoid"),
         ("avoid strong buy", "avoid"),
         ("avoid strong sell", "avoid"),
     ],
@@ -274,6 +276,8 @@ def test_build_action_fields_keeps_compound_no_separator_avoid_guard_with_score_
         "avoid buy",
         "avoid sell",
         "avoid add",
+        "avoid reduce",
+        "avoid trim",
     ],
 )
 def test_build_action_fields_keeps_naked_avoid_english_action(advice: str) -> None:

--- a/tests/test_decision_action.py
+++ b/tests/test_decision_action.py
@@ -25,6 +25,7 @@ from src.schemas.decision_scale import (
     [
         ("strong_buy", "buy"),
         ("强烈买入", "buy"),
+        ("적극 매수", "buy"),
         ("买入", "buy"),
         ("布局", "buy"),
         ("建仓", "buy"),
@@ -668,6 +669,15 @@ def test_display_action_fields_preserves_strong_buy_label_for_explicit_advice() 
         "action_label": "Strong Buy",
     }
 
+    assert display_action_fields(
+        operation_advice="적극 매수",
+        sentiment_score=72,
+        report_language="ko",
+    ) == {
+        "action": "buy",
+        "action_label": "적극 매수",
+    }
+
 
 def test_display_action_fields_prefers_strong_buy_action_label_when_explicit_label_supplied() -> None:
     assert display_action_fields(
@@ -678,6 +688,15 @@ def test_display_action_fields_prefers_strong_buy_action_label_when_explicit_lab
     ) == {
         "action": "buy",
         "action_label": "强烈买入",
+    }
+
+    assert display_action_fields(
+        action_label="적극 매수",
+        sentiment_score=72,
+        report_language="ko",
+    ) == {
+        "action": "buy",
+        "action_label": "적극 매수",
     }
 
 

--- a/tests/test_decision_action.py
+++ b/tests/test_decision_action.py
@@ -89,6 +89,11 @@ from src.schemas.decision_scale import (
         ("경고, 보유", "alert"),
         ("경고, 매수", "buy"),
         ("risk alert, avoid buying", "avoid"),
+        ("avoid buy", "avoid"),
+        ("avoid sell", "avoid"),
+        ("avoid add", "avoid"),
+        ("avoid strong buy", "avoid"),
+        ("avoid strong sell", "avoid"),
     ],
 )
 def test_normalize_decision_action_matrix(value: str, expected: str) -> None:
@@ -253,6 +258,25 @@ def test_build_action_fields_prioritizes_negated_buy_advice_over_embedded_buy_ph
     ],
 )
 def test_build_action_fields_keeps_compound_no_separator_avoid_guard_with_score_alignment(advice: str) -> None:
+    assert build_action_fields(
+        operation_advice=advice,
+        sentiment_score=90,
+        align_with_score=True,
+    ) == {
+        "action": "avoid",
+        "action_label": "回避",
+    }
+
+
+@pytest.mark.parametrize(
+    "advice",
+    [
+        "avoid buy",
+        "avoid sell",
+        "avoid add",
+    ],
+)
+def test_build_action_fields_keeps_naked_avoid_english_action(advice: str) -> None:
     assert build_action_fields(
         operation_advice=advice,
         sentiment_score=90,

--- a/tests/test_decision_action.py
+++ b/tests/test_decision_action.py
@@ -62,6 +62,9 @@ from src.schemas.decision_scale import (
         ("规避买入", "avoid"),
         ("规避卖出", "avoid"),
         ("回避减仓", "avoid"),
+        ("回避加仓", "avoid"),
+        ("规避增持", "avoid"),
+        ("回避建仓", "avoid"),
         ("do not buy", "avoid"),
         ("회피", "avoid"),
         ("alert", "alert"),
@@ -210,9 +213,18 @@ def test_build_action_fields_prioritizes_negated_buy_advice_over_embedded_buy_ph
     }
 
 
-def test_build_action_fields_keeps_compound_no_separator_avoid_buy_with_score_alignment() -> None:
+@pytest.mark.parametrize(
+    "advice",
+    [
+        "回避买入",
+        "回避加仓",
+        "规避增持",
+        "回避建仓",
+    ],
+)
+def test_build_action_fields_keeps_compound_no_separator_avoid_guard_with_score_alignment(advice: str) -> None:
     assert build_action_fields(
-        operation_advice="回避买入",
+        operation_advice=advice,
         sentiment_score=90,
         align_with_score=True,
     ) == {

--- a/tests/test_decision_action.py
+++ b/tests/test_decision_action.py
@@ -786,6 +786,20 @@ def test_extract_decision_guardrail_reason_reads_dashboard_sources() -> None:
     ) == "capital flow is unavailable"
 
 
+def test_build_action_fields_keeps_explicit_watch_action_regardless_of_score() -> None:
+    # Regression: explicit watch action should not be fallback-aligned to buy even with high score.
+    assert build_action_fields(
+        operation_advice="不建议卖出",
+        explicit_action="watch",
+        sentiment_score=72,
+        align_with_score=True,
+        report_language="zh",
+    ) == {
+        "action": "watch",
+        "action_label": "观望",
+    }
+
+
 @pytest.mark.parametrize("applied", [False, "off", "no"])
 def test_extract_decision_guardrail_reason_ignores_unapplied_stability_reason(applied) -> None:
     assert (

--- a/tests/test_decision_action.py
+++ b/tests/test_decision_action.py
@@ -62,11 +62,14 @@ from src.schemas.decision_scale import (
         ("回避买入", "avoid"),
         ("规避买入", "avoid"),
         ("规避卖出", "avoid"),
+        ("不建议强烈买入", "avoid"),
         ("回避减仓", "avoid"),
         ("回避加仓", "avoid"),
         ("规避增持", "avoid"),
         ("回避建仓", "avoid"),
         ("do not buy", "avoid"),
+        ("not a strong buy", "avoid"),
+        ("not a strong sell", "hold"),
         ("회피", "avoid"),
         ("alert", "alert"),
         ("风险预警", "alert"),
@@ -203,6 +206,20 @@ def test_normalize_decision_action_handles_negated_trade_actions(value: str, exp
     assert normalize_decision_action(value) == expected
 
 
+def test_normalize_decision_action_handles_strong_negation_with_embedded_trade_terms() -> None:
+    assert normalize_decision_action("not a strong buy") == "avoid"
+    assert normalize_decision_action("not a strong sell") == "hold"
+    assert build_action_fields(
+        operation_advice="not a strong sell",
+        sentiment_score=90,
+        align_with_score=True,
+        report_language="zh",
+    ) == {
+        "action": "hold",
+        "action_label": "持有",
+    }
+
+
 @pytest.mark.parametrize(
     "advice",
     [
@@ -215,6 +232,8 @@ def test_normalize_decision_action_handles_negated_trade_actions(value: str, exp
         "can't buy before confirmation",
         "not a buy yet",
         "not to buy",
+        "not a strong buy",
+        "不建议强烈买入",
     ],
 )
 def test_build_action_fields_prioritizes_negated_buy_advice_over_embedded_buy_phrase(advice: str) -> None:

--- a/tests/test_history_comparison_service.py
+++ b/tests/test_history_comparison_service.py
@@ -60,6 +60,25 @@ def test_record_to_signal_prefers_legacy_decision_type_over_score_for_persisted_
     assert signal["action_label"] == "卖出"
 
 
+def test_record_to_signal_preserves_strong_sell_label_from_legacy_advice() -> None:
+    signal = _record_to_signal(
+        _history_record(
+            raw_result={
+                "action": "unknown",
+                "operation_advice": "强烈卖出",
+                "report_language": "zh",
+                "guardrail_reason": None,
+            },
+            report_language="zh",
+            sentiment_score=72,
+        )
+    )
+
+    assert signal is not None
+    assert signal["action"] == "sell"
+    assert signal["action_label"] == "强烈卖出"
+
+
 def test_record_to_signal_prefers_action_label_when_action_invalid() -> None:
     signal = _record_to_signal(
         _history_record(

--- a/tests/test_history_comparison_service.py
+++ b/tests/test_history_comparison_service.py
@@ -1,0 +1,135 @@
+# -*- coding: utf-8 -*-
+"""Tests for history comparison action normalization compatibility."""
+
+from datetime import datetime
+from types import SimpleNamespace
+
+from src.services.history_comparison_service import _record_to_signal
+
+
+def _history_record(**kwargs):
+    return SimpleNamespace(
+        raw_result=kwargs.get("raw_result", {}),
+        operation_advice=kwargs.get("operation_advice"),
+        sentiment_score=kwargs.get("sentiment_score", 72),
+        report_language=kwargs.get("report_language"),
+        created_at=kwargs.get("created_at", datetime(2026, 1, 1, 9, 0)),
+        query_id=kwargs.get("query_id", "history-record"),
+        trend_prediction=kwargs.get("trend_prediction", "看多"),
+        report_type=kwargs.get("report_type", "simple"),
+    )
+
+
+def test_record_to_signal_uses_raw_action_field_before_action_label() -> None:
+    signal = _record_to_signal(
+        _history_record(
+            raw_result={
+                "action": "sell",
+                "action_label": "매수",
+                "operation_advice": "观望",
+                "report_language": "ko",
+                "guardrail_reason": None,
+            },
+            report_language="ko",
+            sentiment_score=60,
+        )
+    )
+
+    assert signal is not None
+    assert signal["action"] == "sell"
+    assert signal["action_label"] == "매도"
+
+
+def test_record_to_signal_prefers_action_label_when_action_invalid() -> None:
+    signal = _record_to_signal(
+        _history_record(
+            raw_result={
+                "action": "unknown",
+                "action_label": "回避",
+                "operation_advice": "持有",
+                "report_language": "zh",
+                "guardrail_reason": None,
+            },
+            report_language="zh",
+            sentiment_score=84,
+        )
+    )
+
+    assert signal is not None
+    assert signal["action"] == "avoid"
+    assert signal["action_label"] == "回避"
+
+
+def test_record_to_signal_falls_back_to_action_label_when_action_absent() -> None:
+    signal = _record_to_signal(
+        _history_record(
+            raw_result={
+                "action_label": "경고",
+                "operation_advice": "持有",
+                "report_language": "ko",
+            },
+            report_language="ko",
+            sentiment_score=72,
+        )
+    )
+
+    assert signal is not None
+    assert signal["action"] == "alert"
+    assert signal["action_label"] == "경고"
+
+
+def test_record_to_signal_localizes_action_with_override_language() -> None:
+    signal = _record_to_signal(
+        _history_record(
+            raw_result={
+                "operation_advice": "持有",
+                "report_language": "ko",
+                "guardrail_reason": None,
+            },
+            report_language="ko",
+            sentiment_score=72,
+        ),
+        report_language="en",
+    )
+
+    assert signal is not None
+    assert signal["action"] == "buy"
+    assert signal["action_label"] == "Buy"
+
+
+def test_record_to_signal_localizes_action_label_with_language_override() -> None:
+    signal = _record_to_signal(
+        _history_record(
+            raw_result={
+                "action": None,
+                "action_label": "回避",
+                "operation_advice": "持有",
+                "report_language": "zh",
+            },
+            report_language="zh",
+        ),
+        report_language="en",
+    )
+
+    assert signal is not None
+    assert signal["action"] == "avoid"
+    assert signal["action_label"] == "Avoid"
+
+
+def test_record_to_signal_preserves_hold_with_decision_score_guardrail_reason() -> None:
+    signal = _record_to_signal(
+        _history_record(
+            raw_result={
+                "action": "hold",
+                "operation_advice": "持有",
+                "report_language": "zh",
+                "decision_score_guardrail_reason": "评分偏高但风险仍存",
+            },
+            report_language="zh",
+            sentiment_score=80,
+        )
+    )
+
+    assert signal is not None
+    assert signal["action"] == "hold"
+    assert signal["action_label"] == "持有"

--- a/tests/test_history_comparison_service.py
+++ b/tests/test_history_comparison_service.py
@@ -40,6 +40,26 @@ def test_record_to_signal_uses_raw_action_field_before_action_label() -> None:
     assert signal["action_label"] == "매도"
 
 
+def test_record_to_signal_prefers_legacy_decision_type_over_score_for_persisted_records() -> None:
+    signal = _record_to_signal(
+        _history_record(
+            raw_result={
+                "decision_type": "sell",
+                "action": "unknown",
+                "operation_advice": "持有",
+                "report_language": "zh",
+                "guardrail_reason": None,
+            },
+            report_language="zh",
+            sentiment_score=90,
+        )
+    )
+
+    assert signal is not None
+    assert signal["action"] == "sell"
+    assert signal["action_label"] == "卖出"
+
+
 def test_record_to_signal_prefers_action_label_when_action_invalid() -> None:
     signal = _record_to_signal(
         _history_record(

--- a/tests/test_notification.py
+++ b/tests/test_notification.py
@@ -30,7 +30,7 @@ for optional_module in ("litellm", "json_repair"):
         sys.modules[optional_module] = mock.MagicMock()
 
 from src.config import Config
-from src.notification import NotificationService, NotificationChannel
+from src.notification import NotificationBuilder, NotificationService, NotificationChannel
 from src.notification_noise import reset_notification_noise_state
 from src.analyzer import AnalysisResult
 from bot.models import BotMessage, ChatType
@@ -725,6 +725,91 @@ class TestNotificationServiceReportGeneration(unittest.TestCase):
         self.assertIn("*分析模型: gemini/gemini-2.5-flash*", out)
 
     @mock.patch("src.notification.get_config")
+    def test_generate_brief_report_aligns_display_advice_with_score(self, mock_get_config: mock.MagicMock):
+        mock_get_config.return_value = _make_config(report_renderer_enabled=False)
+        service = NotificationService()
+        result = AnalysisResult(
+            code="301308.SZ",
+            name="江波龙",
+            sentiment_score=70,
+            trend_prediction="看多",
+            operation_advice="持有",
+            analysis_summary="高分但旧建议仍为持有",
+        )
+
+        out = service.generate_brief_report([result], report_date="2026-07-06")
+
+        self.assertIn("> 1 只 | 🟢1 🟡0 🔴0", out)
+        self.assertIn("江波龙(301308.SZ)** 🟢 买入 | 评分 70", out)
+        self.assertNotIn("🟡 持有 | 评分 70", out)
+
+    @mock.patch("src.notification.get_config")
+    def test_generate_brief_report_aligns_legacy_advice_to_strong_buy_for_80_plus(
+        self,
+        mock_get_config: mock.MagicMock,
+    ):
+        mock_get_config.return_value = _make_config(report_renderer_enabled=False)
+        service = NotificationService()
+        result = AnalysisResult(
+            code="301308.SZ",
+            name="江波龙",
+            sentiment_score=85,
+            trend_prediction="看多",
+            operation_advice="持有",
+            analysis_summary="高分且旧建议仍为持有",
+        )
+
+        out = service.generate_brief_report([result], report_date="2026-07-06")
+
+        self.assertIn("> 1 只 | 🟢1 🟡0 🔴0", out)
+        self.assertIn("江波龙(301308.SZ)** 💚 强烈买入 | 评分 85", out)
+        self.assertNotIn("江波龙(301308.SZ)** 💚 买入 | 评分 85", out)
+
+    @mock.patch("src.notification.get_config")
+    def test_generate_brief_report_keeps_guardrailed_hold(self, mock_get_config: mock.MagicMock):
+        mock_get_config.return_value = _make_config(report_renderer_enabled=False)
+        service = NotificationService()
+        result = AnalysisResult(
+            code="600276.SH",
+            name="恒瑞医药",
+            sentiment_score=72,
+            trend_prediction="看多",
+            operation_advice="持有",
+            analysis_summary="有明确降级原因",
+            dashboard={"decision_stability": {"reason": "等待资金流确认"}},
+        )
+
+        out = service.generate_brief_report([result], report_date="2026-07-06")
+
+        self.assertIn("> 1 只 | 🟢0 🟡1 🔴0", out)
+        self.assertIn("恒瑞医药(600276.SH)** 🟡 持有 | 评分 72", out)
+        self.assertNotIn("🟢 买入 | 评分 72", out)
+
+    @mock.patch("src.notification.get_config")
+    def test_generate_brief_report_maps_explicit_guard_action_before_score_fallback(
+        self,
+        mock_get_config: mock.MagicMock,
+    ):
+        mock_get_config.return_value = _make_config(report_renderer_enabled=False)
+        service = NotificationService()
+        result = AnalysisResult(
+            code="301308.SZ",
+            name="江波龙",
+            sentiment_score=72,
+            trend_prediction="看多",
+            operation_advice="持有",
+            analysis_summary="高分但显式回避",
+            action="avoid",
+            action_label="回避",
+        )
+
+        out = service.generate_brief_report([result], report_date="2026-07-06")
+
+        self.assertIn("> 1 只 | 🟢0 🟡1 🔴0", out)
+        self.assertIn("江波龙(301308.SZ)** 🟡 回避 | 评分 72", out)
+        self.assertNotIn("🟢 回避 | 评分 72", out)
+
+    @mock.patch("src.notification.get_config")
     def test_generate_dashboard_report_shows_model_by_default(self, mock_get_config: mock.MagicMock):
         mock_get_config.return_value = _make_config(report_renderer_enabled=False)
         service = NotificationService()
@@ -900,6 +985,42 @@ class TestNotificationServiceReportGeneration(unittest.TestCase):
         self.assertNotIn("动作: 卖出", out)
 
     @mock.patch("src.notification.get_config")
+    def test_generate_wechat_summary_aligns_legacy_advice_to_strong_buy_for_80_plus(
+        self, mock_get_config: mock.MagicMock
+    ):
+        mock_get_config.return_value = _make_config(report_renderer_enabled=False)
+        service = NotificationService()
+        result = AnalysisResult(
+            code="301308.SZ",
+            name="江波龙",
+            sentiment_score=85,
+            trend_prediction="看多",
+            operation_advice="持有",
+            analysis_summary="高分且旧建议仍为持有",
+        )
+
+        out = service.generate_wechat_summary([result])
+
+        self.assertIn("### 💚 江波龙(301308.SZ)", out)
+        self.assertIn("**强烈买入** | 评分:85 |", out)
+        self.assertNotIn("**买入** | 评分:85 |", out)
+
+    def test_build_stock_summary_aligns_legacy_advice_to_score_level_for_80_plus(self) -> None:
+        result = AnalysisResult(
+            code="301308.SZ",
+            name="江波龙",
+            sentiment_score=85,
+            trend_prediction="看多",
+            operation_advice="持有",
+            analysis_summary="高分但旧建议仍为持有",
+        )
+
+        out = NotificationBuilder.build_stock_summary([result])
+
+        self.assertIn("💚 江波龙(301308.SZ): 强烈买入 | 评分 85", out)
+        self.assertNotIn("🟢 江波龙(301308.SZ): 买入 | 评分 85", out)
+
+    @mock.patch("src.notification.get_config")
     def test_generate_dashboard_report_appends_decision_signal_excerpt_with_renderer(
         self, mock_get_config: mock.MagicMock
     ):
@@ -922,6 +1043,45 @@ class TestNotificationServiceReportGeneration(unittest.TestCase):
         self.assertIn("动作: 卖出", detail_section)
         self.assertIn("周期: 1d", detail_section)
         self.assertIn("理由: 技术面走弱", detail_section)
+
+    @mock.patch("src.notification.get_config")
+    @mock.patch("src.services.history_comparison_service.get_signal_changes_batch")
+    def test_generate_dashboard_report_localizes_history_compare_label_with_renderer(
+        self,
+        mock_get_signal_changes_batch: mock.MagicMock,
+        mock_get_config: mock.MagicMock,
+    ):
+        mock_get_config.return_value = _make_config(
+            report_renderer_enabled=True,
+            report_language="en",
+            report_history_compare_n=2,
+        )
+        mock_get_signal_changes_batch.return_value = {
+            "600519": [
+                {
+                    "created_at": "2026-07-01T10:00:00+08:00",
+                    "sentiment_score": 78,
+                    "operation_advice": "持有",
+                    "action_label": "回避",
+                    "trend_prediction": "看多",
+                },
+            ]
+        }
+        service = NotificationService()
+        result = AnalysisResult(
+            code="600519",
+            name="贵州茅台",
+            sentiment_score=72,
+            trend_prediction="看多",
+            operation_advice="持有",
+            analysis_summary="稳健",
+            report_language="en",
+        )
+
+        out = service.generate_dashboard_report([result], report_date="2026-07-01")
+
+        self.assertIn("| 2026-07-01T10:00 | 78 | Avoid |", out)
+        self.assertNotIn("| 2026-07-01T10:00 | 78 | 回避 |", out)
 
     @mock.patch("src.notification.get_config")
     def test_aggregate_reports_show_compact_market_status_only(self, mock_get_config: mock.MagicMock):
@@ -1145,7 +1305,7 @@ class TestNotificationServiceReportGeneration(unittest.TestCase):
         result = AnalysisResult(
             code="AAPL",
             name="Apple",
-            sentiment_score=65,
+            sentiment_score=55,
             trend_prediction="Sideways",
             operation_advice="Hold",
             analysis_summary="Wait for a cleaner breakout.",
@@ -1727,6 +1887,73 @@ class TestNotificationServiceReportGeneration(unittest.TestCase):
         self.assertEqual(first, {"history_by_code": {"600519": []}})
         self.assertEqual(second, {"history_by_code": {"600519": []}})
         mock_batch.assert_called_once()
+
+    @mock.patch("src.notification.get_config")
+    def test_history_compare_context_forwards_report_language(self, mock_get_config: mock.MagicMock):
+        mock_get_config.return_value = _make_config(report_language="en", report_history_compare_n=2)
+        service = NotificationService()
+        result = AnalysisResult(
+            code="600519",
+            name="贵州茅台",
+            sentiment_score=72,
+            trend_prediction="看多",
+            operation_advice="持有",
+            analysis_summary="稳健",
+            report_language="en",
+            query_id="q-lang",
+        )
+
+        with mock.patch(
+            "src.services.history_comparison_service.get_signal_changes_batch",
+            return_value={"600519": []},
+        ) as mock_batch:
+            service._get_history_compare_context([result])
+
+        mock_batch.assert_called_once_with(
+            ["600519"],
+            limit=2,
+            exclude_query_ids={"600519": "q-lang"},
+            report_language="en",
+        )
+
+    @mock.patch("src.notification.get_config")
+    def test_history_compare_context_cache_key_includes_report_language(
+        self, mock_get_config: mock.MagicMock
+    ):
+        mock_get_config.return_value = _make_config(report_history_compare_n=2)
+        service = NotificationService()
+        result = AnalysisResult(
+            code="600519",
+            name="贵州茅台",
+            sentiment_score=72,
+            trend_prediction="看多",
+            operation_advice="持有",
+            analysis_summary="稳健",
+            report_language="en",
+            query_id="q-lang",
+        )
+
+        def fake_signal_changes(codes, **kwargs):
+            report_language = kwargs["report_language"]
+            return {codes[0]: [{"action_label": f"{report_language}-label"}]}
+
+        with mock.patch(
+            "src.services.history_comparison_service.get_signal_changes_batch",
+            side_effect=fake_signal_changes,
+        ) as mock_batch:
+            first = service._get_history_compare_context([result])
+            result.report_language = "zh"
+            second = service._get_history_compare_context([result])
+
+        self.assertEqual(
+            first,
+            {"history_by_code": {"600519": [{"action_label": "en-label"}]}},
+        )
+        self.assertEqual(
+            second,
+            {"history_by_code": {"600519": [{"action_label": "zh-label"}]}},
+        )
+        self.assertEqual(mock_batch.call_count, 2)
 
     @mock.patch("src.notification.get_config")
     @mock.patch("smtplib.SMTP_SSL")

--- a/tests/test_report_language.py
+++ b/tests/test_report_language.py
@@ -64,6 +64,20 @@ class ReportLanguageTestCase(unittest.TestCase):
             ("Strong Buy", "💚", "strong_buy"),
         )
 
+    def test_get_signal_level_preserves_strong_sell_text_below_upgrade_threshold(self) -> None:
+        self.assertEqual(
+            get_signal_level("强烈卖出", 72, "zh"),
+            ("强烈卖出", "🔴", "strong_sell"),
+        )
+        self.assertEqual(
+            get_signal_level("Strong Sell", 72, "en"),
+            ("Strong Sell", "🔴", "strong_sell"),
+        )
+        self.assertEqual(
+            get_signal_level("적극 매도", 72, "ko"),
+            ("적극 매도", "🔴", "strong_sell"),
+        )
+
     def test_get_signal_level_preserves_add_action_for_high_score(self) -> None:
         for advice, language, expected in (
             ("加仓", "zh", "加仓"),

--- a/tests/test_report_language.py
+++ b/tests/test_report_language.py
@@ -33,6 +33,27 @@ class ReportLanguageTestCase(unittest.TestCase):
         self.assertEqual(emoji, "🟢")
         self.assertEqual(signal_tag, "buy")
 
+    def test_get_signal_level_prefers_trade_term_over_alert_prefix(self) -> None:
+        signal_text, emoji, signal_tag = get_signal_level("风险预警，建议卖出", 40, "zh")
+        self.assertEqual(signal_text, "卖出")
+        self.assertEqual(emoji, "🔴")
+        self.assertEqual(signal_tag, "sell")
+
+        signal_text, emoji, signal_tag = get_signal_level("Alert, sell", 40, "en")
+        self.assertEqual(signal_text, "Sell")
+        self.assertEqual(emoji, "🔴")
+        self.assertEqual(signal_tag, "sell")
+
+    def test_get_signal_level_upgrades_legacy_buy_signal_for_high_score(self) -> None:
+        self.assertEqual(
+            get_signal_level("买入", 85, "zh"),
+            ("强烈买入", "💚", "strong_buy"),
+        )
+        self.assertEqual(
+            get_signal_level("Buy", 88, "en"),
+            ("Strong Buy", "💚", "strong_buy"),
+        )
+
     def test_get_signal_level_score_fallback_uses_canonical_scale(self) -> None:
         self.assertEqual(get_signal_level("", 28, "zh"), ("减仓", "🟠", "reduce"))
         self.assertEqual(get_signal_level("", 38, "zh"), ("减仓", "🟠", "reduce"))
@@ -41,6 +62,19 @@ class ReportLanguageTestCase(unittest.TestCase):
         self.assertEqual(get_signal_level("", 60, "zh"), ("买入", "🟢", "buy"))
         self.assertEqual(get_signal_level("", 66, "zh"), ("买入", "🟢", "buy"))
         self.assertEqual(get_signal_level("", 72, "zh"), ("买入", "🟢", "buy"))
+
+    def test_get_signal_level_maps_guard_actions_before_score_fallback(self) -> None:
+        self.assertEqual(get_signal_level("回避", 72, "zh"), ("回避", "🟡", "hold"))
+        self.assertEqual(get_signal_level("Alert", 72, "en"), ("Alert", "🟡", "hold"))
+        self.assertEqual(infer_decision_type_from_advice("风险预警", default="buy"), "hold")
+        self.assertEqual(
+            infer_decision_type_from_advice("风险预警，建议卖出", default="hold"),
+            "sell",
+        )
+        self.assertEqual(
+            infer_decision_type_from_advice("Alert, sell", default="hold"),
+            "sell",
+        )
 
     def test_get_localized_stock_name_replaces_placeholder_for_english(self) -> None:
         self.assertEqual(
@@ -137,6 +171,12 @@ class KoreanReportLanguageTestCase(unittest.TestCase):
     def test_korean_advice_resolves_signal_level(self) -> None:
         self.assertEqual(get_signal_level("매수", 72, "ko"), ("매수", "🟢", "buy"))
         self.assertEqual(get_signal_level("매도", 30, "ko"), ("매도", "🔴", "sell"))
+
+    def test_korean_compound_alert_advice_prefers_trade_action(self) -> None:
+        self.assertEqual(get_signal_level("경고, 매도", 40, "ko"), ("매도", "🔴", "sell"))
+        self.assertEqual(get_signal_level("경고, 비중축소", 40, "ko"), ("비중축소", "🟠", "reduce"))
+        self.assertEqual(infer_decision_type_from_advice("경고, 매도"), "sell")
+        self.assertEqual(infer_decision_type_from_advice("경고, 비중축소"), "sell")
 
     def test_korean_values_canonicalize_back_for_other_languages(self) -> None:
         self.assertEqual(localize_trend_prediction("상승", "en"), "Bullish")

--- a/tests/test_report_language.py
+++ b/tests/test_report_language.py
@@ -54,6 +54,18 @@ class ReportLanguageTestCase(unittest.TestCase):
             ("Strong Buy", "💚", "strong_buy"),
         )
 
+    def test_get_signal_level_preserves_add_action_for_high_score(self) -> None:
+        for advice, language, expected in (
+            ("加仓", "zh", "加仓"),
+            ("Add", "en", "Add"),
+            ("추가 매수", "ko", "추가 매수"),
+        ):
+            with self.subTest(language=language):
+                self.assertEqual(
+                    get_signal_level(advice, 85, language),
+                    (expected, "🟢", "buy"),
+                )
+
     def test_get_signal_level_score_fallback_uses_canonical_scale(self) -> None:
         self.assertEqual(get_signal_level("", 28, "zh"), ("减仓", "🟠", "reduce"))
         self.assertEqual(get_signal_level("", 38, "zh"), ("减仓", "🟠", "reduce"))

--- a/tests/test_report_language.py
+++ b/tests/test_report_language.py
@@ -54,6 +54,16 @@ class ReportLanguageTestCase(unittest.TestCase):
             ("Strong Buy", "💚", "strong_buy"),
         )
 
+    def test_get_signal_level_preserves_strong_buy_text_below_upgrade_threshold(self) -> None:
+        self.assertEqual(
+            get_signal_level("强烈买入", 72, "zh"),
+            ("强烈买入", "💚", "strong_buy"),
+        )
+        self.assertEqual(
+            get_signal_level("Strong Buy", 72, "en"),
+            ("Strong Buy", "💚", "strong_buy"),
+        )
+
     def test_get_signal_level_preserves_add_action_for_high_score(self) -> None:
         for advice, language, expected in (
             ("加仓", "zh", "加仓"),

--- a/tests/test_report_renderer.py
+++ b/tests/test_report_renderer.py
@@ -79,7 +79,34 @@ class TestReportRenderer(unittest.TestCase):
         self.assertIsNotNone(out)
         self.assertIn("决策仪表盘", out)
         self.assertIn("贵州茅台", out)
-        self.assertIn("持有", out)
+        self.assertIn("🟢买入:1 🟡观望:0 🔴卖出:0", out)
+        self.assertIn("买入 | 评分 72", out)
+
+    def test_render_markdown_summary_keeps_guardrailed_hold(self) -> None:
+        r = _make_result(
+            dashboard={
+                "decision_stability": {"reason": "等待支撑确认"},
+            }
+        )
+
+        out = render("markdown", [r], summary_only=True)
+
+        self.assertIsNotNone(out)
+        self.assertIn("🟢买入:0 🟡观望:1 🔴卖出:0", out)
+        self.assertIn("持有 | 评分 72", out)
+        self.assertNotIn("买入 | 评分 72", out)
+
+    def test_render_markdown_summary_keeps_legacy_decision_type_when_display_action_missing(self) -> None:
+        r = _make_result(
+            operation_advice="未知波动信号",
+            decision_type="buy",
+            sentiment_score=72,
+        )
+
+        out = render("markdown", [r], summary_only=True)
+
+        self.assertIsNotNone(out)
+        self.assertIn("🟢买入:1 🟡观望:0 🔴卖出:0", out)
 
     def test_render_markdown_full(self) -> None:
         """Markdown platform renders full report."""
@@ -89,6 +116,173 @@ class TestReportRenderer(unittest.TestCase):
         self.assertIn("核心结论", out)
         self.assertIn("作战计划", out)
         self.assertNotIn("盘中决策护栏", out)
+
+    def test_render_markdown_history_compare_uses_aligned_action_label(self) -> None:
+        r = _make_result(
+            operation_advice="持有",
+            sentiment_score=60,
+        )
+        out = render(
+            "markdown",
+            [r],
+            summary_only=False,
+            extra_context={
+                "history_by_code": {
+                    "600519": [
+                        {
+                            "created_at": "2026-07-01T10:00:00+08:00",
+                            "sentiment_score": 78,
+                            "operation_advice": "持有",
+                            "trend_prediction": "看多",
+                            "action_label": "买入",
+                        }
+                    ]
+                }
+            },
+        )
+
+        self.assertIsNotNone(out)
+        self.assertIn("| 2026-07-01T10:00 | 78 | 买入 | 看多 |", out)
+        self.assertNotIn("| 2026-07-01T10:00 | 78 | 持有 | 看多 |", out)
+
+    def test_render_markdown_history_compare_localizes_stale_action_label_by_report_language(self) -> None:
+        r = _make_result(
+            operation_advice="持有",
+            sentiment_score=60,
+        )
+        out = render(
+            "markdown",
+            [r],
+            summary_only=False,
+            extra_context={
+                "history_by_code": {
+                    "600519": [
+                        {
+                            "created_at": "2026-07-01T10:00:00+08:00",
+                            "sentiment_score": 78,
+                            "operation_advice": "观望",
+                            "action_label": "回避",
+                            "trend_prediction": "看多",
+                        }
+                    ]
+                },
+                "report_language": "en",
+            },
+        )
+
+        self.assertIsNotNone(out)
+        self.assertIn("| 2026-07-01T10:00 | 78 | Avoid |", out)
+        self.assertNotIn("| 2026-07-01T10:00 | 78 | 回避 |", out)
+
+    def test_render_markdown_history_compare_localizes_action_by_report_language(self) -> None:
+        r = _make_result(
+            operation_advice="持有",
+            sentiment_score=60,
+        )
+        out = render(
+            "markdown",
+            [r],
+            summary_only=False,
+            extra_context={
+                "history_by_code": {
+                    "600519": [
+                        {
+                            "created_at": "2026-07-01T10:00:00+08:00",
+                            "sentiment_score": 78,
+                            "operation_advice": "持有",
+                            "action": "buy",
+                            "action_label": "持有",
+                            "trend_prediction": "看多",
+                        }
+                    ]
+                },
+                "report_language": "en",
+            },
+        )
+
+        self.assertIsNotNone(out)
+        self.assertIn("| 2026-07-01T10:00 | 78 | Buy |", out)
+
+    def test_render_markdown_summary_ignores_unapplied_stability_reason(self) -> None:
+        r = _make_result(
+            dashboard={
+                "decision_stability": {
+                    "applied": False,
+                    "reason": "未使用资金流校准",
+                },
+            }
+        )
+
+        out = render("markdown", [r], summary_only=True)
+
+        self.assertIsNotNone(out)
+        self.assertIn("🟢买入:1 🟡观望:0 🔴卖出:0", out)
+        self.assertIn("买入 | 评分 72", out)
+        self.assertNotIn("持有 | 评分 72", out)
+
+    def test_render_markdown_full_shows_strong_buy_signal_for_80_plus_legacy_advice(self) -> None:
+        r = _make_result(
+            operation_advice="持有",
+            sentiment_score=85,
+            analysis_summary="高分但旧建议仍为持有",
+            dashboard={
+                "core_conclusion": {"one_sentence": "高分但旧建议仍为持有"},
+            },
+        )
+
+        out = render("markdown", [r], summary_only=False)
+
+        self.assertIsNotNone(out)
+        self.assertIn("**💚 强烈买入** | 看多", out)
+        self.assertNotIn("**🟢 买入** | 看多", out)
+
+    def test_render_markdown_summary_only_shows_strong_buy_for_80_plus_legacy_advice(self) -> None:
+        r = _make_result(
+            operation_advice="持有",
+            sentiment_score=85,
+            analysis_summary="高分但旧建议仍为持有",
+            dashboard={
+                "core_conclusion": {"one_sentence": "高分但旧建议仍为持有"},
+            },
+        )
+
+        out = render("markdown", [r], summary_only=True)
+
+        self.assertIsNotNone(out)
+        self.assertIn("💚 **贵州茅台(600519)**: 强烈买入 | 评分 85", out)
+        self.assertNotIn("🟢 **贵州茅台(600519)**: 买入 | 评分 85", out)
+
+    def test_render_brief_shows_strong_buy_for_80_plus_legacy_advice(self) -> None:
+        r = _make_result(
+            operation_advice="持有",
+            sentiment_score=85,
+            analysis_summary="高分但旧建议仍为持有",
+            dashboard={
+                "core_conclusion": {"one_sentence": "高分但旧建议仍为持有"},
+            },
+        )
+
+        out = render("brief", [r])
+
+        self.assertIsNotNone(out)
+        self.assertIn("**贵州茅台(600519)** 💚 强烈买入 | 评分 85", out)
+        self.assertNotIn("**贵州茅台(600519)** 🟢 买入 | 评分 85", out)
+
+    def test_render_wechat_summary_only_shows_strong_buy_for_80_plus_legacy_advice(self) -> None:
+        r = _make_result(
+            operation_advice="持有",
+            sentiment_score=85,
+            analysis_summary="高分但旧建议仍为持有",
+            dashboard={
+                "core_conclusion": {"one_sentence": "高分但旧建议仍为持有"},
+            },
+        )
+
+        out = render("wechat", [r], summary_only=True)
+
+        self.assertIsNotNone(out)
+        self.assertIn("💚 **贵州茅台(600519)**: 强烈买入 | 评分 85", out)
+        self.assertNotIn("🟢 **贵州茅台(600519)**: 买入 | 评分 85", out)
 
     def test_render_markdown_keeps_decision_signal_out_of_summary(self) -> None:
         """Markdown summary stays compact while full details keep DecisionSignal excerpts."""

--- a/tests/test_report_renderer.py
+++ b/tests/test_report_renderer.py
@@ -264,6 +264,35 @@ class TestReportRenderer(unittest.TestCase):
         self.assertIn("| 2026-07-01T10:00 | 72 | 强烈买入 | 看多 |", out)
         self.assertNotIn("| 2026-07-01T10:00 | 72 | 买入 | 看多 |", out)
 
+    def test_render_markdown_history_compare_preserves_explicit_strong_sell_label(self) -> None:
+        r = _make_result(
+            operation_advice="持有",
+            sentiment_score=72,
+        )
+        out = render(
+            "markdown",
+            [r],
+            summary_only=False,
+            extra_context={
+                "history_by_code": {
+                    "600519": [
+                        {
+                            "created_at": "2026-07-01T10:00:00+08:00",
+                            "sentiment_score": 72,
+                            "operation_advice": "持有",
+                            "action": "sell",
+                            "action_label": "强烈卖出",
+                            "trend_prediction": "看多",
+                        }
+                    ]
+                }
+            },
+        )
+
+        self.assertIsNotNone(out)
+        self.assertIn("| 2026-07-01T10:00 | 72 | 强烈卖出 | 看多 |", out)
+        self.assertNotIn("| 2026-07-01T10:00 | 72 | 卖出 | 看多 |", out)
+
     def test_render_markdown_summary_ignores_unapplied_stability_reason(self) -> None:
         r = _make_result(
             dashboard={

--- a/tests/test_report_renderer.py
+++ b/tests/test_report_renderer.py
@@ -203,6 +203,36 @@ class TestReportRenderer(unittest.TestCase):
         self.assertIsNotNone(out)
         self.assertIn("| 2026-07-01T10:00 | 78 | Buy |", out)
 
+    def test_render_markdown_history_compare_uses_score_aware_strong_buy_label(self) -> None:
+        r = _make_result(
+            operation_advice="持有",
+            sentiment_score=60,
+        )
+        for report_language, expected_label in (("zh", "强烈买入"), ("en", "Strong Buy")):
+            with self.subTest(report_language=report_language):
+                out = render(
+                    "markdown",
+                    [r],
+                    summary_only=False,
+                    extra_context={
+                        "history_by_code": {
+                            "600519": [
+                                {
+                                    "created_at": "2026-07-01T10:00:00+08:00",
+                                    "sentiment_score": 85,
+                                    "operation_advice": "持有",
+                                    "action": "buy",
+                                    "trend_prediction": "看多",
+                                }
+                            ]
+                        },
+                        "report_language": report_language,
+                    },
+                )
+
+                self.assertIsNotNone(out)
+                self.assertIn(f"| 2026-07-01T10:00 | 85 | {expected_label} |", out)
+
     def test_render_markdown_summary_ignores_unapplied_stability_reason(self) -> None:
         r = _make_result(
             dashboard={

--- a/tests/test_report_renderer.py
+++ b/tests/test_report_renderer.py
@@ -314,6 +314,44 @@ class TestReportRenderer(unittest.TestCase):
         self.assertIn("💚 **贵州茅台(600519)**: 强烈买入 | 评分 85", out)
         self.assertNotIn("🟢 **贵州茅台(600519)**: 买入 | 评分 85", out)
 
+    def test_render_reports_preserve_add_action_for_high_score(self) -> None:
+        r = _make_result(sentiment_score=85)
+        r.action = "add"
+        r.action_label = "加仓"
+
+        for platform in ("markdown", "wechat", "brief"):
+            with self.subTest(platform=platform):
+                out = render(platform, [r], summary_only=True)
+
+                self.assertIsNotNone(out)
+                self.assertIn("加仓 | 评分 85", out)
+                self.assertNotIn("强烈买入 | 评分 85", out)
+
+    def test_render_markdown_history_preserves_add_action_for_high_score(self) -> None:
+        r = _make_result()
+        out = render(
+            "markdown",
+            [r],
+            summary_only=False,
+            extra_context={
+                "history_by_code": {
+                    "600519": [
+                        {
+                            "created_at": "2026-07-01T10:00:00+08:00",
+                            "sentiment_score": 85,
+                            "operation_advice": "买入",
+                            "action": "add",
+                            "trend_prediction": "看多",
+                        }
+                    ]
+                }
+            },
+        )
+
+        self.assertIsNotNone(out)
+        self.assertIn("| 2026-07-01T10:00 | 85 | 加仓 |", out)
+        self.assertNotIn("| 2026-07-01T10:00 | 85 | 强烈买入 |", out)
+
     def test_render_markdown_keeps_decision_signal_out_of_summary(self) -> None:
         """Markdown summary stays compact while full details keep DecisionSignal excerpts."""
         r = _with_decision_signal_summary(_make_result())

--- a/tests/test_report_renderer.py
+++ b/tests/test_report_renderer.py
@@ -235,6 +235,35 @@ class TestReportRenderer(unittest.TestCase):
                 self.assertIsNotNone(out)
                 self.assertIn(f"| 2026-07-01T10:00 | 85 | {expected_label} |", out)
 
+    def test_render_markdown_history_compare_preserves_explicit_strong_buy_label(self) -> None:
+        r = _make_result(
+            operation_advice="持有",
+            sentiment_score=72,
+        )
+        out = render(
+            "markdown",
+            [r],
+            summary_only=False,
+            extra_context={
+                "history_by_code": {
+                    "600519": [
+                        {
+                            "created_at": "2026-07-01T10:00:00+08:00",
+                            "sentiment_score": 72,
+                            "operation_advice": "持有",
+                            "action": "buy",
+                            "action_label": "强烈买入",
+                            "trend_prediction": "看多",
+                        }
+                    ]
+                }
+            },
+        )
+
+        self.assertIsNotNone(out)
+        self.assertIn("| 2026-07-01T10:00 | 72 | 强烈买入 | 看多 |", out)
+        self.assertNotIn("| 2026-07-01T10:00 | 72 | 买入 | 看多 |", out)
+
     def test_render_markdown_summary_ignores_unapplied_stability_reason(self) -> None:
         r = _make_result(
             dashboard={

--- a/tests/test_report_renderer.py
+++ b/tests/test_report_renderer.py
@@ -99,14 +99,16 @@ class TestReportRenderer(unittest.TestCase):
     def test_render_markdown_summary_keeps_legacy_decision_type_when_display_action_missing(self) -> None:
         r = _make_result(
             operation_advice="未知波动信号",
-            decision_type="buy",
+            decision_type="sell",
             sentiment_score=72,
         )
 
         out = render("markdown", [r], summary_only=True)
 
         self.assertIsNotNone(out)
-        self.assertIn("🟢买入:1 🟡观望:0 🔴卖出:0", out)
+        self.assertIn("🟢买入:0 🟡观望:0 🔴卖出:1", out)
+        self.assertIn("卖出 | 评分 72", out)
+        self.assertNotIn("买入 | 评分 72", out)
 
     def test_render_markdown_full(self) -> None:
         """Markdown platform renders full report."""


### PR DESCRIPTION
## PR Type

- [x] fix
- [ ] feat
- [ ] refactor
- [ ] docs
- [ ] chore
- [ ] test

## Background And Problem

Replaces #1950.

Web/API 已经按 canonical `action` / `action_label` 与 `sentiment_score` 对齐展示，但推送通知、Jinja/Markdown 报告和历史报告仍会在部分路径直接使用 legacy `operation_advice` 或无法识别的本地化标签，导致同一条高分记录在 Web 显示为买入，在报告/历史中显示为持有、观望或错误的 guard 标签。

#1950 后续补丁还留下了几个 review 指出的边界：guard action 传入 `get_signal_level()` 后会被分数 fallback 覆盖、未知 action 时没有回退 legacy `decision_type`、80+ 分 legacy neutral 建议没有保留强烈买入文案、韩文 `경고, 매도` / `경고, 비중축소` 这类复合建议会被 guard 前缀盖过实际交易动作。本 PR 在最新 `main` 上重新开干净分支并一次性收敛这些契约。

## Scope Of Change

文件总数 / diff stat:

```text
 api/v1/endpoints/analysis.py               |  45 ++----
 api/v1/endpoints/history.py                |  32 +---
 docs/CHANGELOG.md                          |   1 +
 src/notification.py                        | 101 +++++++-----
 src/report_language.py                     |  63 ++++++--
 src/schemas/decision_action.py             | 228 ++++++++++++++++++++++++---
 src/schemas/decision_scale.py              |  54 ++++++-
 src/services/history_comparison_service.py |  42 ++++-
 src/services/history_service.py            |  33 ++--
 src/services/report_renderer.py            |  24 ++-
 templates/report_brief.j2                  |   2 +-
 templates/report_markdown.j2               |   6 +-
 templates/report_wechat.j2                 |   2 +-
 tests/test_analysis_api_contract.py        | 149 ++++++++++++++++++
 tests/test_analysis_history.py             | 241 +++++++++++++++++++++++++++++
 tests/test_decision_action.py              | 207 ++++++++++++++++++++++++-
 tests/test_history_comparison_service.py   | 135 ++++++++++++++++
 tests/test_notification.py                 | 231 ++++++++++++++++++++++++++-
 tests/test_report_language.py              |  40 +++++
 tests/test_report_renderer.py              | 196 ++++++++++++++++++++++-
 20 files changed, 1680 insertions(+), 152 deletions(-)
```

文件清单:

- `api/v1/endpoints/analysis.py`
- `api/v1/endpoints/history.py`
- `docs/CHANGELOG.md`
- `src/notification.py`
- `src/report_language.py`
- `src/schemas/decision_action.py`
- `src/schemas/decision_scale.py`
- `src/services/history_comparison_service.py`
- `src/services/history_service.py`
- `src/services/report_renderer.py`
- `templates/report_brief.j2`
- `templates/report_markdown.j2`
- `templates/report_wechat.j2`
- `tests/test_analysis_api_contract.py`
- `tests/test_analysis_history.py`
- `tests/test_decision_action.py`
- `tests/test_history_comparison_service.py`
- `tests/test_notification.py`
- `tests/test_report_language.py`
- `tests/test_report_renderer.py`

核心变化:

- 统一 Web/API、通知、Jinja 报告、历史列表/详情/Markdown 导出的 display action 口径。
- 新增共享 action display helper、guardrail reason 提取和 score/action conflict 对齐逻辑。
- 让 guard / add / strong-buy / legacy decision_type / 韩文复合 alert+trade 建议在报告标题、摘要统计和历史比较中保持一致。
- 补齐 #1950 review 反例的回归测试。

文档更新文件: `docs/CHANGELOG.md`

## Issue Link

Fixes #1949

## Verification Commands And Results

当前 Head CI: PR 创建后待跑；请以本 PR 最新 Actions 结果为准。

本地验证:

```bash
venv/bin/python -m py_compile src/schemas/decision_action.py src/report_language.py src/notification.py src/services/report_renderer.py src/services/history_service.py src/services/history_comparison_service.py api/v1/endpoints/analysis.py api/v1/endpoints/history.py
# passed

git diff --check
# passed

PATH="$PWD/venv/bin:$PATH" ./scripts/ci_gate.sh flake8
# passed; flake8 critical checks: 0

venv/bin/python -m pytest tests/test_decision_action.py tests/test_report_language.py tests/test_report_renderer.py tests/test_notification.py tests/test_history_comparison_service.py tests/test_analysis_api_contract.py tests/test_analysis_history.py -q
# 500 passed, 5 warnings
```

完整 backend gate 本地执行情况:

```bash
PATH="$PWD/venv/bin:$PATH" ./scripts/ci_gate.sh
# syntax check: passed
# flake8 critical checks: passed
# deterministic checks: passed
# offline pytest: 4397 passed, 21 failed, 4 deselected, 46 warnings, 413 subtests passed
```

本地完整 gate 的失败集中在未触及模块，主要是 `tests/test_alphasift_api.py`、`tests/test_intelligence_service.py` 和 `tests/test_system_config_service.py` 的运行时配置/外部集成相关用例；本 PR 修改范围内的 action/report/API/history/notification 回归测试已全部通过。该本地 pytest 在打印最终 summary 后仍有 pytest 子进程挂起，已手动终止；上述 summary 为终止前已输出的最终统计。

CI 矩阵占位（PR 创建后更新/以 Actions 为准）:

- ai-governance: pending
- backend-gate: pending
- docker-build: pending
- web-gate: not triggered unless CI detects web changes

## Visual Evidence (if applicable)

未附截图。本 PR 修改的是 Markdown/Jinja/通知/历史报告文本渲染与统计口径，不涉及交互式 Web UI。替代可复现证据为上方 500 个聚焦回归测试，覆盖高分 legacy neutral -> buy/strong-buy、explicit guardrail -> hold/watch、guard action score fallback、韩文复合 alert+sell/reduce、history comparison localization、API/list/detail/Markdown 导出等路径。

## Compatibility And Risk

本 PR 未变更 provider/model/base URL、运行时配置清理迁移语义；历史配置保持不变；回滚方式为 revert 本提交。

兼容性影响: 既有历史记录仍可读取。用户可见变化集中在展示层和统计桶: 当高分记录仅有 legacy neutral `operation_advice` 且没有显式 guardrail/downgrade reason 时，报告/通知/历史会与 Web/API 一样按 canonical score/action 显示为买入或强烈买入；若上游希望高分记录保持持有/观望，需要提供明确的 guardrail/downgrade reason。

风险点: action/advice 文本归一化涉及多语言和历史兼容，已用 targeted regression 覆盖 review 反例；仍需等待 GitHub Actions 对完整环境的 backend gate 结论。

## Rollback Plan

Revert this PR to restore the previous raw `operation_advice` rendering and summary-count behavior. No data migration, config rollback, or provider/model rollback is required.

## EXTRACT_PROMPT Change (if applicable)

Not applicable.

## Checklist

- [x] 本 PR 有明确动机和业务价值 / This PR has a clear motivation and value
- [x] 已提供可复现的验证命令与结果 / Reproducible verification commands and results are included
- [x] 已评估兼容性与风险 / Compatibility and risk have been assessed
- [x] 已提供回滚方案 / A rollback plan is provided
- [x] 若修改报告格式或 Web UI 界面，已在 PR 描述/评论附受影响报告 / 页面截图，且未把一次性验收截图作为仓库文件合入 / If report formatting or Web UI changed, affected report/page screenshots are linked in the PR body/comments and one-off acceptance screenshots are not committed as repository files
- [x] 若本 PR 修改 Web 设置字段（字段、文案或帮助文本），请补充设置页截图；无法截图时需提供替代可视证据（命令 + 产物路径），并指向对应变更项 / If Web settings fields changed (labels or help text), screenshots of the settings page are required; if unavailable, provide alternative visual evidence with command + artifact path that points to the changed item.
- [x] 若涉及用户可见变更，已同步更新相关文档与 `docs/CHANGELOG.md`；`README.md` 仅在首页级信息变化时更新，细节优先写入 `docs/*.md` / If user-visible changes are included, relevant docs and `docs/CHANGELOG.md` are updated; `README.md` is updated only for homepage-level changes, with details kept in `docs/*.md`