### PR TITLE
fix: 安全恢复 fork PR 自动审查

### DIFF
--- a/.github/scripts/ai_review.py
+++ b/.github/scripts/ai_review.py
@@ -2,16 +2,21 @@
 """
 AI code review script used by GitHub Actions PR Review workflow.
 """
+import fnmatch
 import json
 import os
 import subprocess
 import traceback
+import urllib.error
+import urllib.request
 
 
 MAX_DIFF_LENGTH = 18000
 REVIEW_PATHS = [
     '*.py',
     '*.md',
+    '*.ts',
+    '*.tsx',
     'README.md',
     'AGENTS.md',
     'docs/**',
@@ -21,9 +26,15 @@ REVIEW_PATHS = [
     'pyproject.toml',
     'setup.cfg',
     '.github/workflows/*.yml',
+    '.github/workflows/*.yaml',
     '.github/scripts/*.py',
     'apps/dsa-web/**',
+    'docker/Dockerfile',
+    'docker-compose.yml',
 ]
+
+GITHUB_API_PAGE_SIZE = 100
+GITHUB_API_MAX_PAGES = 30
 
 
 def run_git(args):
@@ -35,33 +46,146 @@ def run_git(args):
     return result.stdout.strip()
 
 
+def _event_payload():
+    event_path = os.environ.get('GITHUB_EVENT_PATH')
+    if not event_path or not os.path.exists(event_path):
+        return {}
+    try:
+        with open(event_path, 'r', encoding='utf-8') as f:
+            return json.load(f)
+    except (OSError, ValueError):
+        return {}
+
+
+def _pull_request_number(payload=None):
+    configured = os.environ.get('PR_NUMBER', '').strip()
+    if configured:
+        return int(configured)
+
+    payload = payload if payload is not None else _event_payload()
+    pull_request = payload.get('pull_request') or {}
+    number = pull_request.get('number') or payload.get('number')
+    if not number:
+        raise RuntimeError('PR number is unavailable for GitHub API review')
+    return int(number)
+
+
+def _github_api_json(path):
+    api_url = os.environ.get('GITHUB_API_URL', 'https://api.github.com').rstrip('/')
+    token = os.environ.get('GITHUB_TOKEN', '').strip()
+    headers = {
+        'Accept': 'application/vnd.github+json',
+        'X-GitHub-Api-Version': '2022-11-28',
+        'User-Agent': 'daily-stock-analysis-pr-review',
+    }
+    if token:
+        headers['Authorization'] = f'Bearer {token}'
+
+    request = urllib.request.Request(f'{api_url}{path}', headers=headers)
+    try:
+        with urllib.request.urlopen(request, timeout=30) as response:
+            return json.load(response)
+    except (urllib.error.HTTPError, urllib.error.URLError, ValueError) as exc:
+        raise RuntimeError(f'GitHub API request failed for {path}: {exc}') from exc
+
+
+def _github_repository():
+    repository = os.environ.get('GITHUB_REPOSITORY', '').strip()
+    if repository.count('/') != 1:
+        raise RuntimeError('GITHUB_REPOSITORY must use owner/name format')
+    return repository
+
+
+def _fetch_pull_files():
+    repository = _github_repository()
+    pull_number = _pull_request_number()
+    files = []
+
+    for page in range(1, GITHUB_API_MAX_PAGES + 1):
+        batch = _github_api_json(
+            f'/repos/{repository}/pulls/{pull_number}/files'
+            f'?per_page={GITHUB_API_PAGE_SIZE}&page={page}'
+        )
+        if not isinstance(batch, list):
+            raise RuntimeError('GitHub pull files response is not a list')
+        files.extend(batch)
+        if len(batch) < GITHUB_API_PAGE_SIZE:
+            return files
+
+    raise RuntimeError('GitHub pull files response exceeded the 3000-file API limit')
+
+
+def _is_review_path(filename):
+    return any(fnmatch.fnmatchcase(filename, pattern) for pattern in REVIEW_PATHS)
+
+
+def _build_api_diff(files):
+    chunks = []
+    for file_info in files:
+        filename = file_info.get('filename', '')
+        if not filename or not _is_review_path(filename):
+            continue
+
+        status = file_info.get('status')
+        previous = file_info.get('previous_filename') or filename
+        old_path = '/dev/null' if status == 'added' else f'a/{previous}'
+        new_path = '/dev/null' if status == 'removed' else f'b/{filename}'
+        patch = file_info.get('patch')
+        if not patch:
+            patch = '@@ Patch unavailable from GitHub API (binary or truncated file) @@'
+        chunks.append(
+            f'diff --git a/{previous} b/{filename}\n'
+            f'--- {old_path}\n'
+            f'+++ {new_path}\n'
+            f'{patch}'
+        )
+    return '\n'.join(chunks)
+
+
+def get_review_data():
+    """Return review diff, changed paths, and truncation without executing PR code."""
+    if os.environ.get('AI_REVIEW_SOURCE') == 'github_api':
+        pull_files = _fetch_pull_files()
+        files = [
+            item.get('filename', '')
+            for item in pull_files
+            if item.get('filename') and _is_review_path(item['filename'])
+        ]
+        diff = _build_api_diff(pull_files)
+    else:
+        base_ref = os.environ.get('GITHUB_BASE_REF', 'main')
+        diff = run_git(['git', 'diff', f'origin/{base_ref}...HEAD', '--', *REVIEW_PATHS])
+        output = run_git(['git', 'diff', '--name-only', f'origin/{base_ref}...HEAD', '--', *REVIEW_PATHS])
+        files = output.split('\n') if output else []
+
+    truncated = len(diff) > MAX_DIFF_LENGTH
+    return diff[:MAX_DIFF_LENGTH], files, truncated
+
+
 def get_diff():
     """Get PR diff content for review-relevant files."""
-    base_ref = os.environ.get('GITHUB_BASE_REF', 'main')
-    diff = run_git(['git', 'diff', f'origin/{base_ref}...HEAD', '--', *REVIEW_PATHS])
-    truncated = len(diff) > MAX_DIFF_LENGTH
-    return diff[:MAX_DIFF_LENGTH], truncated
+    diff, _, truncated = get_review_data()
+    return diff, truncated
 
 
 def get_changed_files():
     """Get changed file list for review-relevant files."""
-    base_ref = os.environ.get('GITHUB_BASE_REF', 'main')
-    output = run_git(['git', 'diff', '--name-only', f'origin/{base_ref}...HEAD', '--', *REVIEW_PATHS])
-    return output.split('\n') if output else []
+    _, files, _ = get_review_data()
+    return files
 
 
 def get_pr_context():
     """Read PR title/body from GitHub event payload when available."""
-    event_path = os.environ.get('GITHUB_EVENT_PATH')
-    if not event_path or not os.path.exists(event_path):
-        return '', ''
-    try:
-        with open(event_path, 'r', encoding='utf-8') as f:
-            payload = json.load(f)
-        pr = payload.get('pull_request', {})
-        return (pr.get('title') or '').strip(), (pr.get('body') or '').strip()
-    except Exception:
-        return '', ''
+    payload = _event_payload()
+    pr = payload.get('pull_request') or {}
+    if not pr and os.environ.get('AI_REVIEW_SOURCE') == 'github_api':
+        try:
+            repository = _github_repository()
+            number = _pull_request_number(payload)
+            pr = _github_api_json(f'/repos/{repository}/pulls/{number}')
+        except (RuntimeError, ValueError):
+            pr = {}
+    return (pr.get('title') or '').strip(), (pr.get('body') or '').strip()
 
 
 def classify_files(files):
@@ -80,6 +204,12 @@ def _build_ci_context():
     auto_check_result = os.environ.get('CI_AUTO_CHECK_RESULT', '')
     syntax_ok = os.environ.get('CI_SYNTAX_OK', '')
     has_py = os.environ.get('CI_HAS_PY_CHANGES', 'false')
+
+    if os.environ.get('CI_DELEGATED_TO_PULL_REQUEST', '').lower() == 'true':
+        return """
+## CI 检查状态
+> Python 语法、Flake8、确定性检查和离线测试由独立的 `pull_request` CI / `backend-gate` 执行。本审查工作流不在带 secrets 的 `pull_request_target` 上执行 PR 代码，也不假设并行 CI 已通过；合入判断必须核对当前 Head 的实际 CI 结果。
+"""
 
     if not auto_check_result:
         return """
@@ -251,8 +381,7 @@ def ai_review(diff_content, files, truncated):
 
 
 def main():
-    diff, truncated = get_diff()
-    files = get_changed_files()
+    diff, files, truncated = get_review_data()
 
     if not diff or not files:
         print("没有可审查的代码/文档/配置变更，跳过 AI 审查")

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -1,5 +1,5 @@
-# PR 自动审查 - 语法检查 + AI 语义审查
-# 当有 PR 创建或更新时自动触发
+# PR 自动审查 - 元数据检查 + AI 语义审查
+# 特权 pull_request_target 流程只读取 GitHub API 数据，不检出或执行 fork PR 代码。
 
 name: PR Review
 
@@ -24,180 +24,103 @@ on:
       - '.github/scripts/**'
       - 'docker/Dockerfile'
       - 'docker-compose.yml'
-  # 支持手动触发（用于重新审查）
   workflow_dispatch:
+    inputs:
+      pr_number:
+        description: 要重新审查的 PR 编号
+        required: true
+        type: number
 
-# 限制并发，避免同一 PR 多次触发时重复评论
 concurrency:
-  group: pr-review-${{ github.event.pull_request.number || github.run_id }}
+  group: pr-review-${{ github.event.pull_request.number || inputs.pr_number || github.run_id }}
   cancel-in-progress: true
 
 permissions:
   contents: read
-  pull-requests: write
-  issues: write
 
 jobs:
-  # ==================== 安全检查（检测敏感文件修改）====================
+  # ==================== 安全检查（仅通过 API 读取 PR 元数据）====================
   security-check:
     name: 🔒 安全检查
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
     outputs:
       safe_to_run: ${{ steps.check_sensitive.outputs.safe_to_run }}
       sensitive_files_changed: ${{ steps.check_sensitive.outputs.sensitive_files_changed }}
-    
+      has_py_changes: ${{ steps.check_sensitive.outputs.has_py_changes }}
+      has_reviewable_changes: ${{ steps.check_sensitive.outputs.has_reviewable_changes }}
+
     steps:
-      - name: 📥 检出代码
-        uses: actions/checkout@v5
-        with:
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
-          fetch-depth: 0
-      
-      - name: 🔄 获取 base 分支
-        run: git fetch origin ${{ github.base_ref || 'main' }}:refs/remotes/origin/${{ github.base_ref || 'main' }}
-      
       - name: 🔒 检查敏感文件修改
         id: check_sensitive
-        run: |
-          BASE_REF="${{ github.base_ref || 'main' }}"
-          SENSITIVE_FILES=$(git diff --name-only origin/$BASE_REF...HEAD | grep -E '^(\.github/workflows/.*\.yml|\.github/scripts/.*\.py)$' || echo "")
-          
-          if [ -n "$SENSITIVE_FILES" ]; then
-            echo "⚠️ **检测到敏感文件修改，需要人工审核！**" >> $GITHUB_STEP_SUMMARY
-            echo "" >> $GITHUB_STEP_SUMMARY
-            echo "修改的敏感文件：" >> $GITHUB_STEP_SUMMARY
-            echo '```' >> $GITHUB_STEP_SUMMARY
-            echo "$SENSITIVE_FILES" >> $GITHUB_STEP_SUMMARY
-            echo '```' >> $GITHUB_STEP_SUMMARY
-            echo "" >> $GITHUB_STEP_SUMMARY
-            echo "已标记为敏感变更，请重点人工复核；自动流程继续执行。" >> $GITHUB_STEP_SUMMARY
-            echo "sensitive_files_changed=true" >> $GITHUB_OUTPUT
-            echo "safe_to_run=true" >> $GITHUB_OUTPUT
-          else
-            echo "✅ 未检测到敏感文件修改" >> $GITHUB_STEP_SUMMARY
-            echo "sensitive_files_changed=false" >> $GITHUB_OUTPUT
-            echo "safe_to_run=true" >> $GITHUB_OUTPUT
-          fi
-
-  # ==================== 静态检查（先于 AI 审查）====================
-  auto-check:
-    name: 🔍 静态检查
-    runs-on: ubuntu-latest
-    needs: [security-check]
-    if: needs.security-check.outputs.safe_to_run == 'true'
-    outputs:
-      syntax_ok: ${{ steps.syntax.outputs.syntax_ok }}
-      has_py_changes: ${{ steps.check_files.outputs.has_py_changes }}
-      has_reviewable_changes: ${{ steps.check_files.outputs.has_reviewable_changes }}
-    
-    steps:
-      - name: 📥 检出代码
-        uses: actions/checkout@v5
+        uses: actions/github-script@v8
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number || inputs.pr_number }}
         with:
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
-          fetch-depth: 0
-      
-      - name: 🔄 获取 base 分支
-        run: git fetch origin ${{ github.base_ref || 'main' }}:refs/remotes/origin/${{ github.base_ref || 'main' }}
-      
-      - name: 🐍 设置 Python
-        uses: actions/setup-python@v6
-        with:
-          python-version: '3.11'
-          cache: 'pip'
-      
-      - name: 📦 安装依赖
-        run: |
-          pip install --upgrade pip
-          pip install flake8
-      
-      - name: 📋 检查变更文件
-        id: check_files
-        run: |
-          BASE_REF="${{ github.base_ref || 'main' }}"
-          CHANGED_FILES=$(git diff --name-only origin/$BASE_REF...HEAD -- '*.py' 2>/dev/null || echo "")
-          REVIEWABLE_FILES=$(git diff --name-only origin/$BASE_REF...HEAD -- '*.py' '*.md' 'docs/**' 'README.md' 'AGENTS.md' 'requirements.txt' '.github/requirements-ci.txt' 'pyproject.toml' 'setup.cfg' '.github/PULL_REQUEST_TEMPLATE.md' '.github/workflows/**' '.github/scripts/**' 2>/dev/null || echo "")
+          script: |
+            const pullNumber = Number(process.env.PR_NUMBER);
+            if (!Number.isInteger(pullNumber) || pullNumber <= 0) {
+              core.setFailed('A valid PR number is required.');
+              return;
+            }
 
-          if [ -z "$REVIEWABLE_FILES" ]; then
-            echo "has_reviewable_changes=false" >> $GITHUB_OUTPUT
-          else
-            echo "has_reviewable_changes=true" >> $GITHUB_OUTPUT
-          fi
+            const files = await github.paginate(github.rest.pulls.listFiles, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: pullNumber,
+              per_page: 100
+            });
 
-          if [ -z "$CHANGED_FILES" ]; then
-            echo "has_py_changes=false" >> $GITHUB_OUTPUT
-            echo "✅ 没有修改 Python 文件" >> $GITHUB_STEP_SUMMARY
-          else
-            echo "has_py_changes=true" >> $GITHUB_OUTPUT
-            echo "CHANGED_FILES<<EOF" >> $GITHUB_ENV
-            echo "$CHANGED_FILES" >> $GITHUB_ENV
-            echo "EOF" >> $GITHUB_ENV
-          fi
-      
-      - name: 🐍 Python 语法检查
-        id: syntax
-        if: steps.check_files.outputs.has_py_changes == 'true'
-        run: |
-          echo "## 🐍 语法检查" >> $GITHUB_STEP_SUMMARY
-          echo "检查文件: $CHANGED_FILES"
-          
-          ERRORS=""
-          SYNTAX_OK="true"
-          for file in $CHANGED_FILES; do
-            if [ -f "$file" ]; then
-              if ! python -m py_compile "$file" 2>&1; then
-                ERRORS="$ERRORS\n❌ $file 语法错误"
-                SYNTAX_OK="false"
-              fi
-            fi
-          done
-          
-          echo "syntax_ok=$SYNTAX_OK" >> $GITHUB_OUTPUT
-          
-          if [ "$SYNTAX_OK" = "false" ]; then
-            echo -e "$ERRORS" >> $GITHUB_STEP_SUMMARY
-            exit 1
-          else
-            echo "✅ 所有文件语法正确" >> $GITHUB_STEP_SUMMARY
-          fi
-      
-      - name: 🔎 Flake8 检查（严重错误）
-        if: steps.check_files.outputs.has_py_changes == 'true'
-        run: |
-          echo "## 🔎 代码质量检查" >> $GITHUB_STEP_SUMMARY
-          RESULT=$(flake8 $CHANGED_FILES --select=E9,F63,F7,F82 --format='%(path)s:%(row)d: %(code)s %(text)s' 2>/dev/null || true)
-          if [ -n "$RESULT" ]; then
-            echo "⚠️ 发现以下问题：" >> $GITHUB_STEP_SUMMARY
-            echo '```' >> $GITHUB_STEP_SUMMARY
-            echo "$RESULT" >> $GITHUB_STEP_SUMMARY
-            echo '```' >> $GITHUB_STEP_SUMMARY
-            exit 1
-          else
-            echo "✅ 未发现严重代码问题" >> $GITHUB_STEP_SUMMARY
-          fi
-      
-      - name: 📊 变更统计
-        run: |
-          BASE_REF="${{ github.base_ref || 'main' }}"
-          echo "## 📊 变更统计" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          STATS=$(git diff --stat origin/$BASE_REF...HEAD 2>/dev/null | tail -1)
-          echo "$STATS" >> $GITHUB_STEP_SUMMARY
+            const sensitive = files
+              .map(file => file.filename)
+              .filter(filename => /^(\.github\/workflows\/.*\.ya?ml|\.github\/scripts\/.*\.py)$/.test(filename));
+            const isReviewable = filename =>
+              /\.(py|md|ts|tsx)$/.test(filename) ||
+              filename === 'README.md' ||
+              filename === 'AGENTS.md' ||
+              filename === 'requirements.txt' ||
+              filename === '.github/requirements-ci.txt' ||
+              filename === 'pyproject.toml' ||
+              filename === 'setup.cfg' ||
+              filename === '.github/PULL_REQUEST_TEMPLATE.md' ||
+              filename === 'docker/Dockerfile' ||
+              filename === 'docker-compose.yml' ||
+              filename.startsWith('apps/dsa-web/') ||
+              filename.startsWith('.github/workflows/') ||
+              filename.startsWith('.github/scripts/');
 
-  # ==================== AI 代码审查（依赖静态检查通过）====================
+            core.setOutput('safe_to_run', 'true');
+            core.setOutput('sensitive_files_changed', sensitive.length ? 'true' : 'false');
+            core.setOutput('has_py_changes', files.some(file => file.filename.endsWith('.py')) ? 'true' : 'false');
+            core.setOutput('has_reviewable_changes', files.some(file => isReviewable(file.filename)) ? 'true' : 'false');
+
+            if (sensitive.length) {
+              await core.summary
+                .addHeading('⚠️ 检测到敏感文件修改，需要人工审核！', 2)
+                .addCodeBlock(sensitive.join('\n'))
+                .addRaw('已标记为敏感变更；后续流程只通过 GitHub API 把 PR diff 当作数据读取，不检出或执行 PR 代码。')
+                .write();
+            } else {
+              await core.summary.addRaw('✅ 未检测到敏感文件修改').write();
+            }
+
+  # ==================== AI 代码审查（只运行 base 分支脚本）====================
   ai-review:
     name: 🤖 AI 代码审查
     runs-on: ubuntu-latest
-    needs: [security-check, auto-check]
+    needs: [security-check]
     if: |
       needs.security-check.outputs.safe_to_run == 'true' &&
-      needs.auto-check.result == 'success' &&
-      needs.auto-check.outputs.has_reviewable_changes == 'true' &&
+      needs.security-check.outputs.has_reviewable_changes == 'true' &&
       vars.ENABLE_AI_REVIEW != 'false'
-    
+    permissions:
+      contents: read
+      pull-requests: read
+
     steps:
-      # 先检出主分支（获取最新的 .github/scripts）
-      - name: 📥 检出主分支脚本
+      - name: 📥 检出可信主分支脚本
         uses: actions/checkout@v5
         with:
           ref: ${{ github.event.repository.default_branch }}
@@ -205,32 +128,21 @@ jobs:
             .github/scripts
           sparse-checkout-cone-mode: false
           path: main-scripts
-      
-      # 再检出 PR 代码（用于 diff 分析）
-      - name: 📥 检出 PR 代码
-        uses: actions/checkout@v5
-        with:
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
-          fetch-depth: 0
-          path: pr-code
-      
-      - name: 🔄 获取 base 分支
-        working-directory: pr-code
-        run: git fetch origin ${{ github.base_ref || 'main' }}:refs/remotes/origin/${{ github.base_ref || 'main' }}
-      
+          persist-credentials: false
+
       - name: 🐍 设置 Python
         uses: actions/setup-python@v6
         with:
           python-version: '3.11'
-      
-      - name: 📦 安装依赖
+
+      - name: 📦 安装 AI 客户端依赖
         run: pip install google-genai openai httpx
-      
+
       - name: 🤖 AI 审查代码变更
-        working-directory: pr-code
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GITHUB_BASE_REF: ${{ github.base_ref || 'main' }}
+          PR_NUMBER: ${{ github.event.pull_request.number || inputs.pr_number }}
+          AI_REVIEW_SOURCE: github_api
+          GITHUB_TOKEN: ${{ github.token }}
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
           GEMINI_MODEL: ${{ vars.GEMINI_MODEL || 'gemini-2.5-flash' }}
           GEMINI_MODEL_FALLBACK: ${{ vars.GEMINI_MODEL_FALLBACK || 'gemini-2.5-flash' }}
@@ -238,111 +150,93 @@ jobs:
           OPENAI_BASE_URL: ${{ vars.OPENAI_BASE_URL }}
           OPENAI_MODEL: ${{ vars.OPENAI_MODEL }}
           AI_REVIEW_STRICT: ${{ vars.AI_REVIEW_STRICT || 'false' }}
-          CI_SYNTAX_OK: ${{ needs.auto-check.outputs.syntax_ok || '' }}
-          CI_HAS_PY_CHANGES: ${{ needs.auto-check.outputs.has_py_changes || 'false' }}
-          CI_AUTO_CHECK_RESULT: ${{ needs.auto-check.result || '' }}
-        run: python ../main-scripts/.github/scripts/ai_review.py
-      
+          CI_DELEGATED_TO_PULL_REQUEST: 'true'
+          CI_HAS_PY_CHANGES: ${{ needs.security-check.outputs.has_py_changes }}
+        run: python main-scripts/.github/scripts/ai_review.py
+
       - name: 📤 上传审查结果
         uses: actions/upload-artifact@v6
         if: always()
         with:
           name: ai-review-result
-          path: pr-code/ai_review_result.txt
+          path: ai_review_result.txt
           if-no-files-found: ignore
 
-  # ==================== PR 标签自动分类 ====================
+  # ==================== PR 标签自动分类（仅 GitHub API）====================
   labeler:
     name: 🏷️ 自动标签
     runs-on: ubuntu-latest
-    
+    permissions:
+      contents: read
+      pull-requests: read
+      issues: write
+
     steps:
-      - name: 📥 检出代码
-        uses: actions/checkout@v5
-      
       - name: 🏷️ 添加标签
-        if: github.event_name == 'pull_request_target'
         uses: actions/github-script@v8
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number || inputs.pr_number }}
         with:
           script: |
-            const { data: files } = await github.rest.pulls.listFiles({
+            const pullNumber = Number(process.env.PR_NUMBER);
+            if (!Number.isInteger(pullNumber) || pullNumber <= 0) {
+              core.setFailed('A valid PR number is required.');
+              return;
+            }
+
+            const files = await github.paginate(github.rest.pulls.listFiles, {
               owner: context.repo.owner,
               repo: context.repo.repo,
-              pull_number: context.issue.number
+              pull_number: pullNumber,
+              per_page: 100
             });
-            
             const labels = new Set();
-            
+
             for (const file of files) {
               const filename = file.filename.toLowerCase();
-              
-              if (filename.includes('notification') || filename.includes('webhook')) {
-                labels.add('notification');
-              }
-              if (filename.includes('feishu')) {
-                labels.add('feishu');
-              }
-              if (filename.includes('data_provider') || filename.includes('fetcher')) {
-                labels.add('data-source');
-              }
-              if (filename.includes('analyzer') || filename.includes('ai')) {
-                labels.add('ai');
-              }
-              if (filename.endsWith('.md') || filename.includes('doc')) {
-                labels.add('documentation');
-              }
-              if (filename.includes('workflow') || filename.includes('.github')) {
-                labels.add('ci/cd');
-              }
-              if (filename.includes('config')) {
-                labels.add('configuration');
-              }
-              if (filename.includes('test')) {
-                labels.add('testing');
-              }
+              if (filename.includes('notification') || filename.includes('webhook')) labels.add('notification');
+              if (filename.includes('feishu')) labels.add('feishu');
+              if (filename.includes('data_provider') || filename.includes('fetcher')) labels.add('data-source');
+              if (filename.includes('analyzer') || filename.includes('ai')) labels.add('ai');
+              if (filename.endsWith('.md') || filename.includes('doc')) labels.add('documentation');
+              if (filename.includes('workflow') || filename.includes('.github')) labels.add('ci/cd');
+              if (filename.includes('config')) labels.add('configuration');
+              if (filename.includes('test')) labels.add('testing');
             }
-            
-            const additions = files.reduce((sum, f) => sum + f.additions, 0);
-            const deletions = files.reduce((sum, f) => sum + f.deletions, 0);
-            const totalChanges = additions + deletions;
-            
-            if (totalChanges < 50) {
-              labels.add('size/S');
-            } else if (totalChanges < 200) {
-              labels.add('size/M');
-            } else if (totalChanges < 500) {
-              labels.add('size/L');
-            } else {
-              labels.add('size/XL');
-            }
-            
+
+            const totalChanges = files.reduce((sum, file) => sum + file.additions + file.deletions, 0);
+            if (totalChanges < 50) labels.add('size/S');
+            else if (totalChanges < 200) labels.add('size/M');
+            else if (totalChanges < 500) labels.add('size/L');
+            else labels.add('size/XL');
+
             if (labels.size > 0) {
               try {
                 await github.rest.issues.addLabels({
                   owner: context.repo.owner,
                   repo: context.repo.repo,
-                  issue_number: context.issue.number,
+                  issue_number: pullNumber,
                   labels: Array.from(labels)
                 });
                 console.log(`Added labels: ${Array.from(labels).join(', ')}`);
-              } catch (e) {
-                console.log(`Failed to add labels: ${e.message}`);
+              } catch (error) {
+                console.log(`Failed to add labels: ${error.message}`);
               }
             }
 
-  # ==================== 自动评论检查结果 ====================
+  # ==================== 自动评论检查结果（仅 GitHub API）====================
   comment:
     name: 💬 审查报告
     runs-on: ubuntu-latest
-    needs: [security-check, auto-check, ai-review]
-    if: always() && github.event_name == 'pull_request_target' && needs.security-check.outputs.safe_to_run == 'true'
-    
+    needs: [security-check, ai-review]
+    if: always() && needs.security-check.outputs.safe_to_run == 'true'
+    permissions:
+      actions: read
+      contents: read
+      pull-requests: read
+      issues: write
+
     steps:
-      - name: 📥 检出代码
-        uses: actions/checkout@v5
-        with:
-          fetch-depth: 0
-      
       - name: 📥 下载 AI 审查结果
         uses: actions/download-artifact@v7
         if: needs.ai-review.result == 'success'
@@ -350,72 +244,68 @@ jobs:
         with:
           name: ai-review-result
           path: .
-      
+
       - name: 💬 生成审查报告
-        env:
-          AUTO_CHECK_RESULT: ${{ needs.auto-check.result }}
-          AI_REVIEW_RESULT: ${{ needs.ai-review.result }}
         uses: actions/github-script@v8
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number || inputs.pr_number }}
+          AI_REVIEW_RESULT: ${{ needs.ai-review.result }}
         with:
           script: |
             const fs = require('fs');
-            
-            const { data: files } = await github.rest.pulls.listFiles({
+            const pullNumber = Number(process.env.PR_NUMBER);
+            if (!Number.isInteger(pullNumber) || pullNumber <= 0) {
+              core.setFailed('A valid PR number is required.');
+              return;
+            }
+
+            const files = await github.paginate(github.rest.pulls.listFiles, {
               owner: context.repo.owner,
               repo: context.repo.repo,
-              pull_number: context.issue.number
+              pull_number: pullNumber,
+              per_page: 100
             });
-            
-            const additions = files.reduce((sum, f) => sum + f.additions, 0);
-            const deletions = files.reduce((sum, f) => sum + f.deletions, 0);
-            const changedFiles = files.length;
-            
+            const additions = files.reduce((sum, file) => sum + file.additions, 0);
+            const deletions = files.reduce((sum, file) => sum + file.deletions, 0);
+
             let aiReview = '';
             try {
               aiReview = fs.readFileSync('ai_review_result.txt', 'utf8');
-            } catch (e) {
+            } catch (error) {
               console.log('No AI review result found');
             }
-            
-            const { data: comments } = await github.rest.issues.listComments({
+
+            const comments = await github.paginate(github.rest.issues.listComments, {
               owner: context.repo.owner,
               repo: context.repo.repo,
-              issue_number: context.issue.number
+              issue_number: pullNumber,
+              per_page: 100
             });
-            
-            const botComment = comments.find(c => 
-              c.user.type === 'Bot' && 
-              c.body.includes('## 🤖 自动审查报告')
+            const botComment = comments.find(comment =>
+              comment.user.type === 'Bot' && comment.body.includes('## 🤖 自动审查报告')
             );
-            
-            const checkStatus = process.env.AUTO_CHECK_RESULT === 'success' ? '✅ 通过' : '⚠️ 有问题';
-            const aiStatus = process.env.AI_REVIEW_RESULT === 'success' ? '✅ 已完成' : 
-                            process.env.AI_REVIEW_RESULT === 'skipped' ? '⏭️ 跳过' : '⚠️ 失败';
-            
+
+            const aiStatus = process.env.AI_REVIEW_RESULT === 'success' ? '✅ 已完成' :
+              process.env.AI_REVIEW_RESULT === 'skipped' ? '⏭️ 跳过' : '⚠️ 失败';
             let report = `## 🤖 自动审查报告
 
             | 项目 | 结果 |
             |------|------|
-            | 📊 变更文件 | ${changedFiles} 个 |
+            | 📊 变更文件 | ${files.length} 个 |
             | ➕ 新增行数 | ${additions} 行 |
             | ➖ 删除行数 | ${deletions} 行 |
-            | 🔍 静态检查 | ${checkStatus} |
+            | 🔍 代码检查 | 由独立 \`pull_request\` CI / \`backend-gate\` 执行 |
             | 🧠 AI 审查 | ${aiStatus} |
 
             ### 📁 修改的文件
 
             `;
-            
+
             for (const file of files.slice(0, 20)) {
-              const status = file.status === 'added' ? '🆕' : 
-                            file.status === 'removed' ? '🗑️' : '📝';
+              const status = file.status === 'added' ? '🆕' : file.status === 'removed' ? '🗑️' : '📝';
               report += `- ${status} \`${file.filename}\` (+${file.additions}/-${file.deletions})\n`;
             }
-            
-            if (files.length > 20) {
-              report += `\n... 还有 ${files.length - 20} 个文件\n`;
-            }
-            
+            if (files.length > 20) report += `\n... 还有 ${files.length - 20} 个文件\n`;
             if (aiReview) {
               report += `
             ---
@@ -425,13 +315,12 @@ jobs:
             ${aiReview}
             `;
             }
-            
             report += `
             ---
 
-            > 💡 **提示**: 请确保代码已通过本地测试，并遵循项目代码规范。
+            > 💡 **提示**: 请同时核对独立 CI 结果，并遵循项目代码规范。
             `;
-            
+
             if (botComment) {
               await github.rest.issues.updateComment({
                 owner: context.repo.owner,
@@ -443,7 +332,7 @@ jobs:
               await github.rest.issues.createComment({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
-                issue_number: context.issue.number,
+                issue_number: pullNumber,
                 body: report
               });
             }

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 <!-- 新条目格式：- [类型] 描述（类型取值：新功能/改进/修复/文档/测试/chore）-->
 <!-- 每条独立一行追加到本段末尾，无需分类标题，合并时冲突最小 -->
 - [修复] #2026 外股代码映射到中文显示名时英文新闻相关性判定漏判：新增同源 STOCK_ENGLISH_NAME_MAP 单一真源、canonicalize_foreign_stock_code 规范化入口与 _foreign_english_query_terms 别名解析，使 AAPL/00700/BABA 等 ticker 即使 stock_name 为中文也能在查询构建、相关性打分与多维度情报路径上复用 canonical 英文名，并补齐 .US/.HK suffix / HK 前缀全形式的归类与回归用例；同时在 _score_news_relevance 对 alias 展开 term 做去重，避免 legal alias 展开短名与显式 short alias 重复计分。
+- [修复] #2051 PR Review 的特权 `pull_request_target` 流程不再检出 fork PR head：敏感文件、标签、报告与 AI 审查统一通过 GitHub API 将 PR 元数据和 diff 作为数据读取，只执行主分支可信脚本；Python 语法、Flake8、确定性检查和离线测试继续由无 secrets 的 `pull_request` CI / `backend-gate` 执行，兼容 `actions/checkout` 新增的 fork checkout 安全保护。
 
 ## [3.27.0] - 2026-07-19
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -81,6 +81,7 @@ docs: 更新 README 部署说明
 | backend-gate | `scripts/ci_gate.sh`（py_compile + flake8 严重错误 + 本地核心脚本 + offline pytest） | ✅ |
 | docker-build | Docker 镜像构建与关键模块导入 smoke | ✅ |
 | web-gate | 前端变更时执行 `npm run lint` + `npm run build` | ✅（触发时） |
+| pr-review | `pull_request_target` 辅助审查：通过 GitHub API 读取 PR 元数据和 diff，执行敏感文件标记、AI 审查、自动标签与报告评论；不检出或执行 fork PR 代码，Python/Flake8 等执行型检查由 `backend-gate` 负责 | ❌（辅助项） |
 | network-smoke | 定时/手动执行 `pytest -m network` + `scripts/test.sh quick`（非阻断） | ❌（观测项） |
 
 **本地运行检查：**

--- a/docs/CONTRIBUTING_EN.md
+++ b/docs/CONTRIBUTING_EN.md
@@ -83,6 +83,7 @@ After opening a PR, CI will automatically run the following PR checks:
 | `backend-gate` | `scripts/ci_gate.sh` — py_compile + flake8 critical errors + `./scripts/test.sh code` + `./scripts/test.sh yfinance` + offline pytest | ✅ |
 | `docker-build` | Docker image build and key module import smoke test | ✅ |
 | `web-gate` | `npm run lint` + `npm run build` (triggered when `apps/dsa-web/` changes) | ✅ (when triggered) |
+| `pr-review` | Advisory `pull_request_target` review that reads PR metadata and diff through the GitHub API for sensitive-file flags, AI review, labels, and report comments. It never checks out or executes fork PR code; Python and Flake8 execution remains in `backend-gate`. | ❌ (advisory) |
 
 Separately, the repository also has a non-blocking `network-smoke` workflow in `.github/workflows/network-smoke.yml`, but it is only triggered by `schedule` and `workflow_dispatch`, not by pull requests.
 

--- a/tests/test_ai_review_github_api.py
+++ b/tests/test_ai_review_github_api.py
@@ -1,0 +1,108 @@
+import importlib.util
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT_PATH = ROOT / '.github' / 'scripts' / 'ai_review.py'
+SPEC = importlib.util.spec_from_file_location('ai_review_script', SCRIPT_PATH)
+assert SPEC and SPEC.loader
+ai_review = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(ai_review)
+
+
+def test_github_api_review_data_treats_patch_as_data(monkeypatch):
+    pull_files = [
+        {
+            'filename': 'src/example.py',
+            'status': 'modified',
+            'patch': '@@ -1 +1 @@\n-old\n+new',
+        },
+        {
+            'filename': 'docs/guide.md',
+            'status': 'added',
+            'patch': '@@ -0,0 +1 @@\n+# Guide',
+        },
+        {
+            'filename': 'assets/chart.png',
+            'status': 'added',
+            'patch': None,
+        },
+    ]
+    monkeypatch.setenv('AI_REVIEW_SOURCE', 'github_api')
+    monkeypatch.setattr(ai_review, '_fetch_pull_files', lambda: pull_files)
+    monkeypatch.setattr(
+        ai_review,
+        'run_git',
+        lambda _args: (_ for _ in ()).throw(AssertionError('git must not run')),
+    )
+
+    diff, files, truncated = ai_review.get_review_data()
+
+    assert files == ['src/example.py', 'docs/guide.md']
+    assert 'diff --git a/src/example.py b/src/example.py' in diff
+    assert '--- /dev/null\n+++ b/docs/guide.md' in diff
+    assert 'assets/chart.png' not in diff
+    assert truncated is False
+
+
+def test_github_api_review_data_marks_missing_text_patch(monkeypatch):
+    monkeypatch.setenv('AI_REVIEW_SOURCE', 'github_api')
+    monkeypatch.setattr(
+        ai_review,
+        '_fetch_pull_files',
+        lambda: [{'filename': 'README.md', 'status': 'modified'}],
+    )
+
+    diff, files, truncated = ai_review.get_review_data()
+
+    assert files == ['README.md']
+    assert 'Patch unavailable from GitHub API' in diff
+    assert truncated is False
+
+
+def test_pull_file_api_is_paginated(monkeypatch):
+    paths = []
+
+    def fake_api(path):
+        paths.append(path)
+        if 'page=1' in path:
+            return [{'filename': 'one.py'}, {'filename': 'two.py'}]
+        return [{'filename': 'three.py'}]
+
+    monkeypatch.setenv('GITHUB_REPOSITORY', 'owner/repo')
+    monkeypatch.setenv('PR_NUMBER', '2051')
+    monkeypatch.setattr(ai_review, 'GITHUB_API_PAGE_SIZE', 2)
+    monkeypatch.setattr(ai_review, '_github_api_json', fake_api)
+
+    files = ai_review._fetch_pull_files()
+
+    assert [item['filename'] for item in files] == ['one.py', 'two.py', 'three.py']
+    assert paths == [
+        '/repos/owner/repo/pulls/2051/files?per_page=2&page=1',
+        '/repos/owner/repo/pulls/2051/files?per_page=2&page=2',
+    ]
+
+
+def test_manual_dispatch_context_comes_from_github_api(monkeypatch):
+    monkeypatch.setenv('AI_REVIEW_SOURCE', 'github_api')
+    monkeypatch.setenv('GITHUB_REPOSITORY', 'owner/repo')
+    monkeypatch.setenv('PR_NUMBER', '2051')
+    monkeypatch.delenv('GITHUB_EVENT_PATH', raising=False)
+    monkeypatch.setattr(
+        ai_review,
+        '_github_api_json',
+        lambda path: {'title': 'Fix review', 'body': 'Closes #2051'}
+        if path == '/repos/owner/repo/pulls/2051'
+        else None,
+    )
+
+    assert ai_review.get_pr_context() == ('Fix review', 'Closes #2051')
+
+
+def test_delegated_ci_context_does_not_claim_success(monkeypatch):
+    monkeypatch.setenv('CI_DELEGATED_TO_PULL_REQUEST', 'true')
+
+    context = ai_review._build_ci_context()
+
+    assert 'backend-gate' in context
+    assert '不假设并行 CI 已通过' in context


### PR DESCRIPTION
当前 Head CI：ai-governance:pass / backend-gate:pass / docker-build:pass / web-gate:skipped（无 Web 文件变更）。当前状态：全部适用检查通过（pass）。

## PR Type

- [x] fix
- [ ] feat
- [ ] refactor
- [ ] docs
- [ ] chore
- [ ] test

## Background And Problem

Fixes #2051

`actions/checkout` v5.1.0 开始拒绝在具有 base 仓库权限和 secrets 语义的 `pull_request_target` 中检出 fork PR head。现有 PR Review workflow 的 `security-check`、`auto-check`、`ai-review` 都显式检出该 head，因此 fork PR 的辅助审查链路会在第一个 checkout 处失败。

直接设置 `allow-unsafe-pr-checkout: true` 不是安全修复：原 `auto-check` 随后会在 fork 工作树中运行 Flake8，而 fork 可控制项目配置及本地插件加载路径，等同于重新允许不受信任代码进入特权 job。

本 PR 将边界收敛为：特权 `pull_request_target` 只把 PR 内容当作 API 数据读取；任何会执行 PR 代码/配置的检查仍在无 secrets 的 `pull_request` CI 中运行。

## Scope Of Change

- 文件总数 / 变更行数：6 files changed, 423 insertions(+), 294 deletions(-)
- 文件清单：
  - `.github/workflows/pr-review.yml`
  - `.github/scripts/ai_review.py`
  - `tests/test_ai_review_github_api.py`
  - `docs/CHANGELOG.md`
  - `docs/CONTRIBUTING.md`
  - `docs/CONTRIBUTING_EN.md`
- 文档更新：中英文贡献指南同步说明新的安全边界；Changelog 添加扁平修复条目。

具体变化：

- 敏感文件检测、标签和报告评论改为分页调用 GitHub API，不再 checkout PR head。
- AI job 只 sparse checkout 默认分支的可信脚本，`persist-credentials: false`；PR patch 经 GitHub API 输入。
- 删除特权 workflow 中执行 PR 内容的 `auto-check`；语法、Flake8、确定性检查和离线测试由现有 `pull_request` / `backend-gate` 负责。
- `workflow_dispatch` 增加必填 PR 编号，使手动复审路径可实际工作。
- 新增 API diff、分页、缺失 patch、手动触发上下文和 CI 表述回归测试。

## Issue Link

Fixes #2051

## Verification Commands And Results

- `python -m py_compile .github/scripts/ai_review.py tests/test_ai_review_github_api.py`：pass
- `python -m pytest tests/test_ai_review_github_api.py -q`：5 passed
- `flake8 .github/scripts/ai_review.py tests/test_ai_review_github_api.py --select=E9,F63,F7,F82`：0
- `python scripts/check_ai_assets.py`：pass
- PyYAML + 结构断言：pass；确认仅 4 个预期 job、仅一次可信 base checkout，且不含 PR head checkout / `allow-unsafe-pr-checkout`
- 使用匿名 GitHub API 对 PR #2056 实测：4 个可审查文件、6,428 字符 diff、未截断
- `./scripts/ci_gate.sh`：本地首次全量为 4,737 passed、1 个非改动面用例 `test_fetch_enabled_sources_is_fail_open` 在全量顺序下失败；单独重跑该用例为 passed。当前 Head 的 GitHub `backend-gate` 已在隔离环境完整通过，确认该本地失败不是本 PR 回归。
- `actionlint`：未完成；本机 Go 工具链自身版本不一致（stdlib go1.19 / tool go1.22.2）。已使用 PyYAML 和工作流结构断言替代，GitHub Actions 端结果待回填。

当前 Head CI：

- ai-governance：pass — https://github.com/ZhuLinsen/daily_stock_analysis/actions/runs/29837657914/job/88658041475
- backend-gate：pass — https://github.com/ZhuLinsen/daily_stock_analysis/actions/runs/29837657914/job/88658095927
- docker-build：pass — https://github.com/ZhuLinsen/daily_stock_analysis/actions/runs/29837657914/job/88658095874
- web-gate：skipped（无 Web 文件变更）— https://github.com/ZhuLinsen/daily_stock_analysis/actions/runs/29837657914/job/88658096501

当前状态：全部适用检查通过（pass）。

## Visual Evidence (if applicable)

不适用：仅修改 GitHub Actions、审查脚本和贡献文档，不涉及报告格式、报告渲染或 Web UI。

## Compatibility And Risk

- 不修改应用 runtime、API、Schema、数据、部署产物或用户配置。
- GitHub Pull Files API 对单个 PR 最多返回 3,000 个文件；脚本达到上限时 fail closed，不会回退到 checkout。
- GitHub 对过大或二进制文件可能不返回 `patch`；审查输入会明确标记 patch 不可用，不会伪造完整 diff。
- 由于 `pull_request_target` 使用 base 分支 workflow，本 PR 自身无法证明“合入后 fork PR 使用新 workflow”的端到端行为；合入 main 后必须用真实 fork PR 复验。
- 本 PR 未变更 provider/model/base URL、运行时配置清理迁移语义；历史配置保持不变；回滚方式为 revert 本提交。

## Rollback Plan

Revert 本 PR 即可恢复旧 workflow；无配置、数据或迁移需要额外回滚。注意旧 workflow 在当前 checkout 策略下仍会使 fork PR Review 失败，不应通过开启 unsafe checkout 作为回滚补丁。

## EXTRACT_PROMPT Change (if applicable)

不适用，未修改 `EXTRACT_PROMPT`。

## Checklist

- [x] 本 PR 有明确动机和业务价值
- [x] 已提供可复现的验证命令与结果
- [x] 已评估兼容性与风险
- [x] 已提供回滚方案
- [x] 不涉及报告格式或 Web UI
- [x] 不涉及 Web 设置字段
- [x] 已同步相关文档与 `docs/CHANGELOG.md`
