### PR TITLE
fix: recognize bare Hong Kong stock codes

### DIFF
--- a/data_provider/yfinance_fetcher.py
+++ b/data_provider/yfinance_fetcher.py
@@ -143,6 +143,12 @@ class YfinanceFetcher(BaseFetcher):
             logger.debug(f"转换港股代码: {stock_code} -> {hk_code}.HK")
             return f"{hk_code}.HK"
 
+        # 裸 4-5 位数字代码是港股；A 股代码固定为 6 位。
+        if code.isdigit() and 4 <= len(code) <= 5:
+            hk_code = (code.lstrip('0') or '0').zfill(4)
+            logger.debug(f"转换裸港股代码: {stock_code} -> {hk_code}.HK")
+            return f"{hk_code}.HK"
+
         # 已经包含后缀的情况
         if '.SS' in code or '.SZ' in code or '.HK' in code or '.BJ' in code:
             return code

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - [文档] `.env.example` 与 `.github/workflows/00-daily-analysis.yml` 同步映射 `TUSHARE_HTTP_URL`，避免出现"配置项有但 workflow 漏映射"的半修状态
 - [修复] #2051 PR Review 的特权 `pull_request_target` 流程不再检出 fork PR head：敏感文件、标签、报告与 AI 审查统一通过 GitHub API 将 PR 元数据和 diff 作为数据读取，只执行主分支可信脚本；Python 语法、Flake8、确定性检查和离线测试继续由无 secrets 的 `pull_request` CI / `backend-gate` 执行，兼容 `actions/checkout` 新增的 fork checkout 安全保护。
 - [修复] 修复 Windows 上 mimetypes 冷启动时读取注册表导致的进程卡死
+- [修复] 裸 4-5 位港股代码在 yfinance 兜底数据源中不再被误判为深市代码（fixes #2091）
 
 ## [3.27.0] - 2026-07-19
 

--- a/tests/test_yfinance_hk_indices.py
+++ b/tests/test_yfinance_hk_indices.py
@@ -43,6 +43,26 @@ def _make_mock_yf(hist_df: pd.DataFrame):
     return mock_yf
 
 
+class TestHkStockCodeConversion(unittest.TestCase):
+    """验证裸港股代码能正确转换为 Yahoo Finance 符号。"""
+
+    def test_bare_hk_codes_use_hk_suffix(self):
+        from data_provider.yfinance_fetcher import YfinanceFetcher
+
+        fetcher = YfinanceFetcher()
+
+        self.assertEqual(fetcher._convert_stock_code('00700'), '0700.HK')
+        self.assertEqual(fetcher._convert_stock_code('02513'), '2513.HK')
+
+    def test_six_digit_a_share_codes_keep_their_market(self):
+        from data_provider.yfinance_fetcher import YfinanceFetcher
+
+        fetcher = YfinanceFetcher()
+
+        self.assertEqual(fetcher._convert_stock_code('600519'), '600519.SS')
+        self.assertEqual(fetcher._convert_stock_code('000001'), '000001.SZ')
+
+
 class TestHkIndexSymbolMapping(unittest.TestCase):
     """验证港股指数 Yahoo Finance 符号映射的正确性"""
 


### PR DESCRIPTION
## PR Type

- [x] fix
- [ ] feat
- [ ] refactor
- [ ] docs
- [ ] chore
- [ ] test

## Background And Problem

Bare four- and five-digit Hong Kong stock codes such as `02513` fell through to the Shenzhen fallback, producing invalid Yahoo Finance symbols such as `02513.SZ` and breaking daily-data fallback.

## Scope Of Change

- 文件总数 / 变更行数：3 files changed, 27 insertions(+)
- 文件清单：
  - `data_provider/yfinance_fetcher.py`
  - `tests/test_yfinance_hk_indices.py`
  - `docs/CHANGELOG.md`
- 文档更新文件：`docs/CHANGELOG.md`

## Issue Link

Fixes https://github.com/ZhuLinsen/daily_stock_analysis/issues/2091

## Verification Commands And Results

```bash
# Focused HK symbol tests, using the real source module with optional providers isolated
python tests/test_yfinance_hk_indices.py  # equivalent focused harness: 11 passed

python -m py_compile data_provider/yfinance_fetcher.py tests/test_yfinance_hk_indices.py
flake8 data_provider/yfinance_fetcher.py tests/test_yfinance_hk_indices.py
git diff --check
```

The new regression failed against the original source (`00700.SZ != 0700.HK`) and passed after the fix. All 11 focused HK tests, Flake8, compilation, and the staged/outgoing diff gates passed.

- ai-governance: pending, https://github.com/ZhuLinsen/daily_stock_analysis/actions
- backend-gate: pending, https://github.com/ZhuLinsen/daily_stock_analysis/actions
- docker-build: pending, https://github.com/ZhuLinsen/daily_stock_analysis/actions
- web-gate: not applicable (no Web files changed), https://github.com/ZhuLinsen/daily_stock_analysis/actions

当前 Head CI：ai-governance:pending / backend-gate:pending / docker-build:pending / web-gate:not applicable. Local focused checks are all passing; Head CI will report after PR creation.

## Visual Evidence (if applicable)

- 截图链接：N/A
- 前后对比：N/A
- settings 字段变更说明：N/A
- 不适用原因：Backend-only ticker normalization; the fail-before/pass-after unit regression above is the reproducible evidence.

## Compatibility And Risk

Six-digit A-share routing remains unchanged and is covered by regression assertions for `600519.SS` and `000001.SZ`. The change follows the repository's existing convention that bare five-digit numeric symbols are Hong Kong stocks.

本 PR 未变更 provider/model/base URL、运行时配置清理迁移语义；历史配置保持不变；回滚方式为 revert 本提交。

## Rollback Plan

Revert this PR. No configuration or data migration rollback is required.

## EXTRACT_PROMPT Change (if applicable)

N/A; `EXTRACT_PROMPT` is unchanged.

<details>
<summary>展开 / Expand: Full EXTRACT_PROMPT</summary>

```
N/A
```

</details>

## Checklist

- [x] 本 PR 有明确动机和业务价值 / This PR has a clear motivation and value
- [x] 已提供可复现的验证命令与结果 / Reproducible verification commands and results are included
- [x] 已评估兼容性与风险 / Compatibility and risk have been assessed
- [x] 已提供回滚方案 / A rollback plan is provided
- [x] 若修改报告格式或 Web UI 界面，已在 PR 描述/评论附受影响报告 / 页面截图，且未把一次性验收截图作为仓库文件合入 / If report formatting or Web UI changed, affected report/page screenshots are linked in the PR body/comments and one-off acceptance screenshots are not committed as repository files
- [x] 若本 PR 修改 Web 设置字段（字段、文案或帮助文本），请补充设置页截图；无法截图时需提供替代可视证据（命令 + 产物路径），并指向对应变更项 / If Web settings fields changed, screenshots or equivalent evidence are provided (not applicable: no Web settings changed)
- [x] 若涉及用户可见变更，已同步更新相关文档与 `docs/CHANGELOG.md`；`README.md` 仅在首页级信息变化时更新，细节优先写入 `docs/*.md` / If user-visible changes are included, relevant docs and `docs/CHANGELOG.md` are updated
