### PR TITLE
test: remove stale JP/KR alert expectation

### DIFF
--- a/apps/dsa-web/src/components/alerts/__tests__/AlertRuleForm.test.tsx
+++ b/apps/dsa-web/src/components/alerts/__tests__/AlertRuleForm.test.tsx
@@ -234,18 +234,6 @@ describe('AlertRuleForm', () => {
     expect(screen.queryByText('组合回撤')).not.toBeInTheDocument();
   });
 
-  it('shows JP/KR options for market region in Chinese UI mode', () => {
-    render(<AlertRuleForm onSubmit={onSubmit} />);
-
-    fireEvent.change(screen.getByLabelText('目标范围'), { target: { value: 'market' } });
-
-    expect(screen.getByRole('option', { name: 'A 股（cn）' })).toBeInTheDocument();
-    expect(screen.getByRole('option', { name: '港股（hk）' })).toBeInTheDocument();
-    expect(screen.getByRole('option', { name: '美股（us）' })).toBeInTheDocument();
-    expect(screen.getByRole('option', { name: '日股（jp）' })).toBeInTheDocument();
-    expect(screen.getByRole('option', { name: '韩股（kr）' })).toBeInTheDocument();
-  });
-
   it('submits a market light status rule payload', async () => {
     render(<AlertRuleForm onSubmit={onSubmit} />);
 


### PR DESCRIPTION
Foundation-ID: BLOCKER-SEC-01
Sequence: blocker before 01/34
Depends-On: none

## PR Type

- [ ] fix
- [ ] feat
- [ ] refactor
- [ ] docs
- [ ] chore
- [x] test

## Problem

The unmodified `origin/main@487e49e565ffd1b96a7cf4d855f99cee3c981eaa` fails the Web test gate. `AlertRuleForm.test.tsx` contains an obsolete test that expects JP/KR Market Light options, while the same file's current Chinese and English contract tests require those options to remain absent.

## Root cause

The positive JP/KR assertion introduced with the broader market-review work was not removed when the accepted service boundary was narrowed: JP/KR are supported for market review, but Market Light alerts remain limited to CN/HK/US. The frontend `MarketRegion` type, shared options, runtime behavior, and `docs/market-support.md` all agree on the narrowed boundary.

## Scope

- 1 file, 12 deleted lines.
- `apps/dsa-web/src/components/alerts/__tests__/AlertRuleForm.test.tsx`: remove the stale, contradictory positive assertion.

## Non-goals

- Do not add JP/KR Market Light support.
- Do not change alert runtime behavior, frontend options, API schemas, or market-review behavior.
- Do not change provider/model/base URL or runtime configuration semantics.

## Behavior before/after

- Before: the deterministic Web unit-test suite fails because one stale assertion contradicts the accepted Market Light boundary and the adjacent regression tests.
- After: the existing Chinese and English negative assertions remain authoritative and the full Web unit-test suite passes.

## Data/API compatibility

No runtime, data, schema, API, or configuration behavior changes. Historical configuration remains unchanged.

## Security and privacy

No credentials, user data, logs, traces, or network behavior are changed. The diff was scanned for credential-like values and contains none.

## Issue Link

No issue. This is a deterministic `origin/main` gate blocker discovered while starting Foundation item SEC-01. Acceptance criterion: the untouched Market Light CN/HK/US contract remains enforced and the Web test gate passes.

## Tests

- `cd apps/dsa-web && npm ci` - pass; 461 locked packages installed.
- `cd apps/dsa-web && npm test -- --run src/components/alerts/__tests__/AlertRuleForm.test.tsx` - pass; 17/17.
- `cd apps/dsa-web && npm run test` - pass; 974 passed, 2 skipped.
- `cd apps/dsa-web && npm run lint` - pass.
- `cd apps/dsa-web && npm run build` - pass; 3,229 modules transformed.
- `python3 scripts/check_ai_assets.py` - pass.
- `git diff --check` - pass.

Current Head CI: `action_required` ([run 29656495746](https://github.com/ZhuLinsen/daily_stock_analysis/actions/runs/29656495746)). GitHub did not start `ai-governance`, `backend-gate`, `docker-build`, or `web-gate`; all four have no jobs or pass result. The standard fork-run approval endpoint returned `403 Must have admin rights to Repository` for the PR author. The PR remains Draft and will not be marked ready or merged unless a repository administrator approves the workflow and all required jobs pass.

The separate `pull_request_target` PR Review workflow passed its security check, static check, auto-label, and report jobs ([run 29656495801](https://github.com/ZhuLinsen/daily_stock_analysis/actions/runs/29656495801)); AI semantic review was skipped by the workflow). This does not replace the required CI run.

## Visual evidence

Not applicable. This PR only removes a stale test and does not change Web UI, report rendering, or settings fields. The reproducible evidence is the targeted test command above plus the full Web test and build results.

## Compatibility And Risk

Risk is limited to accidentally removing coverage. That risk is addressed because the same file retains explicit Chinese and English assertions that CN/HK/US are present and JP/KR are absent, plus payload submission coverage.

This PR does not change provider/model/base URL, runtime configuration cleanup or migration semantics. Historical configuration remains unchanged. Rollback is to revert this PR.

## Rollback

Revert this PR. No data, schema, dependency, or configuration rollback is required.

## Review findings and fixes

| Round | Finding | Severity | Fix |
| --- | --- | --- | --- |
| Draft review | Required head CI did not start; PR body needed the final `action_required` state and links. | P1 | Kept the PR Draft and recorded run 29656495746, the four unstarted jobs, and the approval endpoint's 403 response. This remains externally blocked, not resolved. |

No implementation, test-coverage, scope, security, privacy, or user-visible behavior findings were reported. The reviewer confirmed that the adjacent Chinese and English tests retain CN/HK/US-positive and JP/KR-negative coverage matching `docs/market-support.md`.

## EXTRACT_PROMPT Change

Not applicable.

## Checklist

- [x] This PR has a clear motivation and value.
- [x] Reproducible verification commands and results are included.
- [x] Compatibility and risk have been assessed.
- [x] An actionable rollback plan is included.
- [x] Visual evidence is not applicable because there is no UI or report change.
- [x] No Web settings fields are changed.
- [x] No user-visible behavior is changed, so no changelog entry is required.
