### PR TITLE
fix: accept prose around unique explicit json fence

### DIFF
--- a/src/analyzer.py
+++ b/src/analyzer.py
@@ -4384,12 +4384,20 @@ class GeminiAnalyzer:
             raise ValueError("ambiguous_json")
         if len(fenced_matches) == 1:
             match = fenced_matches[0]
-            outside = (text[:match.start()] + text[match.end():]).strip()
-            if outside:
-                raise ValueError("ambiguous_json")
             fence_lang = (match.group("lang") or "").strip().lower()
             if fence_lang not in {"", "json"}:
                 raise ValueError("ambiguous_json")
+            outside = (text[:match.start()] + text[match.end():]).strip()
+            if outside:
+                # 显式 ```` ```json ```` 围栏是模型明确标注的唯一答案，允许围栏外
+                # 存在纯说明文字（推理模型常在围栏前后附带 markdown 报告）；
+                # 但围栏外若还含另一个 JSON 候选，必须继续拒绝，否则两个候选
+                # 给出不同评分/建议时会被静默接受其中一个，导致错误结果被持久化。
+                # 未标注语言的围栏保持严格：外部有任何文本仍视为歧义。
+                if fence_lang != "json":
+                    raise ValueError("ambiguous_json")
+                if self._contains_json_object(outside):
+                    raise ValueError("ambiguous_json")
             json_str = match.group("body").strip()
             data = self._load_analysis_json_candidate(json_str)
             return json_str, data
@@ -4441,6 +4449,25 @@ class GeminiAnalyzer:
             after = text[index + end:].strip()
             if count > 1 or before or after:
                 return True
+        return False
+
+    @staticmethod
+    def _contains_json_object(text: str) -> bool:
+        """Return True if *text* contains any parseable JSON object.
+
+        不同于 :meth:`_contains_embedded_json_object`，本方法对“只有一个独立 JSON
+        对象、且周围没有任何文本”的场景也返回 True，用于显式 ```` ```json ````
+        围栏外严格拒绝额外 JSON 候选的场景。
+        """
+        decoder = json.JSONDecoder()
+        for index, char in enumerate(text):
+            if char != "{":
+                continue
+            try:
+                _obj, _end = decoder.raw_decode(text[index:])
+            except json.JSONDecodeError:
+                continue
+            return True
         return False
 
     def _validate_analysis_minimal_contract(self, data: Dict[str, Any]) -> None:

--- a/tests/test_report_schema.py
+++ b/tests/test_report_schema.py
@@ -386,3 +386,116 @@ class TestAnalyzerSchemaFallback(unittest.TestCase):
         self.assertEqual(result.trend_prediction, "Bullish")
         self.assertEqual(result.operation_advice, "Buy")
         self.assertEqual(result.confidence_level, "Low")
+
+    def test_parse_response_accepts_prose_around_explicit_json_fence(self) -> None:
+        """单个显式 ```` ```json ```` 围栏外的说明文字（markdown 报告）不应判为歧义。"""
+        analyzer = GeminiAnalyzer()
+        response = """## 凯盛新能（600876.SH）决策仪表盘
+
+### ⚠️ 数据情况说明
+- 当前为非交易日，基于上一完整交易日数据
+
+```json
+{
+  "stock_name": "凯盛新能",
+  "sentiment_score": 28,
+  "trend_prediction": "看空",
+  "operation_advice": "观望",
+  "analysis_summary": "空头排列，观望"
+}
+```
+
+## 📋 决策要点速览
+
+| 检查项 | 状态 |
+|--------|------|
+| 多头排列 | ❌ |"""
+
+        result = analyzer._parse_response(response, "600876", "股票600876")
+
+        self.assertTrue(result.success)
+        self.assertEqual(result.sentiment_score, 28)
+
+    def test_parse_response_rejects_explicit_json_fence_with_extra_json_outside(self) -> None:
+        """显式 ```` ```json ```` 围栏外存在另一个裸 JSON 候选，必须继续报歧义并 fail closed。
+
+        防止两个候选给出不同评分/建议时被静默接受其中一个并持久化错误结果。
+        """
+        analyzer = GeminiAnalyzer()
+        response = """## 标题
+```json
+{
+  "stock_name": "凯盛新能",
+  "sentiment_score": 28,
+  "trend_prediction": "看空",
+  "operation_advice": "观望",
+  "analysis_summary": "空头排列"
+}
+```
+说明文字里又漏出了一个独立 JSON：{"stock_name": "other", "sentiment_score": 99}
+"""
+
+        result = analyzer._parse_response(response, "600876", "股票600876")
+
+        self.assertFalse(result.success)
+        self.assertIn("JSON", result.error_message)
+
+    def test_parse_response_rejects_explicit_json_fence_with_isolated_json_outside(self) -> None:
+        """围栏外恰好是单个裸 JSON 对象（周围无文本）也必须继续报歧义。
+
+        该场景会让现有的 ``_contains_embedded_json_object`` 返回 False，因此单独验证
+        ``_contains_json_object`` 守卫真正生效。
+        """
+        analyzer = GeminiAnalyzer()
+        response = """```json
+{
+  "stock_name": "凯盛新能",
+  "sentiment_score": 28,
+  "trend_prediction": "看空",
+  "operation_advice": "观望",
+  "analysis_summary": "空头排列"
+}
+```
+{"stock_name": "other", "sentiment_score": 99}"""
+
+        result = analyzer._parse_response(response, "600876", "股票600876")
+
+        self.assertFalse(result.success)
+        self.assertIn("JSON", result.error_message)
+
+    def test_validate_json_response_accepts_explicit_json_fence_with_prose_outside(self) -> None:
+        analyzer = GeminiAnalyzer.__new__(GeminiAnalyzer)
+        analyzer._config_override = SimpleNamespace(generation_backend="litellm")
+
+        analyzer._validate_json_response("""## 凯盛新能决策仪表盘
+
+```json
+{
+  "stock_name": "贵州茅台",
+  "sentiment_score": 65,
+  "trend_prediction": "看多",
+  "operation_advice": "持有",
+  "analysis_summary": "技术面向好"
+}
+```
+
+## 📋 决策要点速览
+""")
+
+    def test_validate_json_response_rejects_explicit_json_fence_with_extra_json_outside(self) -> None:
+        analyzer = GeminiAnalyzer.__new__(GeminiAnalyzer)
+        analyzer._config_override = SimpleNamespace(generation_backend="litellm")
+
+        with self.assertRaises(Exception) as context:
+            analyzer._validate_json_response("""说明：```json
+{
+  "stock_name": "贵州茅台",
+  "sentiment_score": 65,
+  "trend_prediction": "看多",
+  "operation_advice": "持有",
+  "analysis_summary": "技术面向好"
+}
+```
+补充：{"sentiment_score": 70}""")
+
+        self.assertEqual(getattr(context.exception, "details", {}).get("reason"), "ambiguous_json")


### PR DESCRIPTION
## Problem

`GeminiAnalyzer` 之前要求 JSON 围栏外**完全为空**，否则直接抛 `ambiguous_json`。这导致推理模型（reasoning models）输出失败：它们习惯把 JSON 答案包在 markdown 报告里（`##`、bullet list、段落说明），整段被 reject 后报告直接丢失。

## Root Cause

`src/analyzer.py` 里的 fence 处理逻辑位置写反了：围栏外一旦有任何文字就无条件 reject。

## Fix

- 单个**显式 ```json ``` 围栏**被视为模型的唯一答案，围栏外的纯说明文字（markdown 报告、标题、列表）允许存在
- **歧义判定仍然保留**：围栏外若含另一个 JSON 对象 → reject（避免两个候选评分冲突时静默选错）
- 未标注语言的围栏保持严格：外部有任何文本仍视为歧义
- `<think>` wrapper 仍由 #2039 的 `strip_leading_think_wrapper` 处理，本变更不触碰

## Changes

- `src/analyzer.py`: `GeminiAnalyzer` 的 fence 解析逻辑（`outside` 判定位置 + 显式 `json` 围栏白名单 + 外部 JSON 候选反查）
- `tests/test_report_schema.py`: 加 prose-around-fence 回归用例 + duplicate-JSON-candidate 反例

## Test

```bash
python -m pytest tests/test_report_schema.py -q
# 27 passed
```

## Related

- AGENTS.md §8.1: review feedback 处理 — 同一业务语义涉及的所有入口必须一起收敛
- #2039: `<think>` wrapper 兼容（独立 PR，已合）