### PR TITLE
fix: 修复通知理由字段被截断

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - [修复] 按股票代码删除历史记录时分批清理全部匹配项，并拒绝空白代码，避免超过 10000 条后残留记录或无筛选删除。
 - [修复] 市场结构概念排行为空或超时时复用本轮负结果，避免批量个股分析重复请求同一概念排行数据源。
 - [修复] Windows/macOS 桌面后端打包显式收集并校验 AkShare `file_fold/calendar.json`，避免发行包因缺少交易日历 package data 导致热点题材和选股日线增强降级。
+- [修复] 邮件、Telegram 与报告共享的 DecisionSignal 摘要完整展示已脱敏的理由，避免固定 120 字符在句中无提示截断。
 - [改进] 为 multi-agent DecisionAgent 增加内部低敏分歧摘要输入管线，作为 #1904 P1 解释输出的前置 plumbing；不改变 public API、dashboard schema 或最终解释字段。
 - [修复] 推送报告、Jinja 报告与历史 Markdown 导出复用 Web/API 的评分-action 口径：高分但旧 `operation_advice` 仍为持有且无降级原因时，建议文案与三类统计展示为买入；有明确 guardrail reason 时继续保留持有/观望。
 - [改进] GitHub Actions 每日分析工作流补齐 TickFlow 数据源环境变量映射，并收敛 README 数据源稳定性说明到完整指南。

--- a/docs/decision-signals.md
+++ b/docs/decision-signals.md
@@ -171,6 +171,7 @@ Web 入口位于 `/decision-signals`：
 - 没有 active 信号时，告警 worker 只创建最小 `source_type=alert/action=alert` 信号。
 - 告警信号的 `trace_id=alert-rule-<hash>` 只用于同源重试的 best-effort 去重，不覆盖 active 信号本体。
 - 通知只引用公开摘要字段：`action`、`horizon`、`reason`、`watch_conditions`、`risk_summary`、`source_report_id`。
+- 通知中的 `reason` 在脱敏后完整展示，避免固定字符数在句中截断；`watch_conditions` 和 `risk_summary` 仍保持紧凑摘要上限。
 - 通知不得输出 signal `metadata`、`evidence`、raw diagnostics、webhook URL、token 或 cookie。
 - `GET /api/v1/portfolio/risk` 的 `decision_signal_risk` 只统计当前持仓中的 active `sell/reduce/alert` 信号，查询失败时 fail-open。
 

--- a/src/notification_sender/telegram_sender.py
+++ b/src/notification_sender/telegram_sender.py
@@ -84,12 +84,27 @@ class TelegramSender:
             # Telegram 消息最大长度 4096 字符
             max_length = 4096
 
-            if len(content) <= max_length:
+            telegram_content = self._convert_to_telegram_markdown(content)
+
+            if len(telegram_content) <= max_length:
                 # 单条消息发送
-                return self._send_telegram_message(api_url, chat_id, content, message_thread_id, timeout_seconds=timeout_seconds)
+                return self._send_telegram_message(
+                    api_url,
+                    chat_id,
+                    content,
+                    message_thread_id,
+                    timeout_seconds=timeout_seconds,
+                )
             else:
-                # 分段发送长消息
-                return self._send_telegram_chunked(api_url, chat_id, content, max_length, message_thread_id, timeout_seconds=timeout_seconds)
+                # 按 Markdown 转义后的最终 payload 分段，避免转义字符使请求超限
+                return self._send_telegram_chunked(
+                    api_url,
+                    chat_id,
+                    telegram_content,
+                    max_length,
+                    message_thread_id,
+                    timeout_seconds=timeout_seconds,
+                )
 
         except Exception as e:
             logger.error(f"发送 Telegram 消息失败: {e}")
@@ -105,10 +120,11 @@ class TelegramSender:
         message_thread_id: Optional[str] = None,
         *,
         timeout_seconds: Optional[float] = None,
+        markdown_converted: bool = False,
     ) -> bool:
         """Send a single Telegram message with exponential backoff retry (Fixes #287)"""
         # Convert Markdown to Telegram-compatible format
-        telegram_text = self._convert_to_telegram_markdown(text)
+        telegram_text = text if markdown_converted else self._convert_to_telegram_markdown(text)
 
         payload = {
             "chat_id": chat_id,
@@ -241,7 +257,7 @@ class TelegramSender:
         *,
         timeout_seconds: Optional[float] = None,
     ) -> bool:
-        """分段发送长 Telegram 消息"""
+        """按已转换的 Telegram Markdown payload 分段发送长消息。"""
         # 按段落分割
         sections = content.split("\n---\n")
         delimiter = "\n---\n"
@@ -262,7 +278,14 @@ class TelegramSender:
             chunk_index += 1
             current_chunk = []
             current_length = 0
-            if not self._send_telegram_message(api_url, chat_id, chunk_content, message_thread_id, timeout_seconds=timeout_seconds):
+            if not self._send_telegram_message(
+                api_url,
+                chat_id,
+                chunk_content,
+                message_thread_id,
+                timeout_seconds=timeout_seconds,
+                markdown_converted=True,
+            ):
                 all_success = False
             return all_success
 
@@ -282,7 +305,14 @@ class TelegramSender:
                 for long_chunk in _split_long_section(section, max_length):
                     logger.info(f"发送 Telegram 消息块 {chunk_index}...")
                     chunk_index += 1
-                    if not self._send_telegram_message(api_url, chat_id, long_chunk, message_thread_id, timeout_seconds=timeout_seconds):
+                    if not self._send_telegram_message(
+                        api_url,
+                        chat_id,
+                        long_chunk,
+                        message_thread_id,
+                        timeout_seconds=timeout_seconds,
+                        markdown_converted=True,
+                    ):
                         all_success = False
                 continue
 

--- a/src/notification_sender/telegram_sender.py
+++ b/src/notification_sender/telegram_sender.py
@@ -244,37 +244,64 @@ class TelegramSender:
         """分段发送长 Telegram 消息"""
         # 按段落分割
         sections = content.split("\n---\n")
+        delimiter = "\n---\n"
+        delimiter_length = len(delimiter)
 
         current_chunk = []
         current_length = 0
         all_success = True
         chunk_index = 1
 
-        for section in sections:
-            section_length = len(section) + 5  # +5 for "\n---\n"
+        def _flush_chunk() -> bool:
+            nonlocal current_chunk, current_length, chunk_index, all_success
+            if not current_chunk:
+                return all_success
 
-            if current_length + section_length > max_length:
-                # 发送当前块
-                if current_chunk:
-                    chunk_content = "\n---\n".join(current_chunk)
-                    logger.info(f"发送 Telegram 消息块 {chunk_index}...")
-                    if not self._send_telegram_message(api_url, chat_id, chunk_content, message_thread_id, timeout_seconds=timeout_seconds):
-                        all_success = False
-                    chunk_index += 1
-
-                # 重置
-                current_chunk = [section]
-                current_length = section_length
-            else:
-                current_chunk.append(section)
-                current_length += section_length
-
-        # 发送最后一块
-        if current_chunk:
             chunk_content = "\n---\n".join(current_chunk)
             logger.info(f"发送 Telegram 消息块 {chunk_index}...")
+            chunk_index += 1
+            current_chunk = []
+            current_length = 0
             if not self._send_telegram_message(api_url, chat_id, chunk_content, message_thread_id, timeout_seconds=timeout_seconds):
                 all_success = False
+            return all_success
+
+        def _split_long_section(section: str, limit: int) -> list[str]:
+            if len(section) <= limit:
+                return [section]
+            chunks: list[str] = []
+            for start in range(0, len(section), limit):
+                chunks.append(section[start:start + limit])
+            return chunks
+
+        for section in sections:
+            if len(section) > max_length:
+                # 单段超限时强制切片，避免依赖“\\n---\\n”边界导致的整段超长发送
+                if not _flush_chunk():
+                    return False
+                for long_chunk in _split_long_section(section, max_length):
+                    logger.info(f"发送 Telegram 消息块 {chunk_index}...")
+                    chunk_index += 1
+                    if not self._send_telegram_message(api_url, chat_id, long_chunk, message_thread_id, timeout_seconds=timeout_seconds):
+                        all_success = False
+                continue
+
+            additional_length = len(section)
+            if current_chunk:
+                additional_length += delimiter_length
+
+            if current_length + additional_length > max_length:
+                _flush_chunk()
+                current_chunk = [section]
+                current_length = len(section)
+                continue
+
+            current_chunk.append(section)
+            current_length += additional_length
+
+        # 发送最后一块
+        if not _flush_chunk():
+            return False
 
         return all_success
 

--- a/src/services/decision_signal_summary.py
+++ b/src/services/decision_signal_summary.py
@@ -83,7 +83,8 @@ def format_decision_signal_excerpt(summary: Any, report_language: str = "zh") ->
     if parts:
         lines.append(" | ".join(parts))
     for key in ("reason", "watch_conditions", "risk_summary"):
-        text = _public_text(summary.get(key), max_length=120)
+        max_length = None if key == "reason" else 120
+        text = _public_text(summary.get(key), max_length=max_length)
         if text:
             lines.append(f"- {labels[key]}: {text}")
     return "\n".join(lines)
@@ -95,7 +96,7 @@ def _public_scalar(value: Any, *, max_length: int) -> str:
     return sanitize_decision_signal_text(value)[:max_length]
 
 
-def _public_text(value: Any, *, max_length: int) -> str:
+def _public_text(value: Any, *, max_length: Optional[int]) -> str:
     if value in (None, "", [], {}):
         return ""
     if isinstance(value, (list, tuple)):
@@ -108,4 +109,5 @@ def _public_text(value: Any, *, max_length: int) -> str:
         )
     else:
         text = str(value).strip()
-    return sanitize_decision_signal_text(text)[:max_length]
+    sanitized = sanitize_decision_signal_text(text)
+    return sanitized if max_length is None else sanitized[:max_length]

--- a/tests/test_decision_signal_summary.py
+++ b/tests/test_decision_signal_summary.py
@@ -95,6 +95,27 @@ def test_format_decision_signal_excerpt_formats_english_and_redacts_text() -> No
     assert "- Risk: token=[REDACTED]" in excerpt
 
 
+def test_format_decision_signal_excerpt_preserves_complete_sanitized_reason() -> None:
+    reason = (
+        "159516当前处于中期震荡、短期调整阶段。技术面上，价格缩量回踩MA5，乖离率仅1.29%，"
+        "具备洗盘结束的特征。然而，均线系统尚未形成标准多头排列，且大盘环境风险等级较高，"
+        "压制了反弹空间。建议投资者保持谨慎，关注MA5支撑的有效性，切勿盲目追高。"
+    )
+
+    excerpt = format_decision_signal_excerpt({
+        "reason": f"{reason} token=secret-value",
+        "watch_conditions": "观察" * 80,
+        "risk_summary": "风险" * 80,
+    })
+
+    assert f"- 理由: {reason} token=[REDACTED]" in excerpt
+    assert "切勿盲目追高。" in excerpt
+    watch_line = next(line for line in excerpt.splitlines() if line.startswith("- 观察条件: "))
+    risk_line = next(line for line in excerpt.splitlines() if line.startswith("- 风险: "))
+    assert len(watch_line.removeprefix("- 观察条件: ")) == 120
+    assert len(risk_line.removeprefix("- 风险: ")) == 120
+
+
 def test_format_decision_signal_excerpt_returns_empty_for_invalid_input() -> None:
     assert format_decision_signal_excerpt(None) == ""
     assert format_decision_signal_excerpt({}) == ""

--- a/tests/test_notification_sender.py
+++ b/tests/test_notification_sender.py
@@ -1658,7 +1658,11 @@ class TestTelegramSender(unittest.TestCase):
         content = f"**AI 决策信号**\n- 理由: {long_reason}\n"
 
         result = sender._send_telegram_chunked(
-            "http://api.telegram.org", "CHAT", content, max_length=4096, timeout_seconds=3
+            "http://api.telegram.org",
+            "CHAT",
+            sender._convert_to_telegram_markdown(content),
+            max_length=4096,
+            timeout_seconds=3,
         )
 
         self.assertTrue(result)
@@ -1681,6 +1685,21 @@ class TestTelegramSender(unittest.TestCase):
         for call in mock_send_telegram_message.call_args_list:
             sent_text = call.args[2]
             self.assertLessEqual(len(sent_text), 4096)
+
+    @mock.patch("src.notification_sender.telegram_sender.requests.post")
+    def test_send_chunks_by_final_markdown_payload_length(self, mock_post):
+        mock_post.return_value = _response(200, {"ok": True})
+        cfg = _config(telegram_bot_token="BOT", telegram_chat_id="CHAT")
+        sender = TelegramSender(cfg)
+        content = "(" * 4090
+
+        result = sender.send_to_telegram(content)
+
+        self.assertTrue(result)
+        self.assertGreaterEqual(mock_post.call_count, 2)
+        payload_texts = [call.kwargs["json"]["text"] for call in mock_post.call_args_list]
+        self.assertTrue(all(len(text) <= 4096 for text in payload_texts))
+        self.assertEqual("".join(payload_texts), sender._convert_to_telegram_markdown(content))
 
     @mock.patch("src.notification_sender.telegram_sender.requests.post")
     def test_send_plain_text_fallback_handles_non_json_200(self, mock_post):

--- a/tests/test_notification_sender.py
+++ b/tests/test_notification_sender.py
@@ -1650,6 +1650,38 @@ class TestTelegramSender(unittest.TestCase):
         self.assertIn("[详情](https://example.com/report)", rendered)
         self.assertNotIn("# 日报", rendered)
 
+    @mock.patch.object(TelegramSender, "_send_telegram_message", return_value=True)
+    def test_send_telegram_chunked_splits_large_reason_without_delimiter(self, mock_send_telegram_message):
+        cfg = _config(telegram_bot_token="BOT", telegram_chat_id="CHAT")
+        sender = TelegramSender(cfg)
+        long_reason = "原因过长需分段测试：" + ("A" * 5000)
+        content = f"**AI 决策信号**\n- 理由: {long_reason}\n"
+
+        result = sender._send_telegram_chunked(
+            "http://api.telegram.org", "CHAT", content, max_length=4096, timeout_seconds=3
+        )
+
+        self.assertTrue(result)
+        self.assertGreaterEqual(len(mock_send_telegram_message.call_args_list), 2)
+        for call in mock_send_telegram_message.call_args_list:
+            sent_text = call.args[2]
+            self.assertLessEqual(len(sent_text), 4096)
+
+    @mock.patch.object(TelegramSender, "_send_telegram_message", return_value=True)
+    def test_send_to_telegram_chunked_path_with_long_reason_without_delimiter(self, mock_send_telegram_message):
+        cfg = _config(telegram_bot_token="BOT", telegram_chat_id="CHAT")
+        sender = TelegramSender(cfg)
+        long_reason = "原因过长需分段测试：" + ("B" * 5000)
+        content = f"**AI 决策信号**\n- 理由: {long_reason}\n"
+
+        result = sender.send_to_telegram(content)
+
+        self.assertTrue(result)
+        self.assertGreaterEqual(len(mock_send_telegram_message.call_args_list), 2)
+        for call in mock_send_telegram_message.call_args_list:
+            sent_text = call.args[2]
+            self.assertLessEqual(len(sent_text), 4096)
+
     @mock.patch("src.notification_sender.telegram_sender.requests.post")
     def test_send_plain_text_fallback_handles_non_json_200(self, mock_post):
         markdown_error = _response(400)


### PR DESCRIPTION
## PR Type

- [x] fix
- [ ] feat
- [ ] refactor
- [x] docs
- [ ] chore
- [x] test

## Background And Problem

Fixes #1969.

The DecisionSignal excerpt shared by email, Telegram, and full report rendering silently sliced every public text field to 120 characters. Long `reason` values therefore ended in the middle of a sentence even when the LLM response and persisted signal were complete.

Root cause: `format_decision_signal_excerpt()` passed `max_length=120` to `_public_text()` for `reason`, `watch_conditions`, and `risk_summary` alike. The slice had no truncation marker, and every report channel consumed the same already-truncated excerpt.

This fix preserves the complete sanitized `reason`, while retaining the existing 120-character compact limit for watch conditions and risk summaries.

## Scope Of Change

4 files changed, 28 insertions, 3 deletions:

- `src/services/decision_signal_summary.py`: preserve complete sanitized reasons without broadening the other summary fields.
- `tests/test_decision_signal_summary.py`: cover the issue's long Chinese sentence, secret redaction, and the retained limits for watch/risk fields.
- `docs/decision-signals.md`: document the public notification excerpt contract.
- `docs/CHANGELOG.md`: record the user-visible fix.

## Issue Link

Fixes #1969

## Verification Commands And Results

```bash
git diff --check
# pass

python -m py_compile \
  src/services/decision_signal_summary.py \
  tests/test_decision_signal_summary.py
# pass

python -m flake8 \
  src/services/decision_signal_summary.py \
  tests/test_decision_signal_summary.py \
  --select=E9,F63,F7,F82
# pass

python -c "import runpy; ns=runpy.run_path('tests/test_decision_signal_summary.py'); tests=[v for k,v in ns.items() if k.startswith('test_') and callable(v)]; [test() for test in tests]; print(len(tests))"
# 6 DecisionSignal summary tests passed

./scripts/ci_gate.sh syntax
./scripts/ci_gate.sh flake8
# pass; critical flake8 count: 0
```

Current Head CI: `ai-governance:pass / backend-gate:pass / docker-build:pass / web-gate:skipped`. All applicable checks passed in [CI run 29180901949](https://github.com/ZhuLinsen/daily_stock_analysis/actions/runs/29180901949).

Local validation limitation: the complete pytest/notification integration suites could not start in the minimal local environment because FastAPI and other project runtime dependencies were not installed. The pure formatter suite passed locally, and the repository backend and Docker gates subsequently passed in PR CI.

## Visual Evidence (if applicable)

No screenshot is attached because the changed surface is deterministic notification/report text with no Web layout change. Reproducible alternative evidence:

- Command: the `tests/test_decision_signal_summary.py` command above.
- Contract: the fixture uses the issue's long Chinese rationale and asserts that the final sentence `切勿盲目追高。` remains present after formatting.
- Before: output stopped after the first 120 characters without a marker.
- After: the complete sanitized reason is present; secret-like values are still redacted; watch/risk summaries remain capped.

## Compatibility And Risk

- Public field names and report structure are unchanged; only the `reason` value is no longer silently shortened.
- Telegram continues to use the existing channel chunking logic, while email and saved reports already support longer content.
- Low-sensitive redaction remains applied before the reason is returned.
- `watch_conditions` and `risk_summary` retain their existing compact 120-character limits.
- 本 PR 未变更 provider/model/base URL、运行时配置清理迁移语义；历史配置保持不变；回滚方式为 revert 本提交。

## Rollback Plan

Revert this PR. No configuration, database, or data migration rollback is required.

## EXTRACT_PROMPT Change (if applicable)

Not applicable. `src/services/image_stock_extractor.py` and `EXTRACT_PROMPT` are unchanged.

## Checklist

- [x] 本 PR 有明确动机和业务价值 / This PR has a clear motivation and value
- [x] 已提供可复现的验证命令与结果 / Reproducible verification commands and results are included
- [x] 已评估兼容性与风险 / Compatibility and risk have been assessed
- [x] 已提供回滚方案 / A rollback plan is provided
- [x] 已提供可复现的报告文本替代视觉证据
- [x] Web 设置字段未变更 / Web settings fields are unchanged
- [x] 用户可见变更已同步专题文档与 `docs/CHANGELOG.md`

<!-- autocode:repair-summary:start -->
## AutoCode Repair Update
- Scope: 2 file(s), `+58 / -9`.
- Changed files: `src/notification_sender/telegram_sender.py`, `tests/test_notification_sender.py`
- Validation: lint:PASS, test:PASS
- Commands: `./scripts/ci_gate.sh flake8`; `python -m pytest tests/test_notification_sender.py`
- Execution/self-review summary: 第 1 轮：- Telegram 现按 Markdown 转义后的最终 payload 长度判断并切分。 - 新增回归测试，确保每个请求 payload 不超过 4096 字符。 - 验证通过：114 项相关测试、Python 编译及 `git diff --check`。 第 1 轮提交前自审：- 检查了完整 diff、DecisionSignal → Telegram 调用链、Markdown 转义、分片及纯文本回退路径。 - 修复为按 Markdown 转义后的最终 payload 分片，确保每段不超过 4096 字符，并避免二次转义。 - 新增实际 HTTP payload 回归测试，同时保持短消息纯文本回退使用原文。 - 验证通过：flake8、定向测试 9 项、offline-tests（4451 passed，1 skipped）。 - 建议同步 PR description：补充 Telegram 按最终 payload 分片、相关测试及最新验证结果。未提交、未 push。
- Compatibility, risk, documentation, and PR scope were re-evaluated before this push.
<!-- autocode:repair-summary:end -->