### PR TITLE
fix: 避免港股实时行情重复拉取全市场数据

### DIFF
--- a/data_provider/akshare_fetcher.py
+++ b/data_provider/akshare_fetcher.py
@@ -27,6 +27,7 @@ import logging
 import multiprocessing
 import os
 import random
+import threading
 import time
 from dataclasses import dataclass, field
 from datetime import datetime
@@ -93,6 +94,14 @@ _etf_realtime_cache: Dict[str, Any] = {
     'timestamp': 0,
     'ttl': 1200  # 20分钟缓存有效期
 }
+
+# 港股实时行情缓存。stock_hk_spot_em() 返回全市场数据，单次调用成本较高。
+_hk_realtime_cache: Dict[str, Any] = {
+    'data': None,
+    'timestamp': 0,
+    'ttl': 1200  # 20分钟缓存有效期
+}
+_hk_realtime_cache_lock = threading.Lock()
 
 
 def _is_etf_code(stock_code: str) -> bool:
@@ -1477,10 +1486,6 @@ class AkshareFetcher(BaseFetcher):
         em_key = "akshare_hk_em"
         sina_key = "akshare_hk_sina"
 
-        # 防封禁策略
-        self._set_random_user_agent()
-        self._enforce_rate_limit()
-
         # 确保代码格式正确（5位数字）
         raw_code = stock_code.strip().lower()
         if raw_code.endswith('.hk'):
@@ -1489,53 +1494,119 @@ class AkshareFetcher(BaseFetcher):
             raw_code = raw_code[2:]
         code = raw_code.zfill(5)
 
-        # --- 主数据源：东方财富 ---
-        if circuit_breaker.is_available(em_key):
+        def build_em_quote(df: pd.DataFrame) -> Optional[UnifiedRealtimeQuote]:
+            if df.empty:
+                logger.info(f"[API返回] 港股实时行情数据为空 (stock_hk_spot_em)")
+                return None
+
+            row = df[df['代码'] == code]
+            if row.empty:
+                logger.info(f"[API返回] 未找到港股 {code} 的实时行情 (stock_hk_spot_em)")
+                return None
+
+            row = row.iloc[0]
+            quote = UnifiedRealtimeQuote(
+                code=stock_code,
+                name=str(row.get('名称', '')),
+                source=RealtimeSource.AKSHARE_EM,
+                price=safe_float(row.get('最新价')),
+                change_pct=safe_float(row.get('涨跌幅')),
+                change_amount=safe_float(row.get('涨跌额')),
+                volume=safe_int(row.get('成交量')),
+                amount=safe_float(row.get('成交额')),
+                volume_ratio=safe_float(row.get('量比')),
+                turnover_rate=safe_float(row.get('换手率')),
+                amplitude=safe_float(row.get('振幅')),
+                pe_ratio=safe_float(row.get('市盈率')),
+                pb_ratio=safe_float(row.get('市净率')),
+                total_mv=safe_float(row.get('总市值')),
+                circ_mv=safe_float(row.get('流通市值')),
+                high_52w=safe_float(row.get('52周最高')),
+                low_52w=safe_float(row.get('52周最低')),
+            )
+            logger.info(
+                f"[港股实时行情] {stock_code} {quote.name}: 价格={quote.price}, "
+                f"涨跌={quote.change_pct}%, 换手率={quote.turnover_rate}%"
+            )
+            return quote
+
+        def read_cached_em_quote() -> Tuple[bool, Optional[UnifiedRealtimeQuote]]:
+            current_time = time.time()
+            cache_data = _hk_realtime_cache['data']
+            cache_age = current_time - _hk_realtime_cache['timestamp']
+            if cache_data is None or cache_age >= _hk_realtime_cache['ttl']:
+                return False, None
+
+            logger.debug(
+                f"[缓存命中] 港股实时行情(东财) - 缓存年龄 "
+                f"{int(cache_age)}s/{_hk_realtime_cache['ttl']}s"
+            )
             try:
-                logger.info(f"[API调用] ak.stock_hk_spot_em() 获取港股实时行情...")
-                import time as _time
-                api_start = _time.time()
+                return True, build_em_quote(cache_data)
+            except Exception as e:
+                logger.warning(
+                    f"[缓存错误] 港股实时行情缓存无法解析: {e}，"
+                    "尝试 stock_hk_spot 备用接口"
+                )
+                return True, None
 
-                df = ak.stock_hk_spot_em()
+        cache_hit, quote = read_cached_em_quote()
+        if quote is not None:
+            return quote
 
-                api_elapsed = _time.time() - api_start
-                logger.info(f"[API返回] ak.stock_hk_spot_em 成功: 返回 {len(df)} 只港股, 耗时 {api_elapsed:.2f}s")
-                circuit_breaker.record_success(em_key)
-
-                # 查找指定港股
-                row = df[df['代码'] == code]
-                if row.empty:
-                    logger.info(f"[API返回] 未找到港股 {code} 的实时行情 (stock_hk_spot_em)")
-                else:
-                    row = row.iloc[0]
-                    quote = UnifiedRealtimeQuote(
-                        code=stock_code,
-                        name=str(row.get('名称', '')),
-                        source=RealtimeSource.AKSHARE_EM,
-                        price=safe_float(row.get('最新价')),
-                        change_pct=safe_float(row.get('涨跌幅')),
-                        change_amount=safe_float(row.get('涨跌额')),
-                        volume=safe_int(row.get('成交量')),
-                        amount=safe_float(row.get('成交额')),
-                        volume_ratio=safe_float(row.get('量比')),
-                        turnover_rate=safe_float(row.get('换手率')),
-                        amplitude=safe_float(row.get('振幅')),
-                        pe_ratio=safe_float(row.get('市盈率')),
-                        pb_ratio=safe_float(row.get('市净率')),
-                        total_mv=safe_float(row.get('总市值')),
-                        circ_mv=safe_float(row.get('流通市值')),
-                        high_52w=safe_float(row.get('52周最高')),
-                        low_52w=safe_float(row.get('52周最低')),
-                    )
-                    logger.info(f"[港股实时行情] {stock_code} {quote.name}: 价格={quote.price}, 涨跌={quote.change_pct}%, "
-                                f"换手率={quote.turnover_rate}%")
+        # --- 主数据源：东方财富 ---
+        if not cache_hit:
+            # 组合快照会并发查询多个 symbol；锁内二次检查保证同一进程仅一次冷拉取。
+            with _hk_realtime_cache_lock:
+                cache_hit, quote = read_cached_em_quote()
+                if quote is not None:
                     return quote
 
-            except Exception as e:
-                logger.warning(f"[API错误] ak.stock_hk_spot_em 获取港股 {stock_code} 失败: {e}，尝试 stock_hk_spot 备用接口")
-                circuit_breaker.record_failure(em_key, str(e))
-        else:
-            logger.info(f"[熔断] 数据源 {em_key} 处于熔断状态，尝试使用备用链路")
+                if circuit_breaker.is_available(em_key) and not cache_hit:
+                    try:
+                        # 仅在真正发起网络请求前执行防封禁策略；热缓存命中不等待。
+                        self._set_random_user_agent()
+                        self._enforce_rate_limit()
+
+                        logger.info(f"[API调用] ak.stock_hk_spot_em() 获取港股实时行情...")
+                        import time as _time
+                        api_start = _time.time()
+
+                        df = ak.stock_hk_spot_em()
+
+                        api_elapsed = _time.time() - api_start
+                        logger.info(
+                            f"[API返回] ak.stock_hk_spot_em 成功: 返回 {len(df)} 只港股, "
+                            f"耗时 {api_elapsed:.2f}s"
+                        )
+
+                        if not isinstance(df, pd.DataFrame):
+                            raise TypeError("stock_hk_spot_em 未返回 DataFrame")
+                        if '代码' not in df.columns:
+                            raise KeyError("stock_hk_spot_em 返回结果缺少 代码 列")
+
+                        _hk_realtime_cache['data'] = df
+                        _hk_realtime_cache['timestamp'] = time.time()
+                        logger.info(
+                            f"[缓存更新] 港股实时行情(东财) 缓存已刷新，"
+                            f"TTL={_hk_realtime_cache['ttl']}s"
+                        )
+
+                        quote = build_em_quote(df)
+                        circuit_breaker.record_success(em_key)
+                        if quote is not None:
+                            return quote
+
+                    except Exception as e:
+                        logger.warning(
+                            f"[API错误] ak.stock_hk_spot_em 获取港股 {stock_code} "
+                            f"失败: {e}，尝试 stock_hk_spot 备用接口"
+                        )
+                        circuit_breaker.record_failure(em_key, str(e))
+                elif not cache_hit:
+                    logger.info(
+                        f"[熔断] 数据源 {em_key} 处于熔断状态，尝试使用备用链路"
+                    )
 
         # --- 备用数据源：新浪 ---
         if not circuit_breaker.is_available(sina_key):
@@ -1543,6 +1614,9 @@ class AkshareFetcher(BaseFetcher):
             return None
 
         try:
+            self._set_random_user_agent()
+            self._enforce_rate_limit()
+
             logger.info(f"[API调用] ak.stock_hk_spot() 获取港股实时行情（备用）...")
             import time as _time
             api_start = _time.time()

--- a/data_provider/akshare_fetcher.py
+++ b/data_provider/akshare_fetcher.py
@@ -1596,6 +1596,8 @@ class AkshareFetcher(BaseFetcher):
                             raise TypeError("stock_hk_spot_em 未返回 DataFrame")
                         if '代码' not in df.columns:
                             raise KeyError("stock_hk_spot_em 返回结果缺少 代码 列")
+                        if df.empty:
+                            raise ValueError("stock_hk_spot_em 返回空市场快照")
 
                         _hk_realtime_cache['data'] = df
                         _hk_realtime_cache['timestamp'] = time.time()

--- a/data_provider/akshare_fetcher.py
+++ b/data_provider/akshare_fetcher.py
@@ -99,7 +99,9 @@ _etf_realtime_cache: Dict[str, Any] = {
 _hk_realtime_cache: Dict[str, Any] = {
     'data': None,
     'timestamp': 0,
-    'ttl': 1200  # 20分钟缓存有效期
+    'ttl': 1200,  # 20分钟缓存有效期
+    'failure_ttl': 30,
+    'last_result': None,
 }
 _hk_realtime_cache_lock = threading.Lock()
 
@@ -1534,6 +1536,16 @@ class AkshareFetcher(BaseFetcher):
             current_time = time.time()
             cache_data = _hk_realtime_cache['data']
             cache_age = current_time - _hk_realtime_cache['timestamp']
+            if (
+                _hk_realtime_cache.get('last_result') == 'failure'
+                and cache_age < _hk_realtime_cache.get('failure_ttl', 0)
+            ):
+                logger.debug(
+                    f"[缓存命中] 港股实时行情(东财) - 复用最近失败结果 "
+                    f"{int(cache_age)}s/{_hk_realtime_cache.get('failure_ttl', 0)}s"
+                )
+                return True, None
+
             if cache_data is None or cache_age >= _hk_realtime_cache['ttl']:
                 return False, None
 
@@ -1587,6 +1599,7 @@ class AkshareFetcher(BaseFetcher):
 
                         _hk_realtime_cache['data'] = df
                         _hk_realtime_cache['timestamp'] = time.time()
+                        _hk_realtime_cache['last_result'] = 'success'
                         logger.info(
                             f"[缓存更新] 港股实时行情(东财) 缓存已刷新，"
                             f"TTL={_hk_realtime_cache['ttl']}s"
@@ -1598,6 +1611,9 @@ class AkshareFetcher(BaseFetcher):
                             return quote
 
                     except Exception as e:
+                        _hk_realtime_cache['data'] = None
+                        _hk_realtime_cache['timestamp'] = time.time()
+                        _hk_realtime_cache['last_result'] = 'failure'
                         logger.warning(
                             f"[API错误] ak.stock_hk_spot_em 获取港股 {stock_code} "
                             f"失败: {e}，尝试 stock_hk_spot 备用接口"

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - [修复] DataFetcherManager 港股路由：4-5 位纯数字裸港股码（如 `02513`、`00700`、`0001`）此前仅 `_is_hk_market` 单侧识别，`AkshareFetcher._is_hk_code` 与 `LongbridgeFetcher._is_hk_code` 内仍只接受 5 位裸数字，导致配置了 Yfinance/Akshare/Longbridge 的港股日线/实时链路对 4 位裸港股码静默失败。本 PR 同步三处 `_is_hk_code` 契约到 4-5 位裸数字，并新增 `DataFetcherManager` 港股路由回归测试，避免上游路由判 HK、下游 provider 不识别的部分调用链断口（fixes #2091）
 - [修复] Web 设置页和通知测试入口补齐普通钉钉群机器人配置，支持安全遮罩地保存 `DINGTALK_WEBHOOK_URL` / `DINGTALK_SECRET`、查看专属帮助并发送钉钉测试通知（refs #1957）。
 - [修复] Agent Chat 普通与流式接口在请求未指定 `report_language` 时继承全局 `REPORT_LANGUAGE`，显式请求值仍保持优先，避免回复语言与报告配置不一致。
+- [修复] AkShare 港股实时行情增加 20 分钟全市场数据缓存与并发冷启动 single-flight，热缓存命中不再执行网络限速等待；主接口返回结构异常时仍保持新浪备用接口降级，避免多港股组合快照重复拉取全市场数据而长时间阻塞（refs #1852）。
 
 ## [3.27.0] - 2026-07-19
 

--- a/tests/test_hk_stock_name_fallback.py
+++ b/tests/test_hk_stock_name_fallback.py
@@ -6,7 +6,10 @@ Covers: data_provider/akshare_fetcher.py _get_hk_realtime_quote
 """
 
 import sys
+import threading
+import time
 import unittest
+from concurrent.futures import ThreadPoolExecutor
 from unittest.mock import MagicMock, patch
 
 import pandas as pd
@@ -20,6 +23,7 @@ except ImportError:
     if "json_repair" not in sys.modules:
         sys.modules["json_repair"] = MagicMock()
 
+from data_provider import akshare_fetcher as akshare_fetcher_module
 from data_provider.akshare_fetcher import AkshareFetcher
 
 
@@ -84,6 +88,11 @@ class TestHKRealtimeFallback(unittest.TestCase):
 
     def setUp(self):
         self.fetcher = AkshareFetcher()
+        akshare_fetcher_module._hk_realtime_cache.update({
+            "data": None,
+            "timestamp": 0,
+            "ttl": 1200,
+        })
         # Bypass rate limiting
         self.fetcher._enforce_rate_limit = lambda: None
         self.fetcher._set_random_user_agent = lambda: None
@@ -101,6 +110,58 @@ class TestHKRealtimeFallback(unittest.TestCase):
         self.assertIsNotNone(quote)
         self.assertEqual(quote.name, "腾讯控股")
         self.assertAlmostEqual(quote.price, 370.0)
+
+    @patch("data_provider.akshare_fetcher.get_realtime_circuit_breaker")
+    def test_repeated_em_lookup_uses_hot_cache_without_network_delay(self, mock_cb):
+        """首次拉取后，TTL 内查询不应再次调用接口或执行限速等待。"""
+        mock_cb.return_value = _DummyCircuitBreaker()
+        ak_mock = MagicMock()
+        ak_mock.stock_hk_spot_em.return_value = _make_spot_em_df()
+        self.fetcher._set_random_user_agent = MagicMock()
+        self.fetcher._enforce_rate_limit = MagicMock()
+
+        with patch.dict(sys.modules, {"akshare": ak_mock}):
+            first_quote = self.fetcher._get_hk_realtime_quote("HK00700")
+            cached_quote = self.fetcher._get_hk_realtime_quote("HK00700")
+
+        self.assertIsNotNone(first_quote)
+        self.assertIsNotNone(cached_quote)
+        ak_mock.stock_hk_spot_em.assert_called_once()
+        self.fetcher._set_random_user_agent.assert_called_once()
+        self.fetcher._enforce_rate_limit.assert_called_once()
+
+    @patch("data_provider.akshare_fetcher.get_realtime_circuit_breaker")
+    def test_parallel_cold_lookups_share_one_em_request(self, mock_cb):
+        """组合快照并发冷查询时，全市场主接口只能由一个线程刷新。"""
+        mock_cb.return_value = _DummyCircuitBreaker()
+        codes = ["00700", "09988", "03690", "01810"]
+        em_df = pd.concat(
+            [_make_spot_em_df().assign(代码=code) for code in codes],
+            ignore_index=True,
+        )
+        ak_mock = MagicMock()
+
+        def delayed_em_response():
+            time.sleep(0.05)
+            return em_df
+
+        ak_mock.stock_hk_spot_em.side_effect = delayed_em_response
+        start = threading.Barrier(len(codes))
+
+        def fetch(code: str):
+            fetcher = AkshareFetcher()
+            fetcher._set_random_user_agent = lambda: None
+            fetcher._enforce_rate_limit = lambda: None
+            start.wait(timeout=2)
+            return fetcher._get_hk_realtime_quote(f"HK{code}")
+
+        with patch.dict(sys.modules, {"akshare": ak_mock}):
+            with ThreadPoolExecutor(max_workers=len(codes)) as executor:
+                quotes = list(executor.map(fetch, codes))
+
+        self.assertTrue(all(quote is not None for quote in quotes))
+        ak_mock.stock_hk_spot_em.assert_called_once()
+        ak_mock.stock_hk_spot.assert_not_called()
 
     @patch("data_provider.akshare_fetcher.get_realtime_circuit_breaker")
     def test_em_failure_falls_back_to_spot(self, mock_cb):
@@ -144,6 +205,50 @@ class TestHKRealtimeFallback(unittest.TestCase):
 
         self.assertIsNotNone(quote)
         self.assertEqual(quote.name, "腾讯控股")
+
+    @patch("data_provider.akshare_fetcher.get_realtime_circuit_breaker")
+    def test_em_missing_code_column_falls_back_without_poisoning_cache(self, mock_cb):
+        """主接口结构异常时应保留 fallback，且异常结果不得写入缓存。"""
+        cb = _DummyCircuitBreaker()
+        mock_cb.return_value = cb
+        ak_mock = MagicMock()
+        ak_mock.stock_hk_spot_em.return_value = pd.DataFrame([{
+            "名称": "腾讯控股",
+            "最新价": 370.0,
+        }])
+        ak_mock.stock_hk_spot.return_value = _make_spot_df()
+
+        with patch.dict(sys.modules, {"akshare": ak_mock}):
+            quote = self.fetcher._get_hk_realtime_quote("HK00700")
+
+        self.assertIsNotNone(quote)
+        self.assertAlmostEqual(quote.price, 368.0)
+        ak_mock.stock_hk_spot.assert_called_once()
+        self.assertIsNone(akshare_fetcher_module._hk_realtime_cache["data"])
+        self.assertTrue(any(source == "akshare_hk_em" for source, _ in cb.failures))
+
+    @patch("data_provider.akshare_fetcher.get_realtime_circuit_breaker")
+    def test_malformed_hot_cache_falls_back_without_refetching_em(self, mock_cb):
+        """缓存解析失败时应跳过昂贵的主接口重拉，并使用备用接口。"""
+        mock_cb.return_value = _DummyCircuitBreaker()
+        akshare_fetcher_module._hk_realtime_cache.update({
+            "data": pd.DataFrame([{"名称": "腾讯控股"}]),
+            "timestamp": akshare_fetcher_module.time.time(),
+        })
+        ak_mock = MagicMock()
+        ak_mock.stock_hk_spot.return_value = _make_spot_df()
+        self.fetcher._set_random_user_agent = MagicMock()
+        self.fetcher._enforce_rate_limit = MagicMock()
+
+        with patch.dict(sys.modules, {"akshare": ak_mock}):
+            quote = self.fetcher._get_hk_realtime_quote("HK00700")
+
+        self.assertIsNotNone(quote)
+        self.assertAlmostEqual(quote.price, 368.0)
+        ak_mock.stock_hk_spot_em.assert_not_called()
+        ak_mock.stock_hk_spot.assert_called_once()
+        self.fetcher._set_random_user_agent.assert_called_once()
+        self.fetcher._enforce_rate_limit.assert_called_once()
 
     @patch("data_provider.akshare_fetcher.get_realtime_circuit_breaker")
     def test_circuit_breaker_open_returns_none(self, mock_cb):

--- a/tests/test_hk_stock_name_fallback.py
+++ b/tests/test_hk_stock_name_fallback.py
@@ -92,6 +92,8 @@ class TestHKRealtimeFallback(unittest.TestCase):
             "data": None,
             "timestamp": 0,
             "ttl": 1200,
+            "failure_ttl": 30,
+            "last_result": None,
         })
         # Bypass rate limiting
         self.fetcher._enforce_rate_limit = lambda: None
@@ -178,6 +180,40 @@ class TestHKRealtimeFallback(unittest.TestCase):
         self.assertEqual(quote.name, "腾讯控股")
         self.assertAlmostEqual(quote.price, 368.0)
         ak_mock.stock_hk_spot.assert_called_once()
+
+    @patch("data_provider.akshare_fetcher.get_realtime_circuit_breaker")
+    def test_parallel_em_failure_reuses_negative_cache_before_fallback(self, mock_cb):
+        """并发冷启动失败时应只尝试一次主接口，其余线程复用失败结果后走备用链路。"""
+        mock_cb.return_value = _DummyCircuitBreaker()
+        codes = ["00700", "09988", "03690", "01810"]
+        ak_mock = MagicMock()
+
+        def delayed_em_failure():
+            time.sleep(0.05)
+            raise Exception("东方财富接口超时")
+
+        ak_mock.stock_hk_spot_em.side_effect = delayed_em_failure
+        ak_mock.stock_hk_spot.return_value = pd.concat(
+            [_make_spot_df().assign(代码=code) for code in codes],
+            ignore_index=True,
+        )
+        start = threading.Barrier(len(codes))
+
+        def fetch(code: str):
+            fetcher = AkshareFetcher()
+            fetcher._set_random_user_agent = lambda: None
+            fetcher._enforce_rate_limit = lambda: None
+            start.wait(timeout=2)
+            return fetcher._get_hk_realtime_quote(f"HK{code}")
+
+        with patch.dict(sys.modules, {"akshare": ak_mock}):
+            with ThreadPoolExecutor(max_workers=len(codes)) as executor:
+                quotes = list(executor.map(fetch, codes))
+
+        self.assertTrue(all(quote is not None for quote in quotes))
+        ak_mock.stock_hk_spot_em.assert_called_once()
+        self.assertEqual(ak_mock.stock_hk_spot.call_count, len(codes))
+        self.assertEqual(akshare_fetcher_module._hk_realtime_cache["last_result"], "failure")
 
     @patch("data_provider.akshare_fetcher.get_realtime_circuit_breaker")
     def test_both_fail_returns_none(self, mock_cb):

--- a/tests/test_hk_stock_name_fallback.py
+++ b/tests/test_hk_stock_name_fallback.py
@@ -238,9 +238,16 @@ class TestHKRealtimeFallback(unittest.TestCase):
 
         with patch.dict(sys.modules, {"akshare": ak_mock}):
             quote = self.fetcher._get_hk_realtime_quote("HK00700")
+            cached_fallback_quote = self.fetcher._get_hk_realtime_quote("HK00700")
 
         self.assertIsNotNone(quote)
+        self.assertIsNotNone(cached_fallback_quote)
         self.assertEqual(quote.name, "腾讯控股")
+        self.assertEqual(cached_fallback_quote.name, "腾讯控股")
+        self.assertIsNone(akshare_fetcher_module._hk_realtime_cache["data"])
+        self.assertEqual(akshare_fetcher_module._hk_realtime_cache["last_result"], "failure")
+        ak_mock.stock_hk_spot_em.assert_called_once()
+        self.assertEqual(ak_mock.stock_hk_spot.call_count, 2)
 
     @patch("data_provider.akshare_fetcher.get_realtime_circuit_breaker")
     def test_em_missing_code_column_falls_back_without_poisoning_cache(self, mock_cb):


### PR DESCRIPTION
## PR Type

- [x] fix
- [ ] feat
- [ ] refactor
- [ ] docs
- [ ] chore
- [x] test

当前 Head CI：`ai-governance` / `backend-gate` / `docker-build` 已通过；`web-gate` 与 desktop packaging 按变更检测跳过。CI：https://github.com/ZhuLinsen/daily_stock_analysis/actions/runs/30187803228

## Background And Problem

这是对已关闭 PR #1852 中有效需求的重新实现。

当前 `_get_hk_realtime_quote()` 每查一只港股都会调用 `ak.stock_hk_spot_em()` 拉取一次全市场港股数据。Portfolio snapshot 又会在线程池中并发获取多个 symbol，因此多只港股不仅会串行重复拉取，在并发冷启动时还可能同时发起多个昂贵请求，造成快照长时间阻塞。

原 PR #1852 只增加了无锁缓存，且有三个正确性缺口：

1. 热缓存检查仍在 `_enforce_rate_limit()` 之后，命中缓存也会等待 2–5 秒。
2. 数据查找/解析被移出异常边界，主接口缺列或结构异常时可能绕过新浪 fallback。
3. 并发冷启动没有 single-flight，多个线程仍可同时 miss 并重复拉全市场数据。

## Scope Of Change

3 files changed, 226 insertions(+), 46 deletions(-).

- `data_provider/akshare_fetcher.py`
  - 增加港股全市场行情 20 分钟模块级缓存。
  - 热缓存先于 UA 与 rate-limit 逻辑读取，不发网络请求时不等待。
  - 用模块锁 + 锁内二次检查收敛并发冷启动，仅允许一次主接口刷新。
  - 仅缓存通过 DataFrame 与 `代码` 列校验的结果；接口、结构或缓存解析异常仍进入新浪备用接口。
- `tests/test_hk_stock_name_fallback.py`
  - 覆盖冷/热缓存、4 线程并发 single-flight、主接口异常、空结果、缺列、缓存异常、双源失败和熔断路径。
- `docs/CHANGELOG.md`
  - 按 `[Unreleased]` 扁平格式记录用户可见性能修复。

## Issue Link

Refs #1852（关闭 PR 的重做；原 PR 没有关联独立 issue）。

验收条件：TTL 内重复港股查询不重拉主接口、不执行无网络意义的限速等待；并发冷启动只刷新一次；主接口结构异常不破坏备用接口降级。

## Verification Commands And Results

```bash
python -m pytest tests/test_hk_stock_name_fallback.py -q
# 9 passed

python -m pytest \
  tests/test_hk_stock_name_fallback.py \
  tests/test_hk_realtime_routing.py \
  tests/test_akshare_realtime_logging.py -q
# 19 passed

python -m py_compile data_provider/akshare_fetcher.py tests/test_hk_stock_name_fallback.py
# pass

python -m flake8 data_provider/akshare_fetcher.py tests/test_hk_stock_name_fallback.py \
  --count --select=E9,F63,F7,F82 --show-source --statistics
# 0

git diff --check
# pass

python -m pytest -m "not network" -q
# 4869 passed, 76 failed, 2 skipped, 4 deselected
```

同一主线基线结果为 `4865 passed, 76 failed, 2 skipped, 4 deselected`。本 PR 新增 4 个测试全部通过；通过 `.pytest_cache/v/cache/lastfailed` 逐项比较，76 个 Windows 本地已知失败节点与基线完全相同，0 个新增失败。

未执行真实 AkShare 在线性能测试：外部网络延迟与限流不可重复，且调用会主动拉取全市场数据。测试通过真实方法入口并 mock 网络边界，直接断言串行热缓存和 4 线程冷启动均只调用一次 `stock_hk_spot_em()`，同时覆盖 fallback 契约。

Full-suite note：本地 Windows 全量套件存在主线相同的 POSIX 进程、Shell/Docker 与 SQLite 并发环境失败；当前 Head GitHub CI 的 `ai-governance`、`backend-gate`、`docker-build` 已全部通过。

## Visual Evidence

不适用：本 PR 不修改报告格式、报告渲染或 Web UI。替代证据为上述方法级并发/缓存回归测试。

## Compatibility And Risk

- 不改变 realtime quote API、Schema、provider priority、symbol 归一化或 fallback 顺序。
- 不改变第三方 AkShare 请求参数与返回字段契约；仅复用一次全市场返回结果。
- 数据最多复用 20 分钟，与同文件现有 A 股和 ETF 全市场缓存 TTL 一致。
- 进程内缓存不跨进程共享；多进程部署仍各自维护一次缓存，这是现有模块级缓存边界。
- 模块锁仅覆盖主接口冷刷新；热读与新浪 fallback 不持锁。
- 不变更 provider/model/base URL 或运行时配置保存、清理、迁移语义；历史配置保持不变。

## Rollback Plan

Revert this PR。无配置、数据库或数据迁移需要回滚；回滚后恢复每只港股独立拉取主接口的旧行为。

## EXTRACT_PROMPT Change

不适用。

## Checklist

- [x] This PR has a clear motivation and value
- [x] Reproducible verification commands and results are included
- [x] Compatibility and risk have been assessed
- [x] A rollback plan is provided
- [x] Report/Web UI screenshot requirement is not applicable
- [x] User-visible behavior is recorded in `docs/CHANGELOG.md`

<!-- autocode:repair-summary:start -->
## AutoCode Repair Update
- Scope: 2 file(s), `+9 / -0`.
- Changed files: `data_provider/akshare_fetcher.py`, `tests/test_hk_stock_name_fallback.py`
- Validation: lint:PASS, test:PASS
- Commands: `./scripts/ci_gate.sh flake8`; `python -m pytest tests/test_hk_stock_name_fallback.py`
- Execution/self-review summary: 第 1 轮：已在 `data_provider/akshare_fetcher.py` 收紧港股 EM 全市场快照缓存条件：`stock_hk_spot_em()` 返回空 `DataFrame` 时不再写入成功缓存，而是进入失败分支并使用短失败 TTL。 已更新 `tests/test_hk_stock_name_fallback.py`，补充校验空快照 fallback 后不会污染成功缓存，`last_result` 为 `failure`。 已执行 `python -m py_compile data_provider/akshare_fetcher.py tests/test_hk_stock_name_fallback.py`。 已执行 `python -m pytest tests/test_hk_stock_name_fallback.py tests/test_hk_realtime_routing.py`，11 项全部通过。 第 1 轮提交前自审：已检查 `git diff`、`data_provider/akshare_fetcher.py` 的港股实时行情调用链，以及相关回归测试。修正点是把 `stock_hk_spot_em()` 返回“带 `代码` 列但为空”的全市场快照视为失败刷新，不再写入 20 分钟成功缓存；同时补充测试，明确断言该场景会写入失败状态、TTL 内不重复请求 EM、继续走新浪 fallback。 验证结果：`python -m pytest tests/test_hk_stock_name_fallback.py -q` 通过（10 passed），`python -m pytest tests/test_hk_stock_name_fallback.py tests/test_hk_realtime_routing.py tests/test_akshare_realtime_logging.py -q` 通过（20 passed），`./scripts/ci_gate.sh flake8` 通过。`./scripts/ci_gate.sh offline-tests` 已启动但本轮未拿到终态，暂无改动面相关失败输出。 建议同步 PR description：补一句“空市场快照按失败刷新处理并使用短失败 TTL”，以及这条新增回归断言。
- Compatibility, risk, documentation, and PR scope were re-evaluated before this push.
<!-- autocode:repair-summary:end -->