### PR TITLE
feat: add LOF fund support with precise classification and fallback

### DIFF
--- a/data_provider/akshare_fetcher.py
+++ b/data_provider/akshare_fetcher.py
@@ -95,23 +95,72 @@ _etf_realtime_cache: Dict[str, Any] = {
 }
 
 
-def _is_etf_code(stock_code: str) -> bool:
+def _is_lof_code(stock_code: str) -> bool:
     """
-    判断代码是否为 ETF 基金
-    
-    ETF 代码规则：
-    - 上交所 ETF: 51xxxx, 52xxxx, 56xxxx, 58xxxx
-    - 深交所 ETF: 15xxxx, 16xxxx, 18xxxx
-    
+    判断代码是否为 LOF 基金（上市型开放式基金）。
+
+    LOF 与 ETF 虽然都在交易所挂牌，但 API 端点不同：
+    - LOF 使用 ak.fund_lof_hist_em()
+    - ETF 使用 ak.fund_etf_hist_em()
+
+    代码段（权威分类，互斥于 _is_etf_code，基于 akshare 实际挂牌数据）：
+    - 深交所 LOF: 160xxx-169xxx (160/161/162/163/164/165/166/167/168/169)
+    - 上交所 LOF: 501xxx, 502xxx, 506xxx
+
+    若 ak.fund_lof_hist_em() 返回空或异常，调用方回退到 ETF 接口。
+
     Args:
         stock_code: 股票/基金代码
-        
+
     Returns:
-        True 表示是 ETF 代码，False 表示是普通股票代码
+        True 表示是 LOF 代码
     """
-    etf_prefixes = ('51', '52', '56', '58', '15', '16', '18')
     code = stock_code.strip().split('.')[0]
-    return code.startswith(etf_prefixes) and len(code) == 6
+    if len(code) != 6 or not code.isdigit():
+        return False
+    # 深交所 LOF: 160-169 全段
+    if code.startswith('16'):
+        return True
+    # 上交所 LOF: 501/502/506
+    if code.startswith(('501', '502', '506')):
+        return True
+    return False
+
+
+def _is_etf_code(stock_code: str) -> bool:
+    """
+    判断代码是否为 ETF 基金。
+
+    ETF 代码段（权威分类，互斥于 _is_lof_code，基于 akshare 实际挂牌数据）：
+    - 深交所 ETF: 159xxx
+    - 上交所 ETF: 510xxx-518xxx, 520xxx, 526xxx, 530xxx,
+                  560xxx-563xxx, 588xxx-589xxx
+
+    注意：_is_lof_code 在 _is_etf_code 之前调用，16xxxx 和 501/502/506
+    不会落到这里。18xxxx 为传统封闭式基金，不是 ETF。
+
+    Args:
+        stock_code: 股票/基金代码
+
+    Returns:
+        True 表示是 ETF 代码
+    """
+    code = stock_code.strip().split('.')[0]
+    if len(code) != 6 or not code.isdigit():
+        return False
+    # 深交所 ETF: 159xxx
+    if code.startswith('159'):
+        return True
+    # 上交所 ETF: 510-518, 520, 526, 530, 560-563, 588-589（基于实际挂牌）
+    if code.startswith(('510', '511', '512', '513', '514', '515', '516', '517', '518')):
+        return True
+    if code.startswith(('520', '526', '530')):
+        return True
+    if code.startswith(('560', '561', '562', '563')):
+        return True
+    if code.startswith(('588', '589')):
+        return True
+    return False
 
 
 def _is_hk_code(stock_code: str) -> bool:
@@ -472,6 +521,8 @@ class AkshareFetcher(BaseFetcher):
             )
         elif _is_hk_code(stock_code):
             return self._fetch_hk_data(stock_code, start_date, end_date)
+        elif _is_lof_code(stock_code):
+            return self._fetch_lof_data(stock_code, start_date, end_date)
         elif _is_etf_code(stock_code):
             return self._fetch_etf_data(stock_code, start_date, end_date)
         else:
@@ -648,6 +699,61 @@ class AkshareFetcher(BaseFetcher):
         except Exception as e:
             raise e
     
+    def _fetch_lof_data(self, stock_code: str, start_date: str, end_date: str) -> pd.DataFrame:
+        """
+        获取 LOF 基金历史数据，空响应或异常时回退到 ETF 接口。
+
+        LOF 与部分 ETF 共用 16xxxx 号段，ak.fund_lof_hist_em() 对某些代码
+        可能返回空 DataFrame（该代码实际是 ETF）。因此空响应也需 fallback。
+
+        Args:
+            stock_code: LOF 代码，如 '161116', '501018'
+            start_date: 开始日期，格式 'YYYY-MM-DD'
+            end_date: 结束日期，格式 'YYYY-MM-DD'
+
+        Returns:
+            LOF 或回退 ETF 的历史数据 DataFrame
+        """
+        import akshare as ak
+
+        self._set_random_user_agent()
+        self._enforce_rate_limit()
+
+        logger.info(f"[API调用] ak.fund_lof_hist_em(symbol={stock_code}, period=daily, "
+                     f"start_date={start_date.replace('-', '')}, end_date={end_date.replace('-', '')}, adjust=qfq)")
+
+        import time as _time
+        api_start = _time.time()
+
+        try:
+            df = ak.fund_lof_hist_em(
+                symbol=stock_code,
+                period="daily",
+                start_date=start_date.replace('-', ''),
+                end_date=end_date.replace('-', ''),
+                adjust="qfq",
+            )
+
+            api_elapsed = _time.time() - api_start
+
+            if df is not None and not df.empty:
+                logger.info(f"[API返回] ak.fund_lof_hist_em 成功: 返回 {len(df)} 行数据, 耗时 {api_elapsed:.2f}s")
+                return df
+
+            # 空响应：该代码可能是 ETF 而非 LOF，回退到 ETF 接口
+            logger.warning(f"[API返回] ak.fund_lof_hist_em 返回空数据, 耗时 {api_elapsed:.2f}s, 回退 ETF 接口: {stock_code}")
+            return self._fetch_etf_data(stock_code, start_date, end_date)
+
+        except Exception as e:
+            error_msg = str(e).lower()
+            if any(keyword in error_msg for keyword in ['banned', 'blocked', '频率', 'rate', '限制']):
+                logger.warning(f"检测到可能被封禁: {e}")
+                raise RateLimitError(f"Akshare 可能被限流: {e}") from e
+
+            # 异常：回退到 ETF 接口
+            logger.warning(f"[数据源] LOF API 异常, 回退 ETF API: {stock_code} ({e})")
+            return self._fetch_etf_data(stock_code, start_date, end_date)
+
     def _fetch_etf_data(self, stock_code: str, start_date: str, end_date: str) -> pd.DataFrame:
         """
         获取 ETF 基金历史数据
@@ -930,7 +1036,7 @@ class AkshareFetcher(BaseFetcher):
             return None
         elif _is_hk_code(stock_code):
             return self._get_hk_realtime_quote(stock_code)
-        elif _is_etf_code(stock_code):
+        elif _is_lof_code(stock_code) or _is_etf_code(stock_code):
             source_key = "akshare_etf"
             if not circuit_breaker.is_available(source_key):
                 logger.info(f"[熔断] 数据源 {source_key} 处于熔断状态，跳过")
@@ -1599,9 +1705,9 @@ class AkshareFetcher(BaseFetcher):
             logger.debug(f"[API跳过] {stock_code} 是港股，无筹码分布数据")
             return None
 
-        # ETF/指数没有筹码分布数据
-        if _is_etf_code(stock_code):
-            logger.debug(f"[API跳过] {stock_code} 是 ETF/指数，无筹码分布数据")
+        # ETF/LOF/指数没有筹码分布数据
+        if _is_lof_code(stock_code) or _is_etf_code(stock_code):
+            logger.debug(f"[API跳过] {stock_code} 是 ETF/LOF/指数，无筹码分布数据")
             return None
         
         try:

--- a/data_provider/base.py
+++ b/data_provider/base.py
@@ -149,7 +149,19 @@ def normalize_stock_code(stock_code: str) -> str:
     return code
 
 
-ETF_PREFIXES = ("51", "52", "56", "58", "15", "16", "18")
+# Fund code prefixes: ETF and LOF share these broad prefixes, but LOF
+# adds 501/502/506 for Shanghai LOF.  The granular split lives in
+# data_provider/akshare_fetcher._is_lof_code/_is_etf_code; this tuple is
+# only used for "is this a fund at all?" checks in DataFetcherManager.
+FUND_PREFIXES = (
+    "51", "52", "56", "58",     # Shanghai ETF
+    "15", "16", "18",           # Shenzhen ETF/LOF
+    "501", "502", "506",        # Shanghai LOF
+    "588", "589",               # Shanghai STAR ETF
+)
+
+# Legacy alias (still used by some callers as "ETF or fund")
+ETF_PREFIXES = FUND_PREFIXES
 
 
 def _is_us_market(code: str) -> bool:
@@ -198,7 +210,11 @@ def _is_tw_market(code: str) -> bool:
 
 
 def _is_etf_code(code: str) -> bool:
-    """判定 A 股 ETF 基金代码（保守规则）。"""
+    """判定 A 股 ETF/LOF 基金代码（保守规则）。
+
+    包含 LOF 号段（501/502/506）以保证 DataFetcherManager 和下游
+    服务将 LOF 与 ETF 一并按基金品类处理，而非普通股票。
+    """
     normalized = normalize_stock_code(code)
     return (
         normalized.isdigit()

--- a/data_provider/efinance_fetcher.py
+++ b/data_provider/efinance_fetcher.py
@@ -145,7 +145,7 @@ _etf_realtime_cache: Dict[str, Any] = {
     'ttl': 600  # 10分钟缓存有效期
 }
 
-_ETF_SH_PREFIXES = ('51', '52', '56', '58')
+_ETF_SH_PREFIXES = ('51', '52', '56', '58', '501', '502', '506', '588', '589')
 _ETF_SZ_PREFIXES = ('15', '16', '18')
 
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - [改进] TickFlow 新增基于申万一级行业池的行业涨跌排行 fallback，并将基本面/市场结构单能力默认超时由 3 秒调整为 8 秒，降低正常慢响应被提前降级的概率。
 - [文档] 补充 macOS 未签名、未公证 DMG 被 Gatekeeper 拦截时的架构选择、安全排查与官方安装包临时放行步骤。
 - [新功能] Web AI 建议页支持确认保存基于历史报告快照重算的决策风格信号，以 created/existing/refreshed 区分新建、原样复用和既有记录续期或维度补齐，复用 profile-aware 去重与失效语义，将历史信号的创建时间、有效期和相反信号失效顺序锚定来源报告时间，并提供可审计 guardrail 提示与阻断。
+- [新功能] AkshareFetcher 支持 LOF 基金（深交所 160-169 全段、上交所 501/502/506），优先调用 fund_lof_hist_em，空响应或异常时回退 fund_etf_hist_em，LOF/ETF 代码分类基于 akshare 实际挂牌数据互斥。
 <!-- 新条目格式：- [类型] 描述（类型取值：新功能/改进/修复/文档/测试/chore）-->
 <!-- 每条独立一行追加到本段末尾，无需分类标题，合并时冲突最小 -->
 

--- a/docs/lof-fund-support.md
+++ b/docs/lof-fund-support.md
@@ -1,0 +1,138 @@
+# LOF Fund Support
+
+## 背景
+
+AkshareFetcher 原先只支持 ETF 基金（`fund_etf_hist_em`），不支持 LOF（上市型开放式基金）。
+LOF 与 ETF 共用部分号段（如 16xxxx），但 akshare 的 API 端点不同：
+
+- LOF 使用 `ak.fund_lof_hist_em()`
+- ETF 使用 `ak.fund_etf_hist_em()`
+
+## 权威分类契约
+
+### LOF 代码段
+
+| 交易所 | 号段 | 说明 |
+|--------|------|------|
+| 深交所 | 160xxx-169xxx | 全段，160/161/162/163/164/165/166/167/168/169 |
+| 上交所 | 501xxx | 普通 LOF 基金 |
+| 上交所 | 502xxx | 原分级基金转型的 LOF |
+| 上交所 | 506xxx | 科创板相关 LOF |
+
+### ETF 代码段
+
+| 交易所 | 号段 |
+|--------|------|
+| 深交所 | 159xxx |
+| 上交所 | 510xxx-518xxx, 520xxx, 526xxx, 530xxx, 560xxx-563xxx, 588xxx-589xxx |
+
+### 互斥规则
+
+`_is_lof_code()` 在 dispatch 中优先于 `_is_etf_code()` 调用，确保 16xxxx 不会被 ETF 吞掉。
+
+### 数据来源
+
+分类基于四重交叉验证：
+1. **akshare 实查**：`fund_lof_spot_em()` 返回 390 只 LOF，`fund_etf_spot_em()` 返回 1549 只 ETF
+2. **知乎** — 场内基金的代码体系（160-169 全段，501/502）
+3. **腾讯新闻** — "深交所LOF通常以'160'开头，上交所LOF一般以'501'开头"
+4. **维基百科** — 上海证券交易所上市交易基金列表（501/502/506 详细说明）
+
+## 全栈同步
+
+LOF 分类不止在 AkshareFetcher 中，以下所有模块同步更新：
+
+| 模块 | 改动 | 验证 |
+|------|------|------|
+| `data_provider/akshare_fetcher.py` | `_is_lof_code()` + `_fetch_lof_data()` + dispatch | 49 mock tests |
+| `data_provider/base.py` | `FUND_PREFIXES` 含 501/502/506/588/589 | `test_base_is_etf_code_includes_sh_lof` |
+| `data_provider/efinance_fetcher.py` | `_ETF_SH_PREFIXES` 扩展，secid 路由覆盖 | `test_efinance_secid_for_sh_lof` |
+| `src/search_service.py` | `_A_ETF_PREFIXES` 含 LOF 号段，`is_index_or_etf` 覆盖 | `test_search_service_recognizes_sh_lof_as_fund` |
+| `src/core/pipeline.py` | 通过 `SearchService.is_index_or_etf()` 自动受益 | 间接覆盖 |
+
+## Dispatch 行为
+
+### 历史数据 `_fetch_raw_data()`
+
+```
+_is_us_code → US fetcher
+_is_hk_code → HK fetcher
+_is_lof_code → _fetch_lof_data()   ← 新增
+_is_etf_code → _fetch_etf_data()
+default → _fetch_stock_data()
+```
+
+### LOF Fallback 逻辑
+
+```
+_fetch_lof_data(code)
+  → ak.fund_lof_hist_em(code)
+  → 非空 DataFrame → return
+  → 空 DataFrame → fallback _fetch_etf_data()     ← 核心修复
+  → 普通异常 → fallback _fetch_etf_data()
+  → RateLimitError → raise（不 fallback）
+```
+
+### 其他 dispatch 点
+
+- **实时行情** `get_realtime_quote()`：LOF 走 ETF 实时接口
+- **筹码分布**：LOF 跳过（与 ETF 一致，基金无筹码数据）
+
+## 验证命令与结果
+
+### Mock 测试（CI 默认运行）
+
+```bash
+python -m pytest tests/test_lof_fund_support.py tests/test_etf_daily_routing.py -q -m "not network"
+# 55 passed, 3 deselected
+```
+
+### 网络测试（手动运行）
+
+```bash
+python -m pytest tests/test_lof_fund_support.py::TestLofNetworkValidation -v -m network
+# 需要可访问东方财富 API
+# fund_etf_hist_em 对 ETF 代码返回数据（验证 fallback 目标可用）
+```
+
+### 分类验证
+
+```python
+from data_provider.akshare_fetcher import _is_lof_code, _is_etf_code
+assert _is_lof_code("501018")       # Shanghai LOF
+assert _is_lof_code("164105")       # Shenzhen LOF
+assert not _is_etf_code("164105")   # 164 is LOF, not ETF
+assert not _is_etf_code("180003")   # Traditional closed-end, not ETF
+assert not _is_etf_code("519001")   # 上证基金通, not exchange-traded
+```
+
+## 兼容性风险
+
+| 风险 | 影响范围 | 严重度 |
+|------|---------|--------|
+| 18xxxx 从 ETF 移除 | 传统封闭式基金（已清盘/转型），fall through 到 `_fetch_stock_data` | 低 |
+| 519xxx 不匹配任何基金前缀 | 上证基金通系统基金，走普通股票路径 | 低 |
+| 501/502/506 在 base/search/efinance 中新增 | 可能影响已有 ETF 路由逻辑（但测试无回归） | 极低 |
+| 588/589 在 base/search 中新增 | 科创板 ETF，之前可能未覆盖 | 极低 |
+
+## 回滚方案
+
+此 PR 包含两个 commit：
+
+1. `feat: add LOF fund support` — 核心功能
+2. `fix: sync LOF classification across full stack` — 全栈同步
+
+回滚步骤：
+
+```bash
+# 完全回滚（两个 commit 都 revert）
+git revert <commit-2> <commit-1>
+
+# 或只回滚全栈同步（保留 AkshareFetcher 内的 LOF 支持）
+git revert <commit-2>
+```
+
+回滚后：
+- AkshareFetcher 恢复为仅 ETF 支持
+- base.py / search_service.py / efinance_fetcher.py 恢复旧前缀集
+- 无数据库迁移、无配置变更、无文件系统副作用

--- a/src/search_service.py
+++ b/src/search_service.py
@@ -2475,8 +2475,10 @@ class SearchService:
             return {"search_lang": "en", "country": "US"}
         return {}
 
-    # A-share ETF code prefixes (Shanghai 51/52/56/58, Shenzhen 15/16/18)
-    _A_ETF_PREFIXES = ('51', '52', '56', '58', '15', '16', '18')
+    # A-share ETF/LOF fund code prefixes
+    # Shanghai ETF: 51/52/56/58/588/589, Shanghai LOF: 501/502/506
+    # Shenzhen ETF/LOF: 15/16/18
+    _A_ETF_PREFIXES = ('51', '52', '56', '58', '15', '16', '18', '501', '502', '506', '588', '589')
     _ETF_NAME_KEYWORDS = ('ETF', 'FUND', 'TRUST', 'INDEX', 'TRACKER', 'UNIT')  # US/HK ETF name hints
 
     @staticmethod

--- a/tests/test_lof_fund_support.py
+++ b/tests/test_lof_fund_support.py
@@ -295,3 +295,53 @@ class TestLofNetworkValidation:
             start_date="20250101", end_date="20250301", adjust="qfq",
         )
         assert df is None or df.empty, "fund_lof_hist_em 对 ETF 代码应返回空"
+
+
+# ---------------------------------------------------------------------------
+# End-to-end semantic tests: LOF codes recognized across the full stack
+# ---------------------------------------------------------------------------
+
+class TestLofFullStackSemantics:
+    """Verify that LOF codes (especially 501/502/506) are recognized as
+    funds everywhere — not just in AkshareFetcher, but also in
+    DataFetcherManager, SearchService, and pipeline-level checks.
+    """
+
+    def test_base_is_etf_code_includes_sh_lof(self):
+        """base._is_etf_code must include 501/502/506 for manager-level routing."""
+        from data_provider.base import _is_etf_code as base_is_etf
+        assert base_is_etf("501018"), "501018 should be recognized as fund in base"
+        assert base_is_etf("502000"), "502000 should be recognized as fund in base"
+        assert base_is_etf("506000"), "506000 should be recognized as fund in base"
+
+    def test_base_is_etf_code_includes_sz_lof(self):
+        """base._is_etf_code must include 160-169 for manager-level routing."""
+        from data_provider.base import _is_etf_code as base_is_etf
+        for code in ("160105", "161116", "164105", "169101"):
+            assert base_is_etf(code), f"{code} should be recognized as fund in base"
+
+    def test_search_service_recognizes_sh_lof_as_fund(self):
+        """SearchService.is_index_or_etf must return True for 501/502/506."""
+        from src.search_service import SearchService
+        assert SearchService.is_index_or_etf("501018", "南方原油LOF")
+        assert SearchService.is_index_or_etf("502000", "test")
+        assert SearchService.is_index_or_etf("506000", "test")
+
+    def test_search_service_recognizes_sz_lof_as_fund(self):
+        """SearchService.is_index_or_etf must return True for 16xxxx."""
+        from src.search_service import SearchService
+        assert SearchService.is_index_or_etf("161116", "test")
+        assert SearchService.is_index_or_etf("164105", "test")
+
+    def test_efinance_secid_for_sh_lof(self):
+        """EfinanceFetcher must build correct secid for Shanghai LOF."""
+        from data_provider.efinance_fetcher import _build_eastmoney_etf_secid
+        assert _build_eastmoney_etf_secid("501018") == "1.501018"
+        assert _build_eastmoney_etf_secid("502000") == "1.502000"
+
+    def test_normal_stock_not_recognized_as_fund(self):
+        """Normal A-share stocks must not be recognized as fund."""
+        from data_provider.base import _is_etf_code as base_is_etf
+        from src.search_service import SearchService
+        assert not base_is_etf("600519")
+        assert not SearchService.is_index_or_etf("600519", "贵州茅台")

--- a/tests/test_lof_fund_support.py
+++ b/tests/test_lof_fund_support.py
@@ -1,0 +1,297 @@
+"""LOF fund support: dispatch, empty-response fallback, exception fallback, classification contract.
+
+Covers the scenarios ZhuLinsen required:
+- LOF dispatch calls fund_lof_hist_em
+- Empty LOF response falls back to ETF
+- LOF exception falls back to ETF
+- Classification: LOF and ETF prefixes are mutually exclusive where they should be
+- Fallback actually calls fund_etf_hist_em
+"""
+import os
+import sys
+import types
+from unittest.mock import MagicMock, patch
+
+import pandas as pd
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from data_provider.akshare_fetcher import AkshareFetcher, _is_lof_code, _is_etf_code
+
+
+def _make_fetcher() -> AkshareFetcher:
+    from types import SimpleNamespace
+    with patch(
+        "data_provider.akshare_fetcher.get_config",
+        return_value=SimpleNamespace(enable_eastmoney_patch=False),
+    ):
+        return AkshareFetcher(sleep_min=0, sleep_max=0)
+
+
+def _history_frame(code: str = "161116") -> pd.DataFrame:
+    return pd.DataFrame(
+        {
+            "日期": pd.date_range("2026-01-01", periods=5).strftime("%Y-%m-%d"),
+            "开盘": [1.0, 1.01, 1.02, 1.03, 1.04],
+            "收盘": [1.01, 1.02, 1.03, 1.04, 1.05],
+            "最高": [1.02, 1.03, 1.04, 1.05, 1.06],
+            "最低": [0.99, 1.0, 1.01, 1.02, 1.03],
+            "成交量": [10000, 11000, 12000, 13000, 14000],
+            "成交额": [10100, 11220, 12360, 13520, 14700],
+            "涨跌幅": [0.0, 0.99, 0.98, 0.97, 0.96],
+        }
+    )
+
+
+# ---------------------------------------------------------------------------
+# Classification contract
+# ---------------------------------------------------------------------------
+
+class TestLofClassification:
+    """LOF 与 ETF 代码段互斥分类"""
+
+    @pytest.mark.parametrize("code", [
+        "160123", "161116", "162411", "163406",
+        "164105", "165309", "166009", "167001",
+        "168101", "169101",
+        "501018", "501009", "502000", "506000",
+    ])
+    def test_lof_codes(self, code: str):
+        assert _is_lof_code(code) is True
+
+    @pytest.mark.parametrize("code", [
+        "510010", "512400", "513310", "515000", "516000",
+        "520500", "526000", "530000",
+        "560010", "561000", "562000", "563230",
+        "588000", "589000",
+        "159919",
+    ])
+    def test_etf_codes(self, code: str):
+        assert _is_etf_code(code) is True
+        assert _is_lof_code(code) is False
+
+    @pytest.mark.parametrize("code", [
+        "000001", "600519", "300750", "002050",
+    ])
+    def test_normal_stocks_neither(self, code: str):
+        assert _is_lof_code(code) is False
+        assert _is_etf_code(code) is False
+
+    def test_prefixed_codes(self):
+        assert _is_lof_code("161116.SZ")
+        assert _is_etf_code("513310.SH")
+
+    def test_invalid_codes(self):
+        assert not _is_lof_code("12345")
+        assert not _is_lof_code("abcdef")
+        assert not _is_etf_code("12345")
+        assert not _is_etf_code("abcdef")
+
+
+# ---------------------------------------------------------------------------
+# Dispatch
+# ---------------------------------------------------------------------------
+
+class TestLofDispatch:
+    """LOF 代码走 fund_lof_hist_em，不走 fund_etf_hist_em"""
+
+    def test_lof_dispatch_calls_fund_lof_hist_em(self):
+        fetcher = _make_fetcher()
+        fake_lof = MagicMock(return_value=_history_frame())
+        fake_etf = MagicMock(return_value=_history_frame())
+        fake_akshare = types.SimpleNamespace(
+            fund_lof_hist_em=fake_lof,
+            fund_etf_hist_em=fake_etf,
+        )
+
+        with patch.dict(sys.modules, {"akshare": fake_akshare}):
+            with patch.object(fetcher, "_set_random_user_agent"), \
+                 patch.object(fetcher, "_enforce_rate_limit"):
+                df = fetcher._fetch_raw_data("161116", "2026-01-01", "2026-01-05")
+
+        assert df is not None and not df.empty
+        fake_lof.assert_called_once()
+        fake_etf.assert_not_called()
+
+    def test_lof_dispatch_with_501_prefix(self):
+        """上交所 LOF 501xxx 也走 LOF 接口"""
+        fetcher = _make_fetcher()
+        fake_lof = MagicMock(return_value=_history_frame("501018"))
+        fake_etf = MagicMock(return_value=_history_frame("501018"))
+        fake_akshare = types.SimpleNamespace(
+            fund_lof_hist_em=fake_lof,
+            fund_etf_hist_em=fake_etf,
+        )
+
+        with patch.dict(sys.modules, {"akshare": fake_akshare}):
+            with patch.object(fetcher, "_set_random_user_agent"), \
+                 patch.object(fetcher, "_enforce_rate_limit"):
+                df = fetcher._fetch_raw_data("501018", "2026-01-01", "2026-01-05")
+
+        assert df is not None and not df.empty
+        fake_lof.assert_called_once()
+        fake_etf.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Empty response fallback
+# ---------------------------------------------------------------------------
+
+class TestLofEmptyFallback:
+    """LOF 返回空 DataFrame 时回退到 ETF 接口"""
+
+    def test_empty_lof_response_falls_back_to_etf(self):
+        fetcher = _make_fetcher()
+        empty_df = pd.DataFrame()
+        etf_df = _history_frame()
+        fake_lof = MagicMock(return_value=empty_df)
+        fake_etf = MagicMock(return_value=etf_df)
+        fake_akshare = types.SimpleNamespace(
+            fund_lof_hist_em=fake_lof,
+            fund_etf_hist_em=fake_etf,
+        )
+
+        with patch.dict(sys.modules, {"akshare": fake_akshare}):
+            with patch.object(fetcher, "_set_random_user_agent"), \
+                 patch.object(fetcher, "_enforce_rate_limit"):
+                df = fetcher._fetch_lof_data("161116", "2026-01-01", "2026-01-05")
+
+        # ETF fallback was called
+        fake_lof.assert_called_once()
+        fake_etf.assert_called_once()
+        # Got ETF data back
+        assert df is etf_df
+
+    def test_empty_lof_via_dispatch_falls_back(self):
+        """端到端：通过 _fetch_raw_data dispatch 后空响应也走 fallback"""
+        fetcher = _make_fetcher()
+        empty_df = pd.DataFrame()
+        etf_df = _history_frame()
+        fake_lof = MagicMock(return_value=empty_df)
+        fake_etf = MagicMock(return_value=etf_df)
+        fake_akshare = types.SimpleNamespace(
+            fund_lof_hist_em=fake_lof,
+            fund_etf_hist_em=fake_etf,
+        )
+
+        with patch.dict(sys.modules, {"akshare": fake_akshare}):
+            with patch.object(fetcher, "_set_random_user_agent"), \
+                 patch.object(fetcher, "_enforce_rate_limit"):
+                df = fetcher._fetch_raw_data("162411", "2026-01-01", "2026-01-05")
+
+        fake_lof.assert_called_once()
+        fake_etf.assert_called_once()
+        assert df is etf_df
+
+
+# ---------------------------------------------------------------------------
+# Exception fallback
+# ---------------------------------------------------------------------------
+
+class TestLofExceptionFallback:
+    """LOF API 异常时回退到 ETF 接口"""
+
+    def test_lof_exception_falls_back_to_etf(self):
+        fetcher = _make_fetcher()
+        etf_df = _history_frame()
+        fake_lof = MagicMock(side_effect=RuntimeError("network error"))
+        fake_etf = MagicMock(return_value=etf_df)
+        fake_akshare = types.SimpleNamespace(
+            fund_lof_hist_em=fake_lof,
+            fund_etf_hist_em=fake_etf,
+        )
+
+        with patch.dict(sys.modules, {"akshare": fake_akshare}):
+            with patch.object(fetcher, "_set_random_user_agent"), \
+                 patch.object(fetcher, "_enforce_rate_limit"):
+                df = fetcher._fetch_lof_data("163406", "2026-01-01", "2026-01-05")
+
+        fake_lof.assert_called_once()
+        fake_etf.assert_called_once()
+        assert df is etf_df
+
+    def test_lof_rate_limit_does_not_fallback(self):
+        """限流异常不应该 fallback，而是直接抛出"""
+        from data_provider.base import RateLimitError
+
+        fetcher = _make_fetcher()
+        fake_lof = MagicMock(side_effect=RuntimeError("访问频率超限"))
+        fake_etf = MagicMock(return_value=_history_frame())
+        fake_akshare = types.SimpleNamespace(
+            fund_lof_hist_em=fake_lof,
+            fund_etf_hist_em=fake_etf,
+        )
+
+        with patch.dict(sys.modules, {"akshare": fake_akshare}):
+            with patch.object(fetcher, "_set_random_user_agent"), \
+                 patch.object(fetcher, "_enforce_rate_limit"):
+                with pytest.raises(RateLimitError):
+                    fetcher._fetch_lof_data("161116", "2026-01-01", "2026-01-05")
+
+        fake_etf.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Realtime quote dispatch
+# ---------------------------------------------------------------------------
+
+class TestLofRealtimeDispatch:
+    """LOF 实时行情也走 ETF 实时接口"""
+
+    def test_lof_realtime_uses_etf_realtime(self):
+        fetcher = _make_fetcher()
+        # Mock circuit_breaker via the getter function
+        fake_cb = MagicMock()
+        fake_cb.is_available.return_value = True
+        with patch("data_provider.akshare_fetcher.get_realtime_circuit_breaker", return_value=fake_cb):
+            with patch.object(fetcher, "_get_etf_realtime_quote", return_value={"price": 1.05}) as mock_rt:
+                result = fetcher.get_realtime_quote("161116")
+
+        assert result is not None
+        mock_rt.assert_called_once_with("161116")
+
+
+# ---------------------------------------------------------------------------
+# Network tests (real API calls, marked for manual/CI opt-in)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.network
+class TestLofNetworkValidation:
+    """真实 API 调用验证 LOF dispatch 和 fallback。
+
+    标记为 network，CI 默认不执行。手动验证命令：
+        pytest tests/test_lof_fund_support.py::TestLofNetworkValidation -v -m network
+
+    验证目标：
+    - fund_lof_hist_em 对真实 LOF 代码返回非空数据
+    - fund_etf_hist_em 对真实 ETF 代码返回非空数据
+    - fund_lof_hist_em 对真实 ETF 代码（如 159919）返回空 → fallback 成立
+    """
+
+    def test_real_lof_returns_data(self):
+        """真实 LOF 代码 161116 走 fund_lof_hist_em 返回数据"""
+        import akshare as ak
+        df = ak.fund_lof_hist_em(
+            symbol="161116", period="daily",
+            start_date="20250101", end_date="20250301", adjust="qfq",
+        )
+        assert df is not None and not df.empty, "fund_lof_hist_em 应对 161116 返回数据"
+
+    def test_real_etf_returns_data(self):
+        """真实 ETF 代码 159919 走 fund_etf_hist_em 返回数据"""
+        import akshare as ak
+        df = ak.fund_etf_hist_em(
+            symbol="159919", period="daily",
+            start_date="20250101", end_date="20250301", adjust="qfq",
+        )
+        assert df is not None and not df.empty, "fund_etf_hist_em 应对 159919 返回数据"
+
+    def test_lof_api_returns_empty_for_etf_code(self):
+        """fund_lof_hist_em 对 ETF 代码返回空（证明 fallback 必要性）"""
+        import akshare as ak
+        df = ak.fund_lof_hist_em(
+            symbol="159919", period="daily",
+            start_date="20250101", end_date="20250301", adjust="qfq",
+        )
+        assert df is None or df.empty, "fund_lof_hist_em 对 ETF 代码应返回空"


### PR DESCRIPTION
## Summary

Add LOF fund support to AkshareFetcher with precise code classification and empty-response fallback. This is the standalone LOF PR from the three-way split per ZhuLinsen's review on #2016.

**专题文档**: `docs/lof-fund-support.md`

## Classification (`_is_lof_code` / `_is_etf_code`)

| 类型 | 交易所 | 号段 |
|------|--------|------|
| LOF | 深交所 | 160xxx-169xxx (全段) |
| LOF | 上交所 | 501xxx, 502xxx, 506xxx |
| ETF | 深交所 | 159xxx |
| ETF | 上交所 | 510-518/520/526/530/560-563/588-589 |

- 互斥 dispatch：LOF 在 ETF 之前判断，确保 16xxxx 不被 ETF 吞掉
- 18xxxx 从 ETF 移除（传统封闭式基金，不是 ETF）
- 519xxx 不匹配（上证基金通，非竞价系统交易）
- 分类基于四重交叉验证：akshare 实查 (390 LOF + 1549 ETF) + Brave 搜索 (知乎/腾讯/维基/准上市)

## Full-Stack Sync (OR-COR-99c7ea38 fix)

| 模块 | 改动 |
|------|------|
| `data_provider/akshare_fetcher.py` | `_is_lof_code()` + `_fetch_lof_data()` + 3 dispatch points |
| `data_provider/base.py` | `FUND_PREFIXES` 含 501/502/506/588/589 |
| `data_provider/efinance_fetcher.py` | `_ETF_SH_PREFIXES` 扩展，secid 路由覆盖 |
| `src/search_service.py` | `_A_ETF_PREFIXES` 含 LOF，`is_index_or_etf` 覆盖 |
| `src/core/pipeline.py` | 通过 `SearchService.is_index_or_etf()` 自动受益 |

## Dispatch (`_fetch_lof_data`)

- Calls `ak.fund_lof_hist_em()` first
- **Empty DataFrame → fallback to `_fetch_etf_data()`** (core fix: previously only exceptions triggered fallback)
- **Exception → fallback to ETF**
- **Rate-limit error → no fallback, raise RateLimitError**

## Verification

```bash
# Mock tests (CI default)
python -m pytest tests/test_lof_fund_support.py tests/test_etf_daily_routing.py -q -m "not network"
# 55 passed, 3 deselected

# Classification spot-check
python -c "from data_provider.akshare_fetcher import _is_lof_code, _is_etf_code; \
  assert _is_lof_code('501018') and not _is_etf_code('180003')"
```

## Compatibility Risks

| Risk | Impact | Severity |
|------|--------|----------|
| 18xxxx removed from ETF | Closed-end funds (delisted/converted), fall through to stock path | Low |
| 519xxx not matched | 上证基金通 funds, treated as normal stock | Low |
| 501/502/506/588/589 added to base/search | No regression in existing ETF routing (7 ETF tests green) | Minimal |

## Rollback

```bash
git revert <fix-commit> <feat-commit>
```

No database migration, no config changes, no filesystem side effects.
