### PR TITLE
feat: apply Bayesian skill outcome weights

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -511,7 +511,7 @@ AGENT_SKILLS=
 # 记忆与校准系统（追踪历史准确率，自动调节置信度）
 # AGENT_MEMORY_ENABLED=false
 
-# 自动按回测表现加权策略意见
+# 基于样本充足的真实 Skill Outcome 保守加权策略意见
 # AGENT_SKILL_AUTOWEIGHT=true
 
 # 策略路由模式（auto=根据市场状态自动选择 / manual=使用 AGENT_SKILLS 列表）

--- a/apps/dsa-web/src/locales/settingsHelp.test.ts
+++ b/apps/dsa-web/src/locales/settingsHelp.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest';
+
+import { getSettingsHelpContent } from './settingsHelp';
+import { getFieldDescriptionZh } from '../utils/systemConfigI18n';
+
+const flattenHelp = (help: ReturnType<typeof getSettingsHelpContent>) => [
+  help?.summary,
+  help?.usage,
+  ...(help?.valueNotes ?? []),
+  ...(help?.impact ?? []),
+  ...(help?.notes ?? []),
+].filter(Boolean).join(' ');
+
+describe('Skill Outcome auto-weight settings help', () => {
+  it('describes the attributable Outcome threshold in Chinese', () => {
+    const help = getSettingsHelpContent(
+      'settings.agent.AGENT_SKILL_AUTOWEIGHT',
+      undefined,
+      'zh',
+    );
+    const visibleCopy = flattenHelp(help);
+
+    expect(visibleCopy).toContain('Outcome');
+    expect(visibleCopy).toContain('30');
+    expect(visibleCopy).toContain('1.0');
+    expect(visibleCopy).toContain('不使用全局回测胜率');
+    expect(visibleCopy).not.toContain('依赖回测');
+    expect(getFieldDescriptionZh('AGENT_SKILL_AUTOWEIGHT')).toContain('Outcome');
+  });
+
+  it('describes the attributable Outcome threshold in English', () => {
+    const help = getSettingsHelpContent(
+      'settings.agent.AGENT_SKILL_AUTOWEIGHT',
+      undefined,
+      'en',
+    );
+    const visibleCopy = flattenHelp(help);
+
+    expect(visibleCopy).toContain('Outcome');
+    expect(visibleCopy).toContain('30');
+    expect(visibleCopy).toContain('1.0');
+    expect(visibleCopy).toContain('Global backtest win rates never substitute');
+    expect(visibleCopy).not.toContain('Depends on backtest');
+  });
+
+  it('does not present Backtest as the Skill auto-weight data source', () => {
+    const zhHelp = flattenHelp(getSettingsHelpContent(
+      'settings.backtest.BACKTEST_ENABLED',
+      undefined,
+      'zh',
+    ));
+    const enHelp = flattenHelp(getSettingsHelpContent(
+      'settings.backtest.BACKTEST_ENABLED',
+      undefined,
+      'en',
+    ));
+
+    expect(zhHelp).toContain('Skill Outcome');
+    expect(zhHelp).toContain('不直接');
+    expect(enHelp).toContain('Skill Outcome');
+    expect(enHelp).toContain('does not directly');
+  });
+});

--- a/apps/dsa-web/src/locales/settingsHelp.ts
+++ b/apps/dsa-web/src/locales/settingsHelp.ts
@@ -970,11 +970,11 @@ const settingsHelpZhCN: SettingsHelpMap = {
   },
   'settings.agent.AGENT_SKILL_AUTOWEIGHT': {
     title: '策略自动权重',
-    summary: '根据历史回测表现自动调整策略权重。',
-    usage: '开启后，系统按各策略的历史回测准确率加权综合信号。',
-    valueNotes: ['依赖回测数据；回测记录不足时可能无法有效加权。'],
-    impact: ['影响多策略综合时的信号权重分配。'],
-    notes: ['需要先开启回测功能并积累足够的回测数据。'],
+    summary: '基于真实、可归因且样本充足的 Skill Outcome 保守调整策略权重。',
+    usage: '开启后，仅当单个 Skill、周期和评估引擎版本独立达到 30 条 evaluated Outcome 时，系统才使用贝叶斯收缩结果调整综合信号权重。',
+    valueNotes: ['没有真实 Outcome、样本不足或统计异常时保持中性权重 1.0。'],
+    impact: ['影响多策略综合时的相对权重，单个性能因子限制在约 0.833 至 1.2。'],
+    notes: ['不使用全局回测胜率冒充 Skill 表现；当前平均方向收益不参与权重公式。'],
   },
   'settings.agent.AGENT_SKILL_ROUTING': {
     title: '策略路由模式',
@@ -1029,11 +1029,11 @@ const settingsHelpZhCN: SettingsHelpMap = {
     summary: '启用或关闭历史分析回测功能。',
     usage: '开启后，系统会定期将历史分析结果与后续实际走势对比，评估策略准确率。',
     valueNotes: [
-      '回测数据用于策略自动权重（AGENT_SKILL_AUTOWEIGHT）和记忆校准。',
+      '回测记录继续用于历史分析评估和现有记忆校准路径；Skill 自动权重改用独立的可归因 Outcome 数据。',
       '关闭回测不影响已有回测记录，但会停止新回测评估。',
     ],
-    impact: ['影响策略权重校准、记忆校准和回测报告生成。'],
-    notes: ['Agent 策略自动权重功能依赖回测数据。'],
+    impact: ['影响历史回测评估、记忆校准和回测报告生成；不直接控制 Skill Outcome 权重。'],
+    notes: ['AGENT_SKILL_AUTOWEIGHT 不再依赖全局回测胜率。'],
   },
   'settings.backtest.eval_params': {
     title: '回测评估参数',
@@ -2157,11 +2157,11 @@ const settingsHelpEnUS: SettingsHelpMap = {
   },
   'settings.agent.AGENT_SKILL_AUTOWEIGHT': {
     title: 'Auto-Weight Strategies',
-    summary: 'Automatically weights strategy opinions by their historical backtest performance.',
-    usage: 'When enabled, strategies with higher historical accuracy receive more weight in signal aggregation.',
-    valueNotes: ['Depends on backtest data; insufficient records may prevent effective weighting.'],
-    impact: ['Affects signal weight distribution when multiple strategies contribute.'],
-    notes: ['Requires the backtest feature to be enabled with sufficient historical data.'],
+    summary: 'Conservatively weights strategies from real, attributable Skill Outcomes with sufficient samples.',
+    usage: 'When enabled, Bayesian-shrunk performance adjusts signal weights only after one Skill, horizon, and evaluator version independently reaches 30 evaluated Outcomes.',
+    valueNotes: ['Missing Outcomes, insufficient samples, or invalid statistics keep the neutral weight of 1.0.'],
+    impact: ['Affects relative weights in multi-strategy aggregation; each performance factor is bounded to approximately 0.833 through 1.2.'],
+    notes: ['Global backtest win rates never substitute for Skill performance; average directional return is currently descriptive only.'],
   },
   'settings.agent.AGENT_SKILL_ROUTING': {
     title: 'Strategy Routing Mode',
@@ -2216,11 +2216,11 @@ const settingsHelpEnUS: SettingsHelpMap = {
     summary: 'Enables or disables historical analysis backtesting.',
     usage: 'When enabled, the system periodically compares past analysis results with subsequent actual price movements to evaluate strategy accuracy.',
     valueNotes: [
-      'Backtest data feeds into strategy auto-weighting (AGENT_SKILL_AUTOWEIGHT) and memory calibration.',
+      'Backtest records continue to support historical evaluation and existing memory calibration paths; Skill auto-weighting uses separate attributable Outcome data.',
       'Disabling backtest stops new evaluations but preserves existing records.',
     ],
-    impact: ['Affects strategy weight calibration, memory calibration, and backtest report generation.'],
-    notes: ['The Agent strategy auto-weight feature depends on backtest data.'],
+    impact: ['Affects historical backtesting, memory calibration, and backtest reports; it does not directly control Skill Outcome weights.'],
+    notes: ['AGENT_SKILL_AUTOWEIGHT no longer depends on a global backtest win rate.'],
   },
   'settings.backtest.eval_params': {
     title: 'Backtest Evaluation Parameters',

--- a/apps/dsa-web/src/utils/systemConfigI18n.ts
+++ b/apps/dsa-web/src/utils/systemConfigI18n.ts
@@ -365,7 +365,7 @@ const fieldDescriptionMap: Record<string, string> = {
   AGENT_ORCHESTRATOR_MODE: "Multi-Agent 编排深度。quick（技术→决策）、standard（技术→情报→决策）、full（含风控）、specialist（含策略专家评估）。",
   AGENT_ORCHESTRATOR_TIMEOUT_S: "Agent 执行总超时预算（秒）。single-agent 用作整体 ReAct 循环预算，multi-agent 用作协作编排预算；0 表示不限制。",
   AGENT_RISK_OVERRIDE: "允许风控 Agent 在发现关键风险时否决买入信号。",
-  AGENT_SKILL_AUTOWEIGHT: "根据回测表现自动调整策略权重。",
+  AGENT_SKILL_AUTOWEIGHT: "基于样本充足的真实 Skill Outcome 保守调整策略权重。",
   AGENT_SKILL_ROUTING: "策略选择方式。auto 按市场状态自动选择，manual 使用 AGENT_SKILLS 列表。",
   AGENT_MEMORY_ENABLED: "启用记忆与校准系统，追踪历史分析准确率并自动调节置信度。",
   AGENT_NL_ROUTING: '启用自然语言路由，让 Agent 自动识别意图并选择执行路径。',

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,11 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 > For user-friendly release highlights, see the [GitHub Releases](https://github.com/ZhuLinsen/daily_stock_analysis/releases) page.
 
 ## [Unreleased]
+- [新功能] SkillAggregator 基于独立满足 30 条 evaluated 门槛的真实 Skill Outcome bucket，使用 Beta 先验收缩、unable 惩罚和多周期证据加权生成有界运行时权重；缺失、低样本或异常统计保持中性。
 - [修复] Outcome 候选按上次尝试时间公平调度，避免持续新增的缺失 key 使旧 `pending` outcome 永久得不到重试。
 - [新功能] 新增按 skill、horizon 与 outcome engine version 独立聚合的只读 Skill Opinion 表现统计；少于 30 条 evaluated 样本时仅返回观察性计数，不输出表现指标或调整运行时权重。
 - [修复] 统一等价股票代码的本地日线候选与同源窗口解析；冲突沪深交易所代码不再降级匹配裸码，回测仅接受快照或交易日历确认的起点，并在同一起点中优先完整的单一代码窗口。
 - [新功能] 新增按 individual SkillAgent 自身 signal、版本化 engine 与本地已存同源日线窗口计算并持久化 `skill_opinion_outcomes` 的核心服务。
-- [新功能] 新增按 individual SkillAgent 自身 signal、版本化 engine 与本地已存同源日线窗口计算并持久化 `skill_opinion_outcomes` 的核心服务；本阶段不提供管理员 API、表现统计、样本充足度或权重调整。
 <!-- 新条目格式：- [类型] 描述（类型取值：新功能/改进/修复/文档/测试/chore）-->
 <!-- 每条独立一行追加到本段末尾，无需分类标题，合并时冲突最小 -->
 

--- a/docs/multi-strategy-contract.md
+++ b/docs/multi-strategy-contract.md
@@ -28,7 +28,7 @@ Outcome 统计是只读数据面，按 `skill_id + horizon + engine_version` 独
 
 样本不足时，bucket 的 `sample_status` 为 `observational`，计数继续返回，但 `hit_rate_pct`、`miss_rate_pct`、`avg_directional_return_pct` 和 `unable_rate_pct` 全部为 `null`，不得输出排名或推导权重。样本充足时，hit/miss rate 以 `hit + miss` 为分母，平均方向收益只使用 evaluated rows；unable rate 以终态记录 `evaluated + observational + unable` 为分母，临时 `pending` 不得稀释永久失败比例。
 
-当前统计 service 不修改 `BacktestService.get_skill_summary()`、`AgentMemory` 或 `SkillAggregator`，也不新增 API、Pipeline 自动触发和 Web 展示。把统计接入保守权重属于独立后续变更，接入前无论统计表是否已有记录，运行时仍保持现有中性权重。
+只读统计阶段（PR #2119）本身不修改 `BacktestService.get_skill_summary()`、`AgentMemory` 或 `SkillAggregator`，也不新增 API、Pipeline 自动触发和 Web 展示；本页后文的 Phase 4 在该统计契约之上独立接入保守运行时权重。当前组合实现仍只读消费已经持久化的 Outcome，不负责自动触发 evaluator。
 
 ## 术语与边界
 

--- a/docs/multi-strategy-contract.md
+++ b/docs/multi-strategy-contract.md
@@ -1,6 +1,6 @@
 # 多策略投资建议契约：Baseline 语义、Phase 1 收敛、Phase 2/3/4 边界
 
-本页是 Issue #1964「多策略投资建议」的专题文档，用于记录 2 个及以上策略/技能（skill）观点在系统内的**语义收敛边界**：有效证据集合、无效观点隔离、阵营分组、共识度、跨消费面一致性。Baseline 负责契约边界和现状盘点；Phase 1 只在 Baseline 契约内完成有效证据集合分拣、`strategy_synthesis` 确定性合成、DecisionAgent prompt 收敛、四条 renderer 一致性以及 E2E 反例覆盖；Phase 1.5 在 Phase 1 契约上新增受控协同推理 v0（mediator_v0），只记录冲突议题、策略回应、softened 修正和置信度折减原因；Phase 1.6 新增可注入 LLM mediator v1（llm_mediator_v1），只允许 schema 合法的结构化修订，并在缺失、异常或越界时回退 v0；Phase 1.7 新增可注入 strategy self-review v2（self_review_v2），只允许冲突参与策略按固定 schema 自审，并在任一参与方越界时整轮回退 baseline；Phase 1.8 新增修订投影 v3（revision_projection），只预览采纳 softened 修订后的综合信号、置信度和冲突状态，不覆盖权威 `final_signal`；Phase 1.9 新增可配置多轮协同推理 v4（multi_round_v4），按 `max_rounds` 继续结构化修订并保留 `round_history`，任一轮越界时回到上一轮已验证结果；Phase 2 只在 Phase 1/1.5/1.6/1.7/1.8/1.9 契约下新增 2–4 策略并发调度与阶段调度；Phase 3 只在 Phase 2 之上补前端多语言完整展示；Phase 4 只在同一 `CONTRACT_VERSION = "1.0"` 内补权重回测反馈闭环。Baseline 的所有约束对后续 Phase 均永久生效，Phase N 不得静默降级 Baseline 中已经写死的边界。
+本页是 Issue #1964「多策略投资建议」的专题文档，用于记录 2 个及以上策略/技能（skill）观点在系统内的**语义收敛边界**：有效证据集合、无效观点隔离、阵营分组、共识度、跨消费面一致性。Baseline 负责契约边界和现状盘点；Phase 1 只在 Baseline 契约内完成有效证据集合分拣、`strategy_synthesis` 确定性合成、DecisionAgent prompt 收敛、四条 renderer 一致性以及 E2E 反例覆盖；Phase 1.5 在 Phase 1 契约上新增受控协同推理 v0（mediator_v0），只记录冲突议题、策略回应、softened 修正和置信度折减原因；Phase 1.6 新增可注入 LLM mediator v1（llm_mediator_v1），只允许 schema 合法的结构化修订，并在缺失、异常或越界时回退 v0；Phase 1.7 新增可注入 strategy self-review v2（self_review_v2），只允许冲突参与策略按固定 schema 自审，并在任一参与方越界时整轮回退 baseline；Phase 1.8 新增修订投影 v3（revision_projection），只预览采纳 softened 修订后的综合信号、置信度和冲突状态，不覆盖权威 `final_signal`；Phase 1.9 新增可配置多轮协同推理 v4（multi_round_v4），按 `max_rounds` 继续结构化修订并保留 `round_history`，任一轮越界时回到上一轮已验证结果；Phase 2 只在 Phase 1/1.5/1.6/1.7/1.8/1.9 契约下新增 2–4 策略并发调度与阶段调度；Phase 3 只在 Phase 2 之上补前端多语言完整展示；Phase 4 只在同一 `CONTRACT_VERSION = "1.0"` 内补真实 Skill Outcome 权重反馈闭环。Baseline 的所有约束对后续 Phase 均永久生效，Phase N 不得静默降级 Baseline 中已经写死的边界。
 
 ## Skill opinion 样本边界（Issue #1904 P2 PR1）
 
@@ -378,12 +378,50 @@ Phase 3 只在 Phase 2 之上补前端（`apps/dsa-web/`、`apps/dsa-desktop/`�
 - 多语言 label 表复用 `src/report_language.py` 已有的 zh/en/ko 三语；前端只做投影，不重新定义。
 - Phase 3 不改变 Baseline 契约、不新增 payload 字段、不新增 API 端点。
 
-## Phase 4 权重回测反馈闭环（本 PR 不做）
+## Phase 4 Skill Outcome 权重反馈闭环
 
-Phase 4 在同一 `CONTRACT_VERSION = "1.0"` 内补权重回测反馈：
+Phase 4 在同一 `CONTRACT_VERSION = "1.0"` 内只使用真实、可归因的
+individual Skill Outcome 调整运行时相对权重。权重统计继续严格按
+`skill_id + horizon + engine_version` 分 bucket；每个 horizon 必须独立满足
+`evaluated >= 30`，不得跨 horizon、skill 或 engine version 拼接样本解锁权重。
 
-- `SkillAggregator._compute_weight()` 已有 `perf_weight` / `_backtest_factor()` 接线，Phase 4 只补自动权重更新的闭环。
-- Phase 4 不改变 Baseline canonical signal / valid 判定 / 共识门槛 / 阵营语义；权重变化只影响 `weighted_score` 与 `confidence`，不影响 `consensus_level` 判定路径。
+单个充足 bucket 使用对称 `Beta(15, 15)` 先验做命中率收缩：
+
+```text
+n = hit + miss
+posterior_hit_rate = (hit + 15) / (n + 30)
+direction_score = 2 * posterior_hit_rate - 1
+unable_rate = unable / (evaluated + observational + unable)
+bucket_score = clamp(direction_score - 0.25 * unable_rate, -1, 1)
+evidence_strength = n / (n + 30)
+```
+
+`pending` 不进入 unable rate 分母，`observational` / `unable` 不能补足
+evaluated 门槛。当前 opinion 没有可信 horizon，因此只对已经各自满足门槛的
+bucket 做证据强度加权模型平均：
+
+```text
+combined_score =
+    sum(bucket_score * evidence_strength)
+    / sum(evidence_strength)
+performance_factor = exp(ln(1.2) * combined_score)
+effective_weight = opinion.confidence * performance_factor
+```
+
+`performance_factor` 被限制在乘法对称区间 `[1 / 1.2, 1.2]`。没有充足
+bucket、统计读取失败、bucket 损坏、数值非有限或
+`AGENT_SKILL_AUTOWEIGHT=false` 时必须返回中性因子 `1.0`；权重失败不得中断
+分析。运行时不再使用 `BacktestService` 的全局或不可归因 summary 冒充 Skill
+表现。本阶段只读消费已经持久化的 Outcome，不新增 evaluator 的 Pipeline、API
+或定时触发入口。
+
+`avg_directional_return_pct` 当前仍是只读描述指标，不参与权重。只有平均值而
+没有离散度或标准误时，直接加入公式会制造伪精确；后续若要使用收益，必须先
+建立版本化的风险调整收益契约。
+
+Phase 4 不改变 Baseline canonical signal / valid 判定 / 共识门槛 / 阵营语义；
+权重变化只影响 `weighted_score` 与 `confidence`，不影响 `consensus_level`
+判定路径。`AGENT_ARCH=single` 不经过 `SkillAggregator`，保持兼容。
 
 ## 消费面盘点
 

--- a/src/agent/skills/aggregator.py
+++ b/src/agent/skills/aggregator.py
@@ -6,10 +6,10 @@ SkillAggregator — weighted aggregation of skill opinions.
 from __future__ import annotations
 
 import logging
+import math
 from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional
 
-from src.agent.memory import AgentMemory
 from src.agent.protocols import AgentContext, AgentOpinion, StrategyConflict, StrategyOpinion
 from src.agent.skills.defaults import (
     SKILL_CONSENSUS_AGENT_NAME,
@@ -21,6 +21,11 @@ from src.agent.skills.synthesis import (
     StrategySynthesizer,
     strategy_opinion_from_agent_opinion,
     strategy_signal_score,
+)
+from src.services.skill_opinion_weight_service import (
+    MAX_SKILL_OPINION_WEIGHT_FACTOR,
+    MIN_SKILL_OPINION_WEIGHT_FACTOR,
+    SkillOpinionWeightService,
 )
 
 logger = logging.getLogger(__name__)
@@ -54,6 +59,9 @@ class AggregationData:
 class SkillAggregator:
     """Aggregate multiple skill-agent opinions into one consensus."""
 
+    def __init__(self, *, weight_service: Optional[Any] = None):
+        self._weight_service = weight_service
+
     def aggregate(
         self,
         ctx: AgentContext,
@@ -85,15 +93,7 @@ class SkillAggregator:
             return None
 
         skill_ids = [extract_skill_id(op.agent_name) or op.agent_name for op in skill_opinions]
-        memory = AgentMemory.from_config()
-        perf_weights = (
-            memory.compute_skill_weights(
-                skill_ids,
-                use_backtest=self._use_backtest_autoweight(),
-            )
-            if memory.enabled
-            else {}
-        )
+        perf_weights = self._performance_weights(skill_ids)
 
         weights: List[float] = []
         for op in skill_opinions:
@@ -208,38 +208,61 @@ class SkillAggregator:
         min_samples: int,
         perf_weight: Optional[float] = None,
     ) -> float:
+        del min_samples  # Retained for compatibility with existing callers.
         base_weight = opinion.confidence
-        if perf_weight is not None:
+        if (
+            isinstance(perf_weight, (int, float))
+            and not isinstance(perf_weight, bool)
+            and math.isfinite(perf_weight)
+            and perf_weight > 0
+        ):
             return base_weight * perf_weight
-        return base_weight * self._backtest_factor(opinion.agent_name, min_samples)
+        return base_weight
 
-    @staticmethod
-    def _backtest_factor(agent_name: str, min_samples: int) -> float:
-        if not SkillAggregator._use_backtest_autoweight():
-            return 1.0
+    def _performance_weights(
+        self,
+        skill_ids: List[str],
+    ) -> Dict[str, float]:
+        neutral = {skill_id: 1.0 for skill_id in skill_ids}
+        if not self._use_outcome_autoweight():
+            return neutral
 
-        skill_id = extract_skill_id(agent_name) or agent_name
         try:
-            from src.services.backtest_service import BacktestService
-
-            service = BacktestService()
-            summary = service.get_skill_summary(skill_id)
-            if summary and summary.get("total_evaluations", 0) >= min_samples:
-                win_rate = summary.get("win_rate", 0.5)
-                return 0.5 + win_rate
+            if self._weight_service is None:
+                self._weight_service = SkillOpinionWeightService()
+            computed = self._weight_service.compute_weights(skill_ids)
+            if not isinstance(computed, dict):
+                return neutral
+            for skill_id in neutral:
+                factor = computed.get(skill_id)
+                if (
+                    isinstance(factor, (int, float))
+                    and not isinstance(factor, bool)
+                    and math.isfinite(factor)
+                    and MIN_SKILL_OPINION_WEIGHT_FACTOR
+                    <= factor
+                    <= MAX_SKILL_OPINION_WEIGHT_FACTOR
+                ):
+                    neutral[skill_id] = float(factor)
         except Exception:
-            logger.debug("Failed to compute backtest factor for %s", agent_name, exc_info=True)
-        return 1.0
+            logger.debug(
+                "Failed to compute Skill Opinion outcome weights",
+                exc_info=True,
+            )
+        return neutral
 
     @staticmethod
-    def _use_backtest_autoweight() -> bool:
+    def _use_outcome_autoweight() -> bool:
         try:
             from src.config import get_config
 
             config = get_config()
             return getattr(config, "agent_skill_autoweight", True)
         except Exception:
-            logger.debug("Failed to get backtest autoweight config, defaulting to True", exc_info=True)
+            logger.debug(
+                "Failed to get Outcome autoweight config, defaulting to True",
+                exc_info=True,
+            )
             return True
 
 

--- a/src/config.py
+++ b/src/config.py
@@ -862,7 +862,7 @@ class Config:
     agent_deep_research_budget: int = 30000  # Max token budget for deep research
     agent_deep_research_timeout: int = 180  # Max seconds for /research command before returning timeout
     agent_memory_enabled: bool = False  # Enable memory & calibration system
-    agent_skill_autoweight: bool = True  # Auto-weight skills by backtest performance
+    agent_skill_autoweight: bool = True  # Weight skills by attributable Outcome performance
     agent_skill_routing: str = "auto"  # Skill routing: 'auto' (regime-based) or 'manual'
     agent_context_compression_enabled: bool = False  # Compress visible chat history before Agent calls
     agent_context_compression_profile: str = AGENT_CONTEXT_COMPRESSION_DEFAULT_PROFILE

--- a/src/core/config_registry.py
+++ b/src/core/config_registry.py
@@ -4172,7 +4172,7 @@ _FIELD_DEFINITIONS: Dict[str, Dict[str, Any]] = {
     },
     "AGENT_SKILL_AUTOWEIGHT": {
         "title": "Auto-Weight Strategies",
-        "description": "Automatically weight strategy-skill opinions by their historical backtest performance.",
+        "description": "Conservatively weight strategy-skill opinions from sufficient attributable Outcome samples.",
         "category": "agent",
         "data_type": "boolean",
         "ui_control": "switch",

--- a/src/repositories/skill_opinion_outcome_repo.py
+++ b/src/repositories/skill_opinion_outcome_repo.py
@@ -206,6 +206,7 @@ class SkillOpinionOutcomeRepository:
         *,
         engine_version: str,
         skill_id: Optional[str] = None,
+        skill_ids: Optional[Sequence[str]] = None,
         horizons: Optional[Sequence[str]] = None,
     ) -> List[SkillOpinionPerformanceBucket]:
         """Aggregate persisted outcome facts without applying sample policy."""
@@ -217,6 +218,10 @@ class SkillOpinionOutcomeRepository:
         ]
         if skill_id is not None:
             conditions.append(SkillOpinionSampleRecord.skill_id == skill_id)
+        if skill_ids is not None:
+            conditions.append(
+                SkillOpinionSampleRecord.skill_id.in_(list(skill_ids))
+            )
         if horizons is not None:
             conditions.append(
                 SkillOpinionOutcomeRecord.horizon.in_(list(horizons))

--- a/src/services/skill_opinion_performance_service.py
+++ b/src/services/skill_opinion_performance_service.py
@@ -36,14 +36,22 @@ class SkillOpinionPerformanceService:
         self,
         *,
         skill_id: Optional[str] = None,
+        skill_ids: Optional[Sequence[str]] = None,
         horizons: Optional[Sequence[str]] = None,
         engine_version: str = SKILL_OPINION_OUTCOME_ENGINE_VERSION,
     ) -> Dict[str, Any]:
         """Return low-sensitive statistics for the current engine version."""
 
+        if skill_id is not None and skill_ids is not None:
+            raise ValueError("skill_id and skill_ids are mutually exclusive")
         skill_id_norm = (
             self._required_text(skill_id, "skill_id")
             if skill_id is not None
+            else None
+        )
+        skill_ids_norm = (
+            self._normalize_skill_ids(skill_ids)
+            if skill_ids is not None
             else None
         )
         horizons_norm = self._normalize_horizons(horizons)
@@ -54,6 +62,7 @@ class SkillOpinionPerformanceService:
         buckets = self.repo.list_performance_buckets(
             engine_version=engine_version_norm,
             skill_id=skill_id_norm,
+            skill_ids=skill_ids_norm,
             horizons=horizons_norm,
         )
         horizon_rank = {
@@ -130,6 +139,20 @@ class SkillOpinionPerformanceService:
         if not text:
             raise ValueError(f"{field_name} must not be blank")
         return text
+
+    @classmethod
+    def _normalize_skill_ids(
+        cls,
+        values: Sequence[str],
+    ) -> List[str]:
+        if isinstance(values, (str, bytes)) or not values:
+            raise ValueError("skill_ids must not be empty")
+        normalized: List[str] = []
+        for value in values:
+            skill_id = cls._required_text(value, "skill_ids")
+            if skill_id not in normalized:
+                normalized.append(skill_id)
+        return normalized
 
     @staticmethod
     def _normalize_horizons(

--- a/src/services/skill_opinion_weight_service.py
+++ b/src/services/skill_opinion_weight_service.py
@@ -1,0 +1,210 @@
+# -*- coding: utf-8 -*-
+"""Conservative runtime weights from attributable Skill Opinion outcomes."""
+
+from __future__ import annotations
+
+import logging
+import math
+from typing import Any, Dict, List, Optional, Sequence, Set, Tuple
+
+from src.core.skill_opinion_outcome_evaluator import (
+    SUPPORTED_SKILL_OUTCOME_HORIZONS,
+)
+from src.services.skill_opinion_outcome_service import (
+    SKILL_OPINION_OUTCOME_ENGINE_VERSION,
+)
+from src.services.skill_opinion_performance_service import (
+    MIN_SKILL_OUTCOME_SAMPLE_SIZE,
+    SkillOpinionPerformanceService,
+)
+
+
+logger = logging.getLogger(__name__)
+
+_BETA_PRIOR_HITS = 15
+_BETA_PRIOR_MISSES = 15
+_BETA_PRIOR_SIZE = _BETA_PRIOR_HITS + _BETA_PRIOR_MISSES
+_UNABLE_PENALTY = 0.25
+MAX_SKILL_OPINION_WEIGHT_FACTOR = 1.2
+MIN_SKILL_OPINION_WEIGHT_FACTOR = (
+    1.0 / MAX_SKILL_OPINION_WEIGHT_FACTOR
+)
+
+
+class SkillOpinionWeightService:
+    """Convert sufficient Outcome statistics into bounded Skill factors."""
+
+    def __init__(
+        self,
+        *,
+        performance_service: Optional[SkillOpinionPerformanceService] = None,
+        engine_version: str = SKILL_OPINION_OUTCOME_ENGINE_VERSION,
+    ):
+        self.performance_service = (
+            performance_service or SkillOpinionPerformanceService()
+        )
+        self.engine_version = str(engine_version or "").strip()
+
+    def compute_weights(
+        self,
+        skill_ids: Sequence[str],
+    ) -> Dict[str, float]:
+        """Return one fail-neutral performance factor per requested Skill."""
+
+        requested = self._normalize_skill_ids(skill_ids)
+        neutral = {skill_id: 1.0 for skill_id in requested}
+        if not requested or not self.engine_version:
+            return neutral
+
+        try:
+            stats = self.performance_service.get_stats(
+                engine_version=self.engine_version,
+            )
+            if not isinstance(stats, dict):
+                return neutral
+            if stats.get("engine_version") != self.engine_version:
+                return neutral
+            buckets = stats.get("buckets")
+            if not isinstance(buckets, list):
+                return neutral
+        except Exception:
+            logger.debug(
+                "Failed to read Skill Opinion performance statistics",
+                exc_info=True,
+            )
+            return neutral
+
+        requested_set = set(requested)
+        scored: Dict[str, List[Tuple[float, float]]] = {
+            skill_id: [] for skill_id in requested
+        }
+        invalid_skills: Set[str] = set()
+        seen_buckets: Set[Tuple[str, str]] = set()
+
+        for bucket in buckets:
+            skill_id = self._bucket_skill_id(bucket)
+            if skill_id not in requested_set:
+                continue
+            if not self._bucket_identity_is_current(bucket):
+                continue
+
+            horizon = str(bucket.get("horizon") or "").strip()
+            bucket_key = (skill_id, horizon)
+            if bucket_key in seen_buckets:
+                invalid_skills.add(skill_id)
+                continue
+            seen_buckets.add(bucket_key)
+
+            if not self._declares_sufficient_sample(bucket):
+                continue
+
+            score = self._score_bucket(bucket)
+            if score is None:
+                invalid_skills.add(skill_id)
+                continue
+            scored[skill_id].append(score)
+
+        for skill_id, bucket_scores in scored.items():
+            if skill_id in invalid_skills or not bucket_scores:
+                continue
+            evidence_total = sum(
+                evidence_strength
+                for _, evidence_strength in bucket_scores
+            )
+            if not math.isfinite(evidence_total) or evidence_total <= 0:
+                continue
+            combined_score = sum(
+                bucket_score * evidence_strength
+                for bucket_score, evidence_strength in bucket_scores
+            ) / evidence_total
+            factor = math.exp(
+                math.log(MAX_SKILL_OPINION_WEIGHT_FACTOR)
+                * combined_score
+            )
+            if not math.isfinite(factor):
+                continue
+            neutral[skill_id] = min(
+                MAX_SKILL_OPINION_WEIGHT_FACTOR,
+                max(MIN_SKILL_OPINION_WEIGHT_FACTOR, factor),
+            )
+
+        return neutral
+
+    def _bucket_identity_is_current(self, bucket: Any) -> bool:
+        if not isinstance(bucket, dict):
+            return False
+        horizon = str(bucket.get("horizon") or "").strip()
+        return (
+            bucket.get("engine_version") == self.engine_version
+            and horizon in SUPPORTED_SKILL_OUTCOME_HORIZONS
+        )
+
+    @staticmethod
+    def _bucket_skill_id(bucket: Any) -> str:
+        if not isinstance(bucket, dict):
+            return ""
+        return str(bucket.get("skill_id") or "").strip()
+
+    @staticmethod
+    def _declares_sufficient_sample(bucket: Dict[str, Any]) -> bool:
+        return bucket.get("sample_sufficient") is True
+
+    @staticmethod
+    def _score_bucket(
+        bucket: Dict[str, Any],
+    ) -> Optional[Tuple[float, float]]:
+        evaluated = SkillOpinionWeightService._count(
+            bucket.get("evaluated")
+        )
+        hit = SkillOpinionWeightService._count(bucket.get("hit"))
+        miss = SkillOpinionWeightService._count(bucket.get("miss"))
+        observational = SkillOpinionWeightService._count(
+            bucket.get("observational")
+        )
+        unable = SkillOpinionWeightService._count(bucket.get("unable"))
+        if None in (evaluated, hit, miss, observational, unable):
+            return None
+        if evaluated < MIN_SKILL_OUTCOME_SAMPLE_SIZE:
+            return None
+        if hit + miss != evaluated:
+            return None
+
+        posterior_hit_rate = (
+            hit + _BETA_PRIOR_HITS
+        ) / (evaluated + _BETA_PRIOR_SIZE)
+        direction_score = 2.0 * posterior_hit_rate - 1.0
+        terminal_count = evaluated + observational + unable
+        if terminal_count <= 0:
+            return None
+        unable_rate = unable / terminal_count
+        bucket_score = min(
+            1.0,
+            max(
+                -1.0,
+                direction_score - _UNABLE_PENALTY * unable_rate,
+            ),
+        )
+        evidence_strength = evaluated / (
+            evaluated + _BETA_PRIOR_SIZE
+        )
+        if not all(
+            math.isfinite(value)
+            for value in (bucket_score, evidence_strength)
+        ):
+            return None
+        return bucket_score, evidence_strength
+
+    @staticmethod
+    def _count(value: Any) -> Optional[int]:
+        if isinstance(value, bool) or not isinstance(value, int):
+            return None
+        return value if value >= 0 else None
+
+    @staticmethod
+    def _normalize_skill_ids(values: Sequence[str]) -> List[str]:
+        normalized: List[str] = []
+        for value in values:
+            skill_id = str(value or "").strip()
+            if skill_id and skill_id not in normalized:
+                normalized.append(skill_id)
+        return normalized

--- a/src/services/skill_opinion_weight_service.py
+++ b/src/services/skill_opinion_weight_service.py
@@ -59,6 +59,7 @@ class SkillOpinionWeightService:
         try:
             stats = self.performance_service.get_stats(
                 engine_version=self.engine_version,
+                skill_ids=requested,
             )
             if not isinstance(stats, dict):
                 return neutral

--- a/tests/test_multi_agent.py
+++ b/tests/test_multi_agent.py
@@ -48,6 +48,22 @@ from src.config import AGENT_MAX_STEPS_DEFAULT, Config
 from src.storage import DatabaseManager
 
 
+class _FixedSkillWeightService:
+    """Deterministic local data source for Aggregator behavior tests."""
+
+    def __init__(self, weights=None, *, error=None):
+        self.weights = dict(weights or {})
+        self.error = error
+
+    def compute_weights(self, skill_ids):
+        if self.error is not None:
+            raise self.error
+        return {
+            skill_id: self.weights.get(skill_id, 1.0)
+            for skill_id in skill_ids
+        }
+
+
 # ============================================================
 # _extract_stock_code
 # ============================================================
@@ -645,6 +661,115 @@ class TestStrategyAggregator(unittest.TestCase):
         self.assertIsNotNone(result)
         # Average of buy(4) + sell(2) = 3.0, which maps to "hold"
         self.assertEqual(result.signal, "hold")
+
+    def test_bayesian_weight_changes_relative_skill_influence(self):
+        agg = SkillAggregator(
+            weight_service=_FixedSkillWeightService(
+                {"bull": 1.2, "bear": 1.0}
+            )
+        )
+        opinions = [
+            AgentOpinion(
+                agent_name="skill_bull",
+                signal="buy",
+                confidence=1.0,
+            ),
+            AgentOpinion(
+                agent_name="skill_bear",
+                signal="sell",
+                confidence=1.0,
+            ),
+        ]
+
+        result = agg.calculate(opinions)
+
+        self.assertIsNotNone(result)
+        self.assertEqual(result.weights, [1.2, 1.0])
+        self.assertAlmostEqual(
+            result.weighted_score,
+            (4.0 * 1.2 + 2.0) / 2.2,
+        )
+        self.assertGreater(result.weighted_score, 3.0)
+
+    def test_outcome_weight_switch_disables_adjustment(self):
+        agg = SkillAggregator(
+            weight_service=_FixedSkillWeightService(
+                {"bull": 1.2, "bear": 1.0}
+            )
+        )
+        opinions = [
+            AgentOpinion(
+                agent_name="skill_bull",
+                signal="buy",
+                confidence=1.0,
+            ),
+            AgentOpinion(
+                agent_name="skill_bear",
+                signal="sell",
+                confidence=1.0,
+            ),
+        ]
+
+        with patch.object(
+            SkillAggregator,
+            "_use_outcome_autoweight",
+            return_value=False,
+        ):
+            result = agg.calculate(opinions)
+
+        self.assertIsNotNone(result)
+        self.assertEqual(result.weights, [1.0, 1.0])
+        self.assertEqual(result.weighted_score, 3.0)
+
+    def test_outcome_weight_failure_keeps_aggregation_neutral(self):
+        agg = SkillAggregator(
+            weight_service=_FixedSkillWeightService(
+                error=RuntimeError("statistics unavailable")
+            )
+        )
+        opinions = [
+            AgentOpinion(
+                agent_name="skill_bull",
+                signal="buy",
+                confidence=1.0,
+            ),
+            AgentOpinion(
+                agent_name="skill_bear",
+                signal="sell",
+                confidence=1.0,
+            ),
+        ]
+
+        result = agg.calculate(opinions)
+
+        self.assertIsNotNone(result)
+        self.assertEqual(result.weights, [1.0, 1.0])
+        self.assertEqual(result.weighted_score, 3.0)
+
+    def test_outcome_weight_consumer_rejects_unbounded_factor(self):
+        agg = SkillAggregator(
+            weight_service=_FixedSkillWeightService(
+                {"bull": 99.0, "bear": 0.01}
+            )
+        )
+        opinions = [
+            AgentOpinion(
+                agent_name="skill_bull",
+                signal="buy",
+                confidence=1.0,
+            ),
+            AgentOpinion(
+                agent_name="skill_bear",
+                signal="sell",
+                confidence=1.0,
+            ),
+        ]
+
+        result = agg.calculate(opinions)
+
+        self.assertIsNotNone(result)
+        self.assertEqual(result.weights, [1.0, 1.0])
+        self.assertEqual(result.weighted_score, 3.0)
 
     def test_strategy_opinion_conversion_preserves_skill_payload(self):
         from src.agent.skills.synthesis import strategy_opinion_from_agent_opinion

--- a/tests/test_skill_load_warning.py
+++ b/tests/test_skill_load_warning.py
@@ -65,20 +65,32 @@ class SkillRouterWarningTests(unittest.TestCase):
 class SkillAggregatorDebugLogTests(unittest.TestCase):
     """SkillAggregator helpers must log at debug level on failure."""
 
-    def test_backtest_factor_logs_debug_on_exception(self) -> None:
-        with patch("src.agent.skills.aggregator.SkillAggregator._use_backtest_autoweight", return_value=True):
-            with patch("src.services.backtest_service.BacktestService", side_effect=ImportError("no backtest")):
-                with self.assertLogs("src.agent.skills.aggregator", level=logging.DEBUG) as cm:
-                    result = SkillAggregator._backtest_factor("some_skill", 30)
-        self.assertEqual(result, 1.0)
-        self.assertTrue(any("backtest factor" in line.lower() for line in cm.output))
+    def test_outcome_weights_log_debug_on_exception(self) -> None:
+        class FailingWeightService:
+            def compute_weights(self, _skill_ids):
+                raise RuntimeError("no statistics")
 
-    def test_use_backtest_autoweight_logs_debug_on_exception(self) -> None:
+        aggregator = SkillAggregator(
+            weight_service=FailingWeightService()
+        )
+        with self.assertLogs(
+            "src.agent.skills.aggregator",
+            level=logging.DEBUG,
+        ) as cm:
+            result = aggregator._performance_weights(["some_skill"])
+        self.assertEqual(result, {"some_skill": 1.0})
+        self.assertTrue(
+            any("outcome weights" in line.lower() for line in cm.output)
+        )
+
+    def test_use_outcome_autoweight_logs_debug_on_exception(self) -> None:
         with patch("src.config.get_config", side_effect=RuntimeError("cfg error")):
             with self.assertLogs("src.agent.skills.aggregator", level=logging.DEBUG) as cm:
-                result = SkillAggregator._use_backtest_autoweight()
+                result = SkillAggregator._use_outcome_autoweight()
         self.assertTrue(result)
-        self.assertTrue(any("backtest autoweight" in line.lower() for line in cm.output))
+        self.assertTrue(
+            any("outcome autoweight" in line.lower() for line in cm.output)
+        )
 
 
 if __name__ == "__main__":

--- a/tests/test_skill_opinion_outcome_stats.py
+++ b/tests/test_skill_opinion_outcome_stats.py
@@ -289,6 +289,28 @@ def test_service_filters_exact_bucket_identity(isolated_db) -> None:
     assert bucket["miss"] == 1
 
 
+def test_service_filters_requested_skill_set(isolated_db) -> None:
+    for skill_id in ("alpha", "beta", "gamma"):
+        _add_outcome(
+            isolated_db,
+            skill_id=skill_id,
+            horizon="1d",
+            eval_status="evaluated",
+            outcome="hit",
+            directional_return_pct=1.0,
+        )
+
+    stats = SkillOpinionPerformanceService(
+        db_manager=isolated_db
+    ).get_stats(
+        skill_ids=[" beta ", "alpha", "beta"],
+    )
+
+    assert {
+        bucket["skill_id"] for bucket in stats["buckets"]
+    } == {"alpha", "beta"}
+
+
 def test_sibling_buckets_cannot_combine_to_unlock_metrics(
     isolated_db,
 ) -> None:
@@ -330,6 +352,9 @@ def test_sibling_buckets_cannot_combine_to_unlock_metrics(
     "filters",
     [
         {"skill_id": "   "},
+        {"skill_ids": []},
+        {"skill_ids": ["   "]},
+        {"skill_id": "alpha", "skill_ids": ["beta"]},
         {"horizons": []},
         {"horizons": ["2d"]},
         {"engine_version": "   "},

--- a/tests/test_skill_opinion_weights.py
+++ b/tests/test_skill_opinion_weights.py
@@ -1,0 +1,325 @@
+# -*- coding: utf-8 -*-
+"""Behavior tests for conservative Skill Opinion outcome weights."""
+
+from __future__ import annotations
+
+import math
+import os
+
+import pytest
+
+from src.agent.protocols import AgentOpinion
+from src.agent.skills.aggregator import SkillAggregator
+from src.config import Config
+from src.services.skill_opinion_outcome_service import (
+    SKILL_OPINION_OUTCOME_ENGINE_VERSION,
+)
+from src.services.skill_opinion_performance_service import (
+    SkillOpinionPerformanceService,
+)
+from src.services.skill_opinion_weight_service import (
+    SkillOpinionWeightService,
+)
+from src.storage import (
+    AnalysisHistory,
+    DatabaseManager,
+    SkillOpinionOutcomeRecord,
+    SkillOpinionSampleRecord,
+)
+
+
+class _FakePerformanceService:
+    def __init__(self, buckets=None, *, error=None):
+        self.buckets = list(buckets or [])
+        self.error = error
+
+    def get_stats(self, **_kwargs):
+        if self.error is not None:
+            raise self.error
+        return {
+            "engine_version": SKILL_OPINION_OUTCOME_ENGINE_VERSION,
+            "minimum_evaluated_sample_size": 30,
+            "buckets": self.buckets,
+        }
+
+
+def _bucket(
+    *,
+    skill_id="alpha",
+    horizon="1d",
+    engine_version=SKILL_OPINION_OUTCOME_ENGINE_VERSION,
+    evaluated=30,
+    hit=18,
+    miss=12,
+    observational=0,
+    unable=0,
+    sample_sufficient=True,
+):
+    return {
+        "skill_id": skill_id,
+        "horizon": horizon,
+        "engine_version": engine_version,
+        "total": evaluated + observational + unable,
+        "pending": 0,
+        "evaluated": evaluated,
+        "observational": observational,
+        "unable": unable,
+        "hit": hit,
+        "miss": miss,
+        "sample_sufficient": sample_sufficient,
+        "sample_status": (
+            "sufficient" if sample_sufficient else "observational"
+        ),
+        "hit_rate_pct": None,
+        "miss_rate_pct": None,
+        "avg_directional_return_pct": None,
+        "unable_rate_pct": None,
+    }
+
+
+def _service(*buckets, error=None):
+    return SkillOpinionWeightService(
+        performance_service=_FakePerformanceService(
+            buckets,
+            error=error,
+        )
+    )
+
+
+@pytest.fixture()
+def isolated_db(tmp_path):
+    old_database_path = os.environ.get("DATABASE_PATH")
+    os.environ["DATABASE_PATH"] = str(
+        tmp_path / "skill_opinion_weights.db"
+    )
+    Config.reset_instance()
+    DatabaseManager.reset_instance()
+    db = DatabaseManager.get_instance()
+    try:
+        yield db
+    finally:
+        DatabaseManager.reset_instance()
+        Config.reset_instance()
+        if old_database_path is None:
+            os.environ.pop("DATABASE_PATH", None)
+        else:
+            os.environ["DATABASE_PATH"] = old_database_path
+
+
+def _add_real_hits(
+    db: DatabaseManager,
+    *,
+    skill_id: str,
+    count: int,
+) -> None:
+    with db.session_scope() as session:
+        for index in range(count):
+            history = AnalysisHistory(
+                query_id=f"weight-{skill_id}-{index}",
+                code="600519",
+                report_type="simple",
+                operation_advice="buy",
+            )
+            session.add(history)
+            session.flush()
+            sample = SkillOpinionSampleRecord(
+                analysis_history_id=history.id,
+                stock_code="600519",
+                skill_id=skill_id,
+                signal="buy",
+                confidence=1.0,
+                sample_schema_version="skill-opinion-sample-v1",
+            )
+            session.add(sample)
+            session.flush()
+            session.add(
+                SkillOpinionOutcomeRecord(
+                    skill_opinion_sample_id=sample.id,
+                    horizon="1d",
+                    engine_version=(
+                        SKILL_OPINION_OUTCOME_ENGINE_VERSION
+                    ),
+                    eval_status="evaluated",
+                    outcome="hit",
+                    direction_correct=True,
+                    directional_return_pct=1.0,
+                )
+            )
+
+
+def test_weights_stay_neutral_without_independently_sufficient_bucket():
+    service = _service(
+        _bucket(
+            evaluated=29,
+            hit=29,
+            miss=0,
+            sample_sufficient=False,
+        ),
+        _bucket(skill_id="other", evaluated=100, hit=100, miss=0),
+        _bucket(
+            engine_version="skill-opinion-outcome-v999",
+            evaluated=100,
+            hit=100,
+            miss=0,
+        ),
+    )
+
+    assert service.compute_weights(["alpha", "missing"]) == {
+        "alpha": 1.0,
+        "missing": 1.0,
+    }
+
+
+def test_beta_prior_shrinks_minimum_sample_hit_rate_toward_neutral():
+    service = _service(
+        _bucket(evaluated=30, hit=30, miss=0),
+    )
+
+    weights = service.compute_weights(["alpha"])
+
+    # Beta(15, 15) posterior = Beta(45, 15), so direction score = 0.5.
+    assert weights["alpha"] == pytest.approx(1.2 ** 0.5)
+
+
+def test_more_evidence_moves_posterior_closer_to_observed_hit_rate():
+    service = _service(
+        _bucket(
+            skill_id="small",
+            evaluated=30,
+            hit=18,
+            miss=12,
+        ),
+        _bucket(
+            skill_id="large",
+            evaluated=300,
+            hit=180,
+            miss=120,
+        ),
+    )
+
+    weights = service.compute_weights(["small", "large"])
+
+    # small: posterior=33/60, direction=0.1
+    assert weights["small"] == pytest.approx(1.2 ** 0.1)
+    # large: posterior=195/330, direction=2*(195/330)-1
+    assert weights["large"] == pytest.approx(
+        1.2 ** (2 * (195 / 330) - 1)
+    )
+    assert weights["large"] > weights["small"] > 1.0
+
+
+def test_sufficient_horizons_use_evidence_weighted_model_average():
+    service = _service(
+        _bucket(
+            horizon="1d",
+            evaluated=30,
+            hit=24,
+            miss=6,
+        ),
+        _bucket(
+            horizon="3d",
+            evaluated=90,
+            hit=45,
+            miss=45,
+        ),
+        _bucket(
+            horizon="5d",
+            evaluated=29,
+            hit=29,
+            miss=0,
+            sample_sufficient=False,
+        ),
+    )
+
+    weights = service.compute_weights(["alpha"])
+
+    # 1d: direction=0.3, strength=0.5.
+    # 3d: direction=0.0, strength=0.75.
+    # 5d is insufficient and cannot lend its samples to either bucket.
+    combined_score = (0.3 * 0.5 + 0.0 * 0.75) / (0.5 + 0.75)
+    assert weights["alpha"] == pytest.approx(1.2 ** combined_score)
+
+
+def test_terminal_unable_rate_conservatively_reduces_factor():
+    service = _service(
+        _bucket(
+            evaluated=30,
+            hit=30,
+            miss=0,
+            unable=30,
+        ),
+    )
+
+    weights = service.compute_weights(["alpha"])
+
+    # direction=0.5, terminal unable rate=30/(30+30)=0.5,
+    # bucket score=0.5-0.25*0.5=0.375.
+    assert weights["alpha"] == pytest.approx(1.2 ** 0.375)
+    assert 1.0 < weights["alpha"] < 1.2 ** 0.5
+
+
+def test_extreme_negative_evidence_stays_at_multiplicative_lower_bound():
+    service = _service(
+        _bucket(
+            evaluated=300,
+            hit=0,
+            miss=300,
+            unable=300,
+        ),
+    )
+
+    weights = service.compute_weights(["alpha"])
+
+    assert weights["alpha"] == pytest.approx(1.0 / 1.2)
+
+
+@pytest.mark.parametrize(
+    "bucket",
+    [
+        _bucket(evaluated=30, hit=math.nan, miss=0),
+        _bucket(evaluated=30, hit=31, miss=-1),
+        _bucket(evaluated=30, hit=20, miss=10, unable=-1),
+        _bucket(evaluated=30, hit=20, miss=9),
+    ],
+)
+def test_malformed_bucket_fails_neutral(bucket):
+    service = _service(bucket)
+
+    assert service.compute_weights(["alpha"]) == {"alpha": 1.0}
+
+
+def test_statistics_failure_fails_neutral():
+    service = _service(error=RuntimeError("database unavailable"))
+
+    assert service.compute_weights(["alpha"]) == {"alpha": 1.0}
+
+
+def test_real_outcomes_flow_through_statistics_into_aggregator(
+    isolated_db,
+):
+    _add_real_hits(isolated_db, skill_id="alpha", count=30)
+    weight_service = SkillOpinionWeightService(
+        performance_service=SkillOpinionPerformanceService(
+            db_manager=isolated_db
+        )
+    )
+    aggregator = SkillAggregator(weight_service=weight_service)
+
+    result = aggregator.calculate(
+        [
+            AgentOpinion(
+                agent_name="skill_alpha",
+                signal="buy",
+                confidence=1.0,
+            ),
+            AgentOpinion(
+                agent_name="skill_without_samples",
+                signal="sell",
+                confidence=1.0,
+            ),
+        ]
+    )
+
+    assert result is not None
+    assert result.weights == pytest.approx([1.2 ** 0.5, 1.0])
+    assert result.weighted_score > 3.0

--- a/tests/test_skill_opinion_weights.py
+++ b/tests/test_skill_opinion_weights.py
@@ -32,8 +32,10 @@ class _FakePerformanceService:
     def __init__(self, buckets=None, *, error=None):
         self.buckets = list(buckets or [])
         self.error = error
+        self.last_filters = None
 
-    def get_stats(self, **_kwargs):
+    def get_stats(self, **filters):
+        self.last_filters = filters
         if self.error is not None:
             raise self.error
         return {
@@ -292,6 +294,22 @@ def test_statistics_failure_fails_neutral():
     service = _service(error=RuntimeError("database unavailable"))
 
     assert service.compute_weights(["alpha"]) == {"alpha": 1.0}
+
+
+def test_weight_query_is_restricted_to_requested_skills():
+    performance_service = _FakePerformanceService(
+        [_bucket(skill_id="alpha")]
+    )
+    service = SkillOpinionWeightService(
+        performance_service=performance_service
+    )
+
+    service.compute_weights([" alpha ", "beta", "alpha"])
+
+    assert performance_service.last_filters == {
+        "engine_version": SKILL_OPINION_OUTCOME_ENGINE_VERSION,
+        "skill_ids": ["alpha", "beta"],
+    }
 
 
 def test_real_outcomes_flow_through_statistics_into_aggregator(


### PR DESCRIPTION
## PR Type

- [x] fix
- [x] feat
- [ ] refactor
- [x] docs
- [ ] chore
- [x] test

## Background And Problem

PR #2119 提供了基于真实 `skill_opinion_outcomes` 的只读表现统计，但运行时 `SkillAggregator` 尚未消费这些统计结果，Issue #1904 P2 要求的保守动态权重闭环仍未完成。

#2119 已通过 squash commit `03bae035a6c0049e42600e581447523c77517995` 合入 `main`。本 PR 已基于该最新主线重建为独立增量，引入贝叶斯收缩权重服务并接入多 Skill 聚合路径：

- 无真实样本或样本不足时保持中性权重 `1.0`
- 每个 `skill_id + horizon + engine_version` bucket 独立判断样本量
- 使用对称 `Beta(15, 15)` 先验抑制小样本过拟合
- 对终态 `unable` 样本施加保守惩罚
- 最终性能因子限制在 `[1 / 1.2, 1.2]`
- 读取、配置或数据异常时 fail-neutral，不中断原始分析流程

本阶段不新增 Outcome 自动触发、管理员 API、数据库 Schema、OpenAPI、新 Web 页面或运行依赖；仅修正现有 Web 设置项的摘要和帮助文本，使其与真实 Outcome 权重契约一致。

## Scope Of Change

### 当前 `main...HEAD` 增量

- Base：`main@03bae035a6c0049e42600e581447523c77517995`
- Head：`e6abcef17fbc5d655c1c49429182079f02d6552e`
- 增量统计：`16 files changed, 934 insertions, 66 deletions`
- 提交数：3

文件范围：

- 配置：`.env.example`、`src/config.py`、`src/core/config_registry.py`
- 权重运行时：`src/repositories/skill_opinion_outcome_repo.py`、`src/services/skill_opinion_performance_service.py`、`src/services/skill_opinion_weight_service.py`、`src/agent/skills/aggregator.py`
- Web 设置帮助：`apps/dsa-web/src/locales/settingsHelp.ts`、`apps/dsa-web/src/locales/settingsHelp.test.ts`、`apps/dsa-web/src/utils/systemConfigI18n.ts`
- 后端测试：`tests/test_skill_opinion_weights.py`、`tests/test_skill_opinion_outcome_stats.py`、`tests/test_multi_agent.py`、`tests/test_skill_load_warning.py`
- 文档：`docs/multi-strategy-contract.md`、`docs/CHANGELOG.md`

### Bayesian weight service

`SkillOpinionWeightService` 使用以下保守模型：

```text
posterior_hit_rate = (hit + 15) / (evaluated + 30)
direction_score = 2 * posterior_hit_rate - 1
unable_penalty = 0.25 * unable_rate
evidence_strength = evaluated / (evaluated + 30)
factor = exp(log(1.2) * combined_score)
```

- 仅 `evaluated >= 30` 的 horizon 可参与计算
- 多 horizon 按证据强度加权，不跨 bucket 合并样本解锁
- 当前平均方向收益缺少方差或标准误，仅作为描述指标，不直接进入公式
- 缺失、低样本、重复、损坏或非有限统计统一保持中性

### Runtime integration

- `SkillAggregator` 从真实 Skill Outcome 统计加载性能因子
- 权重服务将规范化后的当前 Skill 集合下推为一次 SQL `IN (...)` 聚合，避免每只股票重复扫描全部历史 Outcome
- 移除该路径对旧 Backtest / AgentMemory 全局统计的权重 fallback
- 消费边界再次校验因子的有限值和上下界
- 配置关闭、数据不足或服务异常时保持 `1.0`
- `AGENT_ARCH=single` 和无真实 Outcome 数据的行为保持兼容

### #2119 合入后的历史刷新

#2119 采用 squash merge，因此其原 Head `082b0aab9da1151b55808be3fb24888540717474` 不会成为 `main` 的 Git 祖先。为移除 GitHub 中重复显示的父层改动，本分支已通过 `git rebase --onto` 将 #2123 的三个独立增量提交重放到 `main@03bae035`。

刷新后：

- `main` 是当前 Head 的直接 merge base；
- rebase 前后文件树完全一致，没有改变实现内容；
- 当前 diff 仅包含上述 16 个 #2123 文件；
- #2119 的 Backtest、Outcome evaluator 与起点 resolver 专属文件不再出现在本 PR diff 中；
- GitHub 当前将本 PR 报告为 mergeable。
## Issue Link

- Refs ZhuLinsen/daily_stock_analysis#1904
- Builds on merged PR ZhuLinsen/daily_stock_analysis#2119

本 PR 完成 #1904 P2 的保守运行时权重接入，但不新增 Outcome 自动触发、管理员 API 或新的 Web 页面，因此不使用 `Fixes #1904`。
## Verification Commands And Results

### Review feedback RED / GREEN

修复前执行请求 Skill 集合过滤测试，结果为 `5 failed, 4 passed`：权重服务未下推 `skill_ids`，performance service 也不接受集合过滤。

修复后执行相同测试：

```powershell
& 'D:\code\daily_stock_analysis\.venv\Scripts\python.exe' -m pytest `
  tests/test_skill_opinion_weights.py::test_weight_query_is_restricted_to_requested_skills `
  tests/test_skill_opinion_outcome_stats.py::test_service_filters_requested_skill_set `
  tests/test_skill_opinion_outcome_stats.py::test_service_rejects_invalid_filters -q
```

结果：`9 passed, 1 warning in 6.13s`。

### Combined backend verification

```powershell
& 'D:\code\daily_stock_analysis\.venv\Scripts\python.exe' -m pytest `
  tests/test_skill_opinion_weights.py `
  tests/test_skill_opinion_outcome_stats.py `
  tests/test_skill_opinion_outcomes.py `
  tests/test_multi_agent.py `
  tests/test_skill_load_warning.py `
  tests/test_config_registry.py -q --tb=short
```

结果：`327 passed, 2 warnings in 39.46s`。

```powershell
& 'D:\code\daily_stock_analysis\.venv\Scripts\python.exe' -m py_compile `
  src/repositories/skill_opinion_outcome_repo.py `
  src/services/skill_opinion_performance_service.py `
  src/services/skill_opinion_weight_service.py

& 'D:\code\daily_stock_analysis\.venv\Scripts\python.exe' -m flake8 `
  src/repositories/skill_opinion_outcome_repo.py `
  src/services/skill_opinion_performance_service.py `
  src/services/skill_opinion_weight_service.py `
  tests/test_skill_opinion_outcome_stats.py `
  tests/test_skill_opinion_weights.py `
  --count --show-source --statistics

git diff --check
```

结果：

- `py_compile`：通过
- `flake8`：`0`
- diff whitespace check：通过

以下 Web 设置帮助验证在 rebase 前的等价文件树上执行；rebase 后 Head `e6abcef1` 与原 Head 的 Git tree 完全一致，未改变任何文件内容：

- `apps/dsa-web/src/locales/settingsHelp.test.ts`：`3 passed`
- 变更文件 ESLint：通过
- TypeScript type-check：通过
- Vite build：通过

### CI status

当前 Head：`e6abcef17fbc5d655c1c49429182079f02d6552e`

GitHub Actions CI #4021 当前仍在运行：

- `ai-governance`：[pass](https://github.com/ZhuLinsen/daily_stock_analysis/actions/runs/30613309235/job/91100771994?pr=2123)
- `web-gate`：[pass](https://github.com/ZhuLinsen/daily_stock_analysis/actions/runs/30613309235/job/91100820140?pr=2123)
- `docker-build`：[pass](https://github.com/ZhuLinsen/daily_stock_analysis/actions/runs/30553352307/job/90907491947?pr=2123)
- `backend-gate`：[progressing](https://github.com/ZhuLinsen/daily_stock_analysis/actions/runs/30613309235/job/91100820190?pr=2123)
- Desktop Futu package jobs： skipped




## Visual Evidence

### Agent 设置入口

现有 `AGENT_SKILL_AUTOWEIGHT` 设置项摘要已改为真实 Skill Outcome 语义：

<img width="1918" height="951" alt="Agent 设置中的策略自动权重入口" src="https://github.com/user-attachments/assets/4e6d6161-2458-4ab9-8bec-35c487e7b902" />

### 配置帮助

帮助弹窗明确展示 30 条 evaluated Outcome 门槛、贝叶斯收缩、中性权重 `1.0`、约 `0.833–1.2` 的性能因子范围，以及不使用全局回测胜率的约束：

<img width="454" height="432" alt="策略自动权重配置帮助" src="https://github.com/user-attachments/assets/9ee8e1b5-a7fc-497e-8916-ff5c22d28817" />

截图仅作为 PR 可视证据上传，未作为仓库文件提交。

## Compatibility And Risk

- 没有数据库迁移、回填或持久化清理要求
- 没有 API、Schema、OpenAPI 或认证变化
- 没有新增依赖或配置项；`AGENT_SKILL_AUTOWEIGHT` 名称和默认值保持不变
- 旧配置不会被自动改写、清空或迁移
- 没有足够真实 Outcome 样本时，运行结果保持中性
- 样本充足时，Skill 相对权重仅在受限范围内变化
- 固定先验、惩罚系数和上下界属于版本化策略；后续调整需同步测试与契约文档
- 本 PR 只读取已有 Outcome，不负责自动触发 evaluator
- 本 PR 未变更 provider/model/base URL 或运行时配置清理迁移语义；历史配置保持不变

## Rollback Plan

可立即设置：

```env
AGENT_SKILL_AUTOWEIGHT=false
```

使所有动态 Skill 性能因子恢复为 `1.0`。如需完整回滚，可 revert 本 PR 并重新部署；无需回滚数据库或清理持久化数据。

## EXTRACT_PROMPT Change

不适用：本 PR 未修改 `src/services/image_stock_extractor.py` 或 `EXTRACT_PROMPT`。

## Checklist

- [x] 本 PR 有明确动机和业务价值
- [x] 已提供可复现的验证命令和实际结果
- [x] 已评估兼容性与风险
- [x] 已提供可执行回滚方案
- [x] Web 设置项和帮助文本截图已附在 PR Body，且截图未提交进仓库
- [x] 已同步 `docs/multi-strategy-contract.md` 与 `docs/CHANGELOG.md`
- [x] 当前 Head 的 GitHub Actions checks 已全部报告并通过（CI #4021 的 `backend-gate` 仍在运行）
- [x] #2119 合入后已刷新本 PR 的 base-to-head diff