### PR TITLE
fix: 升级 Web Axios 安全基线

### DIFF
--- a/apps/dsa-web/package-lock.json
+++ b/apps/dsa-web/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@remixicon/react": "^4.9.0",
-        "axios": "^1.13.4",
+        "axios": "^1.18.1",
         "camelcase-keys": "^10.0.2",
         "clsx": "^2.1.1",
         "lucide-react": "^0.555.0",
@@ -2824,14 +2824,40 @@
       "license": "MIT"
     },
     "node_modules/axios": {
-      "version": "1.13.4",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.4.tgz",
-      "integrity": "sha512-1wVkUaAO6WyaYtCkcYCOx12ZgpGf9Zif+qXa4n+oYzK558YryKqiL6UWwd5DqiH3VRW0GYhTZQ/vlgJrCoNQlg==",
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.18.1.tgz",
+      "integrity": "sha512-3nTvFlvpn9Zu/RkHUqtc7/+al4UpRW5az71ap5zccp6e8RAYEzhMTecX8Dz1wWDYrPpUoB1HAQEGEAEvUr7S9g==",
       "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.15.6",
-        "form-data": "^4.0.4",
-        "proxy-from-env": "^1.1.0"
+        "follow-redirects": "^1.16.0",
+        "form-data": "^4.0.5",
+        "https-proxy-agent": "^5.0.1",
+        "proxy-from-env": "^2.1.0"
+      }
+    },
+    "node_modules/axios/node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/axios/node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/babel-plugin-react-compiler": {
@@ -3949,9 +3975,9 @@
       "license": "ISC"
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.11",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
-      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
       "funding": [
         {
           "type": "individual",
@@ -6228,10 +6254,13 @@
       }
     },
     "node_modules/proxy-from-env": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
-      "license": "MIT"
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/punycode": {
       "version": "2.3.1",

--- a/apps/dsa-web/package.json
+++ b/apps/dsa-web/package.json
@@ -17,7 +17,7 @@
   },
   "dependencies": {
     "@remixicon/react": "^4.9.0",
-    "axios": "^1.13.4",
+    "axios": "^1.18.1",
     "camelcase-keys": "^10.0.2",
     "clsx": "^2.1.1",
     "lucide-react": "^0.555.0",

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - [新功能] Web 首页与 `POST /api/v1/analysis/market-review` 支持用严格校验的 `region` 字符串临时选择单个或多个复盘市场；一次性覆盖不读取或修改全局配置，“服务器默认”在任务提交边界解析为 canonical 实际执行市场，并贯穿 accepted 响应、任务状态/列表/SSE、完成态结构化 payload 与 History。
 - [修复] GitHub Actions PR Review 流程中的 `_event_payload()` 此前用 `except (OSError, ValueError): return {}` 把「事件文件缺失」「文件不可读」「JSON 非法」三类异常统一吞成空对象，下游只表现为 `PR number is unavailable` 无法定位根因；现保留空对象降级行为不变，但分别对三类失败输出不含载荷内容的警告（仅含异常类型与 `GITHUB_EVENT_PATH` 源路径），并补齐三类降级路径与「坏载荷导致 PR 编号不可用」链路的回归测试（fixes #2070）
 - [修复] DataFetcherManager 港股路由：4-5 位纯数字裸港股码（如 `02513`、`00700`、`0001`）此前仅 `_is_hk_market` 单侧识别，`AkshareFetcher._is_hk_code` 与 `LongbridgeFetcher._is_hk_code` 内仍只接受 5 位裸数字，导致配置了 Yfinance/Akshare/Longbridge 的港股日线/实时链路对 4 位裸港股码静默失败。本 PR 同步三处 `_is_hk_code` 契约到 4-5 位裸数字，并新增 `DataFetcherManager` 港股路由回归测试，避免上游路由判 HK、下游 provider 不识别的部分调用链断口（fixes #2091）
+- [修复] Web 端 Axios 从受 CVE-2026-25639 影响的 1.13.4 升级到官方稳定版 1.18.1，并刷新锁文件，避免恶意 `__proto__` 配置触发 `mergeConfig` 拒绝服务（refs #2076）。
 
 ## [3.27.0] - 2026-07-19
 


### PR DESCRIPTION
## PR Type

- [x] fix
- [ ] feat
- [ ] refactor
- [ ] docs
- [x] chore
- [x] test

当前 Head CI：`ai-governance` / `backend-gate` / `docker-build` / `web-gate` 已全部通过。CI：https://github.com/ZhuLinsen/daily_stock_analysis/actions/runs/30187934245

## Background And Problem

这是对已关闭 PR #2076 中有效安全修复的重新实现。

当前 Web 锁文件解析到 Axios 1.13.4。GitHub Reviewed Advisory [GHSA-43fc-jf86-j433 / CVE-2026-25639](https://github.com/advisories/GHSA-43fc-jf86-j433) 明确列出 Axios `>=1.0.0, <=1.13.4` 受影响：带自有 `__proto__` 属性的配置对象可使 `mergeConfig` 抛出 TypeError，造成拒绝服务；1.13.5 是首个修复版本。

旧 PR #2076 仅提议升级到 1.13.5，但没有仓库要求的 changelog、当前完整验证、兼容性和回滚说明。该版本现在也已落后于后续安全加固版本，因此本 PR 使用 Axios 官方当前最新稳定 Release [v1.18.1](https://github.com/axios/axios/releases/tag/v1.18.1)（2026-06-21，签名发布提交），避免提交刚合入就过时的最低补丁版本。

说明：本仓库前端是否存在可由远端用户直接构造 Axios config 的完整利用链尚未证实；本 PR 的确定性价值是移除官方明确标记的已知脆弱依赖版本，不夸大为已确认可远程利用。

## Scope Of Change

3 files changed, 45 insertions(+), 15 deletions(-).

- `apps/dsa-web/package.json`：Axios 版本范围从 `^1.13.4` 更新为 `^1.18.1`。
- `apps/dsa-web/package-lock.json`：锁定 Axios 1.18.1，并仅刷新其实际依赖树：
  - `follow-redirects` 1.15.11 → 1.16.0
  - `proxy-from-env` 1.1.0 → 2.1.0
  - 新增 Axios 直接依赖 `https-proxy-agent` 5.0.1 及其嵌套 `agent-base` 6.0.2
  - 已剔除 npm 11 顺带产生的无关 Tailwind 可选 WASM 锁文件漂移
- `docs/CHANGELOG.md`：按 `[Unreleased]` 扁平格式记录安全修复。

## Issue Link

Refs #2076（关闭 PR 的当前化重做；原 PR 没有关联独立 issue）。

## Verification Commands And Results

```powershell
$env:NODE_TLS_REJECT_UNAUTHORIZED=$null
npm.cmd ci --ignore-scripts
# 462 packages installed from lockfile

npm.cmd run lint
# pass

npm.cmd run build
# tsc -b + vite build pass, 3235 modules transformed

npm.cmd run test
# 96 files passed, 1 failed
# 1033 tests passed, 1 failed, 2 skipped

npm.cmd run test -- --exclude src/components/alerts/__tests__/AlertRuleForm.test.tsx
# 96 files passed
# 1016 tests passed, 2 skipped

npm.cmd ls axios follow-redirects proxy-from-env https-proxy-agent
# axios@1.18.1
# follow-redirects@1.16.0
# proxy-from-env@2.1.0
# https-proxy-agent@5.0.1

node --input-type=module -e "import axios from 'axios'; const malicious = {}; Object.defineProperty(malicious, '__proto__', {value: {x: 1}, enumerable: true}); const merged = axios.mergeConfig({}, malicious); if (Object.hasOwn(merged, '__proto__')) process.exit(1); console.log('mergeConfig __proto__ payload ignored')"
# mergeConfig __proto__ payload ignored

git diff --check
# pass
```

完整 Vitest 的唯一失败为 `AlertRuleForm` 期望 JP/KR 中文市场选项。已在未修改依赖的 Axios 1.13.4 主线基线中执行同一独立用例，结果完全相同，因此不是本 PR 引入；本 PR 未修改该组件、选项或测试。

`npm audit --package-lock-only --json` 未得到有效结果：当前 npm audit 网关返回 gzip 字节但声明/解析为 JSON，npm 报 `audit endpoint returned an error`。未将其伪报为通过；安全版本判断使用上述 GitHub Reviewed Advisory、Axios 官方 Release、锁文件解析与本地反例验证。

Full-suite note：Web lint/build 通过；Vitest 除主线同一已知失败外无新增失败。当前 Head GitHub CI 的 `ai-governance`、`backend-gate`、`docker-build`、`web-gate` 已全部通过。

## Visual Evidence

不适用：本 PR 不修改 Web UI、报告格式或报告渲染。替代证据为 clean install、完整 lint/build、测试基线对照及 CVE 反例命令。

## Compatibility And Risk

- Axios 仍在 1.x semver 主版本内；现有导入与请求调用代码不变。
- 1.18.1 包含 1.13.4 之后的 HTTP adapter、proxy、header 和类型修复；潜在风险主要在 Node adapter 的 proxy/redirect 边界行为。Web production build 和现有前端测试已覆盖仓库调用面。
- 当前应用主要使用浏览器端 Axios；新引入的 Node adapter 依赖不会改变浏览器 bundle API，Vite production build 已验证。
- 不改变后端 API、Schema、provider/model/base URL、运行时配置保存/清理/迁移语义。
- 锁文件来源与 integrity 固定；安装时显式清除了本机不安全的 `NODE_TLS_REJECT_UNAUTHORIZED` 环境覆盖。

## Rollback Plan

Revert this PR 并重新执行 `npm ci`。无配置、数据库或数据迁移需要回滚；回滚会重新引入 Axios 1.13.4 的已知安全风险，不建议作为长期方案。

## EXTRACT_PROMPT Change

不适用。

## Checklist

- [x] This PR has a clear motivation and value
- [x] Reproducible verification commands and results are included
- [x] Compatibility and risk have been assessed
- [x] A rollback plan is provided
- [x] Report/Web UI screenshot requirement is not applicable
- [x] Security behavior is recorded in `docs/CHANGELOG.md`
