### PR TITLE
feat: add skill opinion outcome evaluation core

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - [修复] 统一等价股票代码的本地日线候选与同源窗口解析；冲突沪深交易所代码不再降级匹配裸码，回测仅接受快照或交易日历确认的起点，并在同一起点中优先完整的单一代码窗口。
 - [新功能] 新增按 individual SkillAgent 自身 signal、版本化 engine 与本地已存同源日线窗口计算并持久化 `skill_opinion_outcomes` 的核心服务；本阶段不提供管理员 API、表现统计、样本充足度或权重调整。
 - [修复] 统一等价股票代码的本地日线候选与同源窗口解析；冲突沪深交易所代码不再降级匹配裸码，回测优先使用最近且完整的单一代码窗口。
+- [修复] 统一等价股票代码的本地日线候选与同源窗口解析；冲突沪深交易所代码不再降级匹配裸码，回测仅接受快照或交易日历确认的起点，并在同一起点中优先完整的单一代码窗口。
+- [新功能] 新增按 individual SkillAgent 自身 signal、版本化 engine 与本地已存同源日线窗口计算并持久化 `skill_opinion_outcomes` 的核心服务；本阶段不提供管理员 API、表现统计、样本充足度或权重调整。
+- [修复] 统一等价股票代码的本地日线候选与同源窗口解析；冲突沪深交易所代码不再降级匹配裸码，回测优先使用最近且完整的单一代码窗口。
 - [chore] 暂停 PR Review 的自动触发，仅保留 `workflow_dispatch` 手动入口，避免辅助评审重复运行及评论权限失败产生误导性红灯；正式 CI 检查保持不变。
 - [新功能] Multi-Agent specialist 运行在分析历史保存成功后，按独立 skill 持久化版本化、低敏且幂等的有效 opinion 样本，为后续后验评估提供真实数据；本阶段不计算 outcome、不统计表现、不调整权重。
 - [新功能] Multi-Agent 报告按八态用户 action 追踪 Pipeline 最终调整，排除非法 Agent 意见；仅在 canonical action 可唯一解析时生成 explanation 与 DecisionSignal，并以同一个 `final_action` 统一最终动作契约。

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 - [修复] 统一等价股票代码的本地日线候选与同源窗口解析；冲突沪深交易所代码不再降级匹配裸码，回测仅接受快照或交易日历确认的起点，并在同一起点中优先完整的单一代码窗口。
+- [新功能] 新增按 individual SkillAgent 自身 signal、版本化 engine 与本地已存同源日线窗口计算并持久化 `skill_opinion_outcomes` 的核心服务；本阶段不提供管理员 API、表现统计、样本充足度或权重调整。
+- [修复] 统一等价股票代码的本地日线候选与同源窗口解析；冲突沪深交易所代码不再降级匹配裸码，回测优先使用最近且完整的单一代码窗口。
+- [chore] 暂停 PR Review 的自动触发，仅保留 `workflow_dispatch` 手动入口，避免辅助评审重复运行及评论权限失败产生误导性红灯；正式 CI 检查保持不变。
+- [新功能] Multi-Agent specialist 运行在分析历史保存成功后，按独立 skill 持久化版本化、低敏且幂等的有效 opinion 样本，为后续后验评估提供真实数据；本阶段不计算 outcome、不统计表现、不调整权重。
+- [新功能] Multi-Agent 报告按八态用户 action 追踪 Pipeline 最终调整，排除非法 Agent 意见；仅在 canonical action 可唯一解析时生成 explanation 与 DecisionSignal，并以同一个 `final_action` 统一最终动作契约。
+- [新功能] 新增 `--portfolio futu`，只读导入 Futu OpenD 真实账户的沪深 A 股、港股、美股 LONG 正股持仓作为分析列表。
+- [新功能] 多策略综合新增受控 deliberation v0、可注入 mediator/self-review v1-v2、只读 revision projection v3 与 multi-round v4；所有增强层相对上一层 baseline 只能保持或继续 softened，不覆盖权威最终信号。
+- [新功能] `specialist` 模式最多选择 4 个策略专家，并通过 `AGENT_SKILL_CONCURRENCY` 控制 1–4 个 worker 并发；worker 继承主管线冻结的 target date 等 `ContextVar` 状态，失败 skill 进入权威 Diagnostics 计数且不阻断其它策略或最终决策。
 <!-- 新条目格式：- [类型] 描述（类型取值：新功能/改进/修复/文档/测试/chore）-->
 <!-- 每条独立一行追加到本段末尾，无需分类标题，合并时冲突最小 -->
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,16 +10,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 ## [Unreleased]
 - [修复] 统一等价股票代码的本地日线候选与同源窗口解析；冲突沪深交易所代码不再降级匹配裸码，回测仅接受快照或交易日历确认的起点，并在同一起点中优先完整的单一代码窗口。
 - [新功能] 新增按 individual SkillAgent 自身 signal、版本化 engine 与本地已存同源日线窗口计算并持久化 `skill_opinion_outcomes` 的核心服务；本阶段不提供管理员 API、表现统计、样本充足度或权重调整。
-- [修复] 统一等价股票代码的本地日线候选与同源窗口解析；冲突沪深交易所代码不再降级匹配裸码，回测优先使用最近且完整的单一代码窗口。
-- [修复] 统一等价股票代码的本地日线候选与同源窗口解析；冲突沪深交易所代码不再降级匹配裸码，回测仅接受快照或交易日历确认的起点，并在同一起点中优先完整的单一代码窗口。
-- [新功能] 新增按 individual SkillAgent 自身 signal、版本化 engine 与本地已存同源日线窗口计算并持久化 `skill_opinion_outcomes` 的核心服务；本阶段不提供管理员 API、表现统计、样本充足度或权重调整。
-- [修复] 统一等价股票代码的本地日线候选与同源窗口解析；冲突沪深交易所代码不再降级匹配裸码，回测优先使用最近且完整的单一代码窗口。
-- [chore] 暂停 PR Review 的自动触发，仅保留 `workflow_dispatch` 手动入口，避免辅助评审重复运行及评论权限失败产生误导性红灯；正式 CI 检查保持不变。
-- [新功能] Multi-Agent specialist 运行在分析历史保存成功后，按独立 skill 持久化版本化、低敏且幂等的有效 opinion 样本，为后续后验评估提供真实数据；本阶段不计算 outcome、不统计表现、不调整权重。
-- [新功能] Multi-Agent 报告按八态用户 action 追踪 Pipeline 最终调整，排除非法 Agent 意见；仅在 canonical action 可唯一解析时生成 explanation 与 DecisionSignal，并以同一个 `final_action` 统一最终动作契约。
-- [新功能] 新增 `--portfolio futu`，只读导入 Futu OpenD 真实账户的沪深 A 股、港股、美股 LONG 正股持仓作为分析列表。
-- [新功能] 多策略综合新增受控 deliberation v0、可注入 mediator/self-review v1-v2、只读 revision projection v3 与 multi-round v4；所有增强层相对上一层 baseline 只能保持或继续 softened，不覆盖权威最终信号。
-- [新功能] `specialist` 模式最多选择 4 个策略专家，并通过 `AGENT_SKILL_CONCURRENCY` 控制 1–4 个 worker 并发；worker 继承主管线冻结的 target date 等 `ContextVar` 状态，失败 skill 进入权威 Diagnostics 计数且不阻断其它策略或最终决策。
 <!-- 新条目格式：- [类型] 描述（类型取值：新功能/改进/修复/文档/测试/chore）-->
 <!-- 每条独立一行追加到本段末尾，无需分类标题，合并时冲突最小 -->
 

--- a/docs/multi-strategy-contract.md
+++ b/docs/multi-strategy-contract.md
@@ -10,6 +10,18 @@
 
 当前 `sample_schema_version=skill-opinion-sample-v1`。`skill_version` 与 `horizon` 仅保留为空值兼容位：现有 Skill 定义和 SkillAgent 输出没有可信的版本与周期契约，因此本阶段不得从 LLM `raw_data` 猜测或伪造。PR1 不创建 outcome、不提供 skill 表现统计、不实现 `get_skill_summary()`，也不改变 `AgentMemory` / `SkillAggregator` 权重。
 
+## Skill Opinion Outcome 边界（Issue #1904 P2）
+
+`skill_opinion_outcomes` 表示一条不可变 `skill_opinion_sample` 在一个 `horizon`、一个 `engine_version` 下的独立后验结果，唯一键为 `(skill_opinion_sample_id, horizon, engine_version)`。初始 horizon 仅允许 `1d`、`3d`、`5d`、`10d`；每次运行的 `limit` 限制待处理的 `sample × horizon` outcome key 数量，不是 sample 数量。显式空 horizons、空白 skill/stock 筛选和越界 limit 必须 fail closed，不得退化为全量运行。
+
+每条 outcome 只使用 sample 自己的 canonical `signal`，不得读取最终 Agent decision、`skill_consensus` 或其他 skill 的 signal。`strong_buy` / `buy` 按 bullish 评价，`strong_sell` / `sell` 按 bearish 评价；方向收益严格大于零才是 `hit`，零收益是 `miss`。`hold` 在价格窗口完整后保存为 `observational`，不产生方向正确性。
+
+分析日期优先使用持久化 `market_phase_summary.effective_daily_bar_date`；该来源要求完全相同日期的起始 bar。兼容来源才允许选择目标日期或此前最近一条本地日线。股票代码候选和窗口选择复用父 PR #2073 的共享 resolver：完整窗口优先于部分窗口，再选择最新起始 bar，且起始与 forward bars 必须来自同一 stored code shape，不得跨候选拼接。
+
+缺少起始 bar、未来本地日线不足等可恢复状态保存为可重试 `pending`；永久无效输入保存为 `unable`。同一 engine version 下只有 `pending` 可更新，`evaluated`、`observational`、`unable` 均不可覆盖；规则变化必须提升 engine version。历史删除在同一写事务内按 outcome → sample → history 显式清理，不能依赖 SQLite 外键开关。
+
+本次 stacked PR 只提供 Outcome evaluator、repository 和 service 核心，不新增管理员 API、Schema、OpenAPI 或主 Pipeline 自动触发，也不提供表现统计、样本充足度、排名和权重调整。若后续需要运维入口，应以实际调用方和权限契约为依据独立审查。
+
 ## 术语与边界
 
 当前仓库里有多种名为 opinion / signal / consensus / synthesis 的数据面，Baseline 必须先消歧，避免把现有运行时结构误写成未来 phase。

--- a/docs/multi-strategy-contract.md
+++ b/docs/multi-strategy-contract.md
@@ -20,7 +20,7 @@
 
 权威起始 session 已确定、但对应起始 bar 尚未写入，或未来本地日线不足时，保存为可重试 `pending`。损坏或晚于分析日期的 `effective_daily_bar_date`、股票市场与快照市场冲突，以及无法由可信 phase 与交易日历证明起点等永久无效元数据，保存为终态 `unable`，不得伪装成 `missing_start_bar` 持续重试。同一 engine version 下只有 `pending` 可更新，`evaluated`、`observational`、`unable` 均不可覆盖；规则变化必须提升 engine version。历史删除在同一写事务内按 outcome → sample → history 显式清理，不能依赖 SQLite 外键开关。
 
-本次 stacked PR 只提供 Outcome evaluator、repository 和 service 核心，不新增管理员 API、Schema、OpenAPI 或主 Pipeline 自动触发，也不提供表现统计、样本充足度、排名和权重调整。若后续需要运维入口，应以实际调用方和权限契约为依据独立审查。
+本 PR 基于已合并的 #2073，只提供 Outcome evaluator、repository 和 service 核心，不新增管理员 API、Schema、OpenAPI 或主 Pipeline 自动触发，也不提供表现统计、样本充足度、排名和权重调整。若后续需要运维入口，应以实际调用方和权限契约为依据独立审查。
 
 ## 术语与边界
 

--- a/docs/multi-strategy-contract.md
+++ b/docs/multi-strategy-contract.md
@@ -16,9 +16,9 @@
 
 每条 outcome 只使用 sample 自己的 canonical `signal`，不得读取最终 Agent decision、`skill_consensus` 或其他 skill 的 signal。`strong_buy` / `buy` 按 bullish 评价，`strong_sell` / `sell` 按 bearish 评价；方向收益严格大于零才是 `hit`，零收益是 `miss`。`hold` 在价格窗口完整后保存为 `observational`，不产生方向正确性。
 
-分析日期优先使用持久化 `market_phase_summary.effective_daily_bar_date`；该来源要求完全相同日期的起始 bar。兼容来源才允许选择目标日期或此前最近一条本地日线。股票代码候选和窗口选择复用父 PR #2073 的共享 resolver：完整窗口优先于部分窗口，再选择最新起始 bar，且起始与 forward bars 必须来自同一 stored code shape，不得跨候选拼接。
+历史分析日期来自 `enhanced_context.date`，缺失时才回退到历史记录创建日期。Backtest 与 Outcome 统一通过共享 resolver 解析股票身份、重建受支持的旧市场快照并确定权威起始 session：优先使用市场一致且合法的 `market_phase_summary.effective_daily_bar_date`；缺少该字段时，只有 phase 与交易日历能够证明起点才进行推导，否则 fail closed，不允许选择任意更早的本地日线。共享窗口 resolver 只接受权威起始 session 的 bar，在同日起点中优先完整窗口，且起始与 forward bars 必须来自同一 stored code shape，不得跨候选拼接。
 
-缺少起始 bar、未来本地日线不足等可恢复状态保存为可重试 `pending`；永久无效输入保存为 `unable`。同一 engine version 下只有 `pending` 可更新，`evaluated`、`observational`、`unable` 均不可覆盖；规则变化必须提升 engine version。历史删除在同一写事务内按 outcome → sample → history 显式清理，不能依赖 SQLite 外键开关。
+权威起始 session 已确定、但对应起始 bar 尚未写入，或未来本地日线不足时，保存为可重试 `pending`。损坏或晚于分析日期的 `effective_daily_bar_date`、股票市场与快照市场冲突，以及无法由可信 phase 与交易日历证明起点等永久无效元数据，保存为终态 `unable`，不得伪装成 `missing_start_bar` 持续重试。同一 engine version 下只有 `pending` 可更新，`evaluated`、`observational`、`unable` 均不可覆盖；规则变化必须提升 engine version。历史删除在同一写事务内按 outcome → sample → history 显式清理，不能依赖 SQLite 外键开关。
 
 本次 stacked PR 只提供 Outcome evaluator、repository 和 service 核心，不新增管理员 API、Schema、OpenAPI 或主 Pipeline 自动触发，也不提供表现统计、样本充足度、排名和权重调整。若后续需要运维入口，应以实际调用方和权限契约为依据独立审查。
 

--- a/src/core/skill_opinion_outcome_evaluator.py
+++ b/src/core/skill_opinion_outcome_evaluator.py
@@ -1,0 +1,160 @@
+# -*- coding: utf-8 -*-
+"""Pure forward-outcome evaluation for persisted skill opinions."""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from datetime import date
+import math
+from typing import Any, Dict, Optional, Sequence
+
+from src.agent.protocols import normalize_strategy_signal
+
+
+SUPPORTED_SKILL_OUTCOME_HORIZONS = {
+    "1d": 1,
+    "3d": 3,
+    "5d": 5,
+    "10d": 10,
+}
+
+_BULLISH_SIGNALS = frozenset({"strong_buy", "buy"})
+
+
+@dataclass(frozen=True)
+class SkillOpinionOutcomeEvaluation:
+    """One deterministic sample-by-horizon evaluation result."""
+
+    eval_status: str
+    outcome: Optional[str] = None
+    direction_correct: Optional[bool] = None
+    unable_reason: Optional[str] = None
+    analysis_date: Optional[date] = None
+    start_trade_date: Optional[date] = None
+    end_trade_date: Optional[date] = None
+    start_price: Optional[float] = None
+    end_close: Optional[float] = None
+    stock_return_pct: Optional[float] = None
+    directional_return_pct: Optional[float] = None
+
+    def to_fields(self) -> Dict[str, Any]:
+        return asdict(self)
+
+
+class SkillOpinionOutcomeEvaluator:
+    """Evaluate one immutable skill signal against locally stored daily bars."""
+
+    @classmethod
+    def evaluate(
+        cls,
+        *,
+        signal: Any,
+        horizon: str,
+        analysis_date: Optional[date],
+        start_bar: Any = None,
+        forward_bars: Sequence[Any] = (),
+    ) -> SkillOpinionOutcomeEvaluation:
+        canonical_signal, invalid_signal, _ = normalize_strategy_signal(signal)
+        if invalid_signal:
+            return cls._unable("invalid_signal", analysis_date=analysis_date)
+
+        eval_days = SUPPORTED_SKILL_OUTCOME_HORIZONS.get(str(horizon or "").strip())
+        if eval_days is None:
+            return cls._unable("unsupported_horizon", analysis_date=analysis_date)
+        if analysis_date is None:
+            return cls._unable("missing_analysis_date")
+        if start_bar is None:
+            return cls._pending("missing_start_bar", analysis_date=analysis_date)
+
+        raw_start_price = getattr(start_bar, "close", None)
+        start_price = cls._positive_finite_float(raw_start_price)
+        start_trade_date = cls._bar_date(start_bar)
+        if start_price is None:
+            reason = "missing_start_close" if raw_start_price is None else "invalid_start_price"
+            return cls._pending(
+                reason,
+                analysis_date=analysis_date,
+                start_trade_date=start_trade_date,
+            )
+
+        bars = list(forward_bars)
+        if len(bars) < eval_days:
+            return cls._pending(
+                "insufficient_future_data",
+                analysis_date=analysis_date,
+                start_trade_date=start_trade_date,
+                start_price=start_price,
+            )
+
+        end_bar = bars[eval_days - 1]
+        raw_end_close = getattr(end_bar, "close", None)
+        end_close = cls._positive_finite_float(raw_end_close)
+        end_trade_date = cls._bar_date(end_bar)
+        if end_close is None:
+            reason = "missing_end_close" if raw_end_close is None else "invalid_end_close"
+            return cls._pending(
+                reason,
+                analysis_date=analysis_date,
+                start_trade_date=start_trade_date,
+                end_trade_date=end_trade_date,
+                start_price=start_price,
+            )
+
+        stock_return_pct = (end_close - start_price) / start_price * 100.0
+        common = {
+            "analysis_date": analysis_date,
+            "start_trade_date": start_trade_date,
+            "end_trade_date": end_trade_date,
+            "start_price": start_price,
+            "end_close": end_close,
+            "stock_return_pct": stock_return_pct,
+        }
+
+        if canonical_signal == "hold":
+            return SkillOpinionOutcomeEvaluation(
+                eval_status="observational",
+                outcome="observational",
+                **common,
+            )
+
+        multiplier = 1.0 if canonical_signal in _BULLISH_SIGNALS else -1.0
+        directional_return_pct = stock_return_pct * multiplier
+        direction_correct = directional_return_pct > 0.0
+        return SkillOpinionOutcomeEvaluation(
+            eval_status="evaluated",
+            outcome="hit" if direction_correct else "miss",
+            direction_correct=direction_correct,
+            directional_return_pct=directional_return_pct,
+            **common,
+        )
+
+    @staticmethod
+    def _pending(reason: str, **fields: Any) -> SkillOpinionOutcomeEvaluation:
+        return SkillOpinionOutcomeEvaluation(
+            eval_status="pending",
+            unable_reason=reason,
+            **fields,
+        )
+
+    @staticmethod
+    def _unable(reason: str, **fields: Any) -> SkillOpinionOutcomeEvaluation:
+        return SkillOpinionOutcomeEvaluation(
+            eval_status="unable",
+            unable_reason=reason,
+            **fields,
+        )
+
+    @staticmethod
+    def _positive_finite_float(value: Any) -> Optional[float]:
+        if value is None or isinstance(value, bool):
+            return None
+        try:
+            number = float(value)
+        except (OverflowError, TypeError, ValueError):
+            return None
+        return number if math.isfinite(number) and number > 0 else None
+
+    @staticmethod
+    def _bar_date(bar: Any) -> Optional[date]:
+        value = getattr(bar, "date", None)
+        return value if isinstance(value, date) else None

--- a/src/repositories/skill_opinion_outcome_repo.py
+++ b/src/repositories/skill_opinion_outcome_repo.py
@@ -1,0 +1,198 @@
+# -*- coding: utf-8 -*-
+"""Repository for per-sample skill opinion forward outcomes."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any, Dict, List, Optional, Sequence, Tuple
+
+from sqlalchemy import and_, case, func, select
+
+from src.storage import (
+    AnalysisHistory,
+    DatabaseManager,
+    SkillOpinionOutcomeRecord,
+    SkillOpinionSampleRecord,
+    utc_naive_now,
+)
+
+
+_TERMINAL_EVAL_STATUSES = frozenset({"evaluated", "observational", "unable"})
+
+
+@dataclass(frozen=True)
+class SkillOpinionOutcomeCandidate:
+    sample: SkillOpinionSampleRecord
+    history: AnalysisHistory
+    horizon: str
+    existing_outcome: Optional[SkillOpinionOutcomeRecord]
+
+
+class SkillOpinionOutcomeRepository:
+    """Read candidates and persist outcomes through the shared write guard."""
+
+    def __init__(self, db_manager: Optional[DatabaseManager] = None):
+        self.db = db_manager or DatabaseManager.get_instance()
+
+    def list_candidate_keys(
+        self,
+        *,
+        horizons: Sequence[str],
+        engine_version: str,
+        limit: int,
+        sample_id: Optional[int] = None,
+        analysis_history_id: Optional[int] = None,
+        skill_id: Optional[str] = None,
+        stock_code: Optional[str] = None,
+    ) -> List[SkillOpinionOutcomeCandidate]:
+        """Return at most ``limit`` missing or pending sample-by-horizon keys."""
+
+        candidates: List[SkillOpinionOutcomeCandidate] = []
+        with self.db.get_session() as session:
+            for horizon in horizons:
+                join_condition = and_(
+                    SkillOpinionOutcomeRecord.skill_opinion_sample_id
+                    == SkillOpinionSampleRecord.id,
+                    SkillOpinionOutcomeRecord.horizon == horizon,
+                    SkillOpinionOutcomeRecord.engine_version == engine_version,
+                )
+                conditions = [
+                    (
+                        SkillOpinionOutcomeRecord.id.is_(None)
+                        | (SkillOpinionOutcomeRecord.eval_status == "pending")
+                    )
+                ]
+                if sample_id is not None:
+                    conditions.append(SkillOpinionSampleRecord.id == sample_id)
+                if analysis_history_id is not None:
+                    conditions.append(
+                        SkillOpinionSampleRecord.analysis_history_id == analysis_history_id
+                    )
+                if skill_id is not None:
+                    conditions.append(SkillOpinionSampleRecord.skill_id == skill_id)
+                if stock_code is not None:
+                    conditions.append(SkillOpinionSampleRecord.stock_code == stock_code)
+
+                rows = session.execute(
+                    select(
+                        SkillOpinionSampleRecord,
+                        AnalysisHistory,
+                        SkillOpinionOutcomeRecord,
+                    )
+                    .join(
+                        AnalysisHistory,
+                        AnalysisHistory.id == SkillOpinionSampleRecord.analysis_history_id,
+                    )
+                    .outerjoin(SkillOpinionOutcomeRecord, join_condition)
+                    .where(and_(*conditions))
+                    .order_by(
+                        case(
+                            (SkillOpinionOutcomeRecord.id.is_(None), 0),
+                            else_=1,
+                        ),
+                        func.coalesce(
+                            SkillOpinionOutcomeRecord.updated_at,
+                            SkillOpinionSampleRecord.created_at,
+                        ),
+                        SkillOpinionSampleRecord.id,
+                    )
+                    .limit(limit)
+                ).all()
+                candidates.extend(
+                    SkillOpinionOutcomeCandidate(
+                        sample=sample,
+                        history=history,
+                        horizon=horizon,
+                        existing_outcome=outcome,
+                    )
+                    for sample, history, outcome in rows
+                )
+
+        horizon_rank = {horizon: index for index, horizon in enumerate(horizons)}
+        candidates.sort(
+            key=lambda item: (
+                item.existing_outcome is not None,
+                self._candidate_time(item),
+                int(item.sample.id),
+                horizon_rank[item.horizon],
+            )
+        )
+        return candidates[:limit]
+
+    def persist_outcome(self, fields: Dict[str, Any]) -> Tuple[Optional[int], str]:
+        """Insert a missing key or update pending; never overwrite terminal rows."""
+
+        def _write(session) -> Tuple[Optional[int], str]:
+            sample_id = int(fields["skill_opinion_sample_id"])
+            sample_exists = session.execute(
+                select(SkillOpinionSampleRecord.id)
+                .where(SkillOpinionSampleRecord.id == sample_id)
+                .limit(1)
+            ).scalar_one_or_none()
+            if sample_exists is None:
+                return None, "missing_sample"
+
+            existing = session.execute(
+                select(SkillOpinionOutcomeRecord)
+                .where(
+                    SkillOpinionOutcomeRecord.skill_opinion_sample_id == sample_id,
+                    SkillOpinionOutcomeRecord.horizon == fields["horizon"],
+                    SkillOpinionOutcomeRecord.engine_version == fields["engine_version"],
+                )
+                .limit(1)
+            ).scalar_one_or_none()
+            if existing is not None and existing.eval_status in _TERMINAL_EVAL_STATUSES:
+                return int(existing.id), "skipped"
+
+            if existing is None:
+                row = SkillOpinionOutcomeRecord(**fields)
+                session.add(row)
+                session.flush()
+                return int(row.id), "created"
+
+            for key, value in fields.items():
+                if key in {
+                    "id",
+                    "skill_opinion_sample_id",
+                    "horizon",
+                    "engine_version",
+                    "created_at",
+                }:
+                    continue
+                setattr(existing, key, value)
+            existing.updated_at = utc_naive_now()
+            session.flush()
+            return int(existing.id), "updated"
+
+        return self.db._run_write_transaction(
+            "persist skill opinion outcome",
+            _write,
+        )
+
+    def get_outcome(
+        self,
+        *,
+        sample_id: int,
+        horizon: str,
+        engine_version: str,
+    ) -> Optional[SkillOpinionOutcomeRecord]:
+        with self.db.get_session() as session:
+            return session.execute(
+                select(SkillOpinionOutcomeRecord)
+                .where(
+                    SkillOpinionOutcomeRecord.skill_opinion_sample_id == sample_id,
+                    SkillOpinionOutcomeRecord.horizon == horizon,
+                    SkillOpinionOutcomeRecord.engine_version == engine_version,
+                )
+                .limit(1)
+            ).scalar_one_or_none()
+
+    @staticmethod
+    def _candidate_time(candidate: SkillOpinionOutcomeCandidate) -> datetime:
+        outcome = candidate.existing_outcome
+        return (
+            (outcome.updated_at if outcome is not None else None)
+            or candidate.sample.created_at
+            or datetime.min
+        )

--- a/src/services/backtest_service.py
+++ b/src/services/backtest_service.py
@@ -135,12 +135,16 @@ class BacktestService:
                     else []
                 )
                 expected_start_date = start_resolution.expected_start_date
+                local_start_date = (
+                    expected_start_date
+                    or start_resolution.legacy_local_start_date
+                )
                 daily_window = None
-                if expected_start_date is not None:
+                if local_start_date is not None:
                     daily_window = resolve_stock_daily_window(
                         stock_repo=self.stock_repo,
                         code_candidates=daily_code_candidates,
-                        expected_start_date=expected_start_date,
+                        expected_start_date=local_start_date,
                         eval_window_days=int(eval_window_days),
                     )
 

--- a/src/services/backtest_service.py
+++ b/src/services/backtest_service.py
@@ -13,11 +13,9 @@ from sqlalchemy import and_, select
 from data_provider.base import canonical_stock_code, normalize_stock_code
 from src.config import get_config
 from src.core.backtest_engine import OVERALL_SENTINEL_CODE, BacktestEngine, EvaluationConfig
-from src.core.trading_calendar import resolve_historical_daily_bar_date
 from src.market_phase_summary import (
     extract_market_phase_summary,
     normalize_analysis_phase_bucket,
-    rebuild_market_phase_summary_for_stock_code,
 )
 from src.repositories.backtest_repo import BacktestRepository
 from src.repositories.stock_repo import StockRepository
@@ -26,6 +24,7 @@ from src.services.stock_code_utils import (
     normalize_code as normalize_backtest_code,
     resolve_daily_stock_identity,
 )
+from src.services.stock_daily_start_resolver import resolve_stock_daily_start
 from src.services.stock_daily_window_resolver import resolve_stock_daily_window
 from src.storage import BacktestResult, BacktestSummary, DatabaseManager
 from src.utils.data_processing import parse_json_field
@@ -124,33 +123,18 @@ class BacktestService:
                         )
                     )
                     continue
-                phase_summary = extract_market_phase_summary(
-                    analysis.context_snapshot
+                start_resolution = resolve_stock_daily_start(
+                    stock_code=analysis.code,
+                    context_snapshot=analysis.context_snapshot,
+                    analysis_date=analysis_date,
                 )
-                persisted_market = (
-                    str(phase_summary.get("market") or "").strip().lower()
-                    if isinstance(phase_summary, dict)
-                    else None
-                )
-                daily_identity = resolve_daily_stock_identity(
-                    analysis.code,
-                    market_hint=persisted_market,
-                )
+                daily_identity = start_resolution.identity
                 daily_code_candidates = (
                     list(daily_identity.code_candidates)
                     if daily_identity is not None
                     else []
                 )
-                expected_start_date = self._resolve_expected_start_date(
-                    analysis=analysis,
-                    analysis_date=analysis_date,
-                    market=daily_identity.market if daily_identity is not None else None,
-                    stock_code=(
-                        daily_identity.normalized_code
-                        if daily_identity is not None
-                        else None
-                    ),
-                )
+                expected_start_date = start_resolution.expected_start_date
                 daily_window = None
                 if expected_start_date is not None:
                     daily_window = resolve_stock_daily_window(
@@ -844,63 +828,6 @@ class BacktestService:
             return analysis.created_at.date()
         logger.warning(f"无法确定分析日期，跳过记录: {analysis.code}#{getattr(analysis, 'id', '?')}")
         return None
-
-    @staticmethod
-    def _resolve_expected_start_date(
-        *,
-        analysis,
-        analysis_date: date,
-        market: Optional[str],
-        stock_code: Optional[str],
-    ) -> Optional[date]:
-        phase_summary = extract_market_phase_summary(analysis.context_snapshot)
-        snapshot_market = (
-            str(phase_summary.get("market") or "").strip().lower()
-            if isinstance(phase_summary, dict)
-            else ""
-        )
-        if not market:
-            return None
-        if snapshot_market != market:
-            phase_summary = rebuild_market_phase_summary_for_stock_code(
-                stock_code,
-                analysis.context_snapshot,
-            )
-            snapshot_market = (
-                str(phase_summary.get("market") or "").strip().lower()
-                if isinstance(phase_summary, dict)
-                else ""
-            )
-            if snapshot_market != market:
-                return None
-
-        effective_date_value = (
-            phase_summary.get("effective_daily_bar_date")
-            if isinstance(phase_summary, dict)
-            else None
-        )
-        if effective_date_value:
-            try:
-                effective_date = datetime.strptime(
-                    str(effective_date_value),
-                    "%Y-%m-%d",
-                ).date()
-            except (TypeError, ValueError):
-                return None
-            if effective_date <= analysis_date:
-                return effective_date
-            return None
-
-        phase = (
-            phase_summary.get("phase")
-            if isinstance(phase_summary, dict)
-            else None
-        )
-        return resolve_historical_daily_bar_date(
-            market,
-            analysis_date,
-            phase,
-        )
 
     def _try_fill_daily_data(self, *, code: str, analysis_date: date, eval_window_days: int) -> None:
         refill_code = str(code or "").strip()

--- a/src/services/skill_opinion_outcome_service.py
+++ b/src/services/skill_opinion_outcome_service.py
@@ -1,0 +1,294 @@
+# -*- coding: utf-8 -*-
+"""Orchestrate locally stored daily bars into per-skill opinion outcomes."""
+
+from __future__ import annotations
+
+from datetime import date, datetime
+import logging
+from typing import Any, Dict, List, Optional, Sequence, Tuple
+
+from src.core.skill_opinion_outcome_evaluator import (
+    SUPPORTED_SKILL_OUTCOME_HORIZONS,
+    SkillOpinionOutcomeEvaluation,
+    SkillOpinionOutcomeEvaluator,
+)
+from src.market_phase_summary import extract_market_phase_summary
+from src.repositories.backtest_repo import BacktestRepository
+from src.repositories.skill_opinion_outcome_repo import (
+    SkillOpinionOutcomeCandidate,
+    SkillOpinionOutcomeRepository,
+)
+from src.repositories.stock_repo import StockRepository
+from src.services.stock_code_utils import (
+    InvalidStockCodeError,
+    build_daily_code_candidates,
+)
+from src.services.stock_daily_window_resolver import resolve_stock_daily_window
+from src.storage import (
+    AnalysisHistory,
+    DatabaseManager,
+    SkillOpinionOutcomeRecord,
+    SkillOpinionSampleRecord,
+)
+
+
+logger = logging.getLogger(__name__)
+
+SKILL_OPINION_OUTCOME_ENGINE_VERSION = "skill-opinion-outcome-v1"
+
+
+class SkillOpinionOutcomeService:
+    """Evaluate missing and pending outcome keys without fetching external data."""
+
+    def __init__(
+        self,
+        *,
+        repo: Optional[SkillOpinionOutcomeRepository] = None,
+        stock_repo: Optional[StockRepository] = None,
+        db_manager: Optional[DatabaseManager] = None,
+    ):
+        self.repo = repo or SkillOpinionOutcomeRepository(db_manager)
+        self.stock_repo = stock_repo or StockRepository(db_manager)
+
+    def run_outcomes(
+        self,
+        *,
+        sample_id: Optional[int] = None,
+        analysis_history_id: Optional[int] = None,
+        skill_id: Optional[str] = None,
+        stock_code: Optional[str] = None,
+        horizons: Optional[Sequence[str]] = None,
+        limit: int = 100,
+    ) -> Dict[str, Any]:
+        """Process at most ``limit`` missing/pending sample-by-horizon keys."""
+
+        sample_id_norm = self._optional_positive_int(sample_id, "sample_id")
+        history_id_norm = self._optional_positive_int(
+            analysis_history_id,
+            "analysis_history_id",
+        )
+        skill_id_norm = self._optional_text(skill_id, "skill_id")
+        stock_code_norm = self._optional_text(stock_code, "stock_code")
+        horizons_norm = self._normalize_horizons(horizons)
+        limit_norm = self._bounded_positive_int(limit, "limit", maximum=500)
+
+        candidates = self.repo.list_candidate_keys(
+            horizons=horizons_norm,
+            engine_version=SKILL_OPINION_OUTCOME_ENGINE_VERSION,
+            limit=limit_norm,
+            sample_id=sample_id_norm,
+            analysis_history_id=history_id_norm,
+            skill_id=skill_id_norm,
+            stock_code=stock_code_norm,
+        )
+
+        items: List[Dict[str, Any]] = []
+        errors: List[Dict[str, Any]] = []
+        counts = {"created": 0, "updated": 0, "skipped": 0}
+        for candidate in candidates:
+            try:
+                evaluation = self._evaluate_candidate(candidate)
+                fields = {
+                    "skill_opinion_sample_id": int(candidate.sample.id),
+                    "horizon": candidate.horizon,
+                    "engine_version": SKILL_OPINION_OUTCOME_ENGINE_VERSION,
+                    **evaluation.to_fields(),
+                }
+                _, persist_status = self.repo.persist_outcome(fields)
+                if persist_status == "missing_sample":
+                    counts["skipped"] += 1
+                    continue
+                counts[persist_status] += 1
+                row = self.repo.get_outcome(
+                    sample_id=int(candidate.sample.id),
+                    horizon=candidate.horizon,
+                    engine_version=SKILL_OPINION_OUTCOME_ENGINE_VERSION,
+                )
+                if row is not None:
+                    items.append(self._serialize_outcome(row, candidate.sample))
+            except Exception as exc:
+                error = {
+                    "sample_id": int(candidate.sample.id),
+                    "horizon": candidate.horizon,
+                    "error_type": type(exc).__name__,
+                }
+                errors.append(error)
+                logger.warning(
+                    "Skill opinion outcome evaluation deferred after transient failure: "
+                    "sample_id=%s horizon=%s error_type=%s",
+                    error["sample_id"],
+                    error["horizon"],
+                    error["error_type"],
+                    exc_info=True,
+                )
+
+        return {
+            "items": items,
+            "processed_keys": len(candidates),
+            "created": counts["created"],
+            "updated": counts["updated"],
+            "skipped": counts["skipped"],
+            "failed": len(errors),
+            "errors": errors,
+            "limit_unit": "outcome_key",
+            "engine_version": SKILL_OPINION_OUTCOME_ENGINE_VERSION,
+        }
+
+    def _evaluate_candidate(
+        self,
+        candidate: SkillOpinionOutcomeCandidate,
+    ) -> SkillOpinionOutcomeEvaluation:
+        analysis_date, exact_start_required = self._resolve_analysis_date(candidate.history)
+        try:
+            daily_code_candidates = build_daily_code_candidates(
+                candidate.sample.stock_code
+            )
+        except InvalidStockCodeError:
+            return SkillOpinionOutcomeEvaluation(
+                eval_status="unable",
+                unable_reason="invalid_stock_code",
+                analysis_date=analysis_date,
+            )
+
+        window = None
+        if analysis_date is not None:
+            window = resolve_stock_daily_window(
+                stock_repo=self.stock_repo,
+                code_candidates=daily_code_candidates,
+                analysis_date=analysis_date,
+                eval_window_days=SUPPORTED_SKILL_OUTCOME_HORIZONS.get(
+                    candidate.horizon,
+                    0,
+                ),
+                exact_start_required=exact_start_required,
+            )
+
+        return SkillOpinionOutcomeEvaluator.evaluate(
+            signal=candidate.sample.signal,
+            horizon=candidate.horizon,
+            analysis_date=analysis_date,
+            start_bar=window.start_bar if window is not None else None,
+            forward_bars=window.forward_bars if window is not None else (),
+        )
+
+    @classmethod
+    def _resolve_analysis_date(
+        cls,
+        history: AnalysisHistory,
+    ) -> Tuple[Optional[date], bool]:
+        summary = extract_market_phase_summary(history.context_snapshot)
+        if isinstance(summary, dict):
+            effective_date = cls._parse_date(summary.get("effective_daily_bar_date"))
+            if effective_date is not None:
+                return effective_date, True
+
+        snapshot_date = BacktestRepository.parse_analysis_date_from_snapshot(
+            history.context_snapshot
+        )
+        if snapshot_date is not None:
+            return snapshot_date, False
+        created_at = getattr(history, "created_at", None)
+        if isinstance(created_at, datetime):
+            return created_at.date(), False
+        return None, False
+
+    @staticmethod
+    def _parse_date(value: Any) -> Optional[date]:
+        if isinstance(value, datetime):
+            return value.date()
+        if isinstance(value, date):
+            return value
+        if isinstance(value, str):
+            try:
+                return date.fromisoformat(value.strip()[:10])
+            except ValueError:
+                return None
+        return None
+
+    @staticmethod
+    def _normalize_horizons(values: Optional[Sequence[str]]) -> List[str]:
+        if values is None:
+            return list(SUPPORTED_SKILL_OUTCOME_HORIZONS)
+        if not values:
+            raise ValueError("horizons must not be empty")
+
+        normalized: List[str] = []
+        for value in values:
+            horizon = str(value or "").strip()
+            if horizon not in SUPPORTED_SKILL_OUTCOME_HORIZONS:
+                raise ValueError(
+                    "horizon must be one of "
+                    + ", ".join(SUPPORTED_SKILL_OUTCOME_HORIZONS)
+                )
+            if horizon not in normalized:
+                normalized.append(horizon)
+        return normalized
+
+    @staticmethod
+    def _optional_positive_int(value: Any, field_name: str) -> Optional[int]:
+        if value is None:
+            return None
+        return SkillOpinionOutcomeService._bounded_positive_int(
+            value,
+            field_name,
+        )
+
+    @staticmethod
+    def _bounded_positive_int(
+        value: Any,
+        field_name: str,
+        *,
+        maximum: Optional[int] = None,
+    ) -> int:
+        if isinstance(value, bool):
+            raise ValueError(f"{field_name} must be a positive integer")
+        if isinstance(value, int):
+            number = value
+        elif isinstance(value, str) and value.strip().isdigit():
+            number = int(value)
+        else:
+            raise ValueError(f"{field_name} must be a positive integer")
+        if number <= 0 or (maximum is not None and number > maximum):
+            suffix = f" no greater than {maximum}" if maximum is not None else ""
+            raise ValueError(f"{field_name} must be a positive integer{suffix}")
+        return number
+
+    @staticmethod
+    def _optional_text(value: Any, field_name: str) -> Optional[str]:
+        if value is None:
+            return None
+        text = str(value).strip()
+        if not text:
+            raise ValueError(f"{field_name} must not be blank")
+        return text
+
+    @staticmethod
+    def _serialize_outcome(
+        row: SkillOpinionOutcomeRecord,
+        sample: SkillOpinionSampleRecord,
+    ) -> Dict[str, Any]:
+        return {
+            "id": row.id,
+            "skill_opinion_sample_id": row.skill_opinion_sample_id,
+            "analysis_history_id": sample.analysis_history_id,
+            "stock_code": sample.stock_code,
+            "skill_id": sample.skill_id,
+            "signal": sample.signal,
+            "horizon": row.horizon,
+            "engine_version": row.engine_version,
+            "eval_status": row.eval_status,
+            "outcome": row.outcome,
+            "direction_correct": row.direction_correct,
+            "unable_reason": row.unable_reason,
+            "analysis_date": row.analysis_date.isoformat() if row.analysis_date else None,
+            "start_trade_date": (
+                row.start_trade_date.isoformat() if row.start_trade_date else None
+            ),
+            "end_trade_date": row.end_trade_date.isoformat() if row.end_trade_date else None,
+            "start_price": row.start_price,
+            "end_close": row.end_close,
+            "stock_return_pct": row.stock_return_pct,
+            "directional_return_pct": row.directional_return_pct,
+            "created_at": row.created_at.isoformat() if row.created_at else None,
+            "updated_at": row.updated_at.isoformat() if row.updated_at else None,
+        }

--- a/src/services/skill_opinion_outcome_service.py
+++ b/src/services/skill_opinion_outcome_service.py
@@ -5,24 +5,20 @@ from __future__ import annotations
 
 from datetime import date, datetime
 import logging
-from typing import Any, Dict, List, Optional, Sequence, Tuple
+from typing import Any, Dict, List, Optional, Sequence
 
 from src.core.skill_opinion_outcome_evaluator import (
     SUPPORTED_SKILL_OUTCOME_HORIZONS,
     SkillOpinionOutcomeEvaluation,
     SkillOpinionOutcomeEvaluator,
 )
-from src.market_phase_summary import extract_market_phase_summary
 from src.repositories.backtest_repo import BacktestRepository
 from src.repositories.skill_opinion_outcome_repo import (
     SkillOpinionOutcomeCandidate,
     SkillOpinionOutcomeRepository,
 )
 from src.repositories.stock_repo import StockRepository
-from src.services.stock_code_utils import (
-    InvalidStockCodeError,
-    build_daily_code_candidates,
-)
+from src.services.stock_daily_start_resolver import resolve_stock_daily_start
 from src.services.stock_daily_window_resolver import resolve_stock_daily_window
 from src.storage import (
     AnalysisHistory,
@@ -138,30 +134,28 @@ class SkillOpinionOutcomeService:
         self,
         candidate: SkillOpinionOutcomeCandidate,
     ) -> SkillOpinionOutcomeEvaluation:
-        analysis_date, exact_start_required = self._resolve_analysis_date(candidate.history)
-        try:
-            daily_code_candidates = build_daily_code_candidates(
-                candidate.sample.stock_code
-            )
-        except InvalidStockCodeError:
+        analysis_date = self._resolve_analysis_date(candidate.history)
+        start_resolution = resolve_stock_daily_start(
+            stock_code=candidate.sample.stock_code,
+            context_snapshot=candidate.history.context_snapshot,
+            analysis_date=analysis_date,
+        )
+        if start_resolution.failure_reason is not None:
             return SkillOpinionOutcomeEvaluation(
                 eval_status="unable",
-                unable_reason="invalid_stock_code",
+                unable_reason=start_resolution.failure_reason,
                 analysis_date=analysis_date,
             )
 
-        window = None
-        if analysis_date is not None:
-            window = resolve_stock_daily_window(
-                stock_repo=self.stock_repo,
-                code_candidates=daily_code_candidates,
-                analysis_date=analysis_date,
-                eval_window_days=SUPPORTED_SKILL_OUTCOME_HORIZONS.get(
-                    candidate.horizon,
-                    0,
-                ),
-                exact_start_required=exact_start_required,
-            )
+        window = resolve_stock_daily_window(
+            stock_repo=self.stock_repo,
+            code_candidates=list(start_resolution.identity.code_candidates),
+            expected_start_date=start_resolution.expected_start_date,
+            eval_window_days=SUPPORTED_SKILL_OUTCOME_HORIZONS.get(
+                candidate.horizon,
+                0,
+            ),
+        )
 
         return SkillOpinionOutcomeEvaluator.evaluate(
             signal=candidate.sample.signal,
@@ -171,38 +165,18 @@ class SkillOpinionOutcomeService:
             forward_bars=window.forward_bars if window is not None else (),
         )
 
-    @classmethod
+    @staticmethod
     def _resolve_analysis_date(
-        cls,
         history: AnalysisHistory,
-    ) -> Tuple[Optional[date], bool]:
-        summary = extract_market_phase_summary(history.context_snapshot)
-        if isinstance(summary, dict):
-            effective_date = cls._parse_date(summary.get("effective_daily_bar_date"))
-            if effective_date is not None:
-                return effective_date, True
-
+    ) -> Optional[date]:
         snapshot_date = BacktestRepository.parse_analysis_date_from_snapshot(
             history.context_snapshot
         )
         if snapshot_date is not None:
-            return snapshot_date, False
+            return snapshot_date
         created_at = getattr(history, "created_at", None)
         if isinstance(created_at, datetime):
-            return created_at.date(), False
-        return None, False
-
-    @staticmethod
-    def _parse_date(value: Any) -> Optional[date]:
-        if isinstance(value, datetime):
-            return value.date()
-        if isinstance(value, date):
-            return value
-        if isinstance(value, str):
-            try:
-                return date.fromisoformat(value.strip()[:10])
-            except ValueError:
-                return None
+            return created_at.date()
         return None
 
     @staticmethod

--- a/src/services/stock_daily_start_resolver.py
+++ b/src/services/stock_daily_start_resolver.py
@@ -1,0 +1,120 @@
+# -*- coding: utf-8 -*-
+"""Resolve one authoritative stock identity and local-daily start date."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date, datetime
+from typing import Any, Optional
+
+from src.core.trading_calendar import resolve_historical_daily_bar_date
+from src.market_phase_summary import (
+    extract_market_phase_summary,
+    rebuild_market_phase_summary_for_stock_code,
+)
+from src.services.stock_code_utils import (
+    DailyStockIdentity,
+    resolve_daily_stock_identity,
+)
+
+
+@dataclass(frozen=True)
+class DailyStockStartResolution:
+    """Authoritative identity and start date before local bars are queried."""
+
+    identity: Optional[DailyStockIdentity]
+    expected_start_date: Optional[date]
+    failure_reason: Optional[str]
+
+
+def resolve_stock_daily_start(
+    *,
+    stock_code: Optional[str],
+    context_snapshot: Any,
+    analysis_date: Optional[date],
+) -> DailyStockStartResolution:
+    """Resolve stock identity, validated phase context, and expected start."""
+
+    phase_summary = extract_market_phase_summary(context_snapshot)
+    persisted_market = (
+        str(phase_summary.get("market") or "").strip().lower()
+        if isinstance(phase_summary, dict)
+        else ""
+    )
+    identity = resolve_daily_stock_identity(
+        stock_code,
+        market_hint=persisted_market or None,
+    )
+    if identity is None:
+        return DailyStockStartResolution(None, None, "invalid_stock_code")
+    if analysis_date is None:
+        return DailyStockStartResolution(identity, None, "missing_analysis_date")
+
+    if persisted_market != identity.market:
+        phase_summary = rebuild_market_phase_summary_for_stock_code(
+            identity.normalized_code,
+            context_snapshot,
+        )
+        persisted_market = (
+            str(phase_summary.get("market") or "").strip().lower()
+            if isinstance(phase_summary, dict)
+            else ""
+        )
+        if persisted_market != identity.market:
+            return DailyStockStartResolution(
+                identity,
+                None,
+                "invalid_market_phase_context",
+            )
+
+    effective_date_value = (
+        phase_summary.get("effective_daily_bar_date")
+        if isinstance(phase_summary, dict)
+        else None
+    )
+    if effective_date_value:
+        effective_date = _parse_date(effective_date_value)
+        if effective_date is None:
+            return DailyStockStartResolution(
+                identity,
+                None,
+                "invalid_effective_daily_bar_date",
+            )
+        if effective_date > analysis_date:
+            return DailyStockStartResolution(
+                identity,
+                None,
+                "future_effective_daily_bar_date",
+            )
+        return DailyStockStartResolution(identity, effective_date, None)
+
+    phase = (
+        phase_summary.get("phase")
+        if isinstance(phase_summary, dict)
+        else None
+    )
+    expected_start_date = resolve_historical_daily_bar_date(
+        identity.market,
+        analysis_date,
+        phase,
+    )
+    if expected_start_date is None:
+        return DailyStockStartResolution(
+            identity,
+            None,
+            "unresolvable_expected_start_date",
+        )
+    return DailyStockStartResolution(identity, expected_start_date, None)
+
+
+def _parse_date(value: Any) -> Optional[date]:
+    if isinstance(value, datetime):
+        return value.date()
+    if isinstance(value, date):
+        return value
+    if isinstance(value, str):
+        try:
+            return datetime.strptime(value.strip(), "%Y-%m-%d").date()
+        except ValueError:
+            return None
+    return None

--- a/src/services/stock_daily_start_resolver.py
+++ b/src/services/stock_daily_start_resolver.py
@@ -86,6 +86,19 @@ def resolve_stock_daily_start(
                 None,
                 "future_effective_daily_bar_date",
             )
+        if (
+            resolve_historical_daily_bar_date(
+                identity.market,
+                effective_date,
+                "postmarket",
+            )
+            != effective_date
+        ):
+            return DailyStockStartResolution(
+                identity,
+                None,
+                "invalid_effective_daily_bar_date",
+            )
         return DailyStockStartResolution(identity, effective_date, None)
 
     phase = (

--- a/src/services/stock_daily_start_resolver.py
+++ b/src/services/stock_daily_start_resolver.py
@@ -25,6 +25,7 @@ class DailyStockStartResolution:
     identity: Optional[DailyStockIdentity]
     expected_start_date: Optional[date]
     failure_reason: Optional[str]
+    legacy_local_start_date: Optional[date] = None
 
 
 def resolve_stock_daily_start(
@@ -98,6 +99,7 @@ def resolve_stock_daily_start(
                 identity,
                 None,
                 "invalid_effective_daily_bar_date",
+                legacy_local_start_date=effective_date,
             )
         return DailyStockStartResolution(identity, effective_date, None)
 

--- a/src/storage.py
+++ b/src/storage.py
@@ -34,6 +34,7 @@ from sqlalchemy import (
     ForeignKey,
     Index,
     UniqueConstraint,
+    CheckConstraint,
     Text,
     text,
     select,
@@ -1171,6 +1172,83 @@ class SkillOpinionSampleRecord(Base):
             'ix_skill_opinion_sample_stock_created',
             'stock_code',
             'created_at',
+        ),
+    )
+
+
+class SkillOpinionOutcomeRecord(Base):
+    """Forward outcome for one immutable skill opinion sample and horizon."""
+
+    __tablename__ = 'skill_opinion_outcomes'
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    skill_opinion_sample_id = Column(
+        Integer,
+        ForeignKey('skill_opinion_samples.id', ondelete='CASCADE'),
+        nullable=False,
+        index=True,
+    )
+    horizon = Column(String(16), nullable=False, index=True)
+    engine_version = Column(String(32), nullable=False, index=True)
+    eval_status = Column(String(24), nullable=False, default='pending', index=True)
+    outcome = Column(String(16), index=True)
+    direction_correct = Column(Boolean)
+    unable_reason = Column(String(64), index=True)
+    analysis_date = Column(Date, index=True)
+    start_trade_date = Column(Date, index=True)
+    end_trade_date = Column(Date, index=True)
+    start_price = Column(Float)
+    end_close = Column(Float)
+    stock_return_pct = Column(Float)
+    directional_return_pct = Column(Float)
+    created_at = Column(DateTime, default=utc_naive_now, index=True)
+    updated_at = Column(DateTime, default=utc_naive_now, onupdate=utc_naive_now, index=True)
+
+    __table_args__ = (
+        UniqueConstraint(
+            'skill_opinion_sample_id',
+            'horizon',
+            'engine_version',
+            name='uix_skill_opinion_outcome_key',
+        ),
+        CheckConstraint(
+            "horizon IN ('1d', '3d', '5d', '10d')",
+            name='ck_skill_opinion_outcome_horizon',
+        ),
+        CheckConstraint(
+            "eval_status IN ('pending', 'evaluated', 'observational', 'unable')",
+            name='ck_skill_opinion_outcome_eval_status',
+        ),
+        CheckConstraint(
+            "outcome IS NULL OR outcome IN ('hit', 'miss', 'observational')",
+            name='ck_skill_opinion_outcome_value',
+        ),
+        CheckConstraint(
+            "(eval_status IN ('pending', 'unable') "
+            "AND outcome IS NULL "
+            "AND direction_correct IS NULL "
+            "AND directional_return_pct IS NULL) "
+            "OR (eval_status = 'observational' "
+            "AND outcome = 'observational' "
+            "AND direction_correct IS NULL "
+            "AND directional_return_pct IS NULL) "
+            "OR (eval_status = 'evaluated' "
+            "AND outcome IN ('hit', 'miss') "
+            "AND direction_correct IS NOT NULL "
+            "AND directional_return_pct IS NOT NULL)",
+            name='ck_skill_opinion_outcome_state_fields',
+        ),
+        Index(
+            'ix_skill_opinion_outcome_candidate',
+            'engine_version',
+            'eval_status',
+            'updated_at',
+        ),
+        Index(
+            'ix_skill_opinion_outcome_horizon_status',
+            'engine_version',
+            'horizon',
+            'eval_status',
         ),
     )
 
@@ -2484,6 +2562,21 @@ class DatabaseManager(metaclass=_DatabaseManagerMeta):
             session.execute(
                 delete(BacktestResult).where(BacktestResult.analysis_history_id.in_(existing_ids))
             )
+            linked_skill_sample_ids = sorted(
+                session.execute(
+                    select(SkillOpinionSampleRecord.id).where(
+                        SkillOpinionSampleRecord.analysis_history_id.in_(existing_ids)
+                    )
+                ).scalars().all()
+            )
+            if linked_skill_sample_ids:
+                session.execute(
+                    delete(SkillOpinionOutcomeRecord).where(
+                        SkillOpinionOutcomeRecord.skill_opinion_sample_id.in_(
+                            linked_skill_sample_ids
+                        )
+                    )
+                )
             session.execute(
                 delete(SkillOpinionSampleRecord).where(
                     SkillOpinionSampleRecord.analysis_history_id.in_(existing_ids)

--- a/tests/test_backtest_service.py
+++ b/tests/test_backtest_service.py
@@ -1139,7 +1139,7 @@ class BacktestServiceTestCase(unittest.TestCase):
 
         service = BacktestService(self.db)
         with patch(
-            "src.services.backtest_service.resolve_historical_daily_bar_date",
+            "src.services.stock_daily_start_resolver.resolve_historical_daily_bar_date",
             side_effect=AssertionError("snapshot effective date must take priority"),
         ):
             stats = service.run_backtest(

--- a/tests/test_backtest_service.py
+++ b/tests/test_backtest_service.py
@@ -1140,8 +1140,8 @@ class BacktestServiceTestCase(unittest.TestCase):
         service = BacktestService(self.db)
         with patch(
             "src.services.stock_daily_start_resolver.resolve_historical_daily_bar_date",
-            side_effect=AssertionError("snapshot effective date must take priority"),
-        ):
+            return_value=date(2024, 1, 5),
+        ) as resolve_historical_date:
             stats = service.run_backtest(
                 code="600519.SH",
                 force=False,
@@ -1152,6 +1152,11 @@ class BacktestServiceTestCase(unittest.TestCase):
                 limit=10,
             )
 
+        resolve_historical_date.assert_called_once_with(
+            "cn",
+            date(2024, 1, 5),
+            "postmarket",
+        )
         self.assertEqual(stats["processed"], 1)
         self.assertEqual(stats["completed"], 1)
         self.assertEqual(stats["insufficient"], 0)

--- a/tests/test_backtest_service.py
+++ b/tests/test_backtest_service.py
@@ -1170,6 +1170,68 @@ class BacktestServiceTestCase(unittest.TestCase):
             self.assertEqual(result.start_price, 100.0)
             self.assertEqual(result.end_close, 105.0)
 
+    def test_run_backtest_replays_legacy_non_session_effective_date_from_local_bars(
+        self,
+    ) -> None:
+        self._seed_analysis(
+            query_id="q_legacy_non_session_effective_date",
+            code="600520",
+            analysis_date=date(2024, 1, 1),
+            created_at=datetime(2024, 1, 1, 0, 0, 0),
+            operation_advice="买入",
+            trend_prediction="看多",
+            start_close=100.0,
+            forward_bars=[
+                StockDaily(
+                    code="600520",
+                    date=date(2024, 1, 2),
+                    high=102.0,
+                    low=99.0,
+                    close=101.0,
+                ),
+                StockDaily(
+                    code="600520",
+                    date=date(2024, 1, 3),
+                    high=103.0,
+                    low=100.0,
+                    close=102.0,
+                ),
+                StockDaily(
+                    code="600520",
+                    date=date(2024, 1, 4),
+                    high=104.0,
+                    low=101.0,
+                    close=103.0,
+                ),
+            ],
+            phase="postmarket",
+        )
+
+        service = BacktestService(self.db)
+        with patch.object(service, "_try_fill_daily_data") as refill:
+            stats = service.run_backtest(
+                code="600520",
+                force=False,
+                eval_window_days=3,
+                min_age_days=0,
+                analysis_date_from=date(2024, 1, 1),
+                analysis_date_to=date(2024, 1, 1),
+                limit=10,
+            )
+
+        refill.assert_not_called()
+        self.assertEqual(stats["completed"], 1)
+        self.assertEqual(stats["insufficient"], 0)
+        with self.db.get_session() as session:
+            result = (
+                session.query(BacktestResult)
+                .filter(BacktestResult.code == "600520")
+                .one()
+            )
+            self.assertEqual(result.eval_status, "completed")
+            self.assertEqual(result.start_price, 100.0)
+            self.assertEqual(result.end_close, 103.0)
+
     def test_run_backtest_rebuilds_legacy_cn_snapshot_for_jp_history(self) -> None:
         legacy_snapshot = json.dumps(
             {

--- a/tests/test_skill_opinion_outcomes.py
+++ b/tests/test_skill_opinion_outcomes.py
@@ -1,0 +1,446 @@
+# -*- coding: utf-8 -*-
+"""Tests for Issue #1904 skill opinion forward outcomes."""
+
+from __future__ import annotations
+
+import json
+import os
+from datetime import date, datetime
+from types import SimpleNamespace
+
+import pytest
+from sqlalchemy import inspect
+from sqlalchemy.exc import IntegrityError
+
+from src.config import Config
+from src.core.skill_opinion_outcome_evaluator import SkillOpinionOutcomeEvaluator
+from src.repositories.skill_opinion_outcome_repo import SkillOpinionOutcomeRepository
+from src.services.skill_opinion_outcome_service import (
+    SKILL_OPINION_OUTCOME_ENGINE_VERSION,
+    SkillOpinionOutcomeService,
+)
+from src.storage import (
+    AnalysisHistory,
+    Base,
+    DatabaseManager,
+    SkillOpinionOutcomeRecord,
+    SkillOpinionSampleRecord,
+    StockDaily,
+)
+
+
+@pytest.fixture()
+def isolated_db(tmp_path):
+    old_database_path = os.environ.get("DATABASE_PATH")
+    os.environ["DATABASE_PATH"] = str(tmp_path / "skill_opinion_outcomes.db")
+    Config.reset_instance()
+    DatabaseManager.reset_instance()
+    db = DatabaseManager.get_instance()
+    try:
+        yield db
+    finally:
+        DatabaseManager.reset_instance()
+        Config.reset_instance()
+        if old_database_path is None:
+            os.environ.pop("DATABASE_PATH", None)
+        else:
+            os.environ["DATABASE_PATH"] = old_database_path
+
+
+def _bar(day: date, close: float):
+    return SimpleNamespace(date=day, close=close)
+
+
+def _add_sample(
+    db: DatabaseManager,
+    *,
+    signal: str = "buy",
+    skill_id: str = "alpha",
+    code: str = "600519",
+    context_snapshot=None,
+    created_at: datetime = datetime(2024, 1, 2, 18, 0, 0),
+    operation_advice: str = "hold",
+) -> tuple[int, int]:
+    with db.session_scope() as session:
+        history = AnalysisHistory(
+            query_id=f"outcome-{skill_id}",
+            code=code,
+            report_type="simple",
+            operation_advice=operation_advice,
+            context_snapshot=(
+                json.dumps(context_snapshot)
+                if isinstance(context_snapshot, dict)
+                else context_snapshot
+            ),
+            created_at=created_at,
+        )
+        session.add(history)
+        session.flush()
+        sample = SkillOpinionSampleRecord(
+            analysis_history_id=history.id,
+            stock_code=code,
+            skill_id=skill_id,
+            signal=signal,
+            confidence=0.8,
+            sample_schema_version="skill-opinion-sample-v1",
+        )
+        session.add(sample)
+        session.flush()
+        return int(history.id), int(sample.id)
+
+
+def _seed_bars(
+    db: DatabaseManager,
+    *,
+    code: str,
+    bars: list[tuple[date, float]],
+) -> None:
+    with db.session_scope() as session:
+        for day, close in bars:
+            session.add(
+                StockDaily(
+                    code=code,
+                    date=day,
+                    open=close,
+                    high=close,
+                    low=close,
+                    close=close,
+                )
+            )
+
+
+def _effective_snapshot(day: str) -> dict:
+    return {
+        "market_phase_summary": {
+            "phase": "postmarket",
+            "effective_daily_bar_date": day,
+        }
+    }
+
+
+def _stored_outcome(
+    db: DatabaseManager,
+    sample_id: int,
+    horizon: str = "1d",
+    engine_version: str = SKILL_OPINION_OUTCOME_ENGINE_VERSION,
+):
+    return SkillOpinionOutcomeRepository(db).get_outcome(
+        sample_id=sample_id,
+        horizon=horizon,
+        engine_version=engine_version,
+    )
+
+
+@pytest.mark.parametrize(
+    ("signal", "end_close", "expected_outcome", "expected_correct"),
+    [
+        ("buy", 105.0, "hit", True),
+        ("strong_buy", 95.0, "miss", False),
+        ("sell", 95.0, "hit", True),
+        ("strong_sell", 105.0, "miss", False),
+        ("buy", 100.0, "miss", False),
+    ],
+)
+def test_evaluator_uses_sample_signal_and_zero_is_miss(
+    signal,
+    end_close,
+    expected_outcome,
+    expected_correct,
+) -> None:
+    result = SkillOpinionOutcomeEvaluator.evaluate(
+        signal=signal,
+        horizon="1d",
+        analysis_date=date(2024, 1, 2),
+        start_bar=_bar(date(2024, 1, 2), 100.0),
+        forward_bars=[_bar(date(2024, 1, 3), end_close)],
+    )
+
+    assert result.eval_status == "evaluated"
+    assert result.outcome == expected_outcome
+    assert result.direction_correct is expected_correct
+
+
+def test_evaluator_hold_is_observational() -> None:
+    result = SkillOpinionOutcomeEvaluator.evaluate(
+        signal="hold",
+        horizon="1d",
+        analysis_date=date(2024, 1, 2),
+        start_bar=_bar(date(2024, 1, 2), 100.0),
+        forward_bars=[_bar(date(2024, 1, 3), 105.0)],
+    )
+
+    assert result.eval_status == "observational"
+    assert result.outcome == "observational"
+    assert result.direction_correct is None
+    assert result.directional_return_pct is None
+
+
+def test_effective_daily_bar_date_requires_exact_start_bar(isolated_db) -> None:
+    _, sample_id = _add_sample(
+        isolated_db,
+        context_snapshot=_effective_snapshot("2024-01-03"),
+    )
+    _seed_bars(
+        isolated_db,
+        code="600519",
+        bars=[
+            (date(2024, 1, 2), 100.0),
+            (date(2024, 1, 4), 105.0),
+        ],
+    )
+
+    item = SkillOpinionOutcomeService(db_manager=isolated_db).run_outcomes(
+        sample_id=sample_id,
+        horizons=["1d"],
+    )["items"][0]
+
+    assert item["eval_status"] == "pending"
+    assert item["unable_reason"] == "missing_start_bar"
+    assert item["start_trade_date"] is None
+
+
+def test_outcome_reuses_resolver_to_choose_newest_complete_equivalent_window(
+    isolated_db,
+) -> None:
+    """Regression for the stale-first-candidate blocker raised on PR #2069."""
+
+    _, sample_id = _add_sample(
+        isolated_db,
+        code="600519.SH",
+        context_snapshot={"enhanced_context": {"date": "2024-01-07"}},
+    )
+    _seed_bars(
+        isolated_db,
+        code="600519.SH",
+        bars=[(date(2024, 1, 2), 50.0)],
+    )
+    _seed_bars(
+        isolated_db,
+        code="600519",
+        bars=[
+            (date(2024, 1, 5), 100.0),
+            (date(2024, 1, 8), 105.0),
+        ],
+    )
+
+    item = SkillOpinionOutcomeService(db_manager=isolated_db).run_outcomes(
+        sample_id=sample_id,
+        horizons=["1d"],
+    )["items"][0]
+
+    assert item["eval_status"] == "evaluated"
+    assert item["start_trade_date"] == "2024-01-05"
+    assert item["end_trade_date"] == "2024-01-08"
+    assert item["start_price"] == pytest.approx(100.0)
+    assert item["stock_return_pct"] == pytest.approx(5.0)
+
+
+def test_outcome_never_combines_start_and_forward_bars_across_code_shapes(
+    isolated_db,
+) -> None:
+    _, sample_id = _add_sample(
+        isolated_db,
+        code="600519.SH",
+        context_snapshot=_effective_snapshot("2024-01-02"),
+    )
+    _seed_bars(
+        isolated_db,
+        code="600519.SH",
+        bars=[(date(2024, 1, 2), 100.0)],
+    )
+    _seed_bars(
+        isolated_db,
+        code="600519",
+        bars=[(date(2024, 1, 3), 105.0)],
+    )
+
+    item = SkillOpinionOutcomeService(db_manager=isolated_db).run_outcomes(
+        sample_id=sample_id,
+        horizons=["1d"],
+    )["items"][0]
+
+    assert item["eval_status"] == "pending"
+    assert item["unable_reason"] == "insufficient_future_data"
+    assert item["start_trade_date"] == "2024-01-02"
+    assert item["end_trade_date"] is None
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"horizons": []},
+        {"skill_id": "   "},
+        {"stock_code": ""},
+        {"limit": 0},
+        {"limit": 1.5},
+        {"limit": 501},
+    ],
+)
+def test_explicit_empty_or_out_of_range_filters_fail_closed(
+    isolated_db,
+    kwargs,
+) -> None:
+    _, sample_id = _add_sample(isolated_db)
+    service = SkillOpinionOutcomeService(db_manager=isolated_db)
+
+    with pytest.raises(ValueError):
+        service.run_outcomes(sample_id=sample_id, **kwargs)
+
+    with isolated_db.get_session() as session:
+        assert session.query(SkillOpinionOutcomeRecord).count() == 0
+
+
+def test_each_skill_uses_its_own_signal_not_history_decision(isolated_db) -> None:
+    history_id, buy_sample_id = _add_sample(
+        isolated_db,
+        signal="buy",
+        skill_id="buyer",
+        operation_advice="hold",
+        context_snapshot=_effective_snapshot("2024-01-02"),
+    )
+    with isolated_db.session_scope() as session:
+        sell_sample = SkillOpinionSampleRecord(
+            analysis_history_id=history_id,
+            stock_code="600519",
+            skill_id="seller",
+            signal="sell",
+            confidence=0.8,
+            sample_schema_version="skill-opinion-sample-v1",
+        )
+        session.add(sell_sample)
+        session.flush()
+        sell_sample_id = int(sell_sample.id)
+    _seed_bars(
+        isolated_db,
+        code="600519",
+        bars=[
+            (date(2024, 1, 2), 100.0),
+            (date(2024, 1, 3), 105.0),
+        ],
+    )
+
+    result = SkillOpinionOutcomeService(db_manager=isolated_db).run_outcomes(
+        analysis_history_id=history_id,
+        horizons=["1d"],
+        limit=2,
+    )
+    by_sample = {item["skill_opinion_sample_id"]: item for item in result["items"]}
+
+    assert by_sample[buy_sample_id]["outcome"] == "hit"
+    assert by_sample[sell_sample_id]["outcome"] == "miss"
+
+
+def test_pending_is_retried_but_terminal_outcome_is_immutable(isolated_db) -> None:
+    _, sample_id = _add_sample(
+        isolated_db,
+        context_snapshot=_effective_snapshot("2024-01-02"),
+    )
+    _seed_bars(isolated_db, code="600519", bars=[(date(2024, 1, 2), 100.0)])
+    service = SkillOpinionOutcomeService(db_manager=isolated_db)
+
+    pending = service.run_outcomes(sample_id=sample_id, horizons=["1d"])["items"][0]
+    assert pending["eval_status"] == "pending"
+
+    _seed_bars(isolated_db, code="600519", bars=[(date(2024, 1, 3), 105.0)])
+    evaluated = service.run_outcomes(sample_id=sample_id, horizons=["1d"])["items"][0]
+    assert evaluated["eval_status"] == "evaluated"
+    assert evaluated["stock_return_pct"] == pytest.approx(5.0)
+
+    with isolated_db.session_scope() as session:
+        bar = session.query(StockDaily).filter_by(
+            code="600519",
+            date=date(2024, 1, 3),
+        ).one()
+        bar.close = 90.0
+    assert service.run_outcomes(
+        sample_id=sample_id,
+        horizons=["1d"],
+    )["processed_keys"] == 0
+    assert _stored_outcome(isolated_db, sample_id).stock_return_pct == pytest.approx(5.0)
+
+
+def test_history_deletion_removes_outcomes_before_samples(isolated_db) -> None:
+    history_id, sample_id = _add_sample(isolated_db)
+    repo = SkillOpinionOutcomeRepository(isolated_db)
+    repo.persist_outcome(
+        {
+            "skill_opinion_sample_id": sample_id,
+            "horizon": "1d",
+            "engine_version": SKILL_OPINION_OUTCOME_ENGINE_VERSION,
+            "eval_status": "pending",
+            "outcome": None,
+            "direction_correct": None,
+            "unable_reason": "insufficient_future_data",
+        }
+    )
+
+    assert isolated_db.delete_analysis_history_records([history_id]) == 1
+    with isolated_db.get_session() as session:
+        assert session.query(SkillOpinionOutcomeRecord).count() == 0
+        assert session.query(SkillOpinionSampleRecord).count() == 0
+
+
+def test_engine_version_is_part_of_identity_and_terminal_rows_are_immutable(
+    isolated_db,
+) -> None:
+    _, sample_id = _add_sample(isolated_db)
+    repo = SkillOpinionOutcomeRepository(isolated_db)
+    base = {
+        "skill_opinion_sample_id": sample_id,
+        "horizon": "1d",
+        "eval_status": "evaluated",
+        "outcome": "hit",
+        "direction_correct": True,
+        "unable_reason": None,
+        "stock_return_pct": 5.0,
+        "directional_return_pct": 5.0,
+    }
+
+    _, first = repo.persist_outcome({**base, "engine_version": "engine-v1"})
+    _, repeated = repo.persist_outcome(
+        {
+            **base,
+            "engine_version": "engine-v1",
+            "outcome": "miss",
+            "direction_correct": False,
+        }
+    )
+    _, second = repo.persist_outcome({**base, "engine_version": "engine-v2"})
+
+    assert (first, repeated, second) == ("created", "skipped", "created")
+    with isolated_db.get_session() as session:
+        assert session.query(SkillOpinionOutcomeRecord).count() == 2
+
+
+def test_outcome_schema_enforces_identity_and_state_values(isolated_db) -> None:
+    Base.metadata.create_all(isolated_db._engine)
+    inspector = inspect(isolated_db._engine)
+    unique_constraints = inspector.get_unique_constraints("skill_opinion_outcomes")
+    checks = {
+        item["name"] for item in inspector.get_check_constraints("skill_opinion_outcomes")
+    }
+
+    assert any(
+        item["name"] == "uix_skill_opinion_outcome_key"
+        and item["column_names"]
+        == ["skill_opinion_sample_id", "horizon", "engine_version"]
+        for item in unique_constraints
+    )
+    assert checks >= {
+        "ck_skill_opinion_outcome_horizon",
+        "ck_skill_opinion_outcome_eval_status",
+        "ck_skill_opinion_outcome_value",
+        "ck_skill_opinion_outcome_state_fields",
+    }
+
+    _, sample_id = _add_sample(isolated_db)
+    with pytest.raises(IntegrityError):
+        with isolated_db.session_scope() as session:
+            session.add(
+                SkillOpinionOutcomeRecord(
+                    skill_opinion_sample_id=sample_id,
+                    horizon="20d",
+                    engine_version="invalid",
+                    eval_status="pending",
+                )
+            )

--- a/tests/test_skill_opinion_outcomes.py
+++ b/tests/test_skill_opinion_outcomes.py
@@ -221,6 +221,14 @@ def test_effective_daily_bar_date_requires_exact_start_bar(isolated_db) -> None:
             "future_effective_daily_bar_date",
         ),
         (
+            {
+                "phase": "postmarket",
+                "market": "cn",
+                "effective_daily_bar_date": "2024-01-06",
+            },
+            "invalid_effective_daily_bar_date",
+        ),
+        (
             {"phase": "postmarket", "market": "us"},
             "invalid_market_phase_context",
         ),

--- a/tests/test_skill_opinion_outcomes.py
+++ b/tests/test_skill_opinion_outcomes.py
@@ -111,8 +111,10 @@ def _seed_bars(
 
 def _effective_snapshot(day: str) -> dict:
     return {
+        "enhanced_context": {"date": day},
         "market_phase_summary": {
             "phase": "postmarket",
+            "market": "cn",
             "effective_daily_bar_date": day,
         }
     }
@@ -199,6 +201,111 @@ def test_effective_daily_bar_date_requires_exact_start_bar(isolated_db) -> None:
     assert item["start_trade_date"] is None
 
 
+@pytest.mark.parametrize(
+    ("phase_summary", "expected_reason"),
+    [
+        (
+            {
+                "phase": "postmarket",
+                "market": "cn",
+                "effective_daily_bar_date": "invalid",
+            },
+            "invalid_effective_daily_bar_date",
+        ),
+        (
+            {
+                "phase": "postmarket",
+                "market": "cn",
+                "effective_daily_bar_date": "2024-01-09",
+            },
+            "future_effective_daily_bar_date",
+        ),
+        (
+            {"phase": "postmarket", "market": "us"},
+            "invalid_market_phase_context",
+        ),
+        (
+            {"phase": "unknown", "market": "cn"},
+            "unresolvable_expected_start_date",
+        ),
+    ],
+)
+def test_permanently_invalid_start_metadata_is_terminal_unable(
+    isolated_db,
+    phase_summary,
+    expected_reason,
+) -> None:
+    _, sample_id = _add_sample(
+        isolated_db,
+        code="600519.SH",
+        context_snapshot={
+            "enhanced_context": {"date": "2024-01-08"},
+            "market_phase_summary": phase_summary,
+        },
+    )
+    service = SkillOpinionOutcomeService(db_manager=isolated_db)
+
+    item = service.run_outcomes(
+        sample_id=sample_id,
+        horizons=["1d"],
+    )["items"][0]
+
+    assert item["eval_status"] == "unable"
+    assert item["unable_reason"] == expected_reason
+    assert item["analysis_date"] == "2024-01-08"
+    assert item["start_trade_date"] is None
+    assert item["start_price"] is None
+    assert service.run_outcomes(
+        sample_id=sample_id,
+        horizons=["1d"],
+    )["processed_keys"] == 0
+
+
+def test_outcome_rebuilds_legacy_cn_snapshot_before_using_effective_date(
+    isolated_db,
+) -> None:
+    _, sample_id = _add_sample(
+        isolated_db,
+        code="7203.T",
+        context_snapshot={
+            "enhanced_context": {"date": "2026-01-01"},
+            "market_phase_summary": {
+                "market": "cn",
+                "phase": "postmarket",
+                "market_local_time": "2026-01-01T10:00:00+08:00",
+                "session_date": "2026-01-01",
+                "effective_daily_bar_date": "2025-12-31",
+                "is_trading_day": True,
+                "is_market_open_now": False,
+                "is_partial_bar": False,
+                "trigger_source": "scheduled_job",
+                "analysis_intent": "postmarket",
+                "warnings": ["legacy_snapshot"],
+            },
+        },
+        created_at=datetime(2026, 1, 1, 0, 0, 0),
+    )
+    _seed_bars(
+        isolated_db,
+        code="7203.T",
+        bars=[
+            (date(2025, 12, 30), 100.0),
+            (date(2026, 1, 5), 105.0),
+        ],
+    )
+
+    item = SkillOpinionOutcomeService(db_manager=isolated_db).run_outcomes(
+        sample_id=sample_id,
+        horizons=["1d"],
+    )["items"][0]
+
+    assert item["eval_status"] == "evaluated"
+    assert item["start_trade_date"] == "2025-12-30"
+    assert item["end_trade_date"] == "2026-01-05"
+    assert item["start_price"] == pytest.approx(100.0)
+    assert item["end_close"] == pytest.approx(105.0)
+
+
 def test_outcome_reuses_resolver_to_choose_newest_complete_equivalent_window(
     isolated_db,
 ) -> None:
@@ -207,7 +314,13 @@ def test_outcome_reuses_resolver_to_choose_newest_complete_equivalent_window(
     _, sample_id = _add_sample(
         isolated_db,
         code="600519.SH",
-        context_snapshot={"enhanced_context": {"date": "2024-01-07"}},
+        context_snapshot={
+            "enhanced_context": {"date": "2024-01-07"},
+            "market_phase_summary": {
+                "phase": "non_trading",
+                "market": "cn",
+            },
+        },
     )
     _seed_bars(
         isolated_db,
@@ -233,6 +346,69 @@ def test_outcome_reuses_resolver_to_choose_newest_complete_equivalent_window(
     assert item["end_trade_date"] == "2024-01-08"
     assert item["start_price"] == pytest.approx(100.0)
     assert item["stock_return_pct"] == pytest.approx(5.0)
+
+
+def test_outcome_rejects_all_stale_equivalent_windows(isolated_db) -> None:
+    _, sample_id = _add_sample(
+        isolated_db,
+        code="600517.SH",
+        context_snapshot={
+            "enhanced_context": {"date": "2024-01-07"},
+            "market_phase_summary": {
+                "phase": "non_trading",
+                "market": "cn",
+                "effective_daily_bar_date": "2024-01-05",
+            },
+        },
+    )
+    _seed_bars(
+        isolated_db,
+        code="600517.SH",
+        bars=[
+            (date(2020, 1, 2), 50.0),
+            (date(2024, 1, 8), 55.0),
+        ],
+    )
+    _seed_bars(
+        isolated_db,
+        code="600517",
+        bars=[
+            (date(2021, 1, 4), 60.0),
+            (date(2024, 1, 9), 65.0),
+        ],
+    )
+
+    item = SkillOpinionOutcomeService(db_manager=isolated_db).run_outcomes(
+        sample_id=sample_id,
+        horizons=["1d"],
+    )["items"][0]
+
+    assert item["eval_status"] == "pending"
+    assert item["unable_reason"] == "missing_start_bar"
+    assert item["analysis_date"] == "2024-01-07"
+    assert item["start_trade_date"] is None
+    assert item["end_trade_date"] is None
+    assert item["start_price"] is None
+    assert item["end_close"] is None
+    assert item["stock_return_pct"] is None
+
+
+def test_outcome_invalid_stock_code_fails_closed(isolated_db) -> None:
+    _, sample_id = _add_sample(
+        isolated_db,
+        code="600519.SZ",
+        context_snapshot=_effective_snapshot("2024-01-05"),
+    )
+
+    item = SkillOpinionOutcomeService(db_manager=isolated_db).run_outcomes(
+        sample_id=sample_id,
+        horizons=["1d"],
+    )["items"][0]
+
+    assert item["eval_status"] == "unable"
+    assert item["unable_reason"] == "invalid_stock_code"
+    assert item["start_trade_date"] is None
+    assert item["start_price"] is None
 
 
 def test_outcome_never_combines_start_and_forward_bars_across_code_shapes(


### PR DESCRIPTION
## PR Type

- [x] fix
- [x] feat
- [ ] refactor
- [x] docs
- [ ] chore
- [x] test

## Background And Problem

Issue [#1904](https://github.com/ZhuLinsen/daily_stock_analysis/issues/1904) P2 需要基于真实、可归因的 individual SkillAgent opinion 建立后验 Outcome。仓库已经通过 `skill_opinion_samples` 保存每个 SkillAgent 的独立 signal，但此前缺少按 sample 自身 signal 计算、持久化和重试后验结果的核心链路。

原 PR [#2069](https://github.com/ZhuLinsen/daily_stock_analysis/pull/2069) 同时包含 Outcome、股票代码与日线窗口 correctness、管理员 API 和 OpenAPI，范围过大。共享股票身份和本地日线窗口基础随后拆分至 [#2073](https://github.com/ZhuLinsen/daily_stock_analysis/pull/2073)，且 #2073 现已合并。

本 PR 已 rebase 到包含 #2073 的当前 `main`，不再是 stacked PR。它只增加 Outcome 核心增量：

- 按每条 sample 自身的 canonical signal 计算 `1d`、`3d`、`5d`、`10d` 后验；
- 使用 Backtest 与 Outcome 共用的 expected-start resolver，统一股票身份、旧市场快照重建和权威起始 session；
- 使用共享 daily-window resolver 选择同一代码候选内的 start/forward bars；
- 将行情暂时不足保存为可重试 `pending`；
- 将损坏、冲突或无法证明权威起点的元数据保存为终态 `unable`；
- 同一 engine version 下只允许更新 `pending`，不覆盖终态结果；
- 对空 horizons、空白筛选和非法 limit 在查询及写入前 fail closed。

本 PR 不新增管理员 API、Schema、OpenAPI 或主 Pipeline 自动触发，也不提供表现统计、样本充足度、排名或权重调整。

## Scope Of Change

本描述基于：

- Base：`upstream/main` (`f4d9956c`)
- Head：`b65d867b`
- 提交数：3
- 文件总数：10
- 变更统计：1579 insertions、84 deletions

### Outcome 计算

- `src/core/skill_opinion_outcome_evaluator.py`
  - 使用 sample 自身 signal 计算 bullish、bearish 和 hold 后验；
  - 零方向收益判定为 `miss`；
  - hold 在窗口完整时保存为 `observational`；
  - 保存实际起止交易日、价格、股票收益和方向收益；
  - 区分可重试 `pending` 与永久失败 `unable`。

### 权威起点和日线窗口

- `src/services/stock_daily_start_resolver.py`
  - 提供 Backtest 与 Outcome 共用的股票身份和 expected-start 契约；
  - 复用既有股票 identity、市场快照重建和交易日历入口；
  - 在接受 `effective_daily_bar_date` 前确认股票市场与快照市场一致；
  - 对受支持的 JP/KR/TW legacy snapshot 先重建市场上下文；
  - 严格拒绝损坏或晚于分析日期的 effective date；
  - 缺少有效日期时，仅在 phase 和交易日历能够证明 session 时推导起点。

- `src/services/backtest_service.py`
  - 删除私有 expected-start 实现；
  - 改为与 Outcome 消费同一个共享 resolver；
  - 继续使用同一 identity 驱动候选查询、refill 和窗口计算；
  - 保持 #2073 已建立的 `insufficient_data` 行为。

- `src/services/skill_opinion_outcome_service.py`
  - 查询并编排 missing/pending sample × horizon keys；
  - 使用共享 start resolver 和 daily-window resolver；
  - 不再独立实现股票市场、freshness 或交易日历判断；
  - 永久无效元数据写入终态 `unable`；
  - 单个 key 的临时异常不会写入伪终态，后续仍可处理。

### 持久化

- `src/repositories/skill_opinion_outcome_repo.py`
  - 查询 missing/pending outcome keys；
  - 通过共享写事务插入或更新 Outcome；
  - 同一 engine version 的终态结果不可覆盖；
  - 写入前确认 sample 仍存在，避免孤儿记录。

- `src/storage.py`
  - 新增 `skill_opinion_outcomes` sidecar 表；
  - 唯一键为 `(skill_opinion_sample_id, horizon, engine_version)`；
  - 增加 horizon、状态、outcome 和状态字段组合约束；
  - 删除分析历史时按 outcome → sample → history 顺序显式清理。

### 测试

- `tests/test_skill_opinion_outcomes.py`
  - 覆盖 bullish、bearish、hold 和零收益语义；
  - 覆盖真实 SQLite Outcome 计算和持久化；
  - 覆盖 #2069 的陈旧候选反例及同源窗口约束；
  - 覆盖所有候选陈旧、非法代码和永久无效起点元数据；
  - 覆盖 JP legacy CN snapshot 必须先重建再使用 effective date；
  - 覆盖 pending 重试、终态不可变、engine version identity、历史级联清理和数据库约束；
  - 覆盖非法 horizons、筛选和 limit fail closed。

- `tests/test_backtest_service.py`
  - 更新 calendar patch 入口，使既有 Backtest 回归继续验证共享 resolver。

### 文档

- `docs/multi-strategy-contract.md`
  - 记录 Outcome identity、状态、收益、权威起点、同源窗口和幂等契约；
  - 记录本阶段不包含 API、统计、权重和 Pipeline 自动触发。
 

- `docs/CHANGELOG.md`
  - 记录 Skill Opinion Outcome 核心计算和持久化能力。
  

## Issue Link

Refs [#1904](https://github.com/ZhuLinsen/daily_stock_analysis/issues/1904)

Follow-up and scoped replacement for [#2069](https://github.com/ZhuLinsen/daily_stock_analysis/pull/2069).

Builds on the stock identity and daily-window correctness foundation merged in [#2073](https://github.com/ZhuLinsen/daily_stock_analysis/pull/2073).

本 PR 不声称完成表现统计、样本充足度、权重校准、Web 可见性或完整审计闭环。

## Verification Commands And Results

### Executed local verification

```powershell
& 'D:\code\daily_stock_analysis\.venv\Scripts\python.exe' -m pytest `
  tests/test_skill_opinion_outcomes.py -q
```

结果：` 28 passed, 1 warning in 13.85s`。

```powershell
& 'D:\code\daily_stock_analysis\.venv\Scripts\python.exe' -m pytest `
  tests/test_backtest_service.py::BacktestServiceTestCase::test_run_backtest_rebuilds_legacy_cn_snapshot_for_jp_history `
  tests/test_backtest_service.py::BacktestServiceTestCase::test_unfiltered_rerun_rebuilds_legacy_cn_snapshot_for_indexed_bare_jp_code `
  tests/test_backtest_service.py::BacktestServiceTestCase::test_unfiltered_rerun_uses_persisted_market_for_legacy_jp_kr_bare_codes `
  tests/test_backtest_service.py::BacktestServiceTestCase::test_run_backtest_uses_exact_expected_start_across_code_aliases -q
```

结果：`4 passed, 1 warning in 5.82s`。

```powershell
& 'D:\code\daily_stock_analysis\.venv\Scripts\python.exe' -m py_compile `
  src/services/stock_daily_start_resolver.py `
  src/services/skill_opinion_outcome_service.py `
  src/services/backtest_service.py `
  tests/test_skill_opinion_outcomes.py `
  tests/test_backtest_service.py
```

结果：通过，无输出。

```powershell
& 'D:\code\daily_stock_analysis\.venv\Scripts\python.exe' -m flake8 `
  src/services/stock_daily_start_resolver.py `
  src/services/skill_opinion_outcome_service.py `
  src/services/backtest_service.py `
  tests/test_skill_opinion_outcomes.py `
  tests/test_backtest_service.py
```

结果：通过，无输出。

```powershell
git diff --check
```

结果：通过，无 whitespace error；Git 仅提示未来可能执行 LF → CRLF 转换。



### CI status


- `ai-governance`：[pass](https://github.com/ZhuLinsen/daily_stock_analysis/actions/runs/30337113508/job/90204308134?pr=2116)
- `backend-gate`：[pass](https://github.com/ZhuLinsen/daily_stock_analysis/actions/runs/30337113508/job/90204338147?pr=2116)
- `docker-build`：[pass](https://github.com/ZhuLinsen/daily_stock_analysis/actions/runs/30337113508/job/90204338143?pr=2116)
- `web-gate`：skipped



## Visual Evidence (if applicable)

不适用。

本 PR 只修改后端 Outcome 计算、SQLite 持久化、共享日线起点解析、测试和专题文档，不修改报告格式、报告渲染、Web UI、Web 设置或桌面端界面。

## Compatibility And Risk

- API 与调用入口：
  - 不新增或修改公共 API、Schema、认证和 OpenAPI；
  - Outcome Service 尚未接入主分析 Pipeline，也没有管理员 endpoint。

- 数据库：
  - 应用初始化时新增 `skill_opinion_outcomes` 表；
  - 不改写或 backfill 既有 `skill_opinion_samples` 和分析历史；
  - 终态结果按 engine version 保持不可变，规则变化需要提升 engine version。

- 权威起点：
  - Backtest 与 Outcome 统一消费同一个 start resolver；
  - 旧 JP/KR/TW 市场快照沿用既有重建契约；
  - 无法证明股票身份、市场或起始 session 时 fail closed。

- 行情数据：
  - Outcome 只读取本地已存日线，不主动请求外部行情；
  - horizon 按有序 forward bar 数量计算，不额外验证中间交易 session 连续性；
  - 合法起点已确定但本地 start/forward bars 不足时保持 `pending`。

- 外部依赖：
  - 不新增第三方依赖、网络请求或行情 provider；
  - 不变更 provider、model、base URL 或运行时配置迁移语义。

- 权重和最终建议：
  - 不修改 `SkillAggregator`、`AgentMemory`、最终投资建议或自动权重。

主要风险集中在新增数据库表、Outcome 状态不可变语义，以及共享 expected-start resolver 对 Backtest 和 Outcome 的共同影响。相关路径已有定向 SQLite 与 Backtest 回归，但完整测试套件和当前 Head CI 尚未执行。

## Rollback Plan

最小回滚方式：

1. revert 本 PR；
2. 重新部署或重启相关服务；
3. 保留 `skill_opinion_outcomes` 表及其数据作为未使用的 sidecar 数据，不影响既有分析流程。

若必须彻底恢复数据库 schema，应先备份 SQLite 数据库，再手动删除 `skill_opinion_outcomes` 表。无需回滚运行时配置、`skill_opinion_samples` 或 #2073。

## EXTRACT_PROMPT Change (if applicable)

不适用：本 PR 未修改 `src/services/image_stock_extractor.py` 或 `EXTRACT_PROMPT`。

## Checklist

- [x] 本 PR 有明确动机和业务价值 / This PR has a clear motivation and value
- [x] 已提供可复现的验证命令与真实结果 / Reproducible verification commands and results are included
- [x] 已评估兼容性与风险 / Compatibility and risk have been assessed
- [x] 已提供回滚方案 / A rollback plan is provided
- [x] 本 PR 未修改报告格式或 Web UI，无需截图
- [x] 本 PR 未修改 Web 设置字段，无需设置页截图
- [x] 当前 Head 的阻断型 CI 已确认通过


