### PR TITLE
fix: ai_review 对事件载荷读取/解析失败输出可定位警告（fixes #2070）

### DIFF
--- a/.github/scripts/ai_review.py
+++ b/.github/scripts/ai_review.py
@@ -47,13 +47,29 @@ def run_git(args):
 
 
 def _event_payload():
+    """Read GitHub Actions event payload from ``GITHUB_EVENT_PATH``.
+
+    Returns an empty dict when the file is missing, unreadable, or contains
+    invalid JSON, preserving the prior graceful-degradation behaviour, but
+    emits a warning distinguishing the three failure modes so the failure
+    no longer silently collapses into "PR number is unavailable" downstream.
+    The warning records the exception type and the source path only; it
+    never prints the payload content.
+    """
     event_path = os.environ.get('GITHUB_EVENT_PATH')
-    if not event_path or not os.path.exists(event_path):
+    if not event_path:
+        return {}
+    if not os.path.exists(event_path):
+        print(f"⚠️ GITHUB_EVENT_PATH 指向的文件不存在: {event_path}，事件载荷降级为空对象")
         return {}
     try:
         with open(event_path, 'r', encoding='utf-8') as f:
             return json.load(f)
-    except (OSError, ValueError):
+    except OSError as exc:
+        print(f"⚠️ 事件载荷读取失败 ({type(exc).__name__}): {event_path}，降级为空对象")
+        return {}
+    except json.JSONDecodeError as exc:
+        print(f"⚠️ 事件载荷 JSON 解析失败 ({type(exc).__name__}): {event_path}，降级为空对象")
         return {}
 
 

--- a/.github/scripts/ai_review.py
+++ b/.github/scripts/ai_review.py
@@ -65,6 +65,12 @@ def _event_payload():
     try:
         with open(event_path, 'r', encoding='utf-8') as f:
             return json.load(f)
+    except UnicodeDecodeError as exc:
+        # 文件可读但字节序列不是合法 UTF-8(open 默认会抛 UnicodeDecodeError,
+        # 它是 ValueError 子类但既不是 OSError 也不是 json.JSONDecodeError,
+        # 旧 (OSError, ValueError) 接口接住了它,新分支需显式补充避免回归)。
+        print(f"⚠️ 事件载荷非 UTF-8 ({type(exc).__name__}): {event_path}，降级为空对象")
+        return {}
     except OSError as exc:
         print(f"⚠️ 事件载荷读取失败 ({type(exc).__name__}): {event_path}，降级为空对象")
         return {}

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -22,8 +22,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - [文档] `.env.example` 与 `.github/workflows/00-daily-analysis.yml` 同步映射 `TUSHARE_HTTP_URL`，避免出现"配置项有但 workflow 漏映射"的半修状态
 - [修复] #2051 PR Review 的特权 `pull_request_target` 流程不再检出 fork PR head：敏感文件、标签、报告与 AI 审查统一通过 GitHub API 将 PR 元数据和 diff 作为数据读取，只执行主分支可信脚本；Python 语法、Flake8、确定性检查和离线测试继续由无 secrets 的 `pull_request` CI / `backend-gate` 执行，兼容 `actions/checkout` 新增的 fork checkout 安全保护。
 - [修复] 修复 Windows 上 mimetypes 冷启动时读取注册表导致的进程卡死
-- [新功能] STOCK_LIST 解析新增 `parse_analysis_target()` 单条目解析契约，支持 sh/sz/bj/hk/us 前缀校验、裸码默认归股票、未命中前缀降级为股票三段语义；保留现有 `split_stock_list()`/`serialize_stock_list()` 行为不变，并对外暴露 `IndexRegistry`、`AnalysisTarget`、`ParseStatus`、`default_index_registry()` 以便上层注入自定义指数白名单（关联 issue #2063 Phase 1）
-- [修复] YfinanceFetcher 路由：4-5 位纯数字裸港股码（如 `02513`、`00700`、`0001`）此前落入「无法确定市场默认深市」兜底分支，被错误转成 `02513.SZ` 导致 Yahoo Finance 404、日线链路失败；新增 4-5 位裸数字先于 `.SZ` 兜底分流到 `.HK` 的分支，复用 `HK` 前缀分支的补零逻辑，避免新港股代码在 yfinance 路径静默失败。A 股（6 位）/BSE（4 或 6 位 4xxxxx/8xxxxx/920xxx）/ETF/JP/KR/TW/US 等其它路由保持不变（fixes #2091）
 - [修复] GitHub Actions PR Review 流程中的 `_event_payload()` 此前用 `except (OSError, ValueError): return {}` 把「事件文件缺失」「文件不可读」「JSON 非法」三类异常统一吞成空对象，下游只表现为 `PR number is unavailable` 无法定位根因；现保留空对象降级行为不变，但分别对三类失败输出不含载荷内容的警告（仅含异常类型与 `GITHUB_EVENT_PATH` 源路径），并补齐三类降级路径与「坏载荷导致 PR 编号不可用」链路的回归测试（fixes #2070）
 
 ## [3.27.0] - 2026-07-19

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -22,6 +22,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - [文档] `.env.example` 与 `.github/workflows/00-daily-analysis.yml` 同步映射 `TUSHARE_HTTP_URL`，避免出现"配置项有但 workflow 漏映射"的半修状态
 - [修复] #2051 PR Review 的特权 `pull_request_target` 流程不再检出 fork PR head：敏感文件、标签、报告与 AI 审查统一通过 GitHub API 将 PR 元数据和 diff 作为数据读取，只执行主分支可信脚本；Python 语法、Flake8、确定性检查和离线测试继续由无 secrets 的 `pull_request` CI / `backend-gate` 执行，兼容 `actions/checkout` 新增的 fork checkout 安全保护。
 - [修复] 修复 Windows 上 mimetypes 冷启动时读取注册表导致的进程卡死
+- [新功能] STOCK_LIST 解析新增 `parse_analysis_target()` 单条目解析契约，支持 sh/sz/bj/hk/us 前缀校验、裸码默认归股票、未命中前缀降级为股票三段语义；保留现有 `split_stock_list()`/`serialize_stock_list()` 行为不变，并对外暴露 `IndexRegistry`、`AnalysisTarget`、`ParseStatus`、`default_index_registry()` 以便上层注入自定义指数白名单（关联 issue #2063 Phase 1）
+- [修复] YfinanceFetcher 路由：4-5 位纯数字裸港股码（如 `02513`、`00700`、`0001`）此前落入「无法确定市场默认深市」兜底分支，被错误转成 `02513.SZ` 导致 Yahoo Finance 404、日线链路失败；新增 4-5 位裸数字先于 `.SZ` 兜底分流到 `.HK` 的分支，复用 `HK` 前缀分支的补零逻辑，避免新港股代码在 yfinance 路径静默失败。A 股（6 位）/BSE（4 或 6 位 4xxxxx/8xxxxx/920xxx）/ETF/JP/KR/TW/US 等其它路由保持不变（fixes #2091）
+- [修复] GitHub Actions PR Review 流程中的 `_event_payload()` 此前用 `except (OSError, ValueError): return {}` 把「事件文件缺失」「文件不可读」「JSON 非法」三类异常统一吞成空对象，下游只表现为 `PR number is unavailable` 无法定位根因；现保留空对象降级行为不变，但分别对三类失败输出不含载荷内容的警告（仅含异常类型与 `GITHUB_EVENT_PATH` 源路径），并补齐三类降级路径与「坏载荷导致 PR 编号不可用」链路的回归测试（fixes #2070）
 
 ## [3.27.0] - 2026-07-19
 

--- a/tests/test_ai_review_github_api.py
+++ b/tests/test_ai_review_github_api.py
@@ -182,6 +182,31 @@ def test_event_payload_valid_json_returns_payload_no_warning(monkeypatch, tmp_pa
     assert captured.out == ''
 
 
+def test_event_payload_non_utf8_logs_unicode_error(monkeypatch, tmp_path, capsys):
+    """When the event payload file is readable but contains non-UTF-8 bytes,
+    _event_payload() preserves the empty-payload degradation and logs the
+    UnicodeDecodeError-derived exception class plus the source path.
+
+    Regression for the codex P2 review point on PR #2096: the previous
+    `except (OSError, ValueError)` bucket implicitly caught UnicodeDecodeError
+    (a ValueError subclass); splitting the handler into OSError + JSONDecodeError
+    left UnicodeDecodeError uncaught, which would terminate the review instead
+    of degrading. The dedicated UnicodeDecodeError branch restores parity.
+    """
+    bad = tmp_path / 'event.json'
+    # 写入非法 UTF-8 字节序列 (0xff 0xfe 不构成合法 UTF-8 起始)
+    bad.write_bytes(b'\xff\xfe\x00\x00not-utf8')
+    monkeypatch.setenv('GITHUB_EVENT_PATH', str(bad))
+
+    payload = ai_review._event_payload()
+
+    assert payload == {}
+    captured = capsys.readouterr()
+    assert '事件载荷非 UTF-8' in captured.out
+    assert 'UnicodeDecodeError' in captured.out
+    assert str(bad) in captured.out
+
+
 def test_pull_request_number_failure_after_bad_event_payload(monkeypatch, tmp_path, capsys):
     """When PR_NUMBER is unset and the event payload is unreadable, the
     chain must surface a clearly-named RuntimeError instead of silently

--- a/tests/test_ai_review_github_api.py
+++ b/tests/test_ai_review_github_api.py
@@ -106,3 +106,100 @@ def test_delegated_ci_context_does_not_claim_success(monkeypatch):
 
     assert 'backend-gate' in context
     assert '不假设并行 CI 已通过' in context
+
+
+def test_event_payload_missing_file_logs_warning(monkeypatch, tmp_path, capsys):
+    """When GITHUB_EVENT_PATH points to a non-existent file, _event_payload()
+    returns {} and prints a warning distinguishing 'file missing' from the
+    other failure modes (regression for issue #2070)."""
+    missing = tmp_path / 'does-not-exist.json'
+    monkeypatch.setenv('GITHUB_EVENT_PATH', str(missing))
+
+    payload = ai_review._event_payload()
+
+    assert payload == {}
+    captured = capsys.readouterr()
+    assert 'GITHUB_EVENT_PATH 指向的文件不存在' in captured.out
+    assert str(missing) in captured.out
+
+
+def test_event_payload_unreadable_file_logs_oserror(monkeypatch, tmp_path, capsys):
+    """When the event payload file exists but cannot be read, _event_payload()
+    preserves the empty-payload degradation but logs the OSError-derived
+    exception class and the source path (regression for issue #2070)."""
+    # Make a file and strip read permissions so open() raises PermissionError
+    # (a subclass of OSError). Skip on platforms where chmod is a no-op for
+    # the current user.
+    unreadable = tmp_path / 'event.json'
+    unreadable.write_text('{"pull_request": {"number": 1}}', encoding='utf-8')
+    unreadable.chmod(0o000)
+
+    monkeypatch.setenv('GITHUB_EVENT_PATH', str(unreadable))
+
+    try:
+        payload = ai_review._event_payload()
+    finally:
+        unreadable.chmod(0o600)
+
+    # If the test runner is root (chmod is a no-op), skip the assertion:
+    # the file may actually be readable on such hosts. Either way it must
+    # not raise.
+    if payload == {}:
+        captured = capsys.readouterr()
+        assert '事件载荷读取失败' in captured.out
+        assert str(unreadable) in captured.out
+
+
+def test_event_payload_invalid_json_logs_parse_error(monkeypatch, tmp_path, capsys):
+    """When the event payload file contains invalid JSON, _event_payload()
+    preserves the empty-payload degradation but logs the JSONDecodeError-
+    derived exception class and the source path (regression for issue #2070).
+    """
+    bad = tmp_path / 'event.json'
+    bad.write_text('not-json-at-all', encoding='utf-8')
+    monkeypatch.setenv('GITHUB_EVENT_PATH', str(bad))
+
+    payload = ai_review._event_payload()
+
+    assert payload == {}
+    captured = capsys.readouterr()
+    assert '事件载荷 JSON 解析失败' in captured.out
+    assert str(bad) in captured.out
+
+
+def test_event_payload_valid_json_returns_payload_no_warning(monkeypatch, tmp_path, capsys):
+    """The happy path: a readable, valid JSON file yields the payload and
+    prints no warning. Guards against the warnings accidentally firing on
+    the success path (regression for issue #2070)."""
+    good = tmp_path / 'event.json'
+    good.write_text('{"pull_request": {"number": 4242}}', encoding='utf-8')
+    monkeypatch.setenv('GITHUB_EVENT_PATH', str(good))
+
+    payload = ai_review._event_payload()
+
+    assert payload == {'pull_request': {'number': 4242}}
+    captured = capsys.readouterr()
+    assert captured.out == ''
+
+
+def test_pull_request_number_failure_after_bad_event_payload(monkeypatch, tmp_path, capsys):
+    """When PR_NUMBER is unset and the event payload is unreadable, the
+    chain must surface a clearly-named RuntimeError instead of silently
+    treating the run as success (regression for issue #2070). The warning
+    is printed first so logs distinguish 'bad payload' from 'no PR number'.
+    """
+    bad = tmp_path / 'event.json'
+    bad.write_text('{invalid json', encoding='utf-8')
+    monkeypatch.setenv('GITHUB_EVENT_PATH', str(bad))
+    monkeypatch.delenv('PR_NUMBER', raising=False)
+
+    raised = False
+    try:
+        ai_review._pull_request_number()
+    except RuntimeError as exc:
+        raised = True
+        assert 'PR number is unavailable' in str(exc)
+
+    assert raised, 'Expected RuntimeError when PR number cannot be derived'
+    captured = capsys.readouterr()
+    assert '事件载荷 JSON 解析失败' in captured.out


### PR DESCRIPTION
## 关联 issue
Closes #2070

## 根因
`.github/scripts/ai_review.py::_event_payload()` 在 maintainer 自评中已定位：

```python
except (OSError, ValueError):
    return {}
```

把「事件文件不存在」「文件不可读」「JSON 解析失败」三类异常统一吞成空对象，下游 `_pull_request_number()` 只能抛 `PR number is unavailable`，日志无法区分根因。maintainer 在 issue 中给出了完整修复方向。

## 改动
保留「空对象降级」的现有契约（`PR_NUMBER` 显式提供时坏掉的事件文件不应阻断 GitHub API 审查），但将单一 except 拆成三段：

```python
def _event_payload():
    event_path = os.environ.get('GITHUB_EVENT_PATH')
    if not event_path:
        return {}
    if not os.path.exists(event_path):
        print(f"⚠️ GITHUB_EVENT_PATH 指向的文件不存在: {event_path}，事件载荷降级为空对象")
        return {}
    try:
        with open(event_path, 'r', encoding='utf-8') as f:
            return json.load(f)
    except OSError as exc:
        print(f"⚠️ 事件载荷读取失败 ({type(exc).__name__}): {event_path}，降级为空对象")
        return {}
    except json.JSONDecodeError as exc:
        print(f"⚠️ 事件载荷 JSON 解析失败 ({type(exc).__name__}): {event_path}，降级为空对象")
        return {}
```

警告只输出异常类名与 `GITHUB_EVENT_PATH` 源路径，**不含载荷内容**（按 issue 要求）。

## 行为契约
按 maintainer 在 issue 评论中的两条契约执行：

1. ✅ `PR_NUMBER` 已显式提供时，坏掉的事件文件不阻断 GitHub API 审查 —— `_pull_request_number()` 先验 `PR_NUMBER`，命中则直接 return，不会调用 `_event_payload()`。
2. ✅ `PR_NUMBER` 未提供时，事件载荷读取失败输出可定位原因 —— 警告先打印（区分三种失败模式），`_pull_request_number()` 仍会抛 `PR number is unavailable`，但日志上游已有「事件载荷 JSON 解析失败」之类记录，可定位真正根因。

历史路径 `test_manual_dispatch_context_comes_from_github_api` 已覆盖「`GITHUB_EVENT_PATH` 未设置 + `PR_NUMBER` 提供」契约。

## 测试
`tests/test_ai_review_github_api.py` 新增 5 个回归测试（共 10 个 pass 0.09s）：

| 测试 | 输入 | 期望 |
| --- | --- | --- |
| `test_event_payload_missing_file_logs_warning` | `GITHUB_EVENT_PATH` 指向不存在文件 | `{}` + 警告 `GITHUB_EVENT_PATH 指向的文件不存在` |
| `test_event_payload_unreadable_file_logs_oserror` | chmod 0o000 不可读 | `{}` + 警告 `事件载荷读取失败` (root 跑者跳过断言) |
| `test_event_payload_invalid_json_logs_parse_error` | `not-json-at-all` | `{}` + 警告 `事件载荷 JSON 解析失败` |
| `test_event_payload_valid_json_returns_payload_no_warning` | valid JSON | `payload` + stdout 空（守 success 路径不误警） |
| `test_pull_request_number_failure_after_bad_event_payload` | `PR_NUMBER` 未设 + 坏 JSON | `RuntimeError('PR number is unavailable')` + 警告先于异常打印 |

## 风险
- 行为变化仅在「事件载荷读取/解析失败」这一错误路径，原路径是静默吞+模糊报错，新路径是显式警告+模糊报错。不存在把「原本成功的查询改成失败」的可能。
- 警告通过 `print()` 输出沿用本脚本既有风格（`grep -nE "logger|logging|print\(" .github/scripts/ai_review.py` 显示全脚本用 print，不引入 logging 模块以最小化攻击面）。
- `JSONDecodeError` 是 `ValueError` 子类，except 顺序 `OSError -> JSONDecodeError` 正确，OSError 在前不会捕获 JSONDecodeError，JSONDecodeError 在后专门承接。

## 回滚
单文件 `.github/scripts/ai_review.py` + 测试文件 + 1 行 CHANGELOG，revert 即可完全回滚。