### PR TITLE
fix(#2070): PR Review 事件载荷 4 类异常可定位 + PR_NUMBER fallback 契约化

### DIFF
--- a/.github/scripts/ai_review.py
+++ b/.github/scripts/ai_review.py
@@ -46,28 +46,78 @@ def run_git(args):
     return result.stdout.strip()
 
 
+def _warn_event_payload(reason: str) -> None:
+    """向 stderr 输出事件载荷异常警告。
+
+    issue #2070: 之前 _event_payload 在 GITHUB_EVENT_PATH 缺失/文件不存在/读取失败/JSON
+    非法四种场景下统一静默返回 {},后续 _pull_request_number 只能 raise
+    'PR number is unavailable for GitHub API review',无法区分根因,排障困难。
+
+    本函数只输出异常类型与简短原因,不输出 payload 内容(payload 在 PR review 场景
+    可能包含未脱敏的 commit message / PR body,落入 CI 日志有泄漏风险)。
+    """
+    import sys
+    print(f"⚠️ event payload unavailable: {reason}", file=sys.stderr)
+
+
 def _event_payload():
     event_path = os.environ.get('GITHUB_EVENT_PATH')
-    if not event_path or not os.path.exists(event_path):
+    if not event_path:
+        # runner 未注入 GITHUB_EVENT_PATH(例如本地手跑脚本)。
+        _warn_event_payload("GITHUB_EVENT_PATH env var is not set")
+        return {}
+    if not os.path.exists(event_path):
+        _warn_event_payload(f"GITHUB_EVENT_PATH file does not exist: {event_path}")
         return {}
     try:
         with open(event_path, 'r', encoding='utf-8') as f:
             return json.load(f)
-    except (OSError, ValueError):
+    except OSError as exc:
+        # 文件存在但不可读(权限/IO 错误)。仅记异常类型 + errno,不展开 payload。
+        _warn_event_payload(
+            f"failed to read GITHUB_EVENT_PATH ({type(exc).__name__}, "
+            f"errno={getattr(exc, 'errno', '?')}, path={event_path})"
+        )
+        return {}
+    except ValueError as exc:
+        # json.JSONDecodeError 是 ValueError 子类,统揽覆盖。
+        _warn_event_payload(
+            f"failed to parse GITHUB_EVENT_PATH as JSON ({type(exc).__name__}, "
+            f"path={event_path})"
+        )
         return {}
 
 
 def _pull_request_number(payload=None):
     configured = os.environ.get('PR_NUMBER', '').strip()
     if configured:
-        return int(configured)
+        # 显式 PR_NUMBER 优先级最高,用于 AI_REVIEW_SOURCE=github_api 场景下绕过
+        # 破损的事件文件。issue #2070 契约一:PR_NUMBER 已提供时,坏的事件文件
+        # 不应阻断 GitHub API 流程。
+        try:
+            return int(configured)
+        except ValueError as exc:
+            raise RuntimeError(
+                f"PR_NUMBER env var is not a valid integer: {configured!r} ({exc})"
+            ) from exc
 
     payload = payload if payload is not None else _event_payload()
     pull_request = payload.get('pull_request') or {}
     number = pull_request.get('number') or payload.get('number')
     if not number:
-        raise RuntimeError('PR number is unavailable for GitHub API review')
-    return int(number)
+        # issue #2070 契约二:PR_NUMBER 未提供时,事件载荷路径上的任何失败都已
+        # 通过 _warn_event_payload 输出到 stderr,这里仅携带"PR 编号不可用"上抛,
+        # 排障者结合 stderr 警告即可定位是文件缺失/不可读/JSON 非法/真为空哪一种。
+        raise RuntimeError(
+            'PR number is unavailable for GitHub API review '
+            '(check prior event payload warnings on stderr for root cause)'
+        )
+    try:
+        return int(number)
+    except (TypeError, ValueError) as exc:
+        raise RuntimeError(
+            f'PR number from event payload is not a valid integer: {number!r} ({exc})'
+        ) from exc
 
 
 def _github_api_json(path):

--- a/.github/scripts/ai_review.py
+++ b/.github/scripts/ai_review.py
@@ -102,7 +102,23 @@ def _pull_request_number(payload=None):
             ) from exc
 
     payload = payload if payload is not None else _event_payload()
+    # 防御: payload 合法 JSON 但不是 object(例如 `[]` / `null` / 字符串)时,
+    # 直接 .get('pull_request') 会 AttributeError/typeerror。issue #2070 review
+    # 非阻断建议: 把这种情况也纳入可定位 stderr 警告,避免真实调用链提前崩溃
+    # 而跌破"PR_NUMBER override 可绕过坏事件文件"契约。
+    if not isinstance(payload, dict):
+        _warn_event_payload(
+            f"event payload parsed but is not a JSON object "
+            f"({type(payload).__name__})"
+        )
+        payload = {}
     pull_request = payload.get('pull_request') or {}
+    if not isinstance(pull_request, dict):
+        _warn_event_payload(
+            f"event payload 'pull_request' field is not a JSON object "
+            f"({type(pull_request).__name__})"
+        )
+        pull_request = {}
     number = pull_request.get('number') or payload.get('number')
     if not number:
         # issue #2070 契约二:PR_NUMBER 未提供时,事件载荷路径上的任何失败都已
@@ -227,7 +243,22 @@ def get_changed_files():
 def get_pr_context():
     """Read PR title/body from GitHub event payload when available."""
     payload = _event_payload()
+    # 防御: payload 合法 JSON 但不是 object 时,直接 .get 会 AttributeError。
+    # 与 _pull_request_number 中的等价防御保持一致,异常统一通过 _warn_event_payload
+    # 降到 stderr,这里返回 ('', '') 让 fallback 链路接续。
+    if not isinstance(payload, dict):
+        _warn_event_payload(
+            f"event payload parsed but is not a JSON object "
+            f"({type(payload).__name__})"
+        )
+        payload = {}
     pr = payload.get('pull_request') or {}
+    if not isinstance(pr, dict):
+        _warn_event_payload(
+            f"event payload 'pull_request' field is not a JSON object "
+            f"({type(pr).__name__})"
+        )
+        pr = {}
     if not pr and os.environ.get('AI_REVIEW_SOURCE') == 'github_api':
         try:
             repository = _github_repository()

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 > For user-friendly release highlights, see the [GitHub Releases](https://github.com/ZhuLinsen/daily_stock_analysis/releases) page.
 
 ## [Unreleased]
-- [修复] #2070 PR Review 自动审查脚本 `.github/scripts/ai_review.py` 在 `GITHUB_EVENT_PATH` 缺失、文件不存在、读取失败、JSON 解析失败四类异常下不再静默返回 `{}`，分别向 stderr 输出异常类型与简短原因；`PR_NUMBER` 显式提供时坏的事件文件不再阻断 GitHub API 审查，`PR_NUMBER` 未提供且事件载荷失败时 `_pull_request_number` 抛错带 stderr 警告提示，便于排障定位；补齐 11 个回归测试覆盖四类失败场景与两条行为契约。
+- [修复] #2070 PR Review 自动审查脚本 `.github/scripts/ai_review.py` 在 `GITHUB_EVENT_PATH` 缺失、文件不存在、读取失败、JSON 解析失败四类异常下不再静默返回 `{}`，分别向 stderr 输出异常类型与简短原因；`PR_NUMBER` 显式提供时坏的事件文件不再阻断 GitHub API 审查，`PR_NUMBER` 未提供且事件载荷失败时 `_pull_request_number` 抛错带 stderr 警告提示，便于排障定位；同时 `_pull_request_number` 与 `get_pr_context` 对合法 JSON 但非 object（如 `[]`、`null`、字符串）以及 `pull_request` 字段非 object 的边界情况也通过 stderr 警告可定位，不再抛 AttributeError；补齐 18 个回归测试覆盖四类失败场景与两条行为契约。
 - [chore] 暂停 PR Review 的自动触发，仅保留 `workflow_dispatch` 手动入口，避免辅助评审重复运行及评论权限失败产生误导性红灯；正式 CI 检查保持不变。
 - [新功能] Multi-Agent specialist 运行在分析历史保存成功后，按独立 skill 持久化版本化、低敏且幂等的有效 opinion 样本，为后续后验评估提供真实数据；本阶段不计算 outcome、不统计表现、不调整权重。
 - [新功能] AI 建议页在既有后验统计中增加决策风格历史表现，按每个分组独立的 30 个已完成样本门槛展示命中、区间涨跌、无法评估和最大不利波动，并保持旧统计接口兼容。

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 > For user-friendly release highlights, see the [GitHub Releases](https://github.com/ZhuLinsen/daily_stock_analysis/releases) page.
 
 ## [Unreleased]
+- [修复] #2070 PR Review 自动审查脚本 `.github/scripts/ai_review.py` 在 `GITHUB_EVENT_PATH` 缺失、文件不存在、读取失败、JSON 解析失败四类异常下不再静默返回 `{}`，分别向 stderr 输出异常类型与简短原因；`PR_NUMBER` 显式提供时坏的事件文件不再阻断 GitHub API 审查，`PR_NUMBER` 未提供且事件载荷失败时 `_pull_request_number` 抛错带 stderr 警告提示，便于排障定位；补齐 11 个回归测试覆盖四类失败场景与两条行为契约。
 - [chore] 暂停 PR Review 的自动触发，仅保留 `workflow_dispatch` 手动入口，避免辅助评审重复运行及评论权限失败产生误导性红灯；正式 CI 检查保持不变。
 - [新功能] Multi-Agent specialist 运行在分析历史保存成功后，按独立 skill 持久化版本化、低敏且幂等的有效 opinion 样本，为后续后验评估提供真实数据；本阶段不计算 outcome、不统计表现、不调整权重。
 - [新功能] AI 建议页在既有后验统计中增加决策风格历史表现，按每个分组独立的 30 个已完成样本门槛展示命中、区间涨跌、无法评估和最大不利波动，并保持旧统计接口兼容。

--- a/tests/test_ai_review_github_api.py
+++ b/tests/test_ai_review_github_api.py
@@ -269,3 +269,134 @@ def test_pull_request_number_handles_non_integer_payload_number(monkeypatch):
         assert "'oops'" in str(exc)
     else:
         raise AssertionError('expected RuntimeError for non-integer payload number')
+
+
+# issue #2070 review 非阻断建议: payload 合法 JSON 但不是 object 时
+# (例如 '[]' / 'null' / '"string"'），_pull_request_number / get_pr_context 不
+# 应抛 AttributeError, 而应通过 stderr 警告可定位, 并在 PR_NUMBER override
+# 或 AI_REVIEW_SOURCE=github_api 链路上不影响契约。
+
+def test_pull_request_number_handles_array_payload_with_pr_number_override(monkeypatch, capsys):
+    """契约一延伸: GITHUB_EVENT_PATH 解析成合法 JSON 但不是 object (例如 '[]')
+    时, PR_NUMBER override 必须仍然能绕过, 不应在 .get 上抛 AttributeError。"""
+    monkeypatch.setenv('PR_NUMBER', '2085')
+    monkeypatch.delenv('GITHUB_EVENT_PATH', raising=False)
+
+    number = ai_review._pull_request_number(payload=[])
+
+    assert number == 2085
+    # PR_NUMBER override 路径下根本没碰 payload,不应触发 _warn_event_payload。
+    captured = capsys.readouterr()
+    assert captured.err == ''
+
+
+def test_pull_request_number_warns_on_array_payload_without_pr_number(monkeypatch, capsys):
+    """契约二延伸: 无 PR_NUMBER 且 payload 是 array 时, _pull_request_number
+    应通过 _warn_event_payload 输出可定位 stderr 警告, 并仍以 RuntimeError
+    上抛(信息包含 stderr 提示)。"""
+    monkeypatch.delenv('PR_NUMBER', raising=False)
+    monkeypatch.delenv('GITHUB_EVENT_PATH', raising=False)
+
+    try:
+        ai_review._pull_request_number(payload=[])
+    except RuntimeError as exc:
+        assert 'PR number is unavailable' in str(exc)
+        assert 'check prior event payload warnings on stderr' in str(exc)
+    else:
+        raise AssertionError('expected RuntimeError for array payload without PR_NUMBER')
+
+    captured = capsys.readouterr()
+    assert 'event payload parsed but is not a JSON object' in captured.err
+    assert 'list' in captured.err
+
+
+def test_pull_request_number_warns_on_non_dict_pull_request_field(monkeypatch, capsys):
+    """payload 是 dict, 但 pull_request 字段是 list/string 等非 dict 类型时,
+    应记 stderr 警告(避免 pr.get 提前 AttributeError)。"""
+    monkeypatch.delenv('PR_NUMBER', raising=False)
+
+    try:
+        ai_review._pull_request_number(
+            payload={'pull_request': ['not', 'a', 'dict']}
+        )
+    except RuntimeError as exc:
+        assert 'PR number is unavailable' in str(exc)
+        assert 'check prior event payload warnings on stderr' in str(exc)
+    else:
+        raise AssertionError('expected RuntimeError for non-dict pull_request field')
+
+    captured = capsys.readouterr()
+    assert "event payload 'pull_request' field is not a JSON object" in captured.err
+    assert 'list' in captured.err
+
+
+def test_pull_request_number_handles_none_payload_with_pr_number_override(monkeypatch):
+    """contract: payload=None (GITHUB_EVENT_PATH 缺失 → {}) + PR_NUMBER override 时
+    应跳过事件文件读取,直接返回 PR_NUMBER。"""
+    monkeypatch.setenv('PR_NUMBER', '2085')
+    monkeypatch.delenv('GITHUB_EVENT_PATH', raising=False)
+
+    # payload=None 触发 _event_payload 路径,但因为 PR_NUMBER 优先,函数提前 return。
+    number = ai_review._pull_request_number(payload=None)
+
+    assert number == 2085
+
+
+def test_get_pr_context_warns_on_array_payload(monkeypatch, capsys):
+    """get_pr_context 入口同样应防御非 dict payload, 通过 stderr 警告可定位,
+    而不是抛 AttributeError 让脚本崩溃。"""
+    monkeypatch.delenv('GITHUB_EVENT_PATH', raising=False)
+    monkeypatch.delenv('AI_REVIEW_SOURCE', raising=False)
+
+    # 直接 monkeypatch _event_payload 返回 list,模拟合法 JSON 但不是 object。
+    monkeypatch.setattr(ai_review, '_event_payload', lambda: [])
+
+    title, body = ai_review.get_pr_context()
+
+    assert title == ''
+    assert body == ''
+    captured = capsys.readouterr()
+    assert 'event payload parsed but is not a JSON object' in captured.err
+    assert 'list' in captured.err
+
+
+def test_get_pr_context_warns_on_non_dict_pull_request_field(monkeypatch, capsys):
+    """get_pr_context 中 pr 字段不是 dict 时也应记 stderr 警告并降级返回 ('','')."""
+    monkeypatch.delenv('GITHUB_EVENT_PATH', raising=False)
+    monkeypatch.delenv('AI_REVIEW_SOURCE', raising=False)
+    monkeypatch.setattr(
+        ai_review,
+        '_event_payload',
+        lambda: {'pull_request': 'not-a-dict'},
+    )
+
+    title, body = ai_review.get_pr_context()
+
+    assert title == ''
+    assert body == ''
+    captured = capsys.readouterr()
+    assert "event payload 'pull_request' field is not a JSON object" in captured.err
+    assert 'str' in captured.err
+
+
+def test_get_pr_context_goes_through_github_api_when_payload_is_array(monkeypatch, capsys):
+    """end-to-end: payload 是 array + AI_REVIEW_SOURCE=github_api + PR_NUMBER override
+    时, get_pr_context 应不抛 AttributeError, 而是走 GitHub API fallback 取回 title/body。"""
+    monkeypatch.setenv('AI_REVIEW_SOURCE', 'github_api')
+    monkeypatch.setenv('GITHUB_REPOSITORY', 'owner/repo')
+    monkeypatch.setenv('PR_NUMBER', '2085')
+    monkeypatch.delenv('GITHUB_EVENT_PATH', raising=False)
+    monkeypatch.setattr(ai_review, '_event_payload', lambda: [])
+
+    monkeypatch.setattr(
+        ai_review,
+        '_github_api_json',
+        lambda path: {'title': 'Fix review', 'body': 'Closes #2085'}
+        if path == '/repos/owner/repo/pulls/2085'
+        else None,
+    )
+
+    title, body = ai_review.get_pr_context()
+
+    assert title == 'Fix review'
+    assert body == 'Closes #2085'

--- a/tests/test_ai_review_github_api.py
+++ b/tests/test_ai_review_github_api.py
@@ -106,3 +106,166 @@ def test_delegated_ci_context_does_not_claim_success(monkeypatch):
 
     assert 'backend-gate' in context
     assert '不假设并行 CI 已通过' in context
+
+
+# issue #2070 regression tests: _event_payload 之前在 4 类异常下统一静默
+# 返回 {},排障只能看到 'PR number is unavailable for GitHub API review',
+# 无法区分 GITHUB_EVENT_PATH 未注入 / 文件不存在 / 读取失败 / JSON 非法。
+
+def test_event_payload_warns_when_env_var_missing(monkeypatch, capsys):
+    monkeypatch.delenv('GITHUB_EVENT_PATH', raising=False)
+
+    result = ai_review._event_payload()
+
+    assert result == {}
+    captured = capsys.readouterr()
+    assert 'event payload unavailable' in captured.err
+    assert 'GITHUB_EVENT_PATH env var is not set' in captured.err
+    # 确保没有 payload 内容泄漏到日志
+    assert 'pull_request' not in captured.err
+
+
+def test_event_payload_warns_when_file_does_not_exist(monkeypatch, capsys, tmp_path):
+    missing_path = tmp_path / 'does-not-exist.json'
+    monkeypatch.setenv('GITHUB_EVENT_PATH', str(missing_path))
+
+    result = ai_review._event_payload()
+
+    assert result == {}
+    captured = capsys.readouterr()
+    assert 'event payload unavailable' in captured.err
+    assert 'file does not exist' in captured.err
+    assert str(missing_path) in captured.err
+
+
+def test_event_payload_warns_on_oserror(monkeypatch, capsys, tmp_path):
+    # 创建一个目录作为 GITHUB_EVENT_PATH —— open() 会因为 IsADirectoryError 失败
+    # (OSError 子类,多数平台 errno=21 EISDIR)。
+    bad_path = tmp_path / 'is-a-dir'
+    bad_path.mkdir()
+    monkeypatch.setenv('GITHUB_EVENT_PATH', str(bad_path))
+
+    result = ai_review._event_payload()
+
+    assert result == {}
+    captured = capsys.readouterr()
+    assert 'event payload unavailable' in captured.err
+    assert 'failed to read GITHUB_EVENT_PATH' in captured.err
+    assert 'OSError' in captured.err or 'IsADirectoryError' in captured.err
+    # 异常对象本身不应包含 payload 内容
+    assert 'pull_request' not in captured.err
+
+
+def test_event_payload_warns_on_invalid_json(monkeypatch, capsys, tmp_path):
+    bad_json_path = tmp_path / 'invalid.json'
+    bad_json_path.write_text('{ this is not json ', encoding='utf-8')
+    monkeypatch.setenv('GITHUB_EVENT_PATH', str(bad_json_path))
+
+    result = ai_review._event_payload()
+
+    assert result == {}
+    captured = capsys.readouterr()
+    assert 'event payload unavailable' in captured.err
+    assert 'failed to parse GITHUB_EVENT_PATH as JSON' in captured.err
+    # JSONDecodeError 是 ValueError 子类
+    assert 'json' in captured.err.lower() or 'JSONDecodeError' in captured.err
+    assert 'pull_request' not in captured.err
+
+
+def test_event_payload_returns_dict_on_valid_json(monkeypatch, capsys, tmp_path):
+    payload_path = tmp_path / 'event.json'
+    payload_path.write_text(
+        '{"pull_request": {"number": 42}, "action": "opened"}',
+        encoding='utf-8',
+    )
+    monkeypatch.setenv('GITHUB_EVENT_PATH', str(payload_path))
+
+    result = ai_review._event_payload()
+
+    assert result == {'pull_request': {'number': 42}, 'action': 'opened'}
+    captured = capsys.readouterr()
+    assert captured.err == ''  # 成功路径不应有警告
+
+
+# 契约一: PR_NUMBER 已显式提供时,坏的事件文件不应阻断 GitHub API 审查流程。
+
+def test_pull_request_number_env_override_skips_broken_event_path(monkeypatch, capsys, tmp_path):
+    bad_json_path = tmp_path / 'invalid.json'
+    bad_json_path.write_text('not json', encoding='utf-8')
+    monkeypatch.setenv('GITHUB_EVENT_PATH', str(bad_json_path))
+    monkeypatch.setenv('PR_NUMBER', '2070')
+
+    number = ai_review._pull_request_number()
+
+    assert number == 2070
+
+
+def test_pull_request_number_env_override_handles_non_integer(monkeypatch):
+    monkeypatch.setenv('PR_NUMBER', 'not-a-number')
+    monkeypatch.delenv('GITHUB_EVENT_PATH', raising=False)
+
+    try:
+        ai_review._pull_request_number()
+    except RuntimeError as exc:
+        assert 'PR_NUMBER env var is not a valid integer' in str(exc)
+        assert 'not-a-number' in str(exc)
+    else:
+        raise AssertionError('expected RuntimeError for non-integer PR_NUMBER')
+
+
+# 契约二: PR_NUMBER 未提供时,事件载荷路径上的失败应通过 stderr 警告可定位,
+# 而 _pull_request_number 抛出的 RuntimeError 也要提示去看 stderr 警告。
+
+def test_pull_request_number_from_payload_raises_with_stderr_hint(monkeypatch, capsys):
+    monkeypatch.delenv('PR_NUMBER', raising=False)
+    monkeypatch.delenv('GITHUB_EVENT_PATH', raising=False)
+
+    try:
+        ai_review._pull_request_number()
+    except RuntimeError as exc:
+        msg = str(exc)
+        assert 'PR number is unavailable' in msg
+        assert 'check prior event payload warnings on stderr' in msg
+    else:
+        raise AssertionError('expected RuntimeError when PR number unavailable')
+
+    captured = capsys.readouterr()
+    assert 'event payload unavailable' in captured.err
+    assert 'GITHUB_EVENT_PATH env var is not set' in captured.err
+
+
+def test_pull_request_number_extracts_from_payload_pull_request_key(monkeypatch):
+    monkeypatch.delenv('PR_NUMBER', raising=False)
+    monkeypatch.setenv(
+        'GITHUB_EVENT_PATH',
+        '',  # 直接传入 payload 参数,跳过 _event_payload 重新读取
+    )
+
+    number = ai_review._pull_request_number(
+        payload={'pull_request': {'number': 1234}}
+    )
+
+    assert number == 1234
+
+
+def test_pull_request_number_extracts_from_payload_top_level_number(monkeypatch):
+    # issue_comment 事件没有 pull_request 键,但 number 在顶层(指向 issue/PR 编号)。
+    monkeypatch.delenv('PR_NUMBER', raising=False)
+
+    number = ai_review._pull_request_number(payload={'number': 5678})
+
+    assert number == 5678
+
+
+def test_pull_request_number_handles_non_integer_payload_number(monkeypatch):
+    """防御性测试:如果 payload 里 number 不是整数(比如被篡改成字符串 'oops'),
+    _pull_request_number 应明确报错而不是让 int() 抛 TypeError/ValueError 一路冒泡。"""
+    monkeypatch.delenv('PR_NUMBER', raising=False)
+
+    try:
+        ai_review._pull_request_number(payload={'number': 'oops'})
+    except RuntimeError as exc:
+        assert 'PR number from event payload is not a valid integer' in str(exc)
+        assert "'oops'" in str(exc)
+    else:
+        raise AssertionError('expected RuntimeError for non-integer payload number')


### PR DESCRIPTION
## 关联 issue
Closes #2070

## 问题描述
GitHub Actions PR Review 自动审查流程 `.github/scripts/ai_review.py` 的 `_event_payload()` 在 `GITHUB_EVENT_PATH` 环境变量缺失、文件不存在、读取失败、JSON 解析失败四类异常下统一 `except (OSError, ValueError): return {}` 静默降级。后续 `_pull_request_number()` 只能在拿不到编号时 `raise RuntimeError('PR number is unavailable for GitHub API review')`,排障者从日志只能看到 PR 编号不可用,无法区分是文件缺失/不可读/JSON 非法/真为空哪一种根因,真实异常被掩盖。

## 修复方案
保持"空载荷降级"的总体行为不变(CI 流程不挂),只把异常分类显式化:

1. **`_warn_event_payload(reason)`** 新工具函数,统一向 stderr 输出警告。注意只输出异常类型与简短原因,**不输出 payload 内容**(payload 在 PR review 场景可能包含未脱敏的 commit message / PR body,落入 CI 日志有泄漏风险)。
2. **`_event_payload()`** 把 `if not event_path or not os.path.exists(...)` 拆开,分别记 "env var is not set" 与 "file does not exist";`except (OSError, ValueError)` 拆成两个 except 分支,分别记读取失败(带异常类型 + errno)与 JSON 解析失败。
3. **`_pull_request_number()`** 行为契约化:
   - `PR_NUMBER` 显式提供时优先级最高 —— 用于 `AI_REVIEW_SOURCE=github_api` 手动 dispatch 场景绕过破损的事件文件。若 `PR_NUMBER` 不是整数,改 `raise RuntimeError(...)` 携带原值上下文,不再让 `int()` 抛裸 `ValueError`。
   - `PR_NUMBER` 缺失且 payload 也无 number 时,错误信息加上"check prior event payload warnings on stderr for root cause",排障者结合 stderr 警告即可定位是文件缺失/不可读/JSON 非法/真为空哪一种。
   - payload 中 `number` 字段非整数时(被篡改成字符串等)同样改为携带原值上下文的 `RuntimeError`,而不是让 `int()` 抛 `TypeError`/`ValueError` 一路冒泡。

## 行为契约
- **契约一**: `PR_NUMBER` 已显式提供时,坏的事件文件不应阻断 GitHub API 审查流程。回归用例 `test_pull_request_number_env_override_skips_broken_event_path` 验证:即便 `GITHUB_EVENT_PATH` 指向非法 JSON 文件,只要 `PR_NUMBER` 提供,`_pull_request_number()` 直接返回该值,不读事件文件。
- **契约二**: `PR_NUMBER` 未提供时,事件载荷路径上的任何失败应通过 stderr 警告可定位。回归用例 `test_pull_request_number_from_payload_raises_with_stderr_hint` 验证:`_pull_request_number()` 抛错信息包含 "check prior event payload warnings on stderr",且 stderr 上确实有对应的 `_warn_event_payload` 输出。

## 测试
| 文件 | 原有 | 新增 | 状态 |
| --- | --- | --- | --- |
| `tests/test_ai_review_github_api.py` | 5 | 11 | 16/16 全过 |

新增 11 个回归用例覆盖:
- env 缺失 / 文件不存在 / 读取失败 (IsADirectoryError) / JSON 非法 四类 `_event_payload` 失败路径的 stderr 输出
- 成功路径不应输出任何警告
- `PR_NUMBER` override 跳过坏事件文件
- `PR_NUMBER` 非整数时 RuntimeError 携带原值
- 无 `PR_NUMBER` 且事件载荷失败时 RuntimeError 含 stderr 提示
- payload `pull_request.number` 提取
- payload 顶层 `number` 提取(issue_comment 事件)
- payload `number` 非整数时 RuntimeError 携带原值

```text
$ python -m pytest tests/test_ai_review_github_api.py -v
============================== 16 passed in 0.12s ==============================
```

`python -m flake8 .github/scripts/ai_review.py tests/test_ai_review_github_api.py --max-line-length=120` 干净无输出。

## CHANGELOG
`docs/CHANGELOG.md` `[Unreleased]` 段已补一条 `[修复] #2070 …` 描述,遵循本仓库扁平条目格式,不引入分类标题。
