### PR TITLE
fix(agent): default context report_language to REPORT_LANGUAGE

### DIFF
--- a/api/v1/endpoints/agent.py
+++ b/api/v1/endpoints/agent.py
@@ -167,6 +167,9 @@ async def agent_chat(request: ChatRequest):
         ctx = dict(request.context or {})
         if skills is not None:
             ctx["skills"] = skills
+        # Fall back to the configured report language (REPORT_LANGUAGE) so agent
+        # replies match report language when the caller does not specify one.
+        ctx.setdefault("report_language", config.report_language)
 
         # Offload the blocking call to a thread to avoid blocking the event loop.
         loop = asyncio.get_running_loop()
@@ -401,6 +404,9 @@ async def agent_chat_stream(request: ChatRequest):
     stream_ctx = dict(request.context or {})
     if skills is not None:
         stream_ctx["skills"] = skills
+    # Fall back to the configured report language (REPORT_LANGUAGE) so agent
+    # replies match report language when the caller does not specify one.
+    stream_ctx.setdefault("report_language", config.report_language)
 
     def progress_callback(event: dict):
         # Enrich tool events with display names


### PR DESCRIPTION
## PR Type

- [x] fix

## Background And Problem

`agent_chat` and `agent_chat_stream` pass the caller's `context` through to the
orchestrator untouched. When a caller omits `report_language`, nothing supplies
the configured `REPORT_LANGUAGE`, so the agent replies in whatever language the
model gravitates to — in practice it mirrors the user's input language.

Analysis reports already honour `REPORT_LANGUAGE`. The result is that on a
deployment with `REPORT_LANGUAGE=en`, a generated report is English while an Agent
Chat reply to the same user can come back in Chinese. The two surfaces disagree
on the same configured setting.

## Scope Of Change

```
 api/v1/endpoints/agent.py | 6 ++++++
 1 file changed, 6 insertions(+)
```

- 文件总数 / files: 1
- 文件清单 / file list:
  - `api/v1/endpoints/agent.py` — `ctx.setdefault("report_language", ...)` in
    `agent_chat`; same in `agent_chat_stream` for `stream_ctx`
- 文档更新文件（`docs/*`）: none — no new setting is introduced; this makes an
  existing documented setting (`REPORT_LANGUAGE`) apply to a surface that was
  ignoring it. Happy to add a `docs/CHANGELOG.md` entry on request.

## Issue Link

No existing issue. Motivation and acceptance criteria:

- Motivation: make Agent Chat honour `REPORT_LANGUAGE` the way reports already do.
- Acceptance: with `REPORT_LANGUAGE=en` and no `report_language` in the request
  context, the agent replies in English regardless of the input language; a
  caller-supplied `report_language` still wins.

`setdefault` (rather than direct assignment) is deliberate so that an explicit
caller-provided `report_language` keeps precedence — matching the existing
comment in this function about caller-provided values taking precedence.

## Verification Commands And Results

Config resolves as expected (`.env` has `REPORT_LANGUAGE=en`):

```bash
PYTHONPATH=. python -c "from src.config import get_config; print(repr(get_config().report_language))"
# 'en'
```

A/B on the same request, same deployment, same `.env`. A **Chinese** prompt with
an **empty context** is used deliberately: it discriminates the fix from the
model simply mirroring the input language. (An English prompt does not — it
returns English either way, which proves nothing.)

```bash
curl -s -X POST http://127.0.0.1:8000/api/v1/agent/chat \
  -H 'Content-Type: application/json' \
  -d '{"message":"用一句话解释什么是止损单？","skills":["general"],"context":{}}'
```

Before — `upstream/main` @ `487e49e5`:

```
止损单（Stop-Loss Order）是一种预先设置的交易指令，当股票价格下跌到你指定的触发
价格时，系统会自动以市价或限价卖出股票，从而将这笔交易的亏损控制在可承受的范围内。
```
→ Chinese, ignoring `REPORT_LANGUAGE=en`.

After — this PR:

```
A stop-loss order is an automatic order placed with a broker to sell a stock when
it reaches a specific pre-determined price, designed to limit an investor's
potential loss on a position.
```
→ English, honouring `REPORT_LANGUAGE=en`.

Syntax check:

```bash
python -m py_compile api/v1/endpoints/agent.py   # OK
```

Note on coverage: the A/B above exercises `agent_chat`. The identical change in
`agent_chat_stream` is verified by inspection only (same `config` in scope via
`get_config()`, same `setdefault` semantics on `stream_ctx`); I did not drive the
SSE path end-to-end. Flagging that explicitly rather than implying I tested both.

Full-suite note: I could not run `./scripts/ci_gate.sh` locally — my environment
lacks `flake8` and `pytest`, and I did not want to report a gate result I had not
actually produced. Head CI results cannot exist before this PR opens; I will update
this section with the four gate results and links once the workflows run on this
PR's head.

## Visual Evidence (if applicable)

不适用原因 / Reason if not applicable: no report formatting, report rendering or
Web UI change — this only sets a context default on two API handlers. The
user-visible effect is the reply language, evidenced by the before/after curl
output above.

## Compatibility And Risk

本 PR 未变更 provider/model/base URL、运行时配置清理迁移语义；历史配置保持不变；
回滚方式为 revert 本提交。

- Callers that already send `report_language` are unaffected — `setdefault` does
  not overwrite an existing key.
- Behaviour change to be aware of: deployments that left `report_language` out of
  the chat context and relied on the model mirroring the user's input language
  will now get replies in `REPORT_LANGUAGE`. For a default `REPORT_LANGUAGE=zh`
  deployment answering Chinese users this is a no-op; it is visible on
  deployments whose `REPORT_LANGUAGE` differs from their users' input language.
  Calling this out as an intentional semantic change rather than a pure bugfix:
  there is no runtime opt-out short of sending an explicit `report_language` per
  request (see Rollback).

## Rollback Plan

`revert this PR`. No config or data migration required. Note there is no runtime
opt-out: a caller wanting model-mirrored language rather than `REPORT_LANGUAGE`
would need the revert (or to send an explicit `report_language` per request). If
you would prefer this behind a config flag instead of unconditional, I am happy
to rework it that way.

## Checklist

- [x] 本 PR 有明确动机和业务价值 / This PR has a clear motivation and value
- [x] 已提供可复现的验证命令与结果 / Reproducible verification commands and results are included
- [x] 已评估兼容性与风险 / Compatibility and risk have been assessed
- [x] 已提供回滚方案 / A rollback plan is provided
- [x] 若修改报告格式或 Web UI 界面… / N/A — no report/Web UI change (reason given above)
- [x] 若本 PR 修改 Web 设置字段… / N/A — no settings fields changed
- [ ] `docs/CHANGELOG.md` — not updated; see Scope Of Change. Will add on request.
