### PR TITLE
fix: 修复桌面包缺少 AkShare 交易日历资源

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 - [修复] 市场结构概念排行为空或超时时复用本轮负结果，避免批量个股分析重复请求同一概念排行数据源。
+- [修复] Windows/macOS 桌面后端打包显式收集并校验 AkShare `file_fold/calendar.json`，避免发行包因缺少交易日历 package data 导致热点题材和选股日线增强降级。
 - [改进] 为 multi-agent DecisionAgent 增加内部低敏分歧摘要输入管线，作为 #1904 P1 解释输出的前置 plumbing；不改变 public API、dashboard schema 或最终解释字段。
 - [修复] 推送报告、Jinja 报告与历史 Markdown 导出复用 Web/API 的评分-action 口径：高分但旧 `operation_advice` 仍为持有且无降级原因时，建议文案与三类统计展示为买入；有明确 guardrail reason 时继续保留持有/观望。
 - [改进] GitHub Actions 每日分析工作流补齐 TickFlow 数据源环境变量映射，并收敛 README 数据源稳定性说明到完整指南。

--- a/docs/desktop-package.md
+++ b/docs/desktop-package.md
@@ -190,7 +190,7 @@ npm install
 npm run build
 ```
 
-2) 按现有脚本打包 Python 后端（脚本已内置 AlphaSift 依赖收集）
+2) 按现有脚本打包 Python 后端（脚本已内置 AlphaSift 与 AkShare 数据文件收集）
 
 - Windows：
 
@@ -204,7 +204,7 @@ powershell -ExecutionPolicy Bypass -File scripts\build-backend.ps1
 bash scripts/build-backend-macos.sh
 ```
 
-该脚本会在安装依赖后执行 `--collect-all alphasift`，并校验打包产物中可导入 `alphasift.dsa_adapter`，避免分步命令遗漏内置 AlphaSift 模块。
+该脚本会在安装依赖后执行 `--collect-all alphasift` 和 `--collect-data akshare`。构建完成后会校验 `alphasift.dsa_adapter` 可导入，并确认 AkShare 的 `file_fold/calendar.json` 已进入冻结产物，避免发行包在热点题材或日线增强路径中因缺少 package data 降级。
 
 3) 打包 Electron 桌面应用
 
@@ -296,6 +296,8 @@ win-unpacked/
 ### 后端启动报 ModuleNotFoundError
 
 PyInstaller 打包时缺少模块，需要在 `scripts/build-backend.ps1` 中增加 `--hidden-import`。
+
+如果日志提示缺少 `akshare/file_fold/calendar.json`，说明后端冻结产物没有完整收集 AkShare package data。请使用仓库当前的 `scripts/build-backend.ps1` 或 `scripts/build-backend-macos.sh` 重新构建；脚本会在生成桌面包前检查该文件，缺失时直接终止构建。
 
 ### UI 加载空白
 

--- a/scripts/build-backend-macos.sh
+++ b/scripts/build-backend-macos.sh
@@ -110,7 +110,7 @@ for module in "${hidden_imports[@]}"; do
 done
 
 pushd "${ROOT_DIR}" >/dev/null
-cmd=("${PYTHON_BIN}" -m PyInstaller --name stock_analysis --onedir --noconfirm --noconsole --add-data "static:static" --add-data "strategies:strategies" --collect-data litellm --collect-data tiktoken)
+cmd=("${PYTHON_BIN}" -m PyInstaller --name stock_analysis --onedir --noconfirm --noconsole --add-data "static:static" --add-data "strategies:strategies" --collect-data litellm --collect-data tiktoken --collect-data akshare)
 cmd+=("--collect-all" "alphasift")
 cmd+=("${hidden_import_args[@]}" "main.py")
 
@@ -141,6 +141,16 @@ if DSA_PACKAGED_ALPHASIFT_IMPORT_PROBE=1 "${packaged_entry}" >/tmp/alphasift-pac
 else
   echo "ERROR: packaged backend artifact cannot import alphasift.dsa_adapter."
   cat /tmp/alphasift-packaged-import.log
+  exit 1
+fi
+
+log "Verifying packaged AkShare calendar data..."
+packaged_akshare_calendar="${packaged_root}/_internal/akshare/file_fold/calendar.json"
+if [[ ! -f "${packaged_akshare_calendar}" ]]; then
+  packaged_akshare_calendar="${packaged_root}/akshare/file_fold/calendar.json"
+fi
+if [[ ! -f "${packaged_akshare_calendar}" ]]; then
+  echo "ERROR: packaged AkShare calendar data not found under ${packaged_root}."
   exit 1
 fi
 

--- a/scripts/build-backend.ps1
+++ b/scripts/build-backend.ps1
@@ -124,6 +124,7 @@ $pyInstallerArgs = @(
   '--add-data', 'strategies;strategies',
   '--collect-data', 'litellm',
   '--collect-data', 'tiktoken',
+  '--collect-data', 'akshare',
   '--collect-all', 'alphasift'
 )
 $pyInstallerArgs += $hiddenImportArgs
@@ -159,6 +160,15 @@ try {
   } else {
     $env:DSA_PACKAGED_ALPHASIFT_IMPORT_PROBE = $previousProbe
   }
+}
+
+Write-Host 'Verifying packaged AkShare calendar data...'
+$packagedAkshareCalendar = Join-Path 'dist\backend\stock_analysis' '_internal\akshare\file_fold\calendar.json'
+if (-not (Test-Path $packagedAkshareCalendar)) {
+  $packagedAkshareCalendar = Join-Path 'dist\backend\stock_analysis' 'akshare\file_fold\calendar.json'
+}
+if (-not (Test-Path $packagedAkshareCalendar)) {
+  throw 'Packaged AkShare calendar data not found under dist\backend\stock_analysis.'
 }
 
 Write-Host 'Verifying static asset references (packaged)...'

--- a/tests/test_desktop_packaging_assets.py
+++ b/tests/test_desktop_packaging_assets.py
@@ -1,0 +1,30 @@
+# -*- coding: utf-8 -*-
+"""Static contracts for third-party data bundled in desktop backends."""
+
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+
+class DesktopPackagingAssetsTestCase(unittest.TestCase):
+    """Keep Windows and macOS PyInstaller package-data rules aligned."""
+
+    repo_root = Path(__file__).resolve().parent.parent
+
+    def test_scripts_collect_and_verify_akshare_calendar_data(self) -> None:
+        macos_script = (self.repo_root / "scripts" / "build-backend-macos.sh").read_text(
+            encoding="utf-8"
+        )
+        windows_script = (self.repo_root / "scripts" / "build-backend.ps1").read_text(
+            encoding="utf-8"
+        )
+
+        self.assertIn("--collect-data akshare", macos_script)
+        self.assertIn("'--collect-data', 'akshare'", windows_script)
+        self.assertIn("_internal/akshare/file_fold/calendar.json", macos_script)
+        self.assertIn("_internal\\akshare\\file_fold\\calendar.json", windows_script)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## PR Type

- [x] fix
- [ ] feat
- [ ] refactor
- [x] docs
- [ ] chore
- [x] test

## Background And Problem

Fixes #1930.

Desktop release packages could omit `akshare/file_fold/calendar.json`. AkShare imports still succeeded, but code paths that load the packaged trading calendar failed at runtime, degrading hotspot details and daily K-line enrichment in stock screening.

Root cause: both desktop backend PyInstaller commands collected package data for LiteLLM, tiktoken, and AlphaSift, but did not collect AkShare package data. The build also had no artifact-level check for the calendar file, so incomplete packages could be published.

## Scope Of Change

5 files changed, 56 insertions, 3 deletions:

- `scripts/build-backend.ps1`: collect AkShare data and fail the Windows backend build when the packaged calendar is absent.
- `scripts/build-backend-macos.sh`: apply the same collection and artifact check to macOS builds.
- `tests/test_desktop_packaging_assets.py`: keep the Windows/macOS collection and verification contracts aligned.
- `docs/desktop-package.md`: document the package-data behavior and troubleshooting path.
- `docs/CHANGELOG.md`: record the user-visible desktop packaging fix.

## Issue Link

Fixes #1930

## Verification Commands And Results

```bash
git diff --check
# pass

bash -n scripts/build-backend-macos.sh
# pass

python -m py_compile tests/test_desktop_packaging_assets.py
# pass

python -m flake8 tests/test_desktop_packaging_assets.py --select=E9,F63,F7,F82
# pass

python -m unittest tests.test_desktop_packaging_assets -v
# 1 test passed

./scripts/ci_gate.sh syntax
./scripts/ci_gate.sh flake8
# pass; critical flake8 count: 0
```

Current Head CI: `ai-governance:pass / backend-gate:pass / docker-build:pass / web-gate:skipped`. All applicable checks passed in [CI run 29180902290](https://github.com/ZhuLinsen/daily_stock_analysis/actions/runs/29180902290).

Local validation limitations:

- Windows PowerShell parser validation was not run because `pwsh` is unavailable in the Linux environment.
- Actual Windows/macOS frozen artifacts were not built locally; the release platforms remain the authoritative artifact validation environments.
- The full pytest suite could not start in the local minimal environment because project runtime dependencies were not installed; the new packaging contract test passed locally, and the repository backend and Docker gates subsequently passed in PR CI.

Core script diff evidence (also visible in the PR's **Files changed** tab):

- `scripts/build-backend.ps1` adds `--collect-data akshare` and checks both supported PyInstaller layouts for `akshare/file_fold/calendar.json` before Electron packaging.
- `scripts/build-backend-macos.sh` adds the same collection flag and fail-fast artifact check.
- Both core script changes are present in commit [`af363c62d`](https://github.com/ZhuLinsen/daily_stock_analysis/commit/af363c62d0e95a81729d4bab6c198327d57b061b).

## Visual Evidence (if applicable)

Not applicable: this PR changes backend packaging inputs and artifact validation only. It does not change Web UI or report rendering. The traceable artifact contract is `tests/test_desktop_packaging_assets.py`, and both build scripts now stop before Electron packaging if `akshare/file_fold/calendar.json` is absent.

## Compatibility And Risk

- Source, Docker, API, Web, and runtime configuration behavior are unchanged.
- Desktop backend bundles become slightly larger because AkShare non-code data is now included.
- The post-build check supports both PyInstaller onedir layouts: `_internal/akshare/...` and `akshare/...`.
- If a future AkShare release intentionally moves or removes this resource, the desktop build will fail closed until the package-data contract is updated, instead of publishing a known-incomplete artifact.
- 本 PR 未变更 provider/model/base URL、运行时配置清理迁移语义；历史配置保持不变；回滚方式为 revert 本提交。

## Rollback Plan

Revert this PR. No configuration, database, or data migration rollback is required.

## EXTRACT_PROMPT Change (if applicable)

Not applicable. `src/services/image_stock_extractor.py` and `EXTRACT_PROMPT` are unchanged.

## Checklist

- [x] 本 PR 有明确动机和业务价值 / This PR has a clear motivation and value
- [x] 已提供可复现的验证命令与结果 / Reproducible verification commands and results are included
- [x] 已评估兼容性与风险 / Compatibility and risk have been assessed
- [x] 已提供回滚方案 / A rollback plan is provided
- [x] 报告格式或 Web UI 未变更 / Report formatting and Web UI are unchanged
- [x] Web 设置字段未变更 / Web settings fields are unchanged
- [x] 用户可见变更已同步专题文档与 `docs/CHANGELOG.md`
