### PR TITLE
feat: add US macro reports and manual validation workflow

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -790,6 +790,8 @@ SCHEDULE_RUN_IMMEDIATELY=true
 RUN_IMMEDIATELY=true
 # 是否启用大盘复盘（true/false）
 MARKET_REVIEW_ENABLED=true
+# FRED API Key；使用 python3 main.py --us-macro 生成报告时，未配置仍会输出市场快照，但会标记利率数据缺口
+# FRED_API_KEY=
 # 是否将大盘环境摘要注入个股分析 Prompt 并启用保守护栏（true/false，默认开启）
 DAILY_MARKET_CONTEXT_ENABLED=true
 # 大盘复盘市场区域：cn(A股)、hk(港股)、us(美股)、jp(日股)、kr(韩股)、both(全部市场)；

--- a/.github/workflows/us-macro-manual.yml
+++ b/.github/workflows/us-macro-manual.yml
@@ -1,0 +1,118 @@
+name: 美国宏观与精选股票手动验证
+
+on:
+  workflow_dispatch:
+    inputs:
+      use_ai:
+        description: 使用现有 DeepSeek/LiteLLM 分析与宏观受限解释
+        required: true
+        default: true
+        type: boolean
+      send_notification:
+        description: 发送飞书通知（首次云端验证应保持关闭）
+        required: true
+        default: false
+        type: boolean
+      force_run:
+        description: 跳过交易日检查
+        required: true
+        default: true
+        type: boolean
+      stocks:
+        description: 仅分析这些股票代码，逗号分隔
+        required: true
+        default: 600584,300255,000560
+        type: string
+
+concurrency:
+  group: us-macro-manual-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    env:
+      DATABASE_PATH: data/stock_analysis.db
+      FRED_API_KEY: ${{ secrets.FRED_API_KEY }}
+      DEEPSEEK_API_KEY: ${{ secrets.DEEPSEEK_API_KEY }}
+      LITELLM_MODEL: ${{ vars.LITELLM_MODEL }}
+      FEISHU_WEBHOOK_URL: ${{ secrets.FEISHU_WEBHOOK_URL }}
+      FEISHU_WEBHOOK_SECRET: ${{ secrets.FEISHU_WEBHOOK_SECRET }}
+      FEISHU_WEBHOOK_KEYWORD: ${{ vars.FEISHU_WEBHOOK_KEYWORD }}
+      PYTHONUNBUFFERED: "1"
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+          cache: pip
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -r requirements.txt
+
+      - name: Validate non-secret configuration
+        run: |
+          test -n "$LITELLM_MODEL" || { echo "LITELLM_MODEL repository variable is required"; exit 1; }
+          mkdir -p data logs reports artifacts
+          echo "Configured inputs: use_ai=${{ inputs.use_ai }}, send_notification=${{ inputs.send_notification }}, force_run=${{ inputs.force_run }}"
+          echo "Secrets are present only as masked environment variables."
+
+      - name: Run selected stocks and US macro report
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ "${{ inputs.use_ai }}" != "true" ] && [ "${{ inputs.send_notification }}" = "true" ]; then
+            echo "use_ai=false uses the stock CLI dry-run mode, which cannot send notifications."
+            exit 2
+          fi
+          stock_args=(--stocks "${{ inputs.stocks }}" --no-market-review)
+          macro_args=(--us-macro)
+
+          if [ "${{ inputs.force_run }}" = "true" ]; then
+            stock_args+=(--force-run)
+          fi
+          if [ "${{ inputs.use_ai }}" = "true" ]; then
+            macro_args+=(--us-macro-ai)
+          else
+            stock_args+=(--dry-run)
+          fi
+          if [ "${{ inputs.send_notification }}" != "true" ]; then
+            stock_args+=(--no-notify)
+            macro_args+=(--no-notify)
+          fi
+
+          python main.py "${stock_args[@]}" 2>&1 | tee logs/selected-stocks.log
+          python main.py "${macro_args[@]}" 2>&1 | tee logs/us-macro.log
+
+      - name: Prepare artifacts
+        if: always()
+        run: |
+          if [ -f "$DATABASE_PATH" ]; then cp "$DATABASE_PATH" artifacts/stock_analysis.db; fi
+          printf '%s\n' \
+            "use_ai=${{ inputs.use_ai }}" \
+            "send_notification=${{ inputs.send_notification }}" \
+            "force_run=${{ inputs.force_run }}" \
+            "stocks=${{ inputs.stocks }}" > artifacts/run-summary.txt
+
+      - name: Upload reports, logs, and SQLite copy
+        if: always()
+        uses: actions/upload-artifact@v6
+        with:
+          name: us-macro-manual-${{ github.run_number }}
+          if-no-files-found: warn
+          path: |
+            reports/**/*.md
+            logs/selected-stocks.log
+            logs/us-macro.log
+            artifacts/run-summary.txt
+            artifacts/stock_analysis.db

--- a/data_provider/yfinance_fetcher.py
+++ b/data_provider/yfinance_fetcher.py
@@ -119,6 +119,11 @@ class YfinanceFetcher(BaseFetcher):
         """
         code = stock_code.strip().upper()
 
+        # Yahoo 指数、期货与指数货币符号包含 ``^``、``=`` 或 ``.NYB``，
+        # 不能按 A 股代码追加交易所后缀。
+        if code.startswith('^') or '=' in code or code.endswith('.NYB'):
+            return code
+
         # 美股指数：映射到 Yahoo Finance 符号（如 SPX -> ^GSPC）
         yf_symbol, _ = get_us_index_yf_symbol(code)
         if yf_symbol:

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 > For user-friendly release highlights, see the [GitHub Releases](https://github.com/ZhuLinsen/daily_stock_analysis/releases) page.
 
 ## [Unreleased]
+- [新功能] 新增默认关闭的美国宏观基础报告 CLI（`python3 main.py --us-macro`），独立采集 FRED 利率/国债与 Yahoo Finance 市场快照，规则结论和完整来源数据保存至既有 SQLite 报告历史；未配置 FRED Key 或单数据源失败时降级输出并标记缺口。
+- [改进] 美国宏观与个股飞书预览新增只读展示适配层：中文化标题、字段、单位与数据限制，合并政策利率区间并展示 2Y–10Y 利差；不改变采集、分析、评分、数据库或既有通知类型。
+- [改进] 飞书展示层移除直接交易指令，异常成交量仅以统一数据质量限制呈现；新增仅手动触发的美国宏观与精选股票验证工作流及运行 Artifact。
 - [修复] 桌面与 Docker 发布显式安装 `orjson`，桌面 PyInstaller 产物同时冻结并执行运行时导入探针，避免 LiteLLM 调用时报 `No module named 'orjson'`。
 - [改进] 个股报告不再单独展示“题材主线与个股位置”卡片，相关市场结构数据仍保留在分析上下文、模型 Prompt 与决策信号提取链路中。
 - [改进] 通知推送与完整 Markdown/微信报告不再重复附加“AI 决策信号”摘要，DecisionSignal 的存储、告警和 Web AI 建议页保持不变。

--- a/docs/US_MACRO_MVP.md
+++ b/docs/US_MACRO_MVP.md
@@ -1,0 +1,35 @@
+# 美国宏观 MVP
+
+## 运行
+
+在项目根目录配置 `FRED_API_KEY` 后运行：
+
+```bash
+python3 main.py --us-macro --dry-run --no-notify
+```
+
+该命令不会发送通知，会生成 `reports/us_macro_report.md`，并保存到 `DATABASE_PATH`（默认 `./data/stock_analysis.db`）的 `analysis_history` 表，报告类型为 `global_macro`。
+
+## 数据与降级
+
+FRED 观测使用最近一个非空值；`observation_date` 是原始观测日期，`fetched_at` 是抓取时间，两者不混用。日频观测超过 7 个自然日标记为过期。Yahoo Finance 数据为空或受限流时，报告保留缺失状态并降低规则置信度，不填补或伪造数据。
+
+同一自然日重复运行会更新同一 `us_macro_YYYY-MM-DD` 历史记录，而非创建重复记录。FRED 或 Yahoo 单源失败不会阻断基础报告；SQLite 写入失败会使本次命令失败，不会宣称已保存。
+
+## 飞书展示预览
+
+添加 `--us-macro-preview-notification --no-notify` 可只在本地日志预览三段美国宏观消息，不发送飞书。展示层会将方向、单位与指标名称中文化；政策利率上下限合并为区间，2Y–10Y 利差使用 `bp`。该适配不修改原始快照、规则分数、方向、置信度或历史记录。
+
+## GitHub Actions 手动验证
+
+`.github/workflows/us-macro-manual.yml` 只支持 `workflow_dispatch`，不包含定时触发。首次运行保持 `send_notification=false`；输入默认只分析 `600584,300255,000560`，并独立生成美国宏观报告。需要配置 Repository Secrets：`FRED_API_KEY`、`DEEPSEEK_API_KEY`、`FEISHU_WEBHOOK_URL`、`FEISHU_WEBHOOK_SECRET`；还需配置非敏感 Repository Variable `LITELLM_MODEL`。工作流上传 Markdown 报告、日志摘要和 SQLite 副本为 Artifact，绝不提交这些运行产物回仓库。
+
+## 可选网络测试
+
+默认 pytest 不访问网络。显式执行真实 FRED 冒烟测试：
+
+```bash
+RUN_NETWORK_TESTS=true python3 -m pytest -m network tests/test_us_macro_network.py
+```
+
+测试不会输出或快照 API Key，也不发送通知。

--- a/docs/US_MACRO_REAL_DATA_VALIDATION.md
+++ b/docs/US_MACRO_REAL_DATA_VALIDATION.md
@@ -1,0 +1,19 @@
+# 美国宏观 MVP 真实数据验证
+
+验证日期：2026-07-19（Asia/Shanghai）
+
+## 执行
+
+```bash
+python3 main.py --us-macro --dry-run --no-notify
+```
+
+受控网络运行退出码为 0，耗时约 54 秒；未发送通知。FRED 成功获取 7/7 个序列：目标利率上下限、DFF、SOFR、DGS2、DGS10、VIXCLS。最新观测日期为 2026-07-16 至 2026-07-18；均未超过日频 7 天过期阈值。2Y 为 4.16%、10Y 为 4.57%，曲线为 +0.41 个百分点（41bp）。
+
+Yahoo Finance 对九项市场资产均返回上游限流，报告降级为 FRED 数据与中性/低置信度规则结果；未伪造行情。发现并修复了 Yahoo 特殊 ticker 被错误追加 `.SZ` 的问题，以及 FRED 请求异常可能在日志中包含 URL 查询参数的问题。
+
+SQLite 默认路径为 `./data/stock_analysis.db`，使用 `analysis_history` 的 `global_macro` 记录保存快照和规则结果。初次验证发现同日重复运行会插入记录，现已改为按 `us_macro_YYYY-MM-DD` 更新；该更新路径已由专项回归覆盖。
+
+## 已知限制
+
+本次 Yahoo 验证受上游限流影响，未取得实际市场价格、均线和收益率，待限流窗口恢复后以可选网络测试复验。未接入 DeepSeek、飞书、Actions、晚报或预测复盘。

--- a/main.py
+++ b/main.py
@@ -282,6 +282,7 @@ def parse_arguments() -> argparse.Namespace:
   python main.py --single-notify    # 启用单股推送模式（每分析完一只立即推送）
   python main.py --schedule         # 启用定时任务模式
   python main.py --market-review    # 仅运行大盘复盘
+  python main.py --us-macro         # 生成美国宏观基础报告
         '''
     )
 
@@ -345,6 +346,14 @@ def parse_arguments() -> argparse.Namespace:
         action='store_true',
         help='仅运行大盘复盘分析'
     )
+
+    parser.add_argument(
+        '--us-macro',
+        action='store_true',
+        help='仅运行美国宏观基础报告（FRED 利率与市场快照）'
+    )
+    parser.add_argument('--us-macro-ai', action='store_true', help='为美国宏观报告生成受限 AI 解释')
+    parser.add_argument('--us-macro-preview-notification', action='store_true', help='预览美国宏观飞书消息分段，不发送')
 
     parser.add_argument(
         '--no-market-review',
@@ -1403,6 +1412,21 @@ def main() -> int:
             logger.info(
                 f"回测完成: processed={stats.get('processed')} saved={stats.get('saved')} "
                 f"completed={stats.get('completed')} insufficient={stats.get('insufficient')} errors={stats.get('errors')}"
+            )
+            return 0
+
+        # 模式 0.5: 美国宏观基础报告。显式 CLI 调用不受默认关闭配置影响。
+        if getattr(args, 'us_macro', False):
+            from src.core.us_macro import run_us_macro_report
+
+            logger.info("模式: 美国宏观基础报告")
+            run_us_macro_report(
+                config=config,
+                send_notification=not args.no_notify and not args.dry_run,
+                save_report_file=True,
+                trigger_source="cli",
+                use_ai=getattr(args, 'us_macro_ai', False),
+                preview_notification=getattr(args, 'us_macro_preview_notification', False),
             )
             return 0
 

--- a/src/config.py
+++ b/src/config.py
@@ -1031,6 +1031,7 @@ class Config:
     # 大盘复盘市场区域：cn(A股)、hk(港股)、us(美股)、jp(日股)、kr(韩股)、both(全部市场)
     market_review_region: str = "cn"
     market_review_color_scheme: str = "green_up"
+    fred_api_key: Optional[str] = None
     # 交易日检查：默认启用，非交易日跳过执行；设为 false 或 --force-run 可强制执行（Issue #373）
     trading_day_check_enabled: bool = True
 
@@ -1984,6 +1985,7 @@ class Config:
             market_review_color_scheme=cls._parse_market_review_color_scheme(
                 os.getenv('MARKET_REVIEW_COLOR_SCHEME', 'green_up')
             ),
+            fred_api_key=os.getenv('FRED_API_KEY') or None,
             trading_day_check_enabled=os.getenv('TRADING_DAY_CHECK_ENABLED', 'true').lower() != 'false',
             webui_enabled=os.getenv('WEBUI_ENABLED', 'false').lower() == 'true',
             webui_host=os.getenv('WEBUI_HOST', '127.0.0.1'),

--- a/src/core/us_macro.py
+++ b/src/core/us_macro.py
@@ -1,0 +1,85 @@
+"""CLI-facing runtime for the independent US macro report."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from src.analyzer import AnalysisResult
+from src.notification import NotificationService
+from src.services.feishu_report_display import build_us_macro_feishu_messages
+from src.services.us_macro_report import USMacroReport, USMacroReportService
+
+logger = logging.getLogger(__name__)
+
+US_MACRO_HISTORY_CODE = "US_MACRO"
+US_MACRO_REPORT_TYPE = "global_macro"
+
+
+def run_us_macro_report(
+    *,
+    config: Any,
+    send_notification: bool,
+    save_report_file: bool,
+    trigger_source: str,
+    use_ai: bool = False,
+    preview_notification: bool = False,
+    service: USMacroReportService | None = None,
+    notifier: NotificationService | None = None,
+) -> USMacroReport:
+    runtime_service = service or USMacroReportService(fred_api_key=getattr(config, "fred_api_key", None))
+    report = runtime_service.build_report()
+    if use_ai:
+        from src.analyzer import GeminiAnalyzer
+        report = runtime_service.add_ai_explanation(report, GeminiAnalyzer(config=config))
+    report_id = _persist_report(report)
+    runtime_notifier = notifier or NotificationService()
+    if save_report_file:
+        runtime_notifier.save_report_to_file(report.markdown, "us_macro_report.md")
+    if preview_notification:
+        for index, message in enumerate(build_us_macro_notification_messages(report), start=1):
+            logger.info("美国宏观飞书预览: part=%s chars=%s content=%s", index, len(message), message)
+    if send_notification:
+        success = runtime_notifier.send(
+            report.markdown,
+            email_send_to_all=True,
+            route_type="report",
+            dedup_key=f"us_macro:{report.snapshot.as_of.date().isoformat()}",
+        )
+        if not success:
+            logger.error("美国宏观报告通知失败: report_id=%s trigger_source=%s", report_id, trigger_source)
+    logger.info("美国宏观报告完成: report_id=%s trigger_source=%s", report_id, trigger_source)
+    return report
+
+
+def build_us_macro_notification_messages(report: USMacroReport) -> list[str]:
+    """Render display-only US macro Feishu messages; caller decides whether to send."""
+    return build_us_macro_feishu_messages(report.snapshot, report.assessment, report.ai_explanation)
+
+
+def _persist_report(report: USMacroReport) -> int:
+    """Reuse the versioned report history boundary until macro-specific evaluation tables land."""
+    from src.storage import DatabaseManager
+
+    result = AnalysisResult(
+        code=US_MACRO_HISTORY_CODE,
+        name="美国宏观基础报告",
+        sentiment_score=50,
+        trend_prediction=report.assessment["horizons"]["未来1周"]["direction"],
+        operation_advice="观望",
+        analysis_summary=f"{report.assessment['regime']}；{report.assessment['horizons']['未来1周']['confidence']}置信度",
+        raw_response=report.markdown,
+        data_sources="FRED,Yahoo Finance",
+    )
+    snapshot = {
+        "report_kind": US_MACRO_REPORT_TYPE,
+        "snapshot": report.snapshot.model_dump(mode="json"),
+        "assessment": report.assessment,
+    }
+    db = DatabaseManager.get_instance()
+    query_id = f"us_macro_{report.snapshot.as_of.date().isoformat()}"
+    return db.upsert_us_macro_report_history(
+        result=result,
+        query_id=query_id,
+        context_snapshot=snapshot,
+    )

--- a/src/providers/__init__.py
+++ b/src/providers/__init__.py
@@ -1,0 +1,1 @@
+"""External providers that are not part of the stock quote fallback chain."""

--- a/src/providers/macro/__init__.py
+++ b/src/providers/macro/__init__.py
@@ -1,0 +1,3 @@
+from .fred import FREDProvider, US_FRED_SERIES
+
+__all__ = ["FREDProvider", "US_FRED_SERIES"]

--- a/src/providers/macro/fred.py
+++ b/src/providers/macro/fred.py
@@ -1,0 +1,46 @@
+"""FRED provider for the US macro report; never generates analysis text."""
+
+from __future__ import annotations
+
+from datetime import date, datetime, timezone
+from typing import Any
+
+import requests
+from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential
+
+from src.schemas.macro import MacroObservation
+
+US_FRED_SERIES = {
+    "policy_rate_lower": "DFEDTARL", "policy_rate_upper": "DFEDTARU",
+    "effective_fed_funds_rate": "DFF", "sofr": "SOFR", "treasury_2y": "DGS2",
+    "treasury_10y": "DGS10", "vix": "VIXCLS",
+}
+FRED_DAILY_STALE_AFTER_DAYS = 7
+
+
+class FREDProvider:
+    def __init__(self, api_key: str, base_url: str = "https://api.stlouisfed.org", session: requests.Session | None = None):
+        self.api_key = api_key
+        self.base_url = base_url.rstrip("/")
+        self.session = session or requests.Session()
+
+    @retry(retry=retry_if_exception_type(requests.RequestException), stop=stop_after_attempt(3), wait=wait_exponential(min=1, max=4), reraise=True)
+    def _get(self, path: str, **params: str) -> dict[str, Any]:
+        response = self.session.get(f"{self.base_url}{path}", params={**params, "api_key": self.api_key, "file_type": "json"}, timeout=15)
+        response.raise_for_status()
+        return response.json()
+
+    def fetch_latest(self, indicator: str, series_id: str) -> MacroObservation | None:
+        metadata = self._get("/fred/series", series_id=series_id).get("seriess", [])
+        if not metadata:
+            return None
+        series = metadata[0]
+        observations = self._get("/fred/series/observations", series_id=series_id, sort_order="desc", limit="20").get("observations", [])
+        valid = next((row for row in observations if row.get("value") not in ("", ".", None)), None)
+        now = datetime.now(timezone.utc)
+        observation_date = date.fromisoformat(valid["date"]) if valid else None
+        is_stale = not bool(valid) or (
+            observation_date is not None
+            and (now.date() - observation_date).days > FRED_DAILY_STALE_AFTER_DAYS
+        )
+        return MacroObservation(region="us", indicator=indicator, series_id=series_id, value=float(valid["value"]) if valid else None, unit=series.get("units"), observation_date=observation_date, fetched_at=now, source_name=series.get("source") or "FRED", source_url=f"https://fred.stlouisfed.org/series/{series_id}", frequency=series.get("frequency"), is_stale=is_stale, metadata={"title": series.get("title"), "last_updated": series.get("last_updated")})

--- a/src/schemas/macro.py
+++ b/src/schemas/macro.py
@@ -1,0 +1,40 @@
+"""Stable boundary models for macro data providers and reports."""
+
+from __future__ import annotations
+
+from datetime import date, datetime
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+
+class MacroObservation(BaseModel):
+    region: str
+    indicator: str
+    series_id: str
+    value: float | None = None
+    unit: str | None = None
+    observation_date: date | None = None
+    fetched_at: datetime
+    source_name: str
+    source_url: str | None = None
+    frequency: str | None = None
+    is_stale: bool = False
+    metadata: dict[str, Any] = Field(default_factory=dict)
+
+
+class USMacroSnapshot(BaseModel):
+    as_of: datetime
+    observations: list[MacroObservation] = Field(default_factory=list)
+    market_data: list[dict[str, Any]] = Field(default_factory=list)
+    missing_indicators: list[str] = Field(default_factory=list)
+    warnings: list[str] = Field(default_factory=list)
+
+
+class USMacroAIExplanation(BaseModel):
+    core_logic: str
+    bullish_factors: list[str] = Field(default_factory=list)
+    bearish_factors: list[str] = Field(default_factory=list)
+    sector_impacts: list[str] = Field(default_factory=list)
+    risks: list[str] = Field(default_factory=list)
+    invalidation_conditions: list[str] = Field(default_factory=list)

--- a/src/services/feishu_report_display.py
+++ b/src/services/feishu_report_display.py
@@ -1,0 +1,305 @@
+"""Read-only Feishu display adapters for stock and US macro reports.
+
+These helpers deliberately translate already-produced structured results only.
+They must not collect data, call an LLM, or mutate report history.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from src.schemas.macro import USMacroAIExplanation, USMacroSnapshot
+
+
+STOCK_DISCLAIMER = "仅供信息参考，不构成投资建议。"
+MACRO_DISCLAIMER = "仅供宏观信息参考，不构成投资建议。"
+
+_TREND_LABELS = {
+    "强烈看多": "明显偏多",
+    "看多": "偏多",
+    "震荡": "震荡",
+    "看空": "偏空",
+    "强烈看空": "明显偏空",
+}
+_PROVIDER_LABELS = {
+    "EfinanceFetcher": "东方财富",
+    "TencentFetcher": "腾讯财经",
+    "efinance": "东方财富",
+    "tencent": "腾讯财经",
+}
+_REGIME_LABELS = {
+    "neutral": "中性",
+    "risk_on": "风险偏好改善",
+    "risk_off": "风险偏好走弱",
+    "mixed": "分化",
+}
+_MACRO_INDICATOR_LABELS = {
+    "policy_rate_lower": "美联储目标利率下限",
+    "policy_rate_upper": "美联储目标利率上限",
+    "effective_fed_funds_rate": "有效联邦基金利率",
+    "sofr": "SOFR",
+    "treasury_2y": "美国2年期国债收益率",
+    "treasury_10y": "美国10年期国债收益率",
+    "vix": "VIX",
+}
+
+
+def build_stock_feishu_message(raw: dict[str, Any], context: dict[str, Any] | None = None) -> str:
+    """Render one compact stock message from an already-persisted result."""
+    context = context or {}
+    name = str(raw.get("name") or "未知标的")
+    code = str(raw.get("code") or "未知代码")
+    dashboard = raw.get("dashboard") if isinstance(raw.get("dashboard"), dict) else {}
+    phase = dashboard.get("phase_decision") if isinstance(dashboard.get("phase_decision"), dict) else {}
+    enhanced = context.get("enhanced_context") if isinstance(context.get("enhanced_context"), dict) else {}
+    today = enhanced.get("today") if isinstance(enhanced.get("today"), dict) else {}
+
+    lines = [
+        f"{name}｜{code}｜股票分析",
+        f"数据日期：{_effective_daily_date(phase, today, raw) or '未知'}",
+        f"模型观点：{raw.get('operation_advice') or '观望'}",
+        f"综合评分：{_number(raw.get('sentiment_score'))}",
+        f"趋势判断：{_trend_label(raw.get('trend_prediction'))}",
+    ]
+    reasons = _stock_reasons(enhanced, raw)
+    if reasons:
+        lines.append("核心依据：")
+        lines.extend(f"• {reason}" for reason in reasons[:3])
+    watch = _watch_condition(phase, raw.get("trend_prediction"))
+    if watch:
+        lines.extend(["关注条件：", watch])
+    sources = _stock_sources(raw, enhanced)
+    if sources:
+        lines.append(f"数据来源：{'｜'.join(sources)}")
+    limitations = _stock_limitations(phase, raw)
+    if limitations:
+        lines.append(f"数据限制：{_format_limitations(limitations)}")
+    lines.append(STOCK_DISCLAIMER)
+    return "\n".join(lines)
+
+
+def build_us_macro_feishu_messages(
+    snapshot: USMacroSnapshot,
+    assessment: dict[str, Any],
+    explanation: USMacroAIExplanation | None = None,
+) -> list[str]:
+    """Render the three US macro messages without changing deterministic output."""
+    report_date = snapshot.as_of.date().isoformat()
+    horizons = assessment.get("horizons") or {}
+    core = [f"美国宏观市场晨报｜核心结论｜{report_date}", f"市场环境：{_regime_label(assessment.get('regime'))}"]
+    for key, aliases in (("下一交易日", ("下一交易日", "当日或下一交易日")), ("未来1周", ("未来1周",)), ("未来1个月", ("未来1个月",))):
+        item = next((horizons.get(alias) for alias in aliases if horizons.get(alias)), {})
+        core.append(f"{key}：{_direction_label(item.get('direction'))}｜{_confidence_label(item.get('confidence'))}")
+    drivers = (horizons.get("未来1周") or {}).get("drivers") or []
+    if drivers:
+        core.extend(["核心判断：", "；".join(str(item) for item in drivers[:2])])
+    if snapshot.missing_indicators or snapshot.warnings:
+        core.append("市场行情缺失，缺少风险资产交叉验证。")
+    core.extend(["数据状态：", f"利率与债券：{len(snapshot.observations)}/7", f"市场行情：{len(snapshot.market_data)}/9"])
+
+    rates = [f"美国宏观市场晨报｜利率与债券｜{report_date}"]
+    observations = {item.indicator: item for item in snapshot.observations}
+    lower = observations.get("policy_rate_lower")
+    upper = observations.get("policy_rate_upper")
+    if lower and upper:
+        rates.append(f"美联储目标利率区间：{lower.value:.2f}%–{upper.value:.2f}%")
+    for indicator in ("effective_fed_funds_rate", "sofr", "treasury_2y", "treasury_10y", "vix"):
+        item = observations.get(indicator)
+        if item:
+            rates.append(_format_macro_observation(item))
+    curve = _curve_basis_points(observations.get("treasury_2y"), observations.get("treasury_10y"))
+    if curve is not None:
+        rates.append(f"2Y–10Y利差：{curve:+.0f}bp")
+    rates.append("数据来源：FRED")
+
+    narrative = [f"美国宏观市场晨报｜解释与风险｜{report_date}"]
+    if explanation:
+        narrative.extend(_narrative_lines(explanation))
+    else:
+        narrative.extend(["核心逻辑：", "当前解释暂不可用，结论仍以已展示的确定性规则为准。"])
+    if not snapshot.market_data:
+        narrative.extend(["数据限制：", "当前股指、美元和商品行情不可用，本次解释主要基于利率、国债收益率和VIX数据。"])
+    elif snapshot.missing_indicators or snapshot.warnings:
+        narrative.extend(["数据限制：", "部分指标不可用或存在延迟，结论已按程序规则降级。"])
+    narrative.append(MACRO_DISCLAIMER)
+    return ["\n".join(core), "\n".join(rates), "\n".join(narrative)]
+
+
+def _stock_reasons(enhanced: dict[str, Any], raw: dict[str, Any]) -> list[str]:
+    trend = enhanced.get("trend_analysis") if isinstance(enhanced.get("trend_analysis"), dict) else {}
+    chip = enhanced.get("chip") if isinstance(enhanced.get("chip"), dict) else {}
+    reasons: list[str] = []
+    alignment = str(trend.get("ma_alignment") or "").strip()
+    if alignment:
+        reasons.append(f"均线状态：{alignment}")
+    bias = trend.get("bias_ma5")
+    if isinstance(bias, (int, float)) and abs(bias) >= 5:
+        direction = "短线涨幅偏大" if bias > 0 else "短线偏离均线较大"
+        reasons.append(f"5日乖离率{bias:.2f}%，{direction}")
+    chip_status = str(chip.get("chip_status") or "").strip()
+    if chip_status:
+        reasons.append(f"筹码状态：{chip_status}")
+    risk_factors = [str(item).lstrip("⚠️❌✅ ").strip() for item in trend.get("risk_factors", []) if str(item).strip()]
+    reasons.extend(risk_factors)
+    if reasons:
+        return _unique(reasons)
+    summary = raw.get("key_points") or raw.get("ma_analysis") or raw.get("technical_analysis")
+    return [str(summary).strip()] if summary else []
+
+
+def _watch_condition(phase: dict[str, Any], trend_prediction: Any) -> str | None:
+    conditions = phase.get("watch_conditions") if isinstance(phase.get("watch_conditions"), list) else []
+    for condition in conditions:
+        text = str(condition).strip()
+        if text:
+            text = text.split("：", 1)[-1].strip()
+            if _contains_directive(text):
+                return _neutral_risk_condition(trend_prediction)
+            return text
+    return "等待趋势和量能出现进一步确认。" if phase else None
+
+
+def _stock_sources(raw: dict[str, Any], enhanced: dict[str, Any]) -> list[str]:
+    sources: list[str] = []
+    today = enhanced.get("today") if isinstance(enhanced.get("today"), dict) else {}
+    yesterday = enhanced.get("yesterday") if isinstance(enhanced.get("yesterday"), dict) else {}
+    realtime = enhanced.get("realtime") if isinstance(enhanced.get("realtime"), dict) else {}
+    for source in (yesterday.get("data_source"), today.get("data_source"), realtime.get("source"), raw.get("data_sources")):
+        if not source:
+            continue
+        for part in str(source).replace(",", "|").split("|"):
+            label = _provider_label(part)
+            if label and not _same_provider(label, sources):
+                sources.append(label)
+    return sources
+
+
+def _stock_limitations(phase: dict[str, Any], raw: dict[str, Any]) -> list[str]:
+    limits = phase.get("data_limitations") if isinstance(phase.get("data_limitations"), list) else []
+    rendered: list[str] = []
+    volume_quality_issue = False
+    for limit in limits:
+        text = str(limit).strip()
+        if not text or text == "technical: partial":
+            continue
+        if "成交量" in text and any(marker in text for marker in ("异常", "失真", "降权")):
+            volume_quality_issue = True
+            continue
+        text = text.replace("技术指标为partial状态", "部分技术指标数据不完整").replace("技术面数据为partial状态", "部分技术指标数据不完整")
+        text = text.replace("技术面数据标记为partial", "部分技术指标数据不完整")
+        text = text.replace("（intraday_realtime_overlay）", "").replace("intraday_realtime_overlay", "")
+        text = text.split("：", 1)[-1].strip()
+        if text and text not in rendered:
+            rendered.append(text)
+    if volume_quality_issue:
+        rendered.append("成交量数据存在异常，相关量价信号已从本次判断中降权或忽略")
+    if not raw.get("news_summary") or "暂无" in str(raw.get("news_summary")):
+        rendered.append("暂未获取到有效新闻")
+    return rendered[:3]
+
+
+def _format_macro_observation(item: Any) -> str:
+    label = _MACRO_INDICATOR_LABELS.get(item.indicator, item.indicator)
+    unit = "点" if item.unit == "Index" else "%" if item.unit == "Percent" else (item.unit or "")
+    value = f"{item.value:.2f}{unit}"
+    return f"{label}：{value}｜{item.observation_date.isoformat()}"
+
+
+def _curve_basis_points(two_year: Any, ten_year: Any) -> float | None:
+    if two_year is None or ten_year is None:
+        return None
+    return (ten_year.value - two_year.value) * 100
+
+
+def _narrative_lines(explanation: USMacroAIExplanation) -> list[str]:
+    sections = [
+        ("核心逻辑", explanation.core_logic),
+        ("利多因素", "；".join(explanation.bullish_factors[:3])),
+        ("利空因素", "；".join(explanation.bearish_factors[:3])),
+        ("风险", "；".join(explanation.risks[:3])),
+        ("失效条件", "；".join(explanation.invalidation_conditions[:3])),
+    ]
+    lines: list[str] = []
+    for title, content in sections:
+        if content:
+            lines.extend([f"{title}：", str(content)])
+    return lines
+
+
+def _market_date(raw: dict[str, Any]) -> str | None:
+    snapshot = raw.get("market_snapshot") if isinstance(raw.get("market_snapshot"), dict) else {}
+    value = snapshot.get("date")
+    return str(value) if value else None
+
+
+def _effective_daily_date(phase: dict[str, Any], today: dict[str, Any], raw: dict[str, Any]) -> str | None:
+    context = phase.get("phase_context") if isinstance(phase.get("phase_context"), dict) else {}
+    return str(context.get("effective_daily_bar_date") or today.get("date") or _market_date(raw) or "") or None
+
+
+def _provider_label(value: Any) -> str | None:
+    text = str(value).strip()
+    if not text:
+        return None
+    if text in _PROVIDER_LABELS:
+        return _PROVIDER_LABELS[text]
+    lowered = text.lower()
+    if "efinance" in lowered or "eastmoney" in lowered:
+        return "东方财富日线"
+    if "tencent" in lowered:
+        return "腾讯财经实时行情"
+    return None
+
+
+def _same_provider(label: str, sources: list[str]) -> bool:
+    normalized = label.replace("实时行情", "")
+    return any(source.replace("实时行情", "") == normalized for source in sources)
+
+
+def _contains_directive(text: str) -> bool:
+    return any(token in text for token in ("止损", "离场", "卖出", "减仓", "加仓", "建仓"))
+
+
+def _neutral_risk_condition(trend_prediction: Any) -> str:
+    trend = _trend_label(trend_prediction)
+    if "偏空" in trend:
+        return "关注下一个交易日能否止跌并重新站回短期均线；若继续走弱，当前偏空判断仍然有效。"
+    return "关注下一个交易日的趋势与量能确认；若走势继续走弱，当前判断仍然有效。"
+
+
+def _format_limitations(limitations: list[str]) -> str:
+    clean: list[str] = []
+    for item in limitations:
+        text = str(item).strip().strip("。； ")
+        if text and text not in clean:
+            clean.append(text)
+    return "；".join(clean) + "。"
+
+
+def _number(value: Any) -> str:
+    return str(value) if value is not None else "--"
+
+
+def _trend_label(value: Any) -> str:
+    return _TREND_LABELS.get(str(value), str(value or "未知"))
+
+
+def _regime_label(value: Any) -> str:
+    return _REGIME_LABELS.get(str(value), str(value or "未知"))
+
+
+def _direction_label(value: Any) -> str:
+    return _regime_label(value)
+
+
+def _confidence_label(value: Any) -> str:
+    text = str(value or "低")
+    return text if text.endswith("置信度") else f"{text}置信度"
+
+
+def _unique(values: list[str]) -> list[str]:
+    result: list[str] = []
+    for value in values:
+        if value not in result:
+            result.append(value)
+    return result

--- a/src/services/us_macro_market_data.py
+++ b/src/services/us_macro_market_data.py
@@ -1,0 +1,58 @@
+"""US macro market snapshot built on the existing Yahoo Finance fetcher."""
+
+from __future__ import annotations
+
+from datetime import date, timedelta
+from typing import Any
+
+import pandas as pd
+
+from data_provider.yfinance_fetcher import YfinanceFetcher
+
+US_MACRO_MARKETS = {
+    "sp500": ("^GSPC", "标普500"), "nasdaq_100": ("^NDX", "纳斯达克100"),
+    "dow_jones": ("^DJI", "道琼斯工业指数"), "russell_2000": ("^RUT", "罗素2000"),
+    "vix": ("^VIX", "VIX"), "dollar_index": ("DX-Y.NYB", "美元指数"),
+    "gold": ("GC=F", "黄金"), "crude_oil": ("CL=F", "WTI原油"), "copper": ("HG=F", "铜"),
+}
+
+
+def _pct_change(values: pd.Series, sessions: int) -> float | None:
+    if len(values) <= sessions or not values.iloc[-sessions - 1]:
+        return None
+    return round((float(values.iloc[-1]) / float(values.iloc[-sessions - 1]) - 1) * 100, 3)
+
+
+def summarize_history(name: str, symbol: str, history: pd.DataFrame) -> dict[str, Any] | None:
+    if history.empty or "close" not in history:
+        return None
+    closes = history["close"].dropna()
+    if closes.empty:
+        return None
+    latest = float(closes.iloc[-1])
+    result = {"indicator": name, "symbol": symbol, "value": latest, "observation_date": str(closes.index[-1].date()), "change_1d": _pct_change(closes, 1), "change_5d": _pct_change(closes, 5), "change_20d": _pct_change(closes, 20), "source_name": "Yahoo Finance", "is_delayed": True}
+    for period in (20, 50, 200):
+        if len(closes) >= period:
+            average = float(closes.tail(period).mean())
+            result[f"ma_{period}"] = average
+            result[f"above_ma_{period}"] = latest >= average
+    return result
+
+
+class USMacroMarketDataService:
+    def __init__(self, fetcher: YfinanceFetcher | None = None):
+        self.fetcher = fetcher or YfinanceFetcher()
+
+    def fetch(self) -> tuple[list[dict[str, Any]], list[str]]:
+        start = (date.today() - timedelta(days=330)).isoformat()
+        end = (date.today() + timedelta(days=1)).isoformat()
+        data, missing = [], []
+        for key, (symbol, _label) in US_MACRO_MARKETS.items():
+            try:
+                raw = self.fetcher._fetch_raw_data(symbol, start, end)
+                item = summarize_history(key, symbol, self.fetcher._normalize_data(raw, symbol))
+                if item: data.append(item)
+                else: missing.append(key)
+            except Exception:
+                missing.append(key)
+        return data, missing

--- a/src/services/us_macro_report.py
+++ b/src/services/us_macro_report.py
@@ -1,0 +1,172 @@
+"""Orchestration and deterministic Markdown rendering for the US macro MVP."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+import logging
+from typing import Any
+import json
+
+from src.providers.macro.fred import FREDProvider, US_FRED_SERIES
+from src.schemas.macro import MacroObservation, USMacroAIExplanation, USMacroSnapshot
+from src.services.us_macro_market_data import US_MACRO_MARKETS, USMacroMarketDataService
+from src.services.us_macro_rules import assess_us_macro
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class USMacroReport:
+    snapshot: USMacroSnapshot
+    assessment: dict[str, Any]
+    markdown: str
+    ai_explanation: USMacroAIExplanation | None = None
+    ai_warning: str | None = None
+
+
+class USMacroReportService:
+    """Collect independent sources without allowing one source to block the report."""
+
+    def __init__(
+        self,
+        *,
+        fred_api_key: str | None = None,
+        fred_provider: FREDProvider | None = None,
+        market_service: USMacroMarketDataService | None = None,
+    ) -> None:
+        self.fred_provider = fred_provider or (FREDProvider(fred_api_key) if fred_api_key else None)
+        self.market_service = market_service or USMacroMarketDataService()
+
+    def build_report(self) -> USMacroReport:
+        observations, missing_indicators, warnings = self._fetch_observations()
+        try:
+            market_data, missing_markets = self.market_service.fetch()
+        except Exception as exc:
+            logger.warning("美国宏观市场快照获取失败: %s", exc)
+            market_data, missing_markets = [], list(US_MACRO_MARKETS)
+            warnings.append("市场快照获取失败，已降级为仅利率报告")
+        if missing_markets:
+            warnings.append("缺少市场数据：" + "、".join(missing_markets))
+
+        snapshot = USMacroSnapshot(
+            as_of=datetime.now(timezone.utc),
+            observations=observations,
+            market_data=market_data,
+            missing_indicators=missing_indicators,
+            warnings=warnings,
+        )
+        assessment = assess_us_macro(
+            [item for item in market_data],
+            [item.model_dump() for item in observations],
+        )
+        return USMacroReport(snapshot=snapshot, assessment=assessment, markdown=render_us_macro_markdown(snapshot, assessment))
+
+    def add_ai_explanation(self, report: USMacroReport, analyzer: Any) -> USMacroReport:
+        """Add validated prose only; deterministic data is never accepted from the model."""
+        payload = {
+            "observations": [item.model_dump(mode="json") for item in report.snapshot.observations],
+            "missing_indicators": report.snapshot.missing_indicators,
+            "warnings": report.snapshot.warnings,
+            "assessment": report.assessment,
+        }
+        prompt = (
+            "你是宏观报告解释助手。只能基于以下 JSON 写解释，不能改写或新增任何数值、"
+            "方向、置信度、行情、新闻或政策事实；不得给出买卖点、仓位、收益保证或概率。"
+            "市场价格数据不可用时，不得推测或补全市场价格。仅返回 JSON，字段为 core_logic,"
+            "bullish_factors, bearish_factors, sector_impacts, risks, invalidation_conditions；"
+            "所有列表字段均为字符串数组。\n" + json.dumps(payload, ensure_ascii=False)
+        )
+        try:
+            raw = analyzer.generate_text(prompt, max_tokens=900, temperature=0.1)
+            if not raw:
+                raise ValueError("empty AI explanation")
+            explanation = USMacroAIExplanation.model_validate_json(raw)
+        except Exception as exc:
+            logger.warning("美国宏观 AI 解释不可用: error_type=%s", type(exc).__name__)
+            return USMacroReport(report.snapshot, report.assessment, report.markdown, ai_warning="AI解释暂不可用")
+        markdown = report.markdown + render_ai_explanation(explanation)
+        return USMacroReport(report.snapshot, report.assessment, markdown, explanation)
+
+    def _fetch_observations(self) -> tuple[list[MacroObservation], list[str], list[str]]:
+        if self.fred_provider is None:
+            return [], list(US_FRED_SERIES), ["未配置 FRED_API_KEY，利率数据未获取"]
+
+        observations: list[MacroObservation] = []
+        missing: list[str] = []
+        warnings: list[str] = []
+        for indicator, series_id in US_FRED_SERIES.items():
+            try:
+                observation = self.fred_provider.fetch_latest(indicator, series_id)
+            except Exception as exc:
+                logger.warning(
+                    "FRED 指标获取失败: indicator=%s series=%s error_type=%s",
+                    indicator,
+                    series_id,
+                    type(exc).__name__,
+                )
+                missing.append(indicator)
+                continue
+            if observation is None or observation.value is None:
+                missing.append(indicator)
+            else:
+                observations.append(observation)
+        return observations, missing, warnings
+
+
+def render_us_macro_markdown(snapshot: USMacroSnapshot, assessment: dict[str, Any]) -> str:
+    """Render a data-only report; this path never produces investment advice."""
+    horizon = assessment["horizons"]["未来1周"]
+    lines = [
+        "# 🇺🇸 美国宏观基础报告",
+        "",
+        f"> 生成时间：{snapshot.as_of.astimezone(timezone.utc).strftime('%Y-%m-%d %H:%M UTC')}；数据可能延迟，非投资建议。",
+        "",
+        "## 核心结论",
+        f"- 规则状态：`{assessment['regime']}`",
+        *[
+            f"- {name}：{value['direction']}（置信度：{value['confidence']}，规则分：{value['score']}）"
+            for name, value in assessment["horizons"].items()
+        ],
+    ]
+    if assessment.get("warning"):
+        lines.append(f"- 降级说明：{assessment['warning']}")
+
+    lines.extend(["", "## 利率与宏观观测"])
+    if snapshot.observations:
+        for item in snapshot.observations:
+            date_text = item.observation_date.isoformat() if item.observation_date else "未知日期"
+            stale_note = "，数据已过期" if item.is_stale else ""
+            lines.append(f"- {item.indicator}: {item.value:g} {item.unit or ''}（{date_text}，[{item.source_name}]({item.source_url}){stale_note}）")
+    else:
+        lines.append("- 暂无可用 FRED 观测。")
+
+    lines.extend(["", "## 市场快照"])
+    for item in snapshot.market_data:
+        one_day = item.get("change_1d")
+        five_day = item.get("change_5d")
+        lines.append(
+            f"- {item['indicator']} ({item['symbol']}): {item['value']:.2f}；"
+            f"1日 {one_day if one_day is not None else 'N/A'}%，5日 {five_day if five_day is not None else 'N/A'}%"
+        )
+    if not snapshot.market_data:
+        lines.append("- 暂无可用市场数据。")
+
+    drivers = horizon.get("drivers") or []
+    if drivers:
+        lines.extend(["", "## 规则证据"])
+        lines.extend(f"- {driver}" for driver in drivers)
+    if snapshot.missing_indicators or snapshot.warnings:
+        lines.extend(["", "## 数据缺口"])
+        if snapshot.missing_indicators:
+            lines.append("- 缺少指标：" + "、".join(snapshot.missing_indicators))
+        lines.extend(f"- {warning}" for warning in snapshot.warnings)
+    return "\n".join(lines) + "\n"
+
+
+def render_ai_explanation(explanation: USMacroAIExplanation) -> str:
+    lines = ["\n## AI 受限解释", f"- 核心逻辑：{explanation.core_logic}"]
+    for title, values in (("利多因素", explanation.bullish_factors), ("利空因素", explanation.bearish_factors), ("行业影响", explanation.sector_impacts), ("风险", explanation.risks), ("失效条件", explanation.invalidation_conditions)):
+        if values:
+            lines.append(f"- {title}：" + "；".join(values))
+    return "\n".join(lines) + "\n"

--- a/src/services/us_macro_rules.py
+++ b/src/services/us_macro_rules.py
@@ -1,0 +1,47 @@
+"""Deterministic US macro scoring. LLMs may explain, never override this output."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+Direction = Literal['明显偏多', '偏多', '中性', '偏空', '明显偏空']
+Confidence = Literal['低', '中', '高']
+
+
+@dataclass(frozen=True)
+class MarketSignal:
+    name: str
+    score: int
+    reason: str
+    source_indicators: list[str]
+
+
+def _direction(score: int, enough_data: bool) -> tuple[Direction, Confidence]:
+    if not enough_data: return '中性', '低'
+    if score >= 5: return '明显偏多', '高'
+    if score >= 2: return '偏多', '中'
+    if score <= -5: return '明显偏空', '高'
+    if score <= -2: return '偏空', '中'
+    return '中性', '低'
+
+
+def assess_us_macro(market_data: list[dict], observations: list[dict]) -> dict:
+    market = {item['indicator']: item for item in market_data}
+    rates = {item['indicator']: item for item in observations}
+    signals: list[MarketSignal] = []
+    vix = market.get('vix')
+    spx = market.get('sp500')
+    if vix and vix.get('change_5d') is not None:
+        signals.append(MarketSignal('vix_5d', -2 if vix['change_5d'] > 10 else (1 if vix['change_5d'] < -10 else 0), 'VIX五日变化反映风险偏好', ['vix']))
+    if spx and spx.get('above_ma_20') is not None:
+        signals.append(MarketSignal('spx_trend', 2 if spx['above_ma_20'] and spx.get('above_ma_50') else -2 if not spx['above_ma_20'] else 0, '标普500相对中期均线', ['sp500']))
+    two, ten = rates.get('treasury_2y'), rates.get('treasury_10y')
+    if two and ten and two.get('value') is not None and ten.get('value') is not None:
+        spread = ten['value'] - two['value']
+        signals.append(MarketSignal('curve', 1 if spread > 0 else -1, f'2Y-10Y利差为{spread:.2f}个百分点', ['treasury_2y', 'treasury_10y']))
+    score = sum(signal.score for signal in signals)
+    enough = len(signals) >= 2
+    direction, confidence = _direction(score, enough)
+    regime = 'risk_on' if enough and score >= 3 else 'risk_off' if enough and score <= -3 else 'mixed' if enough and score else 'neutral'
+    horizons = {name: {'direction': direction, 'confidence': confidence, 'score': score, 'drivers': [s.reason for s in signals], 'source_indicator_ids': [key for s in signals for key in s.source_indicators]} for name in ('当日或下一交易日', '未来1周', '未来1个月')}
+    return {'regime': regime, 'signals': [s.__dict__ for s in signals], 'horizons': horizons, 'warning': None if enough else '数据不足或信号相互冲突'}

--- a/src/storage.py
+++ b/src/storage.py
@@ -335,6 +335,7 @@ class AnalysisHistory(Base):
     take_profit = Column(Float)
 
     created_at = Column(DateTime, default=datetime.now, index=True)
+    updated_at = Column(DateTime, default=datetime.now, onupdate=datetime.now, index=True)
 
     __table_args__ = (
         Index('ix_analysis_code_time', 'code', 'created_at'),
@@ -1214,6 +1215,7 @@ class DatabaseManager(metaclass=_DatabaseManagerMeta):
             self._ensure_llm_usage_telemetry_columns()
             self._ensure_decision_signal_profile_schema()
             self._ensure_intelligence_item_scope_values()
+            self._ensure_us_macro_report_schema()
             self._ensure_schema_migration_record()
             self._ensure_intelligence_items_unique_index()
 
@@ -1259,6 +1261,22 @@ class DatabaseManager(metaclass=_DatabaseManagerMeta):
             raise
         finally:
             session.close()
+
+    def _ensure_us_macro_report_schema(self) -> None:
+        """Make same-day US macro reports atomically unique on existing SQLite DBs."""
+        if not self._is_sqlite_engine or not inspect(self._engine).has_table(AnalysisHistory.__tablename__):
+            return
+        columns = {column["name"] for column in inspect(self._engine).get_columns(AnalysisHistory.__tablename__)}
+        if "updated_at" not in columns:
+            with self._engine.begin() as connection:
+                connection.exec_driver_sql("ALTER TABLE analysis_history ADD COLUMN updated_at DATETIME")
+                connection.exec_driver_sql("UPDATE analysis_history SET updated_at = created_at WHERE updated_at IS NULL")
+        with self._engine.begin() as connection:
+            connection.exec_driver_sql(
+                "CREATE UNIQUE INDEX IF NOT EXISTS uix_us_macro_report_business_key "
+                "ON analysis_history (query_id, code, report_type) "
+                "WHERE report_type = 'global_macro'"
+            )
 
     def _ensure_decision_signal_profile_schema(self) -> None:
         """Add and backfill nullable decision_profile for existing SQLite DBs."""
@@ -2154,6 +2172,57 @@ class DatabaseManager(metaclass=_DatabaseManagerMeta):
         except Exception as e:
             logger.error(f"保存分析历史失败: {e}")
             return 0
+
+    def upsert_us_macro_report_history(
+        self,
+        *,
+        result: Any,
+        query_id: str,
+        context_snapshot: Dict[str, Any],
+    ) -> int:
+        """Atomically create or refresh one US macro report per business day."""
+        values = {
+            "query_id": query_id,
+            "code": result.code,
+            "name": result.name,
+            "report_type": "global_macro",
+            "sentiment_score": result.sentiment_score,
+            "operation_advice": result.operation_advice,
+            "trend_prediction": result.trend_prediction,
+            "analysis_summary": result.analysis_summary,
+            "raw_result": self._safe_json_dumps(self._build_raw_result(result)),
+            "context_snapshot": self._safe_json_dumps(context_snapshot),
+            "created_at": datetime.now(),
+            "updated_at": datetime.now(),
+        }
+        def _write(session: Session) -> int:
+            if self._is_sqlite_engine:
+                stmt = sqlite_insert(AnalysisHistory).values(**values).on_conflict_do_update(
+                    index_elements=["query_id", "code", "report_type"],
+                    index_where=text("report_type = 'global_macro'"),
+                    set_={key: value for key, value in values.items() if key not in {"created_at", "query_id", "code", "report_type"}},
+                )
+                session.execute(stmt)
+                return int(session.execute(select(AnalysisHistory.id).where(
+                    AnalysisHistory.query_id == query_id,
+                    AnalysisHistory.code == result.code,
+                    AnalysisHistory.report_type == "global_macro",
+                )).scalar_one())
+            existing = session.execute(select(AnalysisHistory).where(
+                AnalysisHistory.query_id == query_id,
+                AnalysisHistory.code == result.code,
+                AnalysisHistory.report_type == "global_macro",
+            )).scalar_one_or_none()
+            if existing is None:
+                existing = AnalysisHistory(**values)
+                session.add(existing)
+                session.flush()
+            else:
+                for key, value in values.items():
+                    if key != "created_at":
+                        setattr(existing, key, value)
+            return int(existing.id)
+        return self._run_write_transaction(f"upsert_us_macro_report[{query_id}]", _write)
 
     def update_analysis_history_diagnostics(
         self,

--- a/tests/test_feishu_report_display.py
+++ b/tests/test_feishu_report_display.py
@@ -1,0 +1,127 @@
+from datetime import date, datetime, timezone
+from copy import deepcopy
+
+from src.schemas.macro import MacroObservation, USMacroAIExplanation, USMacroSnapshot
+from src.services.feishu_report_display import (
+    MACRO_DISCLAIMER,
+    STOCK_DISCLAIMER,
+    build_stock_feishu_message,
+    build_us_macro_feishu_messages,
+)
+
+
+def _macro_snapshot():
+    values = {
+        "policy_rate_lower": (3.5, "Percent"),
+        "policy_rate_upper": (3.75, "Percent"),
+        "effective_fed_funds_rate": (3.63, "Percent"),
+        "sofr": (3.62, "Percent"),
+        "treasury_2y": (4.16, "Percent"),
+        "treasury_10y": (4.57, "Percent"),
+        "vix": (16.73, "Index"),
+    }
+    return USMacroSnapshot(
+        as_of=datetime(2026, 7, 19, tzinfo=timezone.utc),
+        observations=[
+            MacroObservation(
+                region="us", indicator=indicator, series_id=indicator, value=value, unit=unit,
+                observation_date=date(2026, 7, 16), fetched_at=datetime.now(timezone.utc),
+                source_name="FRED", source_url="https://fred.example", frequency="Daily",
+            )
+            for indicator, (value, unit) in values.items()
+        ],
+        warnings=["缺少市场数据"],
+    )
+
+
+def _assessment():
+    return {
+        "regime": "neutral",
+        "horizons": {
+            "下一交易日": {"direction": "neutral", "confidence": "低"},
+            "未来1周": {"direction": "neutral", "confidence": "低", "drivers": ["2Y-10Y利差为0.41个百分点"]},
+            "未来1个月": {"direction": "neutral", "confidence": "低"},
+        },
+    }
+
+
+def test_stock_display_is_dynamic_and_localizes_sources_and_partial():
+    raw = {
+        "name": "示例公司", "code": "123456", "operation_advice": "观望", "sentiment_score": 54,
+        "trend_prediction": "看多", "data_sources": "EfinanceFetcher,TencentFetcher", "news_summary": "暂无新闻",
+        "market_snapshot": {"date": "2026-07-17"},
+        "dashboard": {"phase_decision": {"watch_conditions": ["观察条件1：等待站上20日均线并出现放量确认"], "data_limitations": ["技术指标为partial状态", "technical: partial"]}},
+    }
+    context = {"enhanced_context": {"today": {"date": "2026-07-17", "data_source": "EfinanceFetcher"}, "realtime": {"source": "TencentFetcher"}, "chip": {"chip_status": "获利筹码较多"}, "trend_analysis": {"ma_alignment": "多头排列", "bias_ma5": 8.2, "risk_factors": ["量能尚待确认", "不应展示的第四项"]}}}
+
+    message = build_stock_feishu_message(raw, context)
+
+    assert message.startswith("示例公司｜123456｜股票分析")
+    assert "趋势判断：偏多" in message
+    assert "东方财富｜腾讯财经" in message
+    assert "部分技术指标数据不完整" in message
+    assert message.count("• ") == 3
+    assert "partial" not in message
+    assert "EfinanceFetcher" not in message
+    assert STOCK_DISCLAIMER in message
+
+
+def test_stock_display_does_not_invent_reasons_when_structured_indicators_missing():
+    message = build_stock_feishu_message({"name": "空数据", "code": "000001", "sentiment_score": 40, "trend_prediction": "震荡"})
+    assert "核心依据：" not in message
+    assert "关注条件：" not in message
+
+
+def test_stock_display_neutralizes_directives_and_volume_quality_limitations():
+    raw = {
+        "name": "风险标的", "code": "000002", "sentiment_score": 25, "trend_prediction": "强烈看空",
+        "dashboard": {"phase_decision": {"watch_conditions": ["持仓者需坚决止损离场"], "data_limitations": ["成交量较前日异常放大136.2倍，存在数据失真风险", "技术指标为partial状态", "技术指标为partial状态"]}},
+    }
+    message = build_stock_feishu_message(raw)
+
+    assert "止损" not in message and "离场" not in message
+    assert "当前偏空判断仍然有效" in message
+    assert "成交量数据存在异常，相关量价信号已从本次判断中降权或忽略" in message
+    assert "136.2倍" not in message
+    assert "。；" not in message and "；；" not in message
+    assert "数据限制：" in message
+    assert "部分技术指标数据不完整" in message
+
+
+def test_stock_display_does_not_mutate_raw_result_or_context_snapshot():
+    raw = {"name": "只读标的", "code": "000003", "sentiment_score": 40, "trend_prediction": "震荡"}
+    context = {"enhanced_context": {"trend_analysis": {"ma_alignment": "震荡"}}}
+    raw_before, context_before = deepcopy(raw), deepcopy(context)
+
+    build_stock_feishu_message(raw, context)
+
+    assert raw == raw_before
+    assert context == context_before
+
+
+def test_macro_display_uses_three_localized_titles_units_and_curve_basis_points():
+    explanation = USMacroAIExplanation(
+        core_logic="收益率曲线为正，但市场行情缺失。",
+        bullish_factors=["曲线正斜率"], bearish_factors=["交叉验证不足"],
+        risks=["市场数据缺失"], invalidation_conditions=["曲线转负"],
+    )
+    messages = build_us_macro_feishu_messages(_macro_snapshot(), _assessment(), explanation)
+    all_text = "\n".join(messages)
+
+    assert len(messages) == 3
+    assert messages[0].startswith("美国宏观市场晨报｜核心结论｜2026-07-19")
+    assert messages[1].startswith("美国宏观市场晨报｜利率与债券｜2026-07-19")
+    assert messages[2].startswith("美国宏观市场晨报｜解释与风险｜2026-07-19")
+    assert "市场环境：中性" in messages[0]
+    assert "美联储目标利率区间：3.50%–3.75%" in messages[1]
+    assert "2Y–10Y利差：+41bp" in messages[1]
+    assert "VIX：16.73点" in messages[1]
+    assert MACRO_DISCLAIMER in messages[2]
+    for internal in ("neutral", "Percent", "Index", "policy_rate_lower", "policy_rate_upper", "treasury_2y", "treasury_10y"):
+        assert internal not in all_text
+
+
+def test_macro_display_without_ai_keeps_deterministic_report_and_no_send_side_effect():
+    messages = build_us_macro_feishu_messages(_macro_snapshot(), _assessment())
+    assert "当前解释暂不可用" in messages[2]
+    assert len(messages) == 3

--- a/tests/test_fred_provider.py
+++ b/tests/test_fred_provider.py
@@ -1,0 +1,27 @@
+from datetime import date
+
+from src.providers.macro.fred import FREDProvider, US_FRED_SERIES
+
+
+class Response:
+    def __init__(self, payload): self.payload = payload
+    def raise_for_status(self): pass
+    def json(self): return self.payload
+
+
+class Session:
+    def get(self, url, params, timeout):
+        if url.endswith('/fred/series'):
+            return Response({'seriess': [{'title': 'Two Year', 'units': 'Percent', 'frequency': 'Daily'}]})
+        return Response({'observations': [{'date': '2026-07-18', 'value': '.'}, {'date': '2026-07-17', 'value': '3.25'}]})
+
+
+def test_fred_provider_skips_missing_observation():
+    observation = FREDProvider('test', session=Session()).fetch_latest('treasury_2y', 'DGS2')
+    assert observation and observation.value == 3.25
+    assert observation.observation_date == date(2026, 7, 17)
+    assert observation.unit == 'Percent'
+
+
+def test_us_series_mapping_is_explicit():
+    assert US_FRED_SERIES['policy_rate_upper'] == 'DFEDTARU'

--- a/tests/test_us_macro_market_data.py
+++ b/tests/test_us_macro_market_data.py
@@ -1,0 +1,16 @@
+import pandas as pd
+
+from src.services.us_macro_market_data import summarize_history
+
+
+def test_market_summary_calculates_returns_and_moving_averages():
+    dates = pd.date_range('2025-01-01', periods=205, freq='B')
+    history = pd.DataFrame({'close': range(100, 305)}, index=dates)
+    summary = summarize_history('sp500', 'SPX', history)
+    assert summary and summary['change_1d'] > 0
+    assert summary['above_ma_20'] is True
+    assert summary['above_ma_200'] is True
+
+
+def test_market_summary_returns_none_for_empty_history():
+    assert summarize_history('sp500', 'SPX', pd.DataFrame()) is None

--- a/tests/test_us_macro_market_symbols.py
+++ b/tests/test_us_macro_market_symbols.py
@@ -1,0 +1,8 @@
+from data_provider.yfinance_fetcher import YfinanceFetcher
+
+
+def test_yahoo_special_symbols_are_not_treated_as_a_share_codes():
+    fetcher = YfinanceFetcher()
+    assert fetcher._convert_stock_code("^GSPC") == "^GSPC"
+    assert fetcher._convert_stock_code("GC=F") == "GC=F"
+    assert fetcher._convert_stock_code("DX-Y.NYB") == "DX-Y.NYB"

--- a/tests/test_us_macro_network.py
+++ b/tests/test_us_macro_network.py
@@ -1,0 +1,26 @@
+"""Opt-in real FRED smoke test; never runs in default pytest."""
+
+import os
+
+import pytest
+
+from src.config import get_config
+from src.providers.macro.fred import FREDProvider
+
+pytestmark = pytest.mark.network
+
+
+@pytest.mark.skipif(
+    os.getenv("RUN_NETWORK_TESTS") != "true",
+    reason="set RUN_NETWORK_TESTS=true to enable real network tests",
+)
+def test_fred_dgs2_real_response_has_safe_boundary_fields():
+    key = get_config().fred_api_key
+    if not key:
+        pytest.skip("FRED_API_KEY is not configured")
+    observation = FREDProvider(key).fetch_latest("treasury_2y", "DGS2")
+    assert observation is not None
+    assert observation.value is not None and 0 < observation.value < 30
+    assert observation.unit
+    assert observation.observation_date is not None
+    assert observation.source_url.endswith("/DGS2")

--- a/tests/test_us_macro_report.py
+++ b/tests/test_us_macro_report.py
@@ -1,0 +1,79 @@
+from datetime import datetime, timezone
+
+from src.core.us_macro import run_us_macro_report
+from src.schemas.macro import MacroObservation
+from src.services.us_macro_report import USMacroReport, USMacroReportService
+
+
+class MarketService:
+    def fetch(self):
+        return ([
+            {"indicator": "vix", "symbol": "VIX", "value": 15.0, "change_1d": -1.0, "change_5d": -12.0},
+            {"indicator": "sp500", "symbol": "SPX", "value": 6000.0, "above_ma_20": True, "above_ma_50": True},
+        ], [])
+
+
+class FRED:
+    def fetch_latest(self, indicator, series_id):
+        values = {"treasury_2y": 4.0, "treasury_10y": 4.2}
+        if indicator not in values:
+            return None
+        return MacroObservation(
+            region="us", indicator=indicator, series_id=series_id, value=values[indicator], unit="Percent",
+            observation_date=datetime(2026, 7, 18, tzinfo=timezone.utc).date(), fetched_at=datetime.now(timezone.utc),
+            source_name="FRED", source_url="https://fred.example", frequency="Daily",
+        )
+
+
+def test_us_macro_report_degrades_without_fred_key():
+    report = USMacroReportService(market_service=MarketService()).build_report()
+    assert report.snapshot.observations == []
+    assert "未配置 FRED_API_KEY" in report.markdown
+    assert "市场快照" in report.markdown
+
+
+def test_us_macro_report_renders_rules_and_sources():
+    report = USMacroReportService(fred_provider=FRED(), market_service=MarketService()).build_report()
+    assert report.assessment["regime"] == "risk_on"
+    assert "[FRED](https://fred.example)" in report.markdown
+    assert "未来1周：偏多" in report.markdown
+
+
+def test_runtime_persists_saves_and_can_skip_notification(monkeypatch):
+    built = USMacroReportService(fred_provider=FRED(), market_service=MarketService()).build_report()
+
+    class Service:
+        def build_report(self):
+            return built
+
+    class Notifier:
+        def __init__(self):
+            self.saved = []
+            self.sent = []
+
+        def save_report_to_file(self, content, filename):
+            self.saved.append((content, filename))
+
+        def send(self, content, **kwargs):
+            self.sent.append((content, kwargs))
+            return True
+
+    monkeypatch.setattr("src.core.us_macro._persist_report", lambda report: 42)
+    notifier = Notifier()
+    report = run_us_macro_report(
+        config=object(), service=Service(), notifier=notifier,
+        send_notification=False, save_report_file=True, trigger_source="test",
+    )
+    assert report is built
+    assert notifier.saved[0][1] == "us_macro_report.md"
+    assert notifier.sent == []
+
+
+def test_fred_failure_logs_no_request_details(caplog):
+    class FailingFRED:
+        def fetch_latest(self, indicator, series_id):
+            raise RuntimeError("https://example.invalid/?api_key=must-not-appear")
+
+    USMacroReportService(fred_provider=FailingFRED(), market_service=MarketService()).build_report()
+    assert "must-not-appear" not in caplog.text
+    assert "RuntimeError" in caplog.text

--- a/tests/test_us_macro_rules.py
+++ b/tests/test_us_macro_rules.py
@@ -1,0 +1,16 @@
+from src.services.us_macro_rules import assess_us_macro
+
+
+def test_rules_return_neutral_low_when_data_is_insufficient():
+    result = assess_us_macro([], [])
+    assert result['horizons']['未来1周']['direction'] == '中性'
+    assert result['horizons']['未来1周']['confidence'] == '低'
+
+
+def test_rules_classify_risk_on_with_supporting_signals():
+    result = assess_us_macro([
+        {'indicator': 'vix', 'change_5d': -12},
+        {'indicator': 'sp500', 'above_ma_20': True, 'above_ma_50': True},
+    ], [{'indicator': 'treasury_2y', 'value': 4.0}, {'indicator': 'treasury_10y', 'value': 4.2}])
+    assert result['regime'] == 'risk_on'
+    assert result['horizons']['当日或下一交易日']['direction'] in ('偏多', '明显偏多')


### PR DESCRIPTION
<!--
For Chinese contributors: 请直接用中文填写。
For English contributors: please fill in English. All fields marked (EN) accept English.
-->

## PR Type

- [ ] fix
- [ ] feat
- [ ] refactor
- [ ] docs
- [ ] chore
- [ ] test

## Background And Problem

请描述当前问题、影响范围与触发场景。  
*(EN) Describe the problem, its impact, and what triggers it.*

## Scope Of Change

请列出本 PR 修改的模块和文件范围。  
*(EN) List the modules and files changed in this PR.*

> 注意：请按实际 `git diff` 全量列出文件范围（建议注明文件总数），避免遗漏文档/后端/API/前端文件导致描述不一致。

> 若本 PR 修改了 `.github/PULL_REQUEST_TEMPLATE.md`、`.github/copilot-instructions.md`、`AGENTS.md`、`.github/instructions/*` 或 `.claude/skills/**` 等协作与治理文件，请补充“变更原因 + 影响面 + 回滚方式（默认 revert）”到 Summary / Compatibility / Rollback，避免 Scope 与描述不一致。

> 建议先执行并粘贴以下命令输出，避免与实际 diff 不一致：

```bash
BASE_REF=$(git merge-base HEAD origin/main)
git diff --stat "$BASE_REF"..HEAD
git diff --name-only "$BASE_REF"..HEAD
```

- 文件总数 / 变更行数（建议粘贴 `git diff --stat "$BASE_REF"..HEAD`）：
- 文件清单（按实际 diff 全量，逐项列出）：
- 文档更新文件（`docs/*`）：

## Issue Link

必须填写以下之一 / Fill in one of:
- `Fixes #<issue_number>`
- `Refs #<issue_number>`
- 无 Issue 时说明原因与验收标准 / If no issue, explain the motivation and acceptance criteria

## Verification Commands And Results

请填写你实际执行过的命令和关键结果（不要只写"已测试"）。  
*(EN) Paste the commands you actually ran and their key output (don't just write "tested"):*

```bash
# example
./scripts/ci_gate.sh
python -m pytest -m "not network"
```

> `Full-suite note` 必须与当次 PR 的当前 Head CI 结果保持一致；若本地复现存在环境相关失败，请明确标注“本地环境差异”并给出 GitHub CI 的结论与链接。  
> 请避免保留与本 PR 无关的历史失败措辞，按本次实际结果填报。
> 如历史描述中仍保留 `./scripts/ci_gate.sh` 失败记录，请先改为当前 Head CI 状态或说明与 Head CI 的差异来源。
> 若 `Full-suite note` 与当前 Head CI 不一致，PR 文本不完整，请先更新 PR 描述后再提交。

- 请在下面按实际结果填写并与 `Full-suite note` 保持一致（任一未填视为信息缺失）：
  - ai-governance：`pass` / `fail`，附链接
  - backend-gate：`pass` / `fail`，附链接
  - docker-build：`pass` / `fail`，附链接
  - web-gate：`pass` / `fail`，附链接
  - 若本 PR 修改 `.github/PULL_REQUEST_TEMPLATE.md` 等流程模板协作文件，请先说明变更必要性、影响边界，并明确回滚方式（默认 `revert this PR`）；否则请在下一版中拆为单独 chore PR。

关键输出/结论 / Key output & conclusion:

- 【必填】当前 Head CI：`ai-governance:pass / backend-gate:pass / docker-build:pass / web-gate:pass`（按实际结果替换）并附对应链接。  
- 若需保留本地失败现象，请在同段写明“本地环境差异 + 当前 CI 通过/失败结果 + CI 链接”。  
- 若全部通过，需补充一句：`当前状态：全部通过（pass）`，并明确 Head CI 全部为 pass。  

- 建议将本行直接粘贴到 PR 描述正文首段：`当前 Head CI：ai-governance:pass / backend-gate:pass / docker-build:pass / web-gate:pass`（仅示例，按实际结果替换）。

> 若上述核验项与 PR 文本冲突，建议先更新 PR 描述再提交，避免审查因状态不一致被阻塞。

## Visual Evidence (if applicable)

【必填】若本 PR 修改报告格式、报告渲染效果或 Web UI 界面，请在此处附受影响报告 / 页面截图；涉及前后差异时，优先附前后对比。Issue / PR 过程截图、审查截图、一次性验收截图和临时可视证据请放在 PR 描述、PR 评论、GitHub 附件、Actions artifact 或外部可访问链接中，不要作为仓库文件合入。
*(EN) If this PR changes report formatting, report rendering, or Web UI, attach screenshots of the affected report/page here; before/after screenshots are preferred when relevant. Issue/PR process screenshots, review screenshots, one-off acceptance screenshots, and temporary visual evidence should be linked from the PR body/comments, GitHub attachments, Actions artifacts, or external accessible evidence; do not commit them as repository files.)*

> 如截图无法获取，请在“原因”中明确写明替代证据（如 Playwright/e2e 产物路径、审查链接）及其可追溯命令，不得留空。涉及 Web 设置/报告渲染变更时，需确保截图或替代证据明确指向变更项。
>
> 若本 PR 修改 Web UI，建议至少补一条可复现路径，例如（优先 settings page）：
>
> - Playwright 截图产物：`apps/dsa-web/e2e/smoke.spec.ts`（`cd apps/dsa-web && npx playwright test e2e/smoke.spec.ts --grep "settings page renders title and save actions after login"`）
> - 审查证据链接：可直接使用 Actions 产物、GitHub 评论附件或外部可访问链接。

> 替代证据模板（设置页变更建议）：
> - 命令：`cd apps/dsa-web && npx playwright test e2e/smoke.spec.ts --grep "settings page"`
> - 产物路径：`apps/dsa-web/test-results/**/smoke-settings-page-*.png`
> - 说明：截图中应可见本次修改的系统设置项（字段、标签、帮助文案）

- 截图链接 / Screenshot links（Web UI/报告改动项必填，未提供请在下方“不适用原因”给出替代证据）：
- settings 页建议命名：`smoke-settings-page-zh` / `smoke-settings-page-en`
- 前后对比 / Before & After（如有）：
- settings 字段变更说明：截图或产物应明确包含 `MARKET_REVIEW_REGION` 字段与帮助文案区块（中文/英文）。
- 不适用原因 / Reason if not applicable（若未附截图，此项务必填写，且包含可复现证据与命令）：
  - Playwright 命令（无截图时）：`cd apps/dsa-web && npx playwright test e2e/smoke.spec.ts --grep "settings page"`
  - 产物路径（无截图时）：`apps/dsa-web/test-results/**/smoke-settings-page-*.png`
  - 说明：截图（或产物）必须可见本次修改的设置字段文案与帮助信息。

> 若本 PR 修改 Web 设置字段（字段、文案或帮助文案），截图或替代证据必须可定位到对应设置项区域并可追溯至变更项；该项为必填。

> 若本 PR 修改 Web UI 或报告展示且无法获取截图，原因栏必须给出可复现替代证据（例如 Playwright 截图产物路径 + 命令），且不得留空。

## Compatibility And Risk

请说明兼容性影响、潜在风险（如无请写 `None`）。  
*(EN) Describe compatibility impact and potential risks (write `None` if not applicable).*

- 若本 PR 修改第三方模型 / API 的兼容语义、请求参数、路由前缀或 provider fallback，请提供**官方来源链接或公告**，并说明这是长期约束、当前运行时约束还是临时兼容处理。  
  请在下方补充所影响外部 API/服务、回归范围与回退方式。  
  *(EN) If this PR changes third-party model/API compatibility, request parameters, routing prefixes, or provider fallback behavior, include an **official source link or announcement** and clarify whether the rule is permanent, runtime-specific, or a temporary compatibility workaround.)*
- 若本 PR 未触及第三方模型/API、provider/model/base URL 或运行时配置保存/清理/迁移逻辑，请在此段直接按以下文案确认（无须再次展开）：  
  `本 PR 未变更 provider/model/base URL、运行时配置清理迁移语义；历史配置保持不变；回滚方式为 revert 本提交。`
- 若本 PR 修改 `.github/PULL_REQUEST_TEMPLATE.md` / PR 流程模板类文件，请在此明确：仅影响协作流程与模板维护，不改 runtime 行为；回退方式为 revert；并补充是否影响自动化提交流程。  
  *(EN) If this PR changes `.github/PULL_REQUEST_TEMPLATE.md` or other PR workflow files, state that it only affects contribution governance templates (no runtime behavior), provide rollback by revert, and note any CI/checklist impact.)*
- 若本 PR 依赖特定运行时 / 锁定依赖窗口（例如 LiteLLM 版本范围、OpenAI-compatible 路由、YAML alias 行为），请写明当前验证过的兼容范围与覆盖路径。  
  *(EN) If this PR depends on a specific runtime or pinned dependency window (for example a LiteLLM version range, OpenAI-compatible routing, or YAML alias behavior), state the compatibility window you verified and which code paths were covered.)*
- 若本 PR 触及运行时配置保存、清理、迁移或回填逻辑，请明确说明旧配置是否会被自动改写、清空、迁移或保持不变，以及用户如何恢复原行为。  
  *(EN) If this PR touches runtime config save/cleanup/migration/backfill logic, explicitly describe whether existing config is rewritten, cleared, migrated, or left intact, and how users can restore the previous behavior.)*
- 若本 PR **未触及** provider/model/base URL 或运行时配置保存/清理/迁移逻辑（本条仅作为声明），请明确写：`本 PR 未变更 provider/model/base URL、运行时配置清理迁移语义；历史配置保持不变；回滚方式为 revert 本提交。`

## Rollback Plan

请至少写一句可执行的回滚方案（必填）。  
*(EN) Provide at least one actionable rollback step (required).*

- 如果是兼容性修复，默认应写出**最小回滚方式**（例如 `revert this PR`），并说明是否需要额外回滚配置或数据迁移。  
  *(EN) For compatibility fixes, include the **minimal rollback path** (for example `revert this PR`) and whether any additional config or data rollback is required.)*

## EXTRACT_PROMPT Change (if applicable)

若本 PR 修改了 `src/services/image_stock_extractor.py` 中的 `EXTRACT_PROMPT`，请在此处粘贴完整变更后的 prompt。  
*If this PR changes `EXTRACT_PROMPT` in `src/services/image_stock_extractor.py`, paste the full updated prompt here:*

<details>
<summary>展开 / Expand: Full EXTRACT_PROMPT</summary>

```
(paste full prompt here)
```

</details>

## Checklist

- [ ] 本 PR 有明确动机和业务价值 / This PR has a clear motivation and value
- [ ] 已提供可复现的验证命令与结果 / Reproducible verification commands and results are included
- [ ] 已评估兼容性与风险 / Compatibility and risk have been assessed
- [ ] 已提供回滚方案 / A rollback plan is provided
- [ ] 若修改报告格式或 Web UI 界面，已在 PR 描述/评论附受影响报告 / 页面截图，且未把一次性验收截图作为仓库文件合入 / If report formatting or Web UI changed, affected report/page screenshots are linked in the PR body/comments and one-off acceptance screenshots are not committed as repository files
- [ ] 若本 PR 修改 Web 设置字段（字段、文案或帮助文本），请补充设置页截图；无法截图时需提供替代可视证据（命令 + 产物路径），并指向对应变更项 / If Web settings fields changed (labels or help text), screenshots of the settings page are required; if unavailable, provide alternative visual evidence with command + artifact path that points to the changed item.
- [ ] 若涉及用户可见变更，已同步更新相关文档与 `docs/CHANGELOG.md`；`README.md` 仅在首页级信息变化时更新，细节优先写入 `docs/*.md` / If user-visible changes are included, relevant docs and `docs/CHANGELOG.md` are updated; `README.md` is updated only for homepage-level changes, with details kept in `docs/*.md`
