### PR TITLE
fix(ci): allow fork PR head checkout in pr-review workflow (fixes #2051)

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -52,6 +52,11 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
           fetch-depth: 0
+          # pr-review.yml 触发于 pull_request_target，运行在 base 仓库的 trusted 上下文
+          # （GITHUB_TOKEN、secrets、default-branch cache）。GitHub 自 2024 起对 pull_request_target
+          # 下检出 fork PR head 默认拒绝，需显式 opt-in。本 job 仅做 `git diff --name-only` 静态
+          # 检查敏感文件，不执行 PR 代码、不安装 PR 依赖，可安全 opt-in。详见 issue #2051。
+          allow-unsafe-pr-checkout: true
       
       - name: 🔄 获取 base 分支
         run: git fetch origin ${{ github.base_ref || 'main' }}:refs/remotes/origin/${{ github.base_ref || 'main' }}
@@ -96,7 +101,11 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
           fetch-depth: 0
-      
+          # auto-check 仅做 `git diff --name-only` + `python -m py_compile`（字节码编译，不 import
+          # PR 代码逻辑）+ `flake8 --select=E9,F63,F7,F82`（静态语法/未定义名检查，不执行 PR
+          # 代码）。pip install 仅装 flake8 工具本身，不装 PR 依赖。本 job 是 review-only workflow，
+          # 可安全 opt-in fork PR head 检出。详见 issue #2051。
+          allow-unsafe-pr-checkout: true
       - name: 🔄 获取 base 分支
         run: git fetch origin ${{ github.base_ref || 'main' }}:refs/remotes/origin/${{ github.base_ref || 'main' }}
       
@@ -213,6 +222,12 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
           fetch-depth: 0
           path: pr-code
+          # ai-review 子步骤 `python ../main-scripts/.github/scripts/ai_review.py` 跑的是
+          # 上面检出的 **base 仓库** 的 ai_review.py（路径 `main-scripts/.github/scripts/`），
+          # PR 代码仅作为 git diff 输入被该脚本静态分析，不 import、不执行 PR 提交的 Python 模块；
+          # pip install 只装工具链 google-genai/openai/httpx，不装 PR 依赖，可安全 opt-in。
+          # 详见 issue #2051。
+          allow-unsafe-pr-checkout: true
       
       - name: 🔄 获取 base 分支
         working-directory: pr-code
@@ -259,6 +274,11 @@ jobs:
     steps:
       - name: 📥 检出代码
         uses: actions/checkout@v5
+        with:
+          # labeler 仅用 actions/github-script 调用 GitHub API 做 PR 文件分类与 addLabels，
+          # 不读 PR checkout 内容。保留 checkout 与 opt-in 主要为防御性一致和未来 labeler
+          # 步骤可能用到的内容读取；当前 step 实际无 checkout 依赖。详见 issue #2051。
+          allow-unsafe-pr-checkout: true
       
       - name: 🏷️ 添加标签
         if: github.event_name == 'pull_request_target'
@@ -342,6 +362,12 @@ jobs:
         uses: actions/checkout@v5
         with:
           fetch-depth: 0
+          # comment job 用 actions/github-script 调用 GitHub API 生成审查报告评论
+          # （listFiles / listComments / createComment / updateComment）。读 ai_review_result.txt
+          # 来自 ai-review job 上传的 artifact，不依赖 checkout 的文件内容也不执行 PR 代码，
+          # 但由于 pull_request_target 触发时默认 ref 仍指向 fork PR merge commit，需要 opt-in
+          # 避免 GitHub 拒绝 checkout。详见 issue #2051。
+          allow-unsafe-pr-checkout: true
       
       - name: 📥 下载 AI 审查结果
         uses: actions/download-artifact@v7

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 <!-- 新条目格式：- [类型] 描述（类型取值：新功能/改进/修复/文档/测试/chore）-->
 <!-- 每条独立一行追加到本段末尾，无需分类标题，合并时冲突最小 -->
 - [修复] #2026 外股代码映射到中文显示名时英文新闻相关性判定漏判：新增同源 STOCK_ENGLISH_NAME_MAP 单一真源、canonicalize_foreign_stock_code 规范化入口与 _foreign_english_query_terms 别名解析，使 AAPL/00700/BABA 等 ticker 即使 stock_name 为中文也能在查询构建、相关性打分与多维度情报路径上复用 canonical 英文名，并补齐 .US/.HK suffix / HK 前缀全形式的归类与回归用例；同时在 _score_news_relevance 对 alias 展开 term 做去重，避免 legal alias 展开短名与显式 short alias 重复计分。
+- [修复] #2051 `.github/workflows/pr-review.yml` 在 `pull_request_target` 触发下检出 fork PR head 被 GitHub 默认拒绝，导致 `security-check` 失败、`auto-check`/`ai-review`/`labeler`/`comment` 串行依赖全 skip、fork PR 无 AI 审查报告：为 `security-check`、`auto-check`、`ai-review`（PR 代码检出）、`labeler`、`comment` 5 个 review-only job 显式 opt-in `allow-unsafe-pr-checkout: true`；这些 job 仅做 `git diff`、`py_compile`/`flake8` 静态检查、跑 base 仓库 `ai_review.py` 脚本对 PR diff 做静态分析、GitHub API 评论回写，不 import / 不执行 PR 提交的 Python 模块、不安装 PR 依赖；同步 `docs/CONTRIBUTING.md` / `docs/CONTRIBUTING_EN.md` CI 表格补 pr-review 行说明。
 
 ## [3.27.0] - 2026-07-19
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -81,6 +81,7 @@ docs: 更新 README 部署说明
 | backend-gate | `scripts/ci_gate.sh`（py_compile + flake8 严重错误 + 本地核心脚本 + offline pytest） | ✅ |
 | docker-build | Docker 镜像构建与关键模块导入 smoke | ✅ |
 | web-gate | 前端变更时执行 `npm run lint` + `npm run build` | ✅（触发时） |
+| pr-review | review-only workflow（`pull_request_target` 触发）：敏感文件标记、Python 语法/`flake8` 静态检查、AI 审查、自动标签、审查报告评论。本工作流仅做静态分析与评论回写，不执行 PR 提交的代码、不安装 PR 依赖；仅在 PR head 显式 opt-in `allow-unsafe-pr-checkout: true` 后才会检出 fork PR 的提交用于 `git diff` 和静态诊断。详见 `.github/workflows/pr-review.yml` | ❌（辅助项） |
 | network-smoke | 定时/手动执行 `pytest -m network` + `scripts/test.sh quick`（非阻断） | ❌（观测项） |
 
 **本地运行检查：**

--- a/docs/CONTRIBUTING_EN.md
+++ b/docs/CONTRIBUTING_EN.md
@@ -83,6 +83,7 @@ After opening a PR, CI will automatically run the following PR checks:
 | `backend-gate` | `scripts/ci_gate.sh` — py_compile + flake8 critical errors + `./scripts/test.sh code` + `./scripts/test.sh yfinance` + offline pytest | ✅ |
 | `docker-build` | Docker image build and key module import smoke test | ✅ |
 | `web-gate` | `npm run lint` + `npm run build` (triggered when `apps/dsa-web/` changes) | ✅ (when triggered) |
+| `pr-review` | review-only workflow triggered by `pull_request_target`: sensitive-file flagging, Python syntax / `flake8` static checks, AI review, auto labels, and a review report comment. The workflow only performs static analysis and comment writeback; it never executes PR-supplied code or installs PR dependencies. A fork PR's commits are checked out only after the PR head opts in via `allow-unsafe-pr-checkout: true`, and that checkout is used solely for `git diff` and static diagnostics. See `.github/workflows/pr-review.yml`. | ❌ (advisory) |
 
 Separately, the repository also has a non-blocking `network-smoke` workflow in `.github/workflows/network-smoke.yml`, but it is only triggered by `schedule` and `workflow_dispatch`, not by pull requests.
 


### PR DESCRIPTION
## Summary

Closes #2051.

Fixes the `🔒 安全检查` (security-check) job in `.github/workflows/pr-review.yml` failing on every fork PR — caused by GitHub rejecting `actions/checkout@v5` with explicit `ref: ${{ github.event.pull_request.head.sha || github.sha }}` under `pull_request_target` workflows unless the step opts in via `allow-unsafe-pr-checkout: true`. The downstream `auto-check` / `ai-review` / `labeler` / `comment` jobs are then skipped via their `needs` chain, leaving fork PRs without AI review, auto labels, or a review report comment.

This is also the root blocker behind the `BLOCKED` merge state of #2048 and #2050 (the fork-PR review pipeline cannot complete to satisfy branch protection).

## Changes

Add `allow-unsafe-pr-checkout: true` to 5 review-only checkout steps that need it. Each step's comment notes why opt-in is safe:

| Job | Step | Why opt-in is safe |
| --- | --- | --- |
| `security-check` | 检出代码 | only `git diff --name-only` to flag sensitive files; never imports/executes PR code, never installs PR deps |
| `auto-check` | 检出代码 | `git diff --name-only` + `python -m py_compile` (bytecode compile, no import) + `flake8 --select=E9,F63,F7,F82` (static syntax / undefined-name check); `pip install` only installs the flake8 tool, not PR deps |
| `ai-review` | 检出 PR 代码 | runs the base-repo `main-scripts/.github/scripts/ai_review.py` against the PR diff as static input; pip install only installs google-genai/openai/httpx, not PR deps |
| `labeler` | 检出代码 | uses `actions/github-script` with GitHub API; checkout is currently redundant, kept with opt-in for defensive consistency |
| `comment` | 检出代码 | uses `actions/github-script` for PR comment writeback; default ref under `pull_request_target` still points at the fork PR merge commit, so opt-in is needed to avoid rejection |

The `ai-review` job's separate `actions/checkout@v5` of `${{ github.event.repository.default_branch }}` for `main-scripts/.github/scripts/ai_review.py` is **not** modified — that ref is the base repo's default branch, not a fork PR ref, so GitHub does not reject it.

## Scope intentionally limited

This PR **only** modifies `.github/workflows/pr-review.yml` (review-only pipeline) plus the contributor docs that describe it. It specifically does **not** modify:
- `.github/workflows/ci.yml` (`backend-gate` / `web-gate` / `docker-build`) — these genuinely execute PR code (`pytest`, `npm run build`, Docker image build) and **must keep** their default GitHub-side fork-checkout safety.
- `.github/workflows/network-smoke.yml` — scheduled / `workflow_dispatch` only, not `pull_request_target`.

## Mapping to the OpenReview Bot's 5 action items on #2051

1. ✅ "至少 security-check、auto-check、ai-review、review-comment、approve-comment 都需要保持一致" — covered (labeler / comment are the current names for what the bot called review-comment / approve-comment).
2. ✅ "确认这些 job 确实只做 git diff、文件分析、评论回写这类只读审查动作" — verified per step above; none of the 5 checkouts result in PR code being imported or executed, and none install PR-supplied dependencies.
3. ✅ "把行为变化记到 `docs/CHANGELOG.md`" — added under `[Unreleased]` as a `[修复] #2051` flat-format entry.
4. ✅ "full-guide.md / full-guide_EN.md 顺手补一句" — the fork-PR Actions documentation lives in `docs/CONTRIBUTING.md` / `docs/CONTRIBUTING_EN.md` (the CI table at "CI 自动检查" / "PR checks"), so the new `pr-review` row was added there rather than in `full-guide.md`, which is the fork-user secrets/configuration guide and does not document CI workflows.
5. ✅ "PR 描述里把受影响文件限定为 `.github/workflows/pr-review.yml`，并明确说明不会扩大到 `backend-gate`、`web-gate`" — see "Scope intentionally limited" above.

## Verification
- `python -c "import yaml; yaml.safe_load(open('.github/workflows/pr-review.yml'))"` passes (workflow YAML syntactically valid).
- `scripts/check_ai_assets.py` passes (no AI asset metadata drift introduced).
- End-to-end verification cannot be done locally — the actual `pull_request_target` behavior only fires on GitHub. Once this PR is merged, the next fork PR opened against `main` will exercise the workflow; the existing fork PRs #2048 and #2050 will also gain review reports / labels on their next push (or via a `workflow_dispatch` rerun).

## Risk

- **Workflow syntax**: opt-in key spelled exactly `allow-unsafe-pr-checkout: true` per `actions/checkout@v5` documentation; YAML linted valid.
- **Behavior change**: behavior change is limited to "fork PRs now actually receive `pr-review` outputs (sensitive-file flag, syntax/flake8 diagnostics, AI review report, auto labels, review report comment) instead of being silently skipped". For non-fork PRs the `pull_request_target` trigger does not fire (the workflow's `on:` lists `pull_request_target` only — same-origin PRs use a different path or are still gated by the same `pr-review` workflow runs), so this PR does not change shout-origin review behavior.
- **Security boundary**: the 5 jobs modified are all review-only (per the bot's #2051 risk assessment); `ci.yml` / `network-smoke.yml` retain their default fork-checkout safety and are untouched.

## Verification update (post-PR-creation)

The `🔒 安全检查` (security-check) job on this PR run still failed (run [#29832070296](https://github.com/ZhuLinsen/daily_stock_analysis/actions/runs/29832070296)) — **this is expected and does not contradict the fix.** The reason is documented in GitHub's `pull_request_target` security model:

> Workflows triggered by `pull_request_target` always use the workflow file from the **base repository's default branch** (i.e. `main`), never the workflow file from the PR head.

Therefore the modified `.github/workflows/pr-review.yml` in this PR head is **not** the workflow that ran for this PR. The run used the pre-fix `pr-review.yml` currently on `main`, which has no `allow-unsafe-pr-checkout: true` opt-in — so `actions/checkout@v5` refused the fork PR head ref with the canonical "Refusing to check out fork pull request code from a 'pull_request_target' workflow" error, exactly the bug this PR fixes.

This is precisely the chicken-and-egg problem noted in issue #2051: a fork PR cannot fix `pr-review.yml` and verify the fix on its own run — the fix must be landed on `main` by a maintainer first, and the next fork PR opened afterward will exercise the corrected workflow. Existing fork PRs (e.g. #2048, #2050) will pick up the corrected `pr-review.yml` after this PR is merged into `main` and they are either re-pushed or have their `pr-review` workflow re-run via `workflow_dispatch` / push.

Local verifications still performed and passing:
- `python -c "import yaml; yaml.safe_load(open('.github/workflows/pr-review.yml'))"` — workflow YAML syntactically valid.
- `scripts/check_ai_assets.py` — no AI asset metadata drift introduced.

Once merged, the efficacy check is: the next fork PR against `main` should see `🔒 安全检查 ✅`, `🔍 静态检查 ✅` (or ⚠️ if PR has syntax issues), `🤖 AI 代码审查 ✅`, `🏷️ 自动标签 ✅`, `💬 审查报告 ✅` instead of the current `🔒 安全检查 ❌` + downstream skipped.