### PR TITLE
Codex/fix alphasift actions screening

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -80,6 +80,13 @@ ALPHASIFT_INSTALL_SPEC=git+https://github.com/ZhuLinsen/alphasift.git@9f522747ca
 # AlphaSift LLM 重排请求输出上限；仅影响 AlphaSift 选股重排，默认 2048。
 # LLM_MAX_TOKENS=2048
 
+# GitHub Actions AlphaSift screening knobs; defaults come from the workflow when unset.
+# ALPHASIFT_STRATEGIES=dual_low,balanced_alpha,momentum_quality,quality_value,oversold_reversal
+# ALPHASIFT_MARKET=cn
+# ALPHASIFT_PER_STRATEGY=3
+# ALPHASIFT_SELECTION_LIMIT=10
+# ALPHASIFT_STRATEGY_TIMEOUT_SECONDS=120
+
 # Finnhub（可选，美股数据源，免费 tier 60 calls/min）
 # 获取: https://finnhub.io/register
 # FINNHUB_API_KEY=

--- a/.github/workflows/00-daily-analysis.yml
+++ b/.github/workflows/00-daily-analysis.yml
@@ -512,6 +512,47 @@ jobs:
             echo "⚡ 已启用强制运行模式（跳过交易日检查）"
           fi
 
+          # ===== alphasift 多策略选股（5策略×Top3，去重取10）=====
+          echo "🔍 开始 alphasift 多策略选股..."
+          STRATEGIES="dual_low balanced_alpha momentum_quality quality_value oversold_reversal"
+          ALL_CODES=""
+          for STRATEGY in $STRATEGIES; do
+            echo "   跑策略: $STRATEGY (Top 3)"
+            alphasift screen "$STRATEGY" --no-llm --no-post-analysis --max-output 3 --json > "/tmp/sel_${STRATEGY}.json" 2>/dev/null || true
+            CODES=$(python -c "
+import json
+try:
+    d = json.load(open('/tmp/sel_${STRATEGY}.json'))
+    picks = d.get('picks', [])
+    print(','.join([p.get('code','') for p in picks if p.get('code')]))
+except:
+    print('')
+" 2>/dev/null)
+            if [ -n "$CODES" ]; then
+              ALL_CODES="${ALL_CODES},${CODES}"
+              echo "   ✅ $STRATEGY: $CODES"
+            else
+              echo "   ⚠️ $STRATEGY: 无候选"
+            fi
+          done
+          # 去重，取前 10 只
+          SELECTED=$(python -c "
+codes = '${ALL_CODES}'.strip(',').split(',')
+seen = []
+for c in codes:
+    c = c.strip()
+    if c and c not in seen:
+        seen.append(c)
+print(','.join(seen[:10]))
+" 2>/dev/null)
+          if [ -n "$SELECTED" ]; then
+            export STOCK_LIST="$SELECTED"
+            echo "✅ 多策略选股完成（去重后 Top 10）: $SELECTED"
+          else
+            echo "⚠️ 选股全部失败，使用默认 STOCK_LIST: $STOCK_LIST"
+          fi
+          # ===== 选股结束 =====
+
           # 执行分析
           if [ "$MODE" = "market-only" ]; then
             python main.py --market-review $FORCE_RUN_ARG

--- a/.github/workflows/00-daily-analysis.yml
+++ b/.github/workflows/00-daily-analysis.yml
@@ -1,9 +1,11 @@
+
 name: 每日股票分析
 
 on:
-  # 定时触发 - 每天北京时间 18:00 (UTC 10:00)
+  # 定时触发 - 每天北京时间 11:00 和 14:45
   schedule:
-    - cron: '0 10 * * 1-5'     # 周一到周五，UTC 10:00 = 北京时间 18:00
+    - cron: '0 3 * * 1-5'      # 周一到周五，UTC 03:00 = 北京时间 11:00
+    - cron: '45 6 * * 1-5'     # 周一到周五，UTC 06:45 = 北京时间 14:45
   
   # 手动触发
   workflow_dispatch:
@@ -22,6 +24,8 @@ on:
         required: false
         default: false
         type: boolean
+
+
 
 # 并发控制：同一时间只运行一个分析任务
 concurrency:

--- a/.github/workflows/00-daily-analysis.yml
+++ b/.github/workflows/00-daily-analysis.yml
@@ -505,7 +505,7 @@ jobs:
           echo "=========================================="
           echo ""
           
-                    # 构建命令行参数
+          # 构建命令行参数
           FORCE_RUN_ARG=""
           if [ "${{ github.event.inputs.force_run }}" = "true" ]; then
             FORCE_RUN_ARG="--force-run"
@@ -519,15 +519,7 @@ jobs:
           for STRATEGY in $STRATEGIES; do
             echo "   跑策略: $STRATEGY (Top 3)"
             alphasift screen "$STRATEGY" --no-llm --no-post-analysis --max-output 3 --json > "/tmp/sel_${STRATEGY}.json" 2>/dev/null || true
-            CODES=$(python -c "
-            import json
-            try:
-                d = json.load(open('/tmp/sel_${STRATEGY}.json'))
-                picks = d.get('picks', [])
-                print(','.join([p.get('code','') for p in picks if p.get('code')]))
-            except:
-                print('')
-            " 2>/dev/null)
+            CODES=$(python -c "import json; d=json.load(open('/tmp/sel_${STRATEGY}.json')); print(','.join([p.get('code','') for p in d.get('picks',[]) if p.get('code')]))" 2>/dev/null || echo "")
             if [ -n "$CODES" ]; then
               ALL_CODES="${ALL_CODES},${CODES}"
               echo "   ✅ $STRATEGY: $CODES"
@@ -535,15 +527,7 @@ jobs:
               echo "   ⚠️ $STRATEGY: 无候选"
             fi
           done
-          SELECTED=$(python -c "
-          codes = '${ALL_CODES}'.strip(',').split(',')
-          seen = []
-          for c in codes:
-              c = c.strip()
-              if c and c not in seen:
-                  seen.append(c)
-          print(','.join(seen[:10]))
-          " 2>/dev/null)
+          SELECTED=$(python -c "codes='${ALL_CODES}'.strip(',').split(','); seen=[]; [seen.append(c.strip()) for c in codes if c.strip() and c.strip() not in seen]; print(','.join(seen[:10]))" 2>/dev/null || echo "")
           if [ -n "$SELECTED" ]; then
             export STOCK_LIST="$SELECTED"
             echo "✅ 多策略选股完成（去重后 Top 10）: $SELECTED"

--- a/.github/workflows/00-daily-analysis.yml
+++ b/.github/workflows/00-daily-analysis.yml
@@ -389,6 +389,11 @@ jobs:
           STOCK_LIST_CONFIG: ${{ vars.STOCK_LIST || secrets.STOCK_LIST }}
           MARKET_REVIEW_REGION: ${{ vars.MARKET_REVIEW_REGION || secrets.MARKET_REVIEW_REGION || 'cn' }}
           MARKET_REVIEW_COLOR_SCHEME: ${{ vars.MARKET_REVIEW_COLOR_SCHEME || secrets.MARKET_REVIEW_COLOR_SCHEME || 'green_up' }}
+          ALPHASIFT_STRATEGIES: ${{ vars.ALPHASIFT_STRATEGIES || secrets.ALPHASIFT_STRATEGIES || '' }}
+          ALPHASIFT_MARKET: ${{ vars.ALPHASIFT_MARKET || secrets.ALPHASIFT_MARKET || 'cn' }}
+          ALPHASIFT_PER_STRATEGY: ${{ vars.ALPHASIFT_PER_STRATEGY || secrets.ALPHASIFT_PER_STRATEGY || '3' }}
+          ALPHASIFT_SELECTION_LIMIT: ${{ vars.ALPHASIFT_SELECTION_LIMIT || secrets.ALPHASIFT_SELECTION_LIMIT || '10' }}
+          ALPHASIFT_STRATEGY_TIMEOUT_SECONDS: ${{ vars.ALPHASIFT_STRATEGY_TIMEOUT_SECONDS || secrets.ALPHASIFT_STRATEGY_TIMEOUT_SECONDS || '120' }}
           
           # ==========================================
           # 运行配置 ⬅️ 新增！
@@ -512,29 +517,20 @@ jobs:
             echo "⚡ 已启用强制运行模式（跳过交易日检查）"
           fi
 
-          # ===== alphasift 多策略选股（5策略×Top3，去重取10）=====
-          echo "🔍 开始 alphasift 多策略选股..."
-          STRATEGIES="dual_low balanced_alpha momentum_quality quality_value oversold_reversal"
-          ALL_CODES=""
-          for STRATEGY in $STRATEGIES; do
-            echo "   跑策略: $STRATEGY (Top 3)"
-            alphasift screen "$STRATEGY" --no-llm --no-post-analysis --max-output 3 --json > "/tmp/sel_${STRATEGY}.json" 2>/dev/null || true
-            CODES=$(python -c "import json; d=json.load(open('/tmp/sel_${STRATEGY}.json')); print(','.join([p.get('code','') for p in d.get('picks',[]) if p.get('code')]))" 2>/dev/null || echo "")
-            if [ -n "$CODES" ]; then
-              ALL_CODES="${ALL_CODES},${CODES}"
-              echo "   ✅ $STRATEGY: $CODES"
-            else
-              echo "   ⚠️ $STRATEGY: 无候选"
-            fi
-          done
-          SELECTED=$(python -c "codes='${ALL_CODES}'.strip(',').split(','); seen=[]; [seen.append(c.strip()) for c in codes if c.strip() and c.strip() not in seen]; print(','.join(seen[:10]))" 2>/dev/null || echo "")
-          if [ -n "$SELECTED" ]; then
-            export STOCK_LIST="$SELECTED"
-            echo "✅ 多策略选股完成（去重后 Top 10）: $SELECTED"
+          # ===== AlphaSift multi-strategy screening (default 5 strategies x Top3, dedupe Top10) =====
+          if [ "$MODE" = "market-only" ]; then
+            echo "INFO: market-only mode skips AlphaSift screening"
           else
-            echo "⚠️ 选股全部失败，使用默认 STOCK_LIST: $STOCK_LIST"
+            python scripts/run_alphasift_selection.py --output-file /tmp/alphasift_selected.txt
+            SELECTED="$(cat /tmp/alphasift_selected.txt 2>/dev/null || true)"
+            if [ -n "$SELECTED" ]; then
+              export STOCK_LIST="$SELECTED"
+              echo "AlphaSift selected STOCK_LIST: $STOCK_LIST"
+            else
+              echo "WARN: AlphaSift produced no picks; keep current STOCK_LIST: $STOCK_LIST"
+            fi
           fi
-          # ===== 选股结束 =====
+          # ===== screening done =====
 
           # 执行分析
           if [ "$MODE" = "market-only" ]; then

--- a/.github/workflows/00-daily-analysis.yml
+++ b/.github/workflows/00-daily-analysis.yml
@@ -505,7 +505,7 @@ jobs:
           echo "=========================================="
           echo ""
           
-          # 构建命令行参数
+                    # 构建命令行参数
           FORCE_RUN_ARG=""
           if [ "${{ github.event.inputs.force_run }}" = "true" ]; then
             FORCE_RUN_ARG="--force-run"
@@ -520,14 +520,14 @@ jobs:
             echo "   跑策略: $STRATEGY (Top 3)"
             alphasift screen "$STRATEGY" --no-llm --no-post-analysis --max-output 3 --json > "/tmp/sel_${STRATEGY}.json" 2>/dev/null || true
             CODES=$(python -c "
-import json
-try:
-    d = json.load(open('/tmp/sel_${STRATEGY}.json'))
-    picks = d.get('picks', [])
-    print(','.join([p.get('code','') for p in picks if p.get('code')]))
-except:
-    print('')
-" 2>/dev/null)
+            import json
+            try:
+                d = json.load(open('/tmp/sel_${STRATEGY}.json'))
+                picks = d.get('picks', [])
+                print(','.join([p.get('code','') for p in picks if p.get('code')]))
+            except:
+                print('')
+            " 2>/dev/null)
             if [ -n "$CODES" ]; then
               ALL_CODES="${ALL_CODES},${CODES}"
               echo "   ✅ $STRATEGY: $CODES"
@@ -535,16 +535,15 @@ except:
               echo "   ⚠️ $STRATEGY: 无候选"
             fi
           done
-          # 去重，取前 10 只
           SELECTED=$(python -c "
-codes = '${ALL_CODES}'.strip(',').split(',')
-seen = []
-for c in codes:
-    c = c.strip()
-    if c and c not in seen:
-        seen.append(c)
-print(','.join(seen[:10]))
-" 2>/dev/null)
+          codes = '${ALL_CODES}'.strip(',').split(',')
+          seen = []
+          for c in codes:
+              c = c.strip()
+              if c and c not in seen:
+                  seen.append(c)
+          print(','.join(seen[:10]))
+          " 2>/dev/null)
           if [ -n "$SELECTED" ]; then
             export STOCK_LIST="$SELECTED"
             echo "✅ 多策略选股完成（去重后 Top 10）: $SELECTED"
@@ -561,6 +560,7 @@ print(','.join(seen[:10]))
           else
             python main.py $FORCE_RUN_ARG
           fi
+
       
       - name: 上传分析报告
         uses: actions/upload-artifact@v6

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 > For user-friendly release highlights, see the [GitHub Releases](https://github.com/ZhuLinsen/daily_stock_analysis/releases) page.
 
 ## [Unreleased]
+- [修复] GitHub Actions daily analysis now uses an observable AlphaSift multi-strategy script to fill `STOCK_LIST` before stock analysis, so CLI failures are no longer silently swallowed before falling back to the existing watchlist or market review.
 - [chore] 暂停 PR Review 的自动触发，仅保留 `workflow_dispatch` 手动入口，避免辅助评审重复运行及评论权限失败产生误导性红灯；正式 CI 检查保持不变。
 - [新功能] Multi-Agent specialist 运行在分析历史保存成功后，按独立 skill 持久化版本化、低敏且幂等的有效 opinion 样本，为后续后验评估提供真实数据；本阶段不计算 outcome、不统计表现、不调整权重。
 - [新功能] AI 建议页在既有后验统计中增加决策风格历史表现，按每个分组独立的 30 个已完成样本门槛展示命中、区间涨跌、无法评估和最大不利波动，并保持旧统计接口兼容。

--- a/docs/alphasift-integration.md
+++ b/docs/alphasift-integration.md
@@ -46,6 +46,20 @@ AlphaSift 作为独立仓库维护的选股引擎接入 DSA。DSA 默认不启�
 - 热点数据源补充：DSA provider 使用直连 HTTP 思路，东财板块兜底源使用 `push2.eastmoney.com/api/qt/clist/get` 并保留涨跌幅、领涨股、上涨/下跌家数等字段；题材详情会在一次 provider 生命周期内缓存并合并东方财富成分股、同花顺页面解析和板块异动龙头兜底，优先返回多只概念股，发酵路线按日期聚合展示，避免把同一盘中观察拆成多条同时间节点；事件催化不再使用 DSA 内置静态文案，只展示 AlphaSift 合约时间线、同花顺摘要、已配置新闻搜索源或东财板块异动结构拿到的真实信息；新闻搜索命中的消息会优先通过已配置 LLM 压缩成一句题材催化摘要，LLM 不可用时回退本地短摘要，避免在时间线中展示完整报道。
 - 风险提示：前端设置页和选股页展示第三方来源与投资风险说明；不会弹窗打断用户。
 
+## GitHub Actions daily screening
+
+`.github/workflows/00-daily-analysis.yml` runs `scripts/run_alphasift_selection.py` before `python main.py` in every non-`market-only` run. By default it runs `dual_low,balanced_alpha,momentum_quality,quality_value,oversold_reversal`, takes Top 3 from each strategy, deduplicates the results, and writes at most 10 codes to `STOCK_LIST` for the downstream stock analysis.
+
+The following GitHub Actions Repository variables or Secrets can override the defaults:
+
+- `ALPHASIFT_STRATEGIES`: comma-separated strategy IDs.
+- `ALPHASIFT_MARKET`: screening market, default `cn`.
+- `ALPHASIFT_PER_STRATEGY`: picks per strategy, default `3`.
+- `ALPHASIFT_SELECTION_LIMIT`: final deduplicated code limit, default `10`.
+- `ALPHASIFT_STRATEGY_TIMEOUT_SECONDS`: timeout per strategy, default `120`.
+
+The script logs each strategy success, empty result, failure, or timeout. If no usable candidates are produced, the workflow keeps the existing `STOCK_LIST` instead of hiding the AlphaSift failure.
+
 ## AlphaSift 适配层要求
 
 AlphaSift 需要提供 `alphasift.dsa_adapter` 模块，并保持以下稳定函数：

--- a/scripts/run_alphasift_selection.py
+++ b/scripts/run_alphasift_selection.py
@@ -1,0 +1,177 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Run AlphaSift multi-strategy screening and emit selected stock codes.
+
+This script is intentionally small and CLI-oriented because GitHub Actions needs
+to turn AlphaSift picks into ``STOCK_LIST`` before invoking ``main.py``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shlex
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any, Iterable
+
+
+DEFAULT_STRATEGIES = (
+    "dual_low",
+    "balanced_alpha",
+    "momentum_quality",
+    "quality_value",
+    "oversold_reversal",
+)
+
+
+def _split_csv(value: str) -> list[str]:
+    return [item.strip() for item in value.replace("\n", ",").split(",") if item.strip()]
+
+
+def _build_command(base_command: str, strategy: str, market: str, max_output: int) -> list[str]:
+    command = shlex.split(base_command, posix=os.name != "nt") if base_command.strip() else []
+    if not command:
+        executable = shutil.which("alphasift")
+        command = [executable] if executable else [sys.executable, "-m", "alphasift"]
+
+    return [
+        *command,
+        "screen",
+        strategy,
+        "--market",
+        market,
+        "--no-llm",
+        "--no-post-analysis",
+        "--max-output",
+        str(max_output),
+        "--json",
+    ]
+
+
+def _candidate_items(payload: Any) -> list[Any]:
+    if isinstance(payload, dict):
+        for key in ("picks", "candidates", "items", "results", "stocks"):
+            value = payload.get(key)
+            if isinstance(value, list):
+                return value
+        return []
+    if isinstance(payload, list):
+        return payload
+    return []
+
+
+def _extract_codes(payload: Any) -> list[str]:
+    codes: list[str] = []
+    for item in _candidate_items(payload):
+        if isinstance(item, dict):
+            code = item.get("code") or item.get("symbol") or item.get("stock_code")
+        else:
+            code = item
+        text = str(code or "").strip()
+        if text:
+            codes.append(text)
+    return codes
+
+
+def _dedupe_limit(groups: Iterable[Iterable[str]], limit: int) -> list[str]:
+    selected: list[str] = []
+    seen: set[str] = set()
+    for group in groups:
+        for code in group:
+            normalized = code.strip()
+            if normalized and normalized not in seen:
+                selected.append(normalized)
+                seen.add(normalized)
+                if len(selected) >= limit:
+                    return selected
+    return selected
+
+
+def _run_strategy(args: argparse.Namespace, strategy: str) -> list[str]:
+    command = _build_command(args.command, strategy, args.market, args.per_strategy)
+    print(f"   跑策略: {strategy} (Top {args.per_strategy})", flush=True)
+    try:
+        completed = subprocess.run(
+            command,
+            check=False,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            timeout=args.timeout,
+        )
+    except subprocess.TimeoutExpired:
+        print(f"   ⚠️ {strategy}: 超时 {args.timeout}s，跳过", flush=True)
+        return []
+    except FileNotFoundError as exc:
+        print(f"   ⚠️ {strategy}: AlphaSift 命令不可用：{exc}", flush=True)
+        return []
+
+    stderr = (completed.stderr or "").strip()
+    if completed.returncode != 0:
+        detail = stderr.splitlines()[-1] if stderr else f"exit={completed.returncode}"
+        print(f"   ⚠️ {strategy}: 运行失败：{detail}", flush=True)
+        return []
+
+    try:
+        payload = json.loads(completed.stdout or "{}")
+    except json.JSONDecodeError as exc:
+        preview = (completed.stdout or "").strip().replace("\n", " ")[:160]
+        print(f"   ⚠️ {strategy}: JSON 解析失败：{exc}; stdout={preview!r}", flush=True)
+        return []
+
+    codes = _extract_codes(payload)[: args.per_strategy]
+    if codes:
+        print(f"   ✅ {strategy}: {','.join(codes)}", flush=True)
+    else:
+        warnings = payload.get("warnings") if isinstance(payload, dict) else None
+        suffix = f"；warnings={warnings}" if warnings else ""
+        print(f"   ⚠️ {strategy}: 无候选{suffix}", flush=True)
+    return codes
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="AlphaSift 多策略选股，输出去重后的股票代码。")
+    parser.add_argument(
+        "--strategies",
+        default=os.getenv("ALPHASIFT_STRATEGIES", ",".join(DEFAULT_STRATEGIES)),
+        help="逗号分隔的策略 ID 列表，默认读取 ALPHASIFT_STRATEGIES。",
+    )
+    parser.add_argument("--market", default=os.getenv("ALPHASIFT_MARKET", "cn"))
+    parser.add_argument("--per-strategy", type=int, default=int(os.getenv("ALPHASIFT_PER_STRATEGY", "3")))
+    parser.add_argument("--limit", type=int, default=int(os.getenv("ALPHASIFT_SELECTION_LIMIT", "10")))
+    parser.add_argument("--timeout", type=int, default=int(os.getenv("ALPHASIFT_STRATEGY_TIMEOUT_SECONDS", "120")))
+    parser.add_argument("--command", default=os.getenv("ALPHASIFT_COMMAND", ""))
+    parser.add_argument("--output-file", default=os.getenv("ALPHASIFT_OUTPUT_FILE", ""))
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv or sys.argv[1:])
+    strategies = _split_csv(args.strategies)
+    print("🔍 开始 AlphaSift 多策略选股...", flush=True)
+    if not strategies:
+        print("⚠️ 未配置 AlphaSift 策略，跳过选股", flush=True)
+        selected: list[str] = []
+    else:
+        selected = _dedupe_limit((_run_strategy(args, strategy) for strategy in strategies), args.limit)
+
+    selected_text = ",".join(selected)
+    if args.output_file:
+        output_path = Path(args.output_file)
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        output_path.write_text(selected_text, encoding="utf-8")
+
+    if selected_text:
+        print(f"✅ 多策略选股完成（去重后 Top {args.limit}）: {selected_text}", flush=True)
+    else:
+        print("⚠️ AlphaSift 未产生可用候选，将继续使用原 STOCK_LIST", flush=True)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
<!--
For Chinese contributors: 请直接用中文填写。
For English contributors: please fill in English. All fields marked (EN) accept English.
-->

## PR Type

- [ ] fix
- [ ] feat
- [ ] refactor
- [ ] docs
- [ ] chore
- [ ] test

## Background And Problem

请描述当前问题、影响范围与触发场景。  
*(EN) Describe the problem, its impact, and what triggers it.*

## Scope Of Change

请列出本 PR 修改的模块和文件范围。  
*(EN) List the modules and files changed in this PR.*

> 注意：请按实际 `git diff` 全量列出文件范围（建议注明文件总数），避免遗漏文档/后端/API/前端文件导致描述不一致。

> 若本 PR 修改了 `.github/PULL_REQUEST_TEMPLATE.md`、`.github/copilot-instructions.md`、`AGENTS.md`、`.github/instructions/*` 或 `.claude/skills/**` 等协作与治理文件，请补充“变更原因 + 影响面 + 回滚方式（默认 revert）”到 Summary / Compatibility / Rollback，避免 Scope 与描述不一致。

> 建议先执行并粘贴以下命令输出，避免与实际 diff 不一致：

```bash
BASE_REF=$(git merge-base HEAD origin/main)
git diff --stat "$BASE_REF"..HEAD
git diff --name-only "$BASE_REF"..HEAD
```

- 文件总数 / 变更行数（建议粘贴 `git diff --stat "$BASE_REF"..HEAD`）：
- 文件清单（按实际 diff 全量，逐项列出）：
- 文档更新文件（`docs/*`）：

## Issue Link

必须填写以下之一 / Fill in one of:
- `Fixes #<issue_number>`
- `Refs #<issue_number>`
- 无 Issue 时说明原因与验收标准 / If no issue, explain the motivation and acceptance criteria

## Verification Commands And Results

请填写你实际执行过的命令和关键结果（不要只写"已测试"）。  
*(EN) Paste the commands you actually ran and their key output (don't just write "tested"):*

```bash
# example
./scripts/ci_gate.sh
python -m pytest -m "not network"
```

> `Full-suite note` 必须与当次 PR 的当前 Head CI 结果保持一致；若本地复现存在环境相关失败，请明确标注“本地环境差异”并给出 GitHub CI 的结论与链接。  
> 请避免保留与本 PR 无关的历史失败措辞，按本次实际结果填报。
> 如历史描述中仍保留 `./scripts/ci_gate.sh` 失败记录，请先改为当前 Head CI 状态或说明与 Head CI 的差异来源。
> 若 `Full-suite note` 与当前 Head CI 不一致，PR 文本不完整，请先更新 PR 描述后再提交。

- 请在下面按实际结果填写并与 `Full-suite note` 保持一致（任一未填视为信息缺失）：
  - ai-governance：`pass` / `fail`，附链接
  - backend-gate：`pass` / `fail`，附链接
  - docker-build：`pass` / `fail`，附链接
  - web-gate：`pass` / `fail`，附链接
  - 若本 PR 修改 `.github/PULL_REQUEST_TEMPLATE.md` 等流程模板协作文件，请先说明变更必要性、影响边界，并明确回滚方式（默认 `revert this PR`）；否则请在下一版中拆为单独 chore PR。

关键输出/结论 / Key output & conclusion:

- 【必填】当前 Head CI：`ai-governance:pass / backend-gate:pass / docker-build:pass / web-gate:pass`（按实际结果替换）并附对应链接。  
- 若需保留本地失败现象，请在同段写明“本地环境差异 + 当前 CI 通过/失败结果 + CI 链接”。  
- 若全部通过，需补充一句：`当前状态：全部通过（pass）`，并明确 Head CI 全部为 pass。  

- 建议将本行直接粘贴到 PR 描述正文首段：`当前 Head CI：ai-governance:pass / backend-gate:pass / docker-build:pass / web-gate:pass`（仅示例，按实际结果替换）。

> 若上述核验项与 PR 文本冲突，建议先更新 PR 描述再提交，避免审查因状态不一致被阻塞。

## Visual Evidence (if applicable)

【必填】若本 PR 修改报告格式、报告渲染效果或 Web UI 界面，请在此处附受影响报告 / 页面截图；涉及前后差异时，优先附前后对比。Issue / PR 过程截图、审查截图、一次性验收截图和临时可视证据请放在 PR 描述、PR 评论、GitHub 附件、Actions artifact 或外部可访问链接中，不要作为仓库文件合入。
*(EN) If this PR changes report formatting, report rendering, or Web UI, attach screenshots of the affected report/page here; before/after screenshots are preferred when relevant. Issue/PR process screenshots, review screenshots, one-off acceptance screenshots, and temporary visual evidence should be linked from the PR body/comments, GitHub attachments, Actions artifacts, or external accessible evidence; do not commit them as repository files.)*

> 如截图无法获取，请在“原因”中明确写明替代证据（如 Playwright/e2e 产物路径、审查链接）及其可追溯命令，不得留空。涉及 Web 设置/报告渲染变更时，需确保截图或替代证据明确指向变更项。
>
> 若本 PR 修改 Web UI，建议至少补一条可复现路径，例如（优先 settings page）：
>
> - Playwright 截图产物：`apps/dsa-web/e2e/smoke.spec.ts`（`cd apps/dsa-web && npx playwright test e2e/smoke.spec.ts --grep "settings page renders title and save actions after login"`）
> - 审查证据链接：可直接使用 Actions 产物、GitHub 评论附件或外部可访问链接。

> 替代证据模板（设置页变更建议）：
> - 命令：`cd apps/dsa-web && npx playwright test e2e/smoke.spec.ts --grep "settings page"`
> - 产物路径：`apps/dsa-web/test-results/**/smoke-settings-page-*.png`
> - 说明：截图中应可见本次修改的系统设置项（字段、标签、帮助文案）

- 截图链接 / Screenshot links（Web UI/报告改动项必填，未提供请在下方“不适用原因”给出替代证据）：
- settings 页建议命名：`smoke-settings-page-zh` / `smoke-settings-page-en`
- 前后对比 / Before & After（如有）：
- settings 字段变更说明：截图或产物应明确包含 `MARKET_REVIEW_REGION` 字段与帮助文案区块（中文/英文）。
- 不适用原因 / Reason if not applicable（若未附截图，此项务必填写，且包含可复现证据与命令）：
  - Playwright 命令（无截图时）：`cd apps/dsa-web && npx playwright test e2e/smoke.spec.ts --grep "settings page"`
  - 产物路径（无截图时）：`apps/dsa-web/test-results/**/smoke-settings-page-*.png`
  - 说明：截图（或产物）必须可见本次修改的设置字段文案与帮助信息。

> 若本 PR 修改 Web 设置字段（字段、文案或帮助文案），截图或替代证据必须可定位到对应设置项区域并可追溯至变更项；该项为必填。

> 若本 PR 修改 Web UI 或报告展示且无法获取截图，原因栏必须给出可复现替代证据（例如 Playwright 截图产物路径 + 命令），且不得留空。

## Compatibility And Risk

请说明兼容性影响、潜在风险（如无请写 `None`）。  
*(EN) Describe compatibility impact and potential risks (write `None` if not applicable).*

- 若本 PR 修改第三方模型 / API 的兼容语义、请求参数、路由前缀或 provider fallback，请提供**官方来源链接或公告**，并说明这是长期约束、当前运行时约束还是临时兼容处理。  
  请在下方补充所影响外部 API/服务、回归范围与回退方式。  
  *(EN) If this PR changes third-party model/API compatibility, request parameters, routing prefixes, or provider fallback behavior, include an **official source link or announcement** and clarify whether the rule is permanent, runtime-specific, or a temporary compatibility workaround.)*
- 若本 PR 未触及第三方模型/API、provider/model/base URL 或运行时配置保存/清理/迁移逻辑，请在此段直接按以下文案确认（无须再次展开）：  
  `本 PR 未变更 provider/model/base URL、运行时配置清理迁移语义；历史配置保持不变；回滚方式为 revert 本提交。`
- 若本 PR 修改 `.github/PULL_REQUEST_TEMPLATE.md` / PR 流程模板类文件，请在此明确：仅影响协作流程与模板维护，不改 runtime 行为；回退方式为 revert；并补充是否影响自动化提交流程。  
  *(EN) If this PR changes `.github/PULL_REQUEST_TEMPLATE.md` or other PR workflow files, state that it only affects contribution governance templates (no runtime behavior), provide rollback by revert, and note any CI/checklist impact.)*
- 若本 PR 依赖特定运行时 / 锁定依赖窗口（例如 LiteLLM 版本范围、OpenAI-compatible 路由、YAML alias 行为），请写明当前验证过的兼容范围与覆盖路径。  
  *(EN) If this PR depends on a specific runtime or pinned dependency window (for example a LiteLLM version range, OpenAI-compatible routing, or YAML alias behavior), state the compatibility window you verified and which code paths were covered.)*
- 若本 PR 触及运行时配置保存、清理、迁移或回填逻辑，请明确说明旧配置是否会被自动改写、清空、迁移或保持不变，以及用户如何恢复原行为。  
  *(EN) If this PR touches runtime config save/cleanup/migration/backfill logic, explicitly describe whether existing config is rewritten, cleared, migrated, or left intact, and how users can restore the previous behavior.)*
- 若本 PR **未触及** provider/model/base URL 或运行时配置保存/清理/迁移逻辑（本条仅作为声明），请明确写：`本 PR 未变更 provider/model/base URL、运行时配置清理迁移语义；历史配置保持不变；回滚方式为 revert 本提交。`

## Rollback Plan

请至少写一句可执行的回滚方案（必填）。  
*(EN) Provide at least one actionable rollback step (required).*

- 如果是兼容性修复，默认应写出**最小回滚方式**（例如 `revert this PR`），并说明是否需要额外回滚配置或数据迁移。  
  *(EN) For compatibility fixes, include the **minimal rollback path** (for example `revert this PR`) and whether any additional config or data rollback is required.)*

## EXTRACT_PROMPT Change (if applicable)

若本 PR 修改了 `src/services/image_stock_extractor.py` 中的 `EXTRACT_PROMPT`，请在此处粘贴完整变更后的 prompt。  
*If this PR changes `EXTRACT_PROMPT` in `src/services/image_stock_extractor.py`, paste the full updated prompt here:*

<details>
<summary>展开 / Expand: Full EXTRACT_PROMPT</summary>

```
(paste full prompt here)
```

</details>

## Checklist

- [ ] 本 PR 有明确动机和业务价值 / This PR has a clear motivation and value
- [ ] 已提供可复现的验证命令与结果 / Reproducible verification commands and results are included
- [ ] 已评估兼容性与风险 / Compatibility and risk have been assessed
- [ ] 已提供回滚方案 / A rollback plan is provided
- [ ] 若修改报告格式或 Web UI 界面，已在 PR 描述/评论附受影响报告 / 页面截图，且未把一次性验收截图作为仓库文件合入 / If report formatting or Web UI changed, affected report/page screenshots are linked in the PR body/comments and one-off acceptance screenshots are not committed as repository files
- [ ] 若本 PR 修改 Web 设置字段（字段、文案或帮助文本），请补充设置页截图；无法截图时需提供替代可视证据（命令 + 产物路径），并指向对应变更项 / If Web settings fields changed (labels or help text), screenshots of the settings page are required; if unavailable, provide alternative visual evidence with command + artifact path that points to the changed item.
- [ ] 若涉及用户可见变更，已同步更新相关文档与 `docs/CHANGELOG.md`；`README.md` 仅在首页级信息变化时更新，细节优先写入 `docs/*.md` / If user-visible changes are included, relevant docs and `docs/CHANGELOG.md` are updated; `README.md` is updated only for homepage-level changes, with details kept in `docs/*.md`
