### PR TITLE
ci: temporarily disable automatic PR review

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -1,29 +1,9 @@
-# PR 自动审查 - 元数据检查 + AI 语义审查
-# 特权 pull_request_target 流程只读取 GitHub API 数据，不检出或执行 fork PR 代码。
+# PR 手动辅助审查 - 元数据检查 + AI 语义审查
+# 暂停 PR 自动触发；维护者可按 PR 编号手动运行，且不会检出或执行 fork PR 代码。
 
 name: PR Review
 
 on:
-  pull_request_target:
-    types: [opened, synchronize, reopened]
-    paths:
-      - '**.py'
-      - '**.md'
-      - '**.ts'
-      - '**.tsx'
-      - 'docs/**'
-      - 'README.md'
-      - 'AGENTS.md'
-      - 'apps/dsa-web/**'
-      - 'requirements.txt'
-      - '.github/requirements-ci.txt'
-      - 'pyproject.toml'
-      - 'setup.cfg'
-      - '.github/PULL_REQUEST_TEMPLATE.md'
-      - '.github/workflows/**'
-      - '.github/scripts/**'
-      - 'docker/Dockerfile'
-      - 'docker-compose.yml'
   workflow_dispatch:
     inputs:
       pr_number:

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 > For user-friendly release highlights, see the [GitHub Releases](https://github.com/ZhuLinsen/daily_stock_analysis/releases) page.
 
 ## [Unreleased]
+- [chore] 暂停 PR Review 的自动触发，仅保留 `workflow_dispatch` 手动入口，避免辅助评审重复运行及评论权限失败产生误导性红灯；正式 CI 检查保持不变。
 - [新功能] Multi-Agent specialist 运行在分析历史保存成功后，按独立 skill 持久化版本化、低敏且幂等的有效 opinion 样本，为后续后验评估提供真实数据；本阶段不计算 outcome、不统计表现、不调整权重。
 - [新功能] Multi-Agent 报告按八态用户 action 追踪 Pipeline 最终调整，排除非法 Agent 意见；仅在 canonical action 可唯一解析时生成 explanation 与 DecisionSignal，并以同一个 `final_action` 统一最终动作契约。
 - [新功能] 新增 `--portfolio futu`，只读导入 Futu OpenD 真实账户的沪深 A 股、港股、美股 LONG 正股持仓作为分析列表。

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -81,7 +81,7 @@ docs: 更新 README 部署说明
 | backend-gate | `scripts/ci_gate.sh`（py_compile + flake8 严重错误 + 本地核心脚本 + offline pytest） | ✅ |
 | docker-build | Docker 镜像构建与关键模块导入 smoke | ✅ |
 | web-gate | 前端变更时执行 `npm run lint` + `npm run build` | ✅（触发时） |
-| pr-review | `pull_request_target` 辅助审查：通过 GitHub API 读取 PR 元数据和 diff，执行敏感文件标记、AI 审查、自动标签与报告评论；不检出或执行 fork PR 代码，Python/Flake8 等执行型检查由 `backend-gate` 负责 | ❌（辅助项） |
+| pr-review | 暂停 PR 自动触发，仅保留维护者通过 `workflow_dispatch` 按 PR 编号手动运行；通过 GitHub API 读取 PR 元数据和 diff，不检出或执行 fork PR 代码 | ❌（辅助项） |
 | network-smoke | 定时/手动执行 `pytest -m network` + `scripts/test.sh quick`（非阻断） | ❌（观测项） |
 
 **本地运行检查：**

--- a/docs/CONTRIBUTING_EN.md
+++ b/docs/CONTRIBUTING_EN.md
@@ -83,7 +83,7 @@ After opening a PR, CI will automatically run the following PR checks:
 | `backend-gate` | `scripts/ci_gate.sh` — py_compile + flake8 critical errors + `./scripts/test.sh code` + `./scripts/test.sh yfinance` + offline pytest | ✅ |
 | `docker-build` | Docker image build and key module import smoke test | ✅ |
 | `web-gate` | `npm run lint` + `npm run build` (triggered when `apps/dsa-web/` changes) | ✅ (when triggered) |
-| `pr-review` | Advisory `pull_request_target` review that reads PR metadata and diff through the GitHub API for sensitive-file flags, AI review, labels, and report comments. It never checks out or executes fork PR code; Python and Flake8 execution remains in `backend-gate`. | ❌ (advisory) |
+| `pr-review` | Automatic PR triggering is temporarily paused. Maintainers can still run it by PR number through `workflow_dispatch`; it reads PR metadata and diff through the GitHub API and never checks out or executes fork PR code. | ❌ (advisory) |
 
 Separately, the repository also has a non-blocking `network-smoke` workflow in `.github/workflows/network-smoke.yml`, but it is only triggered by `schedule` and `workflow_dispatch`, not by pull requests.
 


### PR DESCRIPTION
## PR Type

- [ ] fix
- [ ] feat
- [ ] refactor
- [x] docs
- [x] chore
- [ ] test

## Background And Problem

当前 `PR Review` 辅助 workflow 会在每个 PR 上自动运行 AI 语义审查，并在发布报告评论时返回 403，产生与正式 CI 无关的误导性红灯。仓库已有 Codex 评审，可先暂停重复的自动评审。

## Scope Of Change

- 文件总数：4；5 insertions / 24 deletions
- `.github/workflows/pr-review.yml`：移除 `pull_request_target` 自动触发，只保留带 PR 编号的 `workflow_dispatch`
- `docs/CONTRIBUTING.md`、`docs/CONTRIBUTING_EN.md`：同步说明手动评审方式
- `docs/CHANGELOG.md`：记录临时停用
- 保留 `.github/scripts/ai_review.py`，维护者仍可手动运行，后续也可恢复自动触发

## Issue Link

无关联 Issue。验收标准：新 PR 不再自动启动 `PR Review`；维护者仍可手动指定 PR 运行；`ci.yml` 中的正式检查不受影响。

## Verification Commands And Results

```bash
git diff --check
# pass

ruby -e 'require "yaml"; YAML.parse_file(ARGV[0])' .github/workflows/pr-review.yml
# pass

python scripts/check_ai_assets.py
# [ai-assets] OK
```

`actionlint` 本机未安装，因此未执行。

当前 Head CI：

- [ai-governance: pass](https://github.com/ZhuLinsen/daily_stock_analysis/actions/runs/29929187083/job/88954079641)
- [backend-gate: pass](https://github.com/ZhuLinsen/daily_stock_analysis/actions/runs/29929187083/job/88954115168)
- [docker-build: pass](https://github.com/ZhuLinsen/daily_stock_analysis/actions/runs/29929187083/job/88954115301)
- [web-gate: skipped](https://github.com/ZhuLinsen/daily_stock_analysis/actions/runs/29929187083/job/88954151440)（无 Web 改动）
- [AI 代码审查: pass](https://github.com/ZhuLinsen/daily_stock_analysis/actions/runs/29929187488/job/88954125705)
- [审查报告: fail](https://github.com/ZhuLinsen/daily_stock_analysis/actions/runs/29929187488/job/88954243160)（旧 base workflow 发布评论时复现目标 403；属于本 PR 要停用的辅助流程）

当前状态：正式 CI 全部通过（pass）；仅旧的非阻断审查报告步骤因目标问题失败。

## Visual Evidence

不适用：仅修改 GitHub Actions 触发方式与贡献文档，不涉及报告格式或 Web UI。

## Compatibility And Risk

- 自动 AI 审查、标签和报告评论暂时不再随 PR 自动运行。
- `backend-gate`、`docker-build`、`web-gate`、`ai-governance` 等正式 CI 保持不变。
- 维护者仍可通过 Actions 的 `workflow_dispatch` 输入 PR 编号手动运行。
- 本 PR 未变更 provider/model/base URL、运行时配置清理迁移语义；历史配置保持不变。

## Rollback Plan

Revert this PR 即可恢复 `pull_request_target` 自动触发；无需配置或数据迁移。

## Checklist

- [x] 本 PR 有明确动机和业务价值
- [x] 已提供可复现的验证命令与结果
- [x] 已评估兼容性与风险
- [x] 已提供回滚方案
- [x] 已同步中英文贡献文档与 `docs/CHANGELOG.md`
