### PR TITLE
fix: 兼容 MiniMax 字符串推理包装

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 - [新功能] Web AI 建议页支持确认保存基于历史报告快照重算的决策风格信号，以 created/existing/refreshed 区分新建、原样复用和既有记录续期或维度补齐，复用 profile-aware 去重与失效语义，将历史信号的创建时间、有效期和相反信号失效顺序锚定来源报告时间，并提供可审计 guardrail 提示与阻断。
 - [修复] MiniMax 分析与渠道 JSON 测试仅提取最终文本块，避免推理内容与 JSON 拼接后导致结果无法解析和持久化。
+- [修复] MiniMax 字符串响应仅剥离开头完整的 `<think>` 推理包装，兼容流式分片并保留 JSON 内容中的同名字面标签。
 <!-- 新条目格式：- [类型] 描述（类型取值：新功能/改进/修复/文档/测试/chore）-->
 <!-- 每条独立一行追加到本段末尾，无需分类标题，合并时冲突最小 -->
 

--- a/src/analyzer.py
+++ b/src/analyzer.py
@@ -76,6 +76,7 @@ from src.llm.provider_cache import (
     build_provider_cache_route_context,
     filter_prompt_cache_telemetry,
 )
+from src.llm.response_content import strip_leading_think_wrapper
 from src.storage import persist_llm_usage
 from src.data.stock_mapping import STOCK_NAME_MAP
 from src.report_language import (
@@ -2863,7 +2864,7 @@ class GeminiAnalyzer:
             content_blocks = self._get_response_field(message, "content_blocks")
         block_text = self._extract_text_blocks(content_blocks)
         if block_text:
-            return block_text
+            return strip_leading_think_wrapper(block_text)
 
         content = None
         if message is not None:
@@ -2872,9 +2873,9 @@ class GeminiAnalyzer:
             content = self._get_response_field(choice, "content")
 
         if isinstance(content, list):
-            return self._extract_text_blocks(content)
+            return strip_leading_think_wrapper(self._extract_text_blocks(content))
         if isinstance(content, str):
-            return content.strip()
+            return strip_leading_think_wrapper(content)
         return str(content).strip() if content is not None else ""
 
     def _extract_stream_text(self, chunk: Any) -> str:
@@ -2947,7 +2948,7 @@ class GeminiAnalyzer:
                 partial_received=chars_received > 0,
             ) from exc
 
-        response_text = "".join(chunks).strip()
+        response_text = strip_leading_think_wrapper("".join(chunks))
         if not response_text:
             raise _LiteLLMStreamError(
                 f"{model} stream returned empty response",

--- a/src/llm/response_content.py
+++ b/src/llm/response_content.py
@@ -1,0 +1,28 @@
+"""Helpers for normalizing provider response text."""
+
+from __future__ import annotations
+
+
+_THINK_OPEN_TAG = "<think>"
+_THINK_CLOSE_TAG = "</think>"
+
+
+def strip_leading_think_wrapper(value: str) -> str:
+    """Remove one complete leading ``<think>`` wrapper from a response.
+
+    The match is deliberately anchored at the start of the response.  This
+    keeps literal ``<think>`` markup inside a JSON string or ordinary answer
+    untouched and leaves malformed/unclosed wrappers for strict validation to
+    reject instead of guessing where the final answer begins.
+    """
+
+    text = str(value or "").strip()
+    lowered = text.lower()
+    if not lowered.startswith(_THINK_OPEN_TAG):
+        return text
+
+    close_index = lowered.find(_THINK_CLOSE_TAG, len(_THINK_OPEN_TAG))
+    if close_index < 0:
+        return text
+
+    return text[close_index + len(_THINK_CLOSE_TAG):].strip()

--- a/src/services/system_config_service.py
+++ b/src/services/system_config_service.py
@@ -67,6 +67,7 @@ from src.llm.backend_registry import (
 )
 from src.llm.generation_params import apply_litellm_generation_params
 from src.llm.local_cli_backend import resolve_local_cli_preset
+from src.llm.response_content import strip_leading_think_wrapper
 from src.notification_contracts import (
     FEISHU_APP_BOT_ENV_GROUP,
     FEISHU_WEBHOOK_ENV_GROUP,
@@ -4336,7 +4337,7 @@ class SystemConfigService:
                     text = _field(block, "content")
                 if isinstance(text, str) and text:
                     text_parts.append(text)
-            return "".join(text_parts).strip()
+            return strip_leading_think_wrapper("".join(text_parts))
 
         if response is None:
             return "", "empty_response", "Completion returned no response object", "null_response"
@@ -4367,7 +4368,11 @@ class SystemConfigService:
         raw_content = _field(message, "content")
         if raw_content is None:
             return "", "empty_response", "Completion returned null message content", "null_content"
-        content = _text_from_blocks(raw_content) if isinstance(raw_content, list) else str(raw_content).strip()
+        content = (
+            _text_from_blocks(raw_content)
+            if isinstance(raw_content, list)
+            else strip_leading_think_wrapper(str(raw_content))
+        )
         if not content:
             return "", "empty_response", "Completion returned an empty message content", "empty_content"
         return content, None, None, None

--- a/tests/test_llm_response_content.py
+++ b/tests/test_llm_response_content.py
@@ -1,0 +1,31 @@
+import pytest
+
+from src.llm.response_content import strip_leading_think_wrapper
+
+
+@pytest.mark.parametrize(
+    ("response", "expected"),
+    [
+        (
+            "<THINK>internal reasoning</THINK>\n{\"status\":\"ok\"}",
+            '{"status":"ok"}',
+        ),
+        (
+            '{"summary":"literal <think>text</think>"}',
+            '{"summary":"literal <think>text</think>"}',
+        ),
+        (
+            "prefix <think>internal reasoning</think>{\"status\":\"ok\"}",
+            "prefix <think>internal reasoning</think>{\"status\":\"ok\"}",
+        ),
+        (
+            "<think>unclosed reasoning{\"status\":\"ok\"}",
+            "<think>unclosed reasoning{\"status\":\"ok\"}",
+        ),
+    ],
+)
+def test_strip_leading_think_wrapper_is_anchored_and_fail_closed(
+    response: str,
+    expected: str,
+) -> None:
+    assert strip_leading_think_wrapper(response) == expected

--- a/tests/test_market_analyzer_generate_text.py
+++ b/tests/test_market_analyzer_generate_text.py
@@ -1485,6 +1485,63 @@ class TestAnalyzerGenerateText:
         assert text == '{"sentiment_score": 72}'
         assert model_used == "openai/MiniMax-M3"
 
+    def test_call_litellm_minimax_strips_leading_think_wrapper(self):
+        analyzer = self._make_analyzer()
+        analyzer._config_override = SimpleNamespace(
+            litellm_model="openai/MiniMax-M3",
+            litellm_fallback_models=[],
+            llm_model_list=[],
+        )
+        response = SimpleNamespace(
+            choices=[
+                SimpleNamespace(
+                    content_blocks=None,
+                    message=SimpleNamespace(
+                        content='<think>Internal reasoning</think>\n{"sentiment_score": 72}'
+                    ),
+                )
+            ],
+            usage=None,
+        )
+
+        with patch.object(analyzer, "_dispatch_litellm_completion", return_value=response):
+            text, model_used, _usage = analyzer._call_litellm(
+                "prompt",
+                {"max_tokens": 128, "temperature": 0.2},
+                response_validator=analyzer._validate_json_response,
+            )
+
+        assert text == '{"sentiment_score": 72}'
+        assert model_used == "openai/MiniMax-M3"
+
+    def test_call_litellm_preserves_think_markup_inside_json_string(self):
+        analyzer = self._make_analyzer()
+        analyzer._config_override = SimpleNamespace(
+            litellm_model="openai/MiniMax-M3",
+            litellm_fallback_models=[],
+            llm_model_list=[],
+        )
+        expected = '{"analysis_summary":"literal <think>text</think>"}'
+        response = SimpleNamespace(
+            choices=[
+                SimpleNamespace(
+                    content_blocks=None,
+                    message=SimpleNamespace(content=expected),
+                )
+            ],
+            usage=None,
+        )
+
+        with patch.object(analyzer, "_dispatch_litellm_completion", return_value=response):
+            text, model_used, _usage = analyzer._call_litellm(
+                "prompt",
+                {"max_tokens": 128, "temperature": 0.2},
+                response_validator=analyzer._validate_json_response,
+            )
+
+        assert text == expected
+        assert model_used == "openai/MiniMax-M3"
+
     def test_call_litellm_minimax_stream_ignores_reasoning_blocks(self):
         analyzer = self._make_analyzer()
         analyzer._config_override = SimpleNamespace(
@@ -1517,6 +1574,37 @@ class TestAnalyzerGenerateText:
                 ],
                 usage=None,
             )
+
+        with patch.object(analyzer, "_dispatch_litellm_completion", return_value=stream_response()):
+            text, model_used, _usage = analyzer._call_litellm(
+                "prompt",
+                {"max_tokens": 128, "temperature": 0.2},
+                stream=True,
+                response_validator=analyzer._validate_json_response,
+            )
+
+        assert text == '{"sentiment_score": 72}'
+        assert model_used == "openai/MiniMax-M3"
+
+    def test_call_litellm_minimax_stream_strips_split_think_wrapper(self):
+        analyzer = self._make_analyzer()
+        analyzer._config_override = SimpleNamespace(
+            litellm_model="openai/MiniMax-M3",
+            litellm_fallback_models=[],
+            llm_model_list=[],
+        )
+
+        def stream_response():
+            for content in (
+                "<thi",
+                "nk>Internal reasoning</think>",
+                '{"sentiment_score": ',
+                "72}",
+            ):
+                yield SimpleNamespace(
+                    choices=[SimpleNamespace(delta=SimpleNamespace(content=content))],
+                    usage=None,
+                )
 
         with patch.object(analyzer, "_dispatch_litellm_completion", return_value=stream_response()):
             text, model_used, _usage = analyzer._call_litellm(

--- a/tests/test_system_config_service.py
+++ b/tests/test_system_config_service.py
@@ -3592,6 +3592,25 @@ class SystemConfigServiceTestCase(unittest.TestCase):
         self.assertEqual(payload["capability_results"]["json"]["status"], "passed")
 
     @patch("litellm.completion")
+    def test_test_llm_channel_json_capability_strips_minimax_think_wrapper(self, mock_completion) -> None:
+        mock_completion.side_effect = [
+            self._mock_completion_response("OK"),
+            self._mock_completion_response('<think>Internal reasoning</think>{"status":"ok"}'),
+        ]
+
+        payload = self.service.test_llm_channel(
+            name="minimax",
+            protocol="openai",
+            base_url="https://api.minimax.io/v1",
+            api_key="sk-test-value",
+            models=["MiniMax-M3"],
+            capability_checks=["json"],
+        )
+
+        self.assertTrue(payload["success"])
+        self.assertEqual(payload["capability_results"]["json"]["status"], "passed")
+
+    @patch("litellm.completion")
     def test_test_llm_channel_reports_json_capability_failures(self, mock_completion) -> None:
         mock_completion.side_effect = [
             self._mock_completion_response("OK"),


### PR DESCRIPTION
## PR Type

- [x] fix
- [ ] feat
- [ ] refactor
- [ ] docs
- [ ] chore
- [ ] test

## Background And Problem

PR #2018 已处理 MiniMax/LiteLLM 返回 typed reasoning content blocks 的情况，但 OpenAI-compatible 字符串响应仍可能是 `<think>推理内容</think>{...}`。该字符串此前会原样进入严格 JSON 校验，导致正式分析和渠道 JSON 能力测试继续报 `LLM response is not valid JSON`。

本 PR 只补齐字符串 wrapper 形态，不放宽 JSON 校验，也不改变 provider、模型名、Base URL、fallback 或持久化条件。

## Scope Of Change

- 文件总数 / 变更行数：7 files changed, 179 insertions(+), 6 deletions(-)
- `src/llm/response_content.py`：新增共享的开头 `<think>` wrapper 规范化函数。
- `src/analyzer.py`：非流式、content-block 最终文本及完整流式响应复用相同规范化逻辑。
- `src/services/system_config_service.py`：渠道 JSON probe 复用相同逻辑。
- `tests/test_llm_response_content.py`：覆盖锚定匹配、大小写、未闭合标签、前缀文本和 JSON 内字面标签。
- `tests/test_market_analyzer_generate_text.py`：覆盖正式分析非流式和跨 chunk 流式响应。
- `tests/test_system_config_service.py`：覆盖设置页渠道 JSON 能力测试。
- `docs/CHANGELOG.md`：追加 `[Unreleased]` 扁平修复记录。

## Issue Link

- Refs #2013
- Follow-up to #2018

## Verification Commands And Results

```bash
python -m py_compile src/llm/response_content.py src/analyzer.py src/services/system_config_service.py
python -m flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
python -m pytest tests/test_llm_response_content.py tests/test_market_analyzer_generate_text.py tests/test_system_config_service.py
python -m pytest -m "not network"
```

- Python syntax：pass。
- critical flake8：pass，0 errors。
- 相关完整测试：323 passed、51 subtests passed、2 warnings。
- 本地完整离线套件：4539 passed、76 failed、2 skipped、4 deselected。76 个失败集中在 Windows 不支持的 Codex App Server/进程组、Docker shell、SQLite 并发等平台路径，未触及本 PR 改动文件和 MiniMax 测试。
- `scripts/ci_gate.sh` 在本地 Git Bash/WSL 分别因 PATH 找不到 `flake8`、WSL Python 缺少 `pandas` 中断；上面已使用 Windows Python 执行同等 critical flake8 与完整离线 pytest。

当前 Head CI：

- ai-governance：pass — https://github.com/ZhuLinsen/daily_stock_analysis/actions/runs/29681903774/job/88179417329
- backend-gate：pass — https://github.com/ZhuLinsen/daily_stock_analysis/actions/runs/29681903774/job/88179427309
- docker-build：pass — https://github.com/ZhuLinsen/daily_stock_analysis/actions/runs/29681903774/job/88179427246
- web-gate：skipped（无前端改动）— https://github.com/ZhuLinsen/daily_stock_analysis/actions/runs/29681903774/job/88179431388
- PR 静态检查与 AI 审查：pass — https://github.com/ZhuLinsen/daily_stock_analysis/actions/runs/29681903726

当前状态：全部阻断型检查通过（pass）。

## Visual Evidence (if applicable)

- 不适用：本 PR 不修改 Web UI、报告格式或报告渲染。

## Compatibility And Risk

- MiniMax OpenAI-compatible API 文档：https://platform.minimax.io/docs/api-reference/text-openai-api
- 兼容策略：仅剥离响应开头一个完整闭合的 `<think>...</think>` wrapper；前面存在普通文本、标签未闭合或标签位于 JSON 字符串内部时保持原样，由现有严格校验继续 fail closed。
- 覆盖范围：LiteLLM `>=1.80.10,!=1.82.7,!=1.82.8,<2.0.0` 下的非流式、流式、content-block 最终文本和渠道 JSON probe。
- 本 PR 未变更 provider/model/base URL、运行时配置清理迁移语义；历史配置保持不变；回滚方式为 revert 本提交。

## Rollback Plan

- Revert 本 PR 的 merge commit 即可；不需要配置或数据迁移。
- 回滚后 PR #2018 的 typed content-block 过滤仍然保留，仅字符串 `<think>` wrapper 恢复为原行为。

## EXTRACT_PROMPT Change (if applicable)

- 不适用。

## Checklist

- [x] 本 PR 有明确动机和业务价值
- [x] 已提供可复现的验证命令与结果
- [x] 已评估兼容性与风险
- [x] 已提供回滚方案
- [x] 不涉及报告格式或 Web UI
- [x] 不涉及 Web 设置字段
- [x] 已同步更新 `docs/CHANGELOG.md`
