### PR TITLE
test: 验证 OpenReview webhook 端到端流程

### DIFF
--- a/.github/openreview-webhook-smoke-test.md
+++ b/.github/openreview-webhook-smoke-test.md
@@ -1,0 +1,7 @@
+# OpenReview webhook smoke test
+
+This temporary file exists only to create a non-empty, ready-for-review pull
+request and verify the repository's OpenReview webhook flow end to end.
+
+The pull request must not be merged. It can be closed after webhook delivery,
+CI observation, and automated review have been verified.


### PR DESCRIPTION
## What changed

- Add one temporary Markdown file so this ready-for-review PR has a minimal diff.
- This PR exists only for an end-to-end OpenReview webhook smoke test.

## Why

Verify that a `pull_request/opened` event reaches the public HTTPS endpoint, is
accepted by the hybrid webhook queue, waits for CI when required, and results in
an automated OpenReview analysis.

## Impact

No product or runtime behavior changes. **Do not merge this PR.** It will be
closed after the delivery and automated review flow are verified.

## Validation

- `git diff --cached --check`
- GitHub webhook Recent Deliveries
- OpenReview service logs
- PR checks and automated review/comment timestamps

## Risk and rollback

The only risk is accidentally merging a test-only file. Rollback is to close the
PR without merging; the default branch remains unchanged.
