### PR TITLE
feat: 新增 STOCK_LIST 单条目解析契约（issue #2063 Phase 1）

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -55,6 +55,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 ### 文档
 
 - 修复文档中的失效相对链接。
+- [修复] #2026 外股代码映射到中文显示名时英文新闻相关性判定漏判：新增同源 STOCK_ENGLISH_NAME_MAP 单一真源、canonicalize_foreign_stock_code 规范化入口与 _foreign_english_query_terms 别名解析，使 AAPL/00700/BABA 等 ticker 即使 stock_name 为中文也能在查询构建、相关性打分与多维度情报路径上复用 canonical 英文名，并补齐 .US/.HK suffix / HK 前缀全形式的归类与回归用例；同时在 _score_news_relevance 对 alias 展开 term 做去重，避免 legal alias 展开短名与显式 short alias 重复计分。
+- [新功能] Tushare 数据源支持通过 `TUSHARE_HTTP_URL` 环境变量自定义接入地址，便于网络无法直达 `api.tushare.pro` 时切换自建网关或第三方兼容镜像；留空保持官方默认地址不变（fixes #1985）
+- [文档] `.env.example` 与 `.github/workflows/00-daily-analysis.yml` 同步映射 `TUSHARE_HTTP_URL`，避免出现"配置项有但 workflow 漏映射"的半修状态
+- [修复] #2051 PR Review 的特权 `pull_request_target` 流程不再检出 fork PR head：敏感文件、标签、报告与 AI 审查统一通过 GitHub API 将 PR 元数据和 diff 作为数据读取，只执行主分支可信脚本；Python 语法、Flake8、确定性检查和离线测试继续由无 secrets 的 `pull_request` CI / `backend-gate` 执行，兼容 `actions/checkout` 新增的 fork checkout 安全保护。
+- [修复] 修复 Windows 上 mimetypes 冷启动时读取注册表导致的进程卡死
+- [新功能] STOCK_LIST 解析新增 `parse_analysis_target()` 单条目解析契约，支持 sh/sz/bj/hk/us 前缀校验、裸码默认归股票、未命中前缀降级为股票三段语义；保留现有 `split_stock_list()`/`serialize_stock_list()` 行为不变，并对外暴露 `IndexRegistry`、`AnalysisTarget`、`ParseStatus`、`default_index_registry()` 以便上层注入自定义指数白名单（关联 issue #2063 Phase 1）
 
 ## [3.27.0] - 2026-07-19
 

--- a/src/services/stock_list_parser.py
+++ b/src/services/stock_list_parser.py
@@ -108,9 +108,34 @@ def _split_prefix(token: str) -> Tuple[Optional[str], str]:
     US tickers like ``AAPL`` or ``TSLA`` — return ``(None, token)`` so the
     bare-code path can classify them. Tokens with no alphabetic leader (e.g.
     ``"600519"``) also return ``(None, token)``.
+
+    Guard against US ticker prefix collisions (review blocker
+    ``OR-COR-d24a4e9a``): a token like ``SHOP`` / ``HKD`` / ``BJRI`` / ``USM``
+    / ``SHAK`` / ``USFD`` is a legitimate 1-5 letter US ticker (the same
+    shape ``src/services/stock_code_utils.is_code_like`` already treats as a
+    bare US code via ``^[A-Z]{1,5}$``). It must NOT be split into
+    ``(sh, OP)`` / ``(hk, D)`` / ``(bj, RI)`` / ``(us, M)`` / ``(sh, AK)`` /
+    ``(us, FD)``. We therefore short-circuit when the whole token is 1-5
+    ASCII uppercase letters — preserving it as a bare US ticker so
+    :func:`_classify_bare_code` routes it through the US branch.
+
+    The ``isupper()`` predicate is the key disambiguator: uppercase-only
+    tokens are stock symbols (``USFD``, ``SHAK``, ``AAPL``), never the
+    canonical lowercase exchange prefixes used elsewhere in the codebase
+    (``sh000300``, ``sz399001``, ``usAAPL``). Mixing case — e.g. ``usAAPL``
+    — bypasses the short-circuit and still runs through the prefix splitter
+    so contract #3's "prefix supplied → degrade to stock" semantics remain
+    intact for explicitly-prefixed codes.
     """
     if not token:
         return None, ""
+    # Short-circuit bare US tickers (1-5 ASCII uppercase letters) before
+    # scanning _KNOWN_PREFIXES so prefix collisions don't get mis-split.
+    # Exchange codes (``sh000300``, ``sz399001``) contain digits; explicitly
+    # prefixed US codes (``usAAPL``) are mixed-case — neither matches this
+    # guard, so both still flow through the prefix splitter.
+    if 1 <= len(token) <= 5 and token.isalpha() and token.isascii() and token.isupper():
+        return None, token
     lower = token.lower()
     for p in _KNOWN_PREFIXES_SORTED:
         if lower.startswith(p):
@@ -301,6 +326,23 @@ def _classify_bare_code(bare: str) -> Tuple[str, str]:
                 return "SZ", ParseStatus.STOCK
             if bare.startswith(("4", "8", "9")):
                 return "BJ", ParseStatus.STOCK
+            # A-share ETF prefixes mirror the routing already living in
+            # ``data_provider/baostock_fetcher.py`` and
+            # ``data_provider/yfinance_fetcher.py`` (and the
+            # ``ETF_PREFIXES`` tuple in ``data_provider/base.py``):
+            #   51/52/56/58 -> sh (Shanghai ETF)
+            #   15/16/18    -> sz (Shenzhen ETF)
+            # Routing them through ``CN`` was a review blocker
+            # (``OR-COR-1b643ee6``) because ``_canonicalize_for_stock``
+            # would subsequently synthesise ``cn510300`` / ``cn159915``,
+            # which the upstream fetchers don't accept on input. Keeping
+            # the routing here in lock-step with the fetchers ensures the
+            # canonical_id this PR produces round-trips into ``BaseFetcher``
+            # lookups unchanged.
+            if bare.startswith(("51", "52", "56", "58")):
+                return "SH", ParseStatus.STOCK
+            if bare.startswith(("15", "16", "18")):
+                return "SZ", ParseStatus.STOCK
             return "CN", ParseStatus.STOCK
         if len(bare) == 5:
             # Five-digit numeric — HK stock or legacy B-share.
@@ -396,7 +438,14 @@ def parse_analysis_target(
             unsupported_reason="empty input",
         )
 
-    registry = registry or default_index_registry()
+    # Note: we deliberately use ``is None`` rather than ``or`` so that an
+    # explicitly-injected empty :class:`IndexRegistry` (``IndexRegistry([])``)
+    # is honoured as a legitimate "no indices whitelisted" configuration.
+    # Using ``or`` would silently replace it with the default registry and
+    # re-elevate ``sh000300`` to ``index`` even though the caller asked for
+    # a blank white-list — review blocker ``OR-COR-403bd018``.
+    if registry is None:
+        registry = default_index_registry()
     prefix, bare = _split_prefix(raw)
 
     # Contract #1: prefixed index white-list.

--- a/src/services/stock_list_parser.py
+++ b/src/services/stock_list_parser.py
@@ -1,14 +1,59 @@
 # -*- coding: utf-8 -*-
-"""Helpers for parsing the user-facing STOCK_LIST value."""
+"""Helpers for parsing the user-facing STOCK_LIST value.
+
+Phase 1 (issue #2063): structured analysis-target parsing.
+
+This module exposes :func:`parse_analysis_target`, which converts a single
+user-facing stock-list token (``"sh000300"``, ``"000300"``, ``"600519"``,
+``"hk00700"``, ``"AAPL"`` …) into a structured :class:`AnalysisTarget` with a
+stable ``asset_type`` / ``canonical_id`` / ``display_code`` / ``exchange``
+contract. The legacy :func:`split_stock_list` and :func:`serialize_stock_list`
+helpers are kept untouched so existing ``STOCK_LIST`` callers don't drift.
+
+Three core contracts are pinned by this module and the regression tests in
+``tests/test_stock_list_parser.py``:
+
+1. **前缀白名单指数** — a prefixed token whose prefix is ``sh``/``sz`` and
+   whose bare code is registered in :class:`IndexRegistry` is parsed as an
+   ``index``.
+2. **裸码默认个股** — a bare numeric code without any prefix always parses
+   as a ``stock`` regardless of whether the same code happens to belong to
+   a known index (e.g. ``"000300"`` is a stock, ``"sh000300"`` is an index).
+3. **前缀未命中降级为股票** — a prefixed token whose prefix is not a
+   recognized ``sh``/``sz`` index prefix, or whose bare code is not in the
+   index registry, degrades to a ``stock`` rather than raising.
+
+The module deliberately does **not** touch ``normalize_stock_code()``,
+``BaseFetcher`` signatures, database migrations, or web/bot integration —
+those wait for later phases of issue #2063.
+"""
 
 from __future__ import annotations
 
+import json
 import re
-from typing import List
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Dict, Iterable, List, Optional, Tuple
+
+__all__ = [
+    "AnalysisTarget",
+    "IndexRegistry",
+    "IndexEntry",
+    "ParseStatus",
+    "parse_analysis_target",
+    "serialize_stock_list",
+    "split_stock_list",
+    "default_index_registry",
+]
+
 
 _STOCK_LIST_SEPARATOR_RE = re.compile(r"[\s,;\uFF0C\u3001\uFF1B]+")
 
 
+# ---------------------------------------------------------------------------
+# Legacy helpers (unchanged).
+# ---------------------------------------------------------------------------
 def split_stock_list(value: str) -> List[str]:
     """Split STOCK_LIST values on common copy/paste separators."""
     return [
@@ -21,3 +66,423 @@ def split_stock_list(value: str) -> List[str]:
 def serialize_stock_list(value: str) -> str:
     """Return STOCK_LIST in the canonical comma-separated storage form."""
     return ",".join(split_stock_list(value))
+
+
+# ---------------------------------------------------------------------------
+# Phase 1: structured analysis-target parsing.
+# ---------------------------------------------------------------------------
+# Status enum encoded as plain strings (no stdlib enum dependency) so they
+# serialize cleanly to JSON in API responses later on. Keep the three values
+# stable; downstream phases will branch on these.
+class ParseStatus:
+    STOCK = "stock"
+    INDEX = "index"
+    UNSUPPORTED = "unsupported"
+
+
+# Recognised exchange prefixes. ``sh``/``sz`` are the only prefixes that can
+# elevate a bare code to ``asset_type=index`` (contract #1). Other prefixes
+# (``hk``, ``us``, ``bj`` …) are advisory only and don't change asset_type on
+# their own — they degrade to ``stock`` if the registry doesn't claim the
+# code (contract #3).
+_EXCHANGE_PREFIX_TO_CODE = {
+    "sh": "SH",
+    "sz": "SZ",
+    "bj": "BJ",
+    "hk": "HK",
+    "us": "US",
+}
+# Longest known prefix is 2 chars; let the splitter recognise only the known
+# set so alphanumeric US tickers (``AAPL``, ``TSLA``) don't get mistaken for
+# prefixed tokens. Order matters when scanning: 2-char prefixes first.
+_KNOWN_PREFIXES_SORTED = tuple(
+    sorted(_EXCHANGE_PREFIX_TO_CODE.keys(), key=lambda p: -len(p))
+)
+
+
+def _split_prefix(token: str) -> Tuple[Optional[str], str]:
+    """Split ``token`` into ``(prefix, bare_code)`` when the leader matches
+    one of the known exchange prefixes (``sh``/``sz``/``bj``/``hk``/``us``).
+
+    Tokens whose alphabetic leader isn't in the known set — most importantly
+    US tickers like ``AAPL`` or ``TSLA`` — return ``(None, token)`` so the
+    bare-code path can classify them. Tokens with no alphabetic leader (e.g.
+    ``"600519"``) also return ``(None, token)``.
+    """
+    if not token:
+        return None, ""
+    lower = token.lower()
+    for p in _KNOWN_PREFIXES_SORTED:
+        if lower.startswith(p):
+            rest = token[len(p):]
+            if rest:
+                return p, rest
+            # Token is exactly the prefix string with no code — treat as
+            # bare so the classifier can reject it as unsupported.
+            return None, token
+    return None, token
+
+
+@dataclass(frozen=True)
+class IndexEntry:
+    """A single known index in :class:`IndexRegistry`."""
+
+    bare_code: str
+    exchange: str  # 'SH' or 'SZ'
+    canonical_id: str
+    display_name: str
+    aliases: Tuple[str, ...] = ()
+
+    def matches_code(self, code: str) -> bool:
+        """True if ``code`` is this entry's bare code or any of its aliases."""
+        if code == self.bare_code:
+            return True
+        return code in self.aliases
+
+
+@dataclass(frozen=True)
+class AnalysisTarget:
+    """Structured result of :func:`parse_analysis_target`."""
+
+    raw_input: str
+    asset_type: str  # one of ParseStatus.*
+    canonical_id: str
+    display_code: str
+    exchange: str  # 'SH' / 'SZ' / 'BJ' / 'HK' / 'US' / 'UNKNOWN'
+    unsupported_reason: Optional[str] = None
+    # Diagnostic breadcrumbs — not part of the public contract, but kept so
+    # downstream phases can render sane error UI without re-parsing.
+    normalized_prefix: Optional[str] = None
+    normalized_code: Optional[str] = None
+    matched_index: Optional[IndexEntry] = field(default=None, hash=False, compare=False)
+
+
+class IndexRegistry:
+    """Authoritative source for ``asset_type=index`` resolution.
+
+    The registry is populated with a small built-in white-list of canonical
+    A-share indices (CSI 300 / SSE 50 / STAR 50 / SZSE Component / ChiNext)
+    that already exist as hard-coded white-lists across
+    ``data_provider/*_fetcher.py``. PR1 deliberately keeps the registry
+    in-memory and immutable — later phases of issue #2063 will load the
+    ``asset_type=index`` rows from ``apps/dsa-web/public/stocks.index.json``
+    once that file carries index rows; the parser contract won't change.
+    """
+
+    def __init__(self, entries: Iterable[IndexEntry] = ()):
+        self._entries: List[IndexEntry] = list(entries)
+        self._by_canonical: Dict[str, IndexEntry] = {
+            e.canonical_id: e for e in self._entries
+        }
+
+    def __len__(self) -> int:
+        return len(self._entries)
+
+    def __iter__(self):
+        return iter(self._entries)
+
+    def find_by_prefixed_code(self, prefix: str, bare_code: str) -> Optional[IndexEntry]:
+        """Look up an index entry by (exchange prefix, bare code).
+
+        Only ``sh``/``sz`` prefixes can elevate a code to ``index`` status
+        (contract #1). Other prefixes return ``None`` even if the bare code
+        happens to match a known index — non-A-share exchanges don't host the
+        indices in the built-in registry.
+        """
+        if prefix not in ("sh", "sz"):
+            return None
+        exchange = _EXCHANGE_PREFIX_TO_CODE.get(prefix)
+        if exchange is None:
+            return None
+        canonical = f"{prefix}{bare_code}"
+        entry = self._by_canonical.get(canonical)
+        if entry is not None:
+            return entry
+        # Alias fallback — e.g. user typed ``sz399300`` but registry lists it
+        # under ``sh000300`` via an alias. Walk the registry once.
+        for entry in self._entries:
+            if entry.exchange == exchange and entry.matches_code(bare_code):
+                return entry
+        return None
+
+    def find_by_bare_code(self, bare_code: str) -> Optional[IndexEntry]:
+        """Look up an index by bare code, ignoring the exchange prefix.
+
+        Used by contract #2 sanity checks: when a bare code is ambiguous (it
+        could be either a stock or an index), the parser MUST default to
+        ``stock``; this helper lets callers detect the conflict and emit a
+        warning without changing the resolved asset_type.
+        """
+        for entry in self._entries:
+            if entry.matches_code(bare_code):
+                return entry
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Default index registry — the built-in white-list.
+# ---------------------------------------------------------------------------
+# Five canonical A-share indices, mirroring the hard-coded lists already
+# present in ``data_provider/{efinance,akshare,yfinance,tickflow}_fetcher.py``.
+# Keeping this list in one place + giving it a public ``IndexRegistry`` type
+# is the whole point of PR1; later phases may move the data into
+# ``apps/dsa-web/public/stocks.index.json`` and load it, but the parser
+# contract stays stable.
+_DEFAULT_INDEX_ENTRIES: Tuple[IndexEntry, ...] = (
+    IndexEntry(
+        bare_code="000300",
+        exchange="SH",
+        canonical_id="sh000300",
+        display_name="沪深300",
+        aliases=("000300.SH", "CSI300", "HS300"),
+    ),
+    IndexEntry(
+        bare_code="000016",
+        exchange="SH",
+        canonical_id="sh000016",
+        display_name="上证50",
+        aliases=("000016.SH", "SSE50"),
+    ),
+    IndexEntry(
+        bare_code="000688",
+        exchange="SH",
+        canonical_id="sh000688",
+        display_name="科创50",
+        aliases=("000688.SH", "STAR50"),
+    ),
+    IndexEntry(
+        bare_code="399001",
+        exchange="SZ",
+        canonical_id="sz399001",
+        display_name="深证成指",
+        aliases=("399001.SZ", "SZSE"),
+    ),
+    IndexEntry(
+        bare_code="399006",
+        exchange="SZ",
+        canonical_id="sz399006",
+        display_name="创业板指",
+        aliases=("399006.SZ", "ChiNext"),
+    ),
+)
+
+
+def default_index_registry() -> IndexRegistry:
+    """Return the built-in :class:`IndexRegistry` shipped with PR1.
+
+    ``IndexRegistry`` is intentionally cheap to construct (5 small dataclass
+    entries); callers may rebuild it on every call rather than caching it
+    globally. Once the JSON registry carries ``asset_type=index`` rows this
+    factory should load from disk and stay backward-compatible.
+    """
+    return IndexRegistry(_DEFAULT_INDEX_ENTRIES)
+
+
+# ---------------------------------------------------------------------------
+# Bare-code classification helpers.
+# ---------------------------------------------------------------------------
+def _classify_bare_code(bare: str) -> Tuple[str, str]:
+    """Return ``(exchange, asset_type)`` for a bare numeric/alphanumeric code.
+
+    Mirrors the ``determine_market_and_type`` logic already living in
+    ``scripts/generate_stock_index.py`` so PR1 doesn't introduce a new
+    market-classification world. Returns ``asset_type='stock'`` for every
+    reachable branch — bare codes never resolve to ``index`` on their own
+    (contract #2).
+    """
+    if not bare:
+        return "UNKNOWN", ParseStatus.UNSUPPORTED
+
+    if bare.isdigit():
+        if len(bare) == 6:
+            if bare.startswith("6") or bare.startswith("900"):
+                return "SH", ParseStatus.STOCK
+            if bare.startswith(("0", "2", "3")):
+                return "SZ", ParseStatus.STOCK
+            if bare.startswith(("4", "8", "9")):
+                return "BJ", ParseStatus.STOCK
+            return "CN", ParseStatus.STOCK
+        if len(bare) == 5:
+            # Five-digit numeric — HK stock or legacy B-share.
+            if bare.startswith("0") or bare.startswith("2"):
+                return "HK", ParseStatus.STOCK
+            return "CN", ParseStatus.STOCK
+        if len(bare) == 4:
+            # E.g. HK short codes like 0001, 0941.
+            return "HK", ParseStatus.STOCK
+        # Any other digit length — unsupported until proven otherwise.
+        return "UNKNOWN", ParseStatus.UNSUPPORTED
+
+    # Alphanumeric (US tickers, JP/KR suffix codes, etc.). Treat as US stock
+    # by default; PR1 doesn't need a perfect US taxonomy — contract #3 says
+    # prefixed unknown codes degrade to stock.
+    return "US", ParseStatus.STOCK
+
+
+def _canonicalize_for_index(entry: IndexEntry, raw_input: str) -> Tuple[str, str, str]:
+    """Return ``(canonical_id, display_code, exchange)`` for an index hit."""
+    return entry.canonical_id, entry.display_name, entry.exchange
+
+
+def _canonicalize_for_stock(
+    prefix: Optional[str],
+    bare: str,
+    exchange: str,
+) -> Tuple[str, str]:
+    """Return ``(canonical_id, display_code)`` for a stock resolution.
+
+    ``canonical_id`` follows the conventions the upstream ``data_provider``
+    fetchers already accept on input:
+
+    * A-share: keep the ``sh``/``sz``/``bj`` prefix style (``sh600519``) so
+      the canonical ID is round-trippable into ``BaseFetcher`` lookups.
+    * HK: ``hk00700`` (5-digit numeric) — matches the ``hk`` prefix style
+      already used across fetchers.
+    * US: bare ticker (``AAPL``), no ``us`` prefix — fetchers expect raw
+      uppercase US symbols and don't recognise ``usAAPL``.
+    * Unknown exchange: fall back to the lowercased bare token so downstream
+      can still group without crashing.
+    """
+    if exchange == "UNKNOWN":
+        return bare.lower(), bare
+    if exchange == "US":
+        # US tickers are inherently alphanumeric; preserve case so the
+        # canonical ID doubles as a display code that fetchers accept.
+        return bare, bare
+    if prefix:
+        # If the user already provided sh/sz/hk/... prefix, preserve it.
+        canonical = f"{prefix}{bare}"
+    else:
+        # Synthesize a prefix from the inferred exchange for A-share / HK
+        # bare codes so canonical_id is round-trippable.
+        canonical = f"{exchange.lower()}{bare}"
+    display = bare if prefix is None else f"{prefix}{bare}"
+    return canonical, display
+
+
+# ---------------------------------------------------------------------------
+# Public entry point.
+# ---------------------------------------------------------------------------
+def parse_analysis_target(
+    raw_input: str,
+    registry: Optional[IndexRegistry] = None,
+) -> AnalysisTarget:
+    """Parse one user-facing stock-list token into an :class:`AnalysisTarget`.
+
+    Args:
+        raw_input: A single token from :func:`split_stock_list` (or any
+            user-supplied string you want classified). It may carry a lower
+            or upper-case exchange prefix (``sh``/``sz``/``bj``/``hk``/``us``)
+            or just a bare code.
+        registry: Optional :class:`IndexRegistry`. Defaults to
+            :func:`default_index_registry`. Callers may inject a custom
+            registry (e.g. loaded from ``stocks.index.json`` once that file
+            carries ``asset_type=index`` rows) without changing the parser
+            contract.
+
+    Returns:
+        An :class:`AnalysisTarget` whose ``asset_type`` is one of
+        :class:`ParseStatus`'s three constants. ``unsupported_reason`` is
+        ``None`` unless ``asset_type == 'unsupported'``.
+    """
+    raw = (raw_input or "").strip()
+    if not raw:
+        return AnalysisTarget(
+            raw_input=raw_input or "",
+            asset_type=ParseStatus.UNSUPPORTED,
+            canonical_id="",
+            display_code="",
+            exchange="UNKNOWN",
+            unsupported_reason="empty input",
+        )
+
+    registry = registry or default_index_registry()
+    prefix, bare = _split_prefix(raw)
+
+    # Contract #1: prefixed index white-list.
+    if prefix in ("sh", "sz") and bare:
+        entry = registry.find_by_prefixed_code(prefix, bare)
+        if entry is not None:
+            canonical, display, exchange = _canonicalize_for_index(entry, raw)
+            return AnalysisTarget(
+                raw_input=raw_input,
+                asset_type=ParseStatus.INDEX,
+                canonical_id=canonical,
+                display_code=display,
+                exchange=exchange,
+                normalized_prefix=prefix,
+                normalized_code=bare,
+                matched_index=entry,
+            )
+        # Contract #3: prefix supplied but registry didn't claim it →
+        # degrade to stock and remember the prefix.
+        exchange_for_stock, _ = _classify_bare_code(bare)
+        # Override exchange with the user's explicit prefix when possible.
+        if prefix in _EXCHANGE_PREFIX_TO_CODE:
+            exchange_for_stock = _EXCHANGE_PREFIX_TO_CODE[prefix]
+        canonical, display = _canonicalize_for_stock(prefix, bare, exchange_for_stock)
+        return AnalysisTarget(
+            raw_input=raw_input,
+            asset_type=ParseStatus.STOCK,
+            canonical_id=canonical,
+            display_code=display,
+            exchange=exchange_for_stock,
+            normalized_prefix=prefix,
+            normalized_code=bare,
+        )
+
+    # Contract #2: bare code (no prefix) — always stock, regardless of whether
+    # the registry has a matching index entry. We surface the conflict via
+    # ``matched_index`` so callers can warn, but we don't flip asset_type.
+    exchange, asset_type = _classify_bare_code(bare) if prefix is None else (
+        _EXCHANGE_PREFIX_TO_CODE.get(prefix, "UNKNOWN"),
+        ParseStatus.STOCK,
+    )
+    if asset_type == ParseStatus.UNSUPPORTED:
+        return AnalysisTarget(
+            raw_input=raw_input,
+            asset_type=ParseStatus.UNSUPPORTED,
+            canonical_id=bare.lower(),
+            display_code=raw,
+            exchange=exchange,
+            unsupported_reason="unrecognized code shape",
+            normalized_prefix=prefix,
+            normalized_code=bare,
+        )
+
+    canonical, display = _canonicalize_for_stock(prefix, bare, exchange)
+
+    # Surface potential index conflict (e.g. user typed ``000300`` expecting
+    # the index but got a stock because the contract defaults bare codes to
+    # stock). Don't change asset_type — just expose the match.
+    matched_index = None
+    if prefix is None and bare:
+        candidate = registry.find_by_bare_code(bare)
+        if candidate is not None:
+            matched_index = candidate
+
+    return AnalysisTarget(
+        raw_input=raw_input,
+        asset_type=ParseStatus.STOCK,
+        canonical_id=canonical,
+        display_code=display,
+        exchange=exchange,
+        normalized_prefix=prefix,
+        normalized_code=bare,
+        matched_index=matched_index,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Convenience helpers for batch parsing.
+# ---------------------------------------------------------------------------
+def parse_stock_list(value: str, registry: Optional[IndexRegistry] = None) -> List[AnalysisTarget]:
+    """Parse every token in a STOCK_LIST-style string at once.
+
+    Useful for callers that want to drive the UI directly off a parsed list
+    rather than chaining :func:`split_stock_list` + :func:`parse_analysis_target`.
+    """
+    return [
+        parse_analysis_target(token, registry=registry)
+        for token in split_stock_list(value)
+    ]

--- a/tests/test_stock_list_parser.py
+++ b/tests/test_stock_list_parser.py
@@ -371,3 +371,186 @@ def test_analysis_target_with_index_entry_is_hashable() -> None:
     target = parse_analysis_target("000300")
     assert target.matched_index is not None
     hash(target)  # should not raise
+
+
+# ---------------------------------------------------------------------------
+# Review-blocker regressions — covers the three correctness blockers raised
+# by maintainer on PR #2094 (issue #2063 phase 1):
+#   OR-COR-d24a4e9a: 1-5 letter US tickers colliding with sh/sz/bj/hk/us
+#                    prefixes were mis-split (SHOP -> shOP, HKD -> hkD, ...)
+#   OR-COR-1b643ee6: bare A-share ETF codes (510300 etc.) were canonicalised
+#                    to ``cn510300`` which no upstream fetcher accepts.
+#   OR-COR-403bd018: passing ``IndexRegistry([])`` was silently replaced by
+#                    the default registry, hiding the empty-white-list config.
+# These tests pin the fixes so the same regressions can't land unnoticed.
+# ---------------------------------------------------------------------------
+class TestReviewBlockerRegressions:
+    """Maintainer-specified regression inputs (issue #2063 phase 1 review)."""
+
+    # ---- OR-COR-d24a4e9a: US ticker prefix collisions ---------------------
+
+    @pytest.mark.parametrize(
+        "ticker",
+        ["SHOP", "HKD", "BJRI", "USM", "SHAK", "USFD", "BJDX", "SZKMY",
+         "AAPL", "TSLA", "BRK", "A", "Z"],
+    )
+    def test_us_ticker_prefix_collision_is_not_split(self, ticker: str) -> None:
+        """1-5 letter US tickers must round-trip as US stock, not be split
+        into ``(sh, OP)`` / ``(hk, D)`` / ... by the prefix scanner.
+        """
+        target = parse_analysis_target(ticker)
+        assert target.asset_type == ParseStatus.STOCK
+        assert target.exchange == "US"
+        assert target.canonical_id == ticker
+        assert target.display_code == ticker
+        assert target.normalized_prefix is None
+        assert target.normalized_code == ticker
+        assert target.matched_index is None
+
+    @pytest.mark.parametrize(
+        "ticker,expected_prefix,expected_bare",
+        [
+            ("usAAPL", "us", "AAPL"),
+            ("usBRK", "us", "BRK"),
+            ("hk00700", "hk", "00700"),
+            ("sh000300", "sh", "000300"),
+            ("sz399001", "sz", "399001"),
+            ("bj920001", "bj", "920001"),
+        ],
+    )
+    def test_explicit_prefixed_codes_still_split(
+        self, ticker: str, expected_prefix: str, expected_bare: str
+    ) -> None:
+        """Codes with explicit sh/sz/bj/hk/us prefixes that *also* contain
+        digits must still be split into ``(prefix, bare)``. The US-ticker
+        short-circuit only triggers for 1-5 letter alphabetic tokens.
+        """
+        target = parse_analysis_target(ticker)
+        assert target.normalized_prefix == expected_prefix
+        assert target.normalized_code == expected_bare
+
+    # ---- OR-COR-1b643ee6: bare A-share ETF routing ------------------------
+
+    @pytest.mark.parametrize(
+        "bare_code,expected_exchange,expected_canonical",
+        [
+            # Shanghai ETF prefixes 51/52/56/58
+            ("510300", "SH", "sh510300"),
+            ("510050", "SH", "sh510050"),
+            ("520000", "SH", "sh520000"),
+            ("562000", "SH", "sh562000"),
+            ("588000", "SH", "sh588000"),
+            # Shenzhen ETF prefixes 15/16/18
+            ("159915", "SZ", "sz159915"),
+            ("159919", "SZ", "sz159919"),
+            ("160000", "SZ", "sz160000"),
+            ("164000", "SZ", "sz164000"),
+            ("184000", "SZ", "sz184000"),
+        ],
+    )
+    def test_bare_a_share_etf_routes_to_sh_or_sz(
+        self,
+        bare_code: str,
+        expected_exchange: str,
+        expected_canonical: str,
+    ) -> None:
+        """Bare 6-digit ETF codes must canonicalise through the same sh/sz
+        prefixes already used by ``data_provider/{baostock,yfinance}_fetcher,
+        py`` and the ``ETF_PREFIXES`` tuple in ``data_provider/base.py`` —
+        never through the ``cn`` prefix that no upstream fetcher accepts.
+        """
+        target = parse_analysis_target(bare_code)
+        assert target.asset_type == ParseStatus.STOCK
+        assert target.exchange == expected_exchange
+        assert target.canonical_id == expected_canonical
+        assert target.display_code == bare_code
+        assert target.matched_index is None
+
+    def test_bare_etf_canonical_id_round_trips_into_baostock_fetcher(
+        self,
+    ) -> None:
+        """End-to-end round-trip: the canonical_id produced by
+        ``parse_analysis_target`` for a bare A-share ETF must be accepted
+        verbatim by ``BaostockFetcher._convert_stock_code`` and yield the
+        same ``sh.<code>`` / ``sz.<code>`` form the fetcher already produces
+        for the same bare code. Failures here mean future formatter drift
+        between ``stock_list_parser`` and the upstream fetcher would break
+        STOCK_LIST ingestion.
+        """
+        from data_provider.baostock_fetcher import BaostockFetcher
+
+        fetcher = BaostockFetcher()
+        for bare in ("510300", "159915", "510050", "588000"):
+            target = parse_analysis_target(bare)
+            assert target.canonical_id == fetcher._convert_stock_code(
+                target.canonical_id
+            ).replace(".", "")
+
+    # ---- OR-COR-403bd018: explicit empty IndexRegistry -------------------
+
+    def test_empty_registry_disables_index_elevation_for_sh000300(
+        self,
+    ) -> None:
+        """An explicitly-injected ``IndexRegistry([])`` must be honoured as
+        a "no indices whitelisted" configuration: ``sh000300`` then degrades
+        to a SH stock per contract #3 instead of being elevated to an index.
+        """
+        target = parse_analysis_target("sh000300", registry=IndexRegistry([]))
+        assert target.asset_type == ParseStatus.STOCK
+        assert target.exchange == "SH"
+        assert target.canonical_id == "sh000300"
+        assert target.normalized_prefix == "sh"
+        assert target.normalized_code == "000300"
+        assert target.matched_index is None
+
+    def test_empty_registry_disables_index_elevation_for_sz399001(
+        self,
+    ) -> None:
+        """Same guard for the SZ side — ``sz399001`` (CSI 100 default index)
+        must also degrade to stock under an empty registry.
+        """
+        target = parse_analysis_target("sz399001", registry=IndexRegistry([]))
+        assert target.asset_type == ParseStatus.STOCK
+        assert target.exchange == "SZ"
+        assert target.canonical_id == "sz399001"
+        assert target.matched_index is None
+
+    def test_default_registry_still_elevates_sh000300_after_empty_path(
+        self,
+    ) -> None:
+        """Reading the inverse: with no registry argument the default
+        registry still elevates ``sh000300`` to an index. This guards against
+        accidentally flipping the empty-registry patch into a global override
+        that swallows the default registry too.
+        """
+        target = parse_analysis_target("sh000300")
+        assert target.asset_type == ParseStatus.INDEX
+        assert target.canonical_id == "sh000300"
+        assert target.matched_index is not None
+
+    def test_custom_registry_with_subset_entries_only_matches_subset(
+        self,
+    ) -> None:
+        """A non-empty custom registry only honours the indices it carries;
+        other ``sh``/``sz`` codes (even ones in the default registry) fall
+        through to stock. This is the contract #1 semantics that the
+        ``is None`` change must preserve.
+        """
+        custom = IndexRegistry((
+            IndexEntry(
+                bare_code="000999",
+                exchange="SH",
+                canonical_id="sh000999",
+                display_name="custom-only",
+            ),
+        ))
+        # Custom registry knows sh000999 -> index
+        target = parse_analysis_target("sh000999", registry=custom)
+        assert target.asset_type == ParseStatus.INDEX
+        assert target.matched_index is not None
+
+        # Custom registry does NOT know sh000300 -> degrade to stock
+        target = parse_analysis_target("sh000300", registry=custom)
+        assert target.asset_type == ParseStatus.STOCK
+        assert target.exchange == "SH"
+        assert target.matched_index is None

--- a/tests/test_stock_list_parser.py
+++ b/tests/test_stock_list_parser.py
@@ -1,9 +1,35 @@
 # -*- coding: utf-8 -*-
-"""Tests for STOCK_LIST separator handling."""
+"""Tests for :mod:`src.services.stock_list_parser`.
 
-from src.services.stock_list_parser import serialize_stock_list, split_stock_list
+Phase 1 (issue #2063): covers the three core contracts —
+* 前缀白名单指数: prefixed ``sh``/``sz`` + registry-known code → ``index``
+* 裸码默认个股: bare numeric code → ``stock`` even if it's an index code
+* 前缀未命中降级为股票: prefixed unknown code → ``stock`` (never ``unsupported``)
+
+Also keeps the legacy ``split_stock_list`` / ``serialize_stock_list`` tests
+so PR1 is a strict superset of pre-PR coverage rather than a replacement.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from src.services.stock_list_parser import (
+    AnalysisTarget,
+    IndexEntry,
+    IndexRegistry,
+    ParseStatus,
+    default_index_registry,
+    parse_analysis_target,
+    parse_stock_list,
+    serialize_stock_list,
+    split_stock_list,
+)
 
 
+# ---------------------------------------------------------------------------
+# Legacy helpers — unchanged behaviour.
+# ---------------------------------------------------------------------------
 def test_split_stock_list_accepts_common_copy_paste_separators() -> None:
     value = "600519，300750  hk00700;AAPL、7203.T\n005930.KS；002594"
 
@@ -20,3 +46,328 @@ def test_split_stock_list_accepts_common_copy_paste_separators() -> None:
 
 def test_serialize_stock_list_uses_canonical_commas() -> None:
     assert serialize_stock_list("600519，300750\nAAPL") == "600519,300750,AAPL"
+
+
+# ---------------------------------------------------------------------------
+# Contract #1 — prefixed index white-list.
+# ---------------------------------------------------------------------------
+class TestContract1PrefixedIndex:
+    """前缀白名单指数 — prefixed ``sh``/``sz`` + registry-known code → index."""
+
+    def test_sh000300_resolves_to_index(self) -> None:
+        target = parse_analysis_target("sh000300")
+        assert target.asset_type == ParseStatus.INDEX
+        assert target.canonical_id == "sh000300"
+        assert target.display_code == "沪深300"
+        assert target.exchange == "SH"
+        assert target.normalized_prefix == "sh"
+        assert target.normalized_code == "000300"
+        assert target.matched_index is not None
+        assert target.matched_index.display_name == "沪深300"
+
+    def test_sz399001_resolves_to_index(self) -> None:
+        target = parse_analysis_target("sz399001")
+        assert target.asset_type == ParseStatus.INDEX
+        assert target.canonical_id == "sz399001"
+        assert target.display_code == "深证成指"
+        assert target.exchange == "SZ"
+
+    def test_uppercase_prefix_is_normalized(self) -> None:
+        target = parse_analysis_target("SH000300")
+        assert target.asset_type == ParseStatus.INDEX
+        assert target.canonical_id == "sh000300"
+
+    def test_alias_resolution_sh000300_dot_sh(self) -> None:
+        """Alias-style ``sh000300.SH`` — prefix ``sh`` carries, bare becomes
+        ``000300.SH`` which matches the canonical entry's alias.
+        """
+        # ``sh`` prefix + bare ``000300.SH`` — the registry stores ``000300.SH``
+        # as an alias, so this still resolves to index. Test the alias path
+        # without having to teach the prefix splitter about dots.
+        registry = IndexRegistry([
+            IndexEntry(
+                bare_code="000300",
+                exchange="SH",
+                canonical_id="sh000300",
+                display_name="沪深300",
+                aliases=("000300.SH",),
+            )
+        ])
+        target = parse_analysis_target("sh000300.SH", registry=registry)
+        # Contract #1 — alias matches even when bare carries a dot suffix.
+        assert target.asset_type == ParseStatus.INDEX
+        assert target.canonical_id == "sh000300"
+
+    def test_unknown_prefixed_index_code_degrades_to_stock(self) -> None:
+        """Contract #3 leak: ``sh000999`` isn't in the registry → stock."""
+        target = parse_analysis_target("sh000999")
+        assert target.asset_type == ParseStatus.STOCK
+        assert target.exchange == "SH"
+        assert target.normalized_prefix == "sh"
+        assert target.normalized_code == "000999"
+
+
+# ---------------------------------------------------------------------------
+# Contract #2 — bare code defaults to stock.
+# ---------------------------------------------------------------------------
+class TestContract2BareCodeDefaultsToStock:
+    """裸码默认个股 — bare numeric code always resolves to stock."""
+
+    def test_bare_000300_is_stock_not_index(self) -> None:
+        """Conflict code: ``000300`` is the沪深300 index code, but per the
+        contract the parser MUST default bare codes to ``stock``. We surface
+        the conflict via ``matched_index`` so the UI can warn, but we never
+        flip asset_type.
+
+        ``canonical_id`` follows the synthesised stock exchange (``sz`` because
+        the bare-code classifier routes ``000xxx`` to SZ), NOT the index's
+        ``sh`` exchange — keeping the round-trippable stock canonical lets
+        downstream fetchers look it up without surprise; the index conflict
+        is advertised via ``matched_index`` alone.
+        """
+        target = parse_analysis_target("000300")
+        assert target.asset_type == ParseStatus.STOCK
+        assert target.canonical_id == "sz000300"  # synthesised via SZ detect
+        # display_code preserves the user input shape (bare).
+        assert target.display_code == "000300"
+        # The conflict surface — registry's index entry is exposed but not
+        # used for asset_type resolution.
+        assert target.matched_index is not None
+        assert target.matched_index.display_name == "沪深300"
+
+    def test_bare_000001_is_stock(self) -> None:
+        """Conflict code: ``000001`` is平安银行 (SZ stock) AND the深证成指
+        isn't this — actually 000001.SZ is the stock, the index is sz399001.
+        So bare 000001 → stock, no registry hit.
+        """
+        target = parse_analysis_target("000001")
+        assert target.asset_type == ParseStatus.STOCK
+        assert target.exchange == "SZ"
+        assert target.matched_index is None
+        # canonical_id is round-trippable: sh/sz prefix synthesised from 0/2/3.
+        assert target.canonical_id == "sz000001"
+
+    def test_bare_600519_is_sh_stock(self) -> None:
+        target = parse_analysis_target("600519")
+        assert target.asset_type == ParseStatus.STOCK
+        assert target.exchange == "SH"
+        assert target.canonical_id == "sh600519"
+        assert target.display_code == "600519"
+        assert target.matched_index is None
+
+    def test_bare_000016_conflict_is_visible(self) -> None:
+        """same logic as 000300 — bare code conflicts with sh000016 上证50."""
+        target = parse_analysis_target("000016")
+        assert target.asset_type == ParseStatus.STOCK
+        assert target.matched_index is not None
+        assert target.matched_index.display_name == "上证50"
+
+    def test_bare_300750_is_sz_stock(self) -> None:
+        target = parse_analysis_target("300750")
+        assert target.asset_type == ParseStatus.STOCK
+        assert target.exchange == "SZ"
+        assert target.canonical_id == "sz300750"
+
+    def test_bse_920xxx_is_stock(self) -> None:
+        """920xxx — Beijing Stock Exchange new codes (post-2024 migration)."""
+        target = parse_analysis_target("920001")
+        assert target.asset_type == ParseStatus.STOCK
+        assert target.exchange == "BJ"
+        assert target.canonical_id == "bj920001"
+
+    def test_bare_us_ticker_is_stock(self) -> None:
+        target = parse_analysis_target("AAPL")
+        assert target.asset_type == ParseStatus.STOCK
+        assert target.exchange == "US"
+        # US tickers preserve case so the canonical ID doubles as the
+        # display code that fetchers accept directly.
+        assert target.canonical_id == "AAPL"
+        assert target.display_code == "AAPL"
+        assert target.matched_index is None
+
+    def test_bare_hk_5_digit_is_stock(self) -> None:
+        target = parse_analysis_target("00700")
+        assert target.asset_type == ParseStatus.STOCK
+        assert target.exchange == "HK"
+        assert target.canonical_id == "hk00700"
+
+    def test_bare_hk_4_digit_is_stock(self) -> None:
+        target = parse_analysis_target("0941")
+        assert target.asset_type == ParseStatus.STOCK
+        assert target.exchange == "HK"
+        assert target.canonical_id == "hk0941"
+
+
+# ---------------------------------------------------------------------------
+# Contract #3 — prefixed unknown degrades to stock.
+# ---------------------------------------------------------------------------
+class TestContract3PrefixedUnknownDegradesToStock:
+    """前缀未命中降级为股票 — prefixed unknown → stock (never unsupported)."""
+
+    def test_sh_unknown_code_is_stock(self) -> None:
+        target = parse_analysis_target("sh000999")
+        assert target.asset_type == ParseStatus.STOCK
+        assert target.exchange == "SH"
+        assert target.canonical_id == "sh000999"
+
+    def test_sz_unknown_code_is_stock(self) -> None:
+        target = parse_analysis_target("sz000999")
+        assert target.asset_type == ParseStatus.STOCK
+        assert target.exchange == "SZ"
+        assert target.canonical_id == "sz000999"
+
+    def test_hk_prefixed_code_is_stock(self) -> None:
+        target = parse_analysis_target("hk00700")
+        assert target.asset_type == ParseStatus.STOCK
+        assert target.exchange == "HK"
+        assert target.canonical_id == "hk00700"
+
+    def test_us_prefixed_ticker_is_stock(self) -> None:
+        target = parse_analysis_target("usAAPL")
+        assert target.asset_type == ParseStatus.STOCK
+        assert target.exchange == "US"
+        # ``us`` prefix is recognised, but US canonical IDs are the bare
+        # ticker (fetchers don't accept ``usAAPL``) — the prefix only biases
+        # the exchange detection; it doesn't enter the canonical ID.
+        assert target.canonical_id == "AAPL"
+        assert target.normalized_prefix == "us"
+        assert target.normalized_code == "AAPL"
+
+
+# ---------------------------------------------------------------------------
+# Edge cases — empty input + unsupported shapes.
+# ---------------------------------------------------------------------------
+class TestEdgeCases:
+    def test_empty_string_is_unsupported(self) -> None:
+        target = parse_analysis_target("")
+        assert target.asset_type == ParseStatus.UNSUPPORTED
+        assert target.canonical_id == ""
+        assert target.unsupported_reason == "empty input"
+
+    def test_whitespace_only_is_unsupported(self) -> None:
+        target = parse_analysis_target("   ")
+        assert target.asset_type == ParseStatus.UNSUPPORTED
+        assert target.unsupported_reason == "empty input"
+
+    def test_three_digit_bare_code_is_unsupported(self) -> None:
+        """Three-digit bare codes don't map to any known market shape — the
+        parser surfaces ``unsupported`` with a reason rather than guessing.
+        """
+        target = parse_analysis_target("007")
+        assert target.asset_type == ParseStatus.UNSUPPORTED
+        assert target.unsupported_reason == "unrecognized code shape"
+
+    def test_seven_digit_bare_code_is_unsupported(self) -> None:
+        target = parse_analysis_target("1234567")
+        assert target.asset_type == ParseStatus.UNSUPPORTED
+        assert target.unsupported_reason == "unrecognized code shape"
+
+
+# ---------------------------------------------------------------------------
+# Default registry — public API surface.
+# ---------------------------------------------------------------------------
+class TestDefaultIndexRegistry:
+    def test_default_registry_has_five_entries(self) -> None:
+        registry = default_index_registry()
+        assert len(registry) == 5
+
+    def test_default_registry_canonical_ids(self) -> None:
+        registry = default_index_registry()
+        ids = {entry.canonical_id for entry in registry}
+        assert ids == {"sh000300", "sh000016", "sh000688", "sz399001", "sz399006"}
+
+    def test_default_registry_find_by_prefixed_code(self) -> None:
+        registry = default_index_registry()
+        entry = registry.find_by_prefixed_code("sh", "000300")
+        assert entry is not None
+        assert entry.display_name == "沪深300"
+
+    def test_default_registry_find_by_prefixed_code_rejects_non_sh_sz(self) -> None:
+        registry = default_index_registry()
+        # Even if a code looks like a known index, hk/us/bj prefixes don't
+        # elevate to index status — they degrade to stock (contract #3).
+        assert registry.find_by_prefixed_code("hk", "000300") is None
+        assert registry.find_by_prefixed_code("us", "000300") is None
+
+
+# ---------------------------------------------------------------------------
+# Batch parsing helper.
+# ---------------------------------------------------------------------------
+class TestParseStockList:
+    def test_parse_stock_list_returns_one_target_per_token(self) -> None:
+        targets = parse_stock_list("sh000300,600519,bk0001")
+        # Three tokens, three targets — bk0001 is unrecognized prefix but
+        # contract #3 degrades it to stock rather than raising.
+        assert len(targets) == 3
+        assert targets[0].asset_type == ParseStatus.INDEX
+        assert targets[1].asset_type == ParseStatus.STOCK
+        assert targets[2].asset_type == ParseStatus.STOCK
+
+    def test_parse_stock_list_handles_separators(self) -> None:
+        targets = parse_stock_list("sh000300；600519\nAAPL、hk00700")
+        assert len(targets) == 4
+        assert targets[0].asset_type == ParseStatus.INDEX
+        assert targets[1].asset_type == ParseStatus.STOCK
+        assert targets[2].asset_type == ParseStatus.STOCK
+        assert targets[3].exchange == "HK"
+
+
+# ---------------------------------------------------------------------------
+# Regression — exact maintainer spec samples from issue #2063.
+# ---------------------------------------------------------------------------
+class TestMaintainerSpecSamples:
+    """Six samples ZhuLinsen called out as minimum coverage."""
+
+    def test_sh000300(self) -> None:
+        target = parse_analysis_target("sh000300")
+        assert target.asset_type == ParseStatus.INDEX
+        assert target.canonical_id == "sh000300"
+
+    def test_sz399300_falls_back_to_stock(self) -> None:
+        """sz399300 is NOT in the canonical 5-index white-list (we only carry
+        sz399001 + sz399006 for the SZ side). Per contract #3 it degrades to
+        stock. This sample guards against accidental future registry expand
+        that would silently flip behaviour.
+        """
+        target = parse_analysis_target("sz399300")
+        assert target.asset_type == ParseStatus.STOCK
+        assert target.exchange == "SZ"
+
+    def test_sh600519(self) -> None:
+        target = parse_analysis_target("sh600519")
+        assert target.asset_type == ParseStatus.STOCK
+        assert target.exchange == "SH"
+        assert target.canonical_id == "sh600519"
+
+    def test_bare_000300(self) -> None:
+        target = parse_analysis_target("000300")
+        assert target.asset_type == ParseStatus.STOCK
+
+    def test_bare_000001(self) -> None:
+        target = parse_analysis_target("000001")
+        assert target.asset_type == ParseStatus.STOCK
+
+    def test_bare_920xxx(self) -> None:
+        target = parse_analysis_target("920001")
+        assert target.asset_type == ParseStatus.STOCK
+        assert target.exchange == "BJ"
+
+
+# ---------------------------------------------------------------------------
+# Dataclass serialization sanity — keeps the contract JSON-friendly.
+# ---------------------------------------------------------------------------
+def test_analysis_target_is_immutable_and_hashable() -> None:
+    target = parse_analysis_target("sh000300")
+    with pytest.raises(Exception):
+        target.asset_type = "mutated"  # type: ignore[misc]
+    hash(target)  # should not raise
+
+
+def test_analysis_target_with_index_entry_is_hashable() -> None:
+    """``matched_index`` is non-hashable by default; ensure the dataclass
+    override (``compare=False, hash=False``) keeps AnalysisTarget hashable
+    when an IndexEntry is attached.
+    """
+    target = parse_analysis_target("000300")
+    assert target.matched_index is not None
+    hash(target)  # should not raise


### PR DESCRIPTION
## 关联 issue
Closes #2063 (Phase 1)

## 背景
当前 STOCK_LIST 解析仅有 `split_stock_list()` 这一个 separator helper，调用方拿到 token 后还要自己判断 `sh000300` 是指数还是股票、`000300` 是冲突码还是 typo、`bk0001` 这种未识别前缀应当如何处理。issue #2063 把这块拆成 Phase 1/2/3 三阶段，本 PR 落地 Phase 1 —— 在不破坏现有 `split_stock_list()`/`serialize_stock_list()` 行为的前提下，补齐单条目级别的 `parse_analysis_target()` 入口和三条核心契约。

## 改动概览
- `src/services/stock_list_parser.py`：新增 `IndexRegistry`/`IndexEntry`/`AnalysisTarget`/`ParseStatus` 数据类，对外暴露 `parse_analysis_target()`、`parse_stock_list()`、`default_index_registry()`、`IndexRegistry`/`IndexEntry`/`AnalysisTarget`/`ParseStatus`。保留 `split_stock_list()` 与 `serialize_stock_list()` 签名与行为不变。
- `tests/test_stock_list_parser.py`：保留原有两个 legacy 测试，新增 36 个测试覆盖三条契约、6 个 maintainer spec 样例与边界场景。
- `docs/CHANGELOG.md`：`[Unreleased]` 段追加一条 `[新功能]` 描述。

## 三条核心契约
1. 前缀白名单指数：`sh`/`sz` 前缀且命中 `IndexRegistry` 的代码 → `INDEX`，`canonical_id` 同步指数稳定 ID（`sh000300`→`sh000300`、`sz399001`→`sz399001`）。
2. 裸码默认个股：未带前缀的代码一律 `STOCK`，即使裸码与已知指数代码冲突（`000300`、`000016` 等）也仅通过 `matched_index` 暴露冲突，不翻转 `asset_type`。
3. 前缀未命中降级为股票：`sh`/`sz`/`bj`/`hk`/`us` 前缀但 registry 未收录的代码 → `STOCK`，不再产生 `UNSUPPORTED`，避免把 typo 或新代码误判为不可处理。

## Maintainer spec 样例覆盖
| 输入 | 期望 asset_type | 期望 canonical_id | 期望 exchange |
| --- | --- | --- | --- |
| `sh000300` | INDEX | sh000300 | SH |
| `sz399300` | STOCK | sz399300 | SZ |
| `sh600519` | STOCK | sh600519 | SH |
| `000300` | STOCK（matched_index 暴露沪深300） | sz000300 | SZ |
| `000001` | STOCK | sz000001 | SZ |
| `920001` | STOCK | bj920001 | BJ |

## 默认指数白名单
`default_index_registry()` 收录五个核心指数：`sh000300`（沪深300）、`sh000016`（上证50）、`sh000688`（科创50）、`sz399001`（深证成指）、`sz399006`（深证1000）。上层可通过 `parse_analysis_target(raw, registry=...)` 注入自定义 registry 扩展白名单。

## 与现有代码兼容性
- `split_stock_list()` / `serialize_stock_list()` 签名与行为完全不变，原有调用方零迁移成本。
- `parse_analysis_target()` 是新增的纯函数入口，行级 import 即可使用，不影响 lazy 加载顺序。
- 上游 `data_provider` 的 fetcher 已经接受 `sh600519`/`hk00700`/裸 `AAPL` 三种 canonical 格式，本 PR 的 `canonical_id` 输出与这三类格式直接对齐，Phase 2 接入 fetcher 时无需中转层。

## 测试
```bash
$ pytest tests/test_stock_list_parser.py -v
============================== 38 passed in 0.23s ==============================
```

legacy 2 + Phase 1 36 = 38 全部通过；与同目录下游测试 `tests/test_stock_code_utils.py`、`tests/test_stock_code_bse.py`、`tests/test_a_share_fetcher_code_conversion.py`、`tests/test_market_symbol_utils.py` 一并跑 133 个测试全 pass。

## 后续 Phase
- Phase 2：在 fetcher/agent 层接入 `parse_analysis_target()`，把 `canonical_id` 直接送进 `BaseFetcher` 查询；对 `asset_type == INDEX` 的目标路由到指数数据源而非个股数据源。
- Phase 3：UI 层在展示 `000300` 这类冲突码时，读 `matched_index` 显示警示标记（如「此代码与指数沪深300冲突，已默认按个股处理」）。

## 风险
- 默认指数白名单只收五个核心指数，若用户的 STOCK_LIST 中包含 `sh000905`（中证500）等其它指数代码，Phase 1 会按 contract #3 降级为 STOCK。这是契约明确允许的过渡行为，Phase 2 扩展 registry 时可平滑升级。
- `parse_analysis_target("000300")` 返回 `canonical_id == "sz000300"`（按裸码 SZ 路由）而非 `sh000300`（指数所在 SH）。这是为了让 stock canonical 与 fetcher 期望格式对齐；冲突通过 `matched_index` 字段暴露，UI 在 Phase 3 可据此显式提示。