### PR TITLE
feat: add LOF fund support and A-stock supplementary data

### DIFF
--- a/data_provider/akshare_fetcher.py
+++ b/data_provider/akshare_fetcher.py
@@ -114,6 +114,17 @@ def _is_etf_code(stock_code: str) -> bool:
     return code.startswith(etf_prefixes) and len(code) == 6
 
 
+def _is_lof_code(stock_code: str) -> bool:
+    """判断代码是否为 LOF 基金（上市型开放式基金）。
+
+    LOF 与部分 ETF 共用 16xxxx 前缀，需在 ETF 判断之前优先识别。
+    - 深交所 LOF: 16xxxx
+    - 上交所 LOF: 50xxxx
+    """
+    code = stock_code.strip().split('.')[0]
+    return len(code) == 6 and (code.startswith('16') or code.startswith('50'))
+
+
 def _is_hk_code(stock_code: str) -> bool:
     """
     判断代码是否为港股
@@ -472,6 +483,8 @@ class AkshareFetcher(BaseFetcher):
             )
         elif _is_hk_code(stock_code):
             return self._fetch_hk_data(stock_code, start_date, end_date)
+        elif _is_lof_code(stock_code):
+            return self._fetch_lof_data(stock_code, start_date, end_date)
         elif _is_etf_code(stock_code):
             return self._fetch_etf_data(stock_code, start_date, end_date)
         else:
@@ -709,6 +722,43 @@ class AkshareFetcher(BaseFetcher):
             
             raise DataFetchError(f"Akshare 获取 ETF 数据失败: {e}") from e
     
+    def _fetch_lof_data(self, stock_code: str, start_date: str, end_date: str) -> pd.DataFrame:
+        """获取 LOF 基金历史数据。
+
+        数据源：ak.fund_lof_hist_em()
+        LOF（上市型开放式基金）与 ETF 共用 16xxxx 前缀，但 API 端点不同；
+        优先走 LOF 接口，失败时回退 ETF 接口以兼容同名前缀的 ETF。
+        """
+        import akshare as ak
+
+        self._set_random_user_agent()
+        self._enforce_rate_limit()
+
+        logger.info(
+            f"[API调用] ak.fund_lof_hist_em(symbol={stock_code}, period=daily, "
+            f"start_date={start_date.replace('-', '')}, end_date={end_date.replace('-', '')}, adjust=qfq)"
+        )
+
+        try:
+            import time as _time
+            api_start = _time.time()
+            df = ak.fund_lof_hist_em(
+                symbol=stock_code,
+                period="daily",
+                start_date=start_date.replace('-', ''),
+                end_date=end_date.replace('-', ''),
+                adjust="qfq",
+            )
+            api_elapsed = _time.time() - api_start
+            if df is not None and not df.empty:
+                logger.info(f"[API调用] ak.fund_lof_hist_em 成功: 行数 {len(df)}, 耗时 {api_elapsed:.2f}s")
+            else:
+                logger.warning(f"[API调用] ak.fund_lof_hist_em 返回空, 耗时 {api_elapsed:.2f}s")
+            return df
+        except Exception as e:
+            logger.info(f"[数据源] LOF API 失败，回退 ETF API: {stock_code} ({e})")
+            return self._fetch_etf_data(stock_code, start_date, end_date)
+
     def _fetch_us_data(self, stock_code: str, start_date: str, end_date: str) -> pd.DataFrame:
         """
         获取美股历史数据

--- a/data_provider/astock_data_provider.py
+++ b/data_provider/astock_data_provider.py
@@ -1,0 +1,394 @@
+# -*- coding: utf-8 -*-
+"""
+===================================
+A-Stock Data Provider (from a-stock-data)
+===================================
+
+集成 simonlin1212/a-stock-data 的关键数据函数，
+为 dsa-private 提供龙虎榜、融资融券、大宗交易、
+股东户数、资金流、概念板块等补充数据。
+
+数据源优先级：东财独有数据（限流防封）
+"""
+
+import logging
+import random
+import time
+from datetime import datetime, timedelta
+from typing import Any, Dict, List, Optional
+
+import requests
+
+logger = logging.getLogger(__name__)
+
+# ── 东财防封：全局节流 + 会话复用 ────────────────────────────────────
+UA = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36"
+DATACENTER_URL = "https://datacenter-web.eastmoney.com/api/data/v1/get"
+
+EM_SESSION = requests.Session()
+EM_SESSION.headers.update({"User-Agent": UA})
+try:
+    from requests.adapters import HTTPAdapter
+    from urllib3.util.retry import Retry
+    _em_adapter = HTTPAdapter(max_retries=Retry(
+        total=3, connect=3, backoff_factor=0.6,
+        status_forcelist=[429, 500, 502, 503, 504], allowed_methods=["GET"]))
+    EM_SESSION.mount("https://", _em_adapter)
+    EM_SESSION.mount("http://", _em_adapter)
+except Exception:
+    pass
+
+EM_MIN_INTERVAL = 1.0
+_em_last_call = [0.0]
+
+
+def em_get(url: str, params: dict = None, headers: dict = None,
+           timeout: int = 15, **kwargs) -> requests.Response:
+    """东财统一请求入口：自动节流 + 复用 session + 默认 UA。"""
+    wait = EM_MIN_INTERVAL - (time.time() - _em_last_call[0])
+    if wait > 0:
+        time.sleep(wait + random.uniform(0.1, 0.5))
+    try:
+        return EM_SESSION.get(url, params=params, headers=headers, timeout=timeout, **kwargs)
+    finally:
+        _em_last_call[0] = time.time()
+
+
+def eastmoney_datacenter(report_name: str, columns: str = "ALL",
+                         filter_str: str = "", page_size: int = 50,
+                         sort_columns: str = "", sort_types: str = "-1") -> List[Dict]:
+    """东财数据中心统一查询 — 龙虎榜/解禁/融资融券/大宗交易/股东户数/分红 共用。"""
+    params = {
+        "reportName": report_name, "columns": columns,
+        "filter": filter_str, "pageNumber": "1", "pageSize": str(page_size),
+        "sortColumns": sort_columns, "sortTypes": sort_types,
+        "source": "WEB", "client": "WEB",
+    }
+    r = em_get(DATACENTER_URL, params=params, timeout=15)
+    d = r.json()
+    if d.get("result") and d["result"].get("data"):
+        return d["result"]["data"]
+    return []
+
+
+# ── 数据函数 ─────────────────────────────────────────────────────────
+
+def dragon_tiger_board(code: str, trade_date: str, look_back: int = 30) -> Dict[str, Any]:
+    """
+    龙虎榜数据聚合。
+    trade_date: YYYY-MM-DD
+    返回: {records: [...], seats: {buy: [...], sell: [...]}, institution: {...}}
+    """
+    start = datetime.strptime(trade_date, "%Y-%m-%d") - timedelta(days=look_back)
+    start_str = start.strftime("%Y-%m-%d")
+
+    records = []
+    data = eastmoney_datacenter(
+        "RPT_DAILYBILLBOARD_DETAILSNEW",
+        filter_str=f"(TRADE_DATE>='{start_str}')(TRADE_DATE<='{trade_date}')(SECURITY_CODE=\"{code}\")",
+        page_size=50,
+        sort_columns="TRADE_DATE", sort_types="-1",
+    )
+    for row in data:
+        records.append({
+            "date": str(row.get("TRADE_DATE", ""))[:10],
+            "reason": row.get("EXPLANATION", ""),
+            "net_buy": round((row.get("BILLBOARD_NET_AMT") or 0) / 10000, 1),
+            "turnover": round(float(row.get("TURNOVERRATE") or 0), 2),
+        })
+
+    seats = {"buy": [], "sell": []}
+    buy_data = []
+    sell_data = []
+    if records:
+        latest_date = records[0]["date"]
+        buy_data = eastmoney_datacenter(
+            "RPT_BILLBOARD_DAILYDETAILSBUY",
+            filter_str=f"(TRADE_DATE='{latest_date}')(SECURITY_CODE=\"{code}\")",
+            page_size=10,
+            sort_columns="BUY", sort_types="-1",
+        )
+        for row in buy_data[:5]:
+            seats["buy"].append({
+                "name": row.get("OPERATEDEPT_NAME", ""),
+                "buy_amt": round((row.get("BUY") or 0) / 10000, 1),
+                "sell_amt": round((row.get("SELL") or 0) / 10000, 1),
+                "net": round((row.get("NET") or 0) / 10000, 1),
+            })
+        sell_data = eastmoney_datacenter(
+            "RPT_BILLBOARD_DAILYDETAILSSELL",
+            filter_str=f"(TRADE_DATE='{latest_date}')(SECURITY_CODE=\"{code}\")",
+            page_size=10,
+            sort_columns="SELL", sort_types="-1",
+        )
+        for row in sell_data[:5]:
+            seats["sell"].append({
+                "name": row.get("OPERATEDEPT_NAME", ""),
+                "buy_amt": round((row.get("BUY") or 0) / 10000, 1),
+                "sell_amt": round((row.get("SELL") or 0) / 10000, 1),
+                "net": round((row.get("NET") or 0) / 10000, 1),
+            })
+
+    institution = {"buy_amt": 0, "sell_amt": 0, "net_amt": 0}
+    for detail_data, side in [(buy_data, "buy"), (sell_data, "sell")]:
+        for row in detail_data:
+            if str(row.get("OPERATEDEPT_CODE", "")) == "0":
+                amt = (row.get("BUY") or 0) if side == "buy" else (row.get("SELL") or 0)
+                if side == "buy":
+                    institution["buy_amt"] += amt
+                else:
+                    institution["sell_amt"] += amt
+    institution["buy_amt"] = round(institution["buy_amt"] / 10000, 1)
+    institution["sell_amt"] = round(institution["sell_amt"] / 10000, 1)
+    institution["net_amt"] = round(institution["buy_amt"] - institution["sell_amt"], 1)
+
+    return {"records": records, "seats": seats, "institution": institution}
+
+
+def margin_trading(code: str, page_size: int = 30) -> List[Dict]:
+    """
+    融资融券明细（日级）。
+    返回: [{date, rzye, rzmre, rzche, rqye, rqmcl, rqchl, rzrqye}]
+    """
+    data = eastmoney_datacenter(
+        "RPTA_WEB_RZRQ_GGMX",
+        filter_str=f'(SCODE="{code}")',
+        page_size=page_size,
+        sort_columns="DATE", sort_types="-1",
+    )
+    rows = []
+    for row in data:
+        rows.append({
+            "date": str(row.get("DATE", ""))[:10],
+            "rzye": row.get("RZYE", 0),
+            "rzmre": row.get("RZMRE", 0),
+            "rzche": row.get("RZCHE", 0),
+            "rqye": row.get("RQYE", 0),
+            "rqmcl": row.get("RQMCL", 0),
+            "rqchl": row.get("RQCHL", 0),
+            "rzrqye": row.get("RZRQYE", 0),
+        })
+    return rows
+
+
+def block_trade(code: str, page_size: int = 20) -> List[Dict]:
+    """
+    大宗交易记录。
+    返回: [{date, price, close, premium_pct, vol, amount, buyer, seller}]
+    """
+    data = eastmoney_datacenter(
+        "RPT_DATA_BLOCKTRADE",
+        filter_str=f'(SECURITY_CODE="{code}")',
+        page_size=page_size,
+        sort_columns="TRADE_DATE", sort_types="-1",
+    )
+    rows = []
+    for row in data:
+        close = row.get("CLOSE_PRICE") or 0
+        deal_price = row.get("DEAL_PRICE") or 0
+        premium = ((deal_price / close - 1) * 100) if close else 0
+        rows.append({
+            "date": str(row.get("TRADE_DATE", ""))[:10],
+            "price": deal_price,
+            "close": close,
+            "premium_pct": round(premium, 2),
+            "vol": row.get("DEAL_VOLUME", 0),
+            "amount": row.get("DEAL_AMT", 0),
+            "buyer": row.get("BUYER_NAME", ""),
+            "seller": row.get("SELLER_NAME", ""),
+        })
+    return rows
+
+
+def holder_num_change(code: str, page_size: int = 10) -> List[Dict]:
+    """
+    股东户数变化（季度级）。
+    返回: [{date, holder_num, change_num, change_ratio, avg_shares}]
+    """
+    data = eastmoney_datacenter(
+        "RPT_HOLDERNUMLATEST",
+        filter_str=f'(SECURITY_CODE="{code}")',
+        page_size=page_size,
+        sort_columns="END_DATE", sort_types="-1",
+    )
+    rows = []
+    for row in data:
+        rows.append({
+            "date": str(row.get("END_DATE", ""))[:10],
+            "holder_num": row.get("HOLDER_NUM", 0),
+            "change_num": row.get("HOLDER_NUM_CHANGE", 0),
+            "change_ratio": row.get("HOLDER_NUM_RATIO", 0),
+            "avg_shares": row.get("AVG_FREE_SHARES", 0),
+        })
+    return rows
+
+
+def stock_fund_flow_120d(code: str) -> List[Dict]:
+    """
+    个股资金流（日级，最近120个交易日）。
+    返回: [{date, main_net, small_net, mid_net, large_net, super_net}]
+    单位: 元
+    """
+    market_code = 1 if code.startswith("6") else 0
+    url = "https://push2his.eastmoney.com/api/qt/stock/fflow/daykline/get"
+    params = {
+        "secid": f"{market_code}.{code}",
+        "fields1": "f1,f2,f3,f7",
+        "fields2": "f51,f52,f53,f54,f55,f56,f57,f58,f59,f60,f61,f62,f63,f64,f65",
+        "lmt": "120",
+    }
+    headers = {
+        "User-Agent": UA,
+        "Referer": "https://quote.eastmoney.com/",
+        "Origin": "https://quote.eastmoney.com",
+    }
+    try:
+        r = em_get(url, params=params, headers=headers, timeout=15)
+        d = r.json()
+    except Exception as e:
+        logger.warning("push2 资金流请求失败: %s", e)
+        return []
+    klines = d.get("data", {}).get("klines", [])
+
+    rows = []
+    for line in klines:
+        parts = line.split(",")
+        if len(parts) >= 7:
+            rows.append({
+                "date": parts[0],
+                "main_net": float(parts[1]) if parts[1] != "-" else 0,
+                "small_net": float(parts[2]) if parts[2] != "-" else 0,
+                "mid_net": float(parts[3]) if parts[3] != "-" else 0,
+                "large_net": float(parts[4]) if parts[4] != "-" else 0,
+                "super_net": float(parts[5]) if parts[5] != "-" else 0,
+            })
+    return rows
+
+
+def eastmoney_concept_blocks(code: str) -> Dict[str, Any]:
+    """
+    个股所属板块/概念归属（东财 slist）。
+    返回: {total, boards: [{name, code, change_pct, lead_stock}], concept_tags: [...]}
+    """
+    market_code = 1 if code.startswith("6") else 0
+    params = {
+        "fltt": "2", "invt": "2",
+        "secid": f"{market_code}.{code}",
+        "spt": "3", "pi": "0", "pz": "200", "po": "1",
+        "fields": "f12,f14,f3,f128",
+    }
+    headers = {"User-Agent": UA, "Referer": "https://quote.eastmoney.com/"}
+    try:
+        r = em_get("https://push2.eastmoney.com/api/qt/slist/get",
+                   params=params, headers=headers, timeout=15)
+        d = r.json()
+    except Exception as e:
+        logger.warning("东财板块归属请求失败: %s", e)
+        return {"total": 0, "boards": [], "concept_tags": []}
+
+    diff = (d.get("data") or {}).get("diff") or {}
+    items = diff.values() if isinstance(diff, dict) else diff
+    boards = []
+    for it in items:
+        boards.append({
+            "name": it.get("f14", ""),
+            "code": it.get("f12", ""),
+            "change_pct": it.get("f3", ""),
+            "lead_stock": it.get("f128", ""),
+        })
+    return {
+        "total": len(boards),
+        "boards": boards,
+        "concept_tags": [b["name"] for b in boards],
+    }
+
+
+# ── 统一入口类 ───────────────────────────────────────────────────────
+
+class AstockDataProvider:
+    """
+    A-Stock Data Provider 统一入口。
+    
+    提供 dsa-private 缺少的补充数据维度：
+    - 龙虎榜（机构/游资动向）
+    - 融资融券（杠杆资金）
+    - 大宗交易（机构大宗减持/增持）
+    - 股东户数变化（筹码集中度）
+    - 个股资金流120日（主力/散户资金流向）
+    - 概念板块归属（题材归因）
+    
+    所有东财接口已内置限流防封（em_get）。
+    """
+
+    name = "AstockDataProvider"
+
+    @staticmethod
+    def get_dragon_tiger(code: str, trade_date: str = None, look_back: int = 30) -> Optional[Dict]:
+        """获取龙虎榜数据。trade_date 默认今天。"""
+        if trade_date is None:
+            trade_date = datetime.now().strftime("%Y-%m-%d")
+        try:
+            return dragon_tiger_board(code, trade_date, look_back)
+        except Exception as e:
+            logger.warning("龙虎榜获取失败 %s: %s", code, e)
+            return None
+
+    @staticmethod
+    def get_margin_trading(code: str, page_size: int = 30) -> Optional[List]:
+        """获取融资融券数据。"""
+        try:
+            return margin_trading(code, page_size)
+        except Exception as e:
+            logger.warning("融资融券获取失败 %s: %s", code, e)
+            return None
+
+    @staticmethod
+    def get_block_trade(code: str, page_size: int = 20) -> Optional[List]:
+        """获取大宗交易数据。"""
+        try:
+            return block_trade(code, page_size)
+        except Exception as e:
+            logger.warning("大宗交易获取失败 %s: %s", code, e)
+            return None
+
+    @staticmethod
+    def get_holder_change(code: str, page_size: int = 10) -> Optional[List]:
+        """获取股东户数变化。"""
+        try:
+            return holder_num_change(code, page_size)
+        except Exception as e:
+            logger.warning("股东户数获取失败 %s: %s", code, e)
+            return None
+
+    @staticmethod
+    def get_fund_flow(code: str) -> Optional[List]:
+        """获取个股资金流120日。"""
+        try:
+            return stock_fund_flow_120d(code)
+        except Exception as e:
+            logger.warning("资金流获取失败 %s: %s", code, e)
+            return None
+
+    @staticmethod
+    def get_concept_blocks(code: str) -> Optional[Dict]:
+        """获取概念板块归属。"""
+        try:
+            return eastmoney_concept_blocks(code)
+        except Exception as e:
+            logger.warning("概念板块获取失败 %s: %s", code, e)
+            return None
+
+    def get_supplementary_data(self, code: str, trade_date: str = None) -> Dict[str, Any]:
+        """
+        一次性获取某只股票的所有补充数据。
+        
+        返回 dict，每个 key 对应一类数据，获取失败的 key 值为 None。
+        """
+        return {
+            "dragon_tiger": self.get_dragon_tiger(code, trade_date),
+            "margin_trading": self.get_margin_trading(code),
+            "block_trade": self.get_block_trade(code),
+            "holder_change": self.get_holder_change(code),
+            "fund_flow": self.get_fund_flow(code),
+            "concept_blocks": self.get_concept_blocks(code),
+        }

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -64,6 +64,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 ### 文档
 
 - 在 README 快速开始中补充行情数据源配置说明（`TUSHARE_TOKEN` / Longbridge），明确未配置时仍可使用 AkShare、Baostock、YFinance 等免费兜底源，并同步中英文完整指南。
+- [新功能] 飞书推送新增文件上传能力：`FeishuSender.send_feishu_file(file_path)` 通过 App Bot SDK (`im.v1.file.create`) 上传文件并发送文件消息；Webhook 模式回退为发送文件内容文本；新增 `FEISHU_SEND_AS_FILE=true` 配置开关，开启后飞书以文件形式发送报告而非文字消息。
+- [新功能] 多 Agent 编排 Pipeline 新增子 Agent 独立超时钳位：支持 6 个环境变量为 TechnicalAgent、IntelAgent、RiskAgent、DecisionAgent、PortfolioAgent、SkillAgent 各自配置独立硬上限，互不挤占配额；默认 0 表示关闭钳位。
+- [新功能] 决策仪表盘 `battle_plan.sniper_points` 新增 `buy_reach_probability` / `buy_time_horizon` / `stop_reach_probability` / `stop_time_horizon` 字段：模型对各目标价位（建仓/目标位、止损位）被触及的*主观概率估计*与时间周期；报告与推送渲染该到达概率。属双引擎工作流（AlphaSift 选股 -> DSA 深度分析）的可执行增强。
+- [新功能] PackyAPI 自定义 OpenAI 兼容渠道：通过 `LLM_CHANNELS=packyapi` + `LLM_PACKYAPI_*` 接入 PackyAPI（仅 grok-4.5），供 DSA 与 AlphaSift 共用。
+- [新功能] AlphaSift 选股 -> DSA 深度分析串联：新增 `scripts/alphasift_screen_and_analyze.py`，由工作流在 `ALPHASIFT_SCREEN_ENABLED=true` 时运行，将候选股交给 DSA 深度分析并复用既有通知链路。
+- [新功能] 注入 A 股特色补充数据（龙虎榜/融资融券/大宗交易/股东户数/资金流/概念板块）到分析提示词（数据源：`data_provider/astock_data_provider.py`）。
+- [新功能] 支持 LOF 基金（161116/160644/501018）历史数据获取（`ak.fund_lof_hist_em`，失败回退 ETF）。
 
 ## [3.25.0] - 2026-07-03
 

--- a/src/analyzer.py
+++ b/src/analyzer.py
@@ -3793,6 +3793,13 @@ class GeminiAnalyzer:
 """
 
         # 添加财报与分红（价值投资口径）
+        # A-Stock Data 补充数据（龙虎榜/融资融券/大宗交易/股东户数/资金流/概念板块）
+        astock_data = context.get("astock_supplementary") if isinstance(context, dict) else None
+        if isinstance(astock_data, dict) and astock_data:
+            astock_section = self._build_astock_supplementary_section(astock_data, report_language)
+            if astock_section:
+                prompt += astock_section
+
         fundamental_context = context.get("fundamental_context") if isinstance(context, dict) else None
         earnings_block = (
             fundamental_context.get("earnings", {})
@@ -4173,7 +4180,102 @@ class GeminiAnalyzer:
 """
         
         return prompt
-    
+
+    def _build_astock_supplementary_section(self, astock_data: Dict[str, Any], report_language: str = "zh") -> str:
+        """将 A-Stock Data 补充数据（龙虎榜/融资融券/大宗/股东/资金流/概念）渲染为提示词段落。"""
+        if not isinstance(astock_data, dict):
+            return ""
+        parts = []
+
+        dragon = astock_data.get("dragon_tiger")
+        if isinstance(dragon, dict):
+            records = dragon.get("records") or []
+            inst = dragon.get("institution") or {}
+            lines = []
+            if records:
+                recent = records[0]
+                lines.append(
+                    f"- 最近上榜：{recent.get('date', 'N/A')}｜原因：{recent.get('reason', 'N/A')}｜"
+                    f"净买入：{recent.get('net_buy', 'N/A')} 万｜换手：{recent.get('turnover', 'N/A')}%"
+                )
+                if len(records) > 1:
+                    lines.append(f"- 近 {len(records)} 次上榜（近30日）")
+            if inst:
+                lines.append(
+                    f"- 机构席位：买方 {inst.get('buy_amt', 'N/A')} 万｜卖方 {inst.get('sell_amt', 'N/A')} 万｜"
+                    f"净额 {inst.get('net_amt', 'N/A')} 万"
+                )
+            seats = dragon.get("seats") or {}
+            for side in ("buy", "sell"):
+                seat_list = seats.get(side) or []
+                if seat_list:
+                    names = "、".join(
+                        f"{s.get('name', '?')}(净{seat_list[0].get('net', 'N/A')})" for s in seat_list[:3]
+                    )
+                    lines.append(f"- 龙虎榜{'买' if side == 'buy' else '卖'}方席位：{names}")
+            if lines:
+                parts.append("### 🐯 龙虎榜\n" + "\n".join(lines))
+
+        margin = astock_data.get("margin_trading")
+        if isinstance(margin, list) and margin:
+            latest = margin[0]
+            parts.append(
+                "### 💰 融资融券（最新）\n"
+                f"- 日期：{latest.get('date', 'N/A')}｜融资余额：{latest.get('rzye', 'N/A')}｜"
+                f"融资买入：{latest.get('rzmre', 'N/A')}｜融资偿还：{latest.get('rzche', 'N/A')}｜"
+                f"融券余额：{latest.get('rqye', 'N/A')}｜融券卖出：{latest.get('rqmcl', 'N/A')}"
+            )
+
+        block = astock_data.get("block_trade")
+        if isinstance(block, list) and block:
+            rows = []
+            for b in block[:3]:
+                rows.append(
+                    f"- {b.get('date', 'N/A')}｜成交价 {b.get('price', 'N/A')}｜"
+                    f"溢价 {b.get('premium_pct', 'N/A')}%｜金额 {b.get('amount', 'N/A')}｜"
+                    f"买方：{b.get('buyer', 'N/A')}｜卖方：{b.get('seller', 'N/A')}"
+                )
+            parts.append("### 📜 大宗交易（近3笔）\n" + "\n".join(rows))
+
+        holder = astock_data.get("holder_change")
+        if isinstance(holder, list) and holder:
+            h = holder[0]
+            parts.append(
+                "### 👥 股东户数（最新）\n"
+                f"- 截止 {h.get('date', 'N/A')}｜户数 {h.get('holder_num', 'N/A')}｜"
+                f"变化 {h.get('change_num', 'N/A')}（{h.get('change_ratio', 'N/A')}%）｜"
+                f"户均持股 {h.get('avg_shares', 'N/A')}"
+            )
+
+        flow = astock_data.get("fund_flow")
+        if isinstance(flow, list) and flow:
+            recent_flow = flow[-1]
+            parts.append(
+                "### 🌊 主力资金流（最近交易日）\n"
+                f"- 日期：{recent_flow.get('date', 'N/A')}｜主力净：{recent_flow.get('main_net', 'N/A')}｜"
+                f"超大单净：{recent_flow.get('super_net', 'N/A')}｜大单净：{recent_flow.get('large_net', 'N/A')}｜"
+                f"中单净：{recent_flow.get('mid_net', 'N/A')}｜小单净：{recent_flow.get('small_net', 'N/A')}"
+            )
+            if len(flow) >= 5:
+                recent5 = flow[-5:]
+                avg_main = sum((f.get('main_net') or 0) for f in recent5) / len(recent5)
+                parts.append(f"- 近5日主力净流向均值：{round(avg_main, 1)}")
+
+        concept = astock_data.get("concept_blocks")
+        if isinstance(concept, dict):
+            tags = concept.get("concept_tags") or []
+            if tags:
+                parts.append("### 🏷️ 所属概念板块\n- " + "、".join(str(t) for t in tags[:15]))
+
+        if not parts:
+            return ""
+        header = (
+            "## 🇨🇳 A股特色补充数据\n\n"
+            if report_language != "en"
+            else "## 🇨🇳 A-Share Supplementary Data\n\n"
+        )
+        return header + "\n\n".join(parts) + "\n"
+
     def _format_volume(self, volume: Optional[float]) -> str:
         """格式化成交量显示"""
         if volume is None:

--- a/src/core/pipeline.py
+++ b/src/core/pipeline.py
@@ -671,6 +671,19 @@ class StockAnalysisPipeline:
                 enhanced_context["portfolio_context"] = dict(portfolio_context)
             if isinstance(market_structure_context, dict):
                 enhanced_context["market_structure_context"] = market_structure_context
+
+            # Step 6.5: A-Stock Data 补充数据（龙虎榜/融资融券/大宗交易/股东户数/资金流/概念板块）
+            if market == "cn" and not is_bse_code(normalize_stock_code(code)):
+                try:
+                    from data_provider.astock_data_provider import AstockDataProvider
+                    _trade_date = daily_market_target_date.isoformat() if daily_market_target_date else None
+                    _supplementary = AstockDataProvider().get_supplementary_data(code, trade_date=_trade_date)
+                    _non_empty = {k: v for k, v in _supplementary.items() if v}
+                    if _non_empty:
+                        enhanced_context["astock_supplementary"] = _non_empty
+                        logger.info("%s(%s) A-Stock Data 补充数据: %s", stock_name, code, list(_non_empty.keys()))
+                except Exception as e:
+                    logger.debug("A-Stock Data 补充数据获取失败 %s: %s", code, e)
             
             # Step 7: 调用 AI 分析（传入增强的上下文和新闻）
             (


### PR DESCRIPTION
Adds LOF fund data fetching (akshare und_lof_hist_em with ETF fallback, support codes 16xxxx/50xxxx) and a new A-stock supplementary data provider (dragon tiger board, margin trading, block trades, holder count changes, stock fund flow, concept blocks). Pipeline Step 6.5 injects supplementary data for CN market; analyzer renders it in reports.