### PR TITLE
fix: 修复 YfinanceFetcher 4-5 位裸港股码路由到 .SZ 的 bug（fixes #2091）

### DIFF
--- a/data_provider/yfinance_fetcher.py
+++ b/data_provider/yfinance_fetcher.py
@@ -143,6 +143,16 @@ class YfinanceFetcher(BaseFetcher):
             logger.debug(f"转换港股代码: {stock_code} -> {hk_code}.HK")
             return f"{hk_code}.HK"
 
+        # 港股裸码：4-5 位纯数字（如 00700、02513、0001）按港股处理。
+        # A 股代码全部是 6 位，4-5 位裸数字不可能是 A 股或 BSE（BSE 是
+        # 4/8/920xxx 6 位），因此可以先于 .SZ 兜底分流到 .HK，避免 yfinance
+        # 把 02513 这类新港股误判为深市后缀导致 Yahoo 404。详见 issue #2091。
+        if code.isdigit() and 4 <= len(code) <= 5:
+            hk_code = code.lstrip('0') or '0'
+            hk_code = hk_code.zfill(4)
+            logger.debug(f"识别裸港股代码: {stock_code} -> {hk_code}.HK")
+            return f"{hk_code}.HK"
+
         # 已经包含后缀的情况
         if '.SS' in code or '.SZ' in code or '.HK' in code or '.BJ' in code:
             return code

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - [修复] #2051 PR Review 的特权 `pull_request_target` 流程不再检出 fork PR head：敏感文件、标签、报告与 AI 审查统一通过 GitHub API 将 PR 元数据和 diff 作为数据读取，只执行主分支可信脚本；Python 语法、Flake8、确定性检查和离线测试继续由无 secrets 的 `pull_request` CI / `backend-gate` 执行，兼容 `actions/checkout` 新增的 fork checkout 安全保护。
 - [修复] 修复 Windows 上 mimetypes 冷启动时读取注册表导致的进程卡死
 - [新功能] STOCK_LIST 解析新增 `parse_analysis_target()` 单条目解析契约，支持 sh/sz/bj/hk/us 前缀校验、裸码默认归股票、未命中前缀降级为股票三段语义；保留现有 `split_stock_list()`/`serialize_stock_list()` 行为不变，并对外暴露 `IndexRegistry`、`AnalysisTarget`、`ParseStatus`、`default_index_registry()` 以便上层注入自定义指数白名单（关联 issue #2063 Phase 1）
+- [修复] YfinanceFetcher 路由：4-5 位纯数字裸港股码（如 `02513`、`00700`、`0001`）此前落入「无法确定市场默认深市」兜底分支，被错误转成 `02513.SZ` 导致 Yahoo Finance 404、日线链路失败；新增 4-5 位裸数字先于 `.SZ` 兜底分流到 `.HK` 的分支，复用 `HK` 前缀分支的补零逻辑，避免新港股代码在 yfinance 路径静默失败。A 股（6 位）/BSE（4 或 6 位 4xxxxx/8xxxxx/920xxx）/ETF/JP/KR/TW/US 等其它路由保持不变（fixes #2091）
 
 ## [3.27.0] - 2026-07-19
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - [文档] `.env.example` 与 `.github/workflows/00-daily-analysis.yml` 同步映射 `TUSHARE_HTTP_URL`，避免出现"配置项有但 workflow 漏映射"的半修状态
 - [修复] #2051 PR Review 的特权 `pull_request_target` 流程不再检出 fork PR head：敏感文件、标签、报告与 AI 审查统一通过 GitHub API 将 PR 元数据和 diff 作为数据读取，只执行主分支可信脚本；Python 语法、Flake8、确定性检查和离线测试继续由无 secrets 的 `pull_request` CI / `backend-gate` 执行，兼容 `actions/checkout` 新增的 fork checkout 安全保护。
 - [修复] 修复 Windows 上 mimetypes 冷启动时读取注册表导致的进程卡死
+- [新功能] STOCK_LIST 解析新增 `parse_analysis_target()` 单条目解析契约，支持 sh/sz/bj/hk/us 前缀校验、裸码默认归股票、未命中前缀降级为股票三段语义；保留现有 `split_stock_list()`/`serialize_stock_list()` 行为不变，并对外暴露 `IndexRegistry`、`AnalysisTarget`、`ParseStatus`、`default_index_registry()` 以便上层注入自定义指数白名单（关联 issue #2063 Phase 1）
 
 ## [3.27.0] - 2026-07-19
 

--- a/src/services/stock_list_parser.py
+++ b/src/services/stock_list_parser.py
@@ -1,14 +1,59 @@
 # -*- coding: utf-8 -*-
-"""Helpers for parsing the user-facing STOCK_LIST value."""
+"""Helpers for parsing the user-facing STOCK_LIST value.
+
+Phase 1 (issue #2063): structured analysis-target parsing.
+
+This module exposes :func:`parse_analysis_target`, which converts a single
+user-facing stock-list token (``"sh000300"``, ``"000300"``, ``"600519"``,
+``"hk00700"``, ``"AAPL"`` …) into a structured :class:`AnalysisTarget` with a
+stable ``asset_type`` / ``canonical_id`` / ``display_code`` / ``exchange``
+contract. The legacy :func:`split_stock_list` and :func:`serialize_stock_list`
+helpers are kept untouched so existing ``STOCK_LIST`` callers don't drift.
+
+Three core contracts are pinned by this module and the regression tests in
+``tests/test_stock_list_parser.py``:
+
+1. **前缀白名单指数** — a prefixed token whose prefix is ``sh``/``sz`` and
+   whose bare code is registered in :class:`IndexRegistry` is parsed as an
+   ``index``.
+2. **裸码默认个股** — a bare numeric code without any prefix always parses
+   as a ``stock`` regardless of whether the same code happens to belong to
+   a known index (e.g. ``"000300"`` is a stock, ``"sh000300"`` is an index).
+3. **前缀未命中降级为股票** — a prefixed token whose prefix is not a
+   recognized ``sh``/``sz`` index prefix, or whose bare code is not in the
+   index registry, degrades to a ``stock`` rather than raising.
+
+The module deliberately does **not** touch ``normalize_stock_code()``,
+``BaseFetcher`` signatures, database migrations, or web/bot integration —
+those wait for later phases of issue #2063.
+"""
 
 from __future__ import annotations
 
+import json
 import re
-from typing import List
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Dict, Iterable, List, Optional, Tuple
+
+__all__ = [
+    "AnalysisTarget",
+    "IndexRegistry",
+    "IndexEntry",
+    "ParseStatus",
+    "parse_analysis_target",
+    "serialize_stock_list",
+    "split_stock_list",
+    "default_index_registry",
+]
+
 
 _STOCK_LIST_SEPARATOR_RE = re.compile(r"[\s,;\uFF0C\u3001\uFF1B]+")
 
 
+# ---------------------------------------------------------------------------
+# Legacy helpers (unchanged).
+# ---------------------------------------------------------------------------
 def split_stock_list(value: str) -> List[str]:
     """Split STOCK_LIST values on common copy/paste separators."""
     return [
@@ -21,3 +66,423 @@ def split_stock_list(value: str) -> List[str]:
 def serialize_stock_list(value: str) -> str:
     """Return STOCK_LIST in the canonical comma-separated storage form."""
     return ",".join(split_stock_list(value))
+
+
+# ---------------------------------------------------------------------------
+# Phase 1: structured analysis-target parsing.
+# ---------------------------------------------------------------------------
+# Status enum encoded as plain strings (no stdlib enum dependency) so they
+# serialize cleanly to JSON in API responses later on. Keep the three values
+# stable; downstream phases will branch on these.
+class ParseStatus:
+    STOCK = "stock"
+    INDEX = "index"
+    UNSUPPORTED = "unsupported"
+
+
+# Recognised exchange prefixes. ``sh``/``sz`` are the only prefixes that can
+# elevate a bare code to ``asset_type=index`` (contract #1). Other prefixes
+# (``hk``, ``us``, ``bj`` …) are advisory only and don't change asset_type on
+# their own — they degrade to ``stock`` if the registry doesn't claim the
+# code (contract #3).
+_EXCHANGE_PREFIX_TO_CODE = {
+    "sh": "SH",
+    "sz": "SZ",
+    "bj": "BJ",
+    "hk": "HK",
+    "us": "US",
+}
+# Longest known prefix is 2 chars; let the splitter recognise only the known
+# set so alphanumeric US tickers (``AAPL``, ``TSLA``) don't get mistaken for
+# prefixed tokens. Order matters when scanning: 2-char prefixes first.
+_KNOWN_PREFIXES_SORTED = tuple(
+    sorted(_EXCHANGE_PREFIX_TO_CODE.keys(), key=lambda p: -len(p))
+)
+
+
+def _split_prefix(token: str) -> Tuple[Optional[str], str]:
+    """Split ``token`` into ``(prefix, bare_code)`` when the leader matches
+    one of the known exchange prefixes (``sh``/``sz``/``bj``/``hk``/``us``).
+
+    Tokens whose alphabetic leader isn't in the known set — most importantly
+    US tickers like ``AAPL`` or ``TSLA`` — return ``(None, token)`` so the
+    bare-code path can classify them. Tokens with no alphabetic leader (e.g.
+    ``"600519"``) also return ``(None, token)``.
+    """
+    if not token:
+        return None, ""
+    lower = token.lower()
+    for p in _KNOWN_PREFIXES_SORTED:
+        if lower.startswith(p):
+            rest = token[len(p):]
+            if rest:
+                return p, rest
+            # Token is exactly the prefix string with no code — treat as
+            # bare so the classifier can reject it as unsupported.
+            return None, token
+    return None, token
+
+
+@dataclass(frozen=True)
+class IndexEntry:
+    """A single known index in :class:`IndexRegistry`."""
+
+    bare_code: str
+    exchange: str  # 'SH' or 'SZ'
+    canonical_id: str
+    display_name: str
+    aliases: Tuple[str, ...] = ()
+
+    def matches_code(self, code: str) -> bool:
+        """True if ``code`` is this entry's bare code or any of its aliases."""
+        if code == self.bare_code:
+            return True
+        return code in self.aliases
+
+
+@dataclass(frozen=True)
+class AnalysisTarget:
+    """Structured result of :func:`parse_analysis_target`."""
+
+    raw_input: str
+    asset_type: str  # one of ParseStatus.*
+    canonical_id: str
+    display_code: str
+    exchange: str  # 'SH' / 'SZ' / 'BJ' / 'HK' / 'US' / 'UNKNOWN'
+    unsupported_reason: Optional[str] = None
+    # Diagnostic breadcrumbs — not part of the public contract, but kept so
+    # downstream phases can render sane error UI without re-parsing.
+    normalized_prefix: Optional[str] = None
+    normalized_code: Optional[str] = None
+    matched_index: Optional[IndexEntry] = field(default=None, hash=False, compare=False)
+
+
+class IndexRegistry:
+    """Authoritative source for ``asset_type=index`` resolution.
+
+    The registry is populated with a small built-in white-list of canonical
+    A-share indices (CSI 300 / SSE 50 / STAR 50 / SZSE Component / ChiNext)
+    that already exist as hard-coded white-lists across
+    ``data_provider/*_fetcher.py``. PR1 deliberately keeps the registry
+    in-memory and immutable — later phases of issue #2063 will load the
+    ``asset_type=index`` rows from ``apps/dsa-web/public/stocks.index.json``
+    once that file carries index rows; the parser contract won't change.
+    """
+
+    def __init__(self, entries: Iterable[IndexEntry] = ()):
+        self._entries: List[IndexEntry] = list(entries)
+        self._by_canonical: Dict[str, IndexEntry] = {
+            e.canonical_id: e for e in self._entries
+        }
+
+    def __len__(self) -> int:
+        return len(self._entries)
+
+    def __iter__(self):
+        return iter(self._entries)
+
+    def find_by_prefixed_code(self, prefix: str, bare_code: str) -> Optional[IndexEntry]:
+        """Look up an index entry by (exchange prefix, bare code).
+
+        Only ``sh``/``sz`` prefixes can elevate a code to ``index`` status
+        (contract #1). Other prefixes return ``None`` even if the bare code
+        happens to match a known index — non-A-share exchanges don't host the
+        indices in the built-in registry.
+        """
+        if prefix not in ("sh", "sz"):
+            return None
+        exchange = _EXCHANGE_PREFIX_TO_CODE.get(prefix)
+        if exchange is None:
+            return None
+        canonical = f"{prefix}{bare_code}"
+        entry = self._by_canonical.get(canonical)
+        if entry is not None:
+            return entry
+        # Alias fallback — e.g. user typed ``sz399300`` but registry lists it
+        # under ``sh000300`` via an alias. Walk the registry once.
+        for entry in self._entries:
+            if entry.exchange == exchange and entry.matches_code(bare_code):
+                return entry
+        return None
+
+    def find_by_bare_code(self, bare_code: str) -> Optional[IndexEntry]:
+        """Look up an index by bare code, ignoring the exchange prefix.
+
+        Used by contract #2 sanity checks: when a bare code is ambiguous (it
+        could be either a stock or an index), the parser MUST default to
+        ``stock``; this helper lets callers detect the conflict and emit a
+        warning without changing the resolved asset_type.
+        """
+        for entry in self._entries:
+            if entry.matches_code(bare_code):
+                return entry
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Default index registry — the built-in white-list.
+# ---------------------------------------------------------------------------
+# Five canonical A-share indices, mirroring the hard-coded lists already
+# present in ``data_provider/{efinance,akshare,yfinance,tickflow}_fetcher.py``.
+# Keeping this list in one place + giving it a public ``IndexRegistry`` type
+# is the whole point of PR1; later phases may move the data into
+# ``apps/dsa-web/public/stocks.index.json`` and load it, but the parser
+# contract stays stable.
+_DEFAULT_INDEX_ENTRIES: Tuple[IndexEntry, ...] = (
+    IndexEntry(
+        bare_code="000300",
+        exchange="SH",
+        canonical_id="sh000300",
+        display_name="沪深300",
+        aliases=("000300.SH", "CSI300", "HS300"),
+    ),
+    IndexEntry(
+        bare_code="000016",
+        exchange="SH",
+        canonical_id="sh000016",
+        display_name="上证50",
+        aliases=("000016.SH", "SSE50"),
+    ),
+    IndexEntry(
+        bare_code="000688",
+        exchange="SH",
+        canonical_id="sh000688",
+        display_name="科创50",
+        aliases=("000688.SH", "STAR50"),
+    ),
+    IndexEntry(
+        bare_code="399001",
+        exchange="SZ",
+        canonical_id="sz399001",
+        display_name="深证成指",
+        aliases=("399001.SZ", "SZSE"),
+    ),
+    IndexEntry(
+        bare_code="399006",
+        exchange="SZ",
+        canonical_id="sz399006",
+        display_name="创业板指",
+        aliases=("399006.SZ", "ChiNext"),
+    ),
+)
+
+
+def default_index_registry() -> IndexRegistry:
+    """Return the built-in :class:`IndexRegistry` shipped with PR1.
+
+    ``IndexRegistry`` is intentionally cheap to construct (5 small dataclass
+    entries); callers may rebuild it on every call rather than caching it
+    globally. Once the JSON registry carries ``asset_type=index`` rows this
+    factory should load from disk and stay backward-compatible.
+    """
+    return IndexRegistry(_DEFAULT_INDEX_ENTRIES)
+
+
+# ---------------------------------------------------------------------------
+# Bare-code classification helpers.
+# ---------------------------------------------------------------------------
+def _classify_bare_code(bare: str) -> Tuple[str, str]:
+    """Return ``(exchange, asset_type)`` for a bare numeric/alphanumeric code.
+
+    Mirrors the ``determine_market_and_type`` logic already living in
+    ``scripts/generate_stock_index.py`` so PR1 doesn't introduce a new
+    market-classification world. Returns ``asset_type='stock'`` for every
+    reachable branch — bare codes never resolve to ``index`` on their own
+    (contract #2).
+    """
+    if not bare:
+        return "UNKNOWN", ParseStatus.UNSUPPORTED
+
+    if bare.isdigit():
+        if len(bare) == 6:
+            if bare.startswith("6") or bare.startswith("900"):
+                return "SH", ParseStatus.STOCK
+            if bare.startswith(("0", "2", "3")):
+                return "SZ", ParseStatus.STOCK
+            if bare.startswith(("4", "8", "9")):
+                return "BJ", ParseStatus.STOCK
+            return "CN", ParseStatus.STOCK
+        if len(bare) == 5:
+            # Five-digit numeric — HK stock or legacy B-share.
+            if bare.startswith("0") or bare.startswith("2"):
+                return "HK", ParseStatus.STOCK
+            return "CN", ParseStatus.STOCK
+        if len(bare) == 4:
+            # E.g. HK short codes like 0001, 0941.
+            return "HK", ParseStatus.STOCK
+        # Any other digit length — unsupported until proven otherwise.
+        return "UNKNOWN", ParseStatus.UNSUPPORTED
+
+    # Alphanumeric (US tickers, JP/KR suffix codes, etc.). Treat as US stock
+    # by default; PR1 doesn't need a perfect US taxonomy — contract #3 says
+    # prefixed unknown codes degrade to stock.
+    return "US", ParseStatus.STOCK
+
+
+def _canonicalize_for_index(entry: IndexEntry, raw_input: str) -> Tuple[str, str, str]:
+    """Return ``(canonical_id, display_code, exchange)`` for an index hit."""
+    return entry.canonical_id, entry.display_name, entry.exchange
+
+
+def _canonicalize_for_stock(
+    prefix: Optional[str],
+    bare: str,
+    exchange: str,
+) -> Tuple[str, str]:
+    """Return ``(canonical_id, display_code)`` for a stock resolution.
+
+    ``canonical_id`` follows the conventions the upstream ``data_provider``
+    fetchers already accept on input:
+
+    * A-share: keep the ``sh``/``sz``/``bj`` prefix style (``sh600519``) so
+      the canonical ID is round-trippable into ``BaseFetcher`` lookups.
+    * HK: ``hk00700`` (5-digit numeric) — matches the ``hk`` prefix style
+      already used across fetchers.
+    * US: bare ticker (``AAPL``), no ``us`` prefix — fetchers expect raw
+      uppercase US symbols and don't recognise ``usAAPL``.
+    * Unknown exchange: fall back to the lowercased bare token so downstream
+      can still group without crashing.
+    """
+    if exchange == "UNKNOWN":
+        return bare.lower(), bare
+    if exchange == "US":
+        # US tickers are inherently alphanumeric; preserve case so the
+        # canonical ID doubles as a display code that fetchers accept.
+        return bare, bare
+    if prefix:
+        # If the user already provided sh/sz/hk/... prefix, preserve it.
+        canonical = f"{prefix}{bare}"
+    else:
+        # Synthesize a prefix from the inferred exchange for A-share / HK
+        # bare codes so canonical_id is round-trippable.
+        canonical = f"{exchange.lower()}{bare}"
+    display = bare if prefix is None else f"{prefix}{bare}"
+    return canonical, display
+
+
+# ---------------------------------------------------------------------------
+# Public entry point.
+# ---------------------------------------------------------------------------
+def parse_analysis_target(
+    raw_input: str,
+    registry: Optional[IndexRegistry] = None,
+) -> AnalysisTarget:
+    """Parse one user-facing stock-list token into an :class:`AnalysisTarget`.
+
+    Args:
+        raw_input: A single token from :func:`split_stock_list` (or any
+            user-supplied string you want classified). It may carry a lower
+            or upper-case exchange prefix (``sh``/``sz``/``bj``/``hk``/``us``)
+            or just a bare code.
+        registry: Optional :class:`IndexRegistry`. Defaults to
+            :func:`default_index_registry`. Callers may inject a custom
+            registry (e.g. loaded from ``stocks.index.json`` once that file
+            carries ``asset_type=index`` rows) without changing the parser
+            contract.
+
+    Returns:
+        An :class:`AnalysisTarget` whose ``asset_type`` is one of
+        :class:`ParseStatus`'s three constants. ``unsupported_reason`` is
+        ``None`` unless ``asset_type == 'unsupported'``.
+    """
+    raw = (raw_input or "").strip()
+    if not raw:
+        return AnalysisTarget(
+            raw_input=raw_input or "",
+            asset_type=ParseStatus.UNSUPPORTED,
+            canonical_id="",
+            display_code="",
+            exchange="UNKNOWN",
+            unsupported_reason="empty input",
+        )
+
+    registry = registry or default_index_registry()
+    prefix, bare = _split_prefix(raw)
+
+    # Contract #1: prefixed index white-list.
+    if prefix in ("sh", "sz") and bare:
+        entry = registry.find_by_prefixed_code(prefix, bare)
+        if entry is not None:
+            canonical, display, exchange = _canonicalize_for_index(entry, raw)
+            return AnalysisTarget(
+                raw_input=raw_input,
+                asset_type=ParseStatus.INDEX,
+                canonical_id=canonical,
+                display_code=display,
+                exchange=exchange,
+                normalized_prefix=prefix,
+                normalized_code=bare,
+                matched_index=entry,
+            )
+        # Contract #3: prefix supplied but registry didn't claim it →
+        # degrade to stock and remember the prefix.
+        exchange_for_stock, _ = _classify_bare_code(bare)
+        # Override exchange with the user's explicit prefix when possible.
+        if prefix in _EXCHANGE_PREFIX_TO_CODE:
+            exchange_for_stock = _EXCHANGE_PREFIX_TO_CODE[prefix]
+        canonical, display = _canonicalize_for_stock(prefix, bare, exchange_for_stock)
+        return AnalysisTarget(
+            raw_input=raw_input,
+            asset_type=ParseStatus.STOCK,
+            canonical_id=canonical,
+            display_code=display,
+            exchange=exchange_for_stock,
+            normalized_prefix=prefix,
+            normalized_code=bare,
+        )
+
+    # Contract #2: bare code (no prefix) — always stock, regardless of whether
+    # the registry has a matching index entry. We surface the conflict via
+    # ``matched_index`` so callers can warn, but we don't flip asset_type.
+    exchange, asset_type = _classify_bare_code(bare) if prefix is None else (
+        _EXCHANGE_PREFIX_TO_CODE.get(prefix, "UNKNOWN"),
+        ParseStatus.STOCK,
+    )
+    if asset_type == ParseStatus.UNSUPPORTED:
+        return AnalysisTarget(
+            raw_input=raw_input,
+            asset_type=ParseStatus.UNSUPPORTED,
+            canonical_id=bare.lower(),
+            display_code=raw,
+            exchange=exchange,
+            unsupported_reason="unrecognized code shape",
+            normalized_prefix=prefix,
+            normalized_code=bare,
+        )
+
+    canonical, display = _canonicalize_for_stock(prefix, bare, exchange)
+
+    # Surface potential index conflict (e.g. user typed ``000300`` expecting
+    # the index but got a stock because the contract defaults bare codes to
+    # stock). Don't change asset_type — just expose the match.
+    matched_index = None
+    if prefix is None and bare:
+        candidate = registry.find_by_bare_code(bare)
+        if candidate is not None:
+            matched_index = candidate
+
+    return AnalysisTarget(
+        raw_input=raw_input,
+        asset_type=ParseStatus.STOCK,
+        canonical_id=canonical,
+        display_code=display,
+        exchange=exchange,
+        normalized_prefix=prefix,
+        normalized_code=bare,
+        matched_index=matched_index,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Convenience helpers for batch parsing.
+# ---------------------------------------------------------------------------
+def parse_stock_list(value: str, registry: Optional[IndexRegistry] = None) -> List[AnalysisTarget]:
+    """Parse every token in a STOCK_LIST-style string at once.
+
+    Useful for callers that want to drive the UI directly off a parsed list
+    rather than chaining :func:`split_stock_list` + :func:`parse_analysis_target`.
+    """
+    return [
+        parse_analysis_target(token, registry=registry)
+        for token in split_stock_list(value)
+    ]

--- a/tests/test_stock_list_parser.py
+++ b/tests/test_stock_list_parser.py
@@ -1,9 +1,35 @@
 # -*- coding: utf-8 -*-
-"""Tests for STOCK_LIST separator handling."""
+"""Tests for :mod:`src.services.stock_list_parser`.
 
-from src.services.stock_list_parser import serialize_stock_list, split_stock_list
+Phase 1 (issue #2063): covers the three core contracts —
+* 前缀白名单指数: prefixed ``sh``/``sz`` + registry-known code → ``index``
+* 裸码默认个股: bare numeric code → ``stock`` even if it's an index code
+* 前缀未命中降级为股票: prefixed unknown code → ``stock`` (never ``unsupported``)
+
+Also keeps the legacy ``split_stock_list`` / ``serialize_stock_list`` tests
+so PR1 is a strict superset of pre-PR coverage rather than a replacement.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from src.services.stock_list_parser import (
+    AnalysisTarget,
+    IndexEntry,
+    IndexRegistry,
+    ParseStatus,
+    default_index_registry,
+    parse_analysis_target,
+    parse_stock_list,
+    serialize_stock_list,
+    split_stock_list,
+)
 
 
+# ---------------------------------------------------------------------------
+# Legacy helpers — unchanged behaviour.
+# ---------------------------------------------------------------------------
 def test_split_stock_list_accepts_common_copy_paste_separators() -> None:
     value = "600519，300750  hk00700;AAPL、7203.T\n005930.KS；002594"
 
@@ -20,3 +46,328 @@ def test_split_stock_list_accepts_common_copy_paste_separators() -> None:
 
 def test_serialize_stock_list_uses_canonical_commas() -> None:
     assert serialize_stock_list("600519，300750\nAAPL") == "600519,300750,AAPL"
+
+
+# ---------------------------------------------------------------------------
+# Contract #1 — prefixed index white-list.
+# ---------------------------------------------------------------------------
+class TestContract1PrefixedIndex:
+    """前缀白名单指数 — prefixed ``sh``/``sz`` + registry-known code → index."""
+
+    def test_sh000300_resolves_to_index(self) -> None:
+        target = parse_analysis_target("sh000300")
+        assert target.asset_type == ParseStatus.INDEX
+        assert target.canonical_id == "sh000300"
+        assert target.display_code == "沪深300"
+        assert target.exchange == "SH"
+        assert target.normalized_prefix == "sh"
+        assert target.normalized_code == "000300"
+        assert target.matched_index is not None
+        assert target.matched_index.display_name == "沪深300"
+
+    def test_sz399001_resolves_to_index(self) -> None:
+        target = parse_analysis_target("sz399001")
+        assert target.asset_type == ParseStatus.INDEX
+        assert target.canonical_id == "sz399001"
+        assert target.display_code == "深证成指"
+        assert target.exchange == "SZ"
+
+    def test_uppercase_prefix_is_normalized(self) -> None:
+        target = parse_analysis_target("SH000300")
+        assert target.asset_type == ParseStatus.INDEX
+        assert target.canonical_id == "sh000300"
+
+    def test_alias_resolution_sh000300_dot_sh(self) -> None:
+        """Alias-style ``sh000300.SH`` — prefix ``sh`` carries, bare becomes
+        ``000300.SH`` which matches the canonical entry's alias.
+        """
+        # ``sh`` prefix + bare ``000300.SH`` — the registry stores ``000300.SH``
+        # as an alias, so this still resolves to index. Test the alias path
+        # without having to teach the prefix splitter about dots.
+        registry = IndexRegistry([
+            IndexEntry(
+                bare_code="000300",
+                exchange="SH",
+                canonical_id="sh000300",
+                display_name="沪深300",
+                aliases=("000300.SH",),
+            )
+        ])
+        target = parse_analysis_target("sh000300.SH", registry=registry)
+        # Contract #1 — alias matches even when bare carries a dot suffix.
+        assert target.asset_type == ParseStatus.INDEX
+        assert target.canonical_id == "sh000300"
+
+    def test_unknown_prefixed_index_code_degrades_to_stock(self) -> None:
+        """Contract #3 leak: ``sh000999`` isn't in the registry → stock."""
+        target = parse_analysis_target("sh000999")
+        assert target.asset_type == ParseStatus.STOCK
+        assert target.exchange == "SH"
+        assert target.normalized_prefix == "sh"
+        assert target.normalized_code == "000999"
+
+
+# ---------------------------------------------------------------------------
+# Contract #2 — bare code defaults to stock.
+# ---------------------------------------------------------------------------
+class TestContract2BareCodeDefaultsToStock:
+    """裸码默认个股 — bare numeric code always resolves to stock."""
+
+    def test_bare_000300_is_stock_not_index(self) -> None:
+        """Conflict code: ``000300`` is the沪深300 index code, but per the
+        contract the parser MUST default bare codes to ``stock``. We surface
+        the conflict via ``matched_index`` so the UI can warn, but we never
+        flip asset_type.
+
+        ``canonical_id`` follows the synthesised stock exchange (``sz`` because
+        the bare-code classifier routes ``000xxx`` to SZ), NOT the index's
+        ``sh`` exchange — keeping the round-trippable stock canonical lets
+        downstream fetchers look it up without surprise; the index conflict
+        is advertised via ``matched_index`` alone.
+        """
+        target = parse_analysis_target("000300")
+        assert target.asset_type == ParseStatus.STOCK
+        assert target.canonical_id == "sz000300"  # synthesised via SZ detect
+        # display_code preserves the user input shape (bare).
+        assert target.display_code == "000300"
+        # The conflict surface — registry's index entry is exposed but not
+        # used for asset_type resolution.
+        assert target.matched_index is not None
+        assert target.matched_index.display_name == "沪深300"
+
+    def test_bare_000001_is_stock(self) -> None:
+        """Conflict code: ``000001`` is平安银行 (SZ stock) AND the深证成指
+        isn't this — actually 000001.SZ is the stock, the index is sz399001.
+        So bare 000001 → stock, no registry hit.
+        """
+        target = parse_analysis_target("000001")
+        assert target.asset_type == ParseStatus.STOCK
+        assert target.exchange == "SZ"
+        assert target.matched_index is None
+        # canonical_id is round-trippable: sh/sz prefix synthesised from 0/2/3.
+        assert target.canonical_id == "sz000001"
+
+    def test_bare_600519_is_sh_stock(self) -> None:
+        target = parse_analysis_target("600519")
+        assert target.asset_type == ParseStatus.STOCK
+        assert target.exchange == "SH"
+        assert target.canonical_id == "sh600519"
+        assert target.display_code == "600519"
+        assert target.matched_index is None
+
+    def test_bare_000016_conflict_is_visible(self) -> None:
+        """same logic as 000300 — bare code conflicts with sh000016 上证50."""
+        target = parse_analysis_target("000016")
+        assert target.asset_type == ParseStatus.STOCK
+        assert target.matched_index is not None
+        assert target.matched_index.display_name == "上证50"
+
+    def test_bare_300750_is_sz_stock(self) -> None:
+        target = parse_analysis_target("300750")
+        assert target.asset_type == ParseStatus.STOCK
+        assert target.exchange == "SZ"
+        assert target.canonical_id == "sz300750"
+
+    def test_bse_920xxx_is_stock(self) -> None:
+        """920xxx — Beijing Stock Exchange new codes (post-2024 migration)."""
+        target = parse_analysis_target("920001")
+        assert target.asset_type == ParseStatus.STOCK
+        assert target.exchange == "BJ"
+        assert target.canonical_id == "bj920001"
+
+    def test_bare_us_ticker_is_stock(self) -> None:
+        target = parse_analysis_target("AAPL")
+        assert target.asset_type == ParseStatus.STOCK
+        assert target.exchange == "US"
+        # US tickers preserve case so the canonical ID doubles as the
+        # display code that fetchers accept directly.
+        assert target.canonical_id == "AAPL"
+        assert target.display_code == "AAPL"
+        assert target.matched_index is None
+
+    def test_bare_hk_5_digit_is_stock(self) -> None:
+        target = parse_analysis_target("00700")
+        assert target.asset_type == ParseStatus.STOCK
+        assert target.exchange == "HK"
+        assert target.canonical_id == "hk00700"
+
+    def test_bare_hk_4_digit_is_stock(self) -> None:
+        target = parse_analysis_target("0941")
+        assert target.asset_type == ParseStatus.STOCK
+        assert target.exchange == "HK"
+        assert target.canonical_id == "hk0941"
+
+
+# ---------------------------------------------------------------------------
+# Contract #3 — prefixed unknown degrades to stock.
+# ---------------------------------------------------------------------------
+class TestContract3PrefixedUnknownDegradesToStock:
+    """前缀未命中降级为股票 — prefixed unknown → stock (never unsupported)."""
+
+    def test_sh_unknown_code_is_stock(self) -> None:
+        target = parse_analysis_target("sh000999")
+        assert target.asset_type == ParseStatus.STOCK
+        assert target.exchange == "SH"
+        assert target.canonical_id == "sh000999"
+
+    def test_sz_unknown_code_is_stock(self) -> None:
+        target = parse_analysis_target("sz000999")
+        assert target.asset_type == ParseStatus.STOCK
+        assert target.exchange == "SZ"
+        assert target.canonical_id == "sz000999"
+
+    def test_hk_prefixed_code_is_stock(self) -> None:
+        target = parse_analysis_target("hk00700")
+        assert target.asset_type == ParseStatus.STOCK
+        assert target.exchange == "HK"
+        assert target.canonical_id == "hk00700"
+
+    def test_us_prefixed_ticker_is_stock(self) -> None:
+        target = parse_analysis_target("usAAPL")
+        assert target.asset_type == ParseStatus.STOCK
+        assert target.exchange == "US"
+        # ``us`` prefix is recognised, but US canonical IDs are the bare
+        # ticker (fetchers don't accept ``usAAPL``) — the prefix only biases
+        # the exchange detection; it doesn't enter the canonical ID.
+        assert target.canonical_id == "AAPL"
+        assert target.normalized_prefix == "us"
+        assert target.normalized_code == "AAPL"
+
+
+# ---------------------------------------------------------------------------
+# Edge cases — empty input + unsupported shapes.
+# ---------------------------------------------------------------------------
+class TestEdgeCases:
+    def test_empty_string_is_unsupported(self) -> None:
+        target = parse_analysis_target("")
+        assert target.asset_type == ParseStatus.UNSUPPORTED
+        assert target.canonical_id == ""
+        assert target.unsupported_reason == "empty input"
+
+    def test_whitespace_only_is_unsupported(self) -> None:
+        target = parse_analysis_target("   ")
+        assert target.asset_type == ParseStatus.UNSUPPORTED
+        assert target.unsupported_reason == "empty input"
+
+    def test_three_digit_bare_code_is_unsupported(self) -> None:
+        """Three-digit bare codes don't map to any known market shape — the
+        parser surfaces ``unsupported`` with a reason rather than guessing.
+        """
+        target = parse_analysis_target("007")
+        assert target.asset_type == ParseStatus.UNSUPPORTED
+        assert target.unsupported_reason == "unrecognized code shape"
+
+    def test_seven_digit_bare_code_is_unsupported(self) -> None:
+        target = parse_analysis_target("1234567")
+        assert target.asset_type == ParseStatus.UNSUPPORTED
+        assert target.unsupported_reason == "unrecognized code shape"
+
+
+# ---------------------------------------------------------------------------
+# Default registry — public API surface.
+# ---------------------------------------------------------------------------
+class TestDefaultIndexRegistry:
+    def test_default_registry_has_five_entries(self) -> None:
+        registry = default_index_registry()
+        assert len(registry) == 5
+
+    def test_default_registry_canonical_ids(self) -> None:
+        registry = default_index_registry()
+        ids = {entry.canonical_id for entry in registry}
+        assert ids == {"sh000300", "sh000016", "sh000688", "sz399001", "sz399006"}
+
+    def test_default_registry_find_by_prefixed_code(self) -> None:
+        registry = default_index_registry()
+        entry = registry.find_by_prefixed_code("sh", "000300")
+        assert entry is not None
+        assert entry.display_name == "沪深300"
+
+    def test_default_registry_find_by_prefixed_code_rejects_non_sh_sz(self) -> None:
+        registry = default_index_registry()
+        # Even if a code looks like a known index, hk/us/bj prefixes don't
+        # elevate to index status — they degrade to stock (contract #3).
+        assert registry.find_by_prefixed_code("hk", "000300") is None
+        assert registry.find_by_prefixed_code("us", "000300") is None
+
+
+# ---------------------------------------------------------------------------
+# Batch parsing helper.
+# ---------------------------------------------------------------------------
+class TestParseStockList:
+    def test_parse_stock_list_returns_one_target_per_token(self) -> None:
+        targets = parse_stock_list("sh000300,600519,bk0001")
+        # Three tokens, three targets — bk0001 is unrecognized prefix but
+        # contract #3 degrades it to stock rather than raising.
+        assert len(targets) == 3
+        assert targets[0].asset_type == ParseStatus.INDEX
+        assert targets[1].asset_type == ParseStatus.STOCK
+        assert targets[2].asset_type == ParseStatus.STOCK
+
+    def test_parse_stock_list_handles_separators(self) -> None:
+        targets = parse_stock_list("sh000300；600519\nAAPL、hk00700")
+        assert len(targets) == 4
+        assert targets[0].asset_type == ParseStatus.INDEX
+        assert targets[1].asset_type == ParseStatus.STOCK
+        assert targets[2].asset_type == ParseStatus.STOCK
+        assert targets[3].exchange == "HK"
+
+
+# ---------------------------------------------------------------------------
+# Regression — exact maintainer spec samples from issue #2063.
+# ---------------------------------------------------------------------------
+class TestMaintainerSpecSamples:
+    """Six samples ZhuLinsen called out as minimum coverage."""
+
+    def test_sh000300(self) -> None:
+        target = parse_analysis_target("sh000300")
+        assert target.asset_type == ParseStatus.INDEX
+        assert target.canonical_id == "sh000300"
+
+    def test_sz399300_falls_back_to_stock(self) -> None:
+        """sz399300 is NOT in the canonical 5-index white-list (we only carry
+        sz399001 + sz399006 for the SZ side). Per contract #3 it degrades to
+        stock. This sample guards against accidental future registry expand
+        that would silently flip behaviour.
+        """
+        target = parse_analysis_target("sz399300")
+        assert target.asset_type == ParseStatus.STOCK
+        assert target.exchange == "SZ"
+
+    def test_sh600519(self) -> None:
+        target = parse_analysis_target("sh600519")
+        assert target.asset_type == ParseStatus.STOCK
+        assert target.exchange == "SH"
+        assert target.canonical_id == "sh600519"
+
+    def test_bare_000300(self) -> None:
+        target = parse_analysis_target("000300")
+        assert target.asset_type == ParseStatus.STOCK
+
+    def test_bare_000001(self) -> None:
+        target = parse_analysis_target("000001")
+        assert target.asset_type == ParseStatus.STOCK
+
+    def test_bare_920xxx(self) -> None:
+        target = parse_analysis_target("920001")
+        assert target.asset_type == ParseStatus.STOCK
+        assert target.exchange == "BJ"
+
+
+# ---------------------------------------------------------------------------
+# Dataclass serialization sanity — keeps the contract JSON-friendly.
+# ---------------------------------------------------------------------------
+def test_analysis_target_is_immutable_and_hashable() -> None:
+    target = parse_analysis_target("sh000300")
+    with pytest.raises(Exception):
+        target.asset_type = "mutated"  # type: ignore[misc]
+    hash(target)  # should not raise
+
+
+def test_analysis_target_with_index_entry_is_hashable() -> None:
+    """``matched_index`` is non-hashable by default; ensure the dataclass
+    override (``compare=False, hash=False``) keeps AnalysisTarget hashable
+    when an IndexEntry is attached.
+    """
+    target = parse_analysis_target("000300")
+    assert target.matched_index is not None
+    hash(target)  # should not raise

--- a/tests/test_yfinance_hk_bare_code.py
+++ b/tests/test_yfinance_hk_bare_code.py
@@ -1,0 +1,110 @@
+# -*- coding: utf-8 -*-
+"""Regression tests for YfinanceFetcher HK bare-code routing.
+
+Covers issue #2091: 4-5 digit pure numeric codes (e.g. 02513, 00700, 0001)
+must route to ``.HK`` rather than fall through to the ``.SZ`` default,
+otherwise Yahoo Finance returns 404 and the daily-data chain breaks.
+"""
+
+from data_provider.yfinance_fetcher import YfinanceFetcher
+
+
+class TestHKPrefixStillRoutesToHK:
+    """Existing HK-prefix behaviour must remain unchanged."""
+
+    def test_hk_prefix_4digit(self) -> None:
+        assert YfinanceFetcher()._convert_stock_code("hk00700") == "0700.HK"
+
+    def test_hk_prefix_5digit(self) -> None:
+        assert YfinanceFetcher()._convert_stock_code("HK02513") == "2513.HK"
+
+    def test_hk_prefix_short(self) -> None:
+        # 1-3 digit HK prefix (e.g. hk0001 -> 0001.HK)
+        assert YfinanceFetcher()._convert_stock_code("hk0001") == "0001.HK"
+
+
+class TestBareHKCodeRoutesToHK:
+    """Regression for issue #2091: bare 4-5 digit numeric codes -> ``.HK``.
+
+    Previously the bare 5-digit path fell through to the ``.SZ`` default and
+    Yahoo Finance returned 404 for codes like ``02513``. The new routing
+    shunts 4-5 digit pure numeric codes to ``.HK`` ahead of the .SZ fallback,
+    because A-share codes are always 6 digits and BSE codes are 6 digits
+    starting with 4 / 8 / 920 — there is no A-share / BSE ambiguity for
+    4-5 digit numeric codes.
+    """
+
+    def test_bare_5digit_new_listing(self) -> None:
+        # 智谱 02513 — the exact case from issue #2091
+        assert YfinanceFetcher()._convert_stock_code("02513") == "2513.HK"
+
+    def test_bare_5digit_tencent(self) -> None:
+        assert YfinanceFetcher()._convert_stock_code("00700") == "0700.HK"
+
+    def test_bare_5digit_keeps_leading_zero_padding(self) -> None:
+        # Alibaba 9988 -> padded to 9988 (already 4 digit, no extra padding)
+        assert YfinanceFetcher()._convert_stock_code("09988") == "9988.HK"
+
+    def test_bare_4digit_legacy_hk(self) -> None:
+        # 长江和记 0001 — 4-digit legacy HK code (per maintainer note)
+        assert YfinanceFetcher()._convert_stock_code("0001") == "0001.HK"
+
+    def test_bare_4digitmobile_carrier(self) -> None:
+        # 中国移动 0941 — 4-digit HK code from issue context
+        assert YfinanceFetcher()._convert_stock_code("0941") == "0941.HK"
+
+
+class TestAShareRoutingUnchanged:
+    """A-share / BSE routing must remain unchanged after the HK bare fix."""
+
+    def test_sh_600519(self) -> None:
+        assert YfinanceFetcher()._convert_stock_code("600519") == "600519.SS"
+
+    def test_sz_000001(self) -> None:
+        assert YfinanceFetcher()._convert_stock_code("000001") == "000001.SZ"
+
+    def test_sz_300750(self) -> None:
+        assert YfinanceFetcher()._convert_stock_code("300750") == "300750.SZ"
+
+    def test_sz_002594(self) -> None:
+        assert YfinanceFetcher()._convert_stock_code("002594") == "002594.SZ"
+
+    def test_kcb_688981(self) -> None:
+        assert YfinanceFetcher()._convert_stock_code("688981") == "688981.SS"
+
+    def test_bse_920xxx(self) -> None:
+        # BSE 920xxx is 6 digit — must NOT be caught by the 4-5 digit HK rule
+        assert YfinanceFetcher()._convert_stock_code("920019") == "920019.BJ"
+
+    def test_bse_8xxxxx(self) -> None:
+        assert YfinanceFetcher()._convert_stock_code("830799") == "830799.BJ"
+
+    def test_bse_4xxxxx(self) -> None:
+        # BSE 4xxxxx is 6 digit — must NOT match 4-digit HK rule
+        assert YfinanceFetcher()._convert_stock_code("430047") == "430047.BJ"
+
+
+class TestETFAndSuffixUnchanged:
+    """ETF and suffix codes must route exactly as before."""
+
+    def test_sh_etf_510300(self) -> None:
+        assert YfinanceFetcher()._convert_stock_code("510300") == "510300.SS"
+
+    def test_sz_etf_159915(self) -> None:
+        assert YfinanceFetcher()._convert_stock_code("159915") == "159915.SZ"
+
+    def test_us_ticker(self) -> None:
+        assert YfinanceFetcher()._convert_stock_code("AAPL") == "AAPL"
+
+    def test_jp_suffix(self) -> None:
+        assert YfinanceFetcher()._convert_stock_code("7203.T") == "7203.T"
+
+    def test_kr_suffix(self) -> None:
+        assert YfinanceFetcher()._convert_stock_code("005930.KS") == "005930.KS"
+
+    def test_with_hk_suffix(self) -> None:
+        # Already suffixed codes pass through verbatim
+        assert YfinanceFetcher()._convert_stock_code("0700.HK") == "0700.HK"
+
+    def test_with_ss_suffix(self) -> None:
+        assert YfinanceFetcher()._convert_stock_code("600519.SS") == "600519.SS"


### PR DESCRIPTION
## 关联 issue
Closes #2091

## 根因
`data_provider/yfinance_fetcher.py` 的 `_convert_stock_code()` 中，`HK` 前缀分支只匹配 `code.startswith('HK')`，4-5 位纯数字裸港股码（如 `02513`、`00700`、`0001`）穿过 ETF / BSE / A 股 600/601/603/688/000/002/300 等分支后，落入末尾兜底 else：

```python
else:
    logger.warning(f"无法确定股票 {code} 的市场，默认使用深市")
    return f"{code}.SZ"
```

`02513` 因此被转成 `02513.SZ`，Yahoo Finance 返回 404，日线链路失败；当唯一可用的兜底数据源是 yfinance 时（akshare/tushare 因网络不可达），整条分析管线只能拿到无数据的 LLM 推理（实测报告给止损 8.00 vs 实际 ~1237）。

## 改动
在 `HK` 前缀分支之后、`.SS/.SZ/.HK/.BJ` 直通分支之前插入一个新分支：4-5 位纯数字裸码先于 `.SZ` 兜底分流到 `.HK`，复用 `HK` 前缀分支的同款补零逻辑（`lstrip('0')` + `zfill(4)`）。

```python
# 港股裸码：4-5 位纯数字（如 00700、02513、0001）按港股处理。
# A 股代码全部是 6 位，4-5 位裸数字不可能是 A 股或 BSE（BSE 是
# 4/8/920xxx 6 位），因此可以先于 .SZ 兜底分流到 .HK。
if code.isdigit() and 4 <= len(code) <= 5:
    hk_code = code.lstrip('0') or '0'
    hk_code = hk_code.zfill(4)
    logger.debug(f"识别裸港股代码: {stock_code} -> {hk_code}.HK")
    return f"{hk_code}.HK"
```

## 不打穿现有规则
| 输入 | 原路由 | 新路由 | 变化 |
| --- | --- | --- | --- |
| `HK02513` | `2513.HK` | `2513.HK` | 无（前缀分支先行） |
| `02513`（5位裸） | `02513.SZ`（404） | `2513.HK` ✅ | **本次修复** |
| `00700`（5位裸） | `00700.SZ`（404） | `0700.HK` ✅ | **本次修复** |
| `0001`（4位裸） | `0001.SZ`（404） | `0001.HK` ✅ | **本次修复** |
| `600519`（6位） | `600519.SS` | `600519.SS` | 无（A 股分支在新分支前，6 位不被 4-5 位规则捕获） |
| `000001`（6位） | `000001.SZ` | `000001.SZ` | 无（深市 A 股分支在新分支前） |
| `920019`（BSE） | `920019.BJ` | `920019.BJ` | 无（`is_bse_code` 在新分支前） |
| `430047`（BSE 4xxxxx 6位） | `430047.BJ` | `430047.BJ` | 无（6 位不被 4-5 位规则捕获） |
| `510300`（ETF 6位） | `510300.SS` | `510300.SS` | 无（ETF 分支在新分支前） |
| `AAPL` | `AAPL` | `AAPL` | 无（美股分支在新分支前） |
| `7203.T` | `7203.T` | `7203.T` | 无（JP suffix 分支在新分支前） |

## 1-3 位裸数字为何故意不在本次修复范围
1-3 位裸数字（如 `'1'`、`'12'`、`'123'`）实际不会通过 STOCK_LIST 或 fetcher 调用进入 `_convert_stock_code()`，但仍保留原本的 `.SZ` 兜底行为以维持既有边缘行为不变。issue #2091 中 maintainer 的建议也是「4 到 5 位纯数字视为港股」，本 PR 严格按该口径修复。

## 测试
新增 `tests/test_yfinance_hk_bare_code.py`，23 个测试覆盖：
- HK 前缀分支无 regression（3 个）
- 裸 4-5 位数字路由到 `.HK` 含补零验证（5 个：02513、00700、09988、0001、0941）
- A 股 600/601/688/300/002 等路由无变化（5 个）
- BSE 4xxxxx / 8xxxxx / 920xxx 6 位路由无变化（3 个）
- ETF / 美股 / JP / KR / 直通后缀等无变化（7 个）

```bash
$ pytest tests/test_yfinance_hk_bare_code.py -q
============================== 23 passed in 0.23s ==============================

$ pytest tests/ -k "yfinance or hk_code or convert_stock_code" -q
============== 71 passed, 4862 deselected, 20 warnings in 16.19s ===============
```

## 风险
- 行为变化仅在「4-5 位纯数字裸码」输入域，此域内原行为是 Yahoo 404 失败，新行为是路由港股。不存在把「原本成功的查询改成失败」的路径。
- 与 akshare / longbridge 的 HK 判定差异：akshare `is_hk_stock_code` 只把 5 位纯数字判为 HK（4 位裸数字 akshare 不会判港股但也不会判 A 股，整体失败状态不变）；本 PR 在 yfinance 路径内把 4 位裸数字也判为港股指向 `.HK`。考虑到 4 位裸数字绝不可能是 A 股或 BSE，此差异只在「akshare 失败 + yfinance 试一次」的兜底链路里多救一个候选市场，不会破坏 akshare 主体路由。
- Phase 1 PR #2094 的 `parse_analysis_target()` 已能在解析层把 `02513` 正确归为 HK STOCK，本 PR 在 fetcher 层把这条解析结果对齐到对应数据源调用，两层独立但语义一致。

## 回滚
单文件 `data_provider/yfinance_fetcher.py` + 新增测试文件 + 一行 CHANGELOG。revert commit 即可完全回滚，没有副作用残留。