### PR TITLE
fix: remove incorrect volume unit conversion for TickFlow A-shares

### DIFF
--- a/data_provider/tickflow_fetcher.py
+++ b/data_provider/tickflow_fetcher.py
@@ -218,8 +218,8 @@ class TickFlowFetcher(BaseFetcher):
         for column in ("open", "high", "low", "close", "amount"):
             normalized[column] = pd.to_numeric(raw.get(column), errors="coerce")
 
-        # TickFlow daily volume is in lots for A-shares; project standard is shares.
-        normalized["volume"] = self._cn_lots_to_shares(raw.get("volume"))
+        # TickFlow daily volume is in shares for A-shares (already in correct unit).
+        normalized["volume"] = pd.to_numeric(raw.get("volume"), errors="coerce")
 
         if "pct_chg" in raw.columns:
             normalized["pct_chg"] = pd.to_numeric(raw["pct_chg"], errors="coerce")
@@ -829,7 +829,7 @@ class TickFlowFetcher(BaseFetcher):
         open_price = self._safe_float(quote.get("open"))
         high = self._safe_float(quote.get("high"))
         low = self._safe_float(quote.get("low"))
-        volume = self._cn_lots_to_shares(quote.get("volume"), default=0)
+        volume = self._safe_float(quote.get("volume")) or 0.0
         amount = self._safe_float(quote.get("amount")) or 0.0
         change_amount = self._safe_float(ext.get("change_amount"))
         if change_amount is None and prev_close is not None:


### PR DESCRIPTION
## Problem

TickFlow returns A-share daily volume in **shares** (股), but the code incorrectly called `_cn_lots_to_shares()` which multiplied the value by 100, assuming it was in **lots** (手). This caused all A-share volumes from TickFlow to be inflated by 100x.

## Impact

Example: 洛阳钼业 (603993) on 2026-07-29:
- Reported: **1.88 亿股** (188M shares)
- Actual: **187.8 万股** (1.878M shares)

The volume change ratio was also incorrectly calculated as 111.55x due to this bug.

## Root Cause

The comment in the code stated:
```python
# TickFlow daily volume is in lots for A-shares; project standard is shares.
```

However, TickFlow actually returns volume in **shares** already, not lots. The `_cn_lots_to_shares()` function was incorrectly multiplying by 100.

## Fix

- `_normalize_data()` (line 222): Use raw volume value directly instead of multiplying by 100
- `_build_realtime_quote()` (line 832): Same fix for realtime quote volume

The `_cn_lots_to_shares()` method is kept for potential future use but no longer called in the volume normalization paths.

## Verification

After the fix:
- Volume displays correctly as 187.8 万股 instead of 1.88 亿股
- Volume change ratio calculations are now accurate