### PR TITLE
feat(makefile): add Makefile for agent-discoverable entry points

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,6 +63,8 @@ python scripts/check_ai_assets.py
 
 ## 4. 常用命令
 
+> 单一入口见根目录 `Makefile`（`make help` 查看全部 target）。下列命令为各工具的原始形式，便于复制与故障排查。
+
 ### 运行应用
 
 ```bash

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,72 @@
+SHELL := /usr/bin/env bash
+.DEFAULT_GOAL := help
+
+# A-share / HK / US stock analysis — agent-discoverable entry points.
+# Each target wraps an existing tool or shell script. No new tooling.
+# See AGENTS.md §4 for the canonical command list this Makefile mirrors.
+
+PIP       := python3 -m pip
+PYTEST    := python3 -m pytest
+FLAKE8    := python3 -m flake8
+BLACK     := python3 -m black
+ISORT     := python3 -m isort
+BANDIT    := python3 -m bandit
+PYCOMPILE := python3 -m py_compile
+MAIN      := python3 main.py
+SERVE     := python3 -m uvicorn server:app --reload --host 0.0.0.0 --port 8000
+
+.PHONY: help install install-ci test test-unit lint format security syntax run serve web-install web-lint web-build ci clean
+
+help: ## show this help
+	@awk 'BEGIN {FS = ":.*##"; printf "Targets:\n"} /^[a-zA-Z_-]+:.*##/ { printf "  \033[36m%-14s\033[0m %s\n", $$1, $$2 }' $(MAKEFILE_LIST)
+
+install: ## install runtime deps from requirements.txt
+	$(PIP) install -r requirements.txt
+
+install-ci: ## install runtime + test/lint deps (flake8, pytest)
+	$(PIP) install -r requirements.txt
+	$(PIP) install -r requirements-ci.txt
+
+test: ## run offline test suite (pytest -m "not network")
+	$(PYTEST) -m "not network"
+
+test-unit: ## run unit-marked tests only
+	$(PYTEST) -m unit
+
+lint: ## run flake8 critical checks (E9,F63,F7,F82)
+	$(FLAKE8) . --count --select=E9,F63,F7,F82 --show-source --statistics
+
+syntax: ## py_compile the hot Python files (mirrors scripts/ci_gate.sh syntax_check)
+	$(PYCOMPILE) main.py src/config.py src/auth.py src/analyzer.py src/notification.py
+	$(PYCOMPILE) src/storage.py src/scheduler.py src/search_service.py
+	$(PYCOMPILE) src/market_analyzer.py src/stock_analyzer.py
+	$(PYCOMPILE) data_provider/*.py
+
+format: ## black + isort in check mode (no writes)
+	$(BLACK) --check --diff .
+	$(ISORT) --check-only --diff .
+
+security: ## bandit scan over repo (excludes tests; see setup.cfg [tool:bandit])
+	$(BANDIT) -r . -c pyproject.toml
+
+run: ## run the main analysis entry (python3 main.py)
+	$(MAIN)
+
+serve: ## run FastAPI dev server (uvicorn server:app --reload)
+	$(SERVE)
+
+web-install: ## install web frontend deps
+	cd apps/dsa-web && npm ci
+
+web-lint: ## web frontend lint
+	cd apps/dsa-web && npm run lint
+
+web-build: ## web frontend build
+	cd apps/dsa-web && npm run build
+
+ci: ## run scripts/ci_gate.sh (canonical CI gate)
+	./scripts/ci_gate.sh
+
+clean: ## remove __pycache__ and pytest cache
+	find . -type d -name __pycache__ -not -path './node_modules/*' -not -path './.venv/*' -prune -exec rm -rf {} +
+	rm -rf .pytest_cache .mypy_cache .ruff_cache


### PR DESCRIPTION
## Summary

- Add a single `Makefile` that wraps existing test/lint/format/security/run/serve/web/ci entry points so AI agents can discover them without parsing scattered shell scripts.
- Add a one-line pointer in `AGENTS.md §4` to the Makefile as the canonical single-entry surface; raw commands remain for copy/paste.

## Why

`better-harness` audit flagged finding **manifest-scripts-empty**: `pyproject.toml` and `requirements.txt` have no `scripts` entries, so an agent cannot discover how to install, run, test, or lint the Python backend through standard manifest inspection.

Adaptation from the original plan: the project `pyproject.toml` only has `[tool.black]/[isort]/[bandit]` and `setup.cfg` lacks `[metadata]` — there is no PEP 621 `[project]` table to attach `[project.scripts]` to. Restructuring into a proper packaged project is out of scope. A `Makefile` is the standard agent-discoverable surface and the minimum-invasive fix.

## Changes

| File | Change |
|---|---|
| `Makefile` (new, 72 lines) | 16 targets: help, install, install-ci, test, test-unit, lint, syntax, format, security, run, serve, web-install, web-lint, web-build, ci, clean |
| `AGENTS.md` | +2 lines in §4 pointing to `Makefile` as single-entry surface |

## Verification

- `make help` lists all targets
- `make syntax` (py_compile of hot files from `scripts/ci_gate.sh`) passes
- `make install-ci` succeeds (deps from `requirements-ci.txt`)
- `make ci` runs 1151/1152 tests; 1 pre-existing failure in `test_env.py::test_notification` (env-dependent `wechat_webhook` None error, not introduced here — confirmed by stashing this commit and re-running)

## Unverified

- `make lint` / `make format` / `make security` / `make web-*` not run locally (deferred to CI matrix)
- CI will run `make ci` equivalent via `scripts/ci_gate.sh` workflow

## Risk

- `Makefile` and `AGENTS.md §4` now coexist as two command surfaces. The §4 note makes `Makefile` the canonical single entry; raw commands stay for transparency and copy/paste.
- No source code mutation, no dependency change, no workflow change.

## Rollback

`git revert` this commit on the merge; or `rm Makefile` and drop the two added lines in `AGENTS.md`.

## References

- better-harness report: `dalirystock/.claude/better-harness/report.html`
- finding: `manifest-scripts-empty`