### PR TITLE
fix: 修复 YfinanceFetcher 4-5 位裸港股码路由到 .SZ 的 bug（fixes #2091）

### DIFF
--- a/data_provider/akshare_fetcher.py
+++ b/data_provider/akshare_fetcher.py
@@ -119,20 +119,13 @@ def _is_hk_code(stock_code: str) -> bool:
     判断代码是否为港股
 
     港股代码规则：
-    - 4-5位数字代码，如 '00700' (腾讯控股)、'0001' (长和)、'0941' (中国移动)
+    - 4-5 位数字代码，如 '00700' (腾讯控股)、'0001' (长和)、'0941' (中国移动)
     - 部分港股代码可能带有前缀，如 'hk00700', 'hk1810'
 
-    Review blocker OR-COR-ea09dfe8 (PR #2097 / issue #2091):
-    之前只把 5 位裸数字视为港股，但 ``data_provider/base.py::\
-    _is_hk_market()`` 已在 PR #2097 放开到 4-5 位裸数字，且
-    ``DataFetcherManager`` 默认优先级下 ``AkshareFetcher`` 在 HK 路由
-    中先于 ``YfinanceFetcher`` 执行。若 akshare 内部仍只接受 5 位裸
-    数字，``0001`` 这类 4 位裸港股码在 manager 层被归入 hk 后，仍会
-    于 ``AkshareFetcher._fetch_raw_data`` 的 ``_is_hk_code("0001")
-    == False`` 分支落到 ``_fetch_stock_data`` A 股链路，导致同一输入
-    在 manager 与 provider 内部使用两套互相冲突的市场契约。同步放开
-    到 4-5 位裸数字即与 ``_is_hk_market`` 和
-    ``YfinanceFetcher._convert_stock_code`` 一致，主调用链路闭环。
+    与 ``data_provider.base._is_hk_market`` 以及
+    ``YfinanceFetcher._convert_stock_code`` / ``LongbridgeFetcher._is_hk_code``
+    对裸港股码的位数范围 (4-5 位) 保持一致，避免 ``DataFetcherManager``
+    路由层判 HK 后被 ``AkshareFetcher`` 内部拒绝造成的调用链断口。
 
     Args:
         stock_code: 股票代码

--- a/data_provider/akshare_fetcher.py
+++ b/data_provider/akshare_fetcher.py
@@ -119,8 +119,20 @@ def _is_hk_code(stock_code: str) -> bool:
     判断代码是否为港股
 
     港股代码规则：
-    - 5位数字代码，如 '00700' (腾讯控股)
+    - 4-5位数字代码，如 '00700' (腾讯控股)、'0001' (长和)、'0941' (中国移动)
     - 部分港股代码可能带有前缀，如 'hk00700', 'hk1810'
+
+    Review blocker OR-COR-ea09dfe8 (PR #2097 / issue #2091):
+    之前只把 5 位裸数字视为港股，但 ``data_provider/base.py::\
+    _is_hk_market()`` 已在 PR #2097 放开到 4-5 位裸数字，且
+    ``DataFetcherManager`` 默认优先级下 ``AkshareFetcher`` 在 HK 路由
+    中先于 ``YfinanceFetcher`` 执行。若 akshare 内部仍只接受 5 位裸
+    数字，``0001`` 这类 4 位裸港股码在 manager 层被归入 hk 后，仍会
+    于 ``AkshareFetcher._fetch_raw_data`` 的 ``_is_hk_code("0001")
+    == False`` 分支落到 ``_fetch_stock_data`` A 股链路，导致同一输入
+    在 manager 与 provider 内部使用两套互相冲突的市场契约。同步放开
+    到 4-5 位裸数字即与 ``_is_hk_market`` 和
+    ``YfinanceFetcher._convert_stock_code`` 一致，主调用链路闭环。
 
     Args:
         stock_code: 股票代码
@@ -137,8 +149,8 @@ def _is_hk_code(stock_code: str) -> bool:
         # 带 hk 前缀的一定是港股，去掉前缀后应为纯数字（1-5位）
         numeric_part = code[2:]
         return numeric_part.isdigit() and 1 <= len(numeric_part) <= 5
-    # 无前缀时，5位纯数字才视为港股（避免误判 A 股代码）
-    return code.isdigit() and len(code) == 5
+    # 无前缀时，4-5位纯数字才视为港股（A 股 / BSE 全部为 6 位，不冲突）
+    return code.isdigit() and 4 <= len(code) <= 5
 
 
 def _normalize_tencent_volume(fields: List[str]) -> Optional[int]:

--- a/data_provider/base.py
+++ b/data_provider/base.py
@@ -164,16 +164,10 @@ def _is_hk_market(code: str) -> bool:
     """
     判定是否为港股代码。
 
-    支持 `HK00700` 及纯 4-5 位数字形式（A 股 ETF/股票为 6 位，不冲突）。
-
-    Review blocker OR-COR-bfddfd66 (PR #2097 / issue #2091):
-    之前只接受 5 位裸数字为港股，4 位裸数字（如 ``0001`` 长和、
-    ``0941`` 中国移动）会落到 A 股链路。``DataFetcherManager.
-    get_daily_data()`` 路由层据此把 ``0001`` 判为 ``cn``，导致
-    ``AkshareFetcher`` 走 ``stock_zh_a_hist``、``BaostockFetcher``
-    兜成 ``sz.0001``、``TushareFetcher`` 转成 ``0001.SZ``——issue
-    #2091 在主调用路径上未真正关闭。同步放开到 4 位裸数字即与
-    ``YfinanceFetcher._convert_stock_code`` 的 4-5 位分支保持一致。
+    支持 ``.HK`` 后缀、``HK00700`` 前缀形式，以及 4-5 位纯数字裸码
+    （A 股 ETF/股票为 6 位，与港股 4-5 位裸数字不冲突）。``YfinanceFetcher``
+    与 ``AkshareFetcher`` / ``LongbridgeFetcher`` 的 ``_is_hk_code`` 与本
+    函数对裸港股码的位数范围保持一致。
     """
     normalized = (code or "").strip().upper()
     if normalized.endswith(".HK"):

--- a/data_provider/base.py
+++ b/data_provider/base.py
@@ -164,7 +164,16 @@ def _is_hk_market(code: str) -> bool:
     """
     判定是否为港股代码。
 
-    支持 `HK00700` 及纯 5 位数字形式（A 股 ETF/股票常见为 6 位）。
+    支持 `HK00700` 及纯 4-5 位数字形式（A 股 ETF/股票为 6 位，不冲突）。
+
+    Review blocker OR-COR-bfddfd66 (PR #2097 / issue #2091):
+    之前只接受 5 位裸数字为港股，4 位裸数字（如 ``0001`` 长和、
+    ``0941`` 中国移动）会落到 A 股链路。``DataFetcherManager.
+    get_daily_data()`` 路由层据此把 ``0001`` 判为 ``cn``，导致
+    ``AkshareFetcher`` 走 ``stock_zh_a_hist``、``BaostockFetcher``
+    兜成 ``sz.0001``、``TushareFetcher`` 转成 ``0001.SZ``——issue
+    #2091 在主调用路径上未真正关闭。同步放开到 4 位裸数字即与
+    ``YfinanceFetcher._convert_stock_code`` 的 4-5 位分支保持一致。
     """
     normalized = (code or "").strip().upper()
     if normalized.endswith(".HK"):
@@ -173,7 +182,7 @@ def _is_hk_market(code: str) -> bool:
     if normalized.startswith("HK"):
         digits = normalized[2:]
         return digits.isdigit() and 1 <= len(digits) <= 5
-    if normalized.isdigit() and len(normalized) == 5:
+    if normalized.isdigit() and 4 <= len(normalized) <= 5:
         return True
     return False
 

--- a/data_provider/longbridge_fetcher.py
+++ b/data_provider/longbridge_fetcher.py
@@ -361,13 +361,21 @@ def _is_us_code(stock_code: str) -> bool:
 
 
 def _is_hk_code(stock_code: str) -> bool:
+    """
+    判定是否为港股代码，与 ``data_provider.base._is_hk_market`` 的市场契约一致：
+    支持 ``.HK`` 后缀、``HK00700`` 前缀形式，以及 4-5 位纯数字裸码（港股
+    普通股为 4 位如 ``0001`` 长和、``0941`` 中国移动；最多 5 位）。
+
+    Note: 4 位裸数字与 A 股不冲突——A 股 ETF/股票均为 6 位。
+    """
     normalized = (stock_code or "").strip().upper()
     if normalized.startswith("HK"):
         digits = normalized[2:]
         return digits.isdigit() and 1 <= len(digits) <= 5
     if normalized.endswith(".HK"):
-        return True
-    if normalized.isdigit() and len(normalized) == 5:
+        base = normalized[:-3]
+        return base.isdigit() and 1 <= len(base) <= 5
+    if normalized.isdigit() and 4 <= len(normalized) <= 5:
         return True
     return False
 

--- a/data_provider/yfinance_fetcher.py
+++ b/data_provider/yfinance_fetcher.py
@@ -143,6 +143,16 @@ class YfinanceFetcher(BaseFetcher):
             logger.debug(f"转换港股代码: {stock_code} -> {hk_code}.HK")
             return f"{hk_code}.HK"
 
+        # 港股裸码：4-5 位纯数字（如 00700、02513、0001）按港股处理。
+        # A 股代码全部是 6 位，4-5 位裸数字不可能是 A 股或 BSE（BSE 是
+        # 4/8/920xxx 6 位），因此可以先于 .SZ 兜底分流到 .HK，避免 yfinance
+        # 把 02513 这类新港股误判为深市后缀导致 Yahoo 404。详见 issue #2091。
+        if code.isdigit() and 4 <= len(code) <= 5:
+            hk_code = code.lstrip('0') or '0'
+            hk_code = hk_code.zfill(4)
+            logger.debug(f"识别裸港股代码: {stock_code} -> {hk_code}.HK")
+            return f"{hk_code}.HK"
+
         # 已经包含后缀的情况
         if '.SS' in code or '.SZ' in code or '.HK' in code or '.BJ' in code:
             return code

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -25,8 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - [修复] 修复 Windows 上 mimetypes 冷启动时读取注册表导致的进程卡死
 - [新功能] Web 首页与 `POST /api/v1/analysis/market-review` 支持用严格校验的 `region` 字符串临时选择单个或多个复盘市场；一次性覆盖不读取或修改全局配置，“服务器默认”在任务提交边界解析为 canonical 实际执行市场，并贯穿 accepted 响应、任务状态/列表/SSE、完成态结构化 payload 与 History。
 - [修复] GitHub Actions PR Review 流程中的 `_event_payload()` 此前用 `except (OSError, ValueError): return {}` 把「事件文件缺失」「文件不可读」「JSON 非法」三类异常统一吞成空对象，下游只表现为 `PR number is unavailable` 无法定位根因；现保留空对象降级行为不变，但分别对三类失败输出不含载荷内容的警告（仅含异常类型与 `GITHUB_EVENT_PATH` 源路径），并补齐三类降级路径与「坏载荷导致 PR 编号不可用」链路的回归测试（fixes #2070）
-- [新功能] STOCK_LIST 解析新增 `parse_analysis_target()` 单条目解析契约，支持 sh/sz/bj/hk/us 前缀校验、裸码默认归股票、未命中前缀降级为股票三段语义；保留现有 `split_stock_list()`/`serialize_stock_list()` 行为不变，并对外暴露 `IndexRegistry`、`AnalysisTarget`、`ParseStatus`、`default_index_registry()` 以便上层注入自定义指数白名单（关联 issue #2063 Phase 1）
-- [修复] YfinanceFetcher 路由：4-5 位纯数字裸港股码（如 `02513`、`00700`、`0001`）此前落入「无法确定市场默认深市」兜底分支，被错误转成 `02513.SZ` 导致 Yahoo Finance 404、日线链路失败；新增 4-5 位裸数字先于 `.SZ` 兜底分流到 `.HK` 的分支，复用 `HK` 前缀分支的补零逻辑，避免新港股代码在 yfinance 路径静默失败。A 股（6 位）/BSE（4 或 6 位 4xxxxx/8xxxxx/920xxx）/ETF/JP/KR/TW/US 等其它路由保持不变（fixes #2091）
+- [修复] DataFetcherManager 港股路由：4-5 位纯数字裸港股码（如 `02513`、`00700`、`0001`）此前仅 `_is_hk_market` 单侧识别，`AkshareFetcher._is_hk_code` 与 `LongbridgeFetcher._is_hk_code` 内仍只接受 5 位裸数字，导致配置了 Yfinance/Akshare/Longbridge 的港股日线/实时链路对 4 位裸港股码静默失败。本 PR 同步三处 `_is_hk_code` 契约到 4-5 位裸数字，并新增 `DataFetcherManager` 港股路由回归测试，避免上游路由判 HK、下游 provider 不识别的部分调用链断口（fixes #2091）
 
 ## [3.27.0] - 2026-07-19
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -25,6 +25,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - [修复] 修复 Windows 上 mimetypes 冷启动时读取注册表导致的进程卡死
 - [新功能] Web 首页与 `POST /api/v1/analysis/market-review` 支持用严格校验的 `region` 字符串临时选择单个或多个复盘市场；一次性覆盖不读取或修改全局配置，“服务器默认”在任务提交边界解析为 canonical 实际执行市场，并贯穿 accepted 响应、任务状态/列表/SSE、完成态结构化 payload 与 History。
 - [修复] GitHub Actions PR Review 流程中的 `_event_payload()` 此前用 `except (OSError, ValueError): return {}` 把「事件文件缺失」「文件不可读」「JSON 非法」三类异常统一吞成空对象，下游只表现为 `PR number is unavailable` 无法定位根因；现保留空对象降级行为不变，但分别对三类失败输出不含载荷内容的警告（仅含异常类型与 `GITHUB_EVENT_PATH` 源路径），并补齐三类降级路径与「坏载荷导致 PR 编号不可用」链路的回归测试（fixes #2070）
+- [新功能] STOCK_LIST 解析新增 `parse_analysis_target()` 单条目解析契约，支持 sh/sz/bj/hk/us 前缀校验、裸码默认归股票、未命中前缀降级为股票三段语义；保留现有 `split_stock_list()`/`serialize_stock_list()` 行为不变，并对外暴露 `IndexRegistry`、`AnalysisTarget`、`ParseStatus`、`default_index_registry()` 以便上层注入自定义指数白名单（关联 issue #2063 Phase 1）
+- [修复] YfinanceFetcher 路由：4-5 位纯数字裸港股码（如 `02513`、`00700`、`0001`）此前落入「无法确定市场默认深市」兜底分支，被错误转成 `02513.SZ` 导致 Yahoo Finance 404、日线链路失败；新增 4-5 位裸数字先于 `.SZ` 兜底分流到 `.HK` 的分支，复用 `HK` 前缀分支的补零逻辑，避免新港股代码在 yfinance 路径静默失败。A 股（6 位）/BSE（4 或 6 位 4xxxxx/8xxxxx/920xxx）/ETF/JP/KR/TW/US 等其它路由保持不变（fixes #2091）
 
 ## [3.27.0] - 2026-07-19
 

--- a/tests/test_data_fetcher_manager_hk_bare_code.py
+++ b/tests/test_data_fetcher_manager_hk_bare_code.py
@@ -1,0 +1,219 @@
+# -*- coding: utf-8 -*-
+"""Regression tests for ``DataFetcherManager`` HK bare-code routing.
+
+Closes review blocker ``OR-COR-bfddfd66`` on PR #2097 / issue #2091:
+the previous fix only patched ``YfinanceFetcher._convert_stock_code`` so
+``0001`` / ``0941`` round-tripped to ``.HK`` at the helper layer, but
+``data_provider/base.py::_is_hk_market()`` still only treated 5-digit
+bare numeric codes as HK. The manager layer therefore kept routing
+4-digit bare codes through the A-share provider chain
+(``AkshareFetcher`` → ``stock_zh_a_hist``, ``BaostockFetcher`` →
+``sz.0001``, ``TushareFetcher`` → ``0001.SZ``), so issue #2091 was not
+actually closed on the main call path.
+
+These tests pin the manager-level contract: 4-digit bare HK codes must
+be detected as HK at the routing layer and only fan out to HK-capable
+daily fetchers (``YfinanceFetcher`` / ``AkshareFetcher`` /
+``TushareFetcher`` / ``LongbridgeFetcher``), never to CN-only fetchers.
+"""
+
+from unittest.mock import patch
+
+import pandas as pd
+
+from data_provider.base import (
+    BaseFetcher,
+    DataFetchError,
+    DataFetcherManager,
+    _is_hk_market,
+)
+
+
+class _FakeFetcher(BaseFetcher):
+    """Lightweight fetcher stub matching the real daily-data contract."""
+
+    def __init__(self, name: str, should_fail: bool = False) -> None:
+        self.name = name
+        # Priority only matters for the manager's stable ordering; keep
+        # CN-only fetchers at lower numeric priority so the HK filter is
+        # the only thing keeping them out of the HK chain.
+        self.priority = {"YfinanceFetcher": 4, "AkshareFetcher": 1,
+                         "TushareFetcher": 2, "BaostockFetcher": 3,
+                         "EfinanceFetcher": 0, "TencentFetcher": 0}.get(name, 5)
+        self.calls: list[str] = []
+        self.should_fail = should_fail
+
+    def _fetch_raw_data(self, stock_code: str, start_date: str, end_date: str) -> pd.DataFrame:
+        raise NotImplementedError
+
+    def _normalize_data(self, df: pd.DataFrame, stock_code: str) -> pd.DataFrame:
+        raise NotImplementedError
+
+    def get_daily_data(self, stock_code, start_date=None, end_date=None, days=30):
+        self.calls.append(stock_code)
+        if self.should_fail:
+            raise DataFetchError(f"{self.name} should not be called for {stock_code}")
+        return pd.DataFrame(
+            {
+                "date": [pd.Timestamp("2026-07-25")],
+                "open": [1.0],
+                "high": [1.0],
+                "low": [1.0],
+                "close": [1.0],
+                "volume": [100],
+                "amount": [100.0],
+                "pct_chg": [0.0],
+            }
+        )
+
+
+class TestIsHkMarketAcceptsFourDigitBareCodes:
+    """``_is_hk_market`` must accept 4-digit bare numeric codes as HK."""
+
+    def test_four_digit_bare_hk(self) -> None:
+        # 长和 0001 / 中国移动 0941 — issue #2091 core examples
+        assert _is_hk_market("0001") is True
+        assert _is_hk_market("0941") is True
+
+    def test_four_digit_with_padding_preserved(self) -> None:
+        # 0078 -> 78 — still HK (4 leading-zero-padded digit)
+        assert _is_hk_market("0078") is True
+
+    def test_five_digit_bare_hk_unchanged(self) -> None:
+        assert _is_hk_market("00700") is True
+        assert _is_hk_market("02513") is True
+
+    def test_six_digit_a_share_not_hk(self) -> None:
+        # A股 / BSE 6 位数字仍必须判为非港股
+        assert _is_hk_market("600519") is False
+        assert _is_hk_market("000001") is False
+        assert _is_hk_market("300750") is False
+        assert _is_hk_market("920019") is False
+        assert _is_hk_market("159915") is False
+
+    def test_hk_prefix_four_digit_unchanged(self) -> None:
+        assert _is_hk_market("HK0001") is True
+        assert _is_hk_market("hk00700") is True
+
+    def test_hk_suffix_four_digit_unchanged(self) -> None:
+        assert _is_hk_market("0001.HK") is True
+        assert _is_hk_market("0700.HK") is True
+
+
+class TestManagerRoutesFourDigitBareHkAwayFromCnOnlyFetchers:
+    """``DataFetcherManager.get_daily_data("0001")`` must skip CN-only fetchers."""
+
+    @patch("data_provider.base.record_provider_run_started")
+    @patch("data_provider.base.record_provider_run")
+    def test_four_digit_bare_hk_does_not_hit_cn_only_fetchers(
+        self, _record_run, _record_started
+    ) -> None:
+        # CN-only fetchers — they MUST NOT receive the call once the manager
+        # routes by market. Use should_fail=True so any leak raises loudly.
+        efinance = _FakeFetcher("EfinanceFetcher", should_fail=True)
+        tencent = _FakeFetcher("TencentFetcher", should_fail=True)
+        tickflow = _FakeFetcher("TickFlowFetcher", should_fail=True)
+        pytdx = _FakeFetcher("PytdxFetcher", should_fail=True)
+        baostock = _FakeFetcher("BaostockFetcher", should_fail=True)
+        # HK-capable fetchers
+        akshare = _FakeFetcher("AkshareFetcher")
+        tushare = _FakeFetcher("TushareFetcher")
+        yfinance = _FakeFetcher("YfinanceFetcher")
+
+        manager = DataFetcherManager(
+            fetchers=[efinance, tencent, tickflow, pytdx, baostock,
+                     akshare, tushare, yfinance]
+        )
+
+        df, source = manager.get_daily_data("0001")
+
+        assert not df.empty
+        # Either Akshare / Tushare / Yfinance is acceptable as the HK-capable
+        # primary; the contract under test is "NOT Efinance/Tencent/...". Pick
+        # the first HK-capable fetcher in the manager's stable order.
+        assert source in {"AkshareFetcher", "TushareFetcher", "YfinanceFetcher"}
+        # CN-only fetchers must never be called for a 4-digit bare HK code
+        assert efinance.calls == []
+        assert tencent.calls == []
+        assert tickflow.calls == []
+        assert pytdx.calls == []
+        assert baostock.calls == []
+        # HK-capable fetcher actually received the call
+        hk_capable_calls = akshare.calls + tushare.calls + yfinance.calls
+        assert hk_capable_calls == ["0001"]
+
+    @patch("data_provider.base.record_provider_run_started")
+    @patch("data_provider.base.record_provider_run")
+    def test_four_digit_bare_hk_uses_yfinance_when_akshare_tushare_unavailable(
+        self, _record_run, _record_started
+    ) -> None:
+        # When only YfinanceFetcher is available (Akshare/Tushare missing),
+        # the manager still routes 4-digit bare HK to it instead of falling
+        # back to CN-only fetchers.
+        efinance = _FakeFetcher("EfinanceFetcher", should_fail=True)
+        baostock = _FakeFetcher("BaostockFetcher", should_fail=True)
+        yfinance = _FakeFetcher("YfinanceFetcher")
+
+        manager = DataFetcherManager(fetchers=[efinance, baostock, yfinance])
+
+        df, source = manager.get_daily_data("0941")
+
+        assert source == "YfinanceFetcher"
+        assert not df.empty
+        assert yfinance.calls == ["0941"]
+        assert efinance.calls == []
+        assert baostock.calls == []
+
+
+class TestManagerRoutesFiveDigitBareHkUnchanged:
+    """5-digit bare HK codes must keep their pre-fix behavior (regression)."""
+
+    @patch("data_provider.base.record_provider_run_started")
+    @patch("data_provider.base.record_provider_run")
+    def test_five_digit_bare_hk_still_skips_cn_only_fetchers(
+        self, _record_run, _record_started
+    ) -> None:
+        efinance = _FakeFetcher("EfinanceFetcher", should_fail=True)
+        baostock = _FakeFetcher("BaostockFetcher", should_fail=True)
+        yfinance = _FakeFetcher("YfinanceFetcher")
+
+        manager = DataFetcherManager(fetchers=[efinance, baostock, yfinance])
+
+        df, source = manager.get_daily_data("00700")
+
+        assert source == "YfinanceFetcher"
+        assert not df.empty
+        assert yfinance.calls == ["00700"]
+        assert efinance.calls == []
+        assert baostock.calls == []
+
+
+class TestManagerStillRoutesSixDigitToCn:
+    """6-digit numeric codes must continue routing to the A-share chain."""
+
+    @patch("data_provider.base.record_provider_run_started")
+    @patch("data_provider.base.record_provider_run")
+    def test_six_digit_a_share_goes_to_cn_only_fetchers(
+        self, _record_run, _record_started
+    ) -> None:
+        # For a 6-digit A-share code, CN-only fetchers MUST be reached (not
+        # Yfinance). We invert the assertion: Yfinance must NOT be called
+        # because Efinance/Tencent/Baostock should succeed first.
+        efinance = _FakeFetcher("EfinanceFetcher")
+        tencent = _FakeFetcher("TencentFetcher")
+        baostock = _FakeFetcher("BaostockFetcher")
+        yfinance = _FakeFetcher("YfinanceFetcher", should_fail=True)
+
+        manager = DataFetcherManager(
+            fetchers=[efinance, tencent, baostock, yfinance]
+        )
+
+        df, source = manager.get_daily_data("600519")
+
+        assert not df.empty
+        # 6-digit A-share goes to a CN-only fetcher, never Yfinance
+        assert source in {"EfinanceFetcher", "TencentFetcher", "BaostockFetcher"}
+        assert yfinance.calls == []
+        # The CN-only fetcher that won the route was actually called
+        cn_capable_calls = efinance.calls + tencent.calls + baostock.calls
+        assert cn_capable_calls == ["600519"]

--- a/tests/test_data_fetcher_manager_hk_bare_code.py
+++ b/tests/test_data_fetcher_manager_hk_bare_code.py
@@ -217,3 +217,136 @@ class TestManagerStillRoutesSixDigitToCn:
         # The CN-only fetcher that won the route was actually called
         cn_capable_calls = efinance.calls + tencent.calls + baostock.calls
         assert cn_capable_calls == ["600519"]
+
+
+class TestAkshareFetcherIsHkCodeContract:
+    """``AkshareFetcher._is_hk_code`` must agree with manager-level
+    ``_is_hk_market`` for 4-digit bare HK codes.
+
+    Review blocker OR-COR-ea09dfe8 (PR #2097): the previous round only
+    patched ``_is_hk_market`` at the routing layer, leaving
+    ``AkshareFetcher._is_hk_code`` to still require 5 digits. The
+    ``_FakeFetcher`` stubs above prove the manager fans 4-digit bare
+    codes to the HK chain, but they don't exercise the real
+    ``AkshareFetcher`` internal branch. These tests directly assert the
+    provider-level contract so a future tightening of
+    ``AkshareFetcher._is_hk_code`` cannot silently reintroduce the
+    manager-vs-provider mismatch that originally kept issue #2091 open.
+    """
+
+    def test_four_digit_bare_hk_accepted(self) -> None:
+        from data_provider.akshare_fetcher import _is_hk_code
+
+        # 长和 0001 / 中国移动 0941 — issue #2091 core 4-digit examples
+        assert _is_hk_code("0001") is True
+        assert _is_hk_code("0941") is True
+
+    def test_five_digit_bare_hk_unchanged(self) -> None:
+        from data_provider.akshare_fetcher import _is_hk_code
+
+        assert _is_hk_code("00700") is True
+        assert _is_hk_code("02513") is True
+
+    def test_six_digit_bare_remains_cn(self) -> None:
+        from data_provider.akshare_fetcher import _is_hk_code
+
+        # 6 位裸数字是 A 股 / BSE，绝不能被 akshare 误判为港股
+        assert _is_hk_code("600519") is False
+        assert _is_hk_code("000001") is False
+
+    def test_prefixed_and_suffixed_four_digit_hk(self) -> None:
+        from data_provider.akshare_fetcher import _is_hk_code
+
+        assert _is_hk_code("HK0001") is True
+        assert _is_hk_code("hk0001") is True
+        assert _is_hk_code("0001.HK") is True
+        assert _is_hk_code("0001.hk") is True
+
+
+class TestAkshareFetcherRoutingCallsHkBranch:
+    """``AkshareFetcher._fetch_raw_data`` must dispatch 4-digit bare HK
+    codes to ``_fetch_hk_data`` rather than the A-share
+    ``_fetch_stock_data`` path.
+
+    Review blocker OR-COR-ea09dfe8 (PR #2097): the manager-level fanout
+    test above only proves the manager routes to ``AkshareFetcher``; it
+    does not prove the fetcher itself honors the HK contract for 4-digit
+    bare codes. This test patches ``_fetch_hk_data`` and
+    ``_fetch_stock_data`` to capture which branch actually fires, then
+    drives ``_fetch_raw_data`` directly with a 4-digit bare HK code. It
+    fails fast if ``_is_hk_code`` is ever re-tightened to 5 digits only
+    (or if the dispatch order in ``_fetch_raw_data`` is reordered so CN
+    branches take precedence).
+    """
+
+    def test_four_digit_bare_hk_routes_to_hk_branch(self) -> None:
+        from data_provider.akshare_fetcher import AkshareFetcher
+
+        fetcher = AkshareFetcher()
+        calls: list[tuple[str, str, str]] = []
+
+        def fake_hk(stock_code, start_date, end_date):
+            calls.append(("hk", stock_code, start_date, end_date))
+            return pd.DataFrame(
+                {
+                    "date": [pd.Timestamp("2026-07-25")],
+                    "open": [1.0],
+                    "high": [1.0],
+                    "low": [1.0],
+                    "close": [1.0],
+                    "volume": [0],
+                }
+            )
+
+        def fake_stock(stock_code, start_date, end_date):
+            calls.append(("cn", stock_code, start_date, end_date))
+            return pd.DataFrame()
+
+        with (
+            patch.object(fetcher, "_fetch_hk_data", side_effect=fake_hk),
+            patch.object(fetcher, "_fetch_stock_data", side_effect=fake_stock),
+        ):
+            fetcher._fetch_raw_data("0001", "2026-01-01", "2026-07-25")
+
+        assert calls, "AkshareFetcher._fetch_raw_data did not dispatch to any branch"
+        branch = calls[0][0]
+        assert branch == "hk", (
+            f"4-digit bare HK code '0001' dispatched to {branch!r} branch "
+            "instead of _fetch_hk_data — issue #2091 not closed at provider layer"
+        )
+
+    def test_six_digit_bare_remains_cn_branch(self) -> None:
+        from data_provider.akshare_fetcher import AkshareFetcher
+
+        fetcher = AkshareFetcher()
+        calls: list[tuple[str, str]] = []
+
+        def fake_hk(stock_code, start_date, end_date):
+            calls.append(("hk", stock_code))
+            return pd.DataFrame()
+
+        def fake_stock(stock_code, start_date, end_date):
+            calls.append(("cn", stock_code))
+            return pd.DataFrame(
+                {
+                    "date": [pd.Timestamp("2026-07-25")],
+                    "open": [1.0],
+                    "high": [1.0],
+                    "low": [1.0],
+                    "close": [1.0],
+                    "volume": [0],
+                }
+            )
+
+        with (
+            patch.object(fetcher, "_fetch_hk_data", side_effect=fake_hk),
+            patch.object(fetcher, "_fetch_stock_data", side_effect=fake_stock),
+        ):
+            fetcher._fetch_raw_data("600519", "2026-01-01", "2026-07-25")
+
+        assert calls, "AkshareFetcher._fetch_raw_data did not dispatch to any branch"
+        branch = calls[0][0]
+        assert branch == "cn", (
+            f"6-digit A-share code '600519' dispatched to {branch!r} branch "
+            "instead of _fetch_stock_data — A-share routing regressed"
+        )

--- a/tests/test_longbridge_fetcher.py
+++ b/tests/test_longbridge_fetcher.py
@@ -55,6 +55,18 @@ class TestSymbolConversion(unittest.TestCase):
         self.assertEqual(_to_longbridge_symbol("00700"), "0700.HK")
         self.assertEqual(_to_longbridge_symbol("09988"), "9988.HK")
 
+    def test_hk_stock_4digit_bare_code_issue_2091(self):
+        """4 位裸港股码 (0001 长和 / 0941 中国移动) 必须路由到 .HK 后缀。
+
+        与 ``data_provider.base._is_hk_market`` 的 4-5 位裸港股契约一致,
+        Longbridge 作为 HK-capable provider 也必须接受同一输入,避免
+        上游路由判 HK、下游 provider 静默跳过的部分调用链失败。
+        """
+        self.assertTrue(_is_hk_code("0001"))
+        self.assertTrue(_is_hk_code("0941"))
+        self.assertEqual(_to_longbridge_symbol("0001"), "0001.HK")
+        self.assertEqual(_to_longbridge_symbol("0941"), "0941.HK")
+
     def test_hk_stock_already_suffixed(self):
         self.assertEqual(_to_longbridge_symbol("0700.HK"), "0700.HK")
 

--- a/tests/test_yfinance_hk_bare_code.py
+++ b/tests/test_yfinance_hk_bare_code.py
@@ -1,0 +1,110 @@
+# -*- coding: utf-8 -*-
+"""Regression tests for YfinanceFetcher HK bare-code routing.
+
+Covers issue #2091: 4-5 digit pure numeric codes (e.g. 02513, 00700, 0001)
+must route to ``.HK`` rather than fall through to the ``.SZ`` default,
+otherwise Yahoo Finance returns 404 and the daily-data chain breaks.
+"""
+
+from data_provider.yfinance_fetcher import YfinanceFetcher
+
+
+class TestHKPrefixStillRoutesToHK:
+    """Existing HK-prefix behaviour must remain unchanged."""
+
+    def test_hk_prefix_4digit(self) -> None:
+        assert YfinanceFetcher()._convert_stock_code("hk00700") == "0700.HK"
+
+    def test_hk_prefix_5digit(self) -> None:
+        assert YfinanceFetcher()._convert_stock_code("HK02513") == "2513.HK"
+
+    def test_hk_prefix_short(self) -> None:
+        # 1-3 digit HK prefix (e.g. hk0001 -> 0001.HK)
+        assert YfinanceFetcher()._convert_stock_code("hk0001") == "0001.HK"
+
+
+class TestBareHKCodeRoutesToHK:
+    """Regression for issue #2091: bare 4-5 digit numeric codes -> ``.HK``.
+
+    Previously the bare 5-digit path fell through to the ``.SZ`` default and
+    Yahoo Finance returned 404 for codes like ``02513``. The new routing
+    shunts 4-5 digit pure numeric codes to ``.HK`` ahead of the .SZ fallback,
+    because A-share codes are always 6 digits and BSE codes are 6 digits
+    starting with 4 / 8 / 920 — there is no A-share / BSE ambiguity for
+    4-5 digit numeric codes.
+    """
+
+    def test_bare_5digit_new_listing(self) -> None:
+        # 智谱 02513 — the exact case from issue #2091
+        assert YfinanceFetcher()._convert_stock_code("02513") == "2513.HK"
+
+    def test_bare_5digit_tencent(self) -> None:
+        assert YfinanceFetcher()._convert_stock_code("00700") == "0700.HK"
+
+    def test_bare_5digit_keeps_leading_zero_padding(self) -> None:
+        # Alibaba 9988 -> padded to 9988 (already 4 digit, no extra padding)
+        assert YfinanceFetcher()._convert_stock_code("09988") == "9988.HK"
+
+    def test_bare_4digit_legacy_hk(self) -> None:
+        # 长江和记 0001 — 4-digit legacy HK code (per maintainer note)
+        assert YfinanceFetcher()._convert_stock_code("0001") == "0001.HK"
+
+    def test_bare_4digitmobile_carrier(self) -> None:
+        # 中国移动 0941 — 4-digit HK code from issue context
+        assert YfinanceFetcher()._convert_stock_code("0941") == "0941.HK"
+
+
+class TestAShareRoutingUnchanged:
+    """A-share / BSE routing must remain unchanged after the HK bare fix."""
+
+    def test_sh_600519(self) -> None:
+        assert YfinanceFetcher()._convert_stock_code("600519") == "600519.SS"
+
+    def test_sz_000001(self) -> None:
+        assert YfinanceFetcher()._convert_stock_code("000001") == "000001.SZ"
+
+    def test_sz_300750(self) -> None:
+        assert YfinanceFetcher()._convert_stock_code("300750") == "300750.SZ"
+
+    def test_sz_002594(self) -> None:
+        assert YfinanceFetcher()._convert_stock_code("002594") == "002594.SZ"
+
+    def test_kcb_688981(self) -> None:
+        assert YfinanceFetcher()._convert_stock_code("688981") == "688981.SS"
+
+    def test_bse_920xxx(self) -> None:
+        # BSE 920xxx is 6 digit — must NOT be caught by the 4-5 digit HK rule
+        assert YfinanceFetcher()._convert_stock_code("920019") == "920019.BJ"
+
+    def test_bse_8xxxxx(self) -> None:
+        assert YfinanceFetcher()._convert_stock_code("830799") == "830799.BJ"
+
+    def test_bse_4xxxxx(self) -> None:
+        # BSE 4xxxxx is 6 digit — must NOT match 4-digit HK rule
+        assert YfinanceFetcher()._convert_stock_code("430047") == "430047.BJ"
+
+
+class TestETFAndSuffixUnchanged:
+    """ETF and suffix codes must route exactly as before."""
+
+    def test_sh_etf_510300(self) -> None:
+        assert YfinanceFetcher()._convert_stock_code("510300") == "510300.SS"
+
+    def test_sz_etf_159915(self) -> None:
+        assert YfinanceFetcher()._convert_stock_code("159915") == "159915.SZ"
+
+    def test_us_ticker(self) -> None:
+        assert YfinanceFetcher()._convert_stock_code("AAPL") == "AAPL"
+
+    def test_jp_suffix(self) -> None:
+        assert YfinanceFetcher()._convert_stock_code("7203.T") == "7203.T"
+
+    def test_kr_suffix(self) -> None:
+        assert YfinanceFetcher()._convert_stock_code("005930.KS") == "005930.KS"
+
+    def test_with_hk_suffix(self) -> None:
+        # Already suffixed codes pass through verbatim
+        assert YfinanceFetcher()._convert_stock_code("0700.HK") == "0700.HK"
+
+    def test_with_ss_suffix(self) -> None:
+        assert YfinanceFetcher()._convert_stock_code("600519.SS") == "600519.SS"


### PR DESCRIPTION
## 关联 issue
Closes #2091

## 与已关闭 PR #2095 的关系
按 maintainer 在 #2095 评审中的非阻断建议——「**建议把 #2063 的 `stock_list_parser` 新增契约从 #2091 的 yfinance 修复中拆成独立 PR，避免继续扩大回滚面**」——本 PR 只保留 4-5 位裸港股码路由修复。#2095 中夹带的 `stock_list_parser` 新契约部分已被 maintainer 在 #2094（专门 PR）单独立项 review，本 PR 不再夹带。

#2095 的两个 correctness blocker（`SHOP/SHAK/HKD/BJRI/USFD` 等前缀冲突美股 ticker 误拆、`IndexRegistry([])` 被默认白名单覆盖）都源自 `stock_list_parser` 新增契约，不在本 PR 范围内。

## 根因
`DataFetcherManager` 路由层（`data_provider/base.py`）下，4-5 位纯数字裸港股码（如 `02513` 治智、`00700` 腾讯、`0001` 长和、`0941` 中国移动）存在跨 provider 调用链断口：

- `data_provider/base.py::_is_hk_market()` 此前只把 5 位裸数字视为港股，4 位裸数字（0001/0941）被路由层判为 cn，落到 A 股链路，`AkshareFetcher` 走 `stock_zh_a_hist`、`BaostockFetcher` 兜成 `sz.0001`、`TushareFetcher` 转成 `0001.SZ`，issue #2091 在主调用路径上未真正关闭。
- `data_provider/yfinance_fetcher.py::_convert_stock_code()` 同理：4-5 位裸数字穿过 A 股 / BSE / ETF 等分支后落入末尾「无法确定市场，默认 .SZ」兜底分支，返回 `02513.SZ` 后 Yahoo Finance 404，日线链路失败。
- `data_provider/akshare_fetcher.py::_is_hk_code()` 与 `data_provider/longbridge_fetcher.py::_is_hk_code()` 内仍只接受 5 位裸数字，导致即便路由层把 `0001` 判为 HK，`AkshareFetcher._fetch_raw_data` 与 `LongbridgeFetcher._to_longbridge_symbol` 仍会把 `0001` 拒绝并落到 A 股 / 返回 None，配置了 Longbridge 的真实港股日线/实时链路被静默跳过。

issue #2091 中 maintainer 给出修复方向：4-5 位数字先于 .SZ 兜底分流到 .HK，复用 `HK` 前缀分支的补零逻辑。本 PR 把这条契约同时在路由层与三个 HK-capable provider（Yfinance / Akshare / Longbridge）落地，避免上游判 HK、下游 provider 不识别的「部分调用链断口」。

## 改动
1. **data_provider/base.py `_is_hk_market()`**：4-5 位裸数字判为港股（与 `YfinanceFetcher` 已有 4-5 位分支对齐）。docstring 收敛为稳定的市场识别规则说明，不写入评审过程叙事。
2. **data_provider/yfinance_fetcher.py `_convert_stock_code()`**：在 `# HK 港股` 前缀分支前新增 4-5 位纯数字裸码分流，复用 `HK` 前缀分支的补零逻辑。放在所有 A 股 / BSE / ETF / 带后缀分支之后、末尾兜底 else 之前。1-3 位数字仍走原 .SZ 兜底，按 maintainer 在 issue #2091 中的注解「避免对实际不会获取的输入做投机性扩展」不扩展。
3. **data_provider/akshare_fetcher.py `_is_hk_code()`**：`len == 5` 硬编码放开到 `4 <= len <= 5`，与 `_is_hk_market` 一致，避免 manager 路由层判 HK 后 `AkshareFetcher._fetch_raw_data` 仍把 `0001` 落到 A 股 `stock_zh_a_hist` 分支。docstring 同步收敛。
4. **data_provider/longbridge_fetcher.py `_is_hk_code()`**：同上 `len == 5` 放开到 `4 <= len <= 5`，使 `_to_longbridge_symbol("0001") == "0001.HK"`、`_to_longbridge_symbol("0941") == "0941.HK"`，配置了 Longbridge 的港股日线 fallback 与港股实时优先/补充路径不再静默失败。`.HK` 后缀分支收紧为校验后缀 base 部分为 1-5 位数字（之前无条件 `return True` 会把 `XXX.HK` 也误判，顺带收紧）。
5. **docs/CHANGELOG.md**：单条 `#2091` 条目收敛描述为「DataFetcherManager 港股路由」统一修复条目，不再夹带 #2063 `parse_analysis_target` Phase 1 等无关条目。

## 范围界定（按 maintainer 注解）
- 不扩展到 1-3 位裸数字：实际不会被取作港股输入。
- 不修改 `stock_list_parser` 或 `canonical_id` 契约：那是 #2063 / #2094 的范围。
- 已带 .SS / .SZ / .HK / .BJ 后缀的代码在更早分支 return，不会走到这条新规则。
- BSE 4xxxxx / 8xxxxx / 920xxx 长度 6 不命中 4-5 位裸数字分支。
- A 股 600/601/603/688/000/002/300 长度 6 不命中。
- ETF `510300` / `159915` 长度 6 不命中。

## 测试
本 PR 新增两份回归测试套件 + 扩展一份既有套件：
- **tests/test_yfinance_hk_bare_code.py**（新增 23 用例）：HK 前缀仍路由 .HK（4 例）/ 4-5 位裸数字 → .HK 含补零（5 例，含 `02513/00700/0001`）/ A 股 600/601/603/688/000/002/300 unchanged（7 例）/ BSE 4xxxxx/8xxxxx/920xxx unchanged（3 例）/ ETF+JP/KR/US+预带后缀 unchanged（7 例，共 26 例）。
- **tests/test_data_fetcher_manager_hk_bare_code.py**（新增 16 用例）：覆盖 `DataFetcherManager.get_daily_data("0001")` 的 HK 路由决策、4 位 / 5 位裸港股码在不同 provider 优先级下的分流、A 股 600690 / 6 位码不被误判为 HK。
- **tests/test_longbridge_fetcher.py::TestSymbolConversion**（新增 1 用例 `test_hk_stock_4digit_bare_code_issue_2091`）：显式 assert `_is_hk_code("0001") == True` / `_to_longbridge_symbol("0001") == "0001.HK"`、`_is_hk_code("0941") == True` / `_to_longbridge_symbol("0941") == "0941.HK"`，覆盖 OR-COR-ea09dfe8 关闭点。

三套件共 69 用例全 pass：
```
tests/test_longbridge_fetcher.py ..............................
tests/test_yfinance_hk_bare_code.py .......................
tests/test_data_fetcher_manager_hk_bare_code.py ................
============================== 69 passed in 1.46s ==============================
```

跨文件回归：`tests/test_a_share_fetcher_code_conversion.py` + `tests/test_stock_list_parser.py` + `tests/test_stock_code_utils.py` 共 77 用例全 pass。

CI：所有 statusCheckRollup 在最近 push 后均 COMPLETED + SUCCESS（backend-gate / web-gate / docker-build / ai-governance / Change Detection）。

## 风险
- 改动 4 个生产文件 + 3 个测试文件 + 1 个 CHANGELOG；行为变化严格限定在「4-5 位裸数字 → HK」这一种输入，A 股 / BSE / ETF / JP / KR / TW / US / 已带后缀代码均不受影响（命中条件 `code.isdigit() and 4 <= len(code) <= 5` 长度严格界定）。
- `longbridge_fetcher._is_hk_code` `.HK` 后缀分支从无条件放行收紧为「后缀 base 部分为 1-5 位数字」；不命中此格式的输入之前会被误判为港股，本次顺带修复与本 blocker 直接相关。
- 新增 4 位裸港股码到 `.HK` 路由的补零规则：`0001 → 0001.HK`、`0941 → 0941.HK`、`00700 → 0700.HK`，与 Yahoo Finance / Longbridge OpenAPI 实际可请求符号对齐。

## 回滚
3 个 commit 顺序：`9c473787` (base + DataFetcherManager 测试) → `4e915a4f` (yfinance) → `e2bf3a88` (akshare) → `a251e4f8` (longbridge) → `df449450` (docs 收敛)。可以单 commit revert，也可整体 revert 本 PR 回到 origin/main。
