### PR TITLE
feat: evaluate skill opinion outcomes

### DIFF
--- a/api/v1/endpoints/__init__.py
+++ b/api/v1/endpoints/__init__.py
@@ -21,6 +21,7 @@ from api.v1.endpoints import (
     portfolio,
     alerts,
     decision_signals,
+    skill_opinion_outcomes,
     alphasift,
 )
 __all__ = [
@@ -36,5 +37,6 @@ __all__ = [
     "portfolio",
     "alerts",
     "decision_signals",
+    "skill_opinion_outcomes",
     "alphasift",
 ]

--- a/api/v1/endpoints/skill_opinion_outcomes.py
+++ b/api/v1/endpoints/skill_opinion_outcomes.py
@@ -1,0 +1,131 @@
+# -*- coding: utf-8 -*-
+"""Admin endpoints for per-skill opinion forward outcomes."""
+
+from __future__ import annotations
+
+import logging
+from typing import Optional
+
+from fastapi import APIRouter, HTTPException, Query, Security
+from fastapi.security import APIKeyCookie
+
+from api.v1.schemas.common import ErrorResponse
+from api.v1.schemas.skill_opinion_outcomes import (
+    SkillOpinionOutcomeHorizon,
+    SkillOpinionOutcomeListResponse,
+    SkillOpinionOutcomeRunRequest,
+    SkillOpinionOutcomeRunResponse,
+    SkillOpinionOutcomeStatus,
+    SkillOpinionOutcomeValue,
+)
+from src.auth import COOKIE_NAME
+from src.services.skill_opinion_outcome_service import SkillOpinionOutcomeService
+
+
+logger = logging.getLogger(__name__)
+admin_session_cookie = APIKeyCookie(
+    name=COOKIE_NAME,
+    scheme_name="AdminSessionCookie",
+    auto_error=False,
+)
+router = APIRouter(dependencies=[Security(admin_session_cookie)])
+AUTH_RESPONSE = {
+    401: {
+        "model": ErrorResponse,
+        "description": "未登录或管理员会话无效（ADMIN_AUTH_ENABLED=true 时）",
+    },
+}
+
+
+def _bad_request(exc: Exception) -> HTTPException:
+    return HTTPException(
+        status_code=400,
+        detail={"error": "validation_error", "message": str(exc)},
+    )
+
+
+def _internal_error(message: str, exc: Exception) -> HTTPException:
+    logger.error("%s: %s", message, exc, exc_info=True)
+    return HTTPException(
+        status_code=500,
+        detail={"error": "internal_error", "message": message},
+    )
+
+
+@router.post(
+    "/run",
+    response_model=SkillOpinionOutcomeRunResponse,
+    responses={
+        **AUTH_RESPONSE,
+        400: {"model": ErrorResponse, "description": "请求字段非法"},
+        422: {"model": ErrorResponse, "description": "请求体校验失败"},
+        500: {"model": ErrorResponse, "description": "Skill opinion outcome 计算失败"},
+    },
+    summary="触发 Skill opinion outcome 计算",
+    description="仅使用已持久化 sample 与本地日线，按每条 sample 自身 signal 独立评价。",
+    operation_id="runSkillOpinionOutcomes",
+)
+def run_outcomes(request: SkillOpinionOutcomeRunRequest) -> SkillOpinionOutcomeRunResponse:
+    service = SkillOpinionOutcomeService()
+    try:
+        return SkillOpinionOutcomeRunResponse(
+            **service.run_outcomes(
+                sample_id=request.sample_id,
+                analysis_history_id=request.analysis_history_id,
+                skill_id=request.skill_id,
+                stock_code=request.stock_code,
+                horizons=request.horizons,
+                limit=request.limit,
+            )
+        )
+    except ValueError as exc:
+        raise _bad_request(exc)
+    except Exception as exc:
+        raise _internal_error("Run skill opinion outcomes failed", exc)
+
+
+@router.get(
+    "",
+    response_model=SkillOpinionOutcomeListResponse,
+    responses={
+        **AUTH_RESPONSE,
+        400: {"model": ErrorResponse, "description": "查询参数非法"},
+        422: {"model": ErrorResponse, "description": "查询参数校验失败"},
+        500: {"model": ErrorResponse, "description": "Skill opinion outcome 查询失败"},
+    },
+    summary="逐条查询 Skill opinion outcome",
+    description="只读分页查询，不提供表现统计、排名或权重信息。",
+    operation_id="listSkillOpinionOutcomes",
+)
+def list_outcomes(
+    sample_id: Optional[int] = Query(None, gt=0),
+    analysis_history_id: Optional[int] = Query(None, gt=0),
+    skill_id: Optional[str] = Query(None, min_length=1, max_length=128),
+    stock_code: Optional[str] = Query(None, min_length=1, max_length=16),
+    horizon: Optional[SkillOpinionOutcomeHorizon] = Query(None),
+    engine_version: Optional[str] = Query(None, min_length=1, max_length=32),
+    eval_status: Optional[SkillOpinionOutcomeStatus] = Query(None),
+    outcome: Optional[SkillOpinionOutcomeValue] = Query(None),
+    page: int = Query(1, ge=1),
+    page_size: int = Query(20, ge=1, le=100),
+) -> SkillOpinionOutcomeListResponse:
+    service = SkillOpinionOutcomeService()
+    try:
+        return SkillOpinionOutcomeListResponse(
+            **service.list_outcomes_page(
+                sample_id=sample_id,
+                analysis_history_id=analysis_history_id,
+                skill_id=skill_id,
+                stock_code=stock_code,
+                horizon=horizon,
+                engine_version=engine_version,
+                eval_status=eval_status,
+                outcome=outcome,
+                page=page,
+                page_size=page_size,
+            )
+        )
+    except ValueError as exc:
+        raise _bad_request(exc)
+    except Exception as exc:
+        raise _internal_error("List skill opinion outcomes failed", exc)

--- a/api/v1/router.py
+++ b/api/v1/router.py
@@ -19,6 +19,7 @@ from api.v1.endpoints import (
     auth,
     backtest,
     decision_signals,
+    skill_opinion_outcomes,
     health,
     history,
     intelligence,
@@ -96,6 +97,12 @@ router.include_router(
     decision_signals.router,
     prefix="/decision-signals",
     tags=["DecisionSignals"]
+)
+
+router.include_router(
+    skill_opinion_outcomes.router,
+    prefix="/skill-opinion-outcomes",
+    tags=["SkillOpinionOutcomes"],
 )
 
 router.include_router(

--- a/api/v1/schemas/__init__.py
+++ b/api/v1/schemas/__init__.py
@@ -125,6 +125,13 @@ from api.v1.schemas.decision_signals import (
     DecisionSignalOutcomeStatsResponse,
     DecisionSignalStatusUpdateRequest,
 )
+from api.v1.schemas.skill_opinion_outcomes import (
+    SkillOpinionOutcomeItem,
+    SkillOpinionOutcomeListResponse,
+    SkillOpinionOutcomeRunError,
+    SkillOpinionOutcomeRunRequest,
+    SkillOpinionOutcomeRunResponse,
+)
 
 __all__ = [
     # common
@@ -236,4 +243,10 @@ __all__ = [
     "DecisionSignalOutcomeStatsBucket",
     "DecisionSignalOutcomeStatsResponse",
     "DecisionSignalStatusUpdateRequest",
+    # skill opinion outcomes
+    "SkillOpinionOutcomeItem",
+    "SkillOpinionOutcomeListResponse",
+    "SkillOpinionOutcomeRunError",
+    "SkillOpinionOutcomeRunRequest",
+    "SkillOpinionOutcomeRunResponse",
 ]

--- a/api/v1/schemas/skill_opinion_outcomes.py
+++ b/api/v1/schemas/skill_opinion_outcomes.py
@@ -1,0 +1,73 @@
+# -*- coding: utf-8 -*-
+"""Schemas for admin Skill Opinion Outcome execution and read-only queries."""
+
+from __future__ import annotations
+
+from typing import List, Literal, Optional
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+SkillOpinionOutcomeHorizon = Literal["1d", "3d", "5d", "10d"]
+SkillOpinionOutcomeStatus = Literal["pending", "evaluated", "observational", "unable"]
+SkillOpinionOutcomeValue = Literal["hit", "miss", "observational"]
+
+
+class SkillOpinionOutcomeRunRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    sample_id: Optional[int] = Field(None, gt=0)
+    analysis_history_id: Optional[int] = Field(None, gt=0)
+    skill_id: Optional[str] = Field(None, min_length=1, max_length=128)
+    stock_code: Optional[str] = Field(None, min_length=1, max_length=16)
+    horizons: Optional[List[SkillOpinionOutcomeHorizon]] = None
+    limit: int = Field(100, ge=1, le=500)
+
+
+class SkillOpinionOutcomeItem(BaseModel):
+    id: int
+    skill_opinion_sample_id: int
+    analysis_history_id: int
+    stock_code: str
+    skill_id: str
+    signal: str
+    horizon: SkillOpinionOutcomeHorizon
+    engine_version: str
+    eval_status: SkillOpinionOutcomeStatus
+    outcome: Optional[SkillOpinionOutcomeValue] = None
+    direction_correct: Optional[bool] = None
+    unable_reason: Optional[str] = None
+    analysis_date: Optional[str] = None
+    start_trade_date: Optional[str] = None
+    end_trade_date: Optional[str] = None
+    start_price: Optional[float] = None
+    end_close: Optional[float] = None
+    stock_return_pct: Optional[float] = None
+    directional_return_pct: Optional[float] = None
+    created_at: Optional[str] = None
+    updated_at: Optional[str] = None
+
+
+class SkillOpinionOutcomeRunError(BaseModel):
+    sample_id: int
+    horizon: SkillOpinionOutcomeHorizon
+    error_type: str
+
+
+class SkillOpinionOutcomeRunResponse(BaseModel):
+    items: List[SkillOpinionOutcomeItem] = Field(default_factory=list)
+    processed_keys: int
+    created: int
+    updated: int
+    skipped: int
+    failed: int
+    errors: List[SkillOpinionOutcomeRunError] = Field(default_factory=list)
+    limit_unit: Literal["outcome_key"]
+    engine_version: str
+
+
+class SkillOpinionOutcomeListResponse(BaseModel):
+    items: List[SkillOpinionOutcomeItem] = Field(default_factory=list)
+    total: int
+    page: int
+    page_size: int

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,7 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 > For user-friendly release highlights, see the [GitHub Releases](https://github.com/ZhuLinsen/daily_stock_analysis/releases) page.
 
 ## [Unreleased]
+- [修复] Outcome 行情候选在显式沪深交易所与代码市场冲突时不再降级匹配裸码，并将历史非法样本持久化为不可变的 unable 终态。
 - [chore] 暂停 PR Review 的自动触发，仅保留 `workflow_dispatch` 手动入口，避免辅助评审重复运行及评论权限失败产生误导性红灯；正式 CI 检查保持不变。
+- [新功能] 新增按 individual SkillAgent 自身 signal、版本化 engine 和本地已存日线独立计算的 `skill_opinion_outcomes`，并提供最小管理员执行与逐条只读查询 API；未来数据不足保持可重试 pending，终态结果不可被同版本覆盖，本阶段不接入表现统计、样本充足度或自动权重。
 - [新功能] Multi-Agent specialist 运行在分析历史保存成功后，按独立 skill 持久化版本化、低敏且幂等的有效 opinion 样本，为后续后验评估提供真实数据；本阶段不计算 outcome、不统计表现、不调整权重。
 - [新功能] Multi-Agent 报告按八态用户 action 追踪 Pipeline 最终调整，排除非法 Agent 意见；仅在 canonical action 可唯一解析时生成 explanation 与 DecisionSignal，并以同一个 `final_action` 统一最终动作契约。
 - [新功能] 新增 `--portfolio futu`，只读导入 Futu OpenD 真实账户的沪深 A 股、港股、美股 LONG 正股持仓作为分析列表。

--- a/docs/architecture/api_spec.json
+++ b/docs/architecture/api_spec.json
@@ -2672,10 +2672,735 @@
           }
         ]
       }
+    },
+    "/api/v1/skill-opinion-outcomes/run": {
+      "post": {
+        "tags": [
+          "SkillOpinionOutcomes"
+        ],
+        "summary": "触发 Skill opinion outcome 计算",
+        "description": "仅使用已持久化 sample 与本地日线，按每条 sample 自身 signal 独立评价。",
+        "operationId": "runSkillOpinionOutcomes",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SkillOpinionOutcomeRunRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SkillOpinionOutcomeRunResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "未登录或管理员会话无效（ADMIN_AUTH_ENABLED=true 时）",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "请求字段非法",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "请求体校验失败",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Skill opinion outcome 计算失败",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "AdminSessionCookie": []
+          }
+        ]
+      }
+    },
+    "/api/v1/skill-opinion-outcomes": {
+      "get": {
+        "tags": [
+          "SkillOpinionOutcomes"
+        ],
+        "summary": "逐条查询 Skill opinion outcome",
+        "description": "只读分页查询，不提供表现统计、排名或权重信息。",
+        "operationId": "listSkillOpinionOutcomes",
+        "security": [
+          {
+            "AdminSessionCookie": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "sample_id",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer",
+                  "exclusiveMinimum": 0
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Sample Id"
+            }
+          },
+          {
+            "name": "analysis_history_id",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer",
+                  "exclusiveMinimum": 0
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Analysis History Id"
+            }
+          },
+          {
+            "name": "skill_id",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "minLength": 1,
+                  "maxLength": 128
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Skill Id"
+            }
+          },
+          {
+            "name": "stock_code",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "minLength": 1,
+                  "maxLength": 16
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Stock Code"
+            }
+          },
+          {
+            "name": "horizon",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "enum": [
+                    "1d",
+                    "3d",
+                    "5d",
+                    "10d"
+                  ],
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Horizon"
+            }
+          },
+          {
+            "name": "engine_version",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "minLength": 1,
+                  "maxLength": 32
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Engine Version"
+            }
+          },
+          {
+            "name": "eval_status",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "enum": [
+                    "pending",
+                    "evaluated",
+                    "observational",
+                    "unable"
+                  ],
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Eval Status"
+            }
+          },
+          {
+            "name": "outcome",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "enum": [
+                    "hit",
+                    "miss",
+                    "observational"
+                  ],
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Outcome"
+            }
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "default": 1,
+              "title": "Page"
+            }
+          },
+          {
+            "name": "page_size",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "maximum": 100,
+              "minimum": 1,
+              "default": 20,
+              "title": "Page Size"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SkillOpinionOutcomeListResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "未登录或管理员会话无效（ADMIN_AUTH_ENABLED=true 时）",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "查询参数非法",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "查询参数校验失败",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Skill opinion outcome 查询失败",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
     }
   },
   "components": {
     "schemas": {
+      "SkillOpinionOutcomeItem": {
+        "properties": {
+          "id": {
+            "type": "integer",
+            "title": "Id"
+          },
+          "skill_opinion_sample_id": {
+            "type": "integer",
+            "title": "Skill Opinion Sample Id"
+          },
+          "analysis_history_id": {
+            "type": "integer",
+            "title": "Analysis History Id"
+          },
+          "stock_code": {
+            "type": "string",
+            "title": "Stock Code"
+          },
+          "skill_id": {
+            "type": "string",
+            "title": "Skill Id"
+          },
+          "signal": {
+            "type": "string",
+            "title": "Signal"
+          },
+          "horizon": {
+            "type": "string",
+            "enum": [
+              "1d",
+              "3d",
+              "5d",
+              "10d"
+            ],
+            "title": "Horizon"
+          },
+          "engine_version": {
+            "type": "string",
+            "title": "Engine Version"
+          },
+          "eval_status": {
+            "type": "string",
+            "enum": [
+              "pending",
+              "evaluated",
+              "observational",
+              "unable"
+            ],
+            "title": "Eval Status"
+          },
+          "outcome": {
+            "anyOf": [
+              {
+                "type": "string",
+                "enum": [
+                  "hit",
+                  "miss",
+                  "observational"
+                ]
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Outcome"
+          },
+          "direction_correct": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Direction Correct"
+          },
+          "unable_reason": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Unable Reason"
+          },
+          "analysis_date": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Analysis Date"
+          },
+          "start_trade_date": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Start Trade Date"
+          },
+          "end_trade_date": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "End Trade Date"
+          },
+          "start_price": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Start Price"
+          },
+          "end_close": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "End Close"
+          },
+          "stock_return_pct": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Stock Return Pct"
+          },
+          "directional_return_pct": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Directional Return Pct"
+          },
+          "created_at": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Created At"
+          },
+          "updated_at": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Updated At"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "skill_opinion_sample_id",
+          "analysis_history_id",
+          "stock_code",
+          "skill_id",
+          "signal",
+          "horizon",
+          "engine_version",
+          "eval_status"
+        ],
+        "title": "SkillOpinionOutcomeItem"
+      },
+      "SkillOpinionOutcomeListResponse": {
+        "properties": {
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/SkillOpinionOutcomeItem"
+            },
+            "type": "array",
+            "title": "Items"
+          },
+          "total": {
+            "type": "integer",
+            "title": "Total"
+          },
+          "page": {
+            "type": "integer",
+            "title": "Page"
+          },
+          "page_size": {
+            "type": "integer",
+            "title": "Page Size"
+          }
+        },
+        "type": "object",
+        "required": [
+          "total",
+          "page",
+          "page_size"
+        ],
+        "title": "SkillOpinionOutcomeListResponse"
+      },
+      "SkillOpinionOutcomeRunError": {
+        "properties": {
+          "sample_id": {
+            "type": "integer",
+            "title": "Sample Id"
+          },
+          "horizon": {
+            "type": "string",
+            "enum": [
+              "1d",
+              "3d",
+              "5d",
+              "10d"
+            ],
+            "title": "Horizon"
+          },
+          "error_type": {
+            "type": "string",
+            "title": "Error Type"
+          }
+        },
+        "type": "object",
+        "required": [
+          "sample_id",
+          "horizon",
+          "error_type"
+        ],
+        "title": "SkillOpinionOutcomeRunError"
+      },
+      "SkillOpinionOutcomeRunRequest": {
+        "properties": {
+          "sample_id": {
+            "anyOf": [
+              {
+                "type": "integer",
+                "exclusiveMinimum": 0.0
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Sample Id"
+          },
+          "analysis_history_id": {
+            "anyOf": [
+              {
+                "type": "integer",
+                "exclusiveMinimum": 0.0
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Analysis History Id"
+          },
+          "skill_id": {
+            "anyOf": [
+              {
+                "type": "string",
+                "maxLength": 128,
+                "minLength": 1
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Skill Id"
+          },
+          "stock_code": {
+            "anyOf": [
+              {
+                "type": "string",
+                "maxLength": 16,
+                "minLength": 1
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Stock Code"
+          },
+          "horizons": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string",
+                  "enum": [
+                    "1d",
+                    "3d",
+                    "5d",
+                    "10d"
+                  ]
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Horizons"
+          },
+          "limit": {
+            "type": "integer",
+            "maximum": 500.0,
+            "minimum": 1.0,
+            "title": "Limit",
+            "default": 100
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "title": "SkillOpinionOutcomeRunRequest"
+      },
+      "SkillOpinionOutcomeRunResponse": {
+        "properties": {
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/SkillOpinionOutcomeItem"
+            },
+            "type": "array",
+            "title": "Items"
+          },
+          "processed_keys": {
+            "type": "integer",
+            "title": "Processed Keys"
+          },
+          "created": {
+            "type": "integer",
+            "title": "Created"
+          },
+          "updated": {
+            "type": "integer",
+            "title": "Updated"
+          },
+          "skipped": {
+            "type": "integer",
+            "title": "Skipped"
+          },
+          "failed": {
+            "type": "integer",
+            "title": "Failed"
+          },
+          "errors": {
+            "items": {
+              "$ref": "#/components/schemas/SkillOpinionOutcomeRunError"
+            },
+            "type": "array",
+            "title": "Errors"
+          },
+          "limit_unit": {
+            "type": "string",
+            "const": "outcome_key",
+            "title": "Limit Unit"
+          },
+          "engine_version": {
+            "type": "string",
+            "title": "Engine Version"
+          }
+        },
+        "type": "object",
+        "required": [
+          "processed_keys",
+          "created",
+          "updated",
+          "skipped",
+          "failed",
+          "limit_unit",
+          "engine_version"
+        ],
+        "title": "SkillOpinionOutcomeRunResponse"
+      },
       "RootResponse": {
         "type": "object",
         "properties": {

--- a/docs/multi-strategy-contract.md
+++ b/docs/multi-strategy-contract.md
@@ -1,5 +1,23 @@
 # 多策略投资建议契约：Baseline 语义、Phase 1 收敛、Phase 2/3/4 边界
 
+## Skill Opinion Outcome 边界（Issue #1904 P2 PR2）
+
+`skill_opinion_outcomes` 的一条记录表示一条不可变 `skill_opinion_sample` 在一个 `horizon`、一个 `engine_version` 下的独立后验结果。唯一键为 `(skill_opinion_sample_id, horizon, engine_version)`。初始 horizon 仅允许 `1d`、`3d`、`5d`、`10d`；`limit` 限制待处理的 `sample × horizon` outcome key 数量，不是 sample 数量。
+
+每条 outcome 必须使用 sample 自己的 canonical `signal`。`strong_buy` / `buy` 按 bullish 评价，`strong_sell` / `sell` 按 bearish 评价；不得读取 `AnalysisHistory.operation_advice`、最终 Agent decision、`skill_consensus` 或其他 skill 的 signal。`hold` 只在价格窗口完整后写为 `eval_status=observational`、`outcome=observational`，其 `direction_correct` 和 `directional_return_pct` 均为 `NULL`。
+
+收益字段沿用仓库既有百分数单位：`5.0` 表示 `5%`。`stock_return_pct = (end_close - start_price) / start_price * 100`；bullish 的 `directional_return_pct` 等于股票收益，bearish 等于其相反数。方向收益严格大于零才算 `hit`；小于或等于零均为 `miss`，所以零收益必须保存为 `outcome=miss`、`direction_correct=false`、`directional_return_pct=0`。
+
+分析日期优先使用持久化 `market_phase_summary.effective_daily_bar_date`。命中该来源时，起始日线必须是完全相同日期的 `StockDaily`；缺失时写 `pending/missing_start_bar`，不得回退到更早日期。只有兼容来源 `enhanced_context.date` 或 `AnalysisHistory.created_at.date()` 才允许通过 `StockRepository.get_start_daily()` 选择该日期或此前最近一条本地日线。
+
+horizon v1 按 `StockRepository.get_forward_bars()` 返回的本地已存 `stock_daily` 有序行计数：起始 bar 之后第 N 条本地日线是 N 日 outcome 的结束 bar。仓库虽然有基于 `exchange_calendars` 的市场阶段与有效日线日期解析，但当前没有复用中的 forward 日线完整性校验；因此 v1 无法识别中间真实交易日缺失，不能把该口径描述为已验证完整的交易日历窗口。结果必须保存实际 `start_trade_date` 和 `end_trade_date` 供审计。本阶段不请求外部行情，也不新增 provider。
+
+`eval_status` 仅允许 `pending`、`evaluated`、`observational`、`unable`。缺少起始 bar/close、未来本地日线不足或结束 close 不可用均为可重试 `pending`；`unable` 只用于 `invalid_signal`、`missing_analysis_date` 等永久无效输入。运行时 evaluation/persistence exception 不写 terminal outcome，只在本次运行结果与低敏日志中记录 `sample_id`、`horizon`、`error_type`，下次运行继续选择该 key。
+
+Outcome 写入必须复用 `DatabaseManager._run_write_transaction()` 的 `BEGIN IMMEDIATE`、busy timeout 和 locked retry。在同一 engine version 下，只有 `pending` 可以更新；`evaluated`、`observational`、`unable` 均不可覆盖。规则语义变化必须提升 engine version。历史删除在同一写事务内按 outcome → sample → history 的顺序显式清理，不能依赖 SQLite 外键开关。
+
+本阶段通过管理员鉴权的 `POST /api/v1/skill-opinion-outcomes/run` 显式调用 `SkillOpinionOutcomeService.run_outcomes()`，并通过 `GET /api/v1/skill-opinion-outcomes` 提供逐条只读分页查询。POST 只接受 sample、history、skill、stock、horizon 和 outcome-key limit 筛选，不能由客户端提供 signal、价格、outcome、direction、engine version 或最终 Agent decision。API 不提供表现统计、样本充足度、排名或权重，也不把 Outcome Service 导入主分析 Pipeline。
+
 本页是 Issue #1964「多策略投资建议」的专题文档，用于记录 2 个及以上策略/技能（skill）观点在系统内的**语义收敛边界**：有效证据集合、无效观点隔离、阵营分组、共识度、跨消费面一致性。Baseline 负责契约边界和现状盘点；Phase 1 只在 Baseline 契约内完成有效证据集合分拣、`strategy_synthesis` 确定性合成、DecisionAgent prompt 收敛、四条 renderer 一致性以及 E2E 反例覆盖；Phase 2 只在 Phase 1 契约下新增 2–4 策略并发调度与阶段调度；Phase 3 只在 Phase 2 之上补前端多语言完整展示；Phase 4 只在同一 `CONTRACT_VERSION = "1.0"` 内补权重回测反馈闭环。Baseline 的所有约束对后续 Phase 均永久生效，Phase N 不得静默降级 Baseline 中已经写死的边界。
 
 ## Skill opinion 样本边界（Issue #1904 P2 PR1）

--- a/src/core/skill_opinion_outcome_evaluator.py
+++ b/src/core/skill_opinion_outcome_evaluator.py
@@ -1,0 +1,163 @@
+# -*- coding: utf-8 -*-
+"""Pure forward-outcome evaluation for persisted skill opinions."""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from datetime import date
+import math
+from typing import Any, Dict, Optional, Sequence
+
+from src.agent.protocols import normalize_strategy_signal
+
+
+SUPPORTED_SKILL_OUTCOME_HORIZONS = {
+    "1d": 1,
+    "3d": 3,
+    "5d": 5,
+    "10d": 10,
+}
+
+_BULLISH_SIGNALS = frozenset({"strong_buy", "buy"})
+_BEARISH_SIGNALS = frozenset({"strong_sell", "sell"})
+
+
+@dataclass(frozen=True)
+class SkillOpinionOutcomeEvaluation:
+    """One deterministic sample-by-horizon evaluation result."""
+
+    eval_status: str
+    outcome: Optional[str] = None
+    direction_correct: Optional[bool] = None
+    unable_reason: Optional[str] = None
+    analysis_date: Optional[date] = None
+    start_trade_date: Optional[date] = None
+    end_trade_date: Optional[date] = None
+    start_price: Optional[float] = None
+    end_close: Optional[float] = None
+    stock_return_pct: Optional[float] = None
+    directional_return_pct: Optional[float] = None
+
+    def to_fields(self) -> Dict[str, Any]:
+        return asdict(self)
+
+
+class SkillOpinionOutcomeEvaluator:
+    """Evaluate one immutable skill signal against locally stored daily bars."""
+
+    @classmethod
+    def evaluate(
+        cls,
+        *,
+        signal: Any,
+        horizon: str,
+        analysis_date: Optional[date],
+        start_bar: Any = None,
+        forward_bars: Sequence[Any] = (),
+    ) -> SkillOpinionOutcomeEvaluation:
+        canonical_signal, invalid_signal, _ = normalize_strategy_signal(signal)
+        if invalid_signal:
+            return cls._unable("invalid_signal", analysis_date=analysis_date)
+
+        eval_days = SUPPORTED_SKILL_OUTCOME_HORIZONS.get(str(horizon or "").strip())
+        if eval_days is None:
+            return cls._unable("unsupported_horizon", analysis_date=analysis_date)
+        if analysis_date is None:
+            return cls._unable("missing_analysis_date")
+        if start_bar is None:
+            return cls._pending("missing_start_bar", analysis_date=analysis_date)
+
+        raw_start_price = getattr(start_bar, "close", None)
+        start_price = cls._positive_finite_float(raw_start_price)
+        start_trade_date = cls._bar_date(start_bar)
+        if start_price is None:
+            reason = "missing_start_close" if raw_start_price is None else "invalid_start_price"
+            return cls._pending(
+                reason,
+                analysis_date=analysis_date,
+                start_trade_date=start_trade_date,
+            )
+
+        bars = list(forward_bars)
+        if len(bars) < eval_days:
+            return cls._pending(
+                "insufficient_future_data",
+                analysis_date=analysis_date,
+                start_trade_date=start_trade_date,
+                start_price=start_price,
+            )
+
+        end_bar = bars[eval_days - 1]
+        raw_end_close = getattr(end_bar, "close", None)
+        end_close = cls._positive_finite_float(raw_end_close)
+        end_trade_date = cls._bar_date(end_bar)
+        if end_close is None:
+            reason = "missing_end_close" if raw_end_close is None else "invalid_end_close"
+            return cls._pending(
+                reason,
+                analysis_date=analysis_date,
+                start_trade_date=start_trade_date,
+                end_trade_date=end_trade_date,
+                start_price=start_price,
+            )
+
+        stock_return_pct = (end_close - start_price) / start_price * 100.0
+        common = {
+            "analysis_date": analysis_date,
+            "start_trade_date": start_trade_date,
+            "end_trade_date": end_trade_date,
+            "start_price": start_price,
+            "end_close": end_close,
+            "stock_return_pct": stock_return_pct,
+        }
+
+        if canonical_signal == "hold":
+            return SkillOpinionOutcomeEvaluation(
+                eval_status="observational",
+                outcome="observational",
+                **common,
+            )
+
+        multiplier = 1.0 if canonical_signal in _BULLISH_SIGNALS else -1.0
+        if canonical_signal not in _BULLISH_SIGNALS and canonical_signal not in _BEARISH_SIGNALS:
+            return cls._unable("invalid_signal", analysis_date=analysis_date)
+        directional_return_pct = stock_return_pct * multiplier
+        direction_correct = directional_return_pct > 0.0
+        return SkillOpinionOutcomeEvaluation(
+            eval_status="evaluated",
+            outcome="hit" if direction_correct else "miss",
+            direction_correct=direction_correct,
+            directional_return_pct=directional_return_pct,
+            **common,
+        )
+
+    @staticmethod
+    def _pending(reason: str, **fields: Any) -> SkillOpinionOutcomeEvaluation:
+        return SkillOpinionOutcomeEvaluation(
+            eval_status="pending",
+            unable_reason=reason,
+            **fields,
+        )
+
+    @staticmethod
+    def _unable(reason: str, **fields: Any) -> SkillOpinionOutcomeEvaluation:
+        return SkillOpinionOutcomeEvaluation(
+            eval_status="unable",
+            unable_reason=reason,
+            **fields,
+        )
+
+    @staticmethod
+    def _positive_finite_float(value: Any) -> Optional[float]:
+        if value is None or isinstance(value, bool):
+            return None
+        try:
+            number = float(value)
+        except (OverflowError, TypeError, ValueError):
+            return None
+        return number if math.isfinite(number) and number > 0 else None
+
+    @staticmethod
+    def _bar_date(bar: Any) -> Optional[date]:
+        value = getattr(bar, "date", None)
+        return value if isinstance(value, date) else None

--- a/src/repositories/backtest_repo.py
+++ b/src/repositories/backtest_repo.py
@@ -13,9 +13,12 @@ from typing import List, Optional, Tuple
 
 from sqlalchemy import and_, delete, desc, func, or_, select
 
-from data_provider.base import is_bse_code
 from src.core.backtest_engine import OVERALL_SENTINEL_CODE
-from src.services.stock_code_utils import normalize_code as normalize_backtest_code
+from src.services.stock_code_utils import (
+    build_hk_market_variants,
+    build_market_code_variants,
+    normalize_code as normalize_backtest_code,
+)
 
 from src.storage import BacktestResult, BacktestSummary, DatabaseManager, AnalysisHistory
 
@@ -532,120 +535,9 @@ class BacktestRepository:
     @staticmethod
     def _build_hk_market_variants(hk_digits: str) -> List[str]:
         """Build normalized HK variants for padded/unpadded code shapes."""
-        if not hk_digits.isdigit() or not hk_digits:
-            return []
-
-        padded = hk_digits.zfill(5)
-        unpadded = padded.lstrip("0") or "0"
-
-        variants: List[str] = [
-            f"HK{padded}",
-            f"{padded}.HK",
-            padded,
-            f"HK{unpadded}",
-            f"{unpadded}.HK",
-            f"HK.{padded}",
-        ]
-        if unpadded == padded:
-            variants.pop(3)
-            variants.pop(3)
-
-        # Keep legacy no-leading-zero bare form for 1-3 digit inputs.
-        if len(unpadded) <= 3 and unpadded != padded:
-            variants.append(unpadded)
-            variants.append(f"HK.{unpadded}")
-
-        return variants
+        return build_hk_market_variants(hk_digits)
 
     @staticmethod
     def _build_market_code_variants(raw_code: str, normalized_code: str) -> List[str]:
         """Return additional market-formatted variants for safe stock-code matching."""
-        variants: List[str] = []
-        if not raw_code:
-            return variants
-
-        raw_code_upper = raw_code.upper()
-        normalized_upper = normalized_code.upper() if normalized_code else ""
-
-        def _add_us_variants(code: str) -> None:
-            if not code:
-                return
-            if code.endswith(".US"):
-                bare = code[:-3]
-                if bare.isalpha() and 1 <= len(bare) <= 5:
-                    variants.append(bare)
-                return
-            if "." not in code and code.isalpha() and 1 <= len(code) <= 5:
-                variants.append(f"{code}.US")
-
-        _add_us_variants(raw_code_upper)
-        if normalized_upper != raw_code_upper:
-            _add_us_variants(normalized_upper)
-
-        def _explicit_exchange() -> Optional[str]:
-            if raw_code_upper.startswith(("SH", "SS")) or raw_code_upper.endswith((".SH", ".SS")):
-                return "SH"
-            if raw_code_upper.startswith("SZ") or raw_code_upper.endswith(".SZ"):
-                return "SZ"
-            if raw_code_upper.startswith("BJ") or raw_code_upper.endswith(".BJ"):
-                return "BJ"
-            return None
-
-        def _exchange_by_code(base: str) -> str:
-            if is_bse_code(base):
-                return "BJ"
-            if base.startswith(("5", "6")):
-                return "SH"
-            return "SZ"
-
-        if normalized_upper.isdigit() and len(normalized_upper) == 6:
-            explicit_exchange = _explicit_exchange()
-            if explicit_exchange is not None and explicit_exchange != _exchange_by_code(normalized_upper):
-                return []
-
-            if raw_code_upper.startswith(("SH", "SS")) or raw_code_upper.endswith(".SH") or raw_code_upper.endswith(".SS"):
-                exchange = "SH"
-            elif raw_code_upper.startswith("SZ") or raw_code_upper.endswith(".SZ"):
-                exchange = "SZ"
-            elif raw_code_upper.startswith("BJ") or raw_code_upper.endswith(".BJ") or is_bse_code(normalized_upper):
-                exchange = "BJ"
-            elif normalized_upper.startswith(("5", "6", "9")):
-                exchange = "SH"
-            else:
-                exchange = "SZ"
-
-            variants.append(f"{exchange}{normalized_upper}")
-            variants.append(f"{normalized_upper}.{exchange}")
-            variants.append(f"{exchange}.{normalized_upper}")
-            if exchange == "SH":
-                variants.append(f"SS{normalized_upper}")
-                variants.append(f"{normalized_upper}.SS")
-                variants.append(f"SS.{normalized_upper}")
-
-        if (
-            normalized_upper.startswith("HK")
-            and len(normalized_upper) > 2
-            and normalized_upper[2:].isdigit()
-            and len(normalized_upper[2:]) <= 5
-        ):
-            variants.extend(BacktestRepository._build_hk_market_variants(normalized_upper[2:]))
-
-        if (
-            raw_code_upper.startswith("HK.")
-            and raw_code_upper[3:].isdigit()
-            and len(raw_code_upper[3:]) <= 5
-        ):
-            variants.extend(BacktestRepository._build_hk_market_variants(raw_code_upper[3:]))
-
-        if (
-            raw_code_upper.endswith(".HK")
-            and raw_code_upper[:-3].isdigit()
-            and 1 <= len(raw_code_upper[:-3]) <= 5
-        ):
-            hk_digits = raw_code_upper.rsplit(".", 1)[0]
-            variants.extend(BacktestRepository._build_hk_market_variants(hk_digits))
-
-        if raw_code_upper.isdigit() and len(raw_code_upper) in (4, 5):
-            variants.extend(BacktestRepository._build_hk_market_variants(raw_code_upper))
-
-        return variants
+        return build_market_code_variants(raw_code, normalized_code)

--- a/src/repositories/skill_opinion_outcome_repo.py
+++ b/src/repositories/skill_opinion_outcome_repo.py
@@ -1,0 +1,298 @@
+# -*- coding: utf-8 -*-
+"""Repository for per-sample skill opinion forward outcomes."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any, Dict, List, Optional, Sequence, Tuple
+
+from sqlalchemy import and_, case, desc, func, select
+
+from src.storage import (
+    AnalysisHistory,
+    DatabaseManager,
+    SkillOpinionOutcomeRecord,
+    SkillOpinionSampleRecord,
+    utc_naive_now,
+)
+
+
+_TERMINAL_EVAL_STATUSES = frozenset({"evaluated", "observational", "unable"})
+
+
+@dataclass(frozen=True)
+class SkillOpinionOutcomeCandidate:
+    sample: SkillOpinionSampleRecord
+    history: AnalysisHistory
+    horizon: str
+    existing_outcome: Optional[SkillOpinionOutcomeRecord]
+
+
+class SkillOpinionOutcomeRepository:
+    """Read candidates and persist outcomes through the shared write guard."""
+
+    def __init__(self, db_manager: Optional[DatabaseManager] = None):
+        self.db = db_manager or DatabaseManager.get_instance()
+
+    def list_candidate_keys(
+        self,
+        *,
+        horizons: Sequence[str],
+        engine_version: str,
+        limit: int,
+        sample_id: Optional[int] = None,
+        analysis_history_id: Optional[int] = None,
+        skill_id: Optional[str] = None,
+        stock_code: Optional[str] = None,
+    ) -> List[SkillOpinionOutcomeCandidate]:
+        """Return at most ``limit`` missing or pending sample-by-horizon keys."""
+
+        safe_limit = max(1, min(int(limit), 500))
+        candidates: List[SkillOpinionOutcomeCandidate] = []
+        with self.db.get_session() as session:
+            for horizon in horizons:
+                join_condition = and_(
+                    SkillOpinionOutcomeRecord.skill_opinion_sample_id
+                    == SkillOpinionSampleRecord.id,
+                    SkillOpinionOutcomeRecord.horizon == horizon,
+                    SkillOpinionOutcomeRecord.engine_version == engine_version,
+                )
+                conditions = [
+                    (
+                        SkillOpinionOutcomeRecord.id.is_(None)
+                        | (SkillOpinionOutcomeRecord.eval_status == "pending")
+                    )
+                ]
+                if sample_id is not None:
+                    conditions.append(SkillOpinionSampleRecord.id == sample_id)
+                if analysis_history_id is not None:
+                    conditions.append(
+                        SkillOpinionSampleRecord.analysis_history_id == analysis_history_id
+                    )
+                if skill_id:
+                    conditions.append(SkillOpinionSampleRecord.skill_id == skill_id)
+                if stock_code:
+                    conditions.append(SkillOpinionSampleRecord.stock_code == stock_code)
+
+                rows = session.execute(
+                    select(
+                        SkillOpinionSampleRecord,
+                        AnalysisHistory,
+                        SkillOpinionOutcomeRecord,
+                    )
+                    .join(
+                        AnalysisHistory,
+                        AnalysisHistory.id == SkillOpinionSampleRecord.analysis_history_id,
+                    )
+                    .outerjoin(SkillOpinionOutcomeRecord, join_condition)
+                    .where(and_(*conditions))
+                    .order_by(
+                        case(
+                            (SkillOpinionOutcomeRecord.id.is_(None), 0),
+                            else_=1,
+                        ),
+                        func.coalesce(
+                            SkillOpinionOutcomeRecord.updated_at,
+                            SkillOpinionSampleRecord.created_at,
+                        ),
+                        SkillOpinionSampleRecord.id,
+                    )
+                    .limit(safe_limit)
+                ).all()
+                candidates.extend(
+                    SkillOpinionOutcomeCandidate(
+                        sample=sample,
+                        history=history,
+                        horizon=horizon,
+                        existing_outcome=outcome,
+                    )
+                    for sample, history, outcome in rows
+                )
+
+        horizon_rank = {horizon: index for index, horizon in enumerate(horizons)}
+        candidates.sort(
+            key=lambda item: (
+                item.existing_outcome is not None,
+                self._candidate_time(item),
+                int(item.sample.id),
+                horizon_rank[item.horizon],
+            )
+        )
+        return candidates[:safe_limit]
+
+    def persist_outcome(self, fields: Dict[str, Any]) -> Tuple[Optional[int], str]:
+        """Insert a missing key or update pending; never overwrite terminal rows."""
+
+        def _write(session) -> Tuple[Optional[int], str]:
+            sample_id = int(fields["skill_opinion_sample_id"])
+            sample_exists = session.execute(
+                select(SkillOpinionSampleRecord.id)
+                .where(SkillOpinionSampleRecord.id == sample_id)
+                .limit(1)
+            ).scalar_one_or_none()
+            if sample_exists is None:
+                return None, "missing_sample"
+
+            existing = session.execute(
+                select(SkillOpinionOutcomeRecord)
+                .where(
+                    SkillOpinionOutcomeRecord.skill_opinion_sample_id == sample_id,
+                    SkillOpinionOutcomeRecord.horizon == fields["horizon"],
+                    SkillOpinionOutcomeRecord.engine_version == fields["engine_version"],
+                )
+                .limit(1)
+            ).scalar_one_or_none()
+            if existing is not None and existing.eval_status in _TERMINAL_EVAL_STATUSES:
+                return int(existing.id), "skipped"
+
+            if existing is None:
+                row = SkillOpinionOutcomeRecord(**fields)
+                session.add(row)
+                session.flush()
+                return int(row.id), "created"
+
+            for key, value in fields.items():
+                if key in {
+                    "id",
+                    "skill_opinion_sample_id",
+                    "horizon",
+                    "engine_version",
+                    "created_at",
+                }:
+                    continue
+                setattr(existing, key, value)
+            existing.updated_at = utc_naive_now()
+            session.flush()
+            return int(existing.id), "updated"
+
+        return self.db._run_write_transaction(
+            "persist skill opinion outcome",
+            _write,
+        )
+
+    def get_outcome(
+        self,
+        *,
+        sample_id: int,
+        horizon: str,
+        engine_version: str,
+    ) -> Optional[SkillOpinionOutcomeRecord]:
+        with self.db.get_session() as session:
+            return session.execute(
+                select(SkillOpinionOutcomeRecord)
+                .where(
+                    SkillOpinionOutcomeRecord.skill_opinion_sample_id == sample_id,
+                    SkillOpinionOutcomeRecord.horizon == horizon,
+                    SkillOpinionOutcomeRecord.engine_version == engine_version,
+                )
+                .limit(1)
+            ).scalar_one_or_none()
+
+    def list_outcomes(
+        self,
+        *,
+        sample_id: Optional[int] = None,
+        analysis_history_id: Optional[int] = None,
+        skill_id: Optional[str] = None,
+        stock_code: Optional[str] = None,
+        horizon: Optional[str] = None,
+        engine_version: Optional[str] = None,
+        eval_status: Optional[str] = None,
+        outcome: Optional[str] = None,
+        offset: int = 0,
+        limit: int = 100,
+    ) -> List[Tuple[SkillOpinionOutcomeRecord, SkillOpinionSampleRecord]]:
+        conditions = []
+        if sample_id is not None:
+            conditions.append(SkillOpinionSampleRecord.id == sample_id)
+        if analysis_history_id is not None:
+            conditions.append(
+                SkillOpinionSampleRecord.analysis_history_id == analysis_history_id
+            )
+        if skill_id:
+            conditions.append(SkillOpinionSampleRecord.skill_id == skill_id)
+        if stock_code:
+            conditions.append(SkillOpinionSampleRecord.stock_code == stock_code)
+        if horizon:
+            conditions.append(SkillOpinionOutcomeRecord.horizon == horizon)
+        if engine_version:
+            conditions.append(SkillOpinionOutcomeRecord.engine_version == engine_version)
+        if eval_status:
+            conditions.append(SkillOpinionOutcomeRecord.eval_status == eval_status)
+        if outcome:
+            conditions.append(SkillOpinionOutcomeRecord.outcome == outcome)
+
+        query = (
+            select(SkillOpinionOutcomeRecord, SkillOpinionSampleRecord)
+            .join(
+                SkillOpinionSampleRecord,
+                SkillOpinionSampleRecord.id
+                == SkillOpinionOutcomeRecord.skill_opinion_sample_id,
+            )
+            .order_by(
+                desc(SkillOpinionOutcomeRecord.updated_at),
+                desc(SkillOpinionOutcomeRecord.id),
+            )
+            .offset(max(0, int(offset)))
+            .limit(max(1, min(int(limit), 500)))
+        )
+        if conditions:
+            query = query.where(and_(*conditions))
+        with self.db.get_session() as session:
+            return list(session.execute(query).all())
+
+    def count_outcomes(
+        self,
+        *,
+        sample_id: Optional[int] = None,
+        analysis_history_id: Optional[int] = None,
+        skill_id: Optional[str] = None,
+        stock_code: Optional[str] = None,
+        horizon: Optional[str] = None,
+        engine_version: Optional[str] = None,
+        eval_status: Optional[str] = None,
+        outcome: Optional[str] = None,
+    ) -> int:
+        conditions = []
+        if sample_id is not None:
+            conditions.append(SkillOpinionSampleRecord.id == sample_id)
+        if analysis_history_id is not None:
+            conditions.append(
+                SkillOpinionSampleRecord.analysis_history_id == analysis_history_id
+            )
+        if skill_id:
+            conditions.append(SkillOpinionSampleRecord.skill_id == skill_id)
+        if stock_code:
+            conditions.append(SkillOpinionSampleRecord.stock_code == stock_code)
+        if horizon:
+            conditions.append(SkillOpinionOutcomeRecord.horizon == horizon)
+        if engine_version:
+            conditions.append(SkillOpinionOutcomeRecord.engine_version == engine_version)
+        if eval_status:
+            conditions.append(SkillOpinionOutcomeRecord.eval_status == eval_status)
+        if outcome:
+            conditions.append(SkillOpinionOutcomeRecord.outcome == outcome)
+
+        query = (
+            select(func.count(SkillOpinionOutcomeRecord.id))
+            .select_from(SkillOpinionOutcomeRecord)
+            .join(
+                SkillOpinionSampleRecord,
+                SkillOpinionSampleRecord.id
+                == SkillOpinionOutcomeRecord.skill_opinion_sample_id,
+            )
+        )
+        if conditions:
+            query = query.where(and_(*conditions))
+        with self.db.get_session() as session:
+            return int(session.execute(query).scalar() or 0)
+
+    @staticmethod
+    def _candidate_time(candidate: SkillOpinionOutcomeCandidate) -> datetime:
+        outcome = candidate.existing_outcome
+        return (
+            (outcome.updated_at if outcome is not None else None)
+            or candidate.sample.created_at
+            or datetime.min
+        )

--- a/src/services/backtest_service.py
+++ b/src/services/backtest_service.py
@@ -19,7 +19,10 @@ from src.repositories.stock_repo import StockRepository
 from src.schemas.decision_action import build_action_fields
 from src.storage import BacktestResult, BacktestSummary, DatabaseManager
 from src.utils.data_processing import parse_json_field
-from src.services.stock_code_utils import normalize_code as normalize_backtest_code
+from src.services.stock_code_utils import (
+    build_daily_code_candidates,
+    normalize_code as normalize_backtest_code,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -428,23 +431,7 @@ class BacktestService:
 
     @staticmethod
     def _build_daily_code_candidates(code: Optional[str]) -> List[str]:
-        if not code:
-            return []
-
-        raw_code = str(code).strip()
-        if not raw_code:
-            return []
-
-        raw_code = raw_code.upper()
-        normalized_code = normalize_stock_code(raw_code)
-        backtest_normalized_code = normalize_backtest_code(raw_code)
-        candidates = [raw_code]
-        for candidate in (normalized_code, backtest_normalized_code):
-            if candidate and candidate != raw_code:
-                candidates.append(candidate)
-        for candidate in list(candidates):
-            candidates.extend(BacktestRepository._build_market_code_variants(raw_code, candidate))
-        return list(dict.fromkeys(candidate for candidate in candidates if candidate))
+        return build_daily_code_candidates(code)
 
     @staticmethod
     def _normalize_code(code: Optional[str]) -> Optional[str]:

--- a/src/services/skill_opinion_outcome_service.py
+++ b/src/services/skill_opinion_outcome_service.py
@@ -1,0 +1,359 @@
+# -*- coding: utf-8 -*-
+"""Orchestrate locally stored daily bars into per-skill opinion outcomes."""
+
+from __future__ import annotations
+
+from datetime import date, datetime
+import logging
+from typing import Any, Dict, List, Optional, Sequence, Tuple
+
+from src.core.skill_opinion_outcome_evaluator import (
+    SUPPORTED_SKILL_OUTCOME_HORIZONS,
+    SkillOpinionOutcomeEvaluation,
+    SkillOpinionOutcomeEvaluator,
+)
+from src.market_phase_summary import extract_market_phase_summary
+from src.repositories.backtest_repo import BacktestRepository
+from src.repositories.skill_opinion_outcome_repo import (
+    SkillOpinionOutcomeCandidate,
+    SkillOpinionOutcomeRepository,
+)
+from src.repositories.stock_repo import StockRepository
+from src.services.stock_code_utils import (
+    InvalidStockCodeError,
+    build_daily_code_candidates,
+)
+from src.storage import (
+    AnalysisHistory,
+    DatabaseManager,
+    SkillOpinionOutcomeRecord,
+    SkillOpinionSampleRecord,
+)
+
+
+logger = logging.getLogger(__name__)
+
+SKILL_OPINION_OUTCOME_ENGINE_VERSION = "skill-opinion-outcome-v1"
+
+
+class SkillOpinionOutcomeService:
+    """Evaluate missing and pending outcome keys without fetching external data."""
+
+    def __init__(
+        self,
+        *,
+        repo: Optional[SkillOpinionOutcomeRepository] = None,
+        stock_repo: Optional[StockRepository] = None,
+        db_manager: Optional[DatabaseManager] = None,
+    ):
+        self.repo = repo or SkillOpinionOutcomeRepository(db_manager)
+        self.stock_repo = stock_repo or StockRepository(db_manager)
+
+    def run_outcomes(
+        self,
+        *,
+        sample_id: Optional[int] = None,
+        analysis_history_id: Optional[int] = None,
+        skill_id: Optional[str] = None,
+        stock_code: Optional[str] = None,
+        horizons: Optional[Sequence[str]] = None,
+        limit: int = 100,
+    ) -> Dict[str, Any]:
+        """Process at most ``limit`` missing/pending sample-by-horizon keys."""
+
+        sample_id_norm = self._optional_positive_int(sample_id, "sample_id")
+        history_id_norm = self._optional_positive_int(
+            analysis_history_id,
+            "analysis_history_id",
+        )
+        skill_id_norm = self._optional_text(skill_id)
+        stock_code_norm = self._optional_text(stock_code)
+        horizons_norm = self._normalize_horizons(horizons)
+        safe_limit = max(1, min(int(limit), 500))
+
+        candidates = self.repo.list_candidate_keys(
+            horizons=horizons_norm,
+            engine_version=SKILL_OPINION_OUTCOME_ENGINE_VERSION,
+            limit=safe_limit,
+            sample_id=sample_id_norm,
+            analysis_history_id=history_id_norm,
+            skill_id=skill_id_norm,
+            stock_code=stock_code_norm,
+        )
+
+        items: List[Dict[str, Any]] = []
+        errors: List[Dict[str, Any]] = []
+        counts = {"created": 0, "updated": 0, "skipped": 0}
+        for candidate in candidates:
+            try:
+                evaluation = self._evaluate_candidate(candidate)
+                fields = {
+                    "skill_opinion_sample_id": int(candidate.sample.id),
+                    "horizon": candidate.horizon,
+                    "engine_version": SKILL_OPINION_OUTCOME_ENGINE_VERSION,
+                    **evaluation.to_fields(),
+                }
+                _, persist_status = self.repo.persist_outcome(fields)
+                if persist_status == "missing_sample":
+                    counts["skipped"] += 1
+                    continue
+                counts[persist_status] += 1
+                row = self.repo.get_outcome(
+                    sample_id=int(candidate.sample.id),
+                    horizon=candidate.horizon,
+                    engine_version=SKILL_OPINION_OUTCOME_ENGINE_VERSION,
+                )
+                if row is not None:
+                    items.append(self._serialize_outcome(row, candidate.sample))
+            except Exception as exc:
+                error = {
+                    "sample_id": int(candidate.sample.id),
+                    "horizon": candidate.horizon,
+                    "error_type": type(exc).__name__,
+                }
+                errors.append(error)
+                logger.warning(
+                    "Skill opinion outcome evaluation deferred after transient failure: "
+                    "sample_id=%s horizon=%s error_type=%s",
+                    error["sample_id"],
+                    error["horizon"],
+                    error["error_type"],
+                    exc_info=True,
+                )
+
+        return {
+            "items": items,
+            "processed_keys": len(candidates),
+            "created": counts["created"],
+            "updated": counts["updated"],
+            "skipped": counts["skipped"],
+            "failed": len(errors),
+            "errors": errors,
+            "limit_unit": "outcome_key",
+            "engine_version": SKILL_OPINION_OUTCOME_ENGINE_VERSION,
+        }
+
+    def list_outcomes(
+        self,
+        *,
+        sample_id: Optional[int] = None,
+        analysis_history_id: Optional[int] = None,
+        skill_id: Optional[str] = None,
+        stock_code: Optional[str] = None,
+        horizon: Optional[str] = None,
+        engine_version: Optional[str] = None,
+        eval_status: Optional[str] = None,
+        outcome: Optional[str] = None,
+        offset: int = 0,
+        limit: int = 100,
+    ) -> List[Dict[str, Any]]:
+        rows = self.repo.list_outcomes(
+            sample_id=self._optional_positive_int(sample_id, "sample_id"),
+            analysis_history_id=self._optional_positive_int(
+                analysis_history_id,
+                "analysis_history_id",
+            ),
+            skill_id=self._optional_text(skill_id),
+            stock_code=self._optional_text(stock_code),
+            horizon=self._optional_text(horizon),
+            engine_version=(
+                self._optional_text(engine_version)
+                or SKILL_OPINION_OUTCOME_ENGINE_VERSION
+            ),
+            eval_status=self._optional_text(eval_status),
+            outcome=self._optional_text(outcome),
+            offset=offset,
+            limit=limit,
+        )
+        return [self._serialize_outcome(row, sample) for row, sample in rows]
+
+    def list_outcomes_page(
+        self,
+        *,
+        sample_id: Optional[int] = None,
+        analysis_history_id: Optional[int] = None,
+        skill_id: Optional[str] = None,
+        stock_code: Optional[str] = None,
+        horizon: Optional[str] = None,
+        engine_version: Optional[str] = None,
+        eval_status: Optional[str] = None,
+        outcome: Optional[str] = None,
+        page: int = 1,
+        page_size: int = 20,
+    ) -> Dict[str, Any]:
+        safe_page = max(1, int(page))
+        safe_page_size = max(1, min(int(page_size), 100))
+        filters = {
+            "sample_id": self._optional_positive_int(sample_id, "sample_id"),
+            "analysis_history_id": self._optional_positive_int(
+                analysis_history_id,
+                "analysis_history_id",
+            ),
+            "skill_id": self._optional_text(skill_id),
+            "stock_code": self._optional_text(stock_code),
+            "horizon": self._optional_text(horizon),
+            "engine_version": (
+                self._optional_text(engine_version)
+                or SKILL_OPINION_OUTCOME_ENGINE_VERSION
+            ),
+            "eval_status": self._optional_text(eval_status),
+            "outcome": self._optional_text(outcome),
+        }
+        rows = self.repo.list_outcomes(
+            **filters,
+            offset=(safe_page - 1) * safe_page_size,
+            limit=safe_page_size,
+        )
+        return {
+            "items": [self._serialize_outcome(row, sample) for row, sample in rows],
+            "total": self.repo.count_outcomes(**filters),
+            "page": safe_page,
+            "page_size": safe_page_size,
+        }
+
+    def _evaluate_candidate(self, candidate: SkillOpinionOutcomeCandidate):
+        analysis_date, exact_start_required = self._resolve_analysis_date(candidate.history)
+        try:
+            daily_code_candidates = build_daily_code_candidates(
+                candidate.sample.stock_code
+            )
+        except InvalidStockCodeError:
+            return SkillOpinionOutcomeEvaluation(
+                eval_status="unable",
+                unable_reason="invalid_stock_code",
+                analysis_date=analysis_date,
+            )
+
+        start_bar = None
+        matched_daily_code = None
+        if analysis_date is not None:
+            for daily_code in daily_code_candidates:
+                if exact_start_required:
+                    start_bar = self.stock_repo.get_daily_on_date(
+                        code=daily_code,
+                        target_date=analysis_date,
+                    )
+                else:
+                    start_bar = self.stock_repo.get_start_daily(
+                        code=daily_code,
+                        analysis_date=analysis_date,
+                    )
+                if start_bar is not None:
+                    matched_daily_code = daily_code
+                    break
+
+        forward_bars = []
+        if start_bar is not None:
+            eval_days = SUPPORTED_SKILL_OUTCOME_HORIZONS.get(candidate.horizon, 0)
+            forward_bars = self.stock_repo.get_forward_bars(
+                code=matched_daily_code,
+                analysis_date=start_bar.date,
+                eval_window_days=eval_days,
+            )
+        return SkillOpinionOutcomeEvaluator.evaluate(
+            signal=candidate.sample.signal,
+            horizon=candidate.horizon,
+            analysis_date=analysis_date,
+            start_bar=start_bar,
+            forward_bars=forward_bars,
+        )
+
+    @classmethod
+    def _resolve_analysis_date(
+        cls,
+        history: AnalysisHistory,
+    ) -> Tuple[Optional[date], bool]:
+        summary = extract_market_phase_summary(history.context_snapshot)
+        if isinstance(summary, dict):
+            effective_date = cls._parse_date(summary.get("effective_daily_bar_date"))
+            if effective_date is not None:
+                return effective_date, True
+
+        snapshot_date = BacktestRepository.parse_analysis_date_from_snapshot(
+            history.context_snapshot
+        )
+        if snapshot_date is not None:
+            return snapshot_date, False
+        created_at = getattr(history, "created_at", None)
+        if isinstance(created_at, datetime):
+            return created_at.date(), False
+        return None, False
+
+    @staticmethod
+    def _parse_date(value: Any) -> Optional[date]:
+        if isinstance(value, datetime):
+            return value.date()
+        if isinstance(value, date):
+            return value
+        if isinstance(value, str):
+            try:
+                return date.fromisoformat(value.strip()[:10])
+            except ValueError:
+                return None
+        return None
+
+    @staticmethod
+    def _normalize_horizons(values: Optional[Sequence[str]]) -> List[str]:
+        if not values:
+            return list(SUPPORTED_SKILL_OUTCOME_HORIZONS)
+        normalized: List[str] = []
+        for value in values:
+            horizon = str(value or "").strip()
+            if horizon not in SUPPORTED_SKILL_OUTCOME_HORIZONS:
+                raise ValueError(
+                    "horizon must be one of "
+                    + ", ".join(SUPPORTED_SKILL_OUTCOME_HORIZONS)
+                )
+            if horizon not in normalized:
+                normalized.append(horizon)
+        return normalized
+
+    @staticmethod
+    def _optional_positive_int(value: Any, field_name: str) -> Optional[int]:
+        if value in (None, ""):
+            return None
+        if isinstance(value, bool):
+            raise ValueError(f"{field_name} must be a positive integer")
+        try:
+            number = int(value)
+        except (TypeError, ValueError) as exc:
+            raise ValueError(f"{field_name} must be a positive integer") from exc
+        if number <= 0:
+            raise ValueError(f"{field_name} must be a positive integer")
+        return number
+
+    @staticmethod
+    def _optional_text(value: Any) -> Optional[str]:
+        text = str(value or "").strip()
+        return text or None
+
+    @staticmethod
+    def _serialize_outcome(
+        row: SkillOpinionOutcomeRecord,
+        sample: SkillOpinionSampleRecord,
+    ) -> Dict[str, Any]:
+        return {
+            "id": row.id,
+            "skill_opinion_sample_id": row.skill_opinion_sample_id,
+            "analysis_history_id": sample.analysis_history_id,
+            "stock_code": sample.stock_code,
+            "skill_id": sample.skill_id,
+            "signal": sample.signal,
+            "horizon": row.horizon,
+            "engine_version": row.engine_version,
+            "eval_status": row.eval_status,
+            "outcome": row.outcome,
+            "direction_correct": row.direction_correct,
+            "unable_reason": row.unable_reason,
+            "analysis_date": row.analysis_date.isoformat() if row.analysis_date else None,
+            "start_trade_date": (
+                row.start_trade_date.isoformat() if row.start_trade_date else None
+            ),
+            "end_trade_date": row.end_trade_date.isoformat() if row.end_trade_date else None,
+            "start_price": row.start_price,
+            "end_close": row.end_close,
+            "stock_return_pct": row.stock_return_pct,
+            "directional_return_pct": row.directional_return_pct,
+            "created_at": row.created_at.isoformat() if row.created_at else None,
+            "updated_at": row.updated_at.isoformat() if row.updated_at else None,
+        }

--- a/src/services/stock_code_utils.py
+++ b/src/services/stock_code_utils.py
@@ -6,9 +6,9 @@ Shared stock code utilities.
 from __future__ import annotations
 
 import re
-from typing import Optional
+from typing import List, Optional
 
-from data_provider.base import canonical_stock_code, is_bse_code
+from data_provider.base import canonical_stock_code, is_bse_code, normalize_stock_code
 from src.services.market_symbol_utils import normalize_suffix_market_symbol
 
 
@@ -40,6 +40,10 @@ _SUFFIX_DIGIT_LENS: dict = {
 _PRESERVE_SUFFIXES = {".T", ".KS", ".KQ", ".TW", ".TWO"}
 
 
+class InvalidStockCodeError(ValueError):
+    """Raised when an explicit exchange conflicts with the stock-code market."""
+
+
 def _infer_cn_exchange(base: str) -> str:
     """Infer CN exchange from a 6-digit A/B-share code."""
     if not (base.isdigit() and len(base) == 6):
@@ -62,6 +66,33 @@ def _valid_exchange_code(exchange: str, base: str, digit_lens: tuple[int, ...]) 
     if exchange == "BJ":
         return _infer_cn_exchange(base) == "BJ"
     return True
+
+
+def _has_invalid_explicit_exchange(text: str) -> bool:
+    """Return whether a recognizable explicit exchange conflicts with its base code."""
+    for prefix, digit_lens in _PREFIX_DIGIT_LENS.items():
+        dotted_prefix = f"{prefix}."
+        if text.startswith(dotted_prefix):
+            return not _valid_exchange_code(
+                prefix,
+                text[len(dotted_prefix):],
+                digit_lens,
+            )
+        if text.startswith(prefix):
+            base = text[len(prefix):]
+            # Do not mistake US tickers such as SHOP/HKEX for exchange prefixes.
+            if base.isdigit():
+                return not _valid_exchange_code(prefix, base, digit_lens)
+
+    for suffix, digit_lens in _SUFFIX_DIGIT_LENS.items():
+        if text.endswith(suffix):
+            base = text[: -len(suffix)].strip()
+            return not _valid_exchange_code(
+                suffix.lstrip("."),
+                base,
+                digit_lens,
+            )
+    return False
 
 
 def _strip_exchange_prefix(text: str) -> Optional[str]:
@@ -136,6 +167,114 @@ def normalize_code(raw: str) -> Optional[str]:
     if stripped is not None:
         return stripped
     return None
+
+
+def build_hk_market_variants(hk_digits: str) -> List[str]:
+    """Build normalized HK variants for padded and legacy code shapes."""
+    if not hk_digits.isdigit() or not hk_digits:
+        return []
+
+    padded = hk_digits.zfill(5)
+    unpadded = padded.lstrip("0") or "0"
+    variants = [
+        f"HK{padded}",
+        f"{padded}.HK",
+        padded,
+        f"HK{unpadded}",
+        f"{unpadded}.HK",
+        f"HK.{padded}",
+    ]
+    if unpadded == padded:
+        variants.pop(3)
+        variants.pop(3)
+    if len(unpadded) <= 3 and unpadded != padded:
+        variants.extend([unpadded, f"HK.{unpadded}"])
+    return variants
+
+
+def build_market_code_variants(raw_code: str, normalized_code: str) -> List[str]:
+    """Return additional market-formatted variants for stored-code matching."""
+    variants: List[str] = []
+    if not raw_code:
+        return variants
+
+    raw_code_upper = raw_code.upper()
+    normalized_upper = normalized_code.upper() if normalized_code else ""
+    if _has_invalid_explicit_exchange(raw_code_upper):
+        return []
+
+    def _add_us_variants(code: str) -> None:
+        if not code:
+            return
+        if code.endswith(".US"):
+            bare = code[:-3]
+            if bare.isalpha() and 1 <= len(bare) <= 5:
+                variants.append(bare)
+            return
+        if "." not in code and code.isalpha() and 1 <= len(code) <= 5:
+            variants.append(f"{code}.US")
+
+    _add_us_variants(raw_code_upper)
+    if normalized_upper != raw_code_upper:
+        _add_us_variants(normalized_upper)
+
+    if normalized_upper.isdigit() and len(normalized_upper) == 6:
+        if raw_code_upper.startswith(("SH", "SS")) or raw_code_upper.endswith((".SH", ".SS")):
+            exchange = "SH"
+        elif raw_code_upper.startswith("SZ") or raw_code_upper.endswith(".SZ"):
+            exchange = "SZ"
+        elif raw_code_upper.startswith("BJ") or raw_code_upper.endswith(".BJ") or is_bse_code(normalized_upper):
+            exchange = "BJ"
+        elif normalized_upper.startswith(("5", "6", "9")):
+            exchange = "SH"
+        else:
+            exchange = "SZ"
+
+        variants.extend(
+            [
+                f"{exchange}{normalized_upper}",
+                f"{normalized_upper}.{exchange}",
+                f"{exchange}.{normalized_upper}",
+            ]
+        )
+        if exchange == "SH":
+            variants.extend(
+                [
+                    f"SS{normalized_upper}",
+                    f"{normalized_upper}.SS",
+                    f"SS.{normalized_upper}",
+                ]
+            )
+
+    if normalized_upper.startswith("HK") and normalized_upper[2:].isdigit() and len(normalized_upper[2:]) <= 5:
+        variants.extend(build_hk_market_variants(normalized_upper[2:]))
+    if raw_code_upper.startswith("HK.") and raw_code_upper[3:].isdigit() and len(raw_code_upper[3:]) <= 5:
+        variants.extend(build_hk_market_variants(raw_code_upper[3:]))
+    if raw_code_upper.endswith(".HK") and raw_code_upper[:-3].isdigit() and 1 <= len(raw_code_upper[:-3]) <= 5:
+        variants.extend(build_hk_market_variants(raw_code_upper[:-3]))
+    if raw_code_upper.isdigit() and len(raw_code_upper) in (4, 5):
+        variants.extend(build_hk_market_variants(raw_code_upper))
+
+    return variants
+
+
+def build_daily_code_candidates(code: Optional[str]) -> List[str]:
+    """Build ordered code variants used to locate locally stored daily bars."""
+    raw_code = str(code or "").strip().upper()
+    if not raw_code:
+        return []
+    if _has_invalid_explicit_exchange(raw_code):
+        raise InvalidStockCodeError(
+            f"explicit exchange conflicts with stock code: {raw_code}"
+        )
+
+    candidates = [raw_code]
+    for candidate in (normalize_stock_code(raw_code), normalize_code(raw_code)):
+        if candidate and candidate != raw_code:
+            candidates.append(candidate)
+    for candidate in list(candidates):
+        candidates.extend(build_market_code_variants(raw_code, candidate))
+    return list(dict.fromkeys(candidate for candidate in candidates if candidate))
 
 
 def resolve_index_stock_code_for_analysis(raw: str) -> str:

--- a/src/storage.py
+++ b/src/storage.py
@@ -34,6 +34,7 @@ from sqlalchemy import (
     ForeignKey,
     Index,
     UniqueConstraint,
+    CheckConstraint,
     Text,
     text,
     select,
@@ -1171,6 +1172,83 @@ class SkillOpinionSampleRecord(Base):
             'ix_skill_opinion_sample_stock_created',
             'stock_code',
             'created_at',
+        ),
+    )
+
+
+class SkillOpinionOutcomeRecord(Base):
+    """Forward outcome for one immutable skill opinion sample and horizon."""
+
+    __tablename__ = 'skill_opinion_outcomes'
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    skill_opinion_sample_id = Column(
+        Integer,
+        ForeignKey('skill_opinion_samples.id', ondelete='CASCADE'),
+        nullable=False,
+        index=True,
+    )
+    horizon = Column(String(16), nullable=False, index=True)
+    engine_version = Column(String(32), nullable=False, index=True)
+    eval_status = Column(String(24), nullable=False, default='pending', index=True)
+    outcome = Column(String(16), index=True)
+    direction_correct = Column(Boolean)
+    unable_reason = Column(String(64), index=True)
+    analysis_date = Column(Date, index=True)
+    start_trade_date = Column(Date, index=True)
+    end_trade_date = Column(Date, index=True)
+    start_price = Column(Float)
+    end_close = Column(Float)
+    stock_return_pct = Column(Float)
+    directional_return_pct = Column(Float)
+    created_at = Column(DateTime, default=utc_naive_now, index=True)
+    updated_at = Column(DateTime, default=utc_naive_now, onupdate=utc_naive_now, index=True)
+
+    __table_args__ = (
+        UniqueConstraint(
+            'skill_opinion_sample_id',
+            'horizon',
+            'engine_version',
+            name='uix_skill_opinion_outcome_key',
+        ),
+        CheckConstraint(
+            "horizon IN ('1d', '3d', '5d', '10d')",
+            name='ck_skill_opinion_outcome_horizon',
+        ),
+        CheckConstraint(
+            "eval_status IN ('pending', 'evaluated', 'observational', 'unable')",
+            name='ck_skill_opinion_outcome_eval_status',
+        ),
+        CheckConstraint(
+            "outcome IS NULL OR outcome IN ('hit', 'miss', 'observational')",
+            name='ck_skill_opinion_outcome_value',
+        ),
+        CheckConstraint(
+            "(eval_status IN ('pending', 'unable') "
+            "AND outcome IS NULL "
+            "AND direction_correct IS NULL "
+            "AND directional_return_pct IS NULL) "
+            "OR (eval_status = 'observational' "
+            "AND outcome = 'observational' "
+            "AND direction_correct IS NULL "
+            "AND directional_return_pct IS NULL) "
+            "OR (eval_status = 'evaluated' "
+            "AND outcome IN ('hit', 'miss') "
+            "AND direction_correct IS NOT NULL "
+            "AND directional_return_pct IS NOT NULL)",
+            name='ck_skill_opinion_outcome_state_fields',
+        ),
+        Index(
+            'ix_skill_opinion_outcome_candidate',
+            'engine_version',
+            'eval_status',
+            'updated_at',
+        ),
+        Index(
+            'ix_skill_opinion_outcome_horizon_status',
+            'engine_version',
+            'horizon',
+            'eval_status',
         ),
     )
 
@@ -2484,6 +2562,21 @@ class DatabaseManager(metaclass=_DatabaseManagerMeta):
             session.execute(
                 delete(BacktestResult).where(BacktestResult.analysis_history_id.in_(existing_ids))
             )
+            linked_skill_sample_ids = sorted(
+                session.execute(
+                    select(SkillOpinionSampleRecord.id).where(
+                        SkillOpinionSampleRecord.analysis_history_id.in_(existing_ids)
+                    )
+                ).scalars().all()
+            )
+            if linked_skill_sample_ids:
+                session.execute(
+                    delete(SkillOpinionOutcomeRecord).where(
+                        SkillOpinionOutcomeRecord.skill_opinion_sample_id.in_(
+                            linked_skill_sample_ids
+                        )
+                    )
+                )
             session.execute(
                 delete(SkillOpinionSampleRecord).where(
                     SkillOpinionSampleRecord.analysis_history_id.in_(existing_ids)

--- a/tests/test_api_schema_pydantic.py
+++ b/tests/test_api_schema_pydantic.py
@@ -44,6 +44,17 @@ DECISION_SIGNAL_SCHEMAS = (
     "DecisionSignalStatusUpdateRequest",
     "DecisionSignalWarning",
 )
+SKILL_OPINION_OUTCOME_PATHS = (
+    "/api/v1/skill-opinion-outcomes/run",
+    "/api/v1/skill-opinion-outcomes",
+)
+SKILL_OPINION_OUTCOME_SCHEMAS = (
+    "SkillOpinionOutcomeItem",
+    "SkillOpinionOutcomeListResponse",
+    "SkillOpinionOutcomeRunError",
+    "SkillOpinionOutcomeRunRequest",
+    "SkillOpinionOutcomeRunResponse",
+)
 P6_SIGNAL_LINKED_PATHS = (
     "/api/v1/alerts/triggers",
     "/api/v1/portfolio/risk",
@@ -165,6 +176,14 @@ def test_decision_signal_static_api_spec_matches_runtime_paths() -> None:
     for schema_name in DECISION_SIGNAL_SCHEMAS:
         assert static_spec["components"]["schemas"][schema_name] == runtime_spec["components"]["schemas"][schema_name]
 
+    for path in SKILL_OPINION_OUTCOME_PATHS:
+        assert static_spec["paths"][path] == runtime_spec["paths"][path]
+        for operation in static_spec["paths"][path].values():
+            assert "401" in operation["responses"]
+            assert operation["security"] == [{"AdminSessionCookie": []}]
+    for schema_name in SKILL_OPINION_OUTCOME_SCHEMAS:
+        assert static_spec["components"]["schemas"][schema_name] == runtime_spec["components"]["schemas"][schema_name]
+
     for path in P6_SIGNAL_LINKED_PATHS:
         assert static_spec["paths"][path] == runtime_spec["paths"][path]
     for schema_name in P6_SIGNAL_LINKED_SCHEMAS:
@@ -183,5 +202,6 @@ def test_v1_prefix_is_applied_at_app_mount_level() -> None:
     runtime_paths = create_app().openapi()["paths"]
     assert "/api/v1/history" in runtime_paths
     assert "/api/v1/decision-signals" in runtime_paths
+    assert "/api/v1/skill-opinion-outcomes" in runtime_paths
     assert "/api/v1/history/" not in runtime_paths
     assert "/api/v1/decision-signals/" not in runtime_paths

--- a/tests/test_skill_opinion_outcome_api.py
+++ b/tests/test_skill_opinion_outcome_api.py
@@ -1,0 +1,252 @@
+# -*- coding: utf-8 -*-
+"""Admin API tests for Skill Opinion Outcome execution and read-only queries."""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from datetime import date, datetime
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+from fastapi.testclient import TestClient
+
+try:
+    import litellm  # noqa: F401
+except ModuleNotFoundError:
+    sys.modules["litellm"] = MagicMock()
+
+import src.auth as auth
+from api.app import create_app
+from src.config import Config
+from src.storage import (
+    AnalysisHistory,
+    DatabaseManager,
+    SkillOpinionOutcomeRecord,
+    SkillOpinionSampleRecord,
+    StockDaily,
+)
+
+
+def _reset_auth_globals() -> None:
+    auth._auth_enabled = None
+    auth._session_secret = None
+    auth._password_hash_salt = None
+    auth._password_hash_stored = None
+    auth._rate_limit = {}
+
+
+@pytest.fixture()
+def client_and_db(tmp_path):
+    old_env_file = os.environ.get("ENV_FILE")
+    old_database_path = os.environ.get("DATABASE_PATH")
+    env_path = tmp_path / ".env"
+    db_path = tmp_path / "skill_opinion_outcome_api.db"
+    static_dir = tmp_path / "empty-static"
+    static_dir.mkdir()
+    env_path.write_text(
+        "\n".join(
+            [
+                "STOCK_LIST=600519",
+                "GEMINI_API_KEY=test",
+                "ADMIN_AUTH_ENABLED=false",
+                f"DATABASE_PATH={db_path}",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    os.environ["ENV_FILE"] = str(env_path)
+    os.environ["DATABASE_PATH"] = str(db_path)
+    _reset_auth_globals()
+    Config.reset_instance()
+    DatabaseManager.reset_instance()
+    app = create_app(static_dir=Path(static_dir))
+    client = TestClient(app)
+    db = DatabaseManager.get_instance()
+    try:
+        yield client, db
+    finally:
+        DatabaseManager.reset_instance()
+        Config.reset_instance()
+        _reset_auth_globals()
+        if old_env_file is None:
+            os.environ.pop("ENV_FILE", None)
+        else:
+            os.environ["ENV_FILE"] = old_env_file
+        if old_database_path is None:
+            os.environ.pop("DATABASE_PATH", None)
+        else:
+            os.environ["DATABASE_PATH"] = old_database_path
+
+
+def _add_sample(
+    db: DatabaseManager,
+    *,
+    code: str = "600519",
+    effective_date: str = "2024-01-02",
+) -> int:
+    with db.session_scope() as session:
+        history = AnalysisHistory(
+            query_id=f"outcome-api-{code}",
+            code=code,
+            report_type="simple",
+            operation_advice="hold",
+            context_snapshot=json.dumps(
+                {
+                    "market_phase_summary": {
+                        "phase": "postmarket",
+                        "effective_daily_bar_date": effective_date,
+                    }
+                }
+            ),
+            created_at=datetime(2024, 1, 2, 18, 0, 0),
+        )
+        session.add(history)
+        session.flush()
+        sample = SkillOpinionSampleRecord(
+            analysis_history_id=history.id,
+            stock_code=code,
+            skill_id="alpha",
+            signal="buy",
+            confidence=0.8,
+            sample_schema_version="skill-opinion-sample-v1",
+        )
+        session.add(sample)
+        session.flush()
+        return int(sample.id)
+
+
+def _seed_bars(
+    db: DatabaseManager,
+    *,
+    code: str,
+    bars: list[tuple[date, float]],
+) -> None:
+    with db.session_scope() as session:
+        for day, close in bars:
+            session.add(
+                StockDaily(
+                    code=code,
+                    date=day,
+                    open=close,
+                    high=close,
+                    low=close,
+                    close=close,
+                )
+            )
+
+
+def test_admin_post_generates_variant_outcome_idempotently_and_get_is_read_only(
+    client_and_db,
+) -> None:
+    client, db = client_and_db
+    sample_id = _add_sample(db, code="600519.SH")
+    _seed_bars(
+        db,
+        code="600519",
+        bars=[(date(2024, 1, 2), 100.0), (date(2024, 1, 3), 105.0)],
+    )
+
+    first = client.post(
+        "/api/v1/skill-opinion-outcomes/run",
+        json={"sample_id": sample_id, "horizons": ["1d"]},
+    )
+    assert first.status_code == 200, first.text
+    assert first.json()["created"] == 1
+    assert first.json()["items"][0]["eval_status"] == "evaluated"
+    assert first.json()["items"][0]["stock_return_pct"] == pytest.approx(5.0)
+
+    repeated = client.post(
+        "/api/v1/skill-opinion-outcomes/run",
+        json={"sample_id": sample_id, "horizons": ["1d"]},
+    )
+    assert repeated.status_code == 200, repeated.text
+    assert repeated.json()["processed_keys"] == 0
+
+    with db.get_session() as session:
+        count_before_get = session.query(SkillOpinionOutcomeRecord).count()
+    response = client.get(
+        "/api/v1/skill-opinion-outcomes",
+        params={"sample_id": sample_id, "page": 1, "page_size": 10},
+    )
+    assert response.status_code == 200, response.text
+    assert response.json()["total"] == 1
+    assert response.json()["items"][0]["skill_opinion_sample_id"] == sample_id
+    with db.get_session() as session:
+        assert session.query(SkillOpinionOutcomeRecord).count() == count_before_get == 1
+
+
+def test_admin_post_retries_pending_after_future_bar_arrives(client_and_db) -> None:
+    client, db = client_and_db
+    sample_id = _add_sample(db)
+    _seed_bars(db, code="600519", bars=[(date(2024, 1, 2), 100.0)])
+
+    pending = client.post(
+        "/api/v1/skill-opinion-outcomes/run",
+        json={"sample_id": sample_id, "horizons": ["1d"]},
+    )
+    assert pending.status_code == 200, pending.text
+    assert pending.json()["items"][0]["eval_status"] == "pending"
+
+    _seed_bars(db, code="600519", bars=[(date(2024, 1, 3), 105.0)])
+    evaluated = client.post(
+        "/api/v1/skill-opinion-outcomes/run",
+        json={"sample_id": sample_id, "horizons": ["1d"]},
+    )
+    assert evaluated.status_code == 200, evaluated.text
+    assert evaluated.json()["updated"] == 1
+    assert evaluated.json()["items"][0]["eval_status"] == "evaluated"
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("signal", "sell"),
+        ("outcome", "hit"),
+        ("engine_version", "forged"),
+        ("start_price", 1.0),
+        ("end_close", 2.0),
+        ("direction_correct", True),
+    ],
+)
+def test_admin_post_forbids_client_supplied_evaluation_fields(
+    client_and_db,
+    field,
+    value,
+) -> None:
+    client, _db = client_and_db
+
+    response = client.post(
+        "/api/v1/skill-opinion-outcomes/run",
+        json={"horizons": ["1d"], field: value},
+    )
+
+    assert response.status_code == 422
+
+
+def test_admin_post_keeps_pending_when_exact_variant_start_date_is_missing(
+    client_and_db,
+) -> None:
+    client, db = client_and_db
+    sample_id = _add_sample(
+        db,
+        code="SH600519",
+        effective_date="2024-01-03",
+    )
+    _seed_bars(
+        db,
+        code="600519",
+        bars=[(date(2024, 1, 2), 100.0), (date(2024, 1, 4), 105.0)],
+    )
+
+    response = client.post(
+        "/api/v1/skill-opinion-outcomes/run",
+        json={"sample_id": sample_id, "horizons": ["1d"]},
+    )
+
+    assert response.status_code == 200, response.text
+    assert response.json()["items"][0]["eval_status"] == "pending"
+    assert response.json()["items"][0]["unable_reason"] == "missing_start_bar"

--- a/tests/test_skill_opinion_outcomes.py
+++ b/tests/test_skill_opinion_outcomes.py
@@ -1,0 +1,708 @@
+# -*- coding: utf-8 -*-
+"""Tests for Issue #1904 skill opinion forward outcomes."""
+
+from __future__ import annotations
+
+import json
+import os
+import sqlite3
+from datetime import date, datetime
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+from sqlalchemy import inspect
+from sqlalchemy.exc import IntegrityError, OperationalError
+
+from src.config import Config
+from src.core.skill_opinion_outcome_evaluator import SkillOpinionOutcomeEvaluator
+from src.repositories.skill_opinion_outcome_repo import SkillOpinionOutcomeRepository
+from src.services.skill_opinion_outcome_service import (
+    SKILL_OPINION_OUTCOME_ENGINE_VERSION,
+    SkillOpinionOutcomeService,
+)
+from src.storage import (
+    AnalysisHistory,
+    Base,
+    DatabaseManager,
+    SkillOpinionOutcomeRecord,
+    SkillOpinionSampleRecord,
+    StockDaily,
+)
+
+
+@pytest.fixture()
+def isolated_db(tmp_path):
+    old_database_path = os.environ.get("DATABASE_PATH")
+    os.environ["DATABASE_PATH"] = str(tmp_path / "skill_opinion_outcomes.db")
+    Config.reset_instance()
+    DatabaseManager.reset_instance()
+    db = DatabaseManager.get_instance()
+    try:
+        yield db
+    finally:
+        DatabaseManager.reset_instance()
+        Config.reset_instance()
+        if old_database_path is None:
+            os.environ.pop("DATABASE_PATH", None)
+        else:
+            os.environ["DATABASE_PATH"] = old_database_path
+
+
+def _bar(day: date, close: float):
+    return SimpleNamespace(date=day, close=close)
+
+
+def _add_sample(
+    db: DatabaseManager,
+    *,
+    signal: str = "buy",
+    skill_id: str = "alpha",
+    code: str = "600519",
+    context_snapshot=None,
+    created_at: datetime = datetime(2024, 1, 2, 18, 0, 0),
+    operation_advice: str = "hold",
+) -> tuple[int, int]:
+    with db.session_scope() as session:
+        history = AnalysisHistory(
+            query_id=f"outcome-{skill_id}",
+            code=code,
+            report_type="simple",
+            operation_advice=operation_advice,
+            context_snapshot=(
+                json.dumps(context_snapshot) if isinstance(context_snapshot, dict) else context_snapshot
+            ),
+            created_at=created_at,
+        )
+        session.add(history)
+        session.flush()
+        sample = SkillOpinionSampleRecord(
+            analysis_history_id=history.id,
+            stock_code=code,
+            skill_id=skill_id,
+            signal=signal,
+            confidence=0.8,
+            sample_schema_version="skill-opinion-sample-v1",
+        )
+        session.add(sample)
+        session.flush()
+        return int(history.id), int(sample.id)
+
+
+def _seed_bars(db: DatabaseManager, *, code: str, bars: list[tuple[date, float]]) -> None:
+    with db.session_scope() as session:
+        for day, close in bars:
+            session.add(
+                StockDaily(
+                    code=code,
+                    date=day,
+                    open=close,
+                    high=close,
+                    low=close,
+                    close=close,
+                )
+            )
+
+
+def _effective_snapshot(day: str) -> dict:
+    return {
+        "market_phase_summary": {
+            "phase": "postmarket",
+            "effective_daily_bar_date": day,
+        }
+    }
+
+
+@pytest.mark.parametrize(
+    ("signal", "end_close", "expected_outcome", "expected_correct", "expected_directional"),
+    [
+        ("buy", 105.0, "hit", True, 5.0),
+        ("strong_buy", 95.0, "miss", False, -5.0),
+        ("sell", 95.0, "hit", True, 5.0),
+        ("strong_sell", 105.0, "miss", False, -5.0),
+        ("buy", 100.0, "miss", False, 0.0),
+        ("sell", 100.0, "miss", False, -0.0),
+    ],
+)
+def test_evaluator_uses_each_signal_direction_and_zero_is_miss(
+    signal,
+    end_close,
+    expected_outcome,
+    expected_correct,
+    expected_directional,
+) -> None:
+    result = SkillOpinionOutcomeEvaluator.evaluate(
+        signal=signal,
+        horizon="1d",
+        analysis_date=date(2024, 1, 2),
+        start_bar=_bar(date(2024, 1, 2), 100.0),
+        forward_bars=[_bar(date(2024, 1, 3), end_close)],
+    )
+
+    assert result.eval_status == "evaluated"
+    assert result.outcome == expected_outcome
+    assert result.direction_correct is expected_correct
+    assert result.stock_return_pct == pytest.approx(end_close - 100.0)
+    assert result.directional_return_pct == pytest.approx(expected_directional)
+
+
+def test_evaluator_hold_is_observational_and_pct_unit_is_percentage_points() -> None:
+    result = SkillOpinionOutcomeEvaluator.evaluate(
+        signal="hold",
+        horizon="1d",
+        analysis_date=date(2024, 1, 2),
+        start_bar=_bar(date(2024, 1, 2), 100.0),
+        forward_bars=[_bar(date(2024, 1, 3), 105.0)],
+    )
+
+    assert result.eval_status == "observational"
+    assert result.outcome == "observational"
+    assert result.direction_correct is None
+    assert result.stock_return_pct == pytest.approx(5.0)
+    assert result.directional_return_pct is None
+
+
+def test_evaluator_only_uses_unable_for_permanent_input_errors() -> None:
+    invalid_signal = SkillOpinionOutcomeEvaluator.evaluate(
+        signal="unknown",
+        horizon="1d",
+        analysis_date=date(2024, 1, 2),
+    )
+    missing_date = SkillOpinionOutcomeEvaluator.evaluate(
+        signal="buy",
+        horizon="1d",
+        analysis_date=None,
+    )
+    unsupported = SkillOpinionOutcomeEvaluator.evaluate(
+        signal="buy",
+        horizon="20d",
+        analysis_date=date(2024, 1, 2),
+    )
+    missing_bar = SkillOpinionOutcomeEvaluator.evaluate(
+        signal="buy",
+        horizon="1d",
+        analysis_date=date(2024, 1, 2),
+    )
+
+    assert (invalid_signal.eval_status, invalid_signal.unable_reason) == (
+        "unable",
+        "invalid_signal",
+    )
+    assert (missing_date.eval_status, missing_date.unable_reason) == (
+        "unable",
+        "missing_analysis_date",
+    )
+    assert (unsupported.eval_status, unsupported.unable_reason) == (
+        "unable",
+        "unsupported_horizon",
+    )
+    assert (missing_bar.eval_status, missing_bar.unable_reason) == (
+        "pending",
+        "missing_start_bar",
+    )
+
+
+def test_effective_daily_bar_date_requires_exact_start_bar(isolated_db) -> None:
+    _, sample_id = _add_sample(
+        isolated_db,
+        context_snapshot=_effective_snapshot("2024-01-03"),
+    )
+    _seed_bars(
+        isolated_db,
+        code="600519",
+        bars=[
+            (date(2024, 1, 2), 100.0),
+            (date(2024, 1, 4), 105.0),
+        ],
+    )
+
+    result = SkillOpinionOutcomeService(db_manager=isolated_db).run_outcomes(
+        sample_id=sample_id,
+        horizons=["1d"],
+    )
+
+    item = result["items"][0]
+    assert item["eval_status"] == "pending"
+    assert item["unable_reason"] == "missing_start_bar"
+    assert item["start_trade_date"] is None
+
+
+@pytest.mark.parametrize("sample_code", ["600519.SH", "SH600519"])
+def test_daily_code_candidates_evaluate_suffix_and_prefix_samples(
+    isolated_db,
+    sample_code,
+) -> None:
+    _, sample_id = _add_sample(
+        isolated_db,
+        code=sample_code,
+        context_snapshot=_effective_snapshot("2024-01-02"),
+    )
+    _seed_bars(
+        isolated_db,
+        code="600519",
+        bars=[(date(2024, 1, 2), 100.0), (date(2024, 1, 3), 105.0)],
+    )
+
+    item = SkillOpinionOutcomeService(db_manager=isolated_db).run_outcomes(
+        sample_id=sample_id,
+        horizons=["1d"],
+    )["items"][0]
+
+    assert item["eval_status"] == "evaluated"
+    assert item["start_trade_date"] == "2024-01-02"
+    assert item["end_trade_date"] == "2024-01-03"
+    assert item["stock_return_pct"] == pytest.approx(5.0)
+
+
+def test_conflicting_exchange_is_terminal_unable_without_matching_bare_daily_code(
+    isolated_db,
+) -> None:
+    _, invalid_sample_id = _add_sample(
+        isolated_db,
+        code="600519.SZ",
+        skill_id="invalid-exchange",
+        context_snapshot=_effective_snapshot("2024-01-02"),
+    )
+    _, valid_sample_id = _add_sample(
+        isolated_db,
+        code="600519.SH",
+        skill_id="valid-exchange",
+        context_snapshot=_effective_snapshot("2024-01-02"),
+    )
+    _seed_bars(
+        isolated_db,
+        code="600519",
+        bars=[(date(2024, 1, 2), 100.0), (date(2024, 1, 3), 105.0)],
+    )
+    service = SkillOpinionOutcomeService(db_manager=isolated_db)
+
+    invalid = service.run_outcomes(
+        sample_id=invalid_sample_id,
+        horizons=["1d"],
+    )["items"][0]
+    assert invalid["eval_status"] == "unable"
+    assert invalid["unable_reason"] == "invalid_stock_code"
+    assert invalid["outcome"] is None
+    assert invalid["direction_correct"] is None
+    assert invalid["start_price"] is None
+    assert invalid["end_close"] is None
+    assert invalid["stock_return_pct"] is None
+    assert invalid["directional_return_pct"] is None
+
+    valid = service.run_outcomes(
+        sample_id=valid_sample_id,
+        horizons=["1d"],
+    )["items"][0]
+    assert valid["eval_status"] == "evaluated"
+    assert valid["outcome"] == "hit"
+    assert valid["stock_return_pct"] == pytest.approx(5.0)
+
+    repeated = service.run_outcomes(
+        sample_id=invalid_sample_id,
+        horizons=["1d"],
+    )
+    assert repeated["processed_keys"] == 0
+    stored = service.list_outcomes(sample_id=invalid_sample_id)
+    assert len(stored) == 1
+    assert stored[0]["eval_status"] == "unable"
+    assert stored[0]["unable_reason"] == "invalid_stock_code"
+    assert stored[0]["stock_return_pct"] is None
+
+
+def test_code_candidates_do_not_bypass_exact_effective_start_date(isolated_db) -> None:
+    _, sample_id = _add_sample(
+        isolated_db,
+        code="600519.SH",
+        context_snapshot=_effective_snapshot("2024-01-03"),
+    )
+    _seed_bars(
+        isolated_db,
+        code="600519",
+        bars=[(date(2024, 1, 2), 100.0), (date(2024, 1, 4), 105.0)],
+    )
+
+    item = SkillOpinionOutcomeService(db_manager=isolated_db).run_outcomes(
+        sample_id=sample_id,
+        horizons=["1d"],
+    )["items"][0]
+
+    assert item["eval_status"] == "pending"
+    assert item["unable_reason"] == "missing_start_bar"
+    assert item["start_trade_date"] is None
+
+
+def test_forward_bars_use_the_same_code_as_the_matched_start_bar(isolated_db) -> None:
+    _, sample_id = _add_sample(
+        isolated_db,
+        code="600519.SH",
+        context_snapshot=_effective_snapshot("2024-01-02"),
+    )
+    _seed_bars(
+        isolated_db,
+        code="600519",
+        bars=[(date(2024, 1, 2), 100.0), (date(2024, 1, 3), 105.0)],
+    )
+    _seed_bars(
+        isolated_db,
+        code="600519.SH",
+        bars=[(date(2024, 1, 3), 50.0)],
+    )
+
+    item = SkillOpinionOutcomeService(db_manager=isolated_db).run_outcomes(
+        sample_id=sample_id,
+        horizons=["1d"],
+    )["items"][0]
+
+    assert item["eval_status"] == "evaluated"
+    assert item["end_close"] == pytest.approx(105.0)
+    assert item["stock_return_pct"] == pytest.approx(5.0)
+
+
+def test_compatibility_date_allows_previous_stored_bar(isolated_db) -> None:
+    _, sample_id = _add_sample(
+        isolated_db,
+        context_snapshot={"enhanced_context": {"date": "2024-01-07"}},
+    )
+    _seed_bars(
+        isolated_db,
+        code="600519",
+        bars=[
+            (date(2024, 1, 5), 100.0),
+            (date(2024, 1, 8), 105.0),
+        ],
+    )
+
+    item = SkillOpinionOutcomeService(db_manager=isolated_db).run_outcomes(
+        sample_id=sample_id,
+        horizons=["1d"],
+    )["items"][0]
+
+    assert item["eval_status"] == "evaluated"
+    assert item["analysis_date"] == "2024-01-07"
+    assert item["start_trade_date"] == "2024-01-05"
+    assert item["end_trade_date"] == "2024-01-08"
+
+
+def test_horizon_counts_locally_stored_forward_rows(isolated_db) -> None:
+    _, sample_id = _add_sample(
+        isolated_db,
+        context_snapshot=_effective_snapshot("2024-01-02"),
+    )
+    _seed_bars(
+        isolated_db,
+        code="600519",
+        bars=[
+            (date(2024, 1, 2), 100.0),
+            (date(2024, 1, 3), 101.0),
+            # 2024-01-04 is intentionally absent; v1 does not verify completeness.
+            (date(2024, 1, 5), 102.0),
+            (date(2024, 1, 8), 103.0),
+        ],
+    )
+
+    item = SkillOpinionOutcomeService(db_manager=isolated_db).run_outcomes(
+        sample_id=sample_id,
+        horizons=["3d"],
+    )["items"][0]
+
+    assert item["end_trade_date"] == "2024-01-08"
+    assert item["stock_return_pct"] == pytest.approx(3.0)
+
+
+def test_each_skill_uses_its_own_signal_not_final_history_decision(isolated_db) -> None:
+    history_id, buy_sample_id = _add_sample(
+        isolated_db,
+        signal="buy",
+        skill_id="buyer",
+        operation_advice="hold",
+        context_snapshot=_effective_snapshot("2024-01-02"),
+    )
+    with isolated_db.session_scope() as session:
+        sell_sample = SkillOpinionSampleRecord(
+            analysis_history_id=history_id,
+            stock_code="600519",
+            skill_id="seller",
+            signal="sell",
+            confidence=0.8,
+            sample_schema_version="skill-opinion-sample-v1",
+        )
+        session.add(sell_sample)
+        session.flush()
+        sell_sample_id = int(sell_sample.id)
+    _seed_bars(
+        isolated_db,
+        code="600519",
+        bars=[(date(2024, 1, 2), 100.0), (date(2024, 1, 3), 105.0)],
+    )
+
+    result = SkillOpinionOutcomeService(db_manager=isolated_db).run_outcomes(
+        analysis_history_id=history_id,
+        horizons=["1d"],
+        limit=2,
+    )
+    by_sample = {item["skill_opinion_sample_id"]: item for item in result["items"]}
+
+    assert by_sample[buy_sample_id]["outcome"] == "hit"
+    assert by_sample[sell_sample_id]["outcome"] == "miss"
+
+
+def test_pending_is_retried_but_terminal_outcome_is_immutable(isolated_db) -> None:
+    _, sample_id = _add_sample(
+        isolated_db,
+        context_snapshot=_effective_snapshot("2024-01-02"),
+    )
+    _seed_bars(isolated_db, code="600519", bars=[(date(2024, 1, 2), 100.0)])
+    service = SkillOpinionOutcomeService(db_manager=isolated_db)
+
+    pending = service.run_outcomes(sample_id=sample_id, horizons=["1d"])["items"][0]
+    assert pending["eval_status"] == "pending"
+
+    _seed_bars(isolated_db, code="600519", bars=[(date(2024, 1, 3), 105.0)])
+    evaluated = service.run_outcomes(sample_id=sample_id, horizons=["1d"])["items"][0]
+    assert evaluated["eval_status"] == "evaluated"
+    assert evaluated["stock_return_pct"] == pytest.approx(5.0)
+
+    with isolated_db.session_scope() as session:
+        bar = session.query(StockDaily).filter_by(code="600519", date=date(2024, 1, 3)).one()
+        bar.close = 90.0
+    repeated = service.run_outcomes(sample_id=sample_id, horizons=["1d"])
+    assert repeated["processed_keys"] == 0
+    stored = service.list_outcomes(sample_id=sample_id)[0]
+    assert stored["stock_return_pct"] == pytest.approx(5.0)
+
+
+def test_service_persists_only_permanent_input_errors_as_unable(isolated_db) -> None:
+    _, invalid_sample_id = _add_sample(
+        isolated_db,
+        signal="not-a-signal",
+        skill_id="invalid",
+        context_snapshot=_effective_snapshot("2024-01-02"),
+    )
+    missing_history_id, missing_date_sample_id = _add_sample(
+        isolated_db,
+        skill_id="missing-date",
+        context_snapshot=None,
+    )
+    with isolated_db.session_scope() as session:
+        history = session.get(AnalysisHistory, missing_history_id)
+        history.created_at = None
+
+    service = SkillOpinionOutcomeService(db_manager=isolated_db)
+    invalid = service.run_outcomes(
+        sample_id=invalid_sample_id,
+        horizons=["1d"],
+    )["items"][0]
+    missing_date = service.run_outcomes(
+        sample_id=missing_date_sample_id,
+        horizons=["1d"],
+    )["items"][0]
+
+    assert (invalid["eval_status"], invalid["unable_reason"]) == (
+        "unable",
+        "invalid_signal",
+    )
+    assert (missing_date["eval_status"], missing_date["unable_reason"]) == (
+        "unable",
+        "missing_analysis_date",
+    )
+
+
+def test_limit_counts_outcome_keys_not_samples(isolated_db) -> None:
+    _, sample_id = _add_sample(
+        isolated_db,
+        context_snapshot=_effective_snapshot("2024-01-02"),
+    )
+
+    result = SkillOpinionOutcomeService(db_manager=isolated_db).run_outcomes(
+        sample_id=sample_id,
+        limit=2,
+    )
+
+    assert result["processed_keys"] == 2
+    assert result["limit_unit"] == "outcome_key"
+    assert len(result["items"]) == 2
+
+
+def test_transient_evaluation_exception_is_reported_and_retried(isolated_db) -> None:
+    _, first_id = _add_sample(
+        isolated_db,
+        skill_id="first",
+        context_snapshot=_effective_snapshot("2024-01-02"),
+    )
+    _, second_id = _add_sample(
+        isolated_db,
+        skill_id="second",
+        context_snapshot=_effective_snapshot("2024-01-02"),
+    )
+    _seed_bars(
+        isolated_db,
+        code="600519",
+        bars=[(date(2024, 1, 2), 100.0), (date(2024, 1, 3), 105.0)],
+    )
+    service = SkillOpinionOutcomeService(db_manager=isolated_db)
+    real_evaluate = service._evaluate_candidate
+
+    def fail_first(candidate):
+        if int(candidate.sample.id) == first_id:
+            raise RuntimeError("temporary failure")
+        return real_evaluate(candidate)
+
+    with patch.object(service, "_evaluate_candidate", side_effect=fail_first):
+        first_run = service.run_outcomes(horizons=["1d"], limit=2)
+
+    assert first_run["failed"] == 1
+    assert first_run["errors"] == [
+        {"sample_id": first_id, "horizon": "1d", "error_type": "RuntimeError"}
+    ]
+    assert {item["skill_opinion_sample_id"] for item in first_run["items"]} == {second_id}
+    assert service.list_outcomes(sample_id=first_id) == []
+
+    retried = service.run_outcomes(sample_id=first_id, horizons=["1d"])
+    assert retried["failed"] == 0
+    assert retried["items"][0]["eval_status"] == "evaluated"
+
+
+def test_repository_retries_sqlite_locked_write(isolated_db) -> None:
+    _, sample_id = _add_sample(isolated_db)
+    repo = SkillOpinionOutcomeRepository(isolated_db)
+    first_session = isolated_db.get_session()
+    second_session = isolated_db.get_session()
+    locked = OperationalError(
+        "SELECT",
+        None,
+        sqlite3.OperationalError("database is locked"),
+    )
+    fields = {
+        "skill_opinion_sample_id": sample_id,
+        "horizon": "1d",
+        "engine_version": SKILL_OPINION_OUTCOME_ENGINE_VERSION,
+        "eval_status": "pending",
+        "outcome": None,
+        "direction_correct": None,
+        "unable_reason": "insufficient_future_data",
+    }
+
+    with patch.object(
+        isolated_db,
+        "get_session",
+        side_effect=[first_session, second_session],
+    ):
+        with patch.object(first_session, "execute", side_effect=locked):
+            with patch("src.storage.time.sleep") as sleep:
+                _, status = repo.persist_outcome(fields)
+
+    assert status == "created"
+    sleep.assert_called_once_with(isolated_db._sqlite_write_retry_base_delay)
+
+
+def test_history_deletion_removes_skill_outcomes_without_foreign_key_assumption(isolated_db) -> None:
+    history_id, sample_id = _add_sample(isolated_db)
+    repo = SkillOpinionOutcomeRepository(isolated_db)
+    repo.persist_outcome(
+        {
+            "skill_opinion_sample_id": sample_id,
+            "horizon": "1d",
+            "engine_version": SKILL_OPINION_OUTCOME_ENGINE_VERSION,
+            "eval_status": "pending",
+            "outcome": None,
+            "direction_correct": None,
+            "unable_reason": "insufficient_future_data",
+        }
+    )
+
+    assert isolated_db.delete_analysis_history_records([history_id]) == 1
+    with isolated_db.get_session() as session:
+        assert session.query(SkillOpinionOutcomeRecord).count() == 0
+        assert session.query(SkillOpinionSampleRecord).count() == 0
+
+
+def test_delayed_outcome_write_after_history_delete_does_not_create_orphan(isolated_db) -> None:
+    history_id, sample_id = _add_sample(isolated_db)
+    repo = SkillOpinionOutcomeRepository(isolated_db)
+
+    assert isolated_db.delete_analysis_history_records([history_id]) == 1
+    outcome_id, status = repo.persist_outcome(
+        {
+            "skill_opinion_sample_id": sample_id,
+            "horizon": "1d",
+            "engine_version": SKILL_OPINION_OUTCOME_ENGINE_VERSION,
+            "eval_status": "pending",
+            "outcome": None,
+            "direction_correct": None,
+            "unable_reason": "insufficient_future_data",
+        }
+    )
+
+    assert (outcome_id, status) == (None, "missing_sample")
+    with isolated_db.get_session() as session:
+        assert session.query(SkillOpinionOutcomeRecord).count() == 0
+
+
+def test_engine_version_creates_distinct_key_and_terminal_same_version_is_skipped(
+    isolated_db,
+) -> None:
+    _, sample_id = _add_sample(isolated_db)
+    repo = SkillOpinionOutcomeRepository(isolated_db)
+    base = {
+        "skill_opinion_sample_id": sample_id,
+        "horizon": "1d",
+        "eval_status": "evaluated",
+        "outcome": "hit",
+        "direction_correct": True,
+        "unable_reason": None,
+        "stock_return_pct": 5.0,
+        "directional_return_pct": 5.0,
+    }
+
+    _, first = repo.persist_outcome({**base, "engine_version": "engine-v1"})
+    _, repeated = repo.persist_outcome(
+        {
+            **base,
+            "engine_version": "engine-v1",
+            "outcome": "miss",
+            "direction_correct": False,
+        }
+    )
+    _, second_version = repo.persist_outcome({**base, "engine_version": "engine-v2"})
+
+    assert (first, repeated, second_version) == ("created", "skipped", "created")
+    assert len(repo.list_outcomes(sample_id=sample_id, engine_version=None)) == 2
+
+
+def test_outcome_schema_has_identity_indexes_and_value_constraints(isolated_db) -> None:
+    Base.metadata.create_all(isolated_db._engine)
+    inspector = inspect(isolated_db._engine)
+    unique_constraints = inspector.get_unique_constraints("skill_opinion_outcomes")
+    check_constraints = {
+        item["name"] for item in inspector.get_check_constraints("skill_opinion_outcomes")
+    }
+    indexes = {item["name"] for item in inspector.get_indexes("skill_opinion_outcomes")}
+
+    assert any(
+        item["name"] == "uix_skill_opinion_outcome_key"
+        and item["column_names"]
+        == ["skill_opinion_sample_id", "horizon", "engine_version"]
+        for item in unique_constraints
+    )
+    assert check_constraints >= {
+        "ck_skill_opinion_outcome_horizon",
+        "ck_skill_opinion_outcome_eval_status",
+        "ck_skill_opinion_outcome_value",
+        "ck_skill_opinion_outcome_state_fields",
+    }
+    assert indexes >= {
+        "ix_skill_opinion_outcome_candidate",
+        "ix_skill_opinion_outcome_horizon_status",
+    }
+
+    _, sample_id = _add_sample(isolated_db)
+    with pytest.raises(IntegrityError):
+        with isolated_db.session_scope() as session:
+            session.add(
+                SkillOpinionOutcomeRecord(
+                    skill_opinion_sample_id=sample_id,
+                    horizon="20d",
+                    engine_version="invalid",
+                    eval_status="pending",
+                )
+            )

--- a/tests/test_stock_code_utils.py
+++ b/tests/test_stock_code_utils.py
@@ -9,10 +9,34 @@ import pytest
 from unittest.mock import patch
 
 from src.services.stock_code_utils import (
+    InvalidStockCodeError,
+    build_daily_code_candidates,
     is_code_like,
     normalize_code,
     resolve_index_stock_code_for_analysis,
 )
+
+
+class TestBuildDailyCodeCandidates:
+    @pytest.mark.parametrize("code", ["600519.SZ", "000001.SH"])
+    def test_rejects_conflicting_explicit_exchange_before_any_candidate(self, code):
+        with pytest.raises(InvalidStockCodeError, match="explicit exchange conflicts"):
+            build_daily_code_candidates(code)
+
+    @pytest.mark.parametrize(
+        ("code", "required_candidates"),
+        [
+            ("600519.SH", {"600519.SH", "600519"}),
+            ("600519", {"600519", "600519.SH"}),
+            ("000001.SZ", {"000001.SZ", "000001"}),
+        ],
+    )
+    def test_preserves_valid_explicit_and_legacy_bare_codes(
+        self,
+        code,
+        required_candidates,
+    ):
+        assert set(build_daily_code_candidates(code)) >= required_candidates
 
 
 class TestIsCodeLike:


### PR DESCRIPTION
## PR Type

- [ ] fix
- [x] feat
- [ ] refactor
- [x] docs
- [ ] chore
- [x] test

## Background And Problem

PR #2058 已完成 Issue #1904 P2 的第一阶段：持久化版本化、低敏且可归因的 individual SkillAgent opinion 样本。

但这些样本目前还没有独立的后验结果，系统无法回答某条 skill opinion 在指定观察周期内是否命中，也无法为后续真实表现统计和保守权重校准提供可信输入。

本 PR 建立 sample → outcome 链路：

- 使用每条 sample 自身的 canonical signal 独立评价，不读取最终 Agent decision、skill consensus 或其他 skill 的观点；
- 根据本地已存日线计算 1d、3d、5d、10d 后验；
- 提供管理员显式执行和逐条只读查询 API；
- 对未来数据不足保持可重试状态，不提前生成误导性终态结果。

同时实现 Outcome 行情候选的市场绑定问题：旧逻辑会先保留 raw code，再通过宽松标准化将 `600519.SZ` 降级为 `600519`，从而可能命中错误市场的裸码行情并写入不可变的 `evaluated / hit / miss` 结果。

现在共享候选入口会在生成 raw、裸码或其他变体前校验显式交易所。交易所与代码市场冲突的历史 sample 会持久化为：

- `eval_status = unable`
- `unable_reason = invalid_stock_code`
- 不保存 hit/miss、价格或收益字段

合法 `.SH`、`.SZ` 代码和未显式指定交易所的历史裸码保持兼容。

本阶段仍不提供表现统计、排名、样本充足度判断或自动权重调整。

## Scope Of Change

本 PR 描述当前 HEAD `a54f46e1` 之上的全部 tracked 工作区改动，不包含未跟踪的本地 `.agents/` 工具目录。

- 文件总数：19
- 变更行数：3041 insertions、135 deletions

### 后验计算与持久化

- `src/core/skill_opinion_outcome_evaluator.py`
- `src/repositories/skill_opinion_outcome_repo.py`
- `src/services/skill_opinion_outcome_service.py`
- `src/storage.py`

新增 outcome 评价、候选键查询、SQLite 持久化、状态约束、分页查询和删除清理链路。同一 engine version 下只允许更新 `pending`；`evaluated`、`observational` 和 `unable` 均为不可变终态。

Outcome Service 将冲突交易所代码映射为 `unable / invalid_stock_code`，且不查询本地行情。

### 本地日线代码复用与正确性修复

- `src/services/stock_code_utils.py`
  - 新增共享的本地日线代码候选入口；
  - 复用 `_valid_exchange_code()`、`_infer_cn_exchange()` 和 `is_bse_code()` 校验显式交易所；
  - 在 raw、裸码及其他候选生成前拒绝 `600519.SZ`、`000001.SH` 等冲突代码；
  - 保持 `600519.SH`、`000001.SZ` 和历史裸码兼容。

- `src/repositories/backtest_repo.py`
  - 移除重复代码变体实现，复用共享工具。

- `src/services/backtest_service.py`
  - 通过共享入口构建本地日线候选；
  - 保持合法代码的既有回测行为。

### 管理员 API 与 Schema

- `api/v1/endpoints/__init__.py`
- `api/v1/endpoints/skill_opinion_outcomes.py`
- `api/v1/router.py`
- `api/v1/schemas/__init__.py`
- `api/v1/schemas/skill_opinion_outcomes.py`

新增：

- `POST /api/v1/skill-opinion-outcomes/run`
  - 管理员显式触发 outcome 计算；
  - 不允许客户端提供 signal、价格、outcome、direction 或 engine version。

- `GET /api/v1/skill-opinion-outcomes`
  - 提供逐条只读分页查询；
  - 支持按 sample、history、skill、股票、horizon、engine version、状态和 outcome 筛选。

### 测试

- `tests/test_skill_opinion_outcomes.py`
  - 覆盖方向评价、pending/unable、代码候选、终态不可覆盖和 SQLite repository；
  - 新增真实 SQLite → Outcome Service → 持久化测试；
  - 验证 `600519.SZ` 不会匹配裸码 100 → 105 行情；
  - 验证非法 sample 为 `unable / invalid_stock_code`，合法 `600519.SH` 仍为 `evaluated / hit / +5%`；
  - 验证非法终态重复执行不会新增或改写记录。

- `tests/test_stock_code_utils.py`
  - 验证 `600519.SZ`、`000001.SH` 在候选生成前被拒绝；
  - 验证 `600519.SH`、`600519`、`000001.SZ` 保持兼容。

- `tests/test_skill_opinion_outcome_api.py`
- `tests/test_api_schema_pydantic.py`

现有 `tests/test_backtest_service.py` 用于验证共享候选修改未破坏既有回测路径。

### 文档更新

- `docs/CHANGELOG.md`
- `docs/architecture/api_spec.json`
- `docs/multi-strategy-contract.md`

文档补充 outcome 状态、方向收益、horizon、本地日线口径、幂等性、管理员 API、阶段非目标及冲突交易所代码的终态行为。

## Issue Link

Refs #1904

Follow-up to #2058

PR #2058 建立真实 sample 采集，本 PR 补充独立 outcome 计算与查询。完整 Issue 仍包含表现统计、样本充足度、保守权重校准、Web 可见性及其他阶段，因此本 PR 不关闭 Issue #1904。

## Verification Commands And Results

### Executed local verification

```powershell
$env:PYTHONUTF8='1'
.\.venv\Scripts\python.exe -m pytest tests/test_stock_code_utils.py tests/test_skill_opinion_outcomes.py -q
```

结果：`96 passed, 1 warning in 11.89s`。

```powershell
$env:PYTHONUTF8='1'
.\.venv\Scripts\python.exe -m pytest tests/test_backtest_service.py -q -k "daily_code_candidates or market_code_variants or explicit_wrong_a_share_market or invalid_market_suffix"
```

结果：`8 passed, 48 deselected, 1 warning in 9.61s`。

warning 为既有 Starlette/httpx 弃用提示，无测试失败。

```powershell
python -m py_compile src/services/stock_code_utils.py src/services/skill_opinion_outcome_service.py tests/test_stock_code_utils.py tests/test_skill_opinion_outcomes.py

.\.venv\Scripts\python.exe -m flake8 src/services/stock_code_utils.py src/services/skill_opinion_outcome_service.py tests/test_stock_code_utils.py tests/test_skill_opinion_outcomes.py

git diff --check
git diff --cached --check
```

结果：全部通过。

### Recommended verification — not executed

```powershell
.\.venv\Scripts\python.exe -m pytest tests/test_skill_opinion_outcome_api.py tests/test_api_schema_pydantic.py -q
```

结果：`17 passed, 4 warnings in 21.62s`



### CI status — not run

当前改动尚未形成对应 PR Head CI：

- ai-governance：[PASS](https://github.com/ZhuLinsen/daily_stock_analysis/actions/runs/29935995500/job/88977583479?pr=2069)
- backend-gate：[PASS](https://github.com/ZhuLinsen/daily_stock_analysis/actions/runs/29935995500/job/88977641034?pr=2069)
- docker-build：[PASS](https://github.com/ZhuLinsen/daily_stock_analysis/actions/runs/29935995500/job/88977641013?pr=2069)
- web-gate：Skipped

## Visual Evidence (if applicable)

不适用。本 PR 仅修改后端评价、持久化、管理员 API、OpenAPI 文档和测试，不改变报告格式、报告渲染、Web UI 或桌面端界面。

## Compatibility And Risk

- 前置依赖：依赖 PR #2058 提供的 `skill_opinion_samples` 表和低敏 sample 契约。
- API：仅新增管理员接口和响应 Schema，不修改既有 API。
- 执行方式：Outcome Service 不接入主分析 Pipeline，只通过管理员 POST 显式运行。
- 数据库：新增 `skill_opinion_outcomes` sidecar 表，不改写已有 sample、分析历史或配置。
- 合法代码兼容：`600519.SH`、`000001.SZ` 及未显式指定交易所的历史裸码继续按既有规则生成候选。
- 非法代码：显式交易所与代码市场冲突时 fail closed，不再查询 raw 或裸码行情，并持久化为 `unable / invalid_stock_code`。
- 结果不可变性：非法代码的 `unable` 终态重复执行时不会新增或被改写为 `evaluated`。
- 已有终态：不会自动改写同 engine version 下已经持久化的终态记录。若测试库或预发布库曾产生错误的 `evaluated` 记录，应在发布前清理对应测试数据或提升 engine version，不能依赖普通重跑修复。
- 数据不足：未来本地日线不足时保持 `pending`，后续可重试。
- 日历口径：v1 按本地已存有序日线行计数，不验证中间真实交易日是否缺失。
- 共享调用方：候选入口同时被 BacktestService 使用；冲突代码现在会明确拒绝，合法代码回归已通过聚焦测试。
- 外部依赖：不请求新的第三方行情，不改变 provider、model、base URL 或运行时配置迁移语义。
- 权重：不修改 `SkillAggregator`、`AgentMemory` 或最终投资建议。

## Rollback Plan

最小回滚方式：revert this PR 并重启服务，即可移除管理员 API 并停止新的 outcome 计算，无需回滚现有配置或 sample 数据。

已创建的 `skill_opinion_outcomes` 表及数据可以保留为未使用审计数据。若需彻底恢复数据库 schema，应先备份数据库，再删除 `skill_opinion_outcomes` 表；不要直接修改或覆盖已经持久化的终态结果。

## EXTRACT_PROMPT Change (if applicable)

不适用：本 PR 未修改 `src/services/image_stock_extractor.py` 或 `EXTRACT_PROMPT`。

## Checklist

- [x] 本 PR 有明确动机和业务价值 / This PR has a clear motivation and value
- [x] 已提供可复现的验证命令与结果 / Reproducible verification commands and results are included
- [x] 已评估兼容性与风险 / Compatibility and risk have been assessed
- [x] 已提供回滚方案 / A rollback plan is provided
- [x] 报告格式或 Web UI 未发生变化，无需截图
- [x] Web 设置字段未发生变化，无需设置页截图
- [x] 管理员可见能力及正确性修复已同步专题文档、OpenAPI 文档与 `docs/CHANGELOG.md`
```
