### PR TITLE
fix: 降低 TencentFetcher 兜底优先级，避免日线分析越级降级到该源

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -853,7 +853,7 @@ ADMIN_AUTH_ENABLED=false
 # Data Fetcher Priority Configuration
 # ===========================================
 # Lower number = higher priority (tried first)
-# Default priorities: efinance(0) > akshare(1) > tushare/pytdx(2) > baostock(3) > yfinance(4)
+# Default priorities: efinance(0) > akshare(1) > tushare/pytdx(2) > baostock(3) > yfinance(4) > tencent(5)
 # For US stocks, set YFINANCE_PRIORITY=0 to use Yahoo Finance first
 
 # EFINANCE_PRIORITY=0      # EastMoney (China) - default: 0
@@ -870,6 +870,11 @@ ADMIN_AUTH_ENABLED=false
 # Or multiple servers: PYTDX_SERVERS=ip1:port1,ip2:port2
 # BAOSTOCK_PRIORITY=3      # Baostock (China) - default: 3
 # YFINANCE_PRIORITY=4      # Yahoo Finance (Global) - default: 4
+# TENCENT_PRIORITY=5       # Tencent direct daily K-line (China) - last-resort A-share
+#                          # fallback only (OHLCV/amount only, no fundamentals).
+#                          # Keep it behind efinance/akshare/tushare/pytdx/baostock/
+#                          # yfinance so a single higher-priority source failure
+#                          # doesn't route straight to Tencent. Default: 5
 
 # Example: Prioritize Yahoo Finance for US stocks
 # YFINANCE_PRIORITY=0

--- a/data_provider/__init__.py
+++ b/data_provider/__init__.py
@@ -17,6 +17,7 @@
 4. PytdxFetcher (Priority 2) - 来自 pytdx 库（通达信）
 5. BaostockFetcher (Priority 3) - 来自 baostock 库
 6. YfinanceFetcher (Priority 4) - 来自 yfinance 库
+7. TencentFetcher (Priority 5) - 腾讯直连日K兜底，仅前序 A 股源全部失败时使用
 
 【未配置 TUSHARE_TOKEN 时】
 1. EfinanceFetcher (Priority 0) - 最高优先级，来自 efinance 库
@@ -25,7 +26,8 @@
 4. TushareFetcher (Priority 2) - 来自 tushare 库（不可用）
 5. BaostockFetcher (Priority 3) - 来自 baostock 库
 6. YfinanceFetcher (Priority 4) - 来自 yfinance 库
-7. LongbridgeFetcher (Priority 5) - 长桥 OpenAPI（美股/港股兜底）
+7. TencentFetcher (Priority 5) - 腾讯直连日K兜底，仅前序 A 股源全部失败时使用
+8. LongbridgeFetcher (Priority 5) - 长桥 OpenAPI（美股/港股兜底，与 Tencent 市场不重叠）
 
 提示：优先级数字越小越优先，同优先级按初始化顺序排列
 """

--- a/data_provider/base.py
+++ b/data_provider/base.py
@@ -1150,6 +1150,7 @@ class DataFetcherManager:
           2. PytdxFetcher (Priority 2) - 通达信
           3. BaostockFetcher (Priority 3)
           4. YfinanceFetcher (Priority 4)
+          5. TencentFetcher (Priority 5) - A 股最终兜底，仅在前述数据源都失败/熔断时使用
         """
         from src.config import get_config
         from .efinance_fetcher import EfinanceFetcher
@@ -1215,11 +1216,11 @@ class DataFetcherManager:
         with self._fetchers_lock:
             self._fetchers = [
                 efinance,
-                tencent,
                 akshare,
                 pytdx,
                 baostock,
                 yfinance,
+                tencent,
                 *optional_fetchers,
             ]
 

--- a/data_provider/tencent_fetcher.py
+++ b/data_provider/tencent_fetcher.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import logging
+import os
 from datetime import datetime, timedelta
 from typing import Any, Optional
 
@@ -26,7 +27,12 @@ class TencentFetcher(BaseFetcher):
     """Fetch qfq daily K-line data from Tencent's direct quote endpoint."""
 
     name = "TencentFetcher"
-    priority = 0
+    # Last-resort A-share daily fallback: only OHLCV/amount coverage, no
+    # fundamentals, so it must stay behind the richer built-in cn sources
+    # (efinance/akshare/pytdx/baostock/yfinance). Previously priority=0 tied
+    # it with EfinanceFetcher, so a single Efinance failure/circuit-open
+    # routed straight to Tencent ahead of Akshare/Tushare/Pytdx.
+    priority = int(os.getenv("TENCENT_PRIORITY", "5"))
     allow_empty_daily_data = True
 
     _KLINE_ENDPOINT = "https://web.ifzq.gtimg.cn/appstock/app/fqkline/get"

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 > For user-friendly release highlights, see the [GitHub Releases](https://github.com/ZhuLinsen/daily_stock_analysis/releases) page.
 
 ## [Unreleased]
+- [修复] `TencentFetcher` 兜底优先级从 0（与 EfinanceFetcher 并列）下调为 5，避免 A 股日线在 EfinanceFetcher 单次失败/熔断时越过 AkshareFetcher/TushareFetcher/PytdxFetcher/BaostockFetcher/YfinanceFetcher 直接降级到仅有 OHLCV、无基本面字段的 Tencent 直连源；新增 `TENCENT_PRIORITY` 配置项支持自定义。
 - [修复] 桌面与 Docker 发布显式安装 `orjson`，桌面 PyInstaller 产物同时冻结并执行运行时导入探针，避免 LiteLLM 调用时报 `No module named 'orjson'`。
 - [改进] 个股报告不再单独展示“题材主线与个股位置”卡片，相关市场结构数据仍保留在分析上下文、模型 Prompt 与决策信号提取链路中。
 - [改进] 通知推送与完整 Markdown/微信报告不再重复附加“AI 决策信号”摘要，DecisionSignal 的存储、告警和 Web AI 建议页保持不变。


### PR DESCRIPTION
## 改了什么

`TencentFetcher.priority` 从硬编码 `0` 改为 `int(os.getenv("TENCENT_PRIORITY", "5"))`，使其排在 `EfinanceFetcher(0)/AkshareFetcher(1)/TushareFetcher(2)/PytdxFetcher(2)/BaostockFetcher(3)/YfinanceFetcher(4)` 之后，仅在这些源全部失败/短期熔断时才作为最终兜底使用。同步更新：

- `data_provider/__init__.py`、`data_provider/base.py` 中过期的优先级说明 docstring（此前完全没提到 TencentFetcher）。
- `.env.example` 新增 `TENCENT_PRIORITY` 配置项说明（遵循已有 `*_PRIORITY` 环境变量约定）。
- `docs/CHANGELOG.md` `[Unreleased]` 追加一行修复说明。

## 为什么这么改

`TencentFetcher` 是 #1680 作为"A 股日线兜底源"引入的，PR 描述明确写明 "Tencent is an additional A-share fallback, not a replacement for the existing sources"，但实现时误将 `priority` 设为 `0`，与 `EfinanceFetcher` 并列。由于 `DataFetcherManager` 用稳定排序，`TencentFetcher` 在数据源列表里排在 `EfinanceFetcher` 之后、`AkshareFetcher` 之前，导致：

- 只要 `EfinanceFetcher` 单次失败或被短期熔断（限流、瞬时网络错误等常见场景），下一个尝试的立刻是仅提供 OHLCV/成交额（无基本面、指数、板块等字段，且历史根数上限 800）的 `TencentFetcher`，而不是数据更完整的 `AkshareFetcher`/`TushareFetcher`/`PytdxFetcher`。
- Issue #1894 的日志实证了该顺序：`TushareFetcher(P-1), EfinanceFetcher(P0), TencentFetcher(P0), AkshareFetcher(P1), ...`。

这与该 fetcher 自身文档化的"最终兜底"定位矛盾，导致个股日线分析在 Efinance 稍有波动时就频繁"越级"降级到数据字段最少的 Tencent 源。

## 验证情况

- `python -m py_compile data_provider/tencent_fetcher.py data_provider/base.py data_provider/__init__.py`
- `pytest tests/test_tencent_fetcher.py tests/test_fetcher_source_optimization.py -q` → 21 passed
- `pytest -m "not network" -q`（全量离线测试）→ 4461 passed, 11 failed, 4 deselected
  - 11 个失败集中在 `test_decision_signal_service.py`、`test_intelligence_service.py`、`test_system_config_service.py`，与本次改动的 `data_provider/` 文件无关；在未应用本次改动的 `main` 基线上对相同用例单独运行同样失败，确认是既有环境相关问题，非本 PR 引入。
- 运行时手动确认新默认优先级顺序：`Tencent=5, Efinance=0, Akshare=1, Yfinance=4, Baostock=3`，符合预期的"Tencent 排在所有内置 cn 源之后"。

## 未验证项

- 未在真实 Docker/生产环境跑一次完整分析验证实际线上 fallback 行为（只做了单元测试 + 手动优先级排序检查）。
- 未验证 `TENCENT_PRIORITY` 自定义环境变量在 `.env` 加载链路中的端到端行为（沿用现有 `*_PRIORITY` 模式，风险较低）。

## 风险点

- 若已有用户依赖当前"Tencent 紧跟 Efinance 之后"的顺序（例如刻意用 `EFINANCE_PRIORITY=99` 之类配置组合把 Tencent 当次优源），该行为会改变；可通过新增的 `TENCENT_PRIORITY` 环境变量手动调回。
- 纯配置/顺序调整，不改变任何 fetcher 的抓取逻辑或数据契约。

## 回滚方式

还原本 PR 的 5 个文件改动即可（`git revert`），或设置 `TENCENT_PRIORITY=0` 即可临时恢复旧的排序行为而无需代码回滚。
