### PR TITLE
fix(yfinance): populate pe_ratio/pb_ratio for US realtime quotes

### DIFF
--- a/data_provider/yfinance_fetcher.py
+++ b/data_provider/yfinance_fetcher.py
@@ -34,6 +34,7 @@ from tenacity import (
 from .base import BaseFetcher, DataFetchError, STANDARD_COLUMNS, is_bse_code
 from .realtime_types import UnifiedRealtimeQuote, RealtimeSource
 from .us_index_mapping import get_us_index_yf_symbol, is_us_stock_code
+from .yfinance_fundamental_adapter import _safe_float
 from src.services.market_symbol_utils import get_suffix_market, is_suffix_market_symbol
 
 # 可选导入本地股票映射补丁，若缺失则使用空字典兜底
@@ -880,6 +881,10 @@ class YfinanceFetcher(BaseFetcher):
             except Exception:
                 name = STOCK_NAME_MAP.get(symbol, '')
 
+            # 复用上方已获取的 ticker_info，无额外请求
+            pe_ratio = _safe_float(ticker_info.get('trailingPE'))
+            pb_ratio = _safe_float(ticker_info.get('priceToBook'))
+
             missing_fields = [
                 field
                 for field, value in {
@@ -887,8 +892,8 @@ class YfinanceFetcher(BaseFetcher):
                     "prev_close": prev_close,
                     "volume": volume,
                     "amount": None,
-                    "pe_ratio": None,
-                    "pb_ratio": None,
+                    "pe_ratio": pe_ratio,
+                    "pb_ratio": pb_ratio,
                 }.items()
                 if value is None
             ]
@@ -912,8 +917,8 @@ class YfinanceFetcher(BaseFetcher):
                 high=high,
                 low=low,
                 pre_close=prev_close,
-                pe_ratio=None,
-                pb_ratio=None,
+                pe_ratio=pe_ratio,
+                pb_ratio=pb_ratio,
                 total_mv=market_cap,
                 circ_mv=None,
             )


### PR DESCRIPTION
## PR Type

- [x] fix

## Background And Problem

`YfinanceFetcher.get_realtime_quote` constructs `UnifiedRealtimeQuote` with
`pe_ratio=None` and `pb_ratio=None` hardcoded, and lists the same two literals in
its `missing_fields` computation. As a result every US stock quote:

- returns an empty valuation block (`pe_ratio` / `pb_ratio` always `None`), and
- always reports `data_quality="partial"` with `pe_ratio` / `pb_ratio` in
  `missing_fields`, even when the data is available.

yfinance already exposes both values via `Ticker.info` (`trailingPE`,
`priceToBook`), and `ticker.info` is already fetched a few lines above in the same
function to resolve the stock name. So the values were one dict lookup away.

`.env.example` currently positions Longbridge OpenAPI as the fallback for
"美股/港股…PE 等字段兜底". For PE/PB specifically that fallback is not needed —
yfinance has the data. This narrows the gap Longbridge exists to fill.

## Scope Of Change

```
 data_provider/yfinance_fetcher.py | 13 +++++++++----
 1 file changed, 9 insertions(+), 4 deletions(-)
```

- 文件总数 / files: 1
- 文件清单 / file list:
  - `data_provider/yfinance_fetcher.py` — reuse existing `ticker_info` for
    `pe_ratio`/`pb_ratio`; import `_safe_float`
- 文档更新文件（`docs/*`）: none. If you consider "US quotes now carry PE/PB"
  user-visible enough for `docs/CHANGELOG.md`, I will add an entry on request.

Note: `_get_us_index_realtime_quote` is deliberately **not** changed — indices
have no PE/PB, so its `None` values are correct.

## Issue Link

No existing issue. Motivation and acceptance criteria:

- Motivation: US quotes should carry the valuation fields yfinance already
  returns, rather than reporting them as permanently missing.
- Acceptance: `get_realtime_quote('AAPL')` returns non-None `pe_ratio`/`pb_ratio`,
  and `missing_fields` no longer lists them; index quotes are unaffected.

## Verification Commands And Results

```bash
PYTHONPATH=. python -c "
from dotenv import load_dotenv; load_dotenv('.env', override=True)
from data_provider.yfinance_fetcher import YfinanceFetcher
f = YfinanceFetcher()
q = f.get_realtime_quote('AAPL')
print('AAPL pe:', q.pe_ratio, 'pb:', q.pb_ratio, 'quality:', q.data_quality, 'missing:', q.missing_fields)
i = f.get_realtime_quote('SPX')
print('SPX  pe:', i.pe_ratio, 'price:', i.price)
"
```

Before:

```
AAPL pe: None pb: None quality: partial missing: ['amount', 'pe_ratio', 'pb_ratio']
```

After:

```
AAPL pe: 39.671516 pb: 45.08127 quality: partial missing: ['amount']
SPX  pe: None price: 7543.27001953125      # index unchanged, as intended
```

Cross-check that the values are yfinance's own and not derived:

```bash
PYTHONPATH=. python -c "
import yfinance as yf; i = yf.Ticker('AAPL').info
print(i.get('trailingPE'), i.get('priceToBook'))
"
# 39.696968 45.11019   (differs only by intraday price movement between calls)
```

`data_quality` remains `"partial"` because `amount` is still `None` (yfinance does
not provide turnover); this PR does not attempt to change that.

Syntax check:

```bash
python -m py_compile data_provider/yfinance_fetcher.py   # OK
```

Full-suite note: I could not run `./scripts/ci_gate.sh` locally — my environment
lacks `flake8` and `pytest`, and I did not want to report a gate result I had not
actually produced. Head CI results cannot exist before this PR opens; I will
update this section with the four gate results and links once the workflows run on
this PR's head.

## Visual Evidence (if applicable)

不适用原因 / Reason if not applicable: no report formatting, report rendering or
Web UI change. This PR only populates two numeric fields on the quote object
returned by a data provider. The observable effect is the field values shown in
the before/after command output above.

## Compatibility And Risk

本 PR 未变更 provider/model/base URL、运行时配置清理迁移语义；历史配置保持不变；
回滚方式为 revert 本提交。

- No extra network request: `ticker.info` is already fetched in this function for
  the stock name; this reads two more keys from that existing dict.
- `_safe_float` is reused from `yfinance_fundamental_adapter` (same package, no
  circular import — that module imports nothing from `data_provider`) so NaN and
  non-numeric values degrade to `None` exactly as before.
- Behaviour change to be aware of: `missing_fields` for US stocks shrinks from
  `['amount','pe_ratio','pb_ratio']` to `['amount']`. Any consumer keying off the
  presence of `pe_ratio` in `missing_fields` will now see it absent. I checked
  `data_provider/base.py`; Longbridge selection there is priority-ordered
  (`配置长桥凭据后: Longbridge 为首选`) rather than driven by `missing_fields`, so
  this does not alter provider selection. Flagging it in case there is a consumer
  I did not find.
- US indices are unaffected (verified above).

## Rollback Plan

`revert this PR`. No config or data migration required; the fields simply return
to `None` on restart.

## Checklist

- [x] 本 PR 有明确动机和业务价值 / This PR has a clear motivation and value
- [x] 已提供可复现的验证命令与结果 / Reproducible verification commands and results are included
- [x] 已评估兼容性与风险 / Compatibility and risk have been assessed
- [x] 已提供回滚方案 / A rollback plan is provided
- [x] 若修改报告格式或 Web UI 界面… / N/A — no report/Web UI change (reason given above)
- [x] 若本 PR 修改 Web 设置字段… / N/A — no settings fields changed
- [ ] `docs/CHANGELOG.md` — not updated; see Scope Of Change. Will add on request.
