### PR TITLE
fix(ci): handle fork PR review reporting failures

### DIFF
--- a/.github/scripts/ai_review.py
+++ b/.github/scripts/ai_review.py
@@ -332,8 +332,8 @@ def review_with_gemini(prompt):
 def review_with_openai(prompt):
     """Run review with OpenAI-compatible API as fallback."""
     api_key = os.environ.get('OPENAI_API_KEY')
-    base_url = os.environ.get('OPENAI_BASE_URL', 'https://api.openai.com/v1')
-    model = os.environ.get('OPENAI_MODEL', 'gpt-4o-mini')
+    base_url = os.environ.get('OPENAI_BASE_URL') or 'https://api.openai.com/v1'
+    model = os.environ.get('OPENAI_MODEL') or 'gpt-4o-mini'
 
     if not api_key:
         print("❌ OpenAI API Key 未配置（检查 GitHub Secrets: OPENAI_API_KEY）")

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -118,6 +118,8 @@ jobs:
     permissions:
       contents: read
       pull-requests: read
+    outputs:
+      review_available: ${{ steps.review-result.outputs.available }}
 
     steps:
       - name: 📥 检出可信主分支脚本
@@ -154,13 +156,27 @@ jobs:
           CI_HAS_PY_CHANGES: ${{ needs.security-check.outputs.has_py_changes }}
         run: python main-scripts/.github/scripts/ai_review.py
 
+      - name: 🔎 检查 AI 审查结果
+        id: review-result
+        if: always()
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const fs = require('fs');
+            const available = fs.existsSync('ai_review_result.txt') &&
+              fs.statSync('ai_review_result.txt').size > 0;
+            core.setOutput('available', String(available));
+            if (!available) {
+              core.warning('AI review completed without a report artifact; downstream reporting will mark it unavailable.');
+            }
+
       - name: 📤 上传审查结果
         uses: actions/upload-artifact@v6
-        if: always()
+        if: always() && steps.review-result.outputs.available == 'true'
         with:
           name: ai-review-result
           path: ai_review_result.txt
-          if-no-files-found: ignore
+          if-no-files-found: error
 
   # ==================== PR 标签自动分类（仅 GitHub API）====================
   labeler:
@@ -220,7 +236,11 @@ jobs:
                 });
                 console.log(`Added labels: ${Array.from(labels).join(', ')}`);
               } catch (error) {
-                console.log(`Failed to add labels: ${error.message}`);
+                if (error.status === 403) {
+                  core.warning(`PR labels were not updated because this workflow token is read-only: ${error.message}`);
+                } else {
+                  throw error;
+                }
               }
             }
 
@@ -239,8 +259,7 @@ jobs:
     steps:
       - name: 📥 下载 AI 审查结果
         uses: actions/download-artifact@v7
-        if: needs.ai-review.result == 'success'
-        continue-on-error: true
+        if: needs.ai-review.outputs.review_available == 'true'
         with:
           name: ai-review-result
           path: .
@@ -250,6 +269,7 @@ jobs:
         env:
           PR_NUMBER: ${{ github.event.pull_request.number || inputs.pr_number }}
           AI_REVIEW_RESULT: ${{ needs.ai-review.result }}
+          AI_REVIEW_AVAILABLE: ${{ needs.ai-review.outputs.review_available }}
         with:
           script: |
             const fs = require('fs');
@@ -285,8 +305,9 @@ jobs:
               comment.user.type === 'Bot' && comment.body.includes('## 🤖 自动审查报告')
             );
 
-            const aiStatus = process.env.AI_REVIEW_RESULT === 'success' ? '✅ 已完成' :
-              process.env.AI_REVIEW_RESULT === 'skipped' ? '⏭️ 跳过' : '⚠️ 失败';
+            const aiStatus = process.env.AI_REVIEW_AVAILABLE === 'true' ? '✅ 已完成' :
+              process.env.AI_REVIEW_RESULT === 'skipped' ? '⏭️ 跳过' :
+              process.env.AI_REVIEW_RESULT === 'failure' ? '⚠️ 失败' : '⚠️ 未生成结果';
             let report = `## 🤖 自动审查报告
 
             | 项目 | 结果 |
@@ -321,18 +342,31 @@ jobs:
             > 💡 **提示**: 请同时核对独立 CI 结果，并遵循项目代码规范。
             `;
 
-            if (botComment) {
-              await github.rest.issues.updateComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                comment_id: botComment.id,
-                body: report
-              });
-            } else {
-              await github.rest.issues.createComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: pullNumber,
-                body: report
-              });
+            await core.summary.addRaw(report).write();
+
+            try {
+              if (botComment) {
+                await github.rest.issues.updateComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  comment_id: botComment.id,
+                  body: report
+                });
+              } else {
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: pullNumber,
+                  body: report
+                });
+              }
+            } catch (error) {
+              if (error.status === 403) {
+                core.warning(
+                  `PR comment was not published because this workflow token is read-only; ` +
+                  `the report remains available in the job summary: ${error.message}`
+                );
+              } else {
+                throw error;
+              }
             }

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 > For user-friendly release highlights, see the [GitHub Releases](https://github.com/ZhuLinsen/daily_stock_analysis/releases) page.
 
 ## [Unreleased]
+- [修复] PR Review 在 fork PR 的写入 token 被仓库策略降级时，将自动标签与审查评论降级为 warning，并把报告保留在 Action Summary；同时只在 AI 结果文件真实存在时上传/下载 artifact，避免无结果被误报为审查成功，并恢复空白 OpenAI fallback 配置的默认值。
 - [新功能] Multi-Agent 报告按八态用户 action 追踪 Pipeline 最终调整，排除非法 Agent 意见；仅在 canonical action 可唯一解析时生成 explanation 与 DecisionSignal，并以同一个 `final_action` 统一最终动作契约。
 - [新功能] 新增 `--portfolio futu`，只读导入 Futu OpenD 真实账户的沪深 A 股、港股、美股 LONG 正股持仓作为分析列表。
 <!-- 新条目格式：- [类型] 描述（类型取值：新功能/改进/修复/文档/测试/chore）-->

--- a/tests/test_ai_review_github_api.py
+++ b/tests/test_ai_review_github_api.py
@@ -1,5 +1,7 @@
 import importlib.util
 from pathlib import Path
+import sys
+from types import SimpleNamespace
 
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -106,3 +108,41 @@ def test_delegated_ci_context_does_not_claim_success(monkeypatch):
 
     assert 'backend-gate' in context
     assert '不假设并行 CI 已通过' in context
+
+
+def test_openai_fallback_uses_defaults_for_empty_optional_vars(monkeypatch):
+    captured = {}
+
+    class FakeCompletions:
+        @staticmethod
+        def create(**kwargs):
+            captured['model'] = kwargs['model']
+            return SimpleNamespace(
+                choices=[SimpleNamespace(message=SimpleNamespace(content='review'))]
+            )
+
+    class FakeOpenAI:
+        def __init__(self, *, api_key, base_url):
+            captured['api_key'] = api_key
+            captured['base_url'] = base_url
+            self.chat = SimpleNamespace(
+                completions=FakeCompletions(),
+            )
+
+    monkeypatch.setenv('OPENAI_API_KEY', 'test-key')
+    monkeypatch.setenv('OPENAI_BASE_URL', '')
+    monkeypatch.setenv('OPENAI_MODEL', '')
+    monkeypatch.setitem(
+        sys.modules,
+        'openai',
+        SimpleNamespace(OpenAI=FakeOpenAI),
+    )
+
+    result = ai_review.review_with_openai('prompt')
+
+    assert result == 'review'
+    assert captured == {
+        'api_key': 'test-key',
+        'base_url': 'https://api.openai.com/v1',
+        'model': 'gpt-4o-mini',
+    }


### PR DESCRIPTION
## PR Type

- [x] fix
- [ ] feat
- [ ] refactor
- [x] docs
- [ ] chore
- [x] test
- [x] ci

## Background And Problem

The privileged `PR Review` workflow safely uses `pull_request_target` and only executes trusted base-branch scripts, but repository or organization policy can still downgrade write operations for cross-repository fork PRs.

PR #2062 exposed three related problems:

1. `issues.createComment` returned `403 Resource not accessible by integration`, causing the auxiliary `💬 审查报告` job to fail.
2. Automatic labeling hit the same 403 but caught every exception and reported the job as successful without a visible warning.
3. Gemini exhausted its quota and the OpenAI fallback received empty optional URL/model variables, so no `ai_review_result.txt` was produced. The workflow still treated the AI job result as success, attempted to download a nonexistent artifact, and labeled the AI review as completed.

## Scope Of Change

- Make fork-token 403 responses non-fatal for auxiliary label/comment publishing while surfacing an explicit workflow warning.
- Always retain the generated report in the GitHub Actions job summary, even when the PR comment cannot be published.
- Detect whether a non-empty AI review result actually exists and expose that state as a job output.
- Upload and download `ai-review-result` only when the result file exists.
- Report `⚠️ 未生成结果` instead of `✅ 已完成` when the AI job soft-fails without an artifact.
- Restore intended OpenAI-compatible defaults when `OPENAI_BASE_URL` or `OPENAI_MODEL` exists as an empty environment variable.
- Add a regression test for the empty optional-variable fallback.

## Security Boundary

- The workflow remains on `pull_request_target`.
- It continues to check out and execute only scripts from the trusted base branch.
- Fork PR code is still read only through GitHub API metadata/diff payloads and is never executed in the privileged workflow.
- The change does not add a PAT, broaden secret access, or grant new workflow permissions.

## Verification Commands And Results

```bash
python scripts/check_ai_assets.py
# [ai-assets] OK

python -m pytest --noconftest tests/test_ai_review_github_api.py -q
# 6 passed

PYTHONPYCACHEPREFIX=/private/tmp/dsa_pr_review_fix_pycache \
  python3 -m py_compile \
  .github/scripts/ai_review.py \
  tests/test_ai_review_github_api.py
# pass

flake8 .github/scripts/ai_review.py tests/test_ai_review_github_api.py \
  --count --select=E9,F63,F7,F82 --show-source --statistics
# 0

ruby -e 'require "yaml"; YAML.parse_file(ARGV[0])' \
  .github/workflows/pr-review.yml
# pass

git diff --check
# pass
```

The full `pull_request_target` behavior cannot be proven by this fork PR itself because GitHub evaluates that event using the current base-branch workflow. After merge, the next fork PR update or a maintainer `workflow_dispatch` run will exercise the new reporting path.

## Compatibility And Risk

- Same-repository PRs and fork PRs with write-capable tokens continue to receive labels and the idempotent review comment.
- Fork PRs with read-only tokens no longer fail the auxiliary report job; their report remains available in the Action Summary.
- Non-403 API errors still fail instead of being silently hidden.
- AI provider quota/configuration failures remain visible and no longer masquerade as a completed review.
- Product runtime, backend, Web, Docker, release, and report-rendering behavior are unchanged.

## Visual Evidence

Not applicable: workflow and CI-script behavior only; no user interface or report rendering changed.

## Rollback Plan

Revert this commit. No configuration migration, secret change, database migration, or persisted data update is involved.

## Checklist

- [x] Root cause is documented from the failing #2062 run logs
- [x] Fork code is not executed in the privileged workflow
- [x] Permission degradation is explicit and non-fatal only for 403 writes
- [x] Missing AI artifacts are represented accurately
- [x] Regression and governance checks pass
