### PR TITLE
fix: upgrade axios to 1.13.5, 0.30.3 (CVE-2026-25639)

### DIFF
--- a/apps/dsa-web/package-lock.json
+++ b/apps/dsa-web/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@remixicon/react": "^4.9.0",
-        "axios": "^1.13.4",
+        "axios": "^1.13.5",
         "camelcase-keys": "^10.0.2",
         "clsx": "^2.1.1",
         "lucide-react": "^0.555.0",
@@ -2824,13 +2824,13 @@
       "license": "MIT"
     },
     "node_modules/axios": {
-      "version": "1.13.4",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.4.tgz",
-      "integrity": "sha512-1wVkUaAO6WyaYtCkcYCOx12ZgpGf9Zif+qXa4n+oYzK558YryKqiL6UWwd5DqiH3VRW0GYhTZQ/vlgJrCoNQlg==",
+      "version": "1.13.5",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.5.tgz",
+      "integrity": "sha512-cz4ur7Vb0xS4/KUN0tPWe44eqxrIu31me+fbang3ijiNscE129POzipJJA6zniq2C/Z6sJCjMimjS8Lc/GAs8Q==",
       "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.15.6",
-        "form-data": "^4.0.4",
+        "follow-redirects": "^1.15.11",
+        "form-data": "^4.0.5",
         "proxy-from-env": "^1.1.0"
       }
     },

--- a/apps/dsa-web/package.json
+++ b/apps/dsa-web/package.json
@@ -17,7 +17,7 @@
   },
   "dependencies": {
     "@remixicon/react": "^4.9.0",
-    "axios": "^1.13.4",
+    "axios": "^1.13.5",
     "camelcase-keys": "^10.0.2",
     "clsx": "^2.1.1",
     "lucide-react": "^0.555.0",


### PR DESCRIPTION
## Summary
Upgrade axios from 1.13.4 to 1.13.5, 0.30.3 to fix CVE-2026-25639.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | CVE-2026-25639 |
| **Severity** | HIGH |
| **Scanner** | trivy |
| **Rule** | `CVE-2026-25639` |
| **File** | `apps/dsa-web/package-lock.json` |
| **Assessment** | Likely exploitable |

**Description**: axios: Axios affected by Denial of Service via __proto__ Key in mergeConfig

## Evidence

**Scanner confirmation**: trivy rule `CVE-2026-25639` flagged this pattern.

**Production code**: This file is in the production codebase, not test-only code.

## Threat Model Context

This is a web service - vulnerabilities in request handlers are directly exploitable by remote attackers.

## Changes
- `apps/dsa-web/package.json`
- `apps/dsa-web/package-lock.json`

## Verification
- [x] Build passes
- [x] Scanner re-scan confirms fix
- [x] LLM code review passed

---
*This change addresses a pattern flagged by static analysis. The code path handles user-influenced input and the fix reduces the attack surface against both manual and automated exploitation.*

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
