### PR TITLE
fix(tools): describe get_stock_info as multi-market, not A-share only

### DIFF
--- a/src/agent/tools/data_tools.py
+++ b/src/agent/tools/data_tools.py
@@ -526,7 +526,7 @@ get_stock_info_tool = ToolDefinition(
         ToolParameter(
             name="stock_code",
             type="string",
-            description="A-share stock code, e.g., '600519'",
+            description="Stock code: A-share '600519', US 'AAPL', HK '00700'",
         ),
     ],
     handler=_handle_get_stock_info,


### PR DESCRIPTION
## PR Type

- [x] fix

## Background And Problem

`get_stock_info` describes its `stock_code` parameter to the model as:

```python
description="A-share stock code, e.g., '600519'",
```

The agent reads that schema literally and concludes the tool does not apply to
US/HK tickers, so it never calls `get_stock_info` for them. The handler has
supported those markets all along — `_handle_get_stock_info("AAPL")` returns
`market="us"`, `status="ok"` with `valuation`, `growth` and `earnings` populated
via `YfinanceFundamentalAdapter` (which is documented as "Yfinance fundamental
adapter for HK/US markets"). Only the description is wrong.

Impact: every skill that depends on fundamentals silently degrades for US/HK.
There is no error and no missing-data warning — the agent simply answers from
price/news only. Observed with the `growth_quality` skill on `AAPL`: the report
was a purely technical summary with no revenue, ROE, margin or cash-flow content,
which is the opposite of that skill's stated purpose ("结合收入利润增长、ROE、
现金流和行业空间").

This is the failure mode I would most want caught in review: it looks like a
working feature.

## Scope Of Change

```
 src/agent/tools/data_tools.py | 2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)
```

- 文件总数 / files: 1
- 文件清单 / file list:
  - `src/agent/tools/data_tools.py` — `get_stock_info_tool` parameter description only
- 文档更新文件（`docs/*`）: none (no user-visible behaviour contract changes; the
  tool's capability is unchanged, only its self-description). Happy to add a
  `docs/CHANGELOG.md` entry if you consider the restored US/HK fundamentals
  user-visible — say the word and I will push it.

## Issue Link

No existing issue. Motivation and acceptance criteria:

- Motivation: restore fundamentals coverage for US/HK analysis, which the
  handler already implements.
- Acceptance: for a US ticker, the agent calls `get_stock_info` and the resulting
  report cites fundamental fields (revenue / net profit / ROE), instead of
  silently omitting them.

## Verification Commands And Results

Handler already supports US (no code change needed to get this output):

```bash
PYTHONPATH=. python -c "
from dotenv import load_dotenv; load_dotenv('.env', override=True)
from src.agent.tools.data_tools import _handle_get_stock_info
import json; print(json.dumps(_handle_get_stock_info(stock_code='AAPL'), ensure_ascii=False)[:400])
"
```

```
{"code": "AAPL", "name": "苹果", "pe_ratio": 39.72606, "pb_ratio": 45.14325,
 "total_mv": 4813487343240.112, "circ_mv": null,
 "fundamental_context": {"market": "us", "status": "ok",
 "coverage": {"valuation": "ok", "growth": "ok", "earnings": "ok", ...},
 "growth": {"status": "ok", "data": {"revenue_yoy": 16.5952,
 "net_profit_yoy": 19.3624, "roe": 141.471, "gross_margin": 47.862}}, ...
```

End-to-end via `POST /api/v1/analysis/analyze` with `skills=["growth_quality"]`
on `AAPL`, reading the agent tool-call log.

Before (upstream `main`):

```
Agent requesting 1 tool call(s): ['get_daily_history']
Agent requesting 1 tool call(s): ['analyze_trend']
Agent requesting 1 tool call(s): ['get_chip_distribution']
Agent requesting 1 tool call(s): ['search_stock_news']
```
→ `get_stock_info` never called. Summary contained no fundamentals.

After (this PR):

```
Agent requesting 1 tool call(s): ['get_daily_history']
Agent requesting 1 tool call(s): ['analyze_trend']
Agent requesting 1 tool call(s): ['get_stock_info']
Agent requesting 1 tool call(s): ['search_stock_news']
```
→ Summary now cites "a 19.4% YoY net profit increase and a remarkable ROE of
141.5%", matching `net_profit_yoy: 19.3624` / `roe: 141.471` from the tool.

Syntax check:

```bash
python -m py_compile src/agent/tools/data_tools.py   # OK
```

Full-suite note: I could not run `./scripts/ci_gate.sh` locally — my environment
lacks `flake8` and `pytest`, and I did not want to report a gate result I had not
actually produced. Head CI results are not knowable before this PR opens; I will
update this section with the four gate results and links once the workflows run
on this PR's head.

## Visual Evidence (if applicable)

不适用原因 / Reason if not applicable: this PR changes no report formatting, no
report rendering template and no Web UI. It changes one tool parameter
description string, which is only ever consumed by the model's tool schema and is
never rendered to users. The observable effect is in agent tool-call selection,
evidenced by the before/after tool-call logs above rather than by a screenshot.

## Compatibility And Risk

本 PR 未变更 provider/model/base URL、运行时配置清理迁移语义；历史配置保持不变；
回滚方式为 revert 本提交。

- A-share behaviour is unchanged: `'600519'` remains documented as a valid value,
  it is now simply not presented as the *only* valid value.
- No signature, routing, request-parameter or return-shape change. The handler is
  untouched.
- Risk: the agent will now call `get_stock_info` on US/HK tickers where it
  previously did not, so those analyses gain one extra tool call (latency/token
  cost) and will surface fundamentals that were previously absent. That is the
  intent of the fix, but it does change US/HK report content.

## Rollback Plan

`revert this PR`. No config, data migration or cache invalidation is required —
the change is a single description string, and reverting it restores the previous
tool-selection behaviour immediately on restart.

## Checklist

- [x] 本 PR 有明确动机和业务价值 / This PR has a clear motivation and value
- [x] 已提供可复现的验证命令与结果 / Reproducible verification commands and results are included
- [x] 已评估兼容性与风险 / Compatibility and risk have been assessed
- [x] 已提供回滚方案 / A rollback plan is provided
- [x] 若修改报告格式或 Web UI 界面… / N/A — no report/Web UI change (reason given above)
- [x] 若本 PR 修改 Web 设置字段… / N/A — no settings fields changed
- [ ] `docs/CHANGELOG.md` — not updated; see Scope Of Change. Will add on request.
