### PR TITLE
docs: rewrite v3.26.1 release notes

### DIFF
--- a/.github/release-notes/v3.26.1.md
+++ b/.github/release-notes/v3.26.1.md
@@ -1,0 +1,38 @@
+## v3.26.1
+
+## 发布亮点
+
+- feat: Web 首页新增历史、自选与今日工作区，支持批量分析、今日覆盖判断和评分排行；同时改进股票列表解析、刷新时序与持仓首屏加载体验。
+- feat: 重建 A 股市场结构与题材主线上下文，贯通报告、Agent、DecisionSignal 与 Web 展示；TickFlow 新增基于申万一级行业股票池的板块排行兜底，并通过缓存与更合理的超时设置提升稳定性。
+- feat: 飞书新增文件形式推送报告，多 Agent 支持子 Agent 独立超时钳位与决策前低敏分歧摘要，Agent 流式响应中断时也能给出明确提示。
+- feat: 补齐内部 DSA Tool Surface 与正式的 DecisionSignal `decision_profile` 契约，统一工具权限、股票范围、结构化错误、信号查询、去重、续期和失效语义。
+- improve: 新增资讯池自动抓取开关，优化 AI 建议页股票上下文、移动端设置导航、常见自选股分隔符解析，以及 GitHub Actions 中 TickFlow 与钉钉通知的配置映射。
+- fix: 统一 Web、报告与通知中的评分动作口径，完整保留通知理由，并修复批量删除股票历史记录、零情绪分、市场结构重复请求、持仓加载、桌面端 WebUI 绑定及 Agent 流中断等问题。
+- fix: 加固桌面端与 Docker 发布包，补齐 AkShare 交易日历和 LiteLLM 所需的 `orjson`，完善 AlphaSift 探测与发布资源一致性，避免打包版本启动或数据能力降级。
+- improve: 移除 Web 报告中独立的题材/个股位置卡片及 Markdown、微信、兜底通知中的重复 AI 决策信号摘要，将相同信息收敛到统一的分析上下文和权威展示链路。
+
+## What's Changed
+
+- Added History, Watchlist, and Today workspaces to the Web home page, including batch analysis, same-day coverage checks, score rankings, more tolerant stock-list parsing, safer refresh ordering, and faster initial portfolio loading.
+- Rebuilt A-share market-structure and theme context across reports, Agents, DecisionSignal, and the Web UI. TickFlow now provides an SW1 industry-ranking fallback with caching and a more practical timeout budget.
+- Added Feishu report delivery as file messages, per-sub-agent timeout clamps, a low-sensitivity disagreement summary before decision synthesis, and clearer handling for interrupted Agent streams.
+- Added the internal DSA Tool Surface and promoted DecisionSignal `decision_profile` to a formal contract, aligning tool authorization, stock scope, structured errors, signal queries, deduplication, renewal, and invalidation semantics.
+- Added opt-in intelligence auto-fetch, improved stock context on the AI Recommendations page and mobile settings navigation, normalized common watchlist separators, and mapped TickFlow and DingTalk settings into the daily GitHub Actions workflow.
+- Unified score-to-action presentation across the Web UI, reports, and notifications; preserved complete notification reasons; and fixed bulk history deletion, zero sentiment scores, repeated market-structure requests, portfolio loading, desktop WebUI binding, and interrupted Agent streams.
+- Hardened desktop and Docker release packages by bundling AkShare calendar data and LiteLLM's `orjson` dependency, with stronger AlphaSift probes and release-asset consistency checks.
+- Removed duplicate theme/stock-position cards and AI decision-signal excerpts from Web, Markdown, WeChat, and fallback notification reports, consolidating the same information into canonical context and recommendation paths.
+
+## Full Changelog
+
+https://github.com/ZhuLinsen/daily_stock_analysis/compare/v3.25.0...v3.26.1
+
+## Contributors / 贡献者
+
+- @ZhuLinsen
+- @ShiroKSH
+- @ObVious55
+- @massif-01
+- @Gach-Coder
+- @xinzhifan4
+- @iclinux
+- @Shlok1729


### PR DESCRIPTION
## What changed

- Rewrote the v3.26.1 release notes in Chinese and English.
- Summarized the complete `v3.25.0...v3.26.1` range, covering both v3.26.0 and v3.26.1 changes.
- Added the full comparison link and a final contributor section with all eight verified PR authors.

## Why

The previous notes only described `v3.26.0...v3.26.1`, so they omitted the main v3.26.0 changes and all contributors except the v3.26.1 patch author.

## Impact

Documentation only. No runtime, API, configuration, or release workflow behavior changes.

## Validation

- Verified UTF-8 content and bilingual section structure.
- Verified the comparison range is `v3.25.0...v3.26.1`.
- Cross-checked all eight contributor handles against PR authors in the release range.
- Ran `git diff --check` successfully.

## Rollback

Revert commit `fd1abd12`. No data or configuration rollback is required.