### PR TITLE
fix: 复用市场结构概念排行负结果

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 > For user-friendly release highlights, see the [GitHub Releases](https://github.com/ZhuLinsen/daily_stock_analysis/releases) page.
 
 ## [Unreleased]
+- [修复] 市场结构概念排行为空或超时时复用本轮负结果，避免批量个股分析重复请求同一概念排行数据源。
 - [改进] 为 multi-agent DecisionAgent 增加内部低敏分歧摘要输入管线，作为 #1904 P1 解释输出的前置 plumbing；不改变 public API、dashboard schema 或最终解释字段。
 - [修复] 推送报告、Jinja 报告与历史 Markdown 导出复用 Web/API 的评分-action 口径：高分但旧 `operation_advice` 仍为持有且无降级原因时，建议文案与三类统计展示为买入；有明确 guardrail reason 时继续保留持有/观望。
 - [改进] GitHub Actions 每日分析工作流补齐 TickFlow 数据源环境变量映射，并收敛 README 数据源稳定性说明到完整指南。

--- a/src/core/pipeline.py
+++ b/src/core/pipeline.py
@@ -1145,14 +1145,19 @@ class StockAnalysisPipeline:
 
         top_concepts, bottom_concepts = self._get_concept_rankings_for_market(market)
 
-        if top_concepts or bottom_concepts:
-            enriched_context["concept_boards"] = {
-                "status": "ok" if top_concepts and bottom_concepts else "partial",
-                "data": {
-                    "top": top_concepts,
-                    "bottom": bottom_concepts,
-                },
-            }
+        concept_data: Dict[str, Any] = {
+            "top": top_concepts,
+            "bottom": bottom_concepts,
+        }
+        if not top_concepts and not bottom_concepts:
+            # Empty lists are removed while fundamental contexts are merged.
+            # Keep a non-empty internal marker so downstream consumers can
+            # distinguish an attempted empty result from a missing preload.
+            concept_data["fetch_attempted"] = True
+        enriched_context["concept_boards"] = {
+            "status": "ok" if top_concepts and bottom_concepts else "partial",
+            "data": concept_data,
+        }
 
     def _get_concept_rankings_for_market(
         self,

--- a/tests/test_pipeline_related_boards.py
+++ b/tests/test_pipeline_related_boards.py
@@ -11,6 +11,7 @@ from api.v1.schemas.history import ReportDetails
 from data_provider.base import DataFetcherManager
 from src.core.pipeline import StockAnalysisPipeline
 from src.services.market_hotspot_service import MarketHotspotService
+from src.services.market_structure_service import MarketStructureService
 from src.utils.data_processing import (
     extract_board_detail_fields,
     extract_market_structure_detail_field,
@@ -116,6 +117,59 @@ class PipelineRelatedBoardsTestCase(unittest.TestCase):
         pipeline.fetcher_manager.get_concept_rankings.assert_called_once_with(5)
         self.assertEqual(first["concept_boards"]["data"]["top"][0]["name"], "Robot Theme")
         self.assertEqual(second["concept_boards"]["data"]["top"][0]["name"], "Robot Theme")
+
+    def test_empty_concept_rankings_are_reused_by_market_structure_builds(self) -> None:
+        pipeline = StockAnalysisPipeline.__new__(StockAnalysisPipeline)
+        pipeline.fetcher_manager = MagicMock()
+        pipeline.fetcher_manager.get_belong_boards.side_effect = [
+            [{"name": "Robot Theme", "type": "concept"}],
+            [{"name": "AI Theme", "type": "concept"}],
+        ]
+        pipeline.fetcher_manager.get_concept_rankings.return_value = ([], [])
+
+        context = {
+            "market": "cn",
+            "status": "ok",
+            "coverage": {"boards": "ok"},
+            "boards": {
+                "status": "ok",
+                "data": {
+                    "top": [{"name": "Technology", "change_pct": 1.2}],
+                    "bottom": [],
+                },
+            },
+        }
+
+        first = pipeline._attach_belong_boards_to_fundamental_context("600519", context)
+        second = pipeline._attach_belong_boards_to_fundamental_context("000001", context)
+
+        self.assertEqual(first["concept_boards"]["status"], "partial")
+        self.assertEqual(first["concept_boards"]["data"]["top"], [])
+        self.assertTrue(first["concept_boards"]["data"]["fetch_attempted"])
+        self.assertEqual(
+            extract_board_detail_fields(
+                {"fundamental_context": first}
+            )["concept_rankings"],
+            {"top": [], "bottom": [], "status": "partial"},
+        )
+
+        market_structure_service = MarketStructureService(
+            fetcher_manager=pipeline.fetcher_manager,
+        )
+        market_structure_service.build_context(
+            code="600519",
+            stock_name="First",
+            market="cn",
+            fundamental_context=first,
+        )
+        market_structure_service.build_context(
+            code="000001",
+            stock_name="Second",
+            market="cn",
+            fundamental_context=second,
+        )
+
+        pipeline.fetcher_manager.get_concept_rankings.assert_called_once_with(5)
 
     def test_get_concept_rankings_for_market_no_long_block_with_hanging_fetcher(self) -> None:
         fetcher = _HangingConceptRankingFetcher()


### PR DESCRIPTION
## PR Type

- [x] fix
- [ ] feat
- [ ] refactor
- [ ] docs
- [ ] chore
- [ ] test

## Background And Problem

#1981 为同一 pipeline run 增加了概念排行缓存，但当首次获取返回空列表或超时时，`_attach_concept_rankings_to_fundamental_context()` 不会写入 `concept_boards`。下游 `MarketStructureService` 因而把概念排行视为未预加载，并在批量分析的每只股票上再次请求同一数据源。

根因是空列表在 fundamental context 合并过程中会被移除，单纯写入 `{top: [], bottom: []}` 仍无法把“本轮已尝试”的负结果传到下游。

## Scope Of Change

共 3 个文件：

- `src/core/pipeline.py`
- `tests/test_pipeline_related_boards.py`
- `docs/CHANGELOG.md`

## Issue Link

Refs #1981；这是合入后发现的独立回归修复。

## Verification Commands And Results

- `python -m pytest tests/test_pipeline_related_boards.py -q`：16 passed。
- `python -m pytest tests/test_market_structure_service.py::test_market_hotspot_service_bounds_ranking_fetches -q`：1 passed。该既有严格计时用例在 44 项组合运行中曾因 Windows 调度超过 0.2 秒失败，隔离重跑通过。
- `python -m py_compile src/core/pipeline.py tests/test_pipeline_related_boards.py`：通过。
- `python -m flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics`：通过，0 个错误。
- `git diff --check`：通过。
- `python -m pytest -m "not network"`：4428 passed, 17 failed, 4 deselected；17 个失败集中在 Windows Docker shell、SQLite 迁移/并发、local CLI 和 intelligence fail-open 环境差异，与 #1981 合入前记录的本地失败类别一致，本 PR 聚焦路径通过。
- `bash ./scripts/ci_gate.sh`：Git Bash 找不到 Windows Python 环境中的 `flake8` 可执行文件，未形成有效 gate；已用同一 Python 环境执行上述全量关键 flake8 和完整离线测试。
- `bash ./scripts/test.sh code`：WSL Python 缺少 pandas，无法执行；未修改依赖或代码识别逻辑。

当前 Head CI：新 PR 创建后触发，请以 Checks 为准。

## Compatibility And Risk

- 成功返回概念排行时保持原有 payload 不变。
- 仅在 top/bottom 都为空时增加内部 `fetch_attempted` 标记，使负结果能穿过 fundamental context 合并；API 规范化排行字段不会暴露该标记。
- 下游继续得到 `{top: [], bottom: [], status: partial}`，但不会再次调用概念排行 provider。
- 不修改 API Schema、数据库、配置、provider/model/Base URL 或依赖。
- 风险集中在内部 fundamental context 的空榜单表示，新增两只股票共享一次负结果的回归测试覆盖该路径。

## Rollback Plan

直接 revert 本 PR；不需要配置、数据或数据库回滚。

## Visual Evidence

不适用。本 PR 不修改 Web UI 或报告渲染。

## Checklist

- [x] 本 PR 有明确动机和业务价值
- [x] 已提供可复现的验证命令与结果
- [x] 已评估兼容性与风险
- [x] 已提供回滚方案
- [x] 已更新 `docs/CHANGELOG.md`
