### PR TITLE
fix: 个股分析 JSON 提取兼容推理模型 <think> 输出与围栏外说明文字

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - [新功能] Web AI 建议页支持确认保存基于历史报告快照重算的决策风格信号，以 created/existing/refreshed 区分新建、原样复用和既有记录续期或维度补齐，复用 profile-aware 去重与失效语义，将历史信号的创建时间、有效期和相反信号失效顺序锚定来源报告时间，并提供可审计 guardrail 提示与阻断。
 <!-- 新条目格式：- [类型] 描述（类型取值：新功能/改进/修复/文档/测试/chore）-->
 <!-- 每条独立一行追加到本段末尾，无需分类标题，合并时冲突最小 -->
+- [修复] 修复个股分析使用推理模型（如 MiniMax-M3/M2.7）时因内联 `<think>` 推理块与围栏外说明文字被 JSON 提取器判为 `ambiguous_json`，导致所有模型重试失败、报告无法持久化（"LLM response is not valid JSON"）的问题：提取前剥离成对 `<think>` 块，单个显式 ```json 围栏允许外部说明文字；多围栏、非 json 语言围栏、无语言围栏+外部文本等歧义防护保持不变。
 
 ## [3.26.0] - 2026-07-12
 

--- a/src/analyzer.py
+++ b/src/analyzer.py
@@ -4364,6 +4364,10 @@ class GeminiAnalyzer:
         """Extract the single allowed JSON object from an LLM response."""
 
         text = response_text or ""
+        # 推理模型（如 MiniMax-M3、DeepSeek-R1 同类）会把 <think>...</think> 推理块内联在
+        # content 里，属于元数据而非答案；先剥离成对的推理块，再做唯一 JSON 判定，
+        # 避免推理文本（及其中的草稿围栏）被误判为围栏外内容或多余 JSON 候选。
+        text = re.sub(r"<think>.*?</think>", "", text, flags=re.DOTALL)
         stripped = text.strip()
         if not stripped:
             raise ValueError("empty_response")
@@ -4377,11 +4381,14 @@ class GeminiAnalyzer:
             raise ValueError("ambiguous_json")
         if len(fenced_matches) == 1:
             match = fenced_matches[0]
-            outside = (text[:match.start()] + text[match.end():]).strip()
-            if outside:
-                raise ValueError("ambiguous_json")
             fence_lang = (match.group("lang") or "").strip().lower()
             if fence_lang not in {"", "json"}:
+                raise ValueError("ambiguous_json")
+            outside = (text[:match.start()] + text[match.end():]).strip()
+            # 显式 ```json 围栏是模型明确标注的唯一答案，允许围栏外存在说明性文字
+            # （推理模型常在围栏前后附带 markdown 报告）；未标注语言的围栏保持严格，
+            # 外部有文本仍视为歧义。
+            if outside and fence_lang != "json":
                 raise ValueError("ambiguous_json")
             json_str = match.group("body").strip()
             data = self._load_analysis_json_candidate(json_str)

--- a/tests/test_report_schema.py
+++ b/tests/test_report_schema.py
@@ -289,6 +289,114 @@ class TestAnalyzerSchemaFallback(unittest.TestCase):
 }
 ```""")
 
+    def test_parse_response_strips_reasoning_think_block_before_fence(self) -> None:
+        """推理模型（如 MiniMax-M3）在正文前输出 <think> 块，应剥离后再提取 JSON。"""
+        analyzer = GeminiAnalyzer()
+        response = """<think>Let me analyze this step by step.
+The trend is bearish. Let me construct the complete JSON now.</think>
+
+```json
+{
+  "stock_name": "凯盛新能",
+  "sentiment_score": 22,
+  "trend_prediction": "强烈看空",
+  "operation_advice": "卖出",
+  "analysis_summary": "空头排列"
+}
+```"""
+
+        result = analyzer._parse_response(response, "600876", "股票600876")
+
+        self.assertTrue(result.success)
+        self.assertEqual(result.name, "凯盛新能")
+        self.assertEqual(result.sentiment_score, 22)
+
+    def test_parse_response_ignores_draft_fence_inside_think_block(self) -> None:
+        """<think> 块内的草稿围栏不应被计入围栏数量。"""
+        analyzer = GeminiAnalyzer()
+        response = """<think>Draft:
+```json
+{"sentiment_score": 10}
+```
+Now finalize.</think>
+```json
+{
+  "stock_name": "凯盛新能",
+  "sentiment_score": 25,
+  "trend_prediction": "看空",
+  "operation_advice": "卖出",
+  "analysis_summary": "空头排列"
+}
+```"""
+
+        result = analyzer._parse_response(response, "600876", "股票600876")
+
+        self.assertTrue(result.success)
+        self.assertEqual(result.sentiment_score, 25)
+
+    def test_parse_response_accepts_prose_around_explicit_json_fence(self) -> None:
+        """单个显式 ```json 围栏外的说明文字（markdown 报告）不应判为歧义。"""
+        analyzer = GeminiAnalyzer()
+        response = """## 凯盛新能（600876.SH）决策仪表盘
+
+### ⚠️ 数据情况说明
+- 当前为非交易日，基于上一完整交易日数据
+
+```json
+{
+  "stock_name": "凯盛新能",
+  "sentiment_score": 28,
+  "trend_prediction": "看空",
+  "operation_advice": "观望",
+  "analysis_summary": "空头排列，观望"
+}
+```
+
+## 📋 决策要点速览
+
+| 检查项 | 状态 |
+|--------|------|
+| 多头排列 | ❌ |"""
+
+        result = analyzer._parse_response(response, "600876", "股票600876")
+
+        self.assertTrue(result.success)
+        self.assertEqual(result.sentiment_score, 28)
+
+    def test_parse_response_repairs_unescaped_inner_quotes_after_think_strip(self) -> None:
+        """think 块剥离后，字符串内未转义引号应走 repair 路径修复。"""
+        analyzer = GeminiAnalyzer()
+        response = """<think>reasoning...</think>
+```json
+{
+  "stock_name": "凯盛新能",
+  "sentiment_score": 22,
+  "trend_prediction": "看空",
+  "operation_advice": "卖出",
+  "analysis_summary": "置信度判定为"中"，未给高"
+}
+```"""
+
+        result = analyzer._parse_response(response, "600876", "股票600876")
+
+        self.assertTrue(result.success)
+        self.assertEqual(result.sentiment_score, 22)
+
+    def test_validate_json_response_accepts_think_block_with_json_fence(self) -> None:
+        analyzer = GeminiAnalyzer.__new__(GeminiAnalyzer)
+        analyzer._config_override = SimpleNamespace(generation_backend="litellm")
+
+        analyzer._validate_json_response("""<think>step by step reasoning</think>
+```json
+{
+  "stock_name": "凯盛新能",
+  "sentiment_score": 22,
+  "trend_prediction": "看空",
+  "operation_advice": "卖出",
+  "analysis_summary": "空头排列"
+}
+```""")
+
     def test_validate_json_response_rejects_ambiguous_json_before_repair(self) -> None:
         analyzer = GeminiAnalyzer.__new__(GeminiAnalyzer)
         analyzer._config_override = SimpleNamespace(generation_backend="litellm")


### PR DESCRIPTION
## PR Type

- [x] fix
- [ ] feat
- [ ] refactor
- [ ] docs
- [ ] chore
- [ ] test

## Background And Problem

个股分析要求 LLM 输出严格 JSON 决策仪表盘。当 `LLM_CHANNELS` 配置为推理模型（如 MiniMax-M3 / M2.7，OpenAI-compatible 接口）时，模型会把 `<think>...</think>` 推理块内联在 `message.content` 中，并常在 ```json 围栏前后附带 markdown 说明文字。

`src/analyzer.py` 的 `_extract_analysis_json_object` 要求"单个围栏之外零文本"，上述输出形态每次都被判为 `ambiguous_json` → 所有 deployment 重试全部失败 → 走文本 fallback（`success=False`）→ 报告不持久化，用户在 Web/任务队列看到「请求失败 / LLM response is not valid JSON; analysis result will not be persisted」。

- 影响范围：所有使用内联 think 输出的推理模型做个股分析的用户（失败率 100%）。
- 大盘分析不受影响：其 prompt 要求 markdown（禁止 JSON），不经过该提取器。
- 触发场景：任意个股分析请求（CLI `--stocks` / Web 个股分析 / 任务队列）。

## Scope Of Change

```
 docs/CHANGELOG.md           |   1 +
 src/analyzer.py             |  13 ++++--
 tests/test_report_schema.py | 108 ++++++++++++++++++++++++++++++++++++++++++++
 3 files changed, 119 insertions(+), 3 deletions(-)
```

- 文件总数 / 变更行数：3 个文件，+119 / -3
- 文件清单：
  - `src/analyzer.py`：`_extract_analysis_json_object` 两点修改——(1) 提取前剥离成对 `<think>...</think>` 块（推理元数据，非答案，且可能内含草稿围栏干扰围栏计数）；(2) 单个**显式** ```json 围栏允许围栏外存在说明文字；无语言标注围栏保持严格。
  - `tests/test_report_schema.py`：新增 5 个回归测试，覆盖 4 种真实失败形态（think+围栏、think 内草稿围栏、围栏外 markdown 说明、think+字符串内未转义引号经既有 repair 路径恢复）及 validator 路径。
  - `docs/CHANGELOG.md`：`[Unreleased]` 追加一条 `[修复]`。
- 文档更新文件（`docs/*`）：`docs/CHANGELOG.md`

## Issue Link

无 Issue：问题由本地实际运行日志定位（4 条真实失败响应均可复现），直接修复。
验收标准：
1. 推理模型输出（含 think 块 / 围栏外说明 / 二者叠加）能提取唯一 JSON 并成功持久化；
2. 原有歧义防护保持拒绝：多围栏、非 json 语言围栏、无语言围栏+外部文本、多个裸 JSON（对应既有测试全部保持通过）。

## Verification Commands And Results

```bash
python -m pytest tests/test_report_schema.py -q
# 27 passed（含新增 5 个回归测试；修复前新增用例 4 fail + 1 error，符合 TDD RED→GREEN）

python -m py_compile src/analyzer.py            # OK
flake8 src/analyzer.py tests/test_report_schema.py --count --select=E9,F63,F7,F82   # 0

python -m pytest -m "not network" -q
# 本地：4129 passed / 12 failed / 5 deselected
```

关键输出/结论 / Key output & conclusion:

- 真实响应回放：将 2026-07-18 本地 debug 日志中 4 条真实失败的 MiniMax 响应逐条送入修复后的 `_parse_response`，全部 `success=True` 且 dashboard 完整（其中 2 条含字符串内未转义引号，经既有 `repair_json` 路径恢复）。
- 端到端实跑：`RUN_IMMEDIATELY=true python main.py --stocks 600876 --force-run`，MiniMax-M3 响应一次通过校验，`分析完成: 看空, 评分 28`，已写入 `analysis_history`（修复前同日 6+ 次运行全部失败未入库）。
- 本地环境差异说明：全量离线套件的 12 个失败（`test_system_config_service.py`）与 1 个 deselect（`test_config_env_compat.py`）在**未含本 PR 的 HEAD 基线上完全相同**（本地 `.env` 与套件顺序性状态污染所致），与本 PR 无关，以 Head CI 结论为准。
- 【必填】当前 Head CI：pr-review 辅助工作流 5/5 pass（自动标签 / 静态检查 / 安全检查 / AI 代码审查 / 审查报告，[run 29646652701](https://github.com/ZhuLinsen/daily_stock_analysis/actions/runs/29646652701)）；阻断性 CI（`ai-governance` / `backend-gate` / `docker-build`）当前为 `action_required`——首次贡献者工作流需维护者批准后运行，批准后本段将更新为实际 pass/fail 结果。`web-gate`：本 PR 无 `apps/dsa-web` 改动，预期不触发。

## Visual Evidence (if applicable)

- 不适用原因：本 PR 不修改报告结构、报告渲染效果或 Web UI，仅修复 LLM 响应的 JSON 提取层；报告字段与展示由既有链路生成，格式无变化。
- 替代证据（可复现）：`python -m pytest tests/test_report_schema.py -q`（新增用例名以 `think` / `prose_around` / `unescaped` 为关键词）；端到端命令见上节，产物为 `analysis_history` 新增记录。

## Compatibility And Risk

- 本 PR 未变更 provider/model/base URL、运行时配置清理迁移语义；历史配置保持不变；回滚方式为 revert 本提交。
- 解析语义放宽仅两点：剥离成对 `<think>` 块；单个显式 ```json 围栏容忍外部说明文字。其余歧义防护（多围栏 / 非 json 语言围栏 / 无语言围栏+外部文本 / 多裸 JSON）保持不变，既有防护测试全部保持通过；注入第二个围栏仍会被拒绝。
- 推理模型将 `<think>` 内联到 content 属于第三方模型运行时输出行为（MiniMax M 系列 OpenAI-compatible 接口实测），本修复为防御性解析，属长期安全约束而非临时 workaround；对不输出 think 块的模型行为零变化。
- 未闭合的 `<think>`（响应截断）不剥离，维持 fail-loud，截断答案不会被误采信。

## Rollback Plan

- revert this PR 即可完全回滚；无配置、数据或迁移联动。

## EXTRACT_PROMPT Change (if applicable)

未修改 `EXTRACT_PROMPT`。

## Checklist

- [x] 本 PR 有明确动机和业务价值 / This PR has a clear motivation and value
- [x] 已提供可复现的验证命令与结果 / Reproducible verification commands and results are included
- [x] 已评估兼容性与风险 / Compatibility and risk have been assessed
- [x] 已提供回滚方案 / A rollback plan is provided
- [x] 若修改报告格式或 Web UI 界面，已在 PR 描述/评论附受影响报告 / 页面截图，且未把一次性验收截图作为仓库文件合入（本 PR 不适用，原因与替代证据见 Visual Evidence）
- [x] 若涉及用户可见变更，已同步更新相关文档与 `docs/CHANGELOG.md`
