### PR TITLE
docs: 修复文档中的失效相对链接

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -101,7 +101,7 @@ npm run build
 
 ## 📋 优先贡献方向
 
-查看 [Roadmap](README.md#-roadmap) 了解当前需要的功能：
+查看 [README](../README.md) 了解项目当前的核心能力与主要入口：
 
 - 🔔 新通知渠道（钉钉、飞书、Telegram）
 - 🤖 新 AI 模型支持（GPT-4、Claude）

--- a/docs/bot-command.md
+++ b/docs/bot-command.md
@@ -236,7 +236,7 @@ class CommandDispatcher:
 
 ## 配置
 
-在 [config.py](../config.py) 中新增机器人配置：
+在 [config.py](../src/config.py) 中新增机器人配置：
 
 ```python
 # === 机器人配置 ===
@@ -282,7 +282,7 @@ telegram_webhook_secret: str           # 新增：Webhook 密钥
 - 支持命令频率限制（防刷）
 - 敏感操作（如批量分析）可设置权限白名单
 
-在 [config.py](../config.py) 中新增机器人安全配置：
+在 [config.py](../src/config.py) 中新增机器人安全配置：
 
 ```python
     bot_rate_limit_requests: int = 10     # 频率限制：窗口内最大请求数


### PR DESCRIPTION
## PR Type

- [x] docs

## Background And Problem

Closed PR #1952 identified three broken relative links that are still present on current `main`:

- `docs/CONTRIBUTING.md` resolves `README.md` as the non-existent `docs/README.md`, and the old Roadmap anchor no longer exists.
- `docs/bot-command.md` links twice to the non-existent root `config.py`; the actual file is `src/config.py`.

This is a clean reimplementation from current `main`, not a reuse of the old commit.

## Scope Of Change

- Point the contribution guide at `../README.md` and align the link text with the current README.
- Point both bot configuration links at `../src/config.py`.
- No runtime, API, configuration, or workflow behavior changes.

## Related PR

Reimplements the valid documentation fix from closed PR #1952.

## Verification Commands And Results

```powershell
git diff --check
Test-Path README.md
Test-Path src/config.py
```

Result: passed; both resolved targets exist.

Current Head CI: `ai-governance` / `backend-gate` / `docker-build` passed; Web and desktop jobs were skipped by change detection. CI: https://github.com/ZhuLinsen/daily_stock_analysis/actions/runs/30188674800

Docs only, tests not run. `docs/CHANGELOG.md` is intentionally unchanged because this corrects navigation only and does not change user-visible capability or runtime behavior.

## Compatibility And Risk

Low risk. Only three Markdown link targets/text fragments change. No bilingual counterpart exists for these two documents.

## Rollback Plan

```bash
git revert <merged_commit>
```

## Checklist

- [x] The broken targets were reproduced on current `main`.
- [x] The replacement paths resolve to existing files.
- [x] The change is limited to the affected documentation.
- [x] Rollback is documented.
