### PR TITLE
feat(data_provider): cover free-source optional interfaces

### DIFF
--- a/data_provider/akshare_fetcher.py
+++ b/data_provider/akshare_fetcher.py
@@ -2257,6 +2257,47 @@ class AkshareFetcher(BaseFetcher):
             digits = "".join(ch for ch in text if ch.isdigit())
             return digits.zfill(6) if digits else text
 
+    def get_stock_list(self) -> Optional[pd.DataFrame]:
+        """
+        获取沪深京全市场 A 股代码 + 名称列表 (akshare)
+
+        数据源：ak.stock_info_a_code_name()
+        该方法为 DataFetcherManager.batch_get_stock_names 的兜底实现，
+        配合 Baostock / Tushare / TickFlow 的 get_stock_list 使用。
+        """
+        import akshare as ak
+
+        try:
+            self._set_random_user_agent()
+            self._enforce_rate_limit()
+
+            logger.info("[API调用] ak.stock_info_a_code_name() 获取 A 股列表...")
+            df = ak.stock_info_a_code_name()
+            if df is None or df.empty:
+                logger.warning("[Akshare] A 股列表为空")
+                return None
+
+            rename_map: Dict[str, str] = {}
+            if "code" not in df.columns:
+                for cand in ("代码", "股票代码", "symbol"):
+                    if cand in df.columns:
+                        rename_map[cand] = "code"
+                        break
+            if "name" not in df.columns:
+                for cand in ("name", "名称", "股票名称"):
+                    if cand in df.columns:
+                        rename_map[cand] = "name"
+                        break
+            if rename_map:
+                df = df.rename(columns=rename_map)
+            if "code" not in df.columns or "name" not in df.columns:
+                logger.warning("[Akshare] A 股列表缺少 code/name 列")
+                return None
+            return df[["code", "name"]]
+        except Exception as e:
+            logger.error(f"[Akshare] get_stock_list 失败: {e}")
+            return None
+
     @staticmethod
     def _safe_float(value: Any) -> Optional[float]:
         try:

--- a/data_provider/akshare_fetcher.py
+++ b/data_provider/akshare_fetcher.py
@@ -1907,8 +1907,81 @@ class AkshareFetcher(BaseFetcher):
         if amount_col and amount_col in df.columns:
             df[amount_col] = pd.to_numeric(df[amount_col], errors='coerce')
             stats['total_amount'] = (df[amount_col].sum() / 1e8)
-            
+
         return stats
+
+    def get_belong_board(self, stock_code: str) -> Optional[pd.DataFrame]:
+        """
+        获取股票所属板块（akshare）
+
+        通过遍历行业 + 概念板块的成分股反查实现。
+        该方法为 EfinanceFetcher.get_belong_board 的 akshare 兜底实现，
+        解决所属板块数据源单点故障问题。
+        """
+        import akshare as ak
+
+        target_code = str(stock_code).strip()
+
+        def _collect_boards(
+            names_df: pd.DataFrame,
+            cons_fn,
+            board_kind: str,
+        ) -> List[Dict[str, Any]]:
+            results: List[Dict[str, Any]] = []
+            if names_df is None or names_df.empty:
+                return results
+            for board_name in names_df["板块名称"].tolist():
+                try:
+                    cons_df = cons_fn(symbol=str(board_name))
+                except Exception as exc:
+                    logger.debug(
+                        "[Akshare] %s cons 拉取失败 (%s): %s", board_kind, board_name, exc
+                    )
+                    continue
+                if cons_df is None or cons_df.empty:
+                    continue
+                code_col = next(
+                    (col for col in cons_df.columns if str(col) in {"代码", "code"}),
+                    None,
+                )
+                if code_col is None:
+                    continue
+                if target_code in cons_df[code_col].astype(str).tolist():
+                    results.append({"name": str(board_name), "type": board_kind})
+            return results
+
+        try:
+            self._set_random_user_agent()
+            self._enforce_rate_limit()
+
+            industry_names_df = ak.stock_board_industry_name_em()
+            industry_results = _collect_boards(
+                industry_names_df,
+                ak.stock_board_industry_cons_em,
+                board_kind="行业",
+            )
+        except Exception as e:
+            logger.warning("[Akshare] 获取所属行业板块失败: %s", e)
+            industry_results = []
+
+        try:
+            self._set_random_user_agent()
+            self._enforce_rate_limit()
+
+            concept_names_df = ak.stock_board_concept_name_em()
+            concept_results = _collect_boards(
+                concept_names_df,
+                ak.stock_board_concept_cons_em,
+                board_kind="概念",
+            )
+        except Exception as e:
+            logger.warning("[Akshare] 获取所属概念板块失败: %s", e)
+            concept_results = []
+
+        all_results = industry_results + concept_results
+        if not all_results:
+            return None
+        return pd.DataFrame(all_results)
 
     def get_sector_rankings(self, n: int = 5) -> Optional[Tuple[List[Dict], List[Dict]]]:
         """

--- a/data_provider/efinance_fetcher.py
+++ b/data_provider/efinance_fetcher.py
@@ -1098,7 +1098,46 @@ class EfinanceFetcher(BaseFetcher):
         except Exception as e:
             logger.error(f"[efinance] 获取板块排行失败: {e}")
             return None
-    
+
+    def get_stock_name(self, stock_code: str) -> Optional[str]:
+        """
+        获取股票中文名称 (efinance)
+
+        复用 ef.stock.get_base_info() 的 `股票名称` 字段。
+        该方法让 EfinanceFetcher 接入 DataFetcherManager.get_stock_name
+        的 fallback 链，避免 manager 跳过 efinance。
+        """
+        import efinance as ef
+
+        try:
+            self._set_random_user_agent()
+            self._enforce_rate_limit()
+
+            logger.info(
+                f"[API调用] ef.stock.get_base_info(stock_codes={stock_code}) 获取股票名称..."
+            )
+            info = _ef_call_with_timeout(ef.stock.get_base_info, stock_code)
+        except Exception as e:
+            logger.debug(f"[efinance] get_stock_name {stock_code} 失败: {e}")
+            return None
+
+        if info is None:
+            return None
+
+        def _extract_name(obj) -> Optional[str]:
+            for key in ("股票名称", "name", "名称"):
+                if key in obj.index:
+                    value = obj[key]
+                    if value is not None and not (isinstance(value, float) and pd.isna(value)):
+                        return str(value).strip()
+            return None
+
+        if isinstance(info, pd.Series):
+            return _extract_name(info)
+        if isinstance(info, pd.DataFrame) and not info.empty:
+            return _extract_name(info.iloc[0])
+        return None
+
     def get_base_info(self, stock_code: str) -> Optional[Dict[str, Any]]:
         """
         获取股票基本信息

--- a/data_provider/efinance_fetcher.py
+++ b/data_provider/efinance_fetcher.py
@@ -1138,6 +1138,50 @@ class EfinanceFetcher(BaseFetcher):
             return _extract_name(info.iloc[0])
         return None
 
+    def get_concept_rankings(self, n: int = 5) -> Optional[Tuple[List[Dict], List[Dict]]]:
+        """
+        获取概念/题材涨跌榜 (efinance)
+
+        数据源：ef.stock.get_realtime_quotes(['概念板块'])
+        该方法为 AkshareFetcher.get_concept_rankings 的兜底实现。
+        """
+        import efinance as ef
+
+        try:
+            self._set_random_user_agent()
+            self._enforce_rate_limit()
+
+            logger.info("[API调用] ef.stock.get_realtime_quotes(['概念板块']) 获取概念排行...")
+            df = _ef_call_with_timeout(ef.stock.get_realtime_quotes, ['概念板块'])
+            if df is None or df.empty:
+                logger.warning("[efinance] 概念行情数据为空")
+                return None
+
+            change_col = '涨跌幅' if '涨跌幅' in df.columns else 'pct_chg'
+            name_col = '板块名称' if '板块名称' in df.columns else (
+                '股票名称' if '股票名称' in df.columns else 'name'
+            )
+            if change_col not in df.columns or name_col not in df.columns:
+                return None
+
+            df[change_col] = pd.to_numeric(df[change_col], errors='coerce')
+            df = df.dropna(subset=[change_col])
+            top = df.nlargest(n, change_col)
+            bottom = df.nsmallest(n, change_col)
+
+            top_sectors = [
+                {'name': str(row[name_col]), 'change_pct': float(row[change_col])}
+                for _, row in top.iterrows()
+            ]
+            bottom_sectors = [
+                {'name': str(row[name_col]), 'change_pct': float(row[change_col])}
+                for _, row in bottom.iterrows()
+            ]
+            return top_sectors, bottom_sectors
+        except Exception as e:
+            logger.error(f"[efinance] 获取概念排行失败: {e}")
+            return None
+
     def get_base_info(self, stock_code: str) -> Optional[Dict[str, Any]]:
         """
         获取股票基本信息

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -22,6 +22,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - [文档] `.env.example` 与 `.github/workflows/00-daily-analysis.yml` 同步映射 `TUSHARE_HTTP_URL`，避免出现"配置项有但 workflow 漏映射"的半修状态
 - [修复] #2051 PR Review 的特权 `pull_request_target` 流程不再检出 fork PR head：敏感文件、标签、报告与 AI 审查统一通过 GitHub API 将 PR 元数据和 diff 作为数据读取，只执行主分支可信脚本；Python 语法、Flake8、确定性检查和离线测试继续由无 secrets 的 `pull_request` CI / `backend-gate` 执行，兼容 `actions/checkout` 新增的 fork checkout 安全保护。
 - [修复] 修复 Windows 上 mimetypes 冷启动时读取注册表导致的进程卡死
+- [修复] 个股分析 JSON 提取允许唯一显式 ```` ```json ```` 围栏外存在纯说明文字（推理模型常见的 markdown 报告包裹），同时继续拒绝围栏外的额外 JSON 候选，避免两个候选给出不同评分/建议时被静默接受其中一个并持久化错误结果；`<think>` wrapper 仍由 #2039 的 `strip_leading_think_wrapper` 处理，本变更不再触碰。
+- [文档] 将 `AGENTS.md` "关键架构模式" 实现语义（数据源架构 / LLM 路由 / 配置热加载 / 数据库 / 前后端关系）迁移到 `docs/architecture/overview.md`，AGENTS.md 仅保留指向指针，符合 "实现语义与边界条件优先放 `docs/*.md`" 的文档分层原则；同时在 `docs/INDEX.md` 的 "参考与开发" 一节登记该文档。
+- [改进] data_provider: 补齐 AkshareFetcher.get_belong_board 和 get_stock_list，新增 EfinanceFetcher.get_concept_rankings 和 get_stock_name，关闭 2 个单点故障接口（所属板块、概念涨跌榜）并补齐 2 个主数据源能力（A 股批量列表、efinance 股票名 fallback）
+- [文档] 新增 docs/data-sources-coverage.md，记录 free 源接口覆盖矩阵与付费源 key / 积分需求清单
 
 ## [3.27.0] - 2026-07-19
 

--- a/docs/data-sources-coverage.md
+++ b/docs/data-sources-coverage.md
@@ -1,0 +1,78 @@
+# Data Source 接口覆盖矩阵
+
+> 最近更新：2026-07-23（伴随 data_provider 接口补齐 PR）
+> 关联 spec：`docs/superpowers/specs/2026-07-23-data-provider-free-source-coverage-design.md`
+
+本文件记录 `data_provider/` 中每个 fetcher 的接口实现情况，供日常开发、数据源选型、故障排查参考。
+
+## 接口清单
+
+`BaseFetcher`（`data_provider/base.py`）定义的可选/必选接口：
+
+| 接口 | 说明 | 调用入口 |
+|---|---|---|
+| `_fetch_raw_data` | 日线原始数据（abstract） | `DataFetcherManager.get_daily_data` |
+| `_normalize_data` | 列名标准化（abstract） | 同上 |
+| `get_main_indices` | 大盘指数实时 | `DataFetcherManager.get_main_indices` |
+| `get_market_stats` | 涨跌家数 / 成交额 | `DataFetcherManager.get_market_stats` |
+| `get_sector_rankings` | 板块涨跌榜 | `DataFetcherManager.get_sector_rankings` |
+| `get_concept_rankings` | 概念涨跌榜 | `DataFetcherManager.get_concept_rankings` |
+| `get_hot_stocks` | 人气股榜 | `DataFetcherManager.get_hot_stocks` |
+| `get_limit_up_pool` | 涨停池 / 连板梯队 | `DataFetcherManager.get_limit_up_pool` |
+| `get_realtime_quote` | 个股实时行情 | `DataFetcherManager.get_realtime_quote` |
+| `get_chip_distribution` | 筹码分布 | `DataFetcherManager.get_chip_distribution` |
+| `get_stock_name` | 股票中文名 | `DataFetcherManager.get_stock_name` |
+| `get_stock_list` | 全市场列表（批量名称） | `DataFetcherManager.batch_get_stock_names` |
+| `get_belong_board` | 所属板块 | `DataFetcherManager.get_belong_boards` |
+| `prefetch_realtime_quotes` / `prefetch_daily_klines` | TickFlow 批量预取 | `DataFetcherManager.prefetch_*` |
+
+## Free 源接口矩阵
+
+| 接口 | efinance | tencent | akshare | pytdx | baostock | yfinance |
+|---|---|---|---|---|---|---|
+| `_fetch_raw_data` | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| `_normalize_data` | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| `get_main_indices` | ✅ | ❌ | ✅ | ❌ | ❌ | ✅ |
+| `get_market_stats` | ✅ | ❌ | ✅ | ❌ | ❌ | ❌ |
+| `get_sector_rankings` | ✅ | ❌ | ✅ | ❌ | ❌ | ❌ |
+| `get_concept_rankings` | ✅ | ❌ | ✅ | ❌ | ❌ | ❌ |
+| `get_hot_stocks` | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ |
+| `get_limit_up_pool` | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ |
+| `get_realtime_quote` | ✅ | ❌ | ✅ | ✅ | ❌ | ✅ |
+| `get_chip_distribution` | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ |
+| `get_stock_name` | ✅ | ❌ | ❌ | ✅ | ✅ | ❌ |
+| `get_stock_list` | ❌ | ❌ | ✅ | ❌ | ✅ | ❌ |
+| `get_belong_board` | ✅ | ❌ | ✅ | ❌ | ❌ | ❌ |
+
+**单点故障接口**（只剩 1 个 fetcher 实现，且 free 源侧没有替代方案）：
+- `get_hot_stocks` —— 仅 akshare；efinance 底层无对应 API，无法补
+- `get_limit_up_pool` —— 仅 akshare；efinance 底层无对应 API，无法补
+- `get_chip_distribution` —— 仅 akshare（A股）；付费源 tushare 有但需高级积分
+
+## 付费 / Key 源接口需求
+
+| 数据源 | 需要的凭据 / 积分 | 实现的关键接口 | 适用市场 |
+|---|---|---|---|
+| Tushare | `TUSHARE_TOKEN` + 各接口对应积分（基础 2000、进阶 5000、高级 10000+） | `get_realtime_quote`（5000+）、`get_chip_distribution`（10000+）、`get_main_indices`、`get_market_stats`、`get_sector_rankings`、`get_stock_name`、`get_stock_list` | A 股、港股 |
+| TickFlow | `TICKFLOW_API_KEY` | 几乎所有非日线接口（`get_realtime_quote`、`get_main_indices`、`get_market_stats`、`get_sector_rankings`、`get_stock_name`、`get_stock_list`）以及 `prefetch_realtime_quotes`、`prefetch_daily_klines` | A 股 |
+| Longbridge | `LONGBRIDGE_APP_KEY` / `LONGBRIDGE_APP_SECRET` / `LONGBRIDGE_ACCESS_TOKEN`（OAuth 或 Legacy 凭据） | `get_realtime_quote`、`get_stock_name` | 港股、美股 |
+| Finnhub | `FINNHUB_API_KEY` | `get_realtime_quote`、`get_stock_name` | 美股 |
+| AlphaVantage | `ALPHAVANTAGE_API_KEY` | `get_realtime_quote`、`get_stock_name` | 美股 |
+
+> **积分等级**以 Tushare 官方文档为准，会随时间变化。本表只是粗略指引，调用前请确认对应接口的积分要求。
+
+## manager failover 策略
+
+`DataFetcherManager` 总是按 fetcher.priority 升序遍历可用的 fetcher，第一个返回非空数据的胜出。优先级由各 fetcher 的 `__init__` 决定，运行时可通过 `add_fetcher` / config 调整。
+
+特别规则：
+- **港股 / 美股**：优选 Longbridge（配置凭据后），否则 YfinanceFetcher（美股）/ AkshareFetcher(source="hk", 港股)。
+- **美股指数**：永远 YfinanceFetcher 首选（Longbridge 不提供指数 K 线）。
+- **TickFlow**：仅在配置 `TICKFLOW_API_KEY` 时启用，priority 默认 2。
+- **Tushare**：仅在配置 `TUSHARE_TOKEN` 时启用，会按配置自动调整 priority。
+
+## 维护建议
+
+- 新增 fetcher：补完 abstract 方法 + 至少 `get_realtime_quote` + `get_stock_name`。
+- 新增接口：先在 `BaseFetcher` 加 default `return None`，再在需要的 fetcher 里覆盖。
+- 接口矩阵更新：每次 fetcher 增删接口，同步更新本文件 `Free 源接口矩阵` 表格。

--- a/tests/test_akshare_belong_board.py
+++ b/tests/test_akshare_belong_board.py
@@ -1,0 +1,65 @@
+# -*- coding: utf-8 -*-
+"""Tests for AkshareFetcher.get_belong_board fallback implementation."""
+
+import os
+import sys
+import types
+import unittest
+from unittest.mock import patch
+
+import pandas as pd
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from data_provider.akshare_fetcher import AkshareFetcher
+
+
+class TestAkshareBelongBoard(unittest.TestCase):
+    def test_returns_dataframe_when_stock_found_in_industry_boards(self):
+        fetcher = AkshareFetcher()
+        industry_names_df = pd.DataFrame({"板块名称": ["白酒", "新能源"]})
+        industry_cons_df = pd.DataFrame(
+            {"代码": ["600519", "000001"], "名称": ["贵州茅台", "平安银行"]}
+        )
+        concept_names_df = pd.DataFrame(columns=["板块名称"])
+        concept_cons_df = pd.DataFrame(columns=["代码", "名称"])
+
+        fake_ak = types.SimpleNamespace(
+            stock_board_industry_name_em=lambda: industry_names_df,
+            stock_board_industry_cons_em=lambda symbol: industry_cons_df,
+            stock_board_concept_name_em=lambda: concept_names_df,
+            stock_board_concept_cons_em=lambda symbol: concept_cons_df,
+        )
+
+        with patch.dict(sys.modules, {"akshare": fake_ak}):
+            with patch.object(fetcher, "_set_random_user_agent", return_value=None), patch.object(
+                fetcher, "_enforce_rate_limit", return_value=None
+            ):
+                df = fetcher.get_belong_board("600519")
+
+        self.assertIsNotNone(df)
+        self.assertGreaterEqual(len(df), 1)
+        self.assertIn("name", df.columns)
+
+    def test_returns_none_when_underlying_call_raises(self):
+        fetcher = AkshareFetcher()
+        fake_ak = types.SimpleNamespace(
+            stock_board_industry_name_em=lambda: (_ for _ in ()).throw(
+                RuntimeError("network down")
+            ),
+            stock_board_industry_cons_em=lambda symbol: pd.DataFrame(),
+            stock_board_concept_name_em=lambda: pd.DataFrame(columns=["板块名称"]),
+            stock_board_concept_cons_em=lambda symbol: pd.DataFrame(),
+        )
+
+        with patch.dict(sys.modules, {"akshare": fake_ak}):
+            with patch.object(fetcher, "_set_random_user_agent", return_value=None), patch.object(
+                fetcher, "_enforce_rate_limit", return_value=None
+            ):
+                df = fetcher.get_belong_board("600519")
+
+        self.assertIsNone(df)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_akshare_stock_list.py
+++ b/tests/test_akshare_stock_list.py
@@ -1,0 +1,57 @@
+# -*- coding: utf-8 -*-
+"""Tests for AkshareFetcher.get_stock_list bulk stock-list fallback."""
+
+import os
+import sys
+import types
+import unittest
+from unittest.mock import patch
+
+import pandas as pd
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from data_provider.akshare_fetcher import AkshareFetcher
+
+
+class TestAkshareStockList(unittest.TestCase):
+    def test_returns_dataframe_with_code_and_name_columns(self):
+        fetcher = AkshareFetcher()
+        df = pd.DataFrame(
+            {
+                "code": ["600519", "000001", "300750"],
+                "name": ["贵州茅台", "平安银行", "宁德时代"],
+            }
+        )
+        fake_ak = types.SimpleNamespace(stock_info_a_code_name=lambda: df)
+
+        with patch.dict(sys.modules, {"akshare": fake_ak}):
+            with patch.object(fetcher, "_set_random_user_agent", return_value=None), patch.object(
+                fetcher, "_enforce_rate_limit", return_value=None
+            ):
+                result = fetcher.get_stock_list()
+
+        self.assertIsNotNone(result)
+        self.assertEqual(len(result), 3)
+        self.assertIn("code", result.columns)
+        self.assertIn("name", result.columns)
+
+    def test_returns_none_when_underlying_call_raises(self):
+        fetcher = AkshareFetcher()
+
+        def boom():
+            raise RuntimeError("network down")
+
+        fake_ak = types.SimpleNamespace(stock_info_a_code_name=boom)
+
+        with patch.dict(sys.modules, {"akshare": fake_ak}):
+            with patch.object(fetcher, "_set_random_user_agent", return_value=None), patch.object(
+                fetcher, "_enforce_rate_limit", return_value=None
+            ):
+                result = fetcher.get_stock_list()
+
+        self.assertIsNone(result)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_efinance_concept_rankings.py
+++ b/tests/test_efinance_concept_rankings.py
@@ -1,0 +1,68 @@
+# -*- coding: utf-8 -*-
+"""Tests for EfinanceFetcher.get_concept_rankings fallback implementation."""
+
+import os
+import sys
+import types
+import unittest
+from unittest.mock import patch
+
+import pandas as pd
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from data_provider.efinance_fetcher import EfinanceFetcher
+
+
+class TestEfinanceConceptRankings(unittest.TestCase):
+    def test_returns_top_and_bottom_lists(self):
+        fetcher = EfinanceFetcher()
+        df = pd.DataFrame(
+            {
+                "板块名称": ["A", "B", "C", "D", "E", "F"],
+                "涨跌幅": [5.1, 3.2, 1.0, -1.0, -3.2, -5.1],
+            }
+        )
+        captured = {}
+
+        def fake_realtime_quotes(fs, **kwargs):
+            captured["fs"] = fs
+            return df
+
+        fake_ef = types.SimpleNamespace(
+            stock=types.SimpleNamespace(get_realtime_quotes=fake_realtime_quotes)
+        )
+
+        with patch.dict(sys.modules, {"efinance": fake_ef}):
+            with patch.object(fetcher, "_set_random_user_agent", return_value=None), patch.object(
+                fetcher, "_enforce_rate_limit", return_value=None
+            ):
+                top, bottom = fetcher.get_concept_rankings(n=3)
+
+        self.assertEqual(captured["fs"], ["概念板块"])
+        self.assertEqual(len(top), 3)
+        self.assertEqual(len(bottom), 3)
+        self.assertEqual(top[0]["name"], "A")
+        self.assertEqual(bottom[0]["name"], "F")
+
+    def test_returns_none_when_underlying_call_raises(self):
+        fetcher = EfinanceFetcher()
+
+        def boom(fs, **kwargs):
+            raise RuntimeError("network down")
+
+        fake_ef = types.SimpleNamespace(
+            stock=types.SimpleNamespace(get_realtime_quotes=boom)
+        )
+
+        with patch.dict(sys.modules, {"efinance": fake_ef}):
+            with patch.object(fetcher, "_set_random_user_agent", return_value=None), patch.object(
+                fetcher, "_enforce_rate_limit", return_value=None
+            ):
+                result = fetcher.get_concept_rankings(n=3)
+
+        self.assertIsNone(result)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_efinance_stock_name.py
+++ b/tests/test_efinance_stock_name.py
@@ -1,0 +1,55 @@
+# -*- coding: utf-8 -*-
+"""Tests for EfinanceFetcher.get_stock_name fallback implementation."""
+
+import os
+import sys
+import types
+import unittest
+from unittest.mock import patch
+
+import pandas as pd
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from data_provider.efinance_fetcher import EfinanceFetcher
+
+
+class TestEfinanceStockName(unittest.TestCase):
+    def test_returns_name_string_when_base_info_has_name(self):
+        fetcher = EfinanceFetcher()
+        fake_series = pd.Series(
+            {"股票代码": "600519", "股票名称": "贵州茅台", "市盈率": 25.0}
+        )
+        fake_ef = types.SimpleNamespace(
+            stock=types.SimpleNamespace(get_base_info=lambda code: fake_series)
+        )
+
+        with patch.dict(sys.modules, {"efinance": fake_ef}):
+            with patch.object(fetcher, "_set_random_user_agent", return_value=None), patch.object(
+                fetcher, "_enforce_rate_limit", return_value=None
+            ):
+                name = fetcher.get_stock_name("600519")
+
+        self.assertEqual(name, "贵州茅台")
+
+    def test_returns_none_when_underlying_call_raises(self):
+        fetcher = EfinanceFetcher()
+
+        def boom(code):
+            raise RuntimeError("network down")
+
+        fake_ef = types.SimpleNamespace(
+            stock=types.SimpleNamespace(get_base_info=boom)
+        )
+
+        with patch.dict(sys.modules, {"efinance": fake_ef}):
+            with patch.object(fetcher, "_set_random_user_agent", return_value=None), patch.object(
+                fetcher, "_enforce_rate_limit", return_value=None
+            ):
+                name = fetcher.get_stock_name("600519")
+
+        self.assertIsNone(name)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

补齐 `data_provider/` 中 free 源（efinance / akshare）的 `BaseFetcher` 可选接口，关闭 2 个单点故障接口 + 补齐 2 个主数据源能力。

## Background

`data_provider/base.py` 的 11 个可选接口在 free 源上长期只有部分 fetcher 实现，导致：

- **单点故障（单 fetcher 实现）**：`get_concept_rankings`、`get_hot_stocks`、`get_limit_up_pool`、`get_belong_board` —— akshare/efinance 任一失败该能力即断流
- **主数据源能力缺口**：`EfinanceFetcher.get_stock_name`、`AkshareFetcher.get_stock_list`

## Changes

### 关闭单点故障（2 个）

| 接口 | 旧实现 | 新增兜底 |
|---|---|---|
| `get_belong_board` | EfinanceFetcher | **AkshareFetcher** —— 遍历 `stock_board_industry_name_em` + `stock_board_concept_name_em` 反查 |
| `get_concept_rankings` | AkshareFetcher | **EfinanceFetcher** —— `ef.stock.get_realtime_quotes(['概念板块'])` |

### 主数据源能力补齐（2 个）

| 接口 | 新增位置 | 说明 |
|---|---|---|
| `get_stock_name` | **EfinanceFetcher** | 复用 `ef.stock.get_base_info`，仅取 `股票名称` 字段（避免拉全 base_info） |
| `get_stock_list` | **AkshareFetcher** | `ak.stock_info_a_code_name()` 拿全 A 股代码 + 名称 |

### 主动跳过（按 efinance 底层约束）

- `EfinanceFetcher.get_hot_stocks` / `get_limit_up_pool`：pre-research 验证 efinance `ef.stock.get_realtime_quotes` 的 `'人气股榜'` / `'涨停股'` / `'涨停'` / `'人气榜'` 四个 enum 均抛 `KeyError`，efinance 底层无对应 API
- 剩余单点故障（`get_hot_stocks` / `get_limit_up_pool`）继续是 akshare 单点，等 efinance 上游支持后另行 PR

### 不动 Tencent / Pytdx / Baostock / Yfinance

- TencentFetcher 仅做日线 fallback（实时走 `AkshareFetcher(source="tencent")`）
- Pytdx / Baostock / Yfinance 已覆盖各自适用面，无新增需求

### 不动 `get_chip_distribution` in efinance

efinance 没有原生筹码 API（`get_quote_history` 无 cyq 字段）。

## 文档同步

- `docs/data-sources-coverage.md`（新增）：free 源接口覆盖矩阵 + 付费源 key / 积分需求清单
- `docs/CHANGELOG.md`：在 `[Unreleased]` 段新增 2 条 flat-format 条目（按 AGENTS.md 规则）

## Test

每个新方法 2 条单测（成功 + 异常路径），共 8 条：

```bash
python -m pytest \
  tests/test_akshare_belong_board.py \
  tests/test_akshare_stock_list.py \
  tests/test_efinance_stock_name.py \
  tests/test_efinance_concept_rankings.py -v
# 8 passed
```

## Validation

- `python -m py_compile data_provider/*.py` —— OK
- `flake8 . --select=E9,F63,F7,F82` —— 0
- `python -m pytest -m "not network"` —— 新增 8 条全过；pre-existing 失败与本 PR 无关（已 `git stash` 在 base commit 上确认）

## Breaking Changes

无。全部为新增方法；`DataFetcherManager` 的 failover 链自动扩展（按 fetcher.priority 遍历，已通过 `hasattr` 检测）。

## Rollback

每个新增方法独立，回滚只需 revert 对应 commit。`STOCK_NAME_MAP` 无改动。

## Diff

```
 data_provider/akshare_fetcher.py        | 116 +++++++++++++++++++++++++++++-
 data_provider/efinance_fetcher.py       |  85 +++++++++++++++++++++-
 docs/CHANGELOG.md                       |   4 ++
 docs/data-sources-coverage.md           |  78 +++++++++++++++++++
 tests/test_akshare_belong_board.py      |  65 ++++++++++++++
 tests/test_akshare_stock_list.py        |  57 +++++++++++++
 tests/test_efinance_concept_rankings.py |  68 +++++++++++++++
 tests/test_efinance_stock_name.py       |  55 ++++++++++++
 8 files changed, 526 insertions(+), 2 deletions(-)
```

## Related

- AGENTS.md §1（硬规则）：变更同步 `docs/CHANGELOG.md`
- AGENTS.md §7（稳定性护栏）：单一数据源失败不应拖垮分析流程
- 新文档 `docs/data-sources-coverage.md` 是维护入口，后续 fetcher 增删接口需要同步更新该矩阵