### PR TITLE
fix: GitHub Actions 审查流程静默忽略事件载荷读取与解析错误 (#2070)

### DIFF
--- a/.github/scripts/ai_review.py
+++ b/.github/scripts/ai_review.py
@@ -6,6 +6,7 @@ import fnmatch
 import json
 import os
 import subprocess
+import sys
 import traceback
 import urllib.error
 import urllib.request
@@ -37,6 +38,14 @@ GITHUB_API_PAGE_SIZE = 100
 GITHUB_API_MAX_PAGES = 30
 
 
+def _warn_event_payload_issue(stage, error, reason):
+    print(
+        '⚠️ GitHub event payload stage='
+        f'{stage} failure: {type(error).__name__} - {reason}',
+        file=sys.stderr,
+    )
+
+
 def run_git(args):
     result = subprocess.run(args, capture_output=True, text=True)
     if result.returncode != 0:
@@ -48,12 +57,37 @@ def run_git(args):
 
 def _event_payload():
     event_path = os.environ.get('GITHUB_EVENT_PATH')
-    if not event_path or not os.path.exists(event_path):
+    if not event_path:
+        _warn_event_payload_issue(
+            'read',
+            FileNotFoundError('GITHUB_EVENT_PATH is not configured'),
+            'environment variable GITHUB_EVENT_PATH is missing or empty',
+        )
         return {}
     try:
         with open(event_path, 'r', encoding='utf-8') as f:
-            return json.load(f)
-    except (OSError, ValueError):
+            try:
+                payload = json.load(f)
+            except json.JSONDecodeError as exc:
+                reason = f'line {exc.lineno} column {exc.colno}: {exc.msg}'
+                _warn_event_payload_issue('parse', exc, reason)
+                return {}
+        if not isinstance(payload, dict):
+            _warn_event_payload_issue(
+                'parse',
+                TypeError('Parsed JSON payload is not a dict'),
+                'payload root must be a JSON object',
+            )
+            return {}
+        return payload
+    except (OSError, UnicodeError) as exc:
+        if isinstance(exc, OSError) and exc.strerror:
+            reason = f'{exc.strerror} (path={event_path})'
+        elif isinstance(exc, UnicodeError):
+            reason = 'event file is not valid UTF-8'
+        else:
+            reason = 'operating system error'
+        _warn_event_payload_issue('read', exc, reason)
         return {}
 
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - [文档] `.env.example` 与 `.github/workflows/00-daily-analysis.yml` 同步映射 `TUSHARE_HTTP_URL`，避免出现"配置项有但 workflow 漏映射"的半修状态
 - [修复] #2051 PR Review 的特权 `pull_request_target` 流程不再检出 fork PR head：敏感文件、标签、报告与 AI 审查统一通过 GitHub API 将 PR 元数据和 diff 作为数据读取，只执行主分支可信脚本；Python 语法、Flake8、确定性检查和离线测试继续由无 secrets 的 `pull_request` CI / `backend-gate` 执行，兼容 `actions/checkout` 新增的 fork checkout 安全保护。
 - [修复] 修复 Windows 上 mimetypes 冷启动时读取注册表导致的进程卡死
+- [修复] GitHub Actions 审查脚本补齐事件载荷诊断：缺失/不可读事件文件、JSON 解析异常或顶层事件类型错误均输出可区分的告警（含阶段、异常类型与原因）并返回空对象降级，空事件对象保持静默兼容，告警不泄露事件内容。
 
 ## [3.27.0] - 2026-07-19
 

--- a/tests/test_ai_review_github_api.py
+++ b/tests/test_ai_review_github_api.py
@@ -99,6 +99,120 @@ def test_manual_dispatch_context_comes_from_github_api(monkeypatch):
     assert ai_review.get_pr_context() == ('Fix review', 'Closes #2051')
 
 
+def test_event_payload_warns_when_file_is_missing(monkeypatch, tmp_path, capsys):
+    event_path = tmp_path / 'missing-event.json'
+    monkeypatch.setenv('GITHUB_EVENT_PATH', str(event_path))
+
+    assert ai_review._event_payload() == {}
+
+    warning = capsys.readouterr().err
+    assert 'stage=read failure' in warning
+    assert 'FileNotFoundError' in warning
+    assert 'No such file or directory' in warning
+
+
+def test_event_payload_warns_when_path_not_configured(monkeypatch, capsys):
+    monkeypatch.delenv('GITHUB_EVENT_PATH', raising=False)
+
+    assert ai_review._event_payload() == {}
+
+    warning = capsys.readouterr().err
+    assert 'stage=read failure' in warning
+    assert 'FileNotFoundError' in warning
+
+
+def test_event_payload_warns_when_file_cannot_be_read(
+    monkeypatch,
+    tmp_path,
+    capsys,
+):
+    event_path = tmp_path / 'event.json'
+    event_path.write_text('{}', encoding='utf-8')
+    monkeypatch.setenv('GITHUB_EVENT_PATH', str(event_path))
+
+    def deny_event_read(*_args, **_kwargs):
+        raise PermissionError(13, 'Permission denied')
+
+    monkeypatch.setattr(ai_review, 'open', deny_event_read, raising=False)
+
+    assert ai_review._event_payload() == {}
+
+    warning = capsys.readouterr().err
+    assert 'stage=read failure' in warning
+    assert 'PermissionError' in warning
+    assert 'Permission denied' in warning
+
+
+def test_event_payload_warns_for_invalid_json_without_leaking_content(
+    monkeypatch,
+    tmp_path,
+    capsys,
+):
+    sensitive_value = 'do-not-log-this-token'
+    event_path = tmp_path / 'event.json'
+    event_path.write_text(
+        f'{{"token": "{sensitive_value}", "pull_request": }}',
+        encoding='utf-8',
+    )
+    monkeypatch.setenv('GITHUB_EVENT_PATH', str(event_path))
+
+    assert ai_review._event_payload() == {}
+
+    warning = capsys.readouterr().err
+    assert 'stage=parse failure' in warning
+    assert 'JSONDecodeError' in warning
+    assert sensitive_value not in warning
+
+
+def test_event_payload_warns_when_payload_is_not_a_json_object(
+    monkeypatch,
+    tmp_path,
+    capsys,
+):
+    sensitive_value = 'do-not-log-this-token'
+    event_path = tmp_path / 'event.json'
+    event_path.write_text(f'[{{"token": "{sensitive_value}"}}]', encoding='utf-8')
+    monkeypatch.setenv('GITHUB_EVENT_PATH', str(event_path))
+
+    assert ai_review._event_payload() == {}
+
+    warning = capsys.readouterr().err
+    assert 'stage=parse failure' in warning
+    assert 'TypeError' in warning
+    assert sensitive_value not in warning
+
+
+def test_event_payload_warns_for_invalid_utf8_without_leaking_content(
+    monkeypatch,
+    tmp_path,
+    capsys,
+):
+    sensitive_value = b'do-not-log-these-bytes'
+    event_path = tmp_path / 'event.json'
+    event_path.write_bytes(b'{"token": "' + sensitive_value + b'\xff"}')
+    monkeypatch.setenv('GITHUB_EVENT_PATH', str(event_path))
+
+    assert ai_review._event_payload() == {}
+
+    warning = capsys.readouterr().err
+    assert 'stage=read failure' in warning
+    assert 'UnicodeDecodeError' in warning
+    assert sensitive_value.decode() not in warning
+
+
+def test_event_payload_accepts_empty_object_without_warning(
+    monkeypatch,
+    tmp_path,
+    capsys,
+):
+    event_path = tmp_path / 'event.json'
+    event_path.write_text('{}', encoding='utf-8')
+    monkeypatch.setenv('GITHUB_EVENT_PATH', str(event_path))
+
+    assert ai_review._event_payload() == {}
+    assert capsys.readouterr().err == ''
+
+
 def test_delegated_ci_context_does_not_claim_success(monkeypatch):
     monkeypatch.setenv('CI_DELEGATED_TO_PULL_REQUEST', 'true')
 


### PR DESCRIPTION
## PR Type
- [x] fix
- [ ] feat
- [ ] refactor
- [ ] docs
- [ ] chore
- [ ] test

## Background And Problem
- 当前问题：在保留事件载荷空对象降级行为的前提下，为路径缺失、读取失败和 JSON 解析失败输出不含载荷内容的可诊断警告。
- 影响范围：本次改动涉及 3 个文件，Diff 为 `+152 / -3`。
- 触发来源：Issue 自动执行（Issue #2070）。

## Scope Of Change
- `.github/scripts/ai_review.py`
- `docs/CHANGELOG.md`
- `tests/test_ai_review_github_api.py`

## Documentation And Changelog
- 已同步更新文档/变更记录：`docs/CHANGELOG.md`。
- 当前补丁尚未包含 `README.md` 或专题文档；如用户可见行为发生变化，请补充文档落点。

## Issue Link
Closes #2070

## Verification Commands And Results
```bash
./scripts/ci_gate.sh flake8
./scripts/ci_gate.sh offline-tests
```

关键输出/结论 / Key output & conclusion:
- lint:PASS, test:TIMEOUT

## Pre-commit Self Review
第 1 轮提交前自审：自审完成： 第 2 轮提交前自审：自审完成： 第 3 轮提交前自审：自审完成：

## Compatibility And Risk
- **Medium**：涉及 `.github/scripts/ai_review.py`, `docs/CHANGELOG.md`, `tests/test_ai_review_github_api.py`，建议按文件范围复核。
- 前提假设：
  - 优先采用维护者建议的最小修复，不把事件载荷改为必需输入或引入 fail-fast 行为。
  - 现有 PR_NUMBER 与 GitHub API 回退路径保持不变。
  - 警告仅包含失败阶段、异常类型和简要原因，不输出事件文件内容。
  - 有效但为空的 JSON 对象继续正常返回空对象，并通过测试与异常场景明确区分。

## Rollback Plan
- `git revert <merge-commit>` 回滚本 PR 提交，重点确认 `.github/scripts/ai_review.py`, `docs/CHANGELOG.md`, `tests/test_ai_review_github_api.py` 恢复正常。

## Acceptance Criteria
- GITHUB_EVENT_PATH 指向不存在或不可读取的文件时返回空对象，并输出包含异常类型和简要原因的警告。
- 事件文件包含无效 JSON 时返回空对象，并输出可识别为 JSON 解析失败的警告。
- 警告中不包含完整事件载荷或其片段。
- 有效空载荷仍返回空对象，不被误报为读取或解析异常。
- 现有手动触发、PR_NUMBER 和 GitHub API 上下文回退行为不回归。
- 新增回归测试覆盖读取失败、无效 JSON、空载荷及敏感内容不泄露。

## Checklist
- [x] 本 PR 有明确动机和业务价值 / This PR has a clear motivation and value
- [x] 已提供可复现的验证命令与结果 / Reproducible verification commands and results are included
- [x] 已评估兼容性与风险 / Compatibility and risk have been assessed
- [x] 已提供回滚方案 / A rollback plan is provided
- [ ] 文档与 `docs/CHANGELOG.md` 同步仍需确认；如涉及用户可见变更，请在合并前补充原因与文档落点 / Documentation and `docs/CHANGELOG.md` sync still needs confirmation before merge when user-visible behavior changes