### PR TITLE
feat-a-stock-free-data-sources

### DIFF
--- a/api/v1/endpoints/alphasift.py
+++ b/api/v1/endpoints/alphasift.py
@@ -1,0 +1,201 @@
+# -*- coding: utf-8 -*-
+"""AlphaSift stock screening API routes."""
+
+from __future__ import annotations
+
+import uuid
+from typing import Any, Dict, List, Optional
+
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
+from pydantic import BaseModel, Field
+
+from api.deps import get_config_dep
+from api.v1.errors import api_error
+from src.config import Config
+from src.services.alphasift_service import AlphaSiftService
+from src.services.task_queue import TaskStatus as QueueTaskStatus
+from src.services.task_queue import get_task_queue
+
+router = APIRouter()
+
+
+class AlphaSiftScreenRequest(BaseModel):
+    market: str = Field("cn", min_length=1, max_length=16)
+    strategy: str = Field("dual_low", min_length=1, max_length=64)
+    max_results: int = Field(20, ge=1, le=100)
+
+
+class AlphaSiftStrategyResponse(BaseModel):
+    id: str
+    name: str = ""
+    title: str = ""
+    description: str = ""
+    category: str = ""
+    tag: str = ""
+    tags: List[str] = Field(default_factory=list)
+    market_scope: List[str] = Field(default_factory=list)
+    market: str = ""
+
+
+class AlphaSiftScreenAccepted(BaseModel):
+    task_id: str
+    trace_id: str
+    status: str = "pending"
+    message: str
+    strategy: str
+    market: str
+    max_results: int
+
+
+class AlphaSiftScreenTaskStatus(BaseModel):
+    task_id: str
+    trace_id: Optional[str] = None
+    status: str
+    progress: int = 0
+    message: Optional[str] = None
+    error: Optional[str] = None
+    result: Optional[Dict[str, Any]] = None
+
+
+def _service(config: Config) -> AlphaSiftService:
+    return AlphaSiftService(config=config)
+
+
+def _screening_task_not_found(task_id: str) -> HTTPException:
+    return api_error(
+        404,
+        "alphasift_screen_task_not_found",
+        f"选股任务 {task_id} 不存在或已过期",
+    )
+
+
+@router.get("/status")
+def alphasift_status(config: Config = Depends(get_config_dep)) -> Dict[str, Any]:
+    return _service(config).status()
+
+
+@router.get("/strategies")
+def alphasift_strategies(
+    request: Request,
+    config: Config = Depends(get_config_dep),
+) -> Dict[str, Any]:
+    return _service(config).strategies()
+
+
+@router.get("/hotspots")
+def alphasift_hotspots(
+    provider: str = Query("", max_length=32),
+    top: int = Query(12, ge=1, le=50),
+    refresh: bool = Query(False),
+    include_details: bool = Query(False),
+    config: Config = Depends(get_config_dep),
+) -> Dict[str, Any]:
+    refresh_value = refresh if isinstance(refresh, bool) else bool(getattr(refresh, "default", False))
+    include_details_value = (
+        include_details
+        if isinstance(include_details, bool)
+        else bool(getattr(include_details, "default", False))
+    )
+    return _service(config).hotspots(
+        provider=provider,
+        top=top,
+        refresh=refresh_value,
+        include_details=include_details_value,
+    )
+
+
+@router.get("/hotspots/{topic:path}")
+def alphasift_hotspot_detail(
+    topic: str,
+    provider: str = Query("", max_length=32),
+    refresh: bool = Query(False),
+    config: Config = Depends(get_config_dep),
+) -> Dict[str, Any]:
+    refresh_value = refresh if isinstance(refresh, bool) else bool(getattr(refresh, "default", False))
+    return _service(config).hotspot_detail(topic=topic, provider=provider, refresh=refresh_value)
+
+
+@router.post("/install")
+def alphasift_install(
+    request: Request,
+    config: Config = Depends(get_config_dep),
+) -> Dict[str, Any]:
+    return _service(config).install(request=request)
+
+
+@router.post("/screen/tasks", status_code=202, response_model=AlphaSiftScreenAccepted)
+def alphasift_start_screen_task(
+    request: AlphaSiftScreenRequest,
+    http_request: Request,
+    config: Config = Depends(get_config_dep),
+) -> AlphaSiftScreenAccepted:
+    task_id = uuid.uuid4().hex
+    task_queue = get_task_queue()
+
+    def run_screen() -> Dict[str, Any]:
+        task_queue.update_task_progress(
+            task_id,
+            20,
+            "正在执行 AlphaSift 选股，外部数据源较慢时会持续后台运行",
+        )
+        result = _service(config).screen(
+            strategy=request.strategy,
+            market=request.market,
+            max_results=request.max_results,
+        )
+        task_queue.update_task_progress(
+            task_id,
+            90,
+            f"选股已完成，正在整理 {result.get('candidate_count', 0)} 条候选",
+        )
+        return result
+
+    task = task_queue.submit_background_task(
+        run_screen,
+        stock_code="alphasift_screen",
+        stock_name=f"{request.strategy} / {request.market}",
+        report_type="alphasift_screen",
+        message="AlphaSift 选股任务已提交",
+        task_id=task_id,
+        trace_id=task_id,
+    )
+    return AlphaSiftScreenAccepted(
+        task_id=task.task_id,
+        trace_id=task.trace_id or task.task_id,
+        status=task.status.value if isinstance(task.status, QueueTaskStatus) else str(task.status),
+        message=task.message or "AlphaSift 选股任务已提交",
+        strategy=request.strategy,
+        market=request.market,
+        max_results=request.max_results,
+    )
+
+
+@router.get("/screen/tasks/{task_id}", response_model=AlphaSiftScreenTaskStatus)
+def alphasift_screen_task_status(task_id: str) -> AlphaSiftScreenTaskStatus:
+    task = get_task_queue().get_task(task_id)
+    if task is None or task.report_type != "alphasift_screen":
+        raise _screening_task_not_found(task_id)
+
+    result = task.result if task.status == QueueTaskStatus.COMPLETED and isinstance(task.result, dict) else None
+    return AlphaSiftScreenTaskStatus(
+        task_id=task.task_id,
+        trace_id=task.trace_id or task.task_id,
+        status=task.status.value if isinstance(task.status, QueueTaskStatus) else str(task.status),
+        progress=task.progress,
+        message=task.message,
+        error=task.error,
+        result=result,
+    )
+
+
+@router.post("/screen")
+def alphasift_screen(
+    request: AlphaSiftScreenRequest,
+    http_request: Request,
+    config: Config = Depends(get_config_dep),
+) -> Dict[str, Any]:
+    return _service(config).screen(
+        strategy=request.strategy,
+        market=request.market,
+        max_results=request.max_results,
+    )

--- a/apps/dsa-web/src/api/__tests__/alphasift.test.ts
+++ b/apps/dsa-web/src/api/__tests__/alphasift.test.ts
@@ -1,0 +1,295 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { alphasiftApi } from '../alphasift';
+
+const { get, post, getConfig, updateConfig } = vi.hoisted(() => ({
+  get: vi.fn(),
+  post: vi.fn(),
+  getConfig: vi.fn(),
+  updateConfig: vi.fn(),
+}));
+
+vi.mock('../index', () => ({
+  default: {
+    get,
+    post,
+  },
+}));
+
+vi.mock('../systemConfig', () => ({
+  systemConfigApi: {
+    getConfig: (...args: unknown[]) => getConfig(...args),
+    update: (...args: unknown[]) => updateConfig(...args),
+  },
+}));
+
+describe('alphasiftApi', () => {
+  beforeEach(() => {
+    get.mockReset();
+    post.mockReset();
+    getConfig.mockReset();
+    updateConfig.mockReset();
+  });
+
+  it('enables the config and checks bundled AlphaSift availability', async () => {
+    getConfig.mockResolvedValueOnce({ configVersion: 'v1', maskToken: '******' });
+    updateConfig.mockResolvedValueOnce({ success: true });
+    get.mockResolvedValueOnce({
+      data: {
+        enabled: true,
+        available: true,
+        install_spec_is_default: true,
+      },
+    });
+
+    await alphasiftApi.enable();
+
+    expect(updateConfig).toHaveBeenCalledWith({
+      configVersion: 'v1',
+      maskToken: '******',
+      reloadNow: true,
+      items: [{ key: 'ALPHASIFT_ENABLED', value: 'true' }],
+    });
+    expect(get).toHaveBeenCalledWith('/api/v1/alphasift/status');
+    expect(updateConfig).toHaveBeenCalledTimes(1);
+    expect(post).not.toHaveBeenCalled();
+  });
+
+  it('keeps enable behavior when called without object binding', async () => {
+    getConfig.mockResolvedValueOnce({ configVersion: 'v1', maskToken: '******' });
+    updateConfig.mockResolvedValueOnce({ success: true });
+    get.mockResolvedValueOnce({
+      data: {
+        enabled: true,
+        available: true,
+        install_spec_is_default: true,
+      },
+    });
+
+    const enable = alphasiftApi.enable;
+    await enable();
+
+    expect(updateConfig).toHaveBeenCalledTimes(1);
+    expect(post).not.toHaveBeenCalled();
+  });
+
+  it('rolls back ALPHASIFT_ENABLED when bundled AlphaSift is unavailable', async () => {
+    getConfig
+      .mockResolvedValueOnce({ configVersion: 'v1', maskToken: '******' })
+      .mockResolvedValueOnce({ configVersion: 'v2', maskToken: '******' });
+    updateConfig.mockResolvedValue({ success: true });
+    get.mockResolvedValueOnce({
+      data: {
+        enabled: true,
+        available: false,
+        install_spec_is_default: true,
+        diagnostics: { reason: 'missing_module' },
+      },
+    });
+
+    await expect(alphasiftApi.enable()).rejects.toThrow('pip install -r requirements.txt');
+
+    expect(updateConfig).toHaveBeenNthCalledWith(1, {
+      configVersion: 'v1',
+      maskToken: '******',
+      reloadNow: true,
+      items: [{ key: 'ALPHASIFT_ENABLED', value: 'true' }],
+    });
+    expect(updateConfig).toHaveBeenNthCalledWith(2, {
+      configVersion: 'v2',
+      maskToken: '******',
+      reloadNow: true,
+      items: [{ key: 'ALPHASIFT_ENABLED', value: 'false' }],
+    });
+    expect(post).not.toHaveBeenCalled();
+  });
+
+  it('loads strategies from the AlphaSift API', async () => {
+    get.mockResolvedValueOnce({
+      data: {
+        enabled: true,
+        strategies: [
+          {
+            id: 'dual_low',
+            name: 'Dual Low',
+            description: 'value',
+            category: 'value',
+            market_scope: ['cn'],
+          },
+        ],
+        strategy_count: 1,
+      },
+    });
+
+    const result = await alphasiftApi.getStrategies();
+
+    expect(get).toHaveBeenCalledWith('/api/v1/alphasift/strategies', { timeout: 300000 });
+    expect(result.enabled).toBe(true);
+    expect(result.strategyCount).toBe(1);
+    expect(result.strategies[0].id).toBe('dual_low');
+    expect(result.strategies[0].marketScope).toEqual(['cn']);
+  });
+
+  it('loads hotspot themes from the AlphaSift API', async () => {
+    get.mockResolvedValueOnce({
+      data: {
+        enabled: true,
+        provider: 'akshare',
+        provider_used: 'akshare',
+        hotspots: [
+          {
+            topic: 'AI算力',
+            heat_score: 88,
+            trend_score: 12,
+            sample_stock_count: 8,
+            leaders: ['中际旭创'],
+          },
+        ],
+        hotspot_count: 1,
+        details: {
+          AI绠楀姏: {
+            enabled: true,
+            provider: 'akshare',
+            topic: 'AI绠楀姏',
+            route: [{ title: '盘中发酵', description: '事件摘要' }],
+            stocks: [],
+            stock_count: 0,
+          },
+        },
+      },
+    });
+
+    const result = await alphasiftApi.getHotspots({ provider: 'akshare', top: 12, refresh: true });
+
+    expect(get).toHaveBeenCalledWith('/api/v1/alphasift/hotspots', {
+      params: { provider: 'akshare', top: 12, refresh: true, include_details: true },
+      timeout: 300000,
+    });
+    expect(result.providerUsed).toBe('akshare');
+    expect(result.hotspots[0].heatScore).toBe(88);
+    expect(result.hotspots[0].sampleStockCount).toBe(8);
+    expect(Object.values(result.details || {})[0]?.stockCount).toBe(0);
+  });
+
+  it('keeps prefetched hotspot details addressable by the original topic', async () => {
+    get.mockResolvedValueOnce({
+      data: {
+        enabled: true,
+        provider: 'akshare',
+        provider_used: 'akshare',
+        hotspots: [{ topic: 'Moly Theme', heat_score: 96 }],
+        hotspot_count: 1,
+        details: {
+          moly_theme: {
+            enabled: true,
+            provider: 'akshare',
+            topic: 'Moly Theme',
+            route: [{ title: 'catalyst', description: 'summary' }],
+            stocks: [],
+            stock_count: 0,
+          },
+        },
+      },
+    });
+
+    const result = await alphasiftApi.getHotspots({ provider: 'akshare', top: 12, refresh: false });
+
+    expect(result.details?.['Moly Theme']?.stockCount).toBe(0);
+  });
+
+  it('loads hotspot detail for a concrete topic', async () => {
+    get.mockResolvedValueOnce({
+      data: {
+        enabled: true,
+        provider: 'akshare',
+        topic: '玻璃基板',
+        summary: '玻璃基板盘中发酵',
+        route: [{ title: '盘中发酵', description: '出现大笔买入' }],
+        stocks: [{ code: '920438', name: '戈碧迦', role: '异动核心' }],
+        leader_stocks: [{ code: '920438', name: '戈碧迦', role: '异动核心' }],
+        stock_count: 1,
+      },
+    });
+
+    const result = await alphasiftApi.getHotspotDetail({ topic: '玻璃基板', provider: 'akshare' });
+
+    expect(get).toHaveBeenCalledWith('/api/v1/alphasift/hotspots/%E7%8E%BB%E7%92%83%E5%9F%BA%E6%9D%BF', {
+      params: { provider: 'akshare', refresh: false },
+      timeout: 300000,
+    });
+    expect(result.topic).toBe('玻璃基板');
+    expect(result.stockCount).toBe(1);
+    expect(result.stocks[0].name).toBe('戈碧迦');
+    expect(result.leaderStocks?.[0].name).toBe('戈碧迦');
+  });
+
+  it('uses a long timeout for LLM-backed screening', async () => {
+    post.mockResolvedValueOnce({
+      data: {
+        enabled: true,
+        candidates: [],
+        candidate_count: 0,
+        llm_ranked: true,
+      },
+    });
+
+    await alphasiftApi.screen({ market: 'cn', strategy: 'dual_low', maxResults: 3 });
+
+    expect(post).toHaveBeenCalledWith(
+      '/api/v1/alphasift/screen',
+      { market: 'cn', strategy: 'dual_low', max_results: 3 },
+      { timeout: 180000 }
+    );
+  });
+
+  it('starts an async screening task', async () => {
+    post.mockResolvedValueOnce({
+      data: {
+        task_id: 'screen-task-1',
+        trace_id: 'screen-task-1',
+        status: 'pending',
+        message: 'AlphaSift 选股任务已提交',
+        strategy: 'dual_low',
+        market: 'cn',
+        max_results: 3,
+      },
+    });
+
+    const result = await alphasiftApi.startScreen({ market: 'cn', strategy: 'dual_low', maxResults: 3 });
+
+    expect(post).toHaveBeenCalledWith(
+      '/api/v1/alphasift/screen/tasks',
+      { market: 'cn', strategy: 'dual_low', max_results: 3 }
+    );
+    expect(result.taskId).toBe('screen-task-1');
+    expect(result.maxResults).toBe(3);
+  });
+
+  it('loads async screening task status', async () => {
+    get.mockResolvedValueOnce({
+      data: {
+        task_id: 'screen-task-1',
+        trace_id: 'screen-task-1',
+        status: 'completed',
+        progress: 100,
+        message: '任务执行完成',
+        result: {
+          enabled: true,
+          candidates: [],
+          candidate_count: 0,
+          daily_enriched: true,
+          daily_enrich_count: 4,
+          post_analyzers: ['scorecard'],
+        },
+      },
+    });
+
+    const result = await alphasiftApi.getScreenTask('screen-task-1');
+
+    expect(get).toHaveBeenCalledWith('/api/v1/alphasift/screen/tasks/screen-task-1');
+    expect(result.taskId).toBe('screen-task-1');
+    expect(result.result?.candidateCount).toBe(0);
+    expect(result.result?.dailyEnriched).toBe(true);
+    expect(result.result?.dailyEnrichCount).toBe(4);
+    expect(result.result?.postAnalyzers).toEqual(['scorecard']);
+  });
+});

--- a/apps/dsa-web/src/api/alphasift.ts
+++ b/apps/dsa-web/src/api/alphasift.ts
@@ -1,0 +1,349 @@
+import apiClient from './index';
+import { systemConfigApi } from './systemConfig';
+import { toCamelCase } from './utils';
+
+const ALPHASIFT_SCREEN_TIMEOUT_MS = 180000;
+const ALPHASIFT_INSTALL_TIMEOUT_MS = 300000;
+export const ALPHASIFT_CONFIG_CHANGED_EVENT = 'alphasift-config-changed';
+export const SYSTEM_CONFIG_CHANGED_EVENT = 'dsa-system-config-changed';
+
+export type AlphaSiftStatus = {
+  enabled: boolean;
+  available: boolean;
+  installSpecIsDefault: boolean;
+  contractVersion?: string | null;
+  version?: string | null;
+  strategyCount?: number | null;
+  sourceHealth?: Record<string, Record<string, Record<string, unknown>>>;
+  diagnostics?: Record<string, string>;
+};
+
+export type AlphaSiftInstallResponse = {
+  installed: boolean;
+  alreadyInstalled: boolean;
+  installSpecIsDefault: boolean;
+};
+
+export type AlphaSiftCandidate = {
+  rank: number;
+  code: string;
+  name: string;
+  score?: number | null;
+  screenScore?: number | null;
+  reason: string;
+  riskLevel?: string;
+  riskFlags?: string[];
+  llmScore?: number | null;
+  llmConfidence?: number | null;
+  llmSector?: string;
+  llmTheme?: string;
+  llmTags?: string[];
+  llmThesis?: string;
+  llmCatalysts?: string[];
+  llmRisks?: string[];
+  llmWatchItems?: string[];
+  llmInvalidators?: string[];
+  llmStyleFit?: string;
+  price?: number | null;
+  changePct?: number | null;
+  amount?: number | null;
+  industry?: string;
+  factorScores?: Record<string, number>;
+  postAnalysisSummaries?: Record<string, string>;
+  postAnalysisTags?: string[];
+  dsaContext?: {
+    enriched?: boolean;
+    quote?: Record<string, unknown>;
+    fundamentals?: Record<string, unknown>;
+    news?: {
+      success?: boolean;
+      query?: string;
+      provider?: string;
+      results?: Array<Record<string, unknown>>;
+      error?: string | null;
+    };
+    warnings?: string[];
+  };
+  dsaNews?: Array<{
+    title?: string;
+    snippet?: string;
+    url?: string;
+    source?: string;
+    publishedDate?: string | null;
+  }>;
+  dsaAnalysisSummary?: string;
+  raw: Record<string, unknown>;
+};
+
+export type AlphaSiftStrategy = {
+  id: string;
+  name: string;
+  title?: string;
+  description: string;
+  version?: string;
+  category?: string;
+  tag?: string;
+  tags?: string[];
+  marketScope?: string[];
+  market?: string;
+};
+
+export type AlphaSiftStrategiesResponse = {
+  enabled: boolean;
+  strategies: AlphaSiftStrategy[];
+  strategyCount: number;
+};
+
+export type AlphaSiftHotspot = {
+  topic: string;
+  name?: string;
+  source?: string;
+  rank?: number | null;
+  changePct?: number | null;
+  heatScore?: number | null;
+  trendScore?: number | null;
+  persistenceScore?: number | null;
+  coolingScore?: number | null;
+  observations?: number | null;
+  state?: string;
+  stage?: string;
+  sampleStockCount?: number | null;
+  leaders?: string[];
+  providerUsed?: string;
+  fallbackUsed?: boolean;
+  cacheUsed?: boolean;
+  cachedAt?: string | null;
+  sourceErrors?: string[];
+  stale?: boolean;
+  staleAgeHours?: number | null;
+};
+
+export type AlphaSiftHotspotRouteItem = {
+  title: string;
+  description: string;
+  source?: string;
+  date?: string;
+  time?: string;
+  publishedAt?: string;
+  url?: string;
+};
+
+export type AlphaSiftHotspotStock = {
+  code?: string;
+  name?: string;
+  changePct?: number | null;
+  amount?: number | null;
+  turnoverRate?: number | null;
+  volumeRatio?: number | null;
+  role?: string;
+  hotStockScore?: number | null;
+  source?: string;
+  sourceConfidence?: number | null;
+  fallbackUsed?: boolean;
+};
+
+export type AlphaSiftHotspotDetail = {
+  enabled: boolean;
+  provider: string;
+  topic: string;
+  name?: string;
+  canonicalTopic?: string;
+  aliases?: string[];
+  summary?: string;
+  summaryDetail?: Record<string, unknown>;
+  route: AlphaSiftHotspotRouteItem[];
+  timeline?: AlphaSiftHotspotRouteItem[];
+  stocks: AlphaSiftHotspotStock[];
+  leaderStocks?: AlphaSiftHotspotStock[];
+  stockCount: number;
+  sourceErrors?: string[];
+  qualityStatus?: 'available' | 'partial' | 'stale' | 'failed' | string;
+  missingFields?: string[];
+  fallbackUsed?: boolean;
+  stale?: boolean;
+  staleAgeHours?: number | null;
+  cacheUsed?: boolean;
+  cachedAt?: string | null;
+  resolverCandidates?: Record<string, unknown>[];
+};
+
+export type AlphaSiftHotspotsResponse = {
+  enabled: boolean;
+  provider: string;
+  providerUsed?: string;
+  fallbackUsed?: boolean;
+  cacheUsed?: boolean;
+  cachedAt?: string | null;
+  sourceErrors?: string[];
+  stale?: boolean;
+  staleAgeHours?: number | null;
+  message?: string | null;
+  hotspots: AlphaSiftHotspot[];
+  hotspotCount: number;
+  details?: Record<string, AlphaSiftHotspotDetail>;
+};
+
+export type AlphaSiftScreenResponse = {
+  enabled: boolean;
+  candidates: AlphaSiftCandidate[];
+  candidateCount: number;
+  runId?: string;
+  strategy?: string;
+  market?: string;
+  snapshotCount?: number;
+  afterFilterCount?: number;
+  llmRanked?: boolean;
+  llmMarketView?: string;
+  llmSelectionLogic?: string;
+  llmPortfolioRisk?: string;
+  llmCoverage?: number | null;
+  llmParseErrors?: string[];
+  warnings?: string[];
+  sourceErrors?: string[];
+  dsaEnrichment?: {
+    enabled?: boolean;
+    maxCandidates?: number;
+    requestedCount?: number;
+    enrichedCount?: number;
+    warnings?: string[];
+  };
+  deepAnalysisRequested?: boolean | null;
+  postAnalyzers?: string[];
+  dailyEnriched?: boolean | null;
+  dailyEnrichCount?: number | null;
+  riskEnabled?: boolean | null;
+  portfolioDiversityEnabled?: boolean | null;
+  portfolioConcentrationNotes?: string[];
+};
+
+export type AlphaSiftScreenAccepted = {
+  taskId: string;
+  traceId?: string | null;
+  status: 'pending' | 'processing' | 'completed' | 'failed' | string;
+  message: string;
+  strategy: string;
+  market: string;
+  maxResults: number;
+};
+
+export type AlphaSiftScreenTaskStatus = {
+  taskId: string;
+  traceId?: string | null;
+  status: 'pending' | 'processing' | 'completed' | 'failed' | string;
+  progress?: number | null;
+  message?: string | null;
+  error?: string | null;
+  result?: AlphaSiftScreenResponse | null;
+};
+
+export function notifyAlphaSiftConfigChanged(): void {
+  window.dispatchEvent(new Event(ALPHASIFT_CONFIG_CHANGED_EVENT));
+  notifySystemConfigChanged();
+}
+
+export function notifySystemConfigChanged(): void {
+  window.dispatchEvent(new Event(SYSTEM_CONFIG_CHANGED_EVENT));
+}
+
+async function setAlphaSiftEnabled(value: 'true' | 'false'): Promise<void> {
+  const config = await systemConfigApi.getConfig(false);
+  await systemConfigApi.update({
+    configVersion: config.configVersion,
+    maskToken: config.maskToken,
+    reloadNow: true,
+    items: [{ key: 'ALPHASIFT_ENABLED', value }],
+  });
+  notifyAlphaSiftConfigChanged();
+}
+
+export const alphasiftApi = {
+  async getStatus(): Promise<AlphaSiftStatus> {
+    const response = await apiClient.get<Record<string, unknown>>('/api/v1/alphasift/status');
+    return toCamelCase<AlphaSiftStatus>(response.data);
+  },
+
+  async screen(payload: { market: string; strategy: string; maxResults: number }): Promise<AlphaSiftScreenResponse> {
+    const response = await apiClient.post<Record<string, unknown>>('/api/v1/alphasift/screen', {
+      market: payload.market,
+      strategy: payload.strategy,
+      max_results: payload.maxResults,
+    }, { timeout: ALPHASIFT_SCREEN_TIMEOUT_MS });
+    return toCamelCase<AlphaSiftScreenResponse>(response.data);
+  },
+
+  async startScreen(payload: { market: string; strategy: string; maxResults: number }): Promise<AlphaSiftScreenAccepted> {
+    const response = await apiClient.post<Record<string, unknown>>('/api/v1/alphasift/screen/tasks', {
+      market: payload.market,
+      strategy: payload.strategy,
+      max_results: payload.maxResults,
+    });
+    return toCamelCase<AlphaSiftScreenAccepted>(response.data);
+  },
+
+  async getScreenTask(taskId: string): Promise<AlphaSiftScreenTaskStatus> {
+    const response = await apiClient.get<Record<string, unknown>>(`/api/v1/alphasift/screen/tasks/${encodeURIComponent(taskId)}`);
+    return toCamelCase<AlphaSiftScreenTaskStatus>(response.data);
+  },
+
+  async getStrategies(): Promise<AlphaSiftStrategiesResponse> {
+    const response = await apiClient.get<Record<string, unknown>>('/api/v1/alphasift/strategies', { timeout: ALPHASIFT_INSTALL_TIMEOUT_MS });
+    return toCamelCase<AlphaSiftStrategiesResponse>(response.data);
+  },
+
+  async getHotspots(payload: { provider?: string; top?: number; refresh?: boolean; includeDetails?: boolean } = {}): Promise<AlphaSiftHotspotsResponse> {
+    const response = await apiClient.get<Record<string, unknown>>('/api/v1/alphasift/hotspots', {
+      params: {
+        provider: payload.provider || 'akshare',
+        top: payload.top ?? 12,
+        refresh: payload.refresh ?? false,
+        include_details: payload.includeDetails ?? true,
+      },
+      timeout: ALPHASIFT_INSTALL_TIMEOUT_MS,
+    });
+    const normalized = toCamelCase<AlphaSiftHotspotsResponse>(response.data);
+    if (normalized.details) {
+      const detailsByTopic: Record<string, AlphaSiftHotspotDetail> = {};
+      Object.values(normalized.details).forEach((detail) => {
+        if (detail?.topic) {
+          detailsByTopic[detail.topic] = detail;
+        }
+      });
+      normalized.details = { ...normalized.details, ...detailsByTopic };
+    }
+    return normalized;
+  },
+
+  async getHotspotDetail(payload: { topic: string; provider?: string; refresh?: boolean }): Promise<AlphaSiftHotspotDetail> {
+    const response = await apiClient.get<Record<string, unknown>>(
+      `/api/v1/alphasift/hotspots/${encodeURIComponent(payload.topic)}`,
+      {
+        params: { provider: payload.provider || 'akshare', refresh: payload.refresh ?? false },
+        timeout: ALPHASIFT_INSTALL_TIMEOUT_MS,
+      },
+    );
+    return toCamelCase<AlphaSiftHotspotDetail>(response.data);
+  },
+
+  async install(): Promise<AlphaSiftInstallResponse> {
+    const response = await apiClient.post<Record<string, unknown>>('/api/v1/alphasift/install', {}, { timeout: ALPHASIFT_INSTALL_TIMEOUT_MS });
+    return toCamelCase<AlphaSiftInstallResponse>(response.data);
+  },
+
+  async enable(): Promise<void> {
+    await setAlphaSiftEnabled('true');
+    try {
+      const status = await alphasiftApi.getStatus();
+      if (!status.available) {
+        const reason = status.diagnostics?.reason ? `（${status.diagnostics.reason}）` : '';
+        throw new Error(`AlphaSift 适配层不可用${reason}。请确认后端已安装项目依赖，必要时执行 pip install -r requirements.txt 或重建 Docker/桌面后端。`);
+      }
+    } catch (error) {
+      try {
+        await setAlphaSiftEnabled('false');
+      } catch {
+        // Preserve the original install/status failure for the caller.
+      }
+      throw error;
+    }
+  },
+};

--- a/data_provider/__init__.py
+++ b/data_provider/__init__.py
@@ -43,6 +43,7 @@ from .yfinance_fetcher import YfinanceFetcher
 from .longbridge_fetcher import LongbridgeFetcher
 from .finnhub_fetcher import FinnhubFetcher
 from .alphavantage_fetcher import AlphaVantageFetcher
+from .a_stock_free_fetcher import AStockFreeFetcher
 from .us_index_mapping import is_us_index_code, is_us_stock_code, get_us_index_yf_symbol, US_INDEX_MAPPING
 
 __all__ = [
@@ -58,6 +59,7 @@ __all__ = [
     'LongbridgeFetcher',
     'FinnhubFetcher',
     'AlphaVantageFetcher',
+    'AStockFreeFetcher',
     'is_us_index_code',
     'is_us_stock_code',
     'is_hk_stock_code',

--- a/data_provider/a_stock_free_fetcher.py
+++ b/data_provider/a_stock_free_fetcher.py
@@ -1,0 +1,483 @@
+# -*- coding: utf-8 -*-
+"""Zero-key A-share intelligence and fallback sources.
+
+The implementation is adapted from the a-stock-data skill, but shaped as a
+project-native provider instead of a copied script.  It focuses on sources that
+add information not already covered by the daily K-line fetchers:
+
+- CLS 7x24 telegraph news
+- THS hot-stock reason tags
+- CNINFO announcements with dynamic orgId lookup
+- Sina fund-flow fallback
+- SSE/SZSE official dragon-tiger fallback
+- SZSE/Eastmoney announcement fallback
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import os
+from datetime import datetime
+from typing import Any, Dict, List, Optional
+
+from .base import normalize_stock_code
+from .free_source_http import (
+    DEFAULT_USER_AGENT,
+    FreeSourceError,
+    FreeSourceHttpClient,
+    default_free_source_client,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def _env_enabled(name: str, default: str = "true") -> bool:
+    value = os.getenv(name, default)
+    return str(value).strip().lower() not in {"0", "false", "no", "off"}
+
+
+def _safe_float(value: Any) -> Optional[float]:
+    try:
+        if value is None or value == "":
+            return None
+        return float(str(value).replace("%", "").replace(",", ""))
+    except (TypeError, ValueError):
+        return None
+
+
+def _cninfo_ts_to_date(value: Any) -> str:
+    if value in (None, ""):
+        return ""
+    try:
+        numeric = int(value)
+        if numeric > 10_000_000_000:
+            numeric = numeric // 1000
+        return datetime.fromtimestamp(numeric).strftime("%Y-%m-%d")
+    except (TypeError, ValueError, OSError):
+        text = str(value)
+        return text[:10]
+
+
+def _cls_sign(params: Dict[str, str]) -> str:
+    query = "&".join(f"{key}={params[key]}" for key in sorted(params))
+    return hashlib.md5(hashlib.sha1(query.encode("utf-8")).hexdigest().encode("utf-8")).hexdigest()
+
+
+class AStockFreeFetcher:
+    """Fetch selected free A-share intelligence sources with stable schemas."""
+
+    name = "AStockFreeFetcher"
+
+    def __init__(self, client: Optional[FreeSourceHttpClient] = None):
+        self.client = client or default_free_source_client
+        self.enabled = _env_enabled("FREE_A_STOCK_SOURCES_ENABLED", "true")
+        self.cls_enabled = _env_enabled("CLS_TELEGRAPH_ENABLED", "true")
+        self.ths_hot_enabled = _env_enabled("THS_HOT_REASON_ENABLED", "true")
+        self.cninfo_enabled = _env_enabled("CNINFO_ANNOUNCEMENT_ENABLED", "true")
+        self.sina_fund_flow_enabled = _env_enabled("SINA_FUND_FLOW_FALLBACK_ENABLED", "true")
+        self.official_dragon_tiger_enabled = _env_enabled("OFFICIAL_DRAGON_TIGER_FALLBACK_ENABLED", "true")
+        self.announcement_fallback_enabled = _env_enabled("ANNOUNCEMENT_FALLBACK_ENABLED", "true")
+        self._cninfo_orgid_map: Dict[str, str] = {}
+
+    def cls_telegraph(self, page_size: int = 50) -> List[Dict[str, Any]]:
+        """Return CLS 7x24 telegraph news as zero-key market events."""
+        if not self.enabled or not self.cls_enabled:
+            return []
+        size = max(1, min(int(page_size or 50), 100))
+        params = {
+            "appName": "CailianpressWeb",
+            "os": "web",
+            "sv": "7.7.5",
+            "last_time": "",
+            "refresh_type": "1",
+            "rn": str(size),
+        }
+        query = "&".join(f"{key}={params[key]}" for key in sorted(params))
+        url = f"https://www.cls.cn/v1/roll/get_roll_list?{query}&sign={_cls_sign(params)}"
+        response = self.client.get(
+            url,
+            headers={"Referer": "https://www.cls.cn/", "User-Agent": DEFAULT_USER_AGENT},
+            timeout=10,
+        )
+        payload = response.json()
+        rows: List[Dict[str, Any]] = []
+        for item in payload.get("data", {}).get("roll_data", []) or []:
+            timestamp = item.get("ctime")
+            published_at = ""
+            if timestamp:
+                try:
+                    published_at = datetime.fromtimestamp(int(timestamp)).strftime("%Y-%m-%d %H:%M:%S")
+                except (TypeError, ValueError, OSError):
+                    published_at = ""
+            title = item.get("title") or item.get("brief") or ""
+            rows.append(
+                {
+                    "title": title,
+                    "content": item.get("content") or item.get("brief") or title,
+                    "time": published_at,
+                    "source": "cls",
+                    "url": item.get("shareurl") or item.get("url") or "https://www.cls.cn/",
+                    "raw_id": item.get("id"),
+                }
+            )
+        return rows
+
+    def ths_hot_reason(self, date: Optional[str] = None, limit: Optional[int] = None) -> List[Dict[str, Any]]:
+        """Return THS hot-stock reason tags for the requested trading date."""
+        if not self.enabled or not self.ths_hot_enabled:
+            return []
+        if date is None:
+            date = datetime.now().strftime("%Y-%m-%d")
+        url = (
+            "http://zx.10jqka.com.cn/event/api/getharden/"
+            f"date/{date}/orderby/date/orderway/desc/charset/GBK/"
+        )
+        response = self.client.get(
+            url,
+            headers={
+                "User-Agent": DEFAULT_USER_AGENT,
+                "Referer": "http://zx.10jqka.com.cn/",
+            },
+            timeout=10,
+        )
+        payload = response.json()
+        if int(payload.get("errocode", 0) or 0) != 0:
+            raise FreeSourceError(f"ths hot reason error: {payload.get('errormsg', '')}")
+        rows = payload.get("data") or []
+        if limit:
+            rows = rows[: max(0, int(limit))]
+        normalized: List[Dict[str, Any]] = []
+        for index, item in enumerate(rows, start=1):
+            code = normalize_stock_code(str(item.get("code", "")))
+            normalized.append(
+                {
+                    "code": code,
+                    "name": item.get("name", ""),
+                    "reason": item.get("reason", ""),
+                    "change_pct": _safe_float(item.get("zhangfu")),
+                    "turnover_rate": _safe_float(item.get("huanshou")),
+                    "amount": _safe_float(item.get("chengjiaoe")),
+                    "volume": _safe_float(item.get("chengjiaoliang")),
+                    "large_order_net": _safe_float(item.get("ddejingliang")),
+                    "close": _safe_float(item.get("close")),
+                    "market": item.get("market", ""),
+                    "rank": index,
+                    "date": date,
+                    "source": "ths_hot_reason",
+                }
+            )
+        return normalized
+
+    def cninfo_announcements(self, stock_code: str, page_size: int = 30) -> List[Dict[str, Any]]:
+        """Return CNINFO full-text announcements for an A-share code."""
+        if not self.enabled or not self.cninfo_enabled:
+            return []
+        code = normalize_stock_code(stock_code)
+        if not (code.isdigit() and len(code) == 6):
+            return []
+        org_id = self._cninfo_orgid(code)
+        payload = {
+            "stock": f"{code},{org_id}",
+            "tabName": "fulltext",
+            "pageSize": str(max(1, min(int(page_size or 30), 100))),
+            "pageNum": "1",
+            "column": "",
+            "category": "",
+            "plate": "",
+            "seDate": "",
+            "searchkey": "",
+            "secid": "",
+            "sortName": "",
+            "sortType": "",
+            "isHLtitle": "true",
+        }
+        response = self.client.post(
+            "https://www.cninfo.com.cn/new/hisAnnouncement/query",
+            data=payload,
+            headers={
+                "Content-Type": "application/x-www-form-urlencoded",
+                "Referer": "https://www.cninfo.com.cn/new/disclosure",
+                "Origin": "https://www.cninfo.com.cn",
+                "User-Agent": DEFAULT_USER_AGENT,
+            },
+            timeout=15,
+        )
+        data = response.json()
+        rows: List[Dict[str, Any]] = []
+        for item in data.get("announcements", []) or []:
+            adjunct_url = item.get("adjunctUrl") or ""
+            pdf_url = (
+                f"https://static.cninfo.com.cn/{adjunct_url}"
+                if adjunct_url and not adjunct_url.startswith("http")
+                else adjunct_url
+            )
+            anno_id = item.get("announcementId", "")
+            rows.append(
+                {
+                    "code": code,
+                    "title": item.get("announcementTitle", ""),
+                    "type": item.get("announcementTypeName", ""),
+                    "date": _cninfo_ts_to_date(item.get("announcementTime")),
+                    "url": f"https://www.cninfo.com.cn/new/disclosure/detail?annoId={anno_id}",
+                    "pdf_url": pdf_url,
+                    "source": "cninfo",
+                    "raw_id": anno_id,
+                }
+            )
+        return rows
+
+    def sina_fund_flow_backup(self, stock_code: str, days: int = 60) -> List[Dict[str, Any]]:
+        """Return Sina daily fund-flow rows as an Eastmoney-independent fallback."""
+        if not self.enabled or not self.sina_fund_flow_enabled:
+            return []
+        code = normalize_stock_code(stock_code)
+        if not (code.isdigit() and len(code) == 6):
+            return []
+        size = max(1, min(int(days or 60), 240))
+        prefixed = self._sina_prefixed_code(code)
+        url = (
+            "https://vip.stock.finance.sina.com.cn/quotes_service/api/json_v2.php/"
+            f"MoneyFlow.ssl_qsfx_zjlrqs?page=1&num={size}&sort=opendate&asc=0&daima={prefixed}"
+        )
+        response = self.client.get(
+            url,
+            headers={
+                "User-Agent": DEFAULT_USER_AGENT,
+                "Referer": "https://finance.sina.com.cn/",
+            },
+            timeout=15,
+        )
+        rows = self._parse_sina_json_array(response.text)
+        normalized: List[Dict[str, Any]] = []
+        for item in rows:
+            if not isinstance(item, dict):
+                continue
+            normalized.append(
+                {
+                    "code": code,
+                    "date": item.get("opendate") or item.get("date") or "",
+                    "close": _safe_float(item.get("trade")),
+                    "net_amount": _safe_float(item.get("netamount")),
+                    "turnover": _safe_float(item.get("turnover")),
+                    "source": "sina_fund_flow",
+                }
+            )
+        return normalized
+
+    def official_dragon_tiger_backup(self, trade_date: str) -> Dict[str, Any]:
+        """Return official SZSE/SSE dragon-tiger data as a zero-key fallback."""
+        if not self.enabled or not self.official_dragon_tiger_enabled:
+            return {"date": trade_date, "source": "official_exchange", "sse_raw": "", "szse": []}
+        date_text = str(trade_date or "").strip()
+        if not date_text:
+            return {"date": date_text, "source": "official_exchange", "sse_raw": "", "szse": []}
+
+        result: Dict[str, Any] = {
+            "date": date_text,
+            "source": "official_exchange",
+            "sse_raw": "",
+            "szse": [],
+        }
+
+        szse_url = (
+            "https://www.szse.cn/api/report/ShowReport/data?SHOWTYPE=JSON"
+            f"&CATALOGID=1842_xxpl&TABKEY=tab1&txtStart={date_text}&txtEnd={date_text}&random=0.9"
+        )
+        try:
+            response = self.client.get(
+                szse_url,
+                headers={
+                    "User-Agent": DEFAULT_USER_AGENT,
+                    "Referer": "https://www.szse.cn/disclosure/supervision/dealinfo/index.html",
+                },
+                timeout=15,
+            )
+            payload = response.json()
+            first = payload[0] if isinstance(payload, list) and payload else {}
+            result["szse"] = [
+                {
+                    "code": normalize_stock_code(str(row.get("zqdm", ""))),
+                    "name": row.get("zqjc", ""),
+                    "amount": row.get("cjje"),
+                    "reason": row.get("plyy", ""),
+                    "source": "szse_dragon_tiger",
+                }
+                for row in first.get("data", []) or []
+                if isinstance(row, dict)
+            ]
+        except Exception as exc:
+            result["szse_error"] = str(exc)
+            logger.debug("[AStockFreeFetcher] SZSE dragon-tiger fallback failed: %s", exc)
+
+        sse_url = (
+            "https://query.sse.com.cn/infodisplay/showTradePublicFile.do?"
+            f"jsonCallBack=cb&isPagination=false&dateTx={date_text}"
+        )
+        try:
+            response = self.client.get(
+                sse_url,
+                headers={
+                    "User-Agent": DEFAULT_USER_AGENT,
+                    "Referer": "https://www.sse.com.cn/disclosure/diclosure/public/",
+                },
+                timeout=15,
+            )
+            payload = self._parse_jsonp_object(response.text)
+            result["sse_raw"] = "\n".join(payload.get("fileContents", []) or [])
+        except Exception as exc:
+            result["sse_error"] = str(exc)
+            logger.debug("[AStockFreeFetcher] SSE dragon-tiger fallback failed: %s", exc)
+        return result
+
+    def announcement_fallback(self, stock_code: str, page_size: int = 20) -> List[Dict[str, Any]]:
+        """Return SZSE official / Eastmoney announcement rows as a fallback."""
+        if not self.enabled or not self.announcement_fallback_enabled:
+            return []
+        code = normalize_stock_code(stock_code)
+        if not (code.isdigit() and len(code) == 6):
+            return []
+        size = max(1, min(int(page_size or 20), 100))
+        if code.startswith(("0", "3")):
+            return self._szse_announcement_fallback(code, size)
+        return self._eastmoney_announcement_fallback(code, size)
+
+    def _cninfo_orgid(self, code: str) -> str:
+        if not self._cninfo_orgid_map:
+            try:
+                response = self.client.get(
+                    "http://www.cninfo.com.cn/new/data/szse_stock.json",
+                    headers={"User-Agent": DEFAULT_USER_AGENT},
+                    timeout=15,
+                )
+                data = response.json()
+                self._cninfo_orgid_map = {
+                    str(item.get("code")): str(item.get("orgId"))
+                    for item in data.get("stockList", [])
+                    if item.get("code") and item.get("orgId")
+                }
+            except Exception as exc:  # pragma: no cover - fallback is tested directly
+                logger.warning("[AStockFreeFetcher] CNINFO orgId map unavailable, using fallback: %s", exc)
+        org_id = self._cninfo_orgid_map.get(code)
+        if org_id:
+            return org_id
+        if code.startswith("6"):
+            return f"gssh0{code}"
+        if code.startswith(("8", "4", "9")):
+            return f"gsbj0{code}"
+        return f"gssz0{code}"
+
+    @staticmethod
+    def _sina_prefixed_code(code: str) -> str:
+        if code.startswith(("6", "9")):
+            return f"sh{code}"
+        if code.startswith(("8", "4")):
+            return f"bj{code}"
+        return f"sz{code}"
+
+    @staticmethod
+    def _parse_sina_json_array(text: str) -> List[Dict[str, Any]]:
+        payload = str(text or "").strip()
+        if not payload:
+            return []
+        start = payload.find("[")
+        end = payload.rfind("]")
+        if start >= 0 and end >= start:
+            payload = payload[start : end + 1]
+        data = json.loads(payload)
+        return data if isinstance(data, list) else []
+
+    @staticmethod
+    def _parse_jsonp_object(text: str) -> Dict[str, Any]:
+        payload = str(text or "").strip()
+        start = payload.find("(")
+        end = payload.rfind(")")
+        if start >= 0 and end > start:
+            payload = payload[start + 1 : end]
+        data = json.loads(payload)
+        return data if isinstance(data, dict) else {}
+
+    def _szse_announcement_fallback(self, code: str, page_size: int) -> List[Dict[str, Any]]:
+        body = {
+            "channelCode": ["listedNotice_disc"],
+            "pageSize": page_size,
+            "pageNum": 1,
+            "stock": [code],
+        }
+        response = self.client.post(
+            "https://www.szse.cn/api/disc/announcement/annList",
+            json=body,
+            headers={
+                "User-Agent": DEFAULT_USER_AGENT,
+                "Content-Type": "application/json",
+                "Referer": "https://www.szse.cn/disclosure/listed/notice/index.html",
+            },
+            timeout=15,
+        )
+        data = response.json()
+        rows: List[Dict[str, Any]] = []
+        for item in data.get("data", []) or []:
+            attach_path = item.get("attachPath") or ""
+            rows.append(
+                {
+                    "code": code,
+                    "title": item.get("title", ""),
+                    "date": str(item.get("publishTime", ""))[:10],
+                    "url": "",
+                    "pdf_url": (
+                        f"https://disc.static.szse.cn/download{attach_path}"
+                        if attach_path and not attach_path.startswith("http")
+                        else attach_path
+                    ),
+                    "source": "szse_announcement",
+                    "raw_id": item.get("id") or item.get("announcementId"),
+                }
+            )
+        return rows
+
+    def _eastmoney_announcement_fallback(self, code: str, page_size: int) -> List[Dict[str, Any]]:
+        url = (
+            "https://np-anotice-stock.eastmoney.com/api/security/ann"
+            f"?sr=-1&page_size={page_size}&page_index=1&ann_type=A"
+            f"&client_source=web&stock_list={code}&f_node=0&s_node=0"
+        )
+        response = self.client.get(
+            url,
+            headers={
+                "User-Agent": DEFAULT_USER_AGENT,
+                "Referer": "https://data.eastmoney.com/notices/",
+            },
+            timeout=15,
+        )
+        data = response.json()
+        rows: List[Dict[str, Any]] = []
+        for item in data.get("data", {}).get("list", []) or []:
+            art_code = item.get("art_code", "")
+            rows.append(
+                {
+                    "code": code,
+                    "title": item.get("title", ""),
+                    "date": str(item.get("notice_date", ""))[:10],
+                    "url": "",
+                    "pdf_url": f"https://pdf.dfcfw.com/pdf/H2_{art_code}_1.pdf" if art_code else "",
+                    "source": "eastmoney_announcement_fallback",
+                    "raw_id": art_code,
+                }
+            )
+        return rows
+
+    def snapshot(self, stock_code: Optional[str] = None, *, date: Optional[str] = None) -> Dict[str, Any]:
+        """Convenience method for diagnostics and future pipeline integration."""
+        result: Dict[str, Any] = {
+            "source": self.name,
+            "news": self.cls_telegraph(page_size=20),
+            "hot_reasons": self.ths_hot_reason(date=date, limit=50),
+        }
+        if stock_code:
+            result["announcements"] = self.cninfo_announcements(stock_code, page_size=20)
+            result["fund_flow_fallback"] = self.sina_fund_flow_backup(stock_code, days=20)
+        return result
+
+
+__all__ = ["AStockFreeFetcher", "FreeSourceError"]

--- a/data_provider/akshare_fetcher.py
+++ b/data_provider/akshare_fetcher.py
@@ -60,6 +60,26 @@ RealtimeQuote = UnifiedRealtimeQuote
 
 logger = logging.getLogger(__name__)
 
+
+def _env_flag(name: str, default: bool = False) -> bool:
+    """Read a boolean environment flag with conservative parsing."""
+    value = os.getenv(name)
+    if value is None:
+        return default
+    return str(value).strip().lower() in {"1", "true", "yes", "y", "on"}
+
+
+def _prefer_non_eastmoney_market_sources() -> bool:
+    """
+    Prefer non-Eastmoney routes for broad market-review data.
+
+    Eastmoney remains available for unique datasets, but market breadth and
+    sector rankings have working Sina/Akshare fallbacks. In residential/WSL
+    networks Eastmoney often returns RemoteDisconnected after bursts, so broad
+    review paths default to the lower-noise route.
+    """
+    return _env_flag("FREE_A_STOCK_LOW_NOISE_MODE", True)
+
 SINA_REALTIME_ENDPOINT = "hq.sinajs.cn/list"
 TENCENT_REALTIME_ENDPOINT = "qt.gtimg.cn/q"
 _AKSHARE_HISTORY_CALL_TIMEOUT = 30.0
@@ -1686,6 +1706,10 @@ class AkshareFetcher(BaseFetcher):
         """
         import akshare as ak
 
+        if _prefer_non_eastmoney_market_sources():
+            logger.info("[Akshare] ak.stock_cyq_em skipped reason=low_noise_mode stock_code=%s", stock_code)
+            return None
+
         # 美股没有筹码分布数据（Akshare 不支持）
         if _is_us_code(stock_code):
             logger.debug(f"[API跳过] {stock_code} 是美股，无筹码分布数据")
@@ -1866,7 +1890,14 @@ class AkshareFetcher(BaseFetcher):
                 "[MarketStats] component=market_stats provider=AkshareFetcher "
                 "api=ak.stock_zh_a_spot_em action=request_start"
             )
-            df = ak.stock_zh_a_spot_em()
+            if _prefer_non_eastmoney_market_sources():
+                logger.info(
+                    "[MarketStats] component=market_stats provider=AkshareFetcher "
+                    "api=ak.stock_zh_a_spot_em action=skipped reason=low_noise_mode"
+                )
+                df = None
+            else:
+                df = ak.stock_zh_a_spot_em()
             elapsed = time.monotonic() - started_at
             logger.info(
                 "[MarketStats] component=market_stats provider=AkshareFetcher "
@@ -2041,7 +2072,11 @@ class AkshareFetcher(BaseFetcher):
             self._enforce_rate_limit()
 
             logger.info("[API调用] ak.stock_board_industry_name_em() 获取板块排行...")
-            df = ak.stock_board_industry_name_em()
+            if _prefer_non_eastmoney_market_sources():
+                logger.info("[APIè°ƒç”¨] ak.stock_board_industry_name_em() skipped reason=low_noise_mode")
+                df = None
+            else:
+                df = ak.stock_board_industry_name_em()
             if df is not None and not df.empty:
                 change_col = '涨跌幅'
                 name = '板块名称'
@@ -2070,6 +2105,10 @@ class AkshareFetcher(BaseFetcher):
     def get_concept_rankings(self, n: int = 5) -> Optional[Tuple[List[Dict], List[Dict]]]:
         """获取概念/题材涨跌榜。"""
         import akshare as ak
+
+        if _prefer_non_eastmoney_market_sources():
+            logger.info("[APIè°ƒç”¨] ak.stock_board_concept_name_em() skipped reason=low_noise_mode")
+            return None
 
         try:
             self._set_random_user_agent()

--- a/data_provider/base.py
+++ b/data_provider/base.py
@@ -15,6 +15,7 @@
 """
 
 import logging
+import os
 import random
 import time
 from threading import BoundedSemaphore, RLock, Thread
@@ -34,6 +35,17 @@ from .realtime_types import CircuitBreaker
 
 # 配置日志
 logger = logging.getLogger(__name__)
+
+
+def _env_flag(name: str, default: bool = False) -> bool:
+    value = os.getenv(name)
+    if value is None:
+        return default
+    return str(value).strip().lower() in {"1", "true", "yes", "y", "on"}
+
+
+def _prefer_non_eastmoney_market_sources() -> bool:
+    return _env_flag("FREE_A_STOCK_LOW_NOISE_MODE", True)
 
 
 # === 标准化列名定义 ===
@@ -1497,6 +1509,73 @@ class DataFetcherManager:
     def available_fetchers(self) -> List[str]:
         """返回可用数据源名称列表"""
         return [f.name for f in self._get_fetchers_snapshot()]
+
+    def _get_a_stock_free_fetcher(self):
+        """Lazily create the zero-key A-share intelligence fetcher.
+
+        The free-source provider is intentionally kept outside the daily K-line
+        fetcher list because it returns news, hot reasons, and announcements
+        rather than OHLCV data.
+        """
+        fetcher = getattr(self, "_a_stock_free_fetcher", None)
+        if fetcher is None:
+            from .a_stock_free_fetcher import AStockFreeFetcher
+
+            fetcher = AStockFreeFetcher()
+            self._a_stock_free_fetcher = fetcher
+        return fetcher
+
+    def get_free_market_news(self, page_size: int = 50) -> List[Dict[str, Any]]:
+        """Fetch zero-key market news from CLS."""
+        try:
+            return self._get_a_stock_free_fetcher().cls_telegraph(page_size=page_size)
+        except Exception as exc:
+            logger.warning("[AStockFreeFetcher] CLS telegraph failed: %s", exc)
+            return []
+
+    def get_free_hot_reasons(
+        self,
+        date: Optional[str] = None,
+        limit: Optional[int] = None,
+    ) -> List[Dict[str, Any]]:
+        """Fetch zero-key THS hot-stock reason tags."""
+        try:
+            return self._get_a_stock_free_fetcher().ths_hot_reason(date=date, limit=limit)
+        except Exception as exc:
+            logger.warning("[AStockFreeFetcher] THS hot reasons failed: %s", exc)
+            return []
+
+    def get_free_announcements(self, stock_code: str, page_size: int = 30) -> List[Dict[str, Any]]:
+        """Fetch zero-key CNINFO announcements for a stock."""
+        try:
+            return self._get_a_stock_free_fetcher().cninfo_announcements(stock_code, page_size=page_size)
+        except Exception as exc:
+            logger.warning("[AStockFreeFetcher] CNINFO announcements failed for %s: %s", stock_code, exc)
+            return []
+
+    def get_fallback_fund_flow(self, stock_code: str, days: int = 60) -> List[Dict[str, Any]]:
+        """Fetch Sina daily fund-flow fallback rows for an A-share stock."""
+        try:
+            return self._get_a_stock_free_fetcher().sina_fund_flow_backup(stock_code, days=days)
+        except Exception as exc:
+            logger.warning("[AStockFreeFetcher] Sina fund-flow fallback failed for %s: %s", stock_code, exc)
+            return []
+
+    def get_fallback_dragon_tiger(self, trade_date: str) -> Dict[str, Any]:
+        """Fetch official SSE/SZSE dragon-tiger fallback data."""
+        try:
+            return self._get_a_stock_free_fetcher().official_dragon_tiger_backup(trade_date)
+        except Exception as exc:
+            logger.warning("[AStockFreeFetcher] Official dragon-tiger fallback failed for %s: %s", trade_date, exc)
+            return {"date": trade_date, "source": "official_exchange", "sse_raw": "", "szse": []}
+
+    def get_fallback_announcements(self, stock_code: str, page_size: int = 20) -> List[Dict[str, Any]]:
+        """Fetch SZSE/Eastmoney announcement fallback rows for an A-share stock."""
+        try:
+            return self._get_a_stock_free_fetcher().announcement_fallback(stock_code, page_size=page_size)
+        except Exception as exc:
+            logger.warning("[AStockFreeFetcher] Announcement fallback failed for %s: %s", stock_code, exc)
+            return []
     
     def prefetch_realtime_quotes(self, stock_codes: List[str]) -> int:
         """
@@ -2142,6 +2221,10 @@ class DataFetcherManager:
 
         config = get_config()
 
+        if _prefer_non_eastmoney_market_sources():
+            logger.info("[chip_distribution] %s skipped reason=low_noise_mode", stock_code)
+            return None
+
         # 如果筹码分布功能被禁用，直接返回 None
         if not config.enable_chip_distribution:
             logger.debug(f"[筹码分布] 功能已禁用，跳过 {stock_code}")
@@ -2476,6 +2559,9 @@ class DataFetcherManager:
         for fetcher in self._fetchers:
             if region == "cn" and fetcher.name == "TickFlowFetcher":
                 continue
+            if region == "cn" and fetcher.name == "EfinanceFetcher" and _prefer_non_eastmoney_market_sources():
+                logger.info("[EfinanceFetcher] skip get_main_indices reason=low_noise_mode")
+                continue
             try:
                 data = fetcher.get_main_indices(region=region)
                 if data:
@@ -2521,6 +2607,13 @@ class DataFetcherManager:
 
         for fetcher in self._fetchers:
             if fetcher.name == "TickFlowFetcher":
+                continue
+            if fetcher.name == "EfinanceFetcher" and _prefer_non_eastmoney_market_sources():
+                logger.info(
+                    "[MarketStats] component=market_stats action=provider_skipped "
+                    "purpose=%s provider=EfinanceFetcher reason=low_noise_mode",
+                    purpose,
+                )
                 continue
             started_at = time.monotonic()
             try:
@@ -3598,6 +3691,17 @@ class DataFetcherManager:
 
             # 直接遍历管理器已经按 priority 排好序的数据源列表
             for fetcher in self._fetchers:
+                if fetcher.name == "EfinanceFetcher" and _prefer_non_eastmoney_market_sources():
+                    source_chain.append(
+                        {
+                            "provider": fetcher.name,
+                            "result": "skipped",
+                            "duration_ms": 0,
+                            "error": "low_noise_mode",
+                        }
+                    )
+                    logger.info("[EfinanceFetcher] skip get_sector_rankings reason=low_noise_mode")
+                    continue
                 if not hasattr(fetcher, 'get_sector_rankings'):
                     continue
 
@@ -3668,6 +3772,10 @@ class DataFetcherManager:
         if normalized_n <= 0:
             normalized_n = 5
 
+        if _prefer_non_eastmoney_market_sources():
+            logger.info("[concept_rankings] skipped reason=low_noise_mode n=%s", normalized_n)
+            return [], []
+
         last_error = ""
         now = time.monotonic()
 
@@ -3680,6 +3788,10 @@ class DataFetcherManager:
             top: List[Dict] = []
             bottom: List[Dict] = []
             for fetcher in self._get_fetchers_snapshot():
+                if fetcher.name == "EfinanceFetcher" and _prefer_non_eastmoney_market_sources():
+                    last_error = "EfinanceFetcher skipped by low_noise_mode"
+                    logger.info("[EfinanceFetcher] skip get_concept_rankings reason=low_noise_mode")
+                    continue
                 try:
                     data = fetcher.get_concept_rankings(normalized_n)
                     if data and (data[0] or data[1]):

--- a/data_provider/free_source_http.py
+++ b/data_provider/free_source_http.py
@@ -1,0 +1,106 @@
+"""Shared HTTP utilities for free A-share data sources.
+
+This module ports the operational rules from the a-stock-data skill into the
+project codebase: zero-key sources first, explicit source metadata, bounded
+timeouts, retries for transient failures, and conservative Eastmoney throttling.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import random
+import threading
+import time
+from dataclasses import dataclass
+from typing import Mapping, Optional
+
+import requests
+from requests.adapters import HTTPAdapter
+from urllib3.util.retry import Retry
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_USER_AGENT = (
+    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
+    "AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
+)
+
+
+class FreeSourceError(RuntimeError):
+    """Raised when a free A-share source cannot return usable data."""
+
+
+@dataclass(frozen=True)
+class FreeSourceRequestPolicy:
+    timeout: float = float(os.getenv("FREE_SOURCE_TIMEOUT", "15") or 15)
+    eastmoney_min_interval: float = float(os.getenv("EASTMONEY_MIN_INTERVAL", "1.2") or 1.2)
+    eastmoney_jitter: float = float(os.getenv("EASTMONEY_JITTER", "0.5") or 0.5)
+    max_retries: int = int(os.getenv("EASTMONEY_MAX_RETRIES", "3") or 3)
+
+
+class FreeSourceHttpClient:
+    """Small wrapper around requests.Session with source-aware throttling."""
+
+    def __init__(self, policy: Optional[FreeSourceRequestPolicy] = None):
+        self.policy = policy or FreeSourceRequestPolicy()
+        self.session = requests.Session()
+        self.session.headers.update({"User-Agent": DEFAULT_USER_AGENT})
+        self._eastmoney_lock = threading.Lock()
+        self._eastmoney_last_call = 0.0
+
+        retry = Retry(
+            total=self.policy.max_retries,
+            connect=self.policy.max_retries,
+            read=self.policy.max_retries,
+            backoff_factor=0.6,
+            status_forcelist=[429, 500, 502, 503, 504],
+            allowed_methods=["GET", "POST"],
+        )
+        adapter = HTTPAdapter(max_retries=retry)
+        self.session.mount("https://", adapter)
+        self.session.mount("http://", adapter)
+
+    def request(
+        self,
+        method: str,
+        url: str,
+        *,
+        headers: Optional[Mapping[str, str]] = None,
+        timeout: Optional[float] = None,
+        **kwargs,
+    ) -> requests.Response:
+        if "eastmoney.com" in url:
+            self._throttle_eastmoney()
+        merged_headers = {"User-Agent": DEFAULT_USER_AGENT}
+        if headers:
+            merged_headers.update(dict(headers))
+        try:
+            response = self.session.request(
+                method,
+                url,
+                headers=merged_headers,
+                timeout=timeout or self.policy.timeout,
+                **kwargs,
+            )
+            response.raise_for_status()
+            return response
+        except requests.RequestException as exc:
+            raise FreeSourceError(f"free source request failed: {url}: {exc}") from exc
+
+    def get(self, url: str, **kwargs) -> requests.Response:
+        return self.request("GET", url, **kwargs)
+
+    def post(self, url: str, **kwargs) -> requests.Response:
+        return self.request("POST", url, **kwargs)
+
+    def _throttle_eastmoney(self) -> None:
+        with self._eastmoney_lock:
+            elapsed = time.time() - self._eastmoney_last_call
+            wait = self.policy.eastmoney_min_interval - elapsed
+            if wait > 0:
+                time.sleep(wait + random.uniform(0.1, max(0.1, self.policy.eastmoney_jitter)))
+            self._eastmoney_last_call = time.time()
+
+
+default_free_source_client = FreeSourceHttpClient()

--- a/docs/a-stock-data-integration-plan.md
+++ b/docs/a-stock-data-integration-plan.md
@@ -1,0 +1,65 @@
+# a-stock-data 免费源迁移计划
+
+本项目不直接复制 `a-stock-data/SKILL.md`，而是迁移其中可工程化的抓取方法和稳定零 key 端点。
+
+## 已迁移的工程方法
+
+- 零 key 数据源优先，降低运行门槛。
+- 不把新闻、热点、公告强塞进日线 `BaseFetcher`，而是单独提供 A 股情报源适配器。
+- 统一 HTTP client：
+  - `requests.Session` 复用连接。
+  - 默认浏览器 UA。
+  - 有界超时。
+  - 429 / 5xx 自动重试。
+  - 东方财富域名串行限流、随机抖动。
+- fail-open：免费情报源失败时记录日志并返回空列表，不中断日报主流程。
+- 输出结构保留 `source` 字段，后续进入 LLM prompt 时可做来源标注。
+
+## 第一批已接入源
+
+| 能力 | 方法 | 来源 | 是否 key | 价值 |
+|---|---|---|---|---|
+| 7×24 快讯 | `DataFetcherManager.get_free_market_news()` | 财联社 CLS | 否 | 补市场突发消息，与东财快讯互备 |
+| 强势股题材归因 | `DataFetcherManager.get_free_hot_reasons()` | 同花顺热点 | 否 | 补“为什么涨”的人工题材标签 |
+| 公告增强 | `DataFetcherManager.get_free_announcements()` | 巨潮 CNINFO | 否 | 补正式披露公告与 PDF 链接 |
+
+## 第二批已接入 fallback
+
+| 能力 | 方法 | 来源 | 是否 key | 触发场景 |
+|---|---|---|---|---|
+| 日度资金流备用源 | `DataFetcherManager.get_fallback_fund_flow()` | 新浪 | 否 | 东财资金流失败、风控或返回空 |
+| 龙虎榜官方备用源 | `DataFetcherManager.get_fallback_dragon_tiger()` | 上交所 / 深交所官方 | 否 | 东财龙虎榜失败或需官方交叉验证 |
+| 公告备用源 | `DataFetcherManager.get_fallback_announcements()` | 深交所官方 / 东财公告 PDF | 否 | 巨潮公告失败或返回空 |
+
+## 新增配置
+
+这些开关默认启用；生产环境可在 `.env` 中关闭。
+
+```env
+FREE_A_STOCK_SOURCES_ENABLED=true
+CLS_TELEGRAPH_ENABLED=true
+THS_HOT_REASON_ENABLED=true
+CNINFO_ANNOUNCEMENT_ENABLED=true
+SINA_FUND_FLOW_FALLBACK_ENABLED=true
+OFFICIAL_DRAGON_TIGER_FALLBACK_ENABLED=true
+ANNOUNCEMENT_FALLBACK_ENABLED=true
+
+FREE_SOURCE_TIMEOUT=15
+EASTMONEY_MIN_INTERVAL=1.2
+EASTMONEY_JITTER=0.5
+EASTMONEY_MAX_RETRIES=3
+```
+
+## 下一批建议
+
+1. 将公告 fallback 串到 CNINFO 失败路径，而不是只暴露管理器方法。
+2. 将资金流 fallback 串到个股资金流分析失败路径。
+3. 将龙虎榜 fallback 串到主龙虎榜获取失败路径。
+4. 将第一批结果注入 `DailyMarketContext` 和个股 `news_context`。
+
+## 验收标准
+
+- 离线单元测试覆盖 schema normalization、签名、orgId fallback。
+- Docker 内无需新增付费 key。
+- 新源失败不影响 `server` / `analyzer` 健康状态。
+- 后续进入日报 prompt 时，必须带来源字段，避免 LLM 混淆事实来源。

--- a/docs/alphasift-integration.md
+++ b/docs/alphasift-integration.md
@@ -1,0 +1,224 @@
+# AlphaSift 选股集成说明
+
+数据源失败、fallback 链路和 Tushare / TickFlow / AkShare 等已接入源的推荐配置图示见 [数据源稳定性与故障处理图示](data-source-stability.md)。
+
+AlphaSift 作为独立仓库维护的选股引擎接入 DSA。DSA 默认不启用它，也不把 AlphaSift 的策略逻辑复制进主仓库；后端依赖会随 `requirements.txt` 安装，启用后只通过 `alphasift.dsa_adapter` 稳定适配层调用 AlphaSift。
+
+## 当前方案
+
+- 默认关闭：`ALPHASIFT_ENABLED=false`。
+- 启用入口：设置页或选股页点击开启，或在 `.env` 中配置 `ALPHASIFT_ENABLED=true`。
+- 依赖来源：`requirements.txt` 固定到已验证的 AlphaSift 适配层 commit：`git+https://github.com/ZhuLinsen/alphasift.git@9f522747caafd3c0b1ddb7e14d5cf44c8580b6cf#egg=alphasift`（对应提交 `https://github.com/ZhuLinsen/alphasift/commit/9f522747caafd3c0b1ddb7e14d5cf44c8580b6cf`，覆盖 PR `https://github.com/ZhuLinsen/alphasift/pull/16`、`https://github.com/ZhuLinsen/alphasift/pull/19`、`https://github.com/ZhuLinsen/alphasift/pull/22`、`https://github.com/ZhuLinsen/alphasift/pull/23`、`https://github.com/ZhuLinsen/alphasift/pull/24`、`https://github.com/ZhuLinsen/alphasift/pull/25`、`https://github.com/ZhuLinsen/alphasift/pull/26`、`https://github.com/ZhuLinsen/alphasift/pull/28`、`https://github.com/ZhuLinsen/alphasift/pull/29`、`https://github.com/ZhuLinsen/alphasift/pull/30`、`https://github.com/ZhuLinsen/alphasift/pull/31`、`https://github.com/ZhuLinsen/alphasift/pull/32`、`https://github.com/ZhuLinsen/alphasift/pull/33`、`https://github.com/ZhuLinsen/alphasift/pull/35`、`https://github.com/ZhuLinsen/alphasift/pull/36` 与 `https://github.com/ZhuLinsen/alphasift/pull/37`）。该来源覆盖 `alphasift.dsa_adapter` 契约、`screen/list_strategies/get_status` 调用、Tencent 日 K、Sina snapshot、source health、stale daily fallback、候选级 quote context、wrapper 数据源 caller-side timeout、东财直连限速与抖动、日线数据源健康度/降级诊断、硬过滤瀑布诊断、策略评估摘要、题材匹配得分、策略目录元数据、`blue_chip_income` / `low_volatility_quality` 策略，以及 LLM ranking 的 `LLM_MAX_TOKENS` 输出上限、timeout 后不重复 JSON-mode 重试和更稳健的 JSON 解析边界。
+- 修复安装来源：`ALPHASIFT_INSTALL_SPEC` 仍保留，默认等于同一个受信任 commit。它不再是策略列表或选股接口的运行时安装主路径，只用于显式调用 `/api/v1/alphasift/install` 时做修复安装和来源校验；未显式配置时才按代码常量 `DEFAULT_ALPHASIFT_INSTALL_SPEC` 回退。
+- 迁移边界（显式 `.env` 优先）：
+  - 若 `.env` 中显式保留旧 pin（如 `...de54ea0da367be85770d9589a5bf7ded4f62d386`），DSA 会把该值当作用户覆盖，不会在运行期自动替换为新 pin；
+  - 升级后若要启用新 commit，请手动清理该行/改写后并重建依赖；
+  - `ALPHASIFT_INSTALL_SPEC` 与 `/api/v1/alphasift/install` allow-list 强绑定，单改 `.env` 而不同时回退 `requirements.txt` 与 `src/config.py` 常量会被 `alphasift_install_spec_not_allowed` 拒绝。
+- 回退方式：
+  - 路径 A（业务快速回退，约 5 分钟）：设置 `ALPHASIFT_ENABLED=false` 并重启，恢复原始分析链路；
+  - 路径 B（适配层版本回退）：同步回退 `requirements.txt`、`src/config.py`（`DEFAULT_ALPHASIFT_INSTALL_SPEC`）与 `.env.example` 示例值，重新安装依赖后重建后端镜像/桌面产物。
+- 缺失依赖边界：如果运行环境缺少 `alphasift.dsa_adapter`，`status` 返回 `available=false + diagnostics.reason=missing_module`；`strategies` 和 `screen` 返回 `424` 并提示执行 `pip install -r requirements.txt` 或重建 Docker/桌面后端产物，不会在业务请求中自动 `pip install`。
+- 运行异常边界：若适配层可导入但 `get_status()` 报错或返回 `available=false`，DSA 返回 `424 + diagnostics`，保留故障诊断，防止用重装掩盖真实运行时错误。
+- 策略归属：策略列表、策略参数、全市场快照、初筛、因子评分和 LLM 重排由 AlphaSift 负责；DSA 负责开关、API 壳、数据 provider、展示和错误提示。
+- 普通报告市场结构边界：`market_structure_context` 由 DSA 原生 `MarketHotspotService` / `MarketStructureService` 生成，首版基于 DSA 行业/概念榜单和个股所属板块，输出大盘题材层 `market_theme_context` 与个股位置层 `stock_market_position`。该能力不依赖 AlphaSift runtime；AlphaSift 的热点详情、发酵路线、成分股和 leader stocks 后续可作为可选数据源迁移，但未迁移前普通个股分析不会隐式调用 AlphaSift 或把缺失字段解释为龙头证据。
+
+## 外部契约来源与迁移边界
+
+- 外部契约依据：本次 AlphaSift 运行契约（含 `schema_version=2` 的热点缓存与题材详情字段）对应 GitHub 提交 `https://github.com/ZhuLinsen/alphasift/commit/9f522747caafd3c0b1ddb7e14d5cf44c8580b6cf`。
+  该 commit 在 DSA 中通过以下链路生效：`requirements.txt` 安装 pin、`src/config.py` 默认 `DEFAULT_ALPHASIFT_INSTALL_SPEC`、`.env.example` 默认示例值。
+- 升级路径：
+  - 部署侧只需按部署方式 `git pull` + `pip install -r requirements.txt` + 重启服务；
+  - 接入新行为前请确认 `ALPHASIFT_INSTALL_SPEC` 未显式覆盖为旧值；
+  - 已手动配置 `ALPHASIFT_INSTALL_SPEC` 时，DSA 仅在调用 `install` 时校验来源，不做运行期静默迁移，不会替换原值。
+- 回滚边界（两条路径）：
+  - 路径 A（业务临时回退，5 分钟内可执行）：将 `ALPHASIFT_ENABLED=false` 并重启服务/进程。核心分析、日报报表与原有 LLM 调用链路不受该开关影响；此路径不影响依赖版本。
+  - 路径 B（适配层版本回滚）：恢复到上一个版本的 `requirements.txt` 与 `src/config.py`（`DEFAULT_ALPHASIFT_INSTALL_SPEC`）到旧值，并同步回退 `.env.example` 的默认示例，重建后端镜像/桌面后端产物（等价于完整 revert 本次 PR）后重启。仅改 `.env` 回退 `ALPHASIFT_INSTALL_SPEC` 会被当前 allow-list 拒绝，必须与 `requirements.txt` 与代码 allow-list 一起回退。
+  - 安装入口说明：`/api/v1/alphasift/install` 仅允许当前代码 `ALLOWED_ALPHASIFT_INSTALL_SPECS`（目前为单值集合）中的来源。若确有需要临时接入其他来源，先在环境中手动安装并确认适配层可导入，再重启服务。
+- 兼容说明：`ALPHASIFT_INSTALL_SPEC` 只影响 `install` 调用时的来源校验；`requirements.txt` 与 `src/config.py` 的常量是实际运行时源码约束。`status` 返回 `install_spec_is_default` 可快速判断当前配置是否与 DSA 代码默认源一致。
+
+- DSA 增强：AlphaSift 通过 DSA provider context 在 LLM 重排前只补充 Top 候选的轻量实时行情和基本面上下文，不在初筛阶段抓新闻；DSA API 返回阶段会对最终 Top 候选补新闻和辅助摘要，并通过 `dsa_enrichment` 记录复用或补全情况。
+- 日 K 线补特征：DSA 调用 AlphaSift 时会优先复用 DSA 历史行情加载链路（数据库缓存、Tushare、Efinance、Akshare、Pytdx、Baostock、Yfinance 等 fallback），仅在 DSA 链路无可用数据时回退到 AlphaSift 原始日线数据源，减少单一上游超时拖垮选股。
+- LLM 环境：DSA 调用 AlphaSift 时会桥接 DSA 已解析的 `LITELLM_MODEL`、`LITELLM_FALLBACK_MODELS`、`LLM_CHANNELS`、`LLM_<NAME>_*`、`LITELLM_CONFIG`、渠道额外请求头和各模型密钥；AlphaSift 独立运行时仍使用自己的 `.env`/环境变量。`LLM_TIMEOUT_SEC` 与 `LLM_MAX_TOKENS` 可被 AlphaSift 选股 LLM 重排读取，分别限制单次请求耗时和输出 token 上限。
+- 快照源：DSA 调用 AlphaSift 时，未显式配置 `SNAPSHOT_SOURCE_PRIORITY` 会按 token-aware 顺序注入：有 `TUSHARE_TOKEN` 时为 `tushare,sina,efinance,akshare_em,em_datacenter`，无 token 时为 `sina,efinance,akshare_em,em_datacenter`；同时注入 `DAILY_SOURCE=auto`、`DAILY_FETCH_RETRIES=3`、`DAILY_FETCH_MAX_WORKERS=1` 和默认候选上下文 `news,fund_flow,announcement,quote`。显式配置的源顺序、日线源和候选上下文 provider 会原样保留。
+- 外部数据源超时护栏：AlphaSift 对 efinance、AkShare、Baostock、Tushare、yfinance 等第三方 wrapper 源增加 caller-side timeout；`ALPHASIFT_SNAPSHOT_CALL_TIMEOUT_SEC` 默认 60 秒，`ALPHASIFT_DAILY_CALL_TIMEOUT_SEC` 默认 20 秒，`ALPHASIFT_SOURCE_CALL_TIMEOUT_SEC` 可作为全局兜底，设为 `0`/`off`/`disabled` 可关闭。超时后会记录 source health 与 `last_error`，并继续尝试后续数据源或 last-good / daily history fallback，减少一次 wrapper 卡死拖垮整次选股。
+- 最新 AlphaSift 能力：锁定 commit `9f522747caafd3c0b1ddb7e14d5cf44c8580b6cf` 包含选股 pipeline 性能优化、Tencent 日 K、Sina snapshot、source health、stale daily fallback、candidate quote context、wrapper 数据源 caller-side timeout、东财直连共享重试会话/限速/随机抖动、LLM ranking timeout/max tokens 边界、last-good snapshot fallback、日线历史缓存、行业/概念 provider cache、热点/行业热度因子、hotspot 热点题材榜单、本地 scorecard/post-analysis 元信息、日线数据源健康度排序与告警、硬过滤瀑布诊断、策略评估摘要、多窗口价格路径评估、题材匹配得分、策略目录元数据、`blue_chip_income` 与 `low_volatility_quality` 策略。DSA 调用时会注入隔离缓存默认路径 `data/alphasift`、`data/alphasift/snapshot.last_good.json`、`data/alphasift/daily_history`、`data/alphasift/industry_provider_cache`；Web 选股页提供“热点题材”手动刷新入口，请求 `/api/v1/alphasift/hotspots` 时会显式使用 `akshare` provider 优先拉取具体概念/题材异动（例如钼、铅锌、铜、诊断服务等实时板块异动），行业板块仅作为兜底；默认打开页面时优先读取上一次成功且不少于 3 条的热点题材缓存，点击刷新才实时拉取并覆盖缓存，实时拉取失败时会尽量回退旧缓存；如果 AlphaSift 合约层只返回少量或缺少涨跌幅等关键字段的热点，DSA 会用东方财富板块异动直连榜单替代。点击题材会请求 `/api/v1/alphasift/hotspots/{topic}` 展示发酵路线与概念股；题材详情另有 DSA 侧 30 分钟磁盘缓存，路径为 `data/alphasift/hotspot_details` 或自定义 `ALPHASIFT_DATA_DIR/hotspot_details`，重复点开同一题材会优先返回缓存，实时详情失败时可回退过期缓存；手动刷新热点榜单并保留当前题材时会对详情请求传入 `refresh=true` 绕过详情缓存；不会默认触发 AlphaSift 的 DSA deep-analysis 回调，避免无提示扩大递归调用面。
+- 热点刷新容错：`/api/v1/alphasift/hotspots` 未显式传入 provider 且未配置 `INDUSTRY_PROVIDER` 时，默认使用 DSA EastMoney 兜底 provider（响应中 provider 为 `akshare`），避免落到 AlphaSift 的空 provider 路径；东方财富热点直连源遇到连接中断、超时或 `Connection aborted` 会做短 backoff 重试；手动刷新失败且没有可用热点缓存时返回稳定空态 payload、`source_errors=["eastmoney_hotspot_unavailable"]` 和用户可读 `message`，原始异常仅保留在服务端日志或诊断链路中。桌面端更新会保留 `data/alphasift/hotspots.json`、`data/alphasift/hotspot.history.jsonl`、`data/alphasift/hotspot_details` 与 `data/alphasift/snapshot.last_good.json`，避免更新后丢失 last-good 缓存。
+- 热点数据源补充：DSA provider 使用直连 HTTP 思路，东财板块兜底源使用 `push2.eastmoney.com/api/qt/clist/get` 并保留涨跌幅、领涨股、上涨/下跌家数等字段；题材详情会在一次 provider 生命周期内缓存并合并东方财富成分股、同花顺页面解析和板块异动龙头兜底，优先返回多只概念股，发酵路线按日期聚合展示，避免把同一盘中观察拆成多条同时间节点；事件催化不再使用 DSA 内置静态文案，只展示 AlphaSift 合约时间线、同花顺摘要、已配置新闻搜索源或东财板块异动结构拿到的真实信息；新闻搜索命中的消息会优先通过已配置 LLM 压缩成一句题材催化摘要，LLM 不可用时回退本地短摘要，避免在时间线中展示完整报道。
+- 风险提示：前端设置页和选股页展示第三方来源与投资风险说明；不会弹窗打断用户。
+
+## AlphaSift 适配层要求
+
+AlphaSift 需要提供 `alphasift.dsa_adapter` 模块，并保持以下稳定函数：
+
+- `/api/v1/alphasift/hotspots` 支持 `include_details=true`：列表响应会尽量附带 Top 题材的 `details` 映射，Web 端默认启用，用于批量复用发酵路线和概念股缓存，减少切换不同题材时的二次等待。
+
+```python
+def get_status() -> dict: ...
+def list_strategies() -> list[dict]: ...
+def screen(
+    strategy: str,
+    *,
+    market: str = "cn",
+    max_results: int = 20,
+    use_llm: bool = True,
+    context: dict | None = None,
+) -> dict: ...
+```
+
+`get_status()` 建议返回：
+
+```json
+{
+  "available": true,
+  "contract_version": "1",
+  "version": "0.2.0",
+  "strategy_count": 8,
+  "supported_markets": ["cn"]
+}
+```
+
+`list_strategies()` 至少返回 `id`，建议同时返回 `name`、`description`、`category`、`tags`、`market_scope`。
+
+`screen()` 返回值建议包含：
+
+```json
+{
+  "run_id": "20260531-...",
+  "strategy": "dual_low",
+  "market": "cn",
+  "snapshot_count": 100,
+  "after_filter_count": 5,
+  "llm_ranked": true,
+  "llm_coverage": 1.0,
+  "warnings": [],
+  "source_errors": [],
+  "candidates": []
+}
+```
+
+候选项建议包含 `code`、`name`、`score`、`reason`、`risk_level`、`risk_flags`、`price`、`change_pct`、`amount`、`industry`、`factor_scores`，以及 LLM 字段：`llm_score`、`llm_confidence`、`llm_thesis`、`llm_catalysts`、`llm_risks`、`llm_watch_items` 等。
+
+DSA 会在支持 `context` 的适配层中传入：
+
+```python
+context = {
+    "llm": {
+        "model": "...",
+        "fallback_models": [...],
+        "channels": [...],
+        "model_list": [...],
+    },
+    "dsa": {
+        "contract_version": "1",
+        "mode": "pre_rank_light",
+        "max_candidates": 3,
+        "include_news": False,
+        "news_max_results": 0,
+        "capabilities": ["candidate_context", "daily_history", "realtime_quote", "fundamental_context"],
+        "get_candidate_context": callable,
+        "get_daily_history": callable,
+        "get_realtime_quote": callable,
+        "get_fundamental_context": callable,
+    },
+}
+```
+
+AlphaSift 会在 L1 初筛后、LLM 重排前调用 `context["dsa"]` 中的 provider，为有限 Top 候选补充 DSA 行情和基本面轻量上下文，并把 `dsa_context` 随候选返回。新闻搜索、完整摘要和缺失字段补全由 DSA API 在最终 Top 候选阶段执行；若候选已经携带完整新闻上下文，DSA API 返回阶段会复用这些字段，避免重复请求。
+
+AlphaSift 侧已在 `ZhuLinsen/alphasift@9f522747caafd3c0b1ddb7e14d5cf44c8580b6cf` 提供 DSA provider context 支持、DSA adapter contract，并支持复用 DSA 的 `LLM_TIMEOUT_SEC`；同一 pin 还会读取 `LLM_MAX_TOKENS` 限制 LLM 重排输出，且 timeout 后不再盲目重试无 JSON mode 请求。`dsa_adapter` 稳定契约仍只返回 DSA 已消费的策略基础字段和选股结果字段；上游新增的 strategy facets、overview、本地只读 API 和策略卡片能力暂不进入 DSA API 契约。
+
+## DSA 后端行为
+
+- `/api/v1/alphasift/status`：返回开关、可用性、默认安装来源标识、适配层元信息和 AlphaSift 进程内 snapshot/daily source health；不会暴露完整安装来源。
+- `/api/v1/alphasift/install`：显式修复安装入口。桌面模式（`DSA_DESKTOP_MODE=true`）不要求管理员会话，非桌面部署必须启用 `ADMIN_AUTH_ENABLED=true` 并携带有效管理员会话，否则返回 `401/403`。接口只允许默认受信任安装来源，并会强制重装锁定 commit，避免旧版 `alphasift` 包残留。
+- `/api/v1/alphasift/strategies`：读取 AlphaSift 策略列表；如果 `ALPHASIFT_ENABLED=true` 但适配层缺失或状态异常，返回 `424 + diagnostics`，不触发运行时安装。
+- `/api/v1/alphasift/screen`：调用适配层 `screen(..., use_llm=True)`，并在调用期间临时注入 DSA 已解析的 LLM 运行环境，同时向适配层传入结构化 LLM/DSA provider 配置；AlphaSift 在 LLM 前只消费轻量 DSA provider context，并优先通过 DSA 日线链路补齐 AlphaSift 因子特征，DSA 返回阶段对最终 Top 候选补新闻并复用已增强字段。适配层缺失或运行时异常返回 `424 + diagnostics` 并保留原始错误边界。
+- `/api/v1/alphasift/screen/tasks`：Web/桌面选股页使用的后台任务入口，提交后立即返回 `task_id`，实际选股在共享任务队列中继续执行，避免浏览器长请求被外部快照、行情、新闻或 LLM 延迟拖到超时。
+- `/api/v1/alphasift/screen/tasks/{task_id}`：查询后台选股任务状态。进行中返回 `pending/processing + progress/message`，完成后在 `result` 中返回与 `/screen` 相同的候选结构，失败时返回 `failed + error`；仅接受 `report_type=alphasift_screen` 的任务 ID，普通分析任务不会被误读为选股结果。
+
+## 配置兼容边界（LLM / LiteLLM / Base URL）
+
+- 兼容语义与版本证据（可追溯）：
+  - 运行依赖约束：`requirements.txt` 中将 LiteLLM 固定到 `litellm>=1.80.10,!=1.82.7,!=1.82.8,<2.0.0`，并通过 `git+https://github.com/ZhuLinsen/alphasift.git@9f522747caafd3c0b1ddb7e14d5cf44c8580b6cf` 安装 AlphaSift 适配层。
+  - 文档依据：
+    - LiteLLM Providers: https://docs.litellm.ai/docs/providers
+    - LiteLLM OpenAI-compatible: https://docs.litellm.ai/docs/providers/openai_compatible
+    - LiteLLM model_list/proxy 配置（含 `api_base`、`api_key`、`extra_headers`）: https://docs.litellm.ai/docs/proxy/configs
+    - OpenAI 请求语义与授权头: https://platform.openai.com/docs/api-reference/making-requests、https://platform.openai.com/docs/api-reference/authentication
+
+- 结构化检测澄清：本 PR 触及 `.env.example`、`requirements.txt`、`src/config.py` 与本文档，是因为 AlphaSift 依赖 pin 更新和调用期 runtime bridge 需要把既有 DSA LLM 配置透传给外部适配层；本 PR 没有升级 LiteLLM 主版本、没有新增或改名 provider 协议、没有修改 `LITELLM_MODEL`/`LITELLM_FALLBACK_MODELS`/`LLM_CHANNELS`/`LLM_<NAME>_*` 的持久化解析语义。
+- LLM 运行时兼容边界：AlphaSift 不改变主配置链路，只在调用期注入已解析的 `LITELLM_MODEL`、`LITELLM_FALLBACK_MODELS`、`LLM_CHANNELS` 与 `LLM_<NAME>_*` 到进程环境；受管 provider 的 fallback 过滤行为保持现有策略，不做历史配置的静默迁移。`ALPHASIFT_ENABLED` 是当前场景唯一新增持久化分支。
+- 注意：本注入是**短时内存注入**，不会改写 `.env`、不会回写历史配置、不会静默迁移用户自定义 provider/model 路由；失败或未开启时，除了 AlphaSift 选股能力本身，其它 DSA 业务链路保持既有配置执行。
+- 注入来源与回滚原则：
+  - `LITELLM_MODEL` 与 `LITELLM_FALLBACK_MODELS`优先来自 DSA 已声明路由：`LITELLM_MODEL`、`LITELLM_FALLBACK_MODELS`、`llm_model_list`；未声明的自定义 provider/model 将保留用户原始配置，不被重写。
+  - `OPENAI_BASE_URL` 优先复用主配置的 `OPENAI_BASE_URL`，只有未配置时才会回退到声明为 openai 的 `LLM_CHANNEL` base_url；不会覆盖主配置中的私有网关或别名配置。
+  - `LLM_<NAME>_API_KEYS/BASE_URL/MODELS` 仅按声明渠道合并注入；未声明渠道不会新增注入字段。
+- 若已有自定义模型名、channel、Base URL 或额外头信息，开启/重试 AlphaSift 不会自动覆写 `.env`。如需回退可按原配置恢复：
+  - 回退到旧模型名：直接修改 `LITELLM_MODEL`、`LITELLM_FALLBACK_MODELS`，或清空自定义 `LLM_CHANNELS`。
+  - 恢复旧渠道：保留历史 `LLM_<NAME>_API_KEYS/BASE_URL` 并重启配置生效，不需执行额外迁移脚本。
+- 兼容校验依据（运维核验）：
+  - 依赖版本依据：当前服务端约束为 `litellm>=1.80.10,!=1.82.7,!=1.82.8,<2.0.0`（见 `requirements.txt`），AlphaSift 只复用该依赖的 provider/model 解析、`model_list` 与调用参数语义。
+  - 官方 provider/model 依据：LiteLLM Providers 文档（[https://docs.litellm.ai/docs/providers](https://docs.litellm.ai/docs/providers)）定义 provider 前缀；OpenAI-compatible 文档（[https://docs.litellm.ai/docs/providers/openai_compatible](https://docs.litellm.ai/docs/providers/openai_compatible)）说明 `openai/<model>`、`api_base`、`api_key` 的兼容语义。
+  - 官方 `model_list`/额外头依据：LiteLLM config 文档（[https://docs.litellm.ai/docs/proxy/configs](https://docs.litellm.ai/docs/proxy/configs)）说明 `litellm_params` 支持 `model`、`api_base`、`api_key` 与 `extra_headers`。DSA 只把已声明渠道转换为同类结构传给 AlphaSift，不新增模型路由映射，不做 provider 模式迁移。
+  - 兼容头部语义依据：OpenAI 调用约定（[https://platform.openai.com/docs/api-reference/making-requests](https://platform.openai.com/docs/api-reference/making-requests)）与鉴权约定（[https://platform.openai.com/docs/api-reference/authentication](https://platform.openai.com/docs/api-reference/authentication)）对应 `Authorization` 与自定义 header 传递行为，`extra_headers` 仅用于补充会话头，不改写模型路由。
+  - 回退路径为“设置页关闭 AlphaSift 或保留 `ALPHASIFT_ENABLED=false`”，并保持原有 `LITELLM_*` 与 `LLM_*` 配置，触发失败时可先核对 `status`/`screen` 的 `diagnostics` 后执行服务重启。
+- 旧配置保留证据：
+  - `src/services/alphasift_service.py` 的 `_alphasift_runtime_env()` 会在调用前保存同名 `os.environ` 值，并在调用后逐项恢复或删除本次临时新增键；该路径不调用 `dotenv_values()` 写回，也不修改 `.env` 文件。
+  - `src/services/alphasift_service.py` 的 `_build_alphasift_runtime_env()` 只从当前 `Config` 生成临时 env dict；未声明渠道不会生成 `LLM_<NAME>_*`，已有自定义 provider/model/base URL 不会被重命名或清理。
+  - `tests/test_alphasift_api.py` 覆盖 `test_screen_bridges_dsa_llm_config_into_alphasift_runtime`、`test_screen_bridges_legacy_openai_fields_into_alphasift_runtime_env`、`test_screen_injects_openai_compatible_model_headers_into_alphasift_litellm_calls`、`test_screen_disabled_preserves_existing_llm_env_state` 和 `test_screen_filters_undeclared_managed_fallbacks_for_dsa_routes`，用于证明注入、OpenAI-compatible header/base URL、关闭状态和未声明 fallback 均不改写用户原始配置。
+- 失败可见性：`status`/`screen` 接口返回明确错误码与 `message`，前端在设置页或选股页会将 `403/424/400/422` 等错误直接提示给用户，便于定位并回退到“关闭 AlphaSift + 保持原有 LLM 运行链路”。
+
+## 兼容验收索引（发布前核验）
+
+- 依赖与源码约束核验：`requirements.txt` 中的 `litellm` 约束与 `src/config.py`/`requirements.txt` 一致。
+- Hotspot 契约兼容核验：`docs/alphasift-integration.md` 与 `api/v1/endpoints/alphasift.py`、`src/services/alphasift_service.py` 保持 `hotspots`/`hotspots/{topic}` 字段与 `tests/test_alphasift_api.py` 一致，调用前后默认使用 `snapshot.last_good` 缓存兜底。
+- 外部版本来源：本次集成依赖来源为 `https://github.com/ZhuLinsen/alphasift/commit/9f522747caafd3c0b1ddb7e14d5cf44c8580b6cf`，需在复验时按该 commit pin 回放导入与接口契约。
+- 行为核验：`src/services/alphasift_service.py` 的 `_build_alphasift_runtime_env` 与 `_build_alphasift_context` 仅在调用期写入进程环境；`/api/v1/alphasift/screen`、`strategies`、`status` 在运行期不回写 `.env`。
+- 回退核验：关闭 `ALPHASIFT_ENABLED` 并重启配置链路后，系统恢复原始 `LITELLM_MODEL/FALLBACK_MODELS`、`LLM_CHANNELS` 与 `LLM_*` 运行语义，不执行迁移清理脚本。
+- 语义来源核验：LiteLLM 文档（https://docs.litellm.ai/docs/providers）、OpenAI-compatible 文档（https://docs.litellm.ai/docs/providers/openai_compatible）与 LiteLLM 配置文档（https://docs.litellm.ai/docs/proxy/configs）用于核对 provider/model/base_url/extra_headers 映射链路。
+- 状态诊断：`/api/v1/alphasift/status` 对 AlphaSift 包或 `alphasift.dsa_adapter` 未安装仍保持 `200` + `available=false` 的兼容语义；如果导入过程、`get_status()` 调用或返回结构出现非预期异常，后端会记录 warning，并在响应中追加不含安装来源明文的 `diagnostics` 字段，便于从接口状态和服务端日志定位问题。
+
+错误策略：
+
+- 未开启返回 `403 alphasift_disabled`。
+- 修复安装接口来源不受信任返回 `403 alphasift_install_spec_not_allowed`。
+- AlphaSift 未安装、缺少适配层或适配层不可调用返回 `424`。
+- 市场或策略被适配层拒绝时返回 `400/422`。
+- 运行失败返回 `424 alphasift_screen_failed`。
+
+## Web 行为
+
+- 设置页提供 AlphaSift 开关，开启后写入 `ALPHASIFT_ENABLED=true` 并检查适配层是否可用；若缺失，会回滚开关并提示执行 `pip install -r requirements.txt` 或重建 Docker/桌面后端产物。
+- `ALPHASIFT_ENABLED` 是“开启选股”按钮背后的持久化状态，不作为普通数据源配置项重复展示。
+- 选股页未开启时展示开启按钮；开启后读取 AlphaSift 策略列表。
+- 当前只暴露 A 股 `cn` 市场。
+- 默认返回数量为 3，避免一次选股过慢或结果过多。
+- 选股页通过后台任务提交和状态轮询获取结果；任务 ID 会保存在当前浏览器 tab 的 `sessionStorage`，切换页面后返回选股页会继续恢复进度或最终结果。后端重启或任务被清理时，前端会提示任务不可恢复并允许重新运行。
+- 结果页展示运行 ID、样本数量、过滤后数量、LLM 是否重排、LLM 覆盖率和 DSA 增强计数；如果 AlphaSift 返回 warning/source error/LLM parse error 或 `llm_ranked=false`，页面会明确显示降级原因，避免把本地因子结果误展示成正常 LLM 判断；重复的快照源 fallback warning/source error 会在前端合并展示为一条“数据源降级”提示。
+- 展开候选时展示 AlphaSift 摘要、因子和 LLM 判断；若 DSA 已增强，还会展示 `DSA 增强摘要`、`DSA 新闻` 和 `DSA 增强提示`。
+
+## 桌面端说明
+
+源码运行的桌面端复用同一个 Python 后端环境，并设置 `DSA_DESKTOP_MODE=true`；通过设置页开启时如缺少适配层，会提示更新依赖或重建后端产物。
+
+打包后的桌面端不依赖运行期 `pip install`：Windows/CI 使用 `scripts/build-backend.ps1`，macOS 使用 `scripts/build-backend-macos.sh`，两者均先执行 `pip install -r requirements.txt`，再校验并收集 `alphasift.dsa_adapter` 进 PyInstaller 产物。发布包默认仍关闭；用户在 Web 设置页开启后会先检查适配层，若打包产物异常缺失，应重建或更新桌面后端。
+
+## Docker 说明
+
+Docker 镜像与桌面发布包保持一致：`docker/Dockerfile` 会通过 `requirements.txt` 安装 AlphaSift 并校验 `alphasift.dsa_adapter` 可导入。容器运行时默认仍关闭 AlphaSift；用户通过 `ALPHASIFT_ENABLED=true` 或 Web 设置页开启后使用镜像内置依赖，若运行环境缺失适配层，应重新构建镜像。
+
+## 验证记录
+
+- `python -m pytest tests/test_alphasift_api.py -q`
+- `python -m pytest tests/test_main_schedule_mode.py -q -k "start_api_server_fails_before_thread_when_port_is_busy"`
+- `python -m py_compile api/v1/endpoints/alphasift.py src/services/alphasift_service.py tests/test_alphasift_api.py src/config.py src/core/config_registry.py`
+- `cd apps/dsa-web && npm run test -- alphasift.test.ts StockScreeningPage.test.tsx SettingsPage.test.tsx --run`
+- `cd apps/dsa-web && npm run lint`
+- `cd apps/dsa-web && npm run build`
+
+## 回滚
+
+- 关闭功能：设置页关闭 AlphaSift，或配置 `ALPHASIFT_ENABLED=false`。
+- 版本回退：如需降级 alphasift 适配层，必须同时回退仓库 `requirements.txt` 与 `src/config.py` 中受信任的 pin，否则仅改 `.env` 的 `ALPHASIFT_INSTALL_SPEC` 会被 `alphasift_install_spec_not_allowed` 拒绝；确认后重建依赖与重启服务。
+- 特殊来源：如需使用默认来源之外的 AlphaSift 安装包，先在后端 Python 环境完成手动安装并确认 `alphasift.dsa_adapter` 可导入，随后再重启服务（安装前不要触发 `/api/v1/alphasift/install` 的 allow-list 校验路径）。
+- 回滚代码：移除 AlphaSift API 注册、Web 选股入口和相关配置项即可恢复到集成前流程；默认关闭状态下不会影响原有股票分析、报告生成和通知流程。

--- a/src/market_analyzer.py
+++ b/src/market_analyzer.py
@@ -11,6 +11,7 @@
 """
 
 import logging
+import os
 import re
 import time
 from dataclasses import dataclass, field
@@ -36,6 +37,13 @@ from src.services.intelligence_service import IntelligenceService
 from data_provider.base import DataFetcherManager
 
 logger = logging.getLogger(__name__)
+
+
+def _env_flag(name: str, default: bool = False) -> bool:
+    value = os.getenv(name)
+    if value is None:
+        return default
+    return str(value).strip().lower() in {"1", "true", "yes", "y", "on"}
 
 
 _ENGLISH_SECTION_PATTERNS = {
@@ -597,14 +605,20 @@ Focus on index trend, liquidity, and sector rotation to shape the next-session t
         Returns:
             新闻列表
         """
+        all_news = self._get_free_market_news()
+        if all_news and _env_flag("MARKET_NEWS_FREE_SOURCE_ONLY_WHEN_AVAILABLE", True):
+            logger.info(
+                "[å¤§ç›˜] %s action=search_market_news status=skipped reason=free_source_available count=%d",
+                self._log_context(),
+                len(all_news),
+            )
+            return all_news
         if not self.search_service:
             logger.warning(
                 "[大盘] %s action=search_market_news status=skipped reason=no_search_service",
                 self._log_context(),
             )
-            return []
-        
-        all_news = []
+            return all_news
 
         # 按 region 使用不同的新闻搜索词
         search_queries = self.profile.news_queries
@@ -647,6 +661,39 @@ Focus on index trend, liquidity, and sector rotation to shape the next-session t
             logger.error("[大盘] %s action=search_market_news status=failed error=%s", self._log_context(), e)
         
         return all_news
+
+    def _get_free_market_news(self) -> List[Dict[str, str]]:
+        """Fetch zero-key market news for A-share review as fail-open evidence."""
+        if self.region != "cn":
+            return []
+        try:
+            rows = self.data_manager.get_free_market_news(page_size=5)
+        except Exception as exc:
+            logger.debug("[大盘] %s action=free_market_news status=failed error=%s", self._log_context(), exc)
+            return []
+        news: List[Dict[str, str]] = []
+        for item in rows[:5]:
+            if not isinstance(item, dict):
+                continue
+            title = str(item.get("title") or "").strip()
+            if not title:
+                continue
+            news.append(
+                {
+                    "title": title,
+                    "snippet": str(item.get("content") or "").strip(),
+                    "source": str(item.get("source") or "cls").strip(),
+                    "published_date": str(item.get("time") or "").strip(),
+                    "url": str(item.get("url") or "").strip(),
+                }
+            )
+        if news:
+            logger.info(
+                "[大盘] %s action=free_market_news status=success count=%d",
+                self._log_context(),
+                len(news),
+            )
+        return news
     
     def generate_market_review(self, overview: MarketOverview, news: List) -> str:
         """

--- a/src/services/alphasift_service.py
+++ b/src/services/alphasift_service.py
@@ -1,0 +1,3724 @@
+# -*- coding: utf-8 -*-
+"""AlphaSift service facade and DSA runtime bridge."""
+
+from __future__ import annotations
+
+import importlib
+import hashlib
+import inspect
+import json
+import logging
+import math
+import os
+import re
+import subprocess
+import sys
+import threading
+import time
+from contextvars import ContextVar
+from contextlib import contextmanager
+from dataclasses import asdict, is_dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, Iterator, List, Optional, Tuple
+
+from fastapi import HTTPException, Request
+from pydantic import BaseModel, Field
+
+from src.auth import COOKIE_NAME, is_auth_enabled, refresh_auth_state, verify_session
+from src.config import Config, DEFAULT_ALPHASIFT_INSTALL_SPEC, get_configured_llm_models
+
+logger = logging.getLogger(__name__)
+
+ALPHASIFT_DSA_ADAPTER_MODULE = "alphasift.dsa_adapter"
+ALPHASIFT_EXPECTED_MISSING_MODULES = frozenset({"alphasift", ALPHASIFT_DSA_ADAPTER_MODULE})
+ALLOWED_ALPHASIFT_INSTALL_SPECS = frozenset({DEFAULT_ALPHASIFT_INSTALL_SPEC})
+_ALPHASIFT_INSTALL_LOCK = threading.RLock()
+ALPHASIFT_MANAGED_LITELLM_PROVIDERS = frozenset({"gemini", "vertex_ai", "anthropic", "openai", "deepseek"})
+_ALPHASIFT_RUNTIME_ENV_LOCK = threading.RLock()
+DSA_ENRICHMENT_MAX_CANDIDATES = 3
+DSA_PRE_RANK_CONTEXT_MAX_CANDIDATES = 3
+DSA_ALPHASIFT_LLM_CANDIDATE_MULTIPLIER = 2
+DSA_ALPHASIFT_LLM_MAX_CANDIDATES = 12
+DSA_ALPHASIFT_DAILY_FETCH_RETRIES = 3
+DSA_ALPHASIFT_SNAPSHOT_SOURCE_PRIORITY = "sina,efinance,akshare_em,em_datacenter"
+DSA_ALPHASIFT_SNAPSHOT_SOURCE_PRIORITY_WITH_TUSHARE = "tushare,sina,efinance,akshare_em,em_datacenter"
+DSA_ALPHASIFT_CANDIDATE_CONTEXT_PROVIDERS = "news,fund_flow,announcement,quote"
+DSA_ALPHASIFT_DATA_DIR = Path("data") / "alphasift"
+DSA_ALPHASIFT_HOTSPOT_CACHE_PATH = DSA_ALPHASIFT_DATA_DIR / "hotspots.json"
+DSA_ALPHASIFT_HOTSPOT_HISTORY_PATH = DSA_ALPHASIFT_DATA_DIR / "hotspot.history.jsonl"
+DSA_ALPHASIFT_MIN_HOTSPOT_CACHE_COUNT = 3
+DSA_ALPHASIFT_HOTSPOT_DETAIL_CACHE_TTL_SECONDS = 30 * 60
+DSA_ALPHASIFT_HOTSPOT_EVENT_SUMMARY_MAX_CHARS = 90
+DSA_ALPHASIFT_HOTSPOT_PREFETCH_DETAIL_COUNT = 8
+DSA_ALPHASIFT_HOTSPOT_UNAVAILABLE_CODE = "eastmoney_hotspot_unavailable"
+DSA_ALPHASIFT_HOTSPOT_UNAVAILABLE_MESSAGE = "热点源连接中断，暂无可用缓存。"
+DSA_ALPHASIFT_HOTSPOT_CONNECTIVITY_ERROR_MARKERS = (
+    "remote disconnected",
+    "remote end closed connection",
+    "connection aborted",
+    "connection reset",
+    "connection refused",
+    "connection timed out",
+    "read timed out",
+    "connecttimeout",
+    "readtimeout",
+    "max retries exceeded",
+    "chunkedencodingerror",
+    "protocolerror",
+    "incompleteread",
+)
+_DSA_FETCHER_MANAGER_LOCK = threading.RLock()
+_DSA_FETCHER_MANAGER: Any = None
+_FUNDAMENTAL_BLOCKS = ("valuation", "growth", "earnings", "institution", "capital_flow", "boards")
+_ALPHASIFT_LITELLM_COMPLETION_ROUTES: ContextVar[Optional[Tuple[Dict[str, Any], ...]]] = ContextVar(
+    "alphasift_litellm_completion_routes",
+    default=None,
+)
+_ALPHASIFT_LITELLM_COMPLETION_ATTR = "_alphasift_litellm_completion_bridge"
+_ALPHASIFT_LITELLM_COMPLETION_LOCK = threading.Lock()
+
+
+def _safe_float(value: Any) -> Optional[float]:
+    try:
+        if value is None or value == "":
+            return None
+        number = float(value)
+    except (TypeError, ValueError):
+        return None
+    if not math.isfinite(number):
+        return None
+    return number
+
+
+def _utc_now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z")
+
+
+def _resolve_alphasift_data_dir() -> Path:
+    configured = _env_text(os.getenv("ALPHASIFT_DATA_DIR"))
+    if configured:
+        return Path(configured)
+    return DSA_ALPHASIFT_DATA_DIR
+
+
+def _alphasift_hotspot_cache_path() -> Path:
+    if _env_text(os.getenv("ALPHASIFT_DATA_DIR")):
+        return _resolve_alphasift_data_dir() / "hotspots.json"
+    return DSA_ALPHASIFT_HOTSPOT_CACHE_PATH
+
+
+def _alphasift_hotspot_history_path() -> Path:
+    if _env_text(os.getenv("ALPHASIFT_DATA_DIR")):
+        return _resolve_alphasift_data_dir() / "hotspot.history.jsonl"
+    return DSA_ALPHASIFT_HOTSPOT_HISTORY_PATH
+
+
+def _alphasift_hotspot_detail_cache_dir() -> Path:
+    return _resolve_alphasift_data_dir() / "hotspot_details"
+
+
+def _alphasift_hotspot_detail_cache_path(*, provider: str, topic: str) -> Path:
+    provider_text = re.sub(r"[^A-Za-z0-9_.-]+", "_", _env_text(provider) or "akshare")
+    digest = hashlib.sha1(f"{provider_text}\0{_env_text(topic)}".encode("utf-8")).hexdigest()
+    return _alphasift_hotspot_detail_cache_dir() / f"{provider_text}.{digest}.json"
+
+
+def _parse_cache_datetime(value: Any) -> Optional[datetime]:
+    text = _env_text(value)
+    if not text:
+        return None
+    try:
+        parsed = datetime.fromisoformat(text.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def _load_alphasift_hotspot_detail_cache(
+    *,
+    provider: str,
+    topic: str,
+    allow_stale: bool = False,
+) -> Optional[Dict[str, Any]]:
+    cache_path = _alphasift_hotspot_detail_cache_path(provider=provider, topic=topic)
+    try:
+        raw = json.loads(cache_path.read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        return None
+    except Exception as exc:
+        logger.warning("Failed to read AlphaSift hotspot detail cache from %s: %s", cache_path, exc)
+        return None
+
+    payload = raw.get("payload") if isinstance(raw, dict) else None
+    if not isinstance(payload, dict):
+        return None
+    cached_at = raw.get("cached_at") or payload.get("cached_at")
+    cached_dt = _parse_cache_datetime(cached_at)
+    if cached_dt is None:
+        return None
+    age_seconds = max(0.0, (datetime.now(timezone.utc) - cached_dt).total_seconds())
+    stale = age_seconds > DSA_ALPHASIFT_HOTSPOT_DETAIL_CACHE_TTL_SECONDS
+    if stale and not allow_stale:
+        return None
+
+    cached = _ensure_hotspot_detail_compat_fields(dict(payload))
+    cached.update({
+        "enabled": True,
+        "provider": provider or cached.get("provider") or "akshare",
+        "cache_used": True,
+        "cached_at": cached_at,
+        "stale": bool(cached.get("stale") or stale),
+    })
+    if stale:
+        cached["fallback_used"] = True
+        cached["stale_age_seconds"] = round(age_seconds, 1)
+    return _remove_non_finite_json_values(cached)
+
+
+def _write_alphasift_hotspot_detail_cache(*, provider: str, topic: str, payload: Dict[str, Any]) -> None:
+    cache_path = _alphasift_hotspot_detail_cache_path(provider=provider, topic=topic)
+    try:
+        cache_path.parent.mkdir(parents=True, exist_ok=True)
+        cleaned = _remove_non_finite_json_values(_ensure_hotspot_detail_compat_fields(dict(payload)))
+        cached_at = _utc_now_iso()
+        cache_path.write_text(
+            json.dumps(
+                {
+                    "schema_version": 1,
+                    "provider": provider or cleaned.get("provider") or "akshare",
+                    "topic": topic,
+                    "cached_at": cached_at,
+                    "payload": cleaned,
+                },
+                ensure_ascii=False,
+                indent=2,
+            ),
+            encoding="utf-8",
+        )
+    except Exception as exc:
+        logger.warning("Failed to write AlphaSift hotspot detail cache for %s: %s", topic, exc)
+
+
+def _ensure_hotspot_detail_compat_fields(payload: Dict[str, Any]) -> Dict[str, Any]:
+    """Keep old and new AlphaSift hotspot detail consumers on the same shape."""
+    stocks = payload.get("stocks")
+    leader_stocks = payload.get("leader_stocks")
+    if not isinstance(stocks, list):
+        stocks = []
+    if not isinstance(leader_stocks, list) or not leader_stocks:
+        nested_leader_stocks = _extract_nested_hotspot_leader_stocks(payload)
+        leader_stocks = nested_leader_stocks or (leader_stocks if isinstance(leader_stocks, list) else [])
+    if not stocks and leader_stocks:
+        stocks = leader_stocks
+    if not leader_stocks and stocks:
+        leader_stocks = stocks
+    payload["stocks"] = stocks
+    payload["leader_stocks"] = leader_stocks
+    payload["stock_count"] = len(stocks)
+    return payload
+
+
+def _extract_nested_hotspot_leader_stocks(payload: Dict[str, Any]) -> List[Any]:
+    for key in ("summary_detail", "summary"):
+        summary = payload.get(key)
+        if not isinstance(summary, dict):
+            continue
+        leader_stocks = summary.get("leader_stocks")
+        if isinstance(leader_stocks, list) and leader_stocks:
+            return leader_stocks
+    return []
+
+
+def _load_alphasift_hotspot_cache(*, provider: str, top: int) -> Optional[Dict[str, Any]]:
+    cache_path = _alphasift_hotspot_cache_path()
+    try:
+        raw = json.loads(cache_path.read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        return None
+    except Exception as exc:
+        logger.warning("Failed to read AlphaSift hotspot cache from %s: %s", cache_path, exc)
+        return None
+
+    payload = _normalize_alphasift_hotspot_cache_payload(raw)
+    if not isinstance(payload, dict):
+        return None
+    hotspots = payload.get("hotspots")
+    if not isinstance(hotspots, list) or not hotspots:
+        return None
+
+    top_count = max(1, min(int(top or 12), 50))
+    if len(hotspots) < min(DSA_ALPHASIFT_MIN_HOTSPOT_CACHE_COUNT, top_count):
+        logger.info(
+            "Ignoring AlphaSift hotspot cache with too few rows: %s < %s",
+            len(hotspots),
+            min(DSA_ALPHASIFT_MIN_HOTSPOT_CACHE_COUNT, top_count),
+        )
+        return None
+
+    selected = hotspots[:top_count]
+    cached = dict(payload)
+    cached.update({
+        "enabled": True,
+        "provider": provider or payload.get("provider") or "akshare",
+        "hotspots": selected,
+        "hotspot_count": len(selected),
+        "cache_used": True,
+        "cached_at": raw.get("cached_at") or payload.get("cached_at"),
+    })
+    cached["source_errors"] = list(cached.get("source_errors") or [])
+    return _remove_non_finite_json_values(cached)
+
+
+def _normalize_alphasift_hotspot_cache_payload(raw: Any) -> Optional[Dict[str, Any]]:
+    if not isinstance(raw, dict):
+        return None
+    payload = raw.get("payload")
+    if isinstance(payload, dict):
+        return payload
+    hotspots = raw.get("hotspots")
+    if not isinstance(hotspots, list):
+        return None
+    metadata_raw = raw.get("metadata")
+    metadata: Dict[str, Any] = metadata_raw if isinstance(metadata_raw, dict) else {}
+    cached_at = raw.get("cached_at") or raw.get("generated_at") or metadata.get("generated_at")
+    return {
+        "enabled": True,
+        "provider": _env_text(metadata.get("provider")) or "akshare",
+        "provider_used": _env_text(metadata.get("provider_used")),
+        "fallback_used": False,
+        "cache_used": False,
+        "cached_at": cached_at,
+        "schema_version": raw.get("schema_version") or metadata.get("schema_version"),
+        "source_errors": _list_text_values(raw.get("source_errors") or metadata.get("source_errors")),
+        "stale": bool(raw.get("stale") or metadata.get("stale") or False),
+        "stale_age_hours": raw.get("stale_age_hours") or metadata.get("stale_age_hours"),
+        "hotspots": hotspots,
+        "hotspot_count": len(hotspots),
+    }
+
+
+def _hotspot_route_has_external_event(route: Any) -> bool:
+    if not isinstance(route, list):
+        return False
+    generated_sources = {"", "eastmoney_board_change", "fallback", "dsa_topic_catalyst", "ths_info"}
+    for item in route:
+        if not isinstance(item, dict):
+            continue
+        source = _env_text(item.get("source"))
+        if source and source not in generated_sources:
+            return True
+    return False
+
+
+def _has_configured_hotspot_news_source(config: Config) -> bool:
+    fields = (
+        "bocha_api_keys",
+        "tavily_api_keys",
+        "anspire_api_keys",
+        "brave_api_keys",
+        "serpapi_api_keys",
+        "minimax_api_keys",
+        "searxng_base_urls",
+    )
+    return any(bool(getattr(config, field, None)) for field in fields)
+
+
+def _build_hotspot_event_routes_from_search(topic: str, config: Config) -> List[Dict[str, Any]]:
+    topic_text = _env_text(topic)
+    if not topic_text or not _has_configured_hotspot_news_source(config):
+        return []
+    try:
+        from src.search_service import SearchService
+
+        service = SearchService(
+            bocha_keys=getattr(config, "bocha_api_keys", None),
+            tavily_keys=getattr(config, "tavily_api_keys", None),
+            anspire_keys=getattr(config, "anspire_api_keys", None),
+            brave_keys=getattr(config, "brave_api_keys", None),
+            serpapi_keys=getattr(config, "serpapi_api_keys", None),
+            minimax_keys=getattr(config, "minimax_api_keys", None),
+            searxng_base_urls=getattr(config, "searxng_base_urls", None),
+            searxng_public_instances_enabled=False,
+            news_max_age_days=int(getattr(config, "news_max_age_days", 3) or 3),
+            news_strategy_profile=getattr(config, "news_strategy_profile", "short"),
+        )
+        response = service.search_stock_news(
+            topic_text,
+            topic_text,
+            max_results=3,
+            focus_keywords=[topic_text, "A股", "题材", "催化", "涨价"],
+        )
+    except Exception as exc:
+        logger.info("AlphaSift hotspot event search skipped for %s: %s", topic_text, exc)
+        return []
+
+    if not bool(getattr(response, "success", False)):
+        return []
+    today = datetime.now().date().isoformat()
+    event_parts: List[str] = []
+    sources: List[str] = []
+    first_url = ""
+    first_date = ""
+    first_published = ""
+    for result in list(getattr(response, "results", []) or [])[:2]:
+        title = _env_text(getattr(result, "title", ""))
+        snippet = _env_text(getattr(result, "snippet", ""))
+        if not title and not snippet:
+            continue
+        event_text = _compact_hotspot_news_text(title=title, snippet=snippet)
+        if event_text:
+            event_parts.append(event_text)
+        published = _env_text(getattr(result, "published_date", ""))
+        source = _env_text(getattr(result, "source", "")) or _env_text(getattr(response, "provider", "")) or "news_search"
+        if source and source not in sources:
+            sources.append(source)
+        if not first_url:
+            first_url = _env_text(getattr(result, "url", ""))
+        if not first_date:
+            first_date = _extract_date_text(published) or _extract_date_text(event_text)
+        if not first_published:
+            first_published = published
+    if not event_parts:
+        return []
+    description = _summarize_hotspot_news_event(
+        topic=topic_text,
+        title="",
+        snippet="；".join(event_parts),
+        config=config,
+    )
+    date = first_date or _extract_date_text(description) or today
+    return [{
+        "title": "消息催化",
+        "description": description,
+        "source": ",".join(sources) if sources else "news_search",
+        "date": date,
+        "published_at": first_published or date,
+        "url": first_url,
+    }]
+
+
+def _summarize_hotspot_news_event(*, topic: str, title: str, snippet: str, config: Config) -> str:
+    compact_text = _compact_hotspot_news_text(title=title, snippet=snippet)
+    llm_summary = _summarize_hotspot_news_event_with_llm(topic=topic, text=compact_text, config=config)
+    if llm_summary:
+        return _truncate_text(llm_summary, DSA_ALPHASIFT_HOTSPOT_EVENT_SUMMARY_MAX_CHARS)
+    return _summarize_hotspot_news_event_locally(topic=topic, text=compact_text)
+
+
+def _summarize_hotspot_news_event_locally(*, topic: str, text: str) -> str:
+    cleaned = _strip_hotspot_news_noise(text)
+    if not cleaned:
+        return ""
+    catalyst = _extract_hotspot_catalyst_phrase(cleaned)
+    impacts = _extract_hotspot_impact_phrases(cleaned)
+    if catalyst and impacts:
+        summary = f"{catalyst}，带动{impacts}发酵。"
+    elif catalyst:
+        summary = f"{catalyst}，市场关注{topic}相关产业链机会。"
+    else:
+        summary = _first_meaningful_hotspot_sentence(cleaned)
+    summary = _truncate_text(summary, DSA_ALPHASIFT_HOTSPOT_EVENT_SUMMARY_MAX_CHARS).rstrip(".。…")
+    return _truncate_text(f"{summary}。", DSA_ALPHASIFT_HOTSPOT_EVENT_SUMMARY_MAX_CHARS)
+
+
+def _strip_hotspot_news_noise(text: str) -> str:
+    cleaned = _normalize_inline_text(text)
+    cleaned = re.sub(r"【[^】]{1,24}】", " ", cleaned)
+    cleaned = re.sub(r"\[[^\]]{1,24}\]", " ", cleaned)
+    cleaned = re.sub(r"\b20\d{2}[-/.年]\d{1,2}[-/.月]\d{1,2}[日号]?\b", " ", cleaned)
+    cleaned = re.sub(r"\b\d{1,2}:\d{2}\b", " ", cleaned)
+    cleaned = re.sub(r"\([^)]{0,18}\d+\.\d+[^)]{0,18}\)", " ", cleaned)
+    cleaned = re.sub(r"（[^）]{0,18}\d+\.\d+[^）]{0,18}）", " ", cleaned)
+    cleaned = re.sub(r"截至[^。；;]*", " ", cleaned)
+    cleaned = re.sub(r"(建议关注|后续建议|风险提示|投资建议)[^。；;]*", " ", cleaned)
+    cleaned = re.sub(r"\s+", " ", cleaned)
+    return cleaned.strip(" ，,；;。.")
+
+
+def _extract_hotspot_catalyst_phrase(text: str) -> str:
+    patterns = (
+        r"以[^，。；;]{1,12}代[^，。；;]{1,12}",
+        r"[^，。；;]{1,18}(涨价|价格上行|供需偏紧|供应紧张|资源增储|订单增长|政策催化|出口管制|减产|并购重组|技术突破)[^，。；;]{0,24}",
+        r"[^，。；;]{1,18}(替代|国产替代|需求增长|景气上行)[^，。；;]{0,24}",
+    )
+    for pattern in patterns:
+        match = re.search(pattern, text)
+        if match:
+            return _normalize_inline_text(match.group(0)).strip(" ，,；;。.")
+    return ""
+
+
+def _extract_hotspot_impact_phrases(text: str) -> str:
+    impacts: List[str] = []
+    keyword_groups = (
+        ("小金属", ("小金属", "钼", "钨", "锑", "锗", "铟")),
+        ("有色金属", ("有色", "铜", "铝", "锌", "铅")),
+        ("相关个股", ("涨停", "异动", "走强", "大涨", "拉升")),
+        ("产业链", ("产业链", "上游", "下游", "材料", "资源")),
+    )
+    for label, keywords in keyword_groups:
+        if any(keyword in text for keyword in keywords) and label not in impacts:
+            impacts.append(label)
+    return "、".join(impacts[:3])
+
+
+def _first_meaningful_hotspot_sentence(text: str) -> str:
+    sentences = [
+        _normalize_inline_text(item).strip(" ，,；;。.")
+        for item in re.split(r"[。！？!?；;]", text)
+        if _normalize_inline_text(item)
+    ]
+    for sentence in sentences:
+        if len(sentence) >= 8 and not re.search(r"(现价|成交额|涨跌幅|换手率|建议关注|截至)", sentence):
+            return sentence
+    return sentences[0] if sentences else text
+
+
+def _compact_hotspot_news_text(*, title: str, snippet: str) -> str:
+    title_text = _normalize_inline_text(title)
+    snippet_text = _normalize_inline_text(snippet)
+    if title_text and snippet_text.startswith(title_text):
+        snippet_text = snippet_text[len(title_text):].lstrip(" ：:，,。;；")
+    if title_text and snippet_text == title_text:
+        snippet_text = ""
+    text = "。".join(part for part in (title_text, snippet_text) if part)
+    text = re.sub(r"(\d{4}[-/.年]\d{1,2}[-/.月]\d{1,2}[日号]?)\s+\d{1,2}:\d{2}", r"\1", text)
+    text = re.sub(r"\s+", " ", text).strip()
+    return text
+
+
+def _normalize_inline_text(value: Any) -> str:
+    text = _env_text(value)
+    text = re.sub(r"[\r\n\t]+", " ", text)
+    text = re.sub(r"\s+", " ", text)
+    return text.strip()
+
+
+def _truncate_text(text: str, max_chars: int) -> str:
+    text = _normalize_inline_text(text)
+    if len(text) <= max_chars:
+        return text
+    sentence_parts = re.split(r"(?<=[。！？!?；;])", text)
+    summary = ""
+    for part in sentence_parts:
+        if not part:
+            continue
+        if len(summary) + len(part) > max_chars:
+            break
+        summary += part
+    if summary:
+        return summary.rstrip("，,；;：: ")[:max_chars].rstrip("，,；;：: ") + "..."
+    return text[: max(0, max_chars - 3)].rstrip("，,；;：: ") + "..."
+
+
+def _summarize_hotspot_news_event_with_llm(*, topic: str, text: str, config: Config) -> str:
+    model, _fallback_models = _resolve_alphasift_llm_models(config)
+    if not _env_text(model) or not text:
+        return ""
+    try:
+        import litellm
+
+        prompt = (
+            "请把下面新闻压缩成一句 A 股热点题材催化摘要。"
+            "要求：不超过 70 个中文字符，只保留事件、影响方向和相关链条；"
+            "不要输出完整报道、股票价格流水、免责声明或投资建议。\n\n"
+            f"题材：{topic}\n新闻：{text}"
+        )
+        with _alphasift_litellm_headers(config):
+            response = litellm.completion(
+                model=model,
+                messages=[
+                    {"role": "system", "content": "你是A股题材事件摘要助手，只输出一句短摘要。"},
+                    {"role": "user", "content": prompt},
+                ],
+                temperature=0.2,
+                max_tokens=120,
+                timeout=8,
+            )
+        return _clean_hotspot_llm_summary(_extract_litellm_message_content(response))
+    except Exception as exc:
+        logger.info("AlphaSift hotspot LLM event summary skipped for %s: %s", topic, exc)
+        return ""
+
+
+def _extract_litellm_message_content(response: Any) -> str:
+    try:
+        choices = response.get("choices") if isinstance(response, dict) else getattr(response, "choices", None)
+        if choices:
+            choice = choices[0]
+            message = choice.get("message") if isinstance(choice, dict) else getattr(choice, "message", None)
+            if isinstance(message, dict):
+                return _env_text(message.get("content"))
+            return _env_text(getattr(message, "content", ""))
+    except Exception:
+        return ""
+    return ""
+
+
+def _clean_hotspot_llm_summary(text: str) -> str:
+    summary = _normalize_inline_text(text).strip(" 　\"'“”‘’")
+    summary = re.sub(r"^(摘要|总结|消息催化|事件催化)\s*[:：]\s*", "", summary)
+    return summary
+
+
+def _extract_date_text(text: str) -> str:
+    match = re.search(r"(20\d{2})[-/.年](\d{1,2})[-/.月](\d{1,2})", text or "")
+    if not match:
+        return ""
+    year, month, day = match.groups()
+    return f"{int(year):04d}-{int(month):02d}-{int(day):02d}"
+
+
+def _hotspot_rows_are_thin(rows: List[Any], *, top: int) -> bool:
+    if len(rows) < min(DSA_ALPHASIFT_MIN_HOTSPOT_CACHE_COUNT, max(1, top)):
+        return True
+    rich_count = 0
+    metric_count = 0
+    for item in rows:
+        if not isinstance(item, dict):
+            continue
+        if item.get("change_pct") is not None or item.get("changePct") is not None:
+            rich_count += 1
+        if (
+            item.get("trend_score") is not None
+            or item.get("trendScore") is not None
+            or item.get("persistence_score") is not None
+            or item.get("persistenceScore") is not None
+        ):
+            metric_count += 1
+    return rich_count == 0 or metric_count == 0
+
+
+def _snake_to_camel(value: str) -> str:
+    parts = value.split("_")
+    return parts[0] + "".join(part[:1].upper() + part[1:] for part in parts[1:])
+
+
+def _enrich_hotspot_rows_from_provider(rows: List[Any], provider: Any, *, top: int) -> List[Dict[str, Any]]:
+    try:
+        provider_rows = provider.hotspot_rows(top=max(top, len(rows), 30))
+    except Exception as exc:
+        logger.warning("AlphaSift hotspot metric enrichment failed: %s", exc)
+        return [dict(item) if isinstance(item, dict) else item for item in rows]
+    by_topic: Dict[str, Dict[str, Any]] = {}
+    for item in provider_rows or []:
+        if not isinstance(item, dict):
+            continue
+        topic = _env_text(item.get("topic") or item.get("name"))
+        if topic:
+            by_topic[topic] = item
+        name = _env_text(item.get("name"))
+        if name and "·" in name:
+            by_topic[name.split("·")[-1].strip()] = item
+    enriched: List[Dict[str, Any]] = []
+    for raw in rows:
+        if not isinstance(raw, dict):
+            enriched.append(raw)
+            continue
+        item = dict(raw)
+        topic = _env_text(item.get("topic") or item.get("name"))
+        provider_item = by_topic.get(topic)
+        if not provider_item:
+            enriched.append(item)
+            continue
+        for key in (
+            "change_pct",
+            "heat_score",
+            "trend_score",
+            "persistence_score",
+            "observations",
+            "stage",
+            "state",
+            "sample_stock_count",
+            "leaders",
+            "theme_group",
+        ):
+            camel_key = _snake_to_camel(key)
+            if item.get(key) in (None, "", [], {}) and item.get(camel_key) in (None, "", [], {}):
+                value = provider_item.get(key)
+                if value not in (None, "", [], {}):
+                    item[key] = value
+        if item.get("name") in (None, "", topic):
+            item["name"] = provider_item.get("name") or topic
+        enriched.append(item)
+    return enriched
+
+
+def _write_alphasift_hotspot_cache(payload: Dict[str, Any]) -> None:
+    cache_path = _alphasift_hotspot_cache_path()
+    try:
+        cache_path.parent.mkdir(parents=True, exist_ok=True)
+        cached_at = _utc_now_iso()
+        cache_payload = dict(payload)
+        cache_payload["cache_used"] = False
+        cache_payload["cached_at"] = cached_at
+        cache_path.write_text(
+            json.dumps(
+                {
+                    "schema_version": 2,
+                    "generated_at": cached_at,
+                    "cached_at": cached_at,
+                    "metadata": {
+                        "schema_version": 2,
+                        "asset_type": "hotspot_cache",
+                        "provider": cache_payload.get("provider"),
+                        "provider_used": cache_payload.get("provider_used"),
+                        "row_count": len(cache_payload.get("hotspots") or []),
+                        "source_errors": _list_text_values(cache_payload.get("source_errors")),
+                    },
+                    "hotspots": cache_payload.get("hotspots") or [],
+                    "payload": cache_payload,
+                },
+                ensure_ascii=False,
+                indent=2,
+            ),
+            encoding="utf-8",
+        )
+    except Exception as exc:
+        logger.warning("Failed to write AlphaSift hotspot cache to %s: %s", cache_path, exc)
+
+
+def _hotspot_topic_from_row(row: Any) -> str:
+    if not isinstance(row, dict):
+        return ""
+    return _env_text(row.get("topic") or row.get("name") or row.get("canonical_topic"))
+
+
+def _attach_cached_hotspot_details(
+    payload: Dict[str, Any],
+    *,
+    provider: str,
+    top: int,
+) -> Dict[str, Any]:
+    rows = payload.get("hotspots")
+    if not isinstance(rows, list) or not rows:
+        return payload
+    details = dict(payload.get("details") if isinstance(payload.get("details"), dict) else {})
+    for row in rows[:max(0, min(int(top or 0), DSA_ALPHASIFT_HOTSPOT_PREFETCH_DETAIL_COUNT))]:
+        topic = _hotspot_topic_from_row(row)
+        if not topic or topic in details:
+            continue
+        cached = _load_alphasift_hotspot_detail_cache(provider=provider, topic=topic)
+        if cached is not None:
+            details[topic] = cached
+    if details:
+        attached = dict(payload)
+        attached["details"] = _remove_non_finite_json_values(details)
+        return attached
+    return payload
+
+
+def _empty_alphasift_hotspot_payload(
+    *,
+    provider: str,
+    provider_used: str = "",
+    source_errors: Optional[List[str]] = None,
+    message: str = "",
+) -> Dict[str, Any]:
+    return {
+        "enabled": True,
+        "provider": provider,
+        "provider_used": provider_used,
+        "fallback_used": False,
+        "cache_used": False,
+        "cached_at": None,
+        "source_errors": list(source_errors or []),
+        "stale": False,
+        "stale_age_hours": None,
+        "hotspots": [],
+        "hotspot_count": 0,
+        "message": message,
+    }
+
+
+def _is_known_eastmoney_hotspot_connectivity_error(exc: BaseException) -> bool:
+    retryable_types: List[Any] = [ConnectionError, TimeoutError]
+    try:
+        import requests
+
+        retryable_types.extend(
+            [
+                requests.exceptions.ConnectionError,
+                requests.exceptions.Timeout,
+                requests.exceptions.ChunkedEncodingError,
+            ]
+        )
+    except Exception:
+        pass
+    try:
+        import http.client
+
+        retryable_types.extend([http.client.RemoteDisconnected, http.client.IncompleteRead])
+    except Exception:
+        pass
+    try:
+        import urllib3.exceptions
+
+        retryable_types.extend(
+            [
+                urllib3.exceptions.ProtocolError,
+                urllib3.exceptions.MaxRetryError,
+                urllib3.exceptions.ReadTimeoutError,
+                urllib3.exceptions.ConnectTimeoutError,
+            ]
+        )
+    except Exception:
+        pass
+
+    retryable_tuple = tuple(retryable_types)
+    pending: List[BaseException] = [exc]
+    seen: set[int] = set()
+    while pending:
+        current = pending.pop()
+        current_id = id(current)
+        if current_id in seen:
+            continue
+        seen.add(current_id)
+        if isinstance(current, retryable_tuple):
+            return True
+        message = f"{current.__class__.__name__}: {current}".lower()
+        if any(marker in message for marker in DSA_ALPHASIFT_HOTSPOT_CONNECTIVITY_ERROR_MARKERS):
+            return True
+        cause = getattr(current, "__cause__", None)
+        context = getattr(current, "__context__", None)
+        if isinstance(cause, BaseException):
+            pending.append(cause)
+        if isinstance(context, BaseException):
+            pending.append(context)
+    return False
+
+
+def _should_return_eastmoney_hotspot_unavailable(provider_arg: Any, exc: BaseException) -> bool:
+    return isinstance(provider_arg, DsaEastMoneyHotspotProvider) and _is_known_eastmoney_hotspot_connectivity_error(exc)
+
+
+def _has_degraded_eastmoney_hotspot_failure(provider_arg: Any, source_errors: List[str]) -> bool:
+    if not isinstance(provider_arg, DsaEastMoneyHotspotProvider):
+        return False
+    for source_error in source_errors:
+        if source_error == DSA_ALPHASIFT_HOTSPOT_UNAVAILABLE_CODE:
+            return True
+        if _is_known_eastmoney_hotspot_connectivity_error(RuntimeError(source_error)):
+            return True
+    return False
+
+
+class AlphaSiftStrategyResponse(BaseModel):
+    id: str
+    name: str = ""
+    title: str = ""
+    description: str = ""
+    category: str = ""
+    tag: str = ""
+    tags: List[str] = Field(default_factory=list)
+    market_scope: List[str] = Field(default_factory=list)
+    market: str = ""
+
+
+class AlphaSiftService:
+    """Coordinate AlphaSift calls with DSA-owned runtime capabilities."""
+
+    def __init__(self, config: Config):
+        self.config = config
+
+    def status(self) -> Dict[str, Any]:
+        adapter_status, available, diagnostics = _get_alphasift_status_snapshot()
+        payload = {
+            "enabled": bool(self.config.alphasift_enabled),
+            "available": available,
+            "install_spec_is_default": _is_default_alphasift_install_spec(self.config.alphasift_install_spec),
+            "contract_version": adapter_status.get("contract_version"),
+            "version": adapter_status.get("version"),
+            "strategy_count": adapter_status.get("strategy_count"),
+        }
+        source_health = _get_alphasift_source_health_snapshot()
+        if source_health:
+            payload["source_health"] = source_health
+        if diagnostics:
+            payload["diagnostics"] = diagnostics
+        return payload
+
+    def strategies(self) -> Dict[str, Any]:
+        _ensure_alphasift_enabled(self.config)
+        _ensure_alphasift_available_for_use()
+        strategies = _list_strategies()
+        return {
+            "enabled": True,
+            "strategies": strategies,
+            "strategy_count": len(strategies),
+        }
+
+    def install(self, *, request: Request) -> Dict[str, Any]:
+        _ensure_alphasift_install_access(request)
+        _ensure_alphasift_enabled(self.config)
+        return _install_alphasift(self.config)
+
+    def hotspots(
+        self,
+        *,
+        provider: str = "",
+        top: int = 12,
+        refresh: bool = False,
+        include_details: bool = False,
+    ) -> Dict[str, Any]:
+        _ensure_alphasift_enabled(self.config)
+        _ensure_alphasift_available_for_use()
+        provider_name, provider_arg = _resolve_hotspot_provider(provider)
+        top_count = max(1, min(int(top or 12), 50))
+        if not refresh:
+            cached = _load_alphasift_hotspot_cache(provider=provider_name, top=top_count)
+            if cached is not None:
+                return _attach_cached_hotspot_details(cached, provider=provider_name, top=top_count) if include_details else cached
+            return _empty_alphasift_hotspot_payload(
+                provider=provider_name,
+                message="No cached AlphaSift hotspot snapshot. Click refresh to fetch live hotspots.",
+            )
+
+        hotspot_module = _import_alphasift_hotspot()
+        discover_hotspots = _get_adapter_callable(
+            hotspot_module,
+            "discover_hotspots",
+            "discover_hotspots() is not callable.",
+        )
+
+        try:
+            with _alphasift_runtime_env(self.config):
+                raw = discover_hotspots(
+                    provider=provider_arg,
+                    top=top_count,
+                    history_path=_alphasift_hotspot_history_path(),
+                    fallback_cache_path=_alphasift_hotspot_cache_path(),
+                )
+        except HTTPException:
+            raise
+        except Exception as exc:
+            cached = _load_alphasift_hotspot_cache(provider=provider_name, top=top_count)
+            if cached is not None:
+                errors = list(cached.get("source_errors") or [])
+                errors.append(f"live refresh failed: {exc}")
+                cached["source_errors"] = errors
+                cached["fallback_used"] = True
+                cached["cache_used"] = True
+                return _attach_cached_hotspot_details(cached, provider=provider_name, top=top_count) if include_details else cached
+            if not _should_return_eastmoney_hotspot_unavailable(provider_arg, exc):
+                diagnostics = _log_unexpected_alphasift_exception("hotspot_refresh", exc)
+                raise HTTPException(
+                    status_code=424,
+                    detail={
+                        "error": "alphasift_hotspot_refresh_failed",
+                        "message": f"AlphaSift hotspot refresh failed: {exc}",
+                        "diagnostics": diagnostics,
+                    },
+                ) from exc
+            logger.warning("AlphaSift hotspot live refresh failed without cache: %s", exc)
+            return _empty_alphasift_hotspot_payload(
+                provider=provider_name,
+                provider_used=type(provider_arg).__name__,
+                source_errors=[DSA_ALPHASIFT_HOTSPOT_UNAVAILABLE_CODE],
+                message=DSA_ALPHASIFT_HOTSPOT_UNAVAILABLE_MESSAGE,
+            )
+
+        items = _remove_non_finite_json_values(_to_plain(raw))
+        if not isinstance(items, list):
+            items = []
+        selected = items[:top_count]
+        source_errors = _list_text_values(getattr(raw, "source_errors", []))
+        direct_hotspot_fallback_used = False
+        if isinstance(provider_arg, DsaEastMoneyHotspotProvider) and _hotspot_rows_are_thin(selected, top=top_count):
+            try:
+                direct_hotspots = provider_arg.hotspot_rows(top=top_count)
+            except Exception as exc:
+                logger.warning("AlphaSift DSA direct hotspot fallback failed: %s", exc)
+                direct_hotspots = []
+                source_errors.append(f"dsa_direct_hotspots_failed: {exc}")
+            if len(direct_hotspots) > len(selected):
+                selected = direct_hotspots
+                direct_hotspot_fallback_used = True
+                source_errors.append("AlphaSift hotspot rows were thin; used DSA EastMoney board-change rows.")
+        if isinstance(provider_arg, DsaEastMoneyHotspotProvider) and selected:
+            selected = _enrich_hotspot_rows_from_provider(selected, provider_arg, top=top_count)
+        if not selected and source_errors:
+            cached = _load_alphasift_hotspot_cache(provider=provider_name, top=top_count)
+            if cached is not None:
+                errors = list(cached.get("source_errors") or [])
+                errors.extend(source_errors)
+                cached["source_errors"] = errors
+                cached["fallback_used"] = True
+                cached["cache_used"] = True
+                return _attach_cached_hotspot_details(cached, provider=provider_name, top=top_count) if include_details else cached
+            if _has_degraded_eastmoney_hotspot_failure(provider_arg, source_errors):
+                return _empty_alphasift_hotspot_payload(
+                    provider=provider_name,
+                    provider_used=str(getattr(raw, "provider_used", "") or type(provider_arg).__name__),
+                    source_errors=[DSA_ALPHASIFT_HOTSPOT_UNAVAILABLE_CODE],
+                    message=DSA_ALPHASIFT_HOTSPOT_UNAVAILABLE_MESSAGE,
+                )
+
+        payload = {
+            "enabled": True,
+            "provider": provider_name,
+            "provider_used": "dsa_eastmoney_board_change" if direct_hotspot_fallback_used else str(getattr(raw, "provider_used", "")),
+            "fallback_used": direct_hotspot_fallback_used or bool(getattr(raw, "fallback_used", False)),
+            "cache_used": False,
+            "cached_at": None,
+            "source_errors": source_errors,
+            "stale": bool(getattr(raw, "stale", False)),
+            "stale_age_hours": getattr(raw, "stale_age_hours", None),
+            "hotspots": selected,
+            "hotspot_count": len(selected),
+        }
+        if selected and include_details:
+            payload = self._prefetch_hotspot_details(payload, provider=provider_name, refresh=False)
+        if selected:
+            _write_alphasift_hotspot_cache(payload)
+        return payload
+
+    def _prefetch_hotspot_details(self, payload: Dict[str, Any], *, provider: str, refresh: bool) -> Dict[str, Any]:
+        rows = payload.get("hotspots")
+        if not isinstance(rows, list) or not rows:
+            return payload
+        details = dict(payload.get("details") if isinstance(payload.get("details"), dict) else {})
+        source_errors = _list_text_values(payload.get("source_errors"))
+        for row in rows[:DSA_ALPHASIFT_HOTSPOT_PREFETCH_DETAIL_COUNT]:
+            topic = _hotspot_topic_from_row(row)
+            if not topic or (topic in details and not refresh):
+                continue
+            try:
+                details[topic] = self.hotspot_detail(topic=topic, provider=provider, refresh=refresh)
+            except HTTPException as exc:
+                source_errors.append(f"hotspot_detail_prefetch_failed:{topic}:{exc.detail}")
+            except Exception as exc:
+                source_errors.append(f"hotspot_detail_prefetch_failed:{topic}:{exc}")
+        attached = dict(payload)
+        if details:
+            attached["details"] = _remove_non_finite_json_values(details)
+        if source_errors:
+            attached["source_errors"] = source_errors
+        return attached
+
+    def hotspot_detail(self, *, topic: str, provider: str = "", refresh: bool = False) -> Dict[str, Any]:
+        _ensure_alphasift_enabled(self.config)
+        _ensure_alphasift_available_for_use()
+        topic_text = _env_text(topic)
+        if not topic_text:
+            raise HTTPException(
+                status_code=400,
+                detail={"error": "alphasift_hotspot_topic_required", "message": "热点题材名称不能为空。"},
+            )
+        provider_name, provider_arg = _resolve_hotspot_provider(provider)
+        if not isinstance(provider_arg, DsaEastMoneyHotspotProvider):
+            provider_arg = DsaEastMoneyHotspotProvider()
+        cached = None if refresh else _load_alphasift_hotspot_detail_cache(provider=provider_name, topic=topic_text)
+        if cached is not None:
+            return cached
+        normalized: Dict[str, Any] = {}
+        hotspot_helper_error: str = ""
+        try:
+            try:
+                hotspot_module = _import_alphasift_hotspot()
+                get_hotspot_detail = getattr(hotspot_module, "get_hotspot_detail", None)
+            except Exception:
+                get_hotspot_detail = None
+            with _alphasift_runtime_env(self.config):
+                if callable(get_hotspot_detail) and type(provider_arg) is DsaEastMoneyHotspotProvider:
+                    try:
+                        detail = get_hotspot_detail(
+                            topic_text,
+                            provider=provider_arg,
+                            top_stocks=30,
+                            history_path=_alphasift_hotspot_history_path(),
+                            fallback_cache_path=_alphasift_hotspot_cache_path(),
+                        )
+                        normalized = _normalize_alphasift_hotspot_detail(
+                            detail,
+                            provider=provider_name,
+                            requested_topic=topic_text,
+                        )
+                        normalized = _merge_provider_hotspot_route_fallback(
+                            normalized,
+                            provider=provider_arg,
+                            topic=topic_text,
+                        )
+                    except Exception as exc:
+                        hotspot_helper_error = f"{exc}"
+                        logger.warning(
+                            "AlphaSift contract hotspot detail fallback to provider for topic=%s: %s",
+                            topic_text,
+                            hotspot_helper_error,
+                        )
+                else:
+                    normalized = provider_arg.hotspot_detail(topic_text)
+                if not normalized:
+                    normalized = provider_arg.hotspot_detail(topic_text)
+        except Exception as exc:
+            stale_cached = _load_alphasift_hotspot_detail_cache(
+                provider=provider_name,
+                topic=topic_text,
+                allow_stale=True,
+            )
+            if stale_cached is not None:
+                source_errors = _list_text_values(stale_cached.get("source_errors"))
+                source_errors.append(f"alphasift_hotspot_detail_stale_cache: {exc}")
+                stale_cached["source_errors"] = source_errors
+                stale_cached["fallback_used"] = True
+                return stale_cached
+            raise HTTPException(
+                status_code=424,
+                detail={"error": "alphasift_hotspot_detail_failed", "message": f"AlphaSift hotspot detail failed: {exc}"},
+            ) from exc
+        if hotspot_helper_error:
+            source_errors = _list_text_values(normalized.get("source_errors"))
+            source_errors.append(f"alphasift_hotspot_detail_fallback: {hotspot_helper_error}")
+            normalized["source_errors"] = source_errors
+            normalized["fallback_used"] = True
+            normalized["provider"] = provider_name
+        if not _hotspot_route_has_external_event(normalized.get("route")):
+            search_routes = _build_hotspot_event_routes_from_search(topic_text, self.config)
+            if search_routes:
+                route = normalized.get("route")
+                normalized["route"] = search_routes + (route if isinstance(route, list) else [])
+        normalized = _ensure_hotspot_detail_compat_fields(normalized)
+        normalized["enabled"] = True
+        normalized["provider"] = provider_name
+        cleaned = _remove_non_finite_json_values(normalized)
+        _write_alphasift_hotspot_detail_cache(provider=provider_name, topic=topic_text, payload=cleaned)
+        return cleaned
+
+    def screen(self, *, strategy: str, market: str, max_results: int) -> Dict[str, Any]:
+        _ensure_alphasift_enabled(self.config)
+        _ensure_alphasift_available_for_use()
+        _ensure_supported_market(market)
+        _ensure_supported_strategy(strategy)
+
+        adapter = _get_dsa_adapter()
+        screen = _get_adapter_callable(adapter, "screen", "screen() 不可调用。")
+        try:
+            raw = _call_alphasift_screen(screen, strategy, market, max_results, self.config)
+        except ValueError as exc:
+            raise HTTPException(
+                status_code=400,
+                detail={"error": "alphasift_screen_rejected", "message": str(exc)},
+            ) from exc
+        except (TypeError, KeyError) as exc:
+            raise HTTPException(
+                status_code=422,
+                detail={"error": "alphasift_invalid_input", "message": f"AlphaSift 参数非法：{exc}"},
+            ) from exc
+        except HTTPException:
+            raise
+        except Exception as exc:
+            raise HTTPException(
+                status_code=424,
+                detail={"error": "alphasift_screen_failed", "message": f"AlphaSift 选股运行失败：{exc}"},
+            ) from exc
+
+        raw_data = _to_plain(raw)
+        if not isinstance(raw_data, dict):
+            raw_data = {"candidates": raw_data}
+        raw_data = _remove_non_finite_json_values(raw_data)
+
+        candidates = _normalize_candidates(raw_data)
+        selected = candidates[:max_results]
+        selected, dsa_enrichment = _enrich_candidates_with_dsa(selected)
+        return {
+            "enabled": True,
+            "candidates": selected,
+            "candidate_count": len(selected),
+            "run_id": raw_data.get("run_id"),
+            "strategy": raw_data.get("strategy") or strategy,
+            "market": raw_data.get("market") or market,
+            "snapshot_count": raw_data.get("snapshot_count"),
+            "snapshot_source": raw_data.get("snapshot_source") or "",
+            "after_filter_count": raw_data.get("after_filter_count"),
+            "llm_ranked": raw_data.get("llm_ranked"),
+            "llm_market_view": raw_data.get("llm_market_view") or "",
+            "llm_selection_logic": raw_data.get("llm_selection_logic") or "",
+            "llm_portfolio_risk": raw_data.get("llm_portfolio_risk") or "",
+            "llm_coverage": raw_data.get("llm_coverage"),
+            "llm_parse_errors": _list_text_values(raw_data.get("llm_parse_errors")),
+            "warnings": _list_text_values(raw_data.get("warnings")),
+            "source_errors": _list_text_values(raw_data.get("source_errors")),
+            "dsa_enrichment": dsa_enrichment,
+            "deep_analysis_requested": raw_data.get("deep_analysis_requested"),
+            "post_analyzers": raw_data.get("post_analyzers") or [],
+            "daily_enriched": raw_data.get("daily_enriched"),
+            "daily_enrich_count": raw_data.get("daily_enrich_count"),
+            "risk_enabled": raw_data.get("risk_enabled"),
+            "portfolio_diversity_enabled": raw_data.get("portfolio_diversity_enabled"),
+            "portfolio_concentration_notes": raw_data.get("portfolio_concentration_notes") or [],
+        }
+
+
+def _normalize_alphasift_hotspot_detail(detail: Any, *, provider: str, requested_topic: str) -> Dict[str, Any]:
+    raw_value = _remove_non_finite_json_values(_to_plain(detail))
+    raw: Dict[str, Any] = raw_value if isinstance(raw_value, dict) else {}
+    summary_value = raw.get("summary")
+    summary: Dict[str, Any] = summary_value if isinstance(summary_value, dict) else {}
+    stocks_value = raw.get("stocks")
+    leader_stocks_value = raw.get("leader_stocks")
+    stocks: List[Any] = stocks_value if isinstance(stocks_value, list) else []
+    leader_stocks: List[Any] = leader_stocks_value if isinstance(leader_stocks_value, list) else []
+    timeline_value = raw.get("timeline")
+    timeline: List[Any] = timeline_value if isinstance(timeline_value, list) else []
+    route_value = raw.get("route")
+    route: List[Any] = route_value if isinstance(route_value, list) and route_value else _hotspot_timeline_to_route(timeline)
+    source_errors = _list_text_values(raw.get("source_errors") or summary.get("source_errors"))
+    topic = _env_text(summary.get("topic") or raw.get("topic") or requested_topic)
+    canonical_topic = _env_text(summary.get("canonical_topic") or raw.get("canonical_topic"))
+    name = _env_text(summary.get("name") or raw.get("name") or canonical_topic or topic)
+    quality_status = _env_text(summary.get("quality_status") or raw.get("quality_status"))
+    missing_fields = _list_text_values(summary.get("missing_fields") or raw.get("missing_fields"))
+    summary_text_value = raw.get("summary")
+    summary_text = (
+        summary_text_value
+        if isinstance(summary_text_value, str)
+        else _build_alphasift_hotspot_summary_text(summary, topic=topic, canonical_topic=canonical_topic)
+    )
+    return _ensure_hotspot_detail_compat_fields({
+        "enabled": True,
+        "provider": provider,
+        "topic": topic,
+        "name": name,
+        "canonical_topic": canonical_topic,
+        "aliases": _list_text_values(summary.get("aliases") or raw.get("aliases")),
+        "summary": summary_text,
+        "summary_detail": summary,
+        "route": route,
+        "timeline": timeline,
+        "stocks": stocks,
+        "leader_stocks": leader_stocks,
+        "source_errors": source_errors,
+        "quality_status": quality_status,
+        "missing_fields": missing_fields,
+        "fallback_used": bool(summary.get("fallback_used") or raw.get("fallback_used") or False),
+        "stale": bool(summary.get("stale") or raw.get("stale") or False),
+        "stale_age_hours": summary.get("stale_age_hours") or raw.get("stale_age_hours"),
+        "resolver_candidates": _list_dict_values(summary.get("resolver_candidates") or raw.get("resolver_candidates")),
+    })
+
+
+def _list_text_values(value: Any) -> List[str]:
+    if value is None:
+        return []
+    if isinstance(value, str):
+        text = _env_text(value)
+        return [text] if text else []
+    if not isinstance(value, list):
+        text = _env_text(value)
+        return [text] if text else []
+    return [text for item in value if (text := _env_text(item))]
+
+
+def _list_dict_values(value: Any) -> List[Dict[str, Any]]:
+    if not isinstance(value, list):
+        return []
+    return [item for item in value if isinstance(item, dict)]
+
+
+def _hotspot_timeline_to_route(timeline: List[Any]) -> List[Dict[str, Any]]:
+    route: List[Dict[str, Any]] = []
+    for item in timeline:
+        if not isinstance(item, dict):
+            continue
+        title = _env_text(item.get("title"))
+        if not title:
+            continue
+        date = _env_text(item.get("date") or item.get("published_at"))
+        source = _env_text(item.get("source")) or "alphasift_timeline"
+        route.append({
+            "title": title,
+            "description": f"{date}：{title}" if date else title,
+            "source": source,
+            "url": _env_text(item.get("url")),
+            "published_at": date,
+        })
+    if route:
+        return route
+    return [{
+        "title": "等待发酵",
+        "description": "暂未获取到明确催化事件，可继续观察涨跌幅、成交额和核心个股联动。",
+        "source": "fallback",
+    }]
+
+
+def _merge_provider_hotspot_route_fallback(
+    normalized: Dict[str, Any],
+    *,
+    provider: "DsaEastMoneyHotspotProvider",
+    topic: str,
+) -> Dict[str, Any]:
+    if _has_meaningful_hotspot_route(normalized.get("route")):
+        return normalized
+    try:
+        provider_detail = provider.hotspot_detail(topic)
+    except Exception as exc:
+        logger.warning(
+            "AlphaSift provider route fallback failed for %s; keeping contract detail route: %s",
+            topic,
+            exc,
+        )
+        return normalized
+
+    raw_value = _remove_non_finite_json_values(_to_plain(provider_detail))
+    raw: Dict[str, Any] = raw_value if isinstance(raw_value, dict) else {}
+    provider_route = raw.get("route")
+    if _has_meaningful_hotspot_route(provider_route):
+        normalized["route"] = provider_route
+        provider_timeline = raw.get("timeline")
+        if not normalized.get("timeline") and isinstance(provider_timeline, list):
+            normalized["timeline"] = provider_timeline
+        return normalized
+
+    provider_timeline = raw.get("timeline")
+    if isinstance(provider_timeline, list) and provider_timeline:
+        provider_timeline_route = _hotspot_timeline_to_route(provider_timeline)
+        if _has_meaningful_hotspot_route(provider_timeline_route):
+            normalized["route"] = provider_timeline_route
+            normalized["timeline"] = provider_timeline
+    return normalized
+
+
+def _has_meaningful_hotspot_route(route: Any) -> bool:
+    if not isinstance(route, list):
+        return False
+    for item in route:
+        if not isinstance(item, dict):
+            continue
+        title = _env_text(item.get("title"))
+        description = _env_text(item.get("description"))
+        source = _env_text(item.get("source"))
+        if not title and not description:
+            continue
+        if source == "fallback" and title == "等待发酵":
+            continue
+        return True
+    return False
+
+
+def _build_alphasift_hotspot_summary_text(summary: Dict[str, Any], *, topic: str, canonical_topic: str) -> str:
+    display_topic = canonical_topic or topic
+    quality = _env_text(summary.get("quality_status"))
+    heat = _safe_float(summary.get("heat_score"))
+    stage = _env_text(summary.get("stage"))
+    leaders = summary.get("leaders") if isinstance(summary.get("leaders"), list) else []
+    parts = [f"{display_topic} 当前热点详情"]
+    if heat is not None:
+        parts.append(f"热度 {heat:.1f}")
+    if stage:
+        parts.append(f"阶段 {stage}")
+    if leaders:
+        parts.append("核心股 " + "、".join(_env_text(item) for item in leaders[:3] if _env_text(item)))
+    if quality:
+        parts.append(f"质量状态 {quality}")
+    return "，".join(part for part in parts if part) + "。"
+
+
+def _install_alphasift(config: Config) -> Dict[str, Any]:
+    with _ALPHASIFT_INSTALL_LOCK:
+        install_spec_is_default = _is_default_alphasift_install_spec(config.alphasift_install_spec)
+        if _is_alphasift_available():
+            _get_dsa_adapter()
+            return _build_install_response(
+                already_installed=True,
+                install_spec_is_default=install_spec_is_default,
+            )
+
+        install_spec = _validate_install_spec(config.alphasift_install_spec)
+
+        try:
+            _purge_alphasift_modules()
+            importlib.invalidate_caches()
+            completed = subprocess.run(
+                [sys.executable, "-m", "pip", "install", "--upgrade", "--force-reinstall", install_spec],
+                check=False,
+                capture_output=True,
+                text=True,
+                timeout=300,
+            )
+        except Exception as exc:
+            raise HTTPException(
+                status_code=424,
+                detail={"error": "alphasift_install_failed", "message": f"修复安装 AlphaSift 失败：{exc}"},
+            ) from exc
+
+        if completed.returncode != 0:
+            stderr = (completed.stderr or "").strip()
+            stdout = (completed.stdout or "").strip()
+            detail = stderr or stdout or f"pip exited with code {completed.returncode}"
+            raise HTTPException(
+                status_code=424,
+                detail={
+                    "error": "alphasift_install_failed",
+                    "message": f"修复安装 AlphaSift 失败：{detail}",
+                },
+            )
+
+        importlib.invalidate_caches()
+        _purge_alphasift_modules()
+        adapter_status = _call_alphasift_status()
+        if not _is_adapter_available(adapter_status):
+            raise HTTPException(
+                status_code=424,
+                detail={"error": "alphasift_unavailable", "message": "AlphaSift 安装完成，但适配层当前不可用（available=false）。请检查当前 Python 环境和安装状态后重试。"},
+            )
+        _get_dsa_adapter()
+
+        return _build_install_response(
+            already_installed=False,
+            install_spec_is_default=_is_default_alphasift_install_spec(install_spec),
+        )
+
+
+def _validate_install_spec(raw_install_spec: str) -> str:
+    install_spec = (raw_install_spec or "").strip()
+    if not install_spec or install_spec.lower() == "alphasift":
+        raise HTTPException(
+            status_code=424,
+            detail={
+                "error": "alphasift_install_spec_missing",
+                "message": f"请先将 ALPHASIFT_INSTALL_SPEC 配置为受信任来源：{DEFAULT_ALPHASIFT_INSTALL_SPEC}。",
+            },
+        )
+
+    if install_spec not in ALLOWED_ALPHASIFT_INSTALL_SPECS:
+        raise HTTPException(
+            status_code=403,
+            detail={
+                "error": "alphasift_install_spec_not_allowed",
+                "message": (
+                    "出于安全考虑，修复安装 AlphaSift 仅允许使用受信任来源："
+                    f"{DEFAULT_ALPHASIFT_INSTALL_SPEC}。如需使用本地路径或 wheel，请先手动安装到当前 Python 环境。"
+                ),
+            },
+        )
+
+    return install_spec
+
+
+def _ensure_alphasift_enabled(config: Config) -> None:
+    if not config.alphasift_enabled:
+        raise HTTPException(
+            status_code=403,
+            detail={"error": "alphasift_disabled", "message": "ALPHASIFT_ENABLED is false."},
+        )
+
+
+def _ensure_alphasift_ready(config: Config, *, request: Request) -> None:
+    # Backward-compatible helper for tests/extensions. Normal strategies/screen
+    # calls no longer mutate the Python environment; AlphaSift is installed with
+    # project dependencies and `/install` remains an explicit repair action.
+    _ensure_alphasift_available_for_use()
+
+
+def _ensure_alphasift_available_for_use() -> None:
+    _, available, diagnostics = _get_alphasift_status_snapshot()
+    if available:
+        return
+    normalized_diagnostics = _include_alphasift_diagnostic_suffix(diagnostics)
+    if _is_missing_alphasift_module(diagnostics):
+        raise _alphasift_unavailable_exception(
+            "AlphaSift 是 DSA 的项目依赖，但当前运行环境未安装适配层。请先执行 `pip install -r requirements.txt`，或重建 Docker/桌面后端产物。",
+            diagnostics=normalized_diagnostics,
+        )
+    raise _alphasift_unavailable_exception(
+        "AlphaSift 已开启但当前运行时状态异常。已保留异常诊断，避免自动重装掩盖真实问题。",
+        diagnostics=normalized_diagnostics,
+    )
+
+
+def _is_missing_alphasift_module(diagnostics: Optional[Dict[str, str]]) -> bool:
+    return bool(diagnostics and diagnostics.get("reason") == "missing_module")
+
+
+def _include_alphasift_diagnostic_suffix(
+    diagnostics: Optional[Dict[str, str]],
+) -> Optional[Dict[str, str]]:
+    if diagnostics is None:
+        return None
+    if diagnostics.get("reason") == "missing_module":
+        return diagnostics
+    normalized = dict(diagnostics)
+    normalized.setdefault("resolution", "no_auto_install")
+    normalized.setdefault(
+        "message",
+        "请先检查后端日志并修复运行时异常，当前未触发修复安装。",
+    )
+    return normalized
+
+
+def _get_alphasift_status_snapshot() -> Tuple[Dict[str, Any], bool, Optional[Dict[str, str]]]:
+    try:
+        adapter_status = _call_alphasift_status()
+    except HTTPException as exc:
+        return {}, False, _extract_alphasift_diagnostics(exc)
+    except Exception as exc:
+        diagnostics = _log_unexpected_alphasift_exception("status_probe", exc)
+        return {}, False, diagnostics
+
+    return adapter_status, _is_adapter_available(adapter_status), None
+
+
+def _get_alphasift_source_health_snapshot() -> Dict[str, Any]:
+    health: Dict[str, Any] = {}
+    for module_name, key, function_name in (
+        ("alphasift.snapshot", "snapshot", "snapshot_source_health_snapshot"),
+        ("alphasift.daily", "daily", "daily_source_health_snapshot"),
+    ):
+        try:
+            module = importlib.import_module(module_name)
+            snapshot_func = getattr(module, function_name, None)
+            if callable(snapshot_func):
+                snapshot = _remove_non_finite_json_values(_to_plain(snapshot_func()))
+                if snapshot:
+                    health[key] = snapshot
+        except Exception as exc:
+            logger.debug("AlphaSift %s source health snapshot unavailable: %s", key, exc)
+    return health
+
+
+def _ensure_alphasift_install_access(request: Request) -> None:
+    if os.getenv("DSA_DESKTOP_MODE") == "true":
+        return
+    refresh_auth_state()
+    if not is_auth_enabled():
+        raise HTTPException(
+            status_code=403,
+            detail={
+                "error": "alphasift_install_access_denied",
+                "message": "AlphaSift 修复安装仅允许桌面模式或已启用管理员认证的会话。请先启用管理员认证后重试。",
+            },
+        )
+
+    cookie_val = request.cookies.get(COOKIE_NAME)
+    if cookie_val and verify_session(cookie_val):
+        return
+
+    raise HTTPException(
+        status_code=401,
+        detail={
+            "error": "alphasift_install_access_denied",
+            "message": "AlphaSift 修复安装需要有效管理员会话。",
+        },
+    )
+
+
+def _is_alphasift_available() -> bool:
+    _, available, _ = _get_alphasift_status_snapshot()
+    return available
+
+
+def _is_adapter_available(adapter_status: Any) -> bool:
+    if isinstance(adapter_status, dict):
+        return bool(adapter_status.get("available", True))
+    return True
+
+
+def _import_alphasift() -> Any:
+    try:
+        _prepare_alphasift_runtime_env()
+        return importlib.import_module(ALPHASIFT_DSA_ADAPTER_MODULE)
+    except ModuleNotFoundError as exc:
+        if _is_expected_alphasift_missing(exc):
+            diagnostics = {
+                "reason": "missing_module",
+                "stage": "import_adapter",
+                "error_type": exc.__class__.__name__,
+                "module": str(getattr(exc, "name", ALPHASIFT_DSA_ADAPTER_MODULE)),
+            }
+            raise _alphasift_unavailable_exception(
+                f"AlphaSift 未安装或未挂载到当前 Python 环境，无法导入 {ALPHASIFT_DSA_ADAPTER_MODULE}：{exc}",
+                diagnostics=diagnostics,
+            ) from exc
+        diagnostics = _log_unexpected_alphasift_exception("import_adapter", exc)
+        raise _alphasift_unavailable_exception(
+            f"AlphaSift 适配层导入失败，请检查依赖完整性和当前 Python 环境：{exc}",
+            diagnostics=diagnostics,
+        ) from exc
+    except Exception as exc:
+        diagnostics = _log_unexpected_alphasift_exception("import_adapter", exc)
+        raise _alphasift_unavailable_exception(
+            f"AlphaSift 适配层导入失败，请检查依赖完整性和当前 Python 环境：{exc}",
+            diagnostics=diagnostics,
+        ) from exc
+
+
+def _import_alphasift_hotspot() -> Any:
+    try:
+        _prepare_alphasift_runtime_env()
+        return importlib.import_module("alphasift.hotspot")
+    except ModuleNotFoundError as exc:
+        if getattr(exc, "name", None) in {"alphasift", "alphasift.hotspot"}:
+            diagnostics = {
+                "reason": "missing_module",
+                "stage": "import_hotspot",
+                "error_type": exc.__class__.__name__,
+                "module": str(getattr(exc, "name", "alphasift.hotspot")),
+            }
+            raise _alphasift_unavailable_exception(
+                f"AlphaSift hotspot module is unavailable: {exc}",
+                diagnostics=diagnostics,
+            ) from exc
+        diagnostics = _log_unexpected_alphasift_exception("import_hotspot", exc)
+        raise _alphasift_unavailable_exception(
+            f"AlphaSift hotspot module import failed: {exc}",
+            diagnostics=diagnostics,
+        ) from exc
+    except Exception as exc:
+        diagnostics = _log_unexpected_alphasift_exception("import_hotspot", exc)
+        raise _alphasift_unavailable_exception(
+            f"AlphaSift hotspot module import failed: {exc}",
+            diagnostics=diagnostics,
+        ) from exc
+
+
+def _prepare_alphasift_runtime_env() -> None:
+    if os.getenv("STRATEGIES_DIR"):
+        return
+
+    spec = importlib.util.find_spec("alphasift")
+    if not spec or not spec.origin:
+        return
+
+    package_strategies_dir = Path(spec.origin).resolve().parent / "strategies"
+    if package_strategies_dir.is_dir():
+        os.environ["STRATEGIES_DIR"] = str(package_strategies_dir)
+
+
+def _get_dsa_adapter() -> Any:
+    adapter = _import_alphasift()
+    for attr in ("get_status", "list_strategies", "screen"):
+        _get_adapter_callable(adapter, attr, f"{attr}() 不可调用。")
+    return adapter
+
+
+def _get_adapter_callable(adapter: Any, name: str, missing_error: str) -> Any:
+    callable_obj = getattr(adapter, name, None)
+    if not callable(callable_obj):
+        raise HTTPException(
+            status_code=424,
+            detail={"error": "alphasift_unavailable", "message": f"已导入 alphasift 适配层，但 {missing_error}"},
+        )
+    return callable_obj
+
+
+def _call_alphasift_status() -> Dict[str, Any]:
+    try:
+        adapter = _import_alphasift()
+    except ModuleNotFoundError as exc:
+        if _is_expected_alphasift_missing(exc):
+            logger.warning("AlphaSift import missing expected module during status probe: %s", exc)
+            diagnostics = {
+                "reason": "missing_module",
+                "stage": "import_adapter",
+                "error_type": exc.__class__.__name__,
+                "module": str(getattr(exc, "name", ALPHASIFT_DSA_ADAPTER_MODULE)),
+            }
+            raise _alphasift_unavailable_exception(
+                f"AlphaSift 未安装或未挂载到当前 Python 环境，无法导入 {ALPHASIFT_DSA_ADAPTER_MODULE}：{exc}",
+                diagnostics=diagnostics,
+            ) from exc
+
+        diagnostics = _log_unexpected_alphasift_exception("import_adapter", exc)
+        raise _alphasift_unavailable_exception(
+            f"AlphaSift 适配层导入失败，请检查依赖完整性和当前 Python 环境：{exc}",
+            diagnostics=diagnostics,
+        ) from exc
+    try:
+        get_status = _get_adapter_callable(adapter, "get_status", "get_status() 不可调用。")
+    except HTTPException as exc:
+        diagnostics = _log_unexpected_alphasift_exception("get_status_callable", exc)
+        raise _alphasift_unavailable_exception(
+            "AlphaSift 适配层 get_status 不可调用，请检查适配层版本。",
+            diagnostics=diagnostics,
+        ) from exc
+    try:
+        result = _to_plain(get_status())
+    except Exception as exc:
+        diagnostics = _log_unexpected_alphasift_exception("get_status", exc)
+        raise _alphasift_unavailable_exception(
+            f"AlphaSift 适配层 get_status 调用失败：{exc}",
+            diagnostics=diagnostics,
+        ) from exc
+    if not isinstance(result, dict):
+        exc = TypeError(f"get_status returned {type(result).__name__}, expected dict")
+        diagnostics = _log_unexpected_alphasift_exception("get_status_result", exc)
+        raise _alphasift_unavailable_exception(
+            "AlphaSift 适配层 get_status 返回结构非法，请检查适配层版本。",
+            diagnostics=diagnostics,
+        ) from exc
+    return result
+
+
+def _is_expected_alphasift_missing(exc: ModuleNotFoundError) -> bool:
+    return getattr(exc, "name", None) in ALPHASIFT_EXPECTED_MISSING_MODULES
+
+
+def _purge_alphasift_modules() -> None:
+    for module_name in list(sys.modules):
+        if module_name == "alphasift" or module_name.startswith("alphasift."):
+            sys.modules.pop(module_name, None)
+
+
+def _alphasift_unavailable_exception(
+    message: str,
+    *,
+    diagnostics: Optional[Dict[str, str]] = None,
+) -> HTTPException:
+    detail: Dict[str, Any] = {"error": "alphasift_unavailable", "message": message}
+    if diagnostics:
+        detail["diagnostics"] = diagnostics
+    return HTTPException(status_code=424, detail=detail)
+
+
+def _log_unexpected_alphasift_exception(stage: str, exc: BaseException) -> Dict[str, str]:
+    logger.warning("Unexpected AlphaSift %s failure: %s", stage, exc, exc_info=exc.__traceback__ is not None)
+    return {
+        "reason": "unexpected_exception",
+        "stage": stage,
+        "error_type": exc.__class__.__name__,
+    }
+
+
+def _extract_alphasift_diagnostics(exc: HTTPException) -> Optional[Dict[str, str]]:
+    detail = exc.detail if isinstance(exc.detail, dict) else {}
+    diagnostics = detail.get("diagnostics")
+    if not isinstance(diagnostics, dict):
+        return None
+    return {str(key): str(value) for key, value in diagnostics.items()}
+
+
+def _list_strategies() -> List[Dict[str, Any]]:
+    adapter = _get_dsa_adapter()
+    list_strategies = _get_adapter_callable(adapter, "list_strategies", "list_strategies() 不可调用。")
+    raw = _to_plain(list_strategies())
+    if not isinstance(raw, list):
+        raise HTTPException(
+            status_code=424,
+            detail={"error": "alphasift_invalid_result", "message": "AlphaSift list_strategies 返回非列表。"},
+        )
+
+    normalized: List[Dict[str, Any]] = []
+    for item in raw:
+        strategy = _normalize_strategy(item)
+        if not strategy.get("id"):
+            continue
+        normalized.append(strategy)
+    return normalized
+
+
+def _normalize_strategy(raw: Any) -> Dict[str, Any]:
+    item = _to_plain(raw)
+    if isinstance(item, str):
+        return _strategy_model(id=item, name=item, title=item)
+    if not isinstance(item, dict):
+        value = str(item)
+        return _strategy_model(id=value, name=value, title=value)
+
+    tags = item.get("tags") if isinstance(item.get("tags"), list) else []
+    market_scope = item.get("market_scope") or item.get("marketScope") or []
+    if not isinstance(market_scope, list):
+        market_scope = [str(market_scope)] if market_scope else []
+
+    strategy_id = str(
+        item.get("id")
+        or item.get("strategy")
+        or item.get("strategy_id")
+        or item.get("name")
+        or "",
+    )
+    name = str(item.get("name") or item.get("title") or strategy_id)
+    category = str(item.get("category") or item.get("tag") or "")
+    return _strategy_model(
+        id=strategy_id,
+        name=name,
+        title=str(item.get("title") or name),
+        description=str(item.get("description") or ""),
+        category=category,
+        tag=str(item.get("tag") or category),
+        tags=[str(tag) for tag in tags],
+        market_scope=[str(market) for market in market_scope],
+        market=str(item.get("market") or item.get("market_id") or ""),
+    )
+
+
+def _strategy_model(**kwargs: Any) -> Dict[str, Any]:
+    normalized = AlphaSiftStrategyResponse(**kwargs)
+    try:
+        return normalized.model_dump()
+    except AttributeError:
+        return normalized.dict()
+
+
+def _ensure_supported_strategy(strategy: str) -> None:
+    strategies = _list_strategies()
+    if not strategies:
+        return
+
+    ids = {item.get("id") for item in strategies if item.get("id")}
+    if strategy in ids:
+        return
+
+    # 兼容“策略列表为空时手动输入”以及“用户手动覆盖策略参数”场景，
+    # 策略由适配层进行最终校验，因此在列表外仍保持透传。
+
+
+def _call_alphasift_screen(screen: Any, strategy: str, market: str, max_results: int, config: Config) -> Any:
+    signature = inspect.signature(screen)
+    params = signature.parameters
+    supports_var_kwargs = any(parameter.kind == inspect.Parameter.VAR_KEYWORD for parameter in params.values())
+    positional_params = [
+        parameter
+        for parameter in params.values()
+        if parameter.kind in (inspect.Parameter.POSITIONAL_ONLY, inspect.Parameter.POSITIONAL_OR_KEYWORD)
+    ]
+    supports_var_positional = any(parameter.kind == inspect.Parameter.VAR_POSITIONAL for parameter in params.values())
+
+    supports_max_results = "max_results" in params or supports_var_kwargs
+    supports_max_output = "max_output" in params or supports_var_kwargs
+    supports_use_llm = "use_llm" in params or supports_var_kwargs
+    supports_context = "context" in params or supports_var_kwargs
+
+    kwargs: Dict[str, Any] = {"market": market}
+    if supports_max_results:
+        kwargs["max_results"] = max_results
+    elif supports_max_output:
+        kwargs["max_output"] = max_results
+    else:
+        kwargs["max_results"] = max_results
+
+    if supports_use_llm:
+        kwargs["use_llm"] = True
+    if supports_context:
+        kwargs["context"] = _build_alphasift_context(config, max_results=max_results)
+
+    with (
+        _alphasift_runtime_env(config, max_results=max_results),
+        _alphasift_dsa_daily_history_provider(),
+        _alphasift_litellm_headers(config),
+    ):
+        try:
+            return screen(strategy, **kwargs)
+        except TypeError as exc:
+            message = str(exc)
+            signature_mismatch = ("keyword" in message and "argument" in message) or (
+                "positional" in message and "given" in message
+            )
+            if not signature_mismatch:
+                raise
+            if "context" in kwargs:
+                retry_kwargs = dict(kwargs)
+                retry_kwargs.pop("context", None)
+                try:
+                    return screen(strategy, **retry_kwargs)
+                except TypeError as retry_exc:
+                    exc = retry_exc
+            if not (supports_var_kwargs or supports_var_positional or len(positional_params) >= 3):
+                raise exc
+            return screen(strategy, market, max_results)
+
+
+@contextmanager
+def _alphasift_runtime_env(config: Config, *, max_results: Optional[int] = None) -> Iterator[None]:
+    updates = _build_alphasift_runtime_env(config, max_results=max_results)
+    if not updates:
+        yield
+        return
+
+    sentinel = object()
+    with _ALPHASIFT_RUNTIME_ENV_LOCK:
+        previous = {key: os.environ.get(key, sentinel) for key in updates}
+        os.environ.update(updates)
+        try:
+            yield
+        finally:
+            for key, value in previous.items():
+                if value is sentinel:
+                    os.environ.pop(key, None)
+                else:
+                    os.environ[key] = value  # type: ignore[assignment]
+
+
+@contextmanager
+def _alphasift_dsa_daily_history_provider() -> Iterator[None]:
+    try:
+        daily_module = importlib.import_module("alphasift.daily")
+    except Exception:
+        yield
+        return
+
+    original_fetch = getattr(daily_module, "fetch_daily_history", None)
+    if not callable(original_fetch):
+        yield
+        return
+
+    def fetch_daily_history_with_dsa(
+        code: str,
+        *,
+        lookback_days: int = 120,
+        source: str = "akshare",
+        retries: int = 2,
+    ) -> Any:
+        try:
+            dsa_df, dsa_source = get_dsa_daily_history(code, lookback_days=lookback_days)
+            normalized = _normalize_dsa_daily_history(dsa_df)
+            if normalized is not None and not normalized.empty:
+                normalized.attrs["source"] = f"dsa:{dsa_source}"
+                return normalized
+        except Exception as exc:
+            logger.warning(
+                "AlphaSift DSA daily history fetch failed for %s; falling back to AlphaSift source %s: %s",
+                code,
+                source,
+                exc,
+            )
+        return original_fetch(code, lookback_days=lookback_days, source=source, retries=retries)
+
+    with _ALPHASIFT_RUNTIME_ENV_LOCK:
+        setattr(daily_module, "fetch_daily_history", fetch_daily_history_with_dsa)
+        try:
+            yield
+        finally:
+            setattr(daily_module, "fetch_daily_history", original_fetch)
+
+
+def _resolve_alphasift_snapshot_source_priority(config: Config) -> str:
+    token = _env_text(getattr(config, "tushare_token", None) or os.getenv("TUSHARE_TOKEN"))
+    if token:
+        return DSA_ALPHASIFT_SNAPSHOT_SOURCE_PRIORITY_WITH_TUSHARE
+    return DSA_ALPHASIFT_SNAPSHOT_SOURCE_PRIORITY
+
+
+def _build_alphasift_runtime_env(config: Config, *, max_results: Optional[int] = None) -> Dict[str, str]:
+    # Bridge runtime only: only inject resolved DSA values for this request/process scope.
+    # User .env/config is never rewritten here; unset channels/models are not silently migrated.
+    # 与 LiteLLM provider/model、openai-compatible `api_base` 与 headers 注入语义保持一致，
+    # 参见 https://docs.litellm.ai/docs/providers 与
+    # https://docs.litellm.ai/docs/proxy/configs#the-model_list-key
+    env: Dict[str, str] = {}
+
+    def put(key: str, value: Any) -> None:
+        text = _env_text(value)
+        if text:
+            env[key] = text
+
+    def put_default(key: str, value: Any) -> None:
+        if os.getenv(key) not in (None, ""):
+            return
+        put(key, value)
+
+    litellm_model, fallback_models = _resolve_alphasift_llm_models(config)
+    put("LITELLM_MODEL", litellm_model)
+    if fallback_models:
+        put("LITELLM_FALLBACK_MODELS", ",".join(fallback_models))
+    put("LITELLM_CONFIG", config.litellm_config_path)
+    if os.getenv("LLM_TEMPERATURE") not in (None, ""):
+        put("LLM_TEMPERATURE", config.llm_temperature)
+
+    channels = _normalize_dsa_llm_channels(config)
+    if channels:
+        put("LLM_CHANNELS", ",".join(channel["name"] for channel in channels))
+        for channel in channels:
+            prefix = channel["name"].upper()
+            put(f"LLM_{prefix}_ENABLED", "true")
+            put(f"LLM_{prefix}_PROTOCOL", channel.get("protocol"))
+            put(f"LLM_{prefix}_BASE_URL", channel.get("base_url"))
+            put(f"LLM_{prefix}_API_KEYS", ",".join(channel.get("api_keys") or []))
+            put(f"LLM_{prefix}_MODELS", ",".join(channel.get("models") or []))
+            if channel.get("extra_headers"):
+                put(
+                    f"LLM_{prefix}_EXTRA_HEADERS",
+                    json.dumps(channel.get("extra_headers"), ensure_ascii=False),
+                )
+
+    gemini_keys = _dedupe_strings([
+        *(config.gemini_api_keys or []),
+        *_channel_keys_for_provider(channels, {"gemini", "vertex_ai"}),
+    ])
+    anthropic_keys = _dedupe_strings([
+        *(config.anthropic_api_keys or []),
+        *_channel_keys_for_provider(channels, {"anthropic"}),
+    ])
+    openai_keys = _dedupe_strings([
+        *(config.openai_api_keys or []),
+        *_channel_keys_for_provider(channels, {"openai"}),
+    ])
+    deepseek_keys = _dedupe_strings([
+        *(config.deepseek_api_keys or []),
+        *_channel_keys_for_provider(channels, {"deepseek"}),
+    ])
+
+    _put_provider_keys(env, "GEMINI", gemini_keys)
+    _put_provider_keys(env, "ANTHROPIC", anthropic_keys)
+    _put_provider_keys(env, "OPENAI", openai_keys)
+    _put_provider_keys(env, "DEEPSEEK", deepseek_keys)
+
+    put("OPENAI_BASE_URL", config.openai_base_url or _first_channel_base_url(channels, {"openai"}))
+    put_default("DAILY_SOURCE", "auto")
+    put_default("DAILY_FETCH_RETRIES", str(DSA_ALPHASIFT_DAILY_FETCH_RETRIES))
+    put_default("DAILY_FETCH_MAX_WORKERS", "1")
+    put("LLM_CANDIDATE_CONTEXT_ENABLED", "false")
+    put_default("LLM_CANDIDATE_CONTEXT_PROVIDERS", DSA_ALPHASIFT_CANDIDATE_CONTEXT_PROVIDERS)
+    put_default("LLM_CANDIDATE_MULTIPLIER", str(DSA_ALPHASIFT_LLM_CANDIDATE_MULTIPLIER))
+    put_default("LLM_MAX_CANDIDATES", str(_resolve_dsa_llm_max_candidates(max_results)))
+    put_default("SNAPSHOT_SOURCE_PRIORITY", _resolve_alphasift_snapshot_source_priority(config))
+    alphasift_data_dir = _resolve_alphasift_data_dir()
+    put_default("ALPHASIFT_DATA_DIR", str(alphasift_data_dir))
+    put_default("ALPHASIFT_FALLBACK_SNAPSHOT_PATH", str(alphasift_data_dir / "snapshot.last_good.json"))
+    put_default("ALPHASIFT_DAILY_HISTORY_CACHE_DIR", str(alphasift_data_dir / "daily_history"))
+    put_default("ALPHASIFT_INDUSTRY_PROVIDER_CACHE_DIR", str(alphasift_data_dir / "industry_provider_cache"))
+    return env
+
+
+def _resolve_hotspot_provider(provider: str) -> Tuple[str, Any]:
+    requested = (provider or "").strip()
+    if requested.lower() == "akshare":
+        return requested, DsaEastMoneyHotspotProvider()
+    if requested:
+        return requested, requested
+    configured = (os.getenv("INDUSTRY_PROVIDER") or "").strip()
+    if configured.lower() == "akshare":
+        return configured, DsaEastMoneyHotspotProvider()
+    if configured:
+        return configured, configured
+    return "akshare", DsaEastMoneyHotspotProvider()
+
+
+class DsaEastMoneyHotspotProvider:
+    """Minimal EastMoney board provider for AlphaSift hotspot scoring."""
+
+    _BASE_URL = "https://push2.eastmoney.com/api/qt/clist/get"
+    _HTTP_TIMEOUT_SECONDS = 8
+    _COMMON_PARAMS = {
+        "pn": "1",
+        "po": "1",
+        "np": "1",
+        "ut": "bd1d9ddb04089700cf9c27f6f7426281",
+        "fltt": "2",
+        "invt": "2",
+        "fid": "f12",
+        "fields": "f2,f3,f4,f12,f13,f14,f104,f105,f128,f136,f140,f141,f207",
+    }
+    _BROAD_BOARD_KEYWORDS = (
+        "融资融券",
+        "深股通",
+        "沪股通",
+        "创业板",
+        "昨日",
+        "机构重仓",
+        "富时罗素",
+        "MSCI",
+        "标普",
+        "上证",
+        "深证",
+        "中证",
+        "HS300",
+        "证金",
+        "QFII",
+        "基金",
+        "转融券",
+        "预增",
+        "预盈",
+        "亏损",
+        "低价",
+        "小盘股",
+        "中盘股",
+        "百元股",
+        "破发",
+        "破增发",
+        "趋势股",
+        "广东板块",
+        "江苏板块",
+        "浙江板块",
+        "上海板块",
+        "深圳特区",
+        "央国企",
+        "国企改革",
+        "专精特新",
+        "其他",
+        "Ⅱ",
+        "Ⅲ",
+    )
+    _CHANGE_EVENT_LABELS = {
+        4: "快速拉升",
+        8: "快速回落",
+        16: "大幅上涨",
+        32: "大幅下跌",
+        64: "有大笔买入",
+        128: "有大笔卖出",
+        8193: "火箭发射",
+        8194: "高台跳水",
+        8201: "大笔买入",
+        8202: "大笔卖出",
+        8203: "封涨停板",
+        8204: "打开涨停板",
+        8207: "有打开跌停板",
+        8208: "封跌停板",
+        8209: "向上缺口",
+        8210: "向下缺口",
+        8211: "60日新高",
+        8212: "60日新低",
+        8213: "60日大幅上涨",
+        8214: "60日大幅下跌",
+        8215: "竞价上涨",
+        8216: "竞价下跌",
+        8217: "高开",
+        8218: "低开",
+        8219: "放量",
+        8220: "缩量",
+        8221: "向上突破",
+        8222: "向下破位",
+    }
+    _METAL_TOPIC_GROUPS = {
+        "钼": "小金属",
+        "钨": "小金属",
+        "钴": "小金属",
+        "镍": "小金属",
+        "锑": "小金属",
+        "铟": "小金属",
+        "锗": "小金属",
+        "铅锌": "工业金属",
+        "铜": "工业金属",
+        "铝": "工业金属",
+        "锡": "工业金属",
+        "黄金": "贵金属",
+        "白银": "贵金属",
+        "贵金属": "贵金属",
+    }
+    def __init__(self) -> None:
+        import requests
+
+        self._board_changes_raw_cache: Any = None
+        self._board_changes_frame_cache: Any = None
+        self._constituent_cache: Dict[Tuple[str, str], Any] = {}
+        self._session = requests.Session()
+        self._request_lock = threading.RLock()
+        self._last_request_ts = 0.0
+        self._min_request_interval = 0.25
+
+    def _eastmoney_get_once(self, url: str, **kwargs: Any) -> Any:
+        with self._request_lock:
+            elapsed = time.monotonic() - self._last_request_ts
+            if elapsed < self._min_request_interval:
+                time.sleep(self._min_request_interval - elapsed)
+            try:
+                return self._session.get(url, **kwargs)
+            finally:
+                self._last_request_ts = time.monotonic()
+
+    def _eastmoney_get(self, url: str, **kwargs: Any) -> Any:
+        import requests
+
+        retryable_errors = (
+            requests.exceptions.ConnectionError,
+            requests.exceptions.Timeout,
+            requests.exceptions.ChunkedEncodingError,
+        )
+        delays = (0.3, 0.8)
+        last_error: Optional[BaseException] = None
+        for attempt in range(len(delays) + 1):
+            try:
+                return self._eastmoney_get_once(url, **kwargs)
+            except retryable_errors as exc:
+                last_error = exc
+                if attempt >= len(delays):
+                    break
+                logger.warning(
+                    "AlphaSift EastMoney hotspot request failed; retrying attempt=%s: %s",
+                    attempt + 1,
+                    exc,
+                )
+                time.sleep(delays[attempt])
+        assert last_error is not None
+        raise last_error
+
+    def stock_board_concept_name_em(self) -> Any:
+        frame = self._fetch_board_changes_with_fallback()
+        if frame is not None and not frame.empty:
+            return frame
+        frame = self._fetch_rankings_with_fallback("concept")
+        if frame is not None and not frame.empty:
+            return frame
+        return self._fetch_board_names(source_fs="m:90 t:3 f:!50")
+
+    def stock_board_industry_name_em(self) -> Any:
+        concept_frame = self._fetch_board_changes_with_fallback()
+        if concept_frame is not None and not concept_frame.empty:
+            import pandas as pd
+
+            return pd.DataFrame()
+        frame = self._fetch_rankings_with_fallback("industry")
+        if frame is not None and not frame.empty:
+            return frame
+        return self._fetch_board_names(source_fs="m:90 t:2 f:!50")
+
+    def hotspot_rows(self, *, top: int = 12) -> List[Dict[str, Any]]:
+        import pandas as pd
+
+        frame = self.stock_board_concept_name_em()
+        df = pd.DataFrame(frame)
+        if df.empty:
+            return []
+        rows: List[Dict[str, Any]] = []
+        for index, row in df.head(max(1, min(top, 50))).iterrows():
+            name = _env_text(row.get("name") or row.get("板块名称") or row.get("行业名称") or row.get("名称"))
+            if not name:
+                continue
+            change_pct = _safe_float(row.get("change_pct") or row.get("涨跌幅"))
+            event_count = int(_safe_float(row.get("event_count") or row.get("observations")) or 0)
+            leader = _env_text(row.get("leader"))
+            leaders_raw = row.get("leaders")
+            leaders = _list_text_values(leaders_raw) or ([leader] if leader else [])
+            heat_score = _safe_float(row.get("heat_score"))
+            if heat_score is None:
+                heat_score = min(99.0, max(1.0, max(change_pct or 0.0, 0.0) * 9.0 + event_count / 120.0))
+            trend_score = _safe_float(row.get("trend_score"))
+            if trend_score is None:
+                trend_score = self._derive_trend_score(change_pct=change_pct, event_count=event_count)
+            persistence_score = _safe_float(row.get("persistence_score"))
+            if persistence_score is None:
+                persistence_score = self._derive_persistence_score(event_count=event_count)
+            stage = _env_text(row.get("stage") or row.get("state")) or self._derive_hotspot_stage(
+                change_pct=change_pct,
+                event_count=event_count,
+            )
+            display_name = self._display_hotspot_name(name)
+            rows.append({
+                "topic": name,
+                "name": display_name,
+                "theme_group": self._hotspot_group(name),
+                "source": "dsa_eastmoney_board_change",
+                "rank": len(rows) + 1,
+                "change_pct": change_pct,
+                "heat_score": round(float(heat_score), 2),
+                "trend_score": trend_score,
+                "persistence_score": persistence_score,
+                "observations": event_count,
+                "state": stage,
+                "stage": stage,
+                "sample_stock_count": int(_safe_float(row.get("sample_stock_count")) or len(leaders)),
+                "leaders": leaders,
+            })
+        return rows
+
+    def stock_board_concept_cons_em(self, symbol: str = "") -> Any:
+        cached = self._get_constituent_cache("concept", symbol)
+        if cached is not None:
+            return cached
+        frames = [self._fetch_eastmoney_constituents(symbol, source="concept")]
+        try:
+            frames.append(self._fetch_ths_constituents(symbol))
+        except Exception as exc:
+            logger.warning(
+                "AlphaSift THS constituent fetch failed for %s; falling back to alternative sources: %s",
+                symbol,
+                exc,
+            )
+        frames.append(self._fallback_constituents(symbol))
+        frames.append(self._related_hotspot_constituents(symbol))
+        frame = self._merge_constituent_frames(frames)
+        self._set_constituent_cache("concept", symbol, frame)
+        return frame
+
+    def stock_board_industry_cons_em(self, symbol: str = "") -> Any:
+        cached = self._get_constituent_cache("industry", symbol)
+        if cached is not None:
+            return cached
+        frame = self._merge_constituent_frames([
+            self._fetch_eastmoney_constituents(symbol, source="industry"),
+            self._fallback_constituents(symbol),
+        ])
+        self._set_constituent_cache("industry", symbol, frame)
+        return frame
+
+    def hotspot_detail(self, topic: str) -> Dict[str, Any]:
+        try:
+            summary = self._find_board_change(topic)
+        except Exception as exc:
+            logger.warning(
+                "AlphaSift board-change summary fetch failed for %s; continuing without summary: %s",
+                topic,
+                exc,
+            )
+            summary = {}
+        if self._is_industry_hotspot(topic):
+            stocks = self._normalize_constituent_records(self.stock_board_industry_cons_em(topic))
+        else:
+            stocks = self._normalize_constituent_records(self.stock_board_concept_cons_em(topic))
+        stocks = self._enrich_constituent_quotes(stocks)
+        route = self._build_hotspot_route(topic, summary)
+        info = self._fetch_ths_info(topic)
+        if info:
+            route.append({
+                "title": "同花顺板块概况",
+                "description": "；".join(f"{key} {value}" for key, value in list(info.items())[:4]),
+                "source": "ths_info",
+            })
+        if not stocks and summary:
+            stock_code = _env_text(summary.get("板块异动最频繁个股及所属类型-股票代码"))
+            stock_name = _env_text(summary.get("板块异动最频繁个股及所属类型-股票名称"))
+            if stock_code or stock_name:
+                stocks.append({
+                    "code": stock_code,
+                    "name": stock_name,
+                    "role": "异动核心",
+                    "change_pct": None,
+                    "hot_stock_score": 60.0,
+                })
+        return _ensure_hotspot_detail_compat_fields({
+            "topic": topic,
+            "name": self._display_hotspot_name(topic),
+            "canonical_topic": topic,
+            "summary": self._build_hotspot_summary(topic, summary),
+            "route": route,
+            "stocks": stocks[:30],
+            "leader_stocks": stocks[:30],
+            "stock_count": len(stocks),
+            "source_errors": [],
+        })
+
+    def _fetch_board_changes(self) -> Any:
+        import pandas as pd
+
+        if self._board_changes_frame_cache is not None:
+            return self._board_changes_frame_cache.copy()
+
+        df = self._fetch_board_changes_raw()
+        if df is None or df.empty:
+            return pd.DataFrame()
+        rows = []
+        for index, row in df.iterrows():
+            topic = _env_text(row.get("板块名称"))
+            if not topic or self._is_broad_board(topic):
+                continue
+            change_pct = _safe_float(row.get("涨跌幅"))
+            event_count = int(_safe_float(row.get("板块异动总次数")) or 0)
+            leader = _env_text(row.get("板块异动最频繁个股及所属类型-股票名称"))
+            heat_score = min(99.0, max(1.0, event_count / 120.0 + max(change_pct or 0.0, 0.0) * 9.0))
+            trend_score = self._derive_trend_score(change_pct=change_pct, event_count=event_count)
+            persistence_score = self._derive_persistence_score(event_count=event_count)
+            leaders = [leader] if leader else []
+            stage = self._derive_hotspot_stage(change_pct=change_pct, event_count=event_count)
+            rows.append({
+                "name": topic,
+                "change_pct": change_pct,
+                "rank": index + 1,
+                "heat_score": heat_score,
+                "trend_score": trend_score,
+                "persistence_score": persistence_score,
+                "observations": event_count,
+                "state": stage,
+                "stage": stage,
+                "sample_stock_count": len(leaders),
+                "leaders": leaders,
+                "leader": leader,
+                "event_count": event_count,
+            })
+        rows.sort(key=lambda item: (item.get("heat_score") or 0, item.get("event_count") or 0), reverse=True)
+        frame = pd.DataFrame(rows)
+        self._board_changes_frame_cache = frame
+        return frame.copy()
+
+    def _fetch_board_changes_raw(self) -> Any:
+        import akshare as ak
+
+        if self._board_changes_raw_cache is not None:
+            return self._board_changes_raw_cache.copy()
+        df = ak.stock_board_change_em()
+        self._board_changes_raw_cache = df
+        return df.copy() if df is not None else df
+
+    def _fetch_board_changes_with_fallback(self) -> Any:
+        import pandas as pd
+
+        try:
+            return self._fetch_board_changes()
+        except Exception as exc:
+            logger.warning("AlphaSift hotspot board-change fetch failed; falling back to ranking/board names: %s", exc)
+            return pd.DataFrame()
+
+    def _is_broad_board(self, name: str) -> bool:
+        return any(keyword in name for keyword in self._BROAD_BOARD_KEYWORDS)
+
+    def _fetch_rankings(self, source: str) -> Any:
+        import pandas as pd
+
+        manager = _get_dsa_fetcher_manager()
+        fetch = manager.get_concept_rankings if source == "concept" else manager.get_sector_rankings
+        top, _bottom = fetch(100)
+        rows = []
+        for index, item in enumerate(top or []):
+            name = _env_text((item or {}).get("name"))
+            if not name:
+                continue
+            rows.append({
+                "name": name,
+                "change_pct": (item or {}).get("change_pct"),
+                "rank": index + 1,
+            })
+        return pd.DataFrame(rows)
+
+    def _fetch_rankings_with_fallback(self, source: str) -> Any:
+        import pandas as pd
+
+        try:
+            return self._fetch_rankings(source)
+        except Exception as exc:
+            logger.warning("AlphaSift hotspot %s ranking fetch failed; falling back to board names: %s", source, exc)
+            return pd.DataFrame()
+
+    def _fetch_board_names(self, *, source_fs: str) -> Any:
+        import pandas as pd
+
+        params = dict(self._COMMON_PARAMS)
+        params.update({"pz": "100", "fs": source_fs})
+        response = self._eastmoney_get(
+            self._BASE_URL,
+            params=params,
+            timeout=self._HTTP_TIMEOUT_SECONDS,
+            headers={"User-Agent": "Mozilla/5.0", "Accept": "application/json,text/plain,*/*"},
+        )
+        response.raise_for_status()
+        payload = response.json()
+        rows = ((payload.get("data") or {}).get("diff") or []) if isinstance(payload, dict) else []
+        normalized = [
+            {
+                "板块名称": str(row.get("f14") or "").strip(),
+                "涨跌幅": row.get("f3"),
+                "序号": index + 1,
+                "name": str(row.get("f14") or "").strip(),
+                "change_pct": row.get("f3"),
+                "rank": index + 1,
+                "leader": str(row.get("f140") or row.get("f128") or "").strip(),
+                "up_count": row.get("f104"),
+                "down_count": row.get("f105"),
+                "source": "eastmoney_push2_board_spot",
+            }
+            for index, row in enumerate(rows)
+            if str(row.get("f14") or "").strip()
+        ]
+        return pd.DataFrame(normalized)
+
+    def _find_board_change(self, topic: str) -> Dict[str, Any]:
+        df = self._fetch_board_changes_raw()
+        if df is None or df.empty:
+            return {}
+        rows = df[df["板块名称"].astype(str) == topic]
+        if rows.empty:
+            rows = df[df["板块名称"].astype(str).str.contains(re.escape(topic), case=False, na=False)]
+        if rows.empty:
+            return {}
+        return rows.iloc[0].to_dict()
+
+    def _is_industry_hotspot(self, topic: str) -> bool:
+        # EastMoney board-change rows are concept-like hot boards; if the topic is
+        # already in that live change set, avoid an extra industry request.
+        try:
+            concept_frame = self._fetch_board_changes_with_fallback()
+            if self._board_frame_contains_topic(concept_frame, topic):
+                return False
+        except Exception:
+            pass
+        try:
+            frame = self.stock_board_industry_name_em()
+        except Exception as exc:
+            logger.warning(
+                "AlphaSift industry hotspot source check failed for %s; using concept constituents: %s",
+                topic,
+                exc,
+            )
+            return False
+        return self._board_frame_contains_topic(frame, topic)
+
+    def _derive_trend_score(self, *, change_pct: Optional[float], event_count: int) -> float:
+        change_component = max(change_pct or 0.0, 0.0) * 12.0
+        event_component = min(event_count / 8.0, 45.0)
+        return round(min(99.0, max(1.0, change_component + event_component)), 1)
+
+    def _derive_persistence_score(self, *, event_count: int) -> float:
+        return round(min(99.0, max(1.0, event_count / 3.0)), 1)
+
+    def _derive_hotspot_stage(self, *, change_pct: Optional[float], event_count: int) -> str:
+        positive_change = max(change_pct or 0.0, 0.0)
+        if event_count >= 180 and positive_change >= 3.0:
+            return "加速发酵"
+        if event_count >= 90:
+            return "持续发酵"
+        if positive_change >= 5.0:
+            return "快速拉升"
+        return "初次异动"
+
+    def _hotspot_group(self, topic: str) -> str:
+        topic_text = _env_text(topic)
+        for keyword, group in self._METAL_TOPIC_GROUPS.items():
+            if keyword and keyword in topic_text:
+                return group
+        return ""
+
+    def _display_hotspot_name(self, topic: str) -> str:
+        topic_text = _env_text(topic)
+        group = self._hotspot_group(topic_text)
+        if group and topic_text != group:
+            return f"{group} · {topic_text}"
+        return topic_text
+
+    def _board_frame_contains_topic(self, frame: Any, topic: str) -> bool:
+        import pandas as pd
+
+        topic_text = _env_text(topic)
+        if not topic_text:
+            return False
+        df = pd.DataFrame(frame)
+        if df.empty:
+            return False
+        for column in ("name", "板块名称", "行业名称", "名称"):
+            if column not in df.columns:
+                continue
+            values = df[column].map(_env_text)
+            if bool((values == topic_text).any()):
+                return True
+        return False
+
+    def _build_hotspot_summary(self, topic: str, summary: Dict[str, Any]) -> str:
+        if not summary:
+            return f"{topic} 当前暂无可用的板块异动摘要。"
+        change_pct = _safe_float(summary.get("涨跌幅"))
+        event_count = int(_safe_float(summary.get("板块异动总次数")) or 0)
+        leader = _env_text(summary.get("板块异动最频繁个股及所属类型-股票名称"))
+        action = _env_text(summary.get("板块异动最频繁个股及所属类型-买卖方向"))
+        parts = [f"{topic} 当前涨跌幅 {change_pct:.2f}%" if change_pct is not None else f"{topic} 当前有异动记录"]
+        if event_count:
+            parts.append(f"盘中异动 {event_count} 次")
+        if leader:
+            parts.append(f"高频异动个股为 {leader}{f'（{action}）' if action else ''}")
+        return "，".join(parts) + "。"
+
+    def _build_hotspot_route(self, topic: str, summary: Dict[str, Any]) -> List[Dict[str, Any]]:
+        route_by_date: Dict[str, Dict[str, Any]] = {}
+        today = datetime.now().date().isoformat()
+
+        def put_daily_item(*, date: str, title: str, description: str, source: str) -> None:
+            day = date or today
+            existing = route_by_date.get(day)
+            if existing:
+                existing["description"] = f"{existing['description']}；{description}"
+                if source and source not in str(existing.get("source") or ""):
+                    existing["source"] = f"{existing.get('source')},{source}"
+                return
+            route_by_date[day] = {
+                "title": title,
+                "description": description,
+                "source": source,
+                "date": day,
+                "published_at": day,
+            }
+
+        ths_event = self._fetch_ths_summary_event(topic)
+        if ths_event:
+            event_date = self._extract_route_date(ths_event) or today
+            put_daily_item(
+                date=event_date,
+                title="题材驱动",
+                description=ths_event,
+                source="ths_summary",
+            )
+        if summary:
+            change_events = self._parse_change_events(summary.get("板块具体异动类型列表及出现次数"))[:5]
+            event_text = "；".join(f"{item['label']}出现 {item['count']} 次" for item in change_events)
+            description = self._build_hotspot_summary(topic, summary)
+            if event_text:
+                description = f"{description} 当日结构：{event_text}。"
+            put_daily_item(
+                date=today,
+                title="当日发酵",
+                description=description,
+                source="eastmoney_board_change",
+            )
+        route = [
+            route_by_date[date]
+            for date in sorted(route_by_date.keys(), reverse=True)
+        ]
+        if not route:
+            route.append({
+                "title": "等待发酵",
+                "description": "暂未获取到明确催化事件，可继续观察涨跌幅、成交额和核心个股联动。",
+                "source": "fallback",
+                "date": today,
+                "published_at": today,
+            })
+        return route
+
+    def _extract_route_date(self, text: str) -> str:
+        match = re.search(r"(20\d{2})[-/.年](\d{1,2})[-/.月](\d{1,2})", text or "")
+        if not match:
+            return ""
+        year, month, day = match.groups()
+        return f"{year}-{int(month):02d}-{int(day):02d}"
+
+    def _parse_change_events(self, raw: Any) -> List[Dict[str, Any]]:
+        if isinstance(raw, str):
+            try:
+                import ast
+
+                raw = ast.literal_eval(raw)
+            except Exception:
+                raw = []
+        events = []
+        for item in raw or []:
+            if not isinstance(item, dict):
+                continue
+            event_type = int(_safe_float(item.get("t")) or 0)
+            count = int(_safe_float(item.get("ct")) or 0)
+            if not count:
+                continue
+            events.append({
+                "type": event_type,
+                "label": self._CHANGE_EVENT_LABELS.get(event_type, f"异动类型 {event_type}"),
+                "count": count,
+            })
+        return sorted(events, key=lambda item: item["count"], reverse=True)
+
+    def _fetch_ths_summary_event(self, topic: str) -> str:
+        import akshare as ak
+
+        try:
+            df = ak.stock_board_concept_summary_ths()
+        except Exception:
+            return ""
+        if df is None or df.empty:
+            return ""
+        if "概念名称" not in df.columns:
+            logger.warning(
+                "AlphaSift THS summary missing required column '概念名称'; skip enrichment.",
+            )
+            return ""
+        rows = df[df["概念名称"].astype(str) == topic]
+        if rows.empty:
+            rows = df[df["概念名称"].astype(str).str.contains(re.escape(topic), case=False, na=False)]
+        if rows.empty:
+            return ""
+        row = rows.iloc[0]
+        date = _env_text(row.get("日期"))
+        event = _env_text(row.get("驱动事件"))
+        return f"{date}：{event}" if date and event else event
+
+    def _fetch_ths_info(self, topic: str) -> Dict[str, str]:
+        import akshare as ak
+
+        try:
+            df = ak.stock_board_concept_info_ths(symbol=topic)
+        except Exception:
+            return {}
+        if df is None or df.empty or "项目" not in df.columns or "值" not in df.columns:
+            return {}
+        return {
+            _env_text(row.get("项目")): _env_text(row.get("值"))
+            for _, row in df.iterrows()
+            if _env_text(row.get("项目"))
+        }
+
+    def _fetch_eastmoney_constituents(self, topic: str, *, source: str) -> Any:
+        import akshare as ak
+
+        try:
+            if source == "industry":
+                return ak.stock_board_industry_cons_em(symbol=topic)
+            return ak.stock_board_concept_cons_em(symbol=topic)
+        except Exception:
+            return None
+
+    def _fetch_ths_constituents(self, topic: str) -> Any:
+        import pandas as pd
+        import requests
+
+        code = self._resolve_ths_concept_code(topic)
+        if not code:
+            return pd.DataFrame()
+        url = f"http://q.10jqka.com.cn/gn/detail/code/{code}/"
+        response = requests.get(
+            url,
+            headers={"User-Agent": "Mozilla/5.0", "Referer": "http://q.10jqka.com.cn/gn/"},
+            timeout=self._HTTP_TIMEOUT_SECONDS,
+        )
+        response.raise_for_status()
+        html = response.content.decode("gbk", "ignore")
+        rows = []
+        seen = set()
+        for match in re.finditer(r">(\d{6})<.*?>([^<>\n]{2,12})<", html, re.S):
+            code_text = match.group(1)
+            name_text = re.sub(r"\s+", "", match.group(2))
+            if code_text in seen or not name_text or re.search(r"\d", name_text):
+                continue
+            seen.add(code_text)
+            rows.append({"code": code_text, "name": name_text})
+            if len(rows) >= 80:
+                break
+        return pd.DataFrame(rows)
+
+    def _resolve_ths_concept_code(self, topic: str) -> str:
+        import akshare as ak
+
+        try:
+            df = ak.stock_board_concept_name_ths()
+        except Exception:
+            return ""
+        if df is None or df.empty:
+            return ""
+        rows = df[df["name"].astype(str) == topic]
+        if rows.empty:
+            rows = df[df["name"].astype(str).str.contains(re.escape(topic), case=False, na=False)]
+        if rows.empty and topic.endswith("概念"):
+            base = topic[:-2]
+            rows = df[df["name"].astype(str).str.contains(re.escape(base), case=False, na=False)]
+        if rows.empty:
+            return ""
+        return _env_text(rows.iloc[0].get("code"))
+
+    def _fallback_constituents(self, topic: str) -> Any:
+        import pandas as pd
+
+        try:
+            summary = self._find_board_change(topic)
+        except Exception as exc:
+            logger.warning(
+                "AlphaSift board-change constituent fallback failed for %s; trying other sources: %s",
+                topic,
+                exc,
+            )
+            return pd.DataFrame()
+        code = _env_text(summary.get("板块异动最频繁个股及所属类型-股票代码"))
+        name = _env_text(summary.get("板块异动最频繁个股及所属类型-股票名称"))
+        if not code and not name:
+            return pd.DataFrame()
+        return pd.DataFrame([{
+            "code": code,
+            "name": name,
+            "change_pct": None,
+            "hot_stock_score": 60.0,
+        }])
+
+    def _related_hotspot_constituents(self, topic: str) -> Any:
+        import pandas as pd
+
+        group = self._hotspot_group(topic)
+        if not group:
+            return pd.DataFrame()
+        try:
+            raw = self._fetch_board_changes_raw()
+        except Exception:
+            return pd.DataFrame()
+        df = pd.DataFrame(raw)
+        if df.empty:
+            return pd.DataFrame()
+        rows: List[Dict[str, Any]] = []
+        seen: set[str] = set()
+        for _, row in df.iterrows():
+            board_name = _env_text(row.get("板块名称"))
+            if not board_name or self._hotspot_group(board_name) != group:
+                continue
+            code = _env_text(row.get("板块异动最频繁个股及所属类型-股票代码"))
+            name = _env_text(row.get("板块异动最频繁个股及所属类型-股票名称"))
+            if not code and not name:
+                continue
+            key = code or name
+            if key in seen:
+                continue
+            seen.add(key)
+            rows.append({
+                "code": code,
+                "name": name,
+                "change_pct": _safe_float(row.get("涨跌幅")),
+                "role": f"{group}活跃股",
+                "hot_stock_score": 35.0,
+                "source": "eastmoney_board_change.related_group",
+            })
+            if len(rows) >= 12:
+                break
+        return pd.DataFrame(rows)
+
+    def _get_constituent_cache(self, source: str, topic: str) -> Any:
+        import pandas as pd
+
+        if not hasattr(self, "_constituent_cache"):
+            self._constituent_cache = {}
+        frame = self._constituent_cache.get((source, _env_text(topic)))
+        if frame is None:
+            return None
+        return pd.DataFrame(frame).copy()
+
+    def _set_constituent_cache(self, source: str, topic: str, frame: Any) -> None:
+        import pandas as pd
+
+        if not hasattr(self, "_constituent_cache"):
+            self._constituent_cache = {}
+        self._constituent_cache[(source, _env_text(topic))] = pd.DataFrame(frame).copy()
+
+    def _merge_constituent_frames(self, frames: List[Any]) -> Any:
+        import pandas as pd
+
+        merged: List[Dict[str, Any]] = []
+        seen: set[str] = set()
+        for frame in frames:
+            df = pd.DataFrame(frame)
+            if df.empty:
+                continue
+            for _, row in df.iterrows():
+                code = _env_text(row.get("code") or row.get("代码") or row.get("证券代码"))
+                name = _env_text(row.get("name") or row.get("名称") or row.get("股票名称"))
+                if not code and not name:
+                    continue
+                key = code or name
+                if key in seen:
+                    continue
+                seen.add(key)
+                record = row.to_dict()
+                record.setdefault("code", code)
+                record.setdefault("name", name)
+                merged.append(record)
+        return pd.DataFrame(merged)
+
+    def _enrich_constituent_quotes(self, stocks: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+        codes = [str(item.get("code") or "").strip() for item in stocks if item.get("code")]
+        codes = [code for code in codes if code][:12]
+        if len(codes) < 4:
+            return stocks
+        try:
+            manager = _get_dsa_fetcher_manager()
+            manager.prefetch_realtime_quotes(codes)
+        except Exception as exc:
+            logger.debug("AlphaSift hotspot quote prefetch skipped: %s", exc)
+            return stocks
+        quote_by_code: Dict[str, Any] = {}
+        for code in codes:
+            try:
+                quote = manager.get_realtime_quote(code, log_final_failure=False)
+            except Exception:
+                quote = None
+            if quote is not None:
+                quote_by_code[code] = quote
+        if not quote_by_code:
+            return stocks
+        enriched: List[Dict[str, Any]] = []
+        for item in stocks:
+            next_item = dict(item)
+            code = str(next_item.get("code") or "").strip()
+            quote = quote_by_code.get(code)
+            if quote is not None:
+                if next_item.get("change_pct") is None:
+                    next_item["change_pct"] = _safe_float(getattr(quote, "change_pct", None))
+                if next_item.get("amount") is None:
+                    next_item["amount"] = _safe_float(getattr(quote, "amount", None))
+                if next_item.get("turnover_rate") is None:
+                    next_item["turnover_rate"] = _safe_float(getattr(quote, "turnover_rate", None))
+                if next_item.get("volume_ratio") is None:
+                    next_item["volume_ratio"] = _safe_float(getattr(quote, "volume_ratio", None))
+                if next_item.get("hot_stock_score") in (None, 0.0):
+                    next_item["hot_stock_score"] = min(99.0, max(1.0, abs(next_item.get("change_pct") or 0.0) * 8.0))
+            enriched.append(next_item)
+        return enriched
+
+    def _normalize_constituent_records(self, frame: Any) -> List[Dict[str, Any]]:
+        import pandas as pd
+
+        df = pd.DataFrame(frame)
+        if df.empty:
+            return []
+        records = []
+        for _, row in df.iterrows():
+            code = _env_text(row.get("code") or row.get("代码") or row.get("证券代码"))
+            name = _env_text(row.get("name") or row.get("名称") or row.get("股票名称"))
+            if not code and not name:
+                continue
+            records.append({
+                "code": code,
+                "name": name,
+                "change_pct": _safe_float(row.get("change_pct") or row.get("涨跌幅") or row.get("涨幅")),
+                "amount": _safe_float(row.get("amount") or row.get("成交额") or row.get("成交金额")),
+                "turnover_rate": _safe_float(row.get("turnover_rate") or row.get("换手率")),
+                "volume_ratio": _safe_float(row.get("volume_ratio") or row.get("量比")),
+                "role": _env_text(row.get("role")) or "概念股",
+                "hot_stock_score": _safe_float(row.get("hot_stock_score")) or 0.0,
+            })
+        return records
+
+
+def _build_alphasift_context(config: Config, *, max_results: Optional[int] = None) -> Dict[str, Any]:
+    # context.llm.model/fallback/model_list 与 LiteLLM 路由语义保持一致，
+    # 参见 https://docs.litellm.ai/docs/proxy/configs#the-model_list-key
+    channels = _normalize_dsa_llm_channels(config)
+    litellm_model, fallback_models = _resolve_alphasift_llm_models(config)
+    return {
+        "llm": {
+            "model": litellm_model,
+            "fallback_models": fallback_models,
+            "temperature": config.llm_temperature,
+            "channels": channels,
+            "model_list": _build_alphasift_litellm_model_list(config, channels),
+            "litellm_config_path": config.litellm_config_path or "",
+            "candidate_context_enabled": False,
+            "candidate_multiplier": DSA_ALPHASIFT_LLM_CANDIDATE_MULTIPLIER,
+            "max_candidates": _resolve_dsa_llm_max_candidates(max_results),
+        },
+        "dsa": {
+            "contract_version": "1",
+            "mode": "pre_rank_light",
+            "max_candidates": DSA_PRE_RANK_CONTEXT_MAX_CANDIDATES,
+            "include_news": False,
+            "news_max_results": 0,
+            "capabilities": [
+                "candidate_context",
+                "daily_history",
+                "realtime_quote",
+                "fundamental_context",
+            ],
+            "get_candidate_context": get_dsa_candidate_context,
+            "get_daily_history": get_dsa_daily_history,
+            "get_realtime_quote": get_dsa_realtime_quote,
+            "get_fundamental_context": get_dsa_fundamental_context,
+        },
+    }
+
+@contextmanager
+def _alphasift_litellm_headers(config: Config) -> Iterator[None]:
+    header_routes = _build_alphasift_litellm_header_routes(config)
+    if not header_routes:
+        yield
+        return
+
+    try:
+        litellm_module = importlib.import_module("litellm")
+    except Exception:
+        yield
+        return
+
+    completion = getattr(litellm_module, "completion", None)
+    if not callable(completion):
+        yield
+        return
+
+    bridge_completion = getattr(completion, _ALPHASIFT_LITELLM_COMPLETION_ATTR, None)
+    if bridge_completion:
+        token = _ALPHASIFT_LITELLM_COMPLETION_ROUTES.set(
+            tuple(route.copy() for route in header_routes),
+        )
+        try:
+            yield
+        finally:
+            _ALPHASIFT_LITELLM_COMPLETION_ROUTES.reset(token)
+        return
+
+    original_completion = completion
+
+    def completion_with_dsa_headers(*args: Any, **kwargs: Any) -> Any:
+        routes = _ALPHASIFT_LITELLM_COMPLETION_ROUTES.get()
+        if routes:
+            headers = _match_alphasift_litellm_headers(args, kwargs, routes)
+            if headers:
+                existing_headers = kwargs.get("extra_headers")
+                if isinstance(existing_headers, dict):
+                    merged_headers = dict(headers)
+                    merged_headers.update(existing_headers)
+                    kwargs = dict(kwargs)
+                    kwargs["extra_headers"] = merged_headers
+                elif existing_headers in (None, ""):
+                    kwargs = dict(kwargs)
+                    kwargs["extra_headers"] = dict(headers)
+        return original_completion(*args, **kwargs)
+
+    setattr(completion_with_dsa_headers, _ALPHASIFT_LITELLM_COMPLETION_ATTR, True)
+    setattr(completion_with_dsa_headers, "_alphasift_litellm_completion_original", original_completion)
+    completion_with_dsa_headers.__name__ = "completion_with_dsa_headers"
+
+    if completion is not completion_with_dsa_headers:
+        with _ALPHASIFT_LITELLM_COMPLETION_LOCK:
+            if not getattr(getattr(litellm_module, "completion", None), _ALPHASIFT_LITELLM_COMPLETION_ATTR, False):
+                setattr(litellm_module, "completion", completion_with_dsa_headers)
+
+    token = _ALPHASIFT_LITELLM_COMPLETION_ROUTES.set(
+        tuple(route.copy() for route in header_routes),
+    )
+    try:
+        yield
+    finally:
+        _ALPHASIFT_LITELLM_COMPLETION_ROUTES.reset(token)
+
+
+def _build_alphasift_litellm_model_list(config: Config, channels: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    explicit_model_list = _to_plain(config.llm_model_list or [])
+    if isinstance(explicit_model_list, list) and explicit_model_list:
+        return explicit_model_list
+    return _channel_litellm_model_list(channels)
+
+
+def _channel_litellm_model_list(channels: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    model_list_builder = getattr(Config, "_channels_to_model_list", None)
+    if callable(model_list_builder):
+        return _to_plain(model_list_builder(channels))
+
+    model_list: List[Dict[str, Any]] = []
+    for channel in channels:
+        headers = dict(channel.get("extra_headers") or {})
+        base_url = _env_text(channel.get("base_url"))
+        for model_name in channel.get("models") or []:
+            for api_key in channel.get("api_keys") or []:
+                litellm_params: Dict[str, Any] = {"model": model_name}
+                if api_key:
+                    litellm_params["api_key"] = api_key
+                if base_url:
+                    litellm_params["api_base"] = base_url
+                if headers:
+                    litellm_params["extra_headers"] = dict(headers)
+                model_list.append({"model_name": model_name, "litellm_params": litellm_params})
+    return model_list
+
+
+def _build_alphasift_litellm_header_routes(config: Config) -> List[Dict[str, Any]]:
+    channels = _normalize_dsa_llm_channels(config)
+    model_list = _build_alphasift_litellm_model_list(config, channels)
+    routes: List[Dict[str, Any]] = []
+    for entry in model_list:
+        if not isinstance(entry, dict):
+            continue
+        params = entry.get("litellm_params") or {}
+        if not isinstance(params, dict):
+            continue
+        headers = params.get("extra_headers")
+        if not isinstance(headers, dict) or not headers:
+            continue
+        model_names = _dedupe_strings([
+            entry.get("model_name"),
+            params.get("model"),
+        ])
+        if not model_names:
+            continue
+        routes.append(
+            {
+                "models": model_names,
+                "api_key": _env_text(params.get("api_key")),
+                "api_base": _env_text(params.get("api_base") or params.get("base_url")),
+                "extra_headers": dict(headers),
+            }
+        )
+    return routes
+
+
+def _match_alphasift_litellm_headers(
+    args: Tuple[Any, ...],
+    kwargs: Dict[str, Any],
+    routes: List[Dict[str, Any]],
+) -> Dict[str, Any]:
+    model = _env_text(kwargs.get("model"))
+    if not model and args:
+        model = _env_text(args[0])
+    if not model:
+        return {}
+
+    api_key = _env_text(kwargs.get("api_key"))
+    api_base = _env_text(kwargs.get("api_base") or kwargs.get("base_url"))
+    for route in routes:
+        if model not in set(route.get("models") or []):
+            continue
+        route_api_key = _env_text(route.get("api_key"))
+        if route_api_key and api_key and route_api_key != api_key:
+            continue
+        route_api_base = _env_text(route.get("api_base"))
+        if route_api_base and api_base and route_api_base != api_base:
+            continue
+        headers = route.get("extra_headers")
+        return dict(headers) if isinstance(headers, dict) else {}
+    return {}
+
+
+def _resolve_dsa_llm_max_candidates(max_results: Optional[int]) -> int:
+    requested = max_results if isinstance(max_results, int) and max_results > 0 else DSA_ENRICHMENT_MAX_CANDIDATES
+    return min(
+        DSA_ALPHASIFT_LLM_MAX_CANDIDATES,
+        max(requested, requested * DSA_ALPHASIFT_LLM_CANDIDATE_MULTIPLIER),
+    )
+
+
+def _resolve_alphasift_llm_models(config: Config) -> Tuple[str, List[str]]:
+    primary = _env_text(config.litellm_model)
+    configured_models = get_configured_llm_models(config.llm_model_list or [])
+    configured_model_set = set(configured_models)
+
+    if configured_models and (
+        not primary or (primary not in configured_model_set and _is_managed_litellm_model(primary))
+    ):
+        primary = configured_models[0]
+
+    raw_fallbacks = _dedupe_strings(config.litellm_fallback_models or [])
+    if not configured_models:
+        return primary, [model for model in raw_fallbacks if model != primary]
+
+    fallback_models: List[str] = []
+    seen = {primary} if primary else set()
+
+    for model in raw_fallbacks:
+        if model in seen:
+            continue
+        if model in configured_model_set or not _is_managed_litellm_model(model):
+            fallback_models.append(model)
+            seen.add(model)
+
+    for model in configured_models:
+        if model and model not in seen:
+            fallback_models.append(model)
+            seen.add(model)
+
+    return primary, fallback_models
+
+
+def _is_managed_litellm_model(model: str) -> bool:
+    text = _env_text(model)
+    if not text:
+        return False
+    provider = text.split("/", 1)[0].lower() if "/" in text else "openai"
+    return provider in ALPHASIFT_MANAGED_LITELLM_PROVIDERS
+
+
+def _normalize_dsa_llm_channels(config: Config) -> List[Dict[str, Any]]:
+    channels: List[Dict[str, Any]] = []
+    for index, raw in enumerate(config.llm_channels or []):
+        if not isinstance(raw, dict):
+            continue
+        name = _env_text(raw.get("name")) or f"channel{index + 1}"
+        api_keys = _dedupe_strings(raw.get("api_keys") if isinstance(raw.get("api_keys"), list) else [])
+        models = _dedupe_strings(raw.get("models") if isinstance(raw.get("models"), list) else [])
+        channel = {
+            "name": name,
+            "protocol": _env_text(raw.get("protocol")),
+            "base_url": _env_text(raw.get("base_url")),
+            "api_keys": api_keys,
+            "models": models,
+            "extra_headers": raw.get("extra_headers") if isinstance(raw.get("extra_headers"), dict) else {},
+            "enabled": bool(raw.get("enabled", True)),
+        }
+        if channel["enabled"] and (api_keys or models or channel["base_url"] or channel["extra_headers"]):
+            channels.append(channel)
+    return channels
+
+
+def _channel_keys_for_provider(channels: List[Dict[str, Any]], providers: set[str]) -> List[str]:
+    keys: List[str] = []
+    for channel in channels:
+        protocol = _env_text(channel.get("protocol")).lower()
+        models = channel.get("models") or []
+        model_providers = {
+            str(model).split("/", 1)[0].lower()
+            for model in models
+            if isinstance(model, str) and "/" in model
+        }
+        if protocol in providers or model_providers.intersection(providers):
+            keys.extend(channel.get("api_keys") or [])
+    return keys
+
+
+def _first_channel_base_url(channels: List[Dict[str, Any]], providers: set[str]) -> str:
+    for channel in channels:
+        protocol = _env_text(channel.get("protocol")).lower()
+        base_url = _env_text(channel.get("base_url"))
+        if base_url and protocol in providers:
+            return base_url
+    return ""
+
+
+def _put_provider_keys(env: Dict[str, str], provider: str, keys: List[str]) -> None:
+    if not keys:
+        return
+    env[f"{provider}_API_KEYS"] = ",".join(keys)
+    env[f"{provider}_API_KEY"] = keys[0]
+
+
+def _dedupe_strings(values: Any) -> List[str]:
+    result: List[str] = []
+    seen: set[str] = set()
+    if not isinstance(values, list):
+        return result
+    for value in values:
+        text = _env_text(value)
+        if not text or text in seen:
+            continue
+        result.append(text)
+        seen.add(text)
+    return result
+
+
+def _env_text(value: Any) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, float) and not math.isfinite(value):
+        return ""
+    text = str(value).strip()
+    if text.lower() in {"nan", "none", "null"}:
+        return ""
+    return text
+
+
+def _get_dsa_fetcher_manager() -> Any:
+    global _DSA_FETCHER_MANAGER
+    if _DSA_FETCHER_MANAGER is None:
+        with _DSA_FETCHER_MANAGER_LOCK:
+            if _DSA_FETCHER_MANAGER is None:
+                from data_provider import DataFetcherManager
+
+                _DSA_FETCHER_MANAGER = DataFetcherManager()
+    return _DSA_FETCHER_MANAGER
+
+
+def _get_dsa_search_service() -> Any:
+    from src.search_service import get_search_service
+
+    return get_search_service()
+
+
+def get_dsa_daily_history(stock_code: str, *, lookback_days: int = 120) -> Tuple[Any, str]:
+    from src.services.history_loader import load_history_df
+
+    normalized_code = _env_text(stock_code).zfill(6)
+    days = max(int(lookback_days or 0), 30)
+    return load_history_df(normalized_code, days=days)
+
+
+def _normalize_dsa_daily_history(raw_df: Any) -> Any:
+    if raw_df is None:
+        return None
+
+    import pandas as pd
+
+    df = pd.DataFrame(raw_df).copy()
+    if df.empty:
+        return df
+
+    aliases = {
+        "date": ("date", "trade_date", "datetime", "日期"),
+        "open": ("open", "开盘"),
+        "high": ("high", "最高"),
+        "low": ("low", "最低"),
+        "close": ("close", "收盘", "price"),
+        "volume": ("volume", "vol", "成交量"),
+        "amount": ("amount", "成交额"),
+    }
+    normalized = pd.DataFrame(index=df.index)
+    for target, candidates in aliases.items():
+        source_column = next((column for column in candidates if column in df.columns), None)
+        if source_column is not None:
+            normalized[target] = df[source_column]
+
+    if "close" not in normalized.columns:
+        return pd.DataFrame()
+    for column in ("open", "high", "low"):
+        if column not in normalized.columns:
+            normalized[column] = normalized["close"]
+    if "volume" not in normalized.columns:
+        normalized["volume"] = 0
+
+    if "date" in normalized.columns:
+        normalized["date"] = normalized["date"].map(_normalize_daily_date_value)
+
+    for column in ("open", "high", "low", "close", "volume", "amount"):
+        if column in normalized.columns:
+            normalized[column] = pd.to_numeric(normalized[column], errors="coerce")
+    normalized = normalized.dropna(subset=["close"])
+    return normalized.reset_index(drop=True)
+
+
+def _normalize_daily_date_value(value: Any) -> str:
+    text = _env_text(value)
+    if len(text) == 8 and text.isdigit():
+        return f"{text[:4]}-{text[4:6]}-{text[6:]}"
+    return text
+
+
+def get_dsa_realtime_quote(stock_code: str) -> Dict[str, Any]:
+    manager = _get_dsa_fetcher_manager()
+    quote = manager.get_realtime_quote(stock_code, log_final_failure=False)
+    if quote is None:
+        return {}
+    if hasattr(quote, "to_dict") and callable(quote.to_dict):
+        return _remove_non_finite_json_values(quote.to_dict())
+    payload = _to_plain(quote)
+    return _remove_non_finite_json_values(payload if isinstance(payload, dict) else {})
+
+
+def get_dsa_fundamental_context(stock_code: str) -> Dict[str, Any]:
+    manager = _get_dsa_fetcher_manager()
+    context = manager.get_fundamental_context(stock_code, budget_seconds=4.0)
+    return _compact_fundamental_context(_remove_non_finite_json_values(_to_plain(context)))
+
+
+def search_dsa_stock_news(stock_code: str, stock_name: str = "", max_results: int = 3) -> Dict[str, Any]:
+    service = _get_dsa_search_service()
+    if not getattr(service, "is_available", False):
+        return {
+            "success": False,
+            "error": "DSA search service unavailable",
+            "results": [],
+        }
+
+    response = service.search_stock_news(stock_code, stock_name or stock_code, max_results=max_results)
+    results = []
+    for item in getattr(response, "results", []) or []:
+        results.append(
+            {
+                "title": getattr(item, "title", ""),
+                "snippet": getattr(item, "snippet", ""),
+                "url": getattr(item, "url", ""),
+                "source": getattr(item, "source", ""),
+                "published_date": getattr(item, "published_date", None),
+            }
+        )
+    return _remove_non_finite_json_values(
+        {
+            "query": getattr(response, "query", ""),
+            "provider": getattr(response, "provider", ""),
+            "success": bool(getattr(response, "success", False)),
+            "error": getattr(response, "error_message", None),
+            "results": results,
+        }
+    )
+
+
+def get_dsa_candidate_context(
+    stock_code: str,
+    stock_name: str = "",
+    *,
+    include_news: bool = False,
+    include_fundamentals: bool = True,
+    mode: str = "pre_rank_light",
+) -> Dict[str, Any]:
+    candidate = {"code": stock_code, "name": stock_name, "raw": {}}
+    context = _build_dsa_candidate_context(
+        candidate,
+        include_news=include_news,
+        include_fundamentals=include_fundamentals,
+        profile=mode or "pre_rank_light",
+    )
+    return context.get("dsa_context", {})
+
+
+def _enrich_candidates_with_dsa(candidates: List[Dict[str, Any]]) -> Tuple[List[Dict[str, Any]], Dict[str, Any]]:
+    enriched_count = 0
+    warnings: List[str] = []
+    limit = min(len(candidates), DSA_ENRICHMENT_MAX_CANDIDATES)
+
+    for index, candidate in enumerate(candidates):
+        if index >= limit:
+            continue
+        existing_context = candidate.get("dsa_context")
+        if (
+            isinstance(existing_context, dict)
+            and existing_context.get("enriched")
+            and _candidate_has_dsa_news(candidate)
+        ):
+            enriched_count += 1
+            existing_warnings = existing_context.get("warnings") or []
+            if isinstance(existing_warnings, list):
+                warnings.extend(str(item) for item in existing_warnings if item)
+            elif existing_warnings:
+                warnings.append(str(existing_warnings))
+            continue
+        try:
+            enriched = _build_dsa_candidate_context(
+                candidate,
+                include_news=True,
+                include_fundamentals=True,
+                profile="post_rank_full",
+            )
+            candidate.update(enriched)
+            if enriched.get("dsa_context", {}).get("enriched"):
+                enriched_count += 1
+            warnings.extend(enriched.get("dsa_context", {}).get("warnings") or [])
+        except Exception as exc:  # noqa: BLE001 - DSA enrichment must not block screening.
+            code = candidate.get("code") or f"rank-{candidate.get('rank', index + 1)}"
+            message = f"{code}: {exc}"
+            warnings.append(message)
+            logger.warning("DSA enrichment failed for AlphaSift candidate %s: %s", code, exc)
+            candidate["dsa_context"] = {
+                "enriched": False,
+                "warnings": [message],
+            }
+
+    return candidates, {
+        "enabled": True,
+        "max_candidates": DSA_ENRICHMENT_MAX_CANDIDATES,
+        "requested_count": limit,
+        "enriched_count": enriched_count,
+        "warnings": _dedupe_strings(warnings),
+    }
+
+
+def _candidate_has_dsa_news(candidate: Dict[str, Any]) -> bool:
+    news_items = candidate.get("dsa_news")
+    if isinstance(news_items, list) and any(isinstance(item, dict) for item in news_items):
+        return True
+    context = candidate.get("dsa_context")
+    if not isinstance(context, dict):
+        return False
+    return _news_has_results(context.get("news"))
+
+
+def _news_has_results(news: Any) -> bool:
+    if isinstance(news, dict):
+        results = news.get("results")
+        return isinstance(results, list) and any(isinstance(item, dict) for item in results)
+    if isinstance(news, list):
+        return any(isinstance(item, dict) for item in news)
+    return False
+
+
+def _build_dsa_candidate_context(
+    candidate: Dict[str, Any],
+    *,
+    include_news: bool = True,
+    include_fundamentals: bool = True,
+    profile: str = "post_rank_full",
+) -> Dict[str, Any]:
+    code = _env_text(candidate.get("code"))
+    name = _env_text(candidate.get("name"))
+    warnings: List[str] = []
+    if not code:
+        return {
+            "dsa_context": {
+                "enriched": False,
+                "warnings": ["missing candidate code"],
+            }
+        }
+
+    existing_context = candidate.get("dsa_context")
+    if not isinstance(existing_context, dict):
+        existing_context = {}
+
+    quote = existing_context.get("quote") if isinstance(existing_context.get("quote"), dict) else {}
+    fundamentals = (
+        existing_context.get("fundamentals")
+        if isinstance(existing_context.get("fundamentals"), dict)
+        else {}
+    )
+    existing_news = existing_context.get("news") if isinstance(existing_context.get("news"), dict) else {}
+    news: Dict[str, Any] = dict(existing_news) if existing_news else {"success": False, "results": []}
+    existing_warnings = existing_context.get("warnings") or []
+    if isinstance(existing_warnings, list):
+        warnings.extend(str(item) for item in existing_warnings if item)
+    elif existing_warnings:
+        warnings.append(str(existing_warnings))
+
+    try:
+        manager = _get_dsa_fetcher_manager()
+        resolved_name = manager.get_stock_name(code, allow_realtime=False)
+        if resolved_name and (not name or name == code):
+            name = resolved_name
+            candidate["name"] = resolved_name
+    except Exception as exc:  # noqa: BLE001
+        warnings.append(f"stock_name_failed: {exc}")
+
+    if not quote:
+        try:
+            quote = get_dsa_realtime_quote(code)
+            if not quote:
+                warnings.append("realtime_quote_missing")
+        except Exception as exc:  # noqa: BLE001
+            warnings.append(f"realtime_quote_failed: {exc}")
+            quote = {}
+
+    if quote:
+        candidate["price"] = _first_non_empty(candidate.get("price"), quote.get("price"))
+        candidate["change_pct"] = _first_non_empty(candidate.get("change_pct"), quote.get("change_pct"))
+        candidate["amount"] = _first_non_empty(candidate.get("amount"), quote.get("amount"))
+        if not candidate.get("name") and quote.get("name"):
+            candidate["name"] = quote.get("name")
+
+    if include_fundamentals and not fundamentals:
+        try:
+            fundamentals = get_dsa_fundamental_context(code)
+        except Exception as exc:  # noqa: BLE001
+            warnings.append(f"fundamental_context_failed: {exc}")
+            fundamentals = {}
+
+    if include_news:
+        if not _news_has_results(news):
+            try:
+                news = search_dsa_stock_news(code, _env_text(candidate.get("name")) or name or code, max_results=3)
+                if not news.get("success"):
+                    warnings.append(news.get("error") or "stock_news_unavailable")
+            except Exception as exc:  # noqa: BLE001
+                warnings.append(f"stock_news_failed: {exc}")
+                news = {"success": False, "error": str(exc), "results": []}
+    elif not _news_has_results(news):
+        news = {
+            "success": False,
+            "skipped": True,
+            "reason": "pre_rank_light_context",
+            "results": [],
+        }
+
+    summary = _build_dsa_analysis_summary(candidate, quote, fundamentals, news)
+    context = {
+        "enriched": bool(quote or fundamentals or news.get("results")),
+        "profile": profile,
+        "news_included": bool(include_news),
+        "quote": quote,
+        "fundamentals": fundamentals,
+        "news": news,
+        "warnings": _dedupe_strings(warnings),
+    }
+    return {
+        "dsa_context": context,
+        "dsa_news": news.get("results") or [],
+        "dsa_analysis_summary": summary,
+    }
+
+
+def _first_non_empty(*values: Any) -> Any:
+    for value in values:
+        if value not in (None, ""):
+            return value
+    return None
+
+
+def _compact_fundamental_context(context: Any) -> Dict[str, Any]:
+    if not isinstance(context, dict):
+        return {}
+    compact: Dict[str, Any] = {
+        "market": context.get("market"),
+        "status": context.get("status"),
+        "coverage": context.get("coverage") if isinstance(context.get("coverage"), dict) else {},
+    }
+    for block in _FUNDAMENTAL_BLOCKS:
+        payload = context.get(block)
+        if isinstance(payload, dict):
+            compact[block] = {
+                "status": payload.get("status"),
+                "data": payload.get("data") if isinstance(payload.get("data"), dict) else {},
+            }
+    errors = context.get("errors")
+    if isinstance(errors, list) and errors:
+        compact["errors"] = [str(item) for item in errors[:3]]
+    return compact
+
+
+def _build_dsa_analysis_summary(
+    candidate: Dict[str, Any],
+    quote: Dict[str, Any],
+    fundamentals: Dict[str, Any],
+    news: Dict[str, Any],
+) -> str:
+    parts: List[str] = []
+    price = _first_non_empty(quote.get("price"), candidate.get("price"))
+    change_pct = _first_non_empty(quote.get("change_pct"), candidate.get("change_pct"))
+    if price is not None:
+        text = f"DSA行情：现价 {price}"
+        if change_pct is not None:
+            text += f"，涨跌幅 {change_pct}%"
+        parts.append(text)
+
+    coverage = fundamentals.get("coverage") if isinstance(fundamentals, dict) else {}
+    if isinstance(coverage, dict) and coverage:
+        available_blocks = [key for key, value in coverage.items() if str(value).lower() in {"available", "partial"}]
+        if available_blocks:
+            parts.append(f"DSA基本面覆盖：{', '.join(available_blocks[:4])}")
+
+    news_results = news.get("results") if isinstance(news, dict) else []
+    if isinstance(news_results, list) and news_results:
+        titles = [str(item.get("title") or "").strip() for item in news_results if isinstance(item, dict)]
+        titles = [title for title in titles if title]
+        if titles:
+            parts.append(f"DSA新闻：{'；'.join(titles[:2])}")
+
+    if not parts:
+        return ""
+    return "；".join(parts)
+
+
+def _ensure_supported_market(market: str) -> None:
+    status = _call_alphasift_status()
+    supported_markets = status.get("supported_markets") or status.get("markets") or status.get("market")
+    if not supported_markets:
+        return
+
+    normalized: List[Any]
+    if isinstance(supported_markets, str):
+        normalized = [supported_markets]
+    elif isinstance(supported_markets, (list, tuple, set)):
+        normalized = list(supported_markets)
+    else:
+        normalized = []
+
+    if market not in normalized:
+        raise HTTPException(
+            status_code=422,
+            detail={
+                "error": "alphasift_invalid_market",
+                "message": (
+                    f"市场 {market} 不在 AlphaSift 适配层支持范围内"
+                    f"（支持市场：{', '.join(map(str, normalized)) or '未知'}）。"
+                ),
+            },
+        )
+
+
+def _normalize_candidates(raw: Any) -> List[Dict[str, Any]]:
+    data = _to_plain(raw)
+    items = data
+    if isinstance(data, dict):
+        for key in ("candidates", "picks", "items", "results", "stocks"):
+            if isinstance(data.get(key), list):
+                items = data[key]
+                break
+    if not isinstance(items, list):
+        return []
+    return [_normalize_candidate(item, index + 1) for index, item in enumerate(items)]
+
+
+def _normalize_candidate(raw: Any, rank: int) -> Dict[str, Any]:
+    item = _remove_non_finite_json_values(_to_plain(raw))
+    if not isinstance(item, dict):
+        item = {"code": str(item)}
+    source = item.get("raw") if isinstance(item.get("raw"), dict) else item
+    dsa_context = item.get("dsa_context") or source.get("dsa_context") or {}
+    dsa_news = item.get("dsa_news") or source.get("dsa_news") or _extract_dsa_news_from_context(dsa_context)
+    dsa_analysis_summary = (
+        item.get("dsa_analysis_summary")
+        or source.get("dsa_analysis_summary")
+        or _extract_dsa_analysis_summary_from_context(dsa_context)
+    )
+    return {
+        "rank": item.get("rank") or source.get("rank") or rank,
+        "code": item.get("code") or source.get("code") or item.get("symbol") or source.get("symbol") or item.get("stock_code") or source.get("stock_code") or "",
+        "name": item.get("name") or source.get("name") or item.get("stock_name") or source.get("stock_name") or "",
+        "score": _first_present(item, source, "score", "final_score"),
+        "screen_score": _first_present(item, source, "screen_score"),
+        "reason": item.get("reason") or source.get("reason") or source.get("ranking_reason") or source.get("risk_summary") or item.get("summary") or _build_candidate_reason(source),
+        "risk_level": item.get("risk_level") or source.get("risk_level") or "",
+        "risk_flags": item.get("risk_flags") or source.get("risk_flags") or [],
+        "llm_score": _first_present(item, source, "llm_score"),
+        "llm_confidence": _first_present(item, source, "llm_confidence"),
+        "llm_sector": item.get("llm_sector") or source.get("llm_sector") or "",
+        "llm_theme": item.get("llm_theme") or source.get("llm_theme") or "",
+        "llm_tags": item.get("llm_tags") or source.get("llm_tags") or [],
+        "llm_thesis": item.get("llm_thesis") or source.get("llm_thesis") or "",
+        "llm_catalysts": item.get("llm_catalysts") or source.get("llm_catalysts") or [],
+        "llm_risks": item.get("llm_risks") or source.get("llm_risks") or [],
+        "llm_watch_items": item.get("llm_watch_items") or source.get("llm_watch_items") or [],
+        "llm_invalidators": item.get("llm_invalidators") or source.get("llm_invalidators") or [],
+        "llm_style_fit": item.get("llm_style_fit") or source.get("llm_style_fit") or "",
+        "price": _first_present(item, source, "price"),
+        "change_pct": _first_present(item, source, "change_pct"),
+        "amount": _first_present(item, source, "amount"),
+        "industry": item.get("industry") or source.get("industry") or "",
+        "factor_scores": item.get("factor_scores") or source.get("factor_scores") or {},
+        "dsa_context": dsa_context,
+        "dsa_news": dsa_news,
+        "dsa_analysis_summary": dsa_analysis_summary,
+        "post_analysis_summaries": item.get("post_analysis_summaries") or source.get("post_analysis_summaries") or {},
+        "post_analysis_tags": item.get("post_analysis_tags") or source.get("post_analysis_tags") or [],
+        "raw": source,
+    }
+
+
+def _extract_dsa_news_from_context(context: Any) -> List[Dict[str, Any]]:
+    if not isinstance(context, dict):
+        return []
+    news = context.get("news")
+    if isinstance(news, dict):
+        results = news.get("results")
+    elif isinstance(news, list):
+        results = news
+    else:
+        results = None
+    if not isinstance(results, list):
+        return []
+    return [item for item in results if isinstance(item, dict)]
+
+
+def _extract_dsa_analysis_summary_from_context(context: Any) -> str:
+    if not isinstance(context, dict):
+        return ""
+    for key in ("dsa_analysis_summary", "analysis_summary", "summary"):
+        value = context.get(key)
+        if isinstance(value, str) and value.strip():
+            return value
+    news = context.get("news")
+    if isinstance(news, dict):
+        for key in ("analysis_summary", "summary"):
+            value = news.get(key)
+            if isinstance(value, str) and value.strip():
+                return value
+    news_items = _extract_dsa_news_from_context(context)
+    if not news_items:
+        return ""
+    quote = context.get("quote") if isinstance(context.get("quote"), dict) else {}
+    fundamentals = context.get("fundamentals") if isinstance(context.get("fundamentals"), dict) else {}
+    return _build_dsa_analysis_summary({}, quote, fundamentals, {"results": news_items})
+
+
+def _first_present(primary: Dict[str, Any], source: Dict[str, Any], *keys: str) -> Any:
+    for key in keys:
+        if primary.get(key) is not None:
+            return primary.get(key)
+        if source.get(key) is not None:
+            return source.get(key)
+    return None
+
+
+def _build_candidate_reason(item: Dict[str, Any]) -> str:
+    summaries = item.get("post_analysis_summaries")
+    if isinstance(summaries, dict):
+        summary = next((str(value) for value in summaries.values() if value), "")
+        if summary:
+            return summary
+
+    factors = item.get("factor_scores")
+    parts: List[str] = []
+    if isinstance(factors, dict) and factors:
+        top_factors = sorted(
+            ((key, value) for key, value in factors.items() if isinstance(value, (int, float))),
+            key=lambda pair: pair[1],
+            reverse=True,
+        )[:3]
+        if top_factors:
+            factor_text = "、".join(f"{key} {value:.1f}" for key, value in top_factors)
+            parts.append(f"主要因子：{factor_text}")
+    if item.get("industry"):
+        parts.append(f"行业：{item['industry']}")
+    if item.get("risk_level"):
+        parts.append(f"风险等级：{item['risk_level']}")
+    return "；".join(parts)
+
+
+def _to_plain(value: Any) -> Any:
+    if is_dataclass(value):
+        return asdict(value)
+    if hasattr(value, "model_dump"):
+        return value.model_dump()
+    if hasattr(value, "dict") and callable(value.dict):
+        return value.dict()
+    if isinstance(value, list):
+        return [_to_plain(item) for item in value]
+    return value
+
+
+def _remove_non_finite_json_values(value: Any) -> Any:
+    if isinstance(value, list):
+        return [_remove_non_finite_json_values(item) for item in value]
+    if isinstance(value, tuple):
+        return [_remove_non_finite_json_values(item) for item in value]
+    if isinstance(value, dict):
+        return {key: _remove_non_finite_json_values(item) for key, item in value.items()}
+    if isinstance(value, float):
+        return value if math.isfinite(value) else None
+    return value
+
+
+def _build_install_response(already_installed: bool, install_spec_is_default: bool) -> Dict[str, Any]:
+    return {
+        "installed": True,
+        "already_installed": already_installed,
+        "install_spec_is_default": install_spec_is_default,
+    }
+
+
+def _is_default_alphasift_install_spec(install_spec: str) -> bool:
+    return (install_spec or "").strip() == DEFAULT_ALPHASIFT_INSTALL_SPEC

--- a/tests/test_a_stock_free_fetcher.py
+++ b/tests/test_a_stock_free_fetcher.py
@@ -1,0 +1,239 @@
+# -*- coding: utf-8 -*-
+"""Offline tests for zero-key A-share free-source adapters."""
+
+import os
+import sys
+import unittest
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+
+class _FakeResponse:
+    def __init__(self, payload, text=None):
+        self._payload = payload
+        self.text = text if text is not None else ""
+
+    def json(self):
+        return self._payload
+
+
+class _FakeClient:
+    def __init__(self):
+        self.calls = []
+
+    def get(self, url, **kwargs):
+        self.calls.append(("GET", url, kwargs))
+        if "cls.cn/v1/roll/get_roll_list" in url:
+            return _FakeResponse(
+                {
+                    "data": {
+                        "roll_data": [
+                            {
+                                "id": "1",
+                                "ctime": 1785391200,
+                                "title": "快讯标题",
+                                "content": "快讯内容",
+                                "shareurl": "https://www.cls.cn/detail/1",
+                            }
+                        ]
+                    }
+                }
+            )
+        if "getharden" in url:
+            return _FakeResponse(
+                {
+                    "errocode": 0,
+                    "data": [
+                        {
+                            "code": "SH600519",
+                            "name": "贵州茅台",
+                            "reason": "白酒+消费",
+                            "zhangfu": "3.21",
+                            "huanshou": "0.8",
+                            "chengjiaoe": "1234567",
+                            "close": "1500.5",
+                        }
+                    ],
+                }
+            )
+        if "szse_stock.json" in url:
+            return _FakeResponse({"stockList": [{"code": "601318", "orgId": "9900002221"}]})
+        if "MoneyFlow.ssl_qsfx_zjlrqs" in url:
+            return _FakeResponse(
+                None,
+                text='[{"opendate":"2026-07-29","trade":"1500.5","netamount":"12345","turnover":"1.2"}]',
+            )
+        if "ShowReport/data" in url:
+            return _FakeResponse(
+                [
+                    {
+                        "data": [
+                            {
+                                "zqdm": "000001",
+                                "zqjc": "平安银行",
+                                "cjje": "1000000",
+                                "plyy": "日涨幅偏离值达到7%",
+                            }
+                        ]
+                    }
+                ]
+            )
+        if "showTradePublicFile.do" in url:
+            return _FakeResponse(None, text='cb({"fileContents":["600519 贵州茅台 营业部席位"]})')
+        if "np-anotice-stock.eastmoney.com" in url:
+            return _FakeResponse(
+                {
+                    "data": {
+                        "list": [
+                            {
+                                "art_code": "AN202607300001",
+                                "title": "沪市公告",
+                                "notice_date": "2026-07-30 00:00:00",
+                            }
+                        ]
+                    }
+                }
+            )
+        raise AssertionError(f"unexpected GET: {url}")
+
+    def post(self, url, **kwargs):
+        self.calls.append(("POST", url, kwargs))
+        if "hisAnnouncement/query" in url:
+            return _FakeResponse(
+                {
+                    "announcements": [
+                        {
+                            "announcementId": "abc",
+                            "announcementTitle": "年度报告",
+                            "announcementTypeName": "定期报告",
+                            "announcementTime": 1785369600000,
+                            "adjunctUrl": "finalpage/2026-07-30/test.pdf",
+                        }
+                    ]
+                }
+            )
+        if "announcement/annList" in url:
+            return _FakeResponse(
+                {
+                    "data": [
+                        {
+                            "id": "sz-1",
+                            "title": "深市公告",
+                            "publishTime": "2026-07-30 12:00:00",
+                            "attachPath": "/disc/2026/test.pdf",
+                        }
+                    ]
+                }
+            )
+        raise AssertionError(f"unexpected POST: {url}")
+
+
+class TestAStockFreeFetcher(unittest.TestCase):
+    def setUp(self):
+        from data_provider.a_stock_free_fetcher import AStockFreeFetcher
+
+        self.fetcher = AStockFreeFetcher(client=_FakeClient())
+
+    def test_cls_telegraph_normalizes_rows(self):
+        rows = self.fetcher.cls_telegraph(page_size=10)
+
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(rows[0]["source"], "cls")
+        self.assertEqual(rows[0]["title"], "快讯标题")
+        self.assertIn("time", rows[0])
+
+    def test_ths_hot_reason_normalizes_code_and_reason(self):
+        rows = self.fetcher.ths_hot_reason(date="2026-07-30")
+
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(rows[0]["code"], "600519")
+        self.assertEqual(rows[0]["reason"], "白酒+消费")
+        self.assertAlmostEqual(rows[0]["change_pct"], 3.21)
+        self.assertEqual(rows[0]["source"], "ths_hot_reason")
+
+    def test_cninfo_announcements_use_dynamic_orgid_and_pdf_url(self):
+        rows = self.fetcher.cninfo_announcements("601318", page_size=5)
+
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(rows[0]["code"], "601318")
+        self.assertEqual(rows[0]["source"], "cninfo")
+        self.assertTrue(rows[0]["pdf_url"].startswith("https://static.cninfo.com.cn/"))
+
+        post_call = [c for c in self.fetcher.client.calls if c[0] == "POST"][0]
+        self.assertIn("601318,9900002221", post_call[2]["data"]["stock"])
+
+    def test_cninfo_orgid_fallback_rules(self):
+        from data_provider.a_stock_free_fetcher import AStockFreeFetcher
+
+        class FailingClient(_FakeClient):
+            def get(self, url, **kwargs):
+                if "szse_stock.json" in url:
+                    raise RuntimeError("offline")
+                return super().get(url, **kwargs)
+
+        fetcher = AStockFreeFetcher(client=FailingClient())
+        self.assertEqual(fetcher._cninfo_orgid("600519"), "gssh0600519")
+        self.assertEqual(fetcher._cninfo_orgid("000001"), "gssz0000001")
+        self.assertEqual(fetcher._cninfo_orgid("920001"), "gsbj0920001")
+
+    def test_sina_fund_flow_backup_normalizes_rows(self):
+        rows = self.fetcher.sina_fund_flow_backup("600519", days=5)
+
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(rows[0]["code"], "600519")
+        self.assertEqual(rows[0]["date"], "2026-07-29")
+        self.assertAlmostEqual(rows[0]["net_amount"], 12345.0)
+        self.assertEqual(rows[0]["source"], "sina_fund_flow")
+
+    def test_official_dragon_tiger_backup_combines_exchange_sources(self):
+        data = self.fetcher.official_dragon_tiger_backup("2026-07-30")
+
+        self.assertEqual(data["source"], "official_exchange")
+        self.assertEqual(data["szse"][0]["code"], "000001")
+        self.assertIn("贵州茅台", data["sse_raw"])
+
+    def test_announcement_fallback_uses_szse_for_shenzhen(self):
+        rows = self.fetcher.announcement_fallback("000001", page_size=3)
+
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(rows[0]["source"], "szse_announcement")
+        self.assertTrue(rows[0]["pdf_url"].startswith("https://disc.static.szse.cn/download"))
+
+    def test_announcement_fallback_uses_eastmoney_for_shanghai(self):
+        rows = self.fetcher.announcement_fallback("600519", page_size=3)
+
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(rows[0]["source"], "eastmoney_announcement_fallback")
+        self.assertIn("AN202607300001", rows[0]["pdf_url"])
+
+
+class TestAStockFreeFetcherManagerHooks(unittest.TestCase):
+    @patch("src.config.get_config")
+    def test_manager_free_source_methods_fail_open(self, mock_get_config):
+        mock_get_config.return_value = SimpleNamespace()
+
+        from data_provider.base import DataFetcherManager
+
+        fetcher = MagicMock()
+        fetcher.cls_telegraph.side_effect = RuntimeError("network")
+        fetcher.ths_hot_reason.return_value = [{"code": "600519"}]
+        fetcher.cninfo_announcements.return_value = [{"title": "公告"}]
+        fetcher.sina_fund_flow_backup.return_value = [{"date": "2026-07-29"}]
+        fetcher.official_dragon_tiger_backup.return_value = {"date": "2026-07-30", "szse": []}
+        fetcher.announcement_fallback.return_value = [{"title": "fallback"}]
+
+        manager = DataFetcherManager(fetchers=[])
+        manager._a_stock_free_fetcher = fetcher
+
+        self.assertEqual(manager.get_free_market_news(), [])
+        self.assertEqual(manager.get_free_hot_reasons(), [{"code": "600519"}])
+        self.assertEqual(manager.get_free_announcements("600519"), [{"title": "公告"}])
+        self.assertEqual(manager.get_fallback_fund_flow("600519"), [{"date": "2026-07-29"}])
+        self.assertEqual(manager.get_fallback_dragon_tiger("2026-07-30"), {"date": "2026-07-30", "szse": []})
+        self.assertEqual(manager.get_fallback_announcements("600519"), [{"title": "fallback"}])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_alphasift_api.py
+++ b/tests/test_alphasift_api.py
@@ -1,0 +1,3045 @@
+# -*- coding: utf-8 -*-
+"""Tests for the AlphaSift screening endpoints."""
+
+from __future__ import annotations
+
+import os
+import json
+import sys
+import tempfile
+import time
+import unittest
+from datetime import datetime
+from pathlib import Path
+from types import ModuleType, SimpleNamespace
+from typing import Any, Dict, List
+from unittest.mock import ANY, MagicMock, patch
+import threading
+
+from fastapi import FastAPI, HTTPException
+from fastapi.testclient import TestClient
+
+try:
+    import litellm  # noqa: F401
+except ModuleNotFoundError:
+    sys.modules["litellm"] = MagicMock()
+
+from api.v1.endpoints import alphasift as alphasift_endpoint
+from src.config import Config, DEFAULT_ALPHASIFT_INSTALL_SPEC
+from src.services import alphasift_service
+from src.services.task_queue import TaskInfo, TaskStatus as QueueTaskStatus
+
+DEFAULT_ALPHASIFT_TEST_SPEC = DEFAULT_ALPHASIFT_INSTALL_SPEC
+
+
+def _alphasift_unavailable() -> HTTPException:
+    return HTTPException(
+        status_code=424,
+        detail={"error": "alphasift_unavailable", "message": "AlphaSift is unavailable"},
+    )
+
+
+def _raise_alphasift_unavailable() -> None:
+    raise _alphasift_unavailable()
+
+
+def _make_adapter_module(
+    *,
+    screen=None,
+    list_strategies=None,
+    get_status=None,
+) -> SimpleNamespace:
+    return SimpleNamespace(
+        screen=screen or MagicMock(return_value=[]),
+        list_strategies=list_strategies or (lambda: [{"id": "dual_low", "name": "双低选股", "description": "", "category": "价值"}]),
+        get_status=get_status or (lambda: {"supported_markets": ["cn"], "contract_version": "1", "version": "0.2.0", "strategy_count": 1}),
+    )
+
+
+def _missing_alphasift_module_diagnostics() -> Dict[str, str]:
+    return {
+        "reason": "missing_module",
+        "stage": "import_adapter",
+        "error_type": "ModuleNotFoundError",
+        "module": "alphasift.dsa_adapter",
+    }
+
+
+class AlphaSiftOpportunitiesApiTestCase(unittest.TestCase):
+    def setUp(self) -> None:
+        Config.reset_instance()
+        self.env_patch = patch.dict(os.environ, {"ALPHASIFT_DATA_DIR": ""}, clear=False)
+        self.env_patch.start()
+
+    def tearDown(self) -> None:
+        self.env_patch.stop()
+        Config.reset_instance()
+
+    def _config(self, *, enabled: bool, install_spec: str = DEFAULT_ALPHASIFT_TEST_SPEC) -> Config:
+        return Config(alphasift_enabled=enabled, alphasift_install_spec=install_spec)
+
+    @staticmethod
+    def _request(cookies=None) -> SimpleNamespace:
+        return SimpleNamespace(cookies=cookies or {})
+
+    def _screen(self, config: Config, *, mock_enrichment: bool = True, **kwargs):
+        if not mock_enrichment:
+            return alphasift_endpoint.alphasift_screen(
+                alphasift_endpoint.AlphaSiftScreenRequest(**kwargs),
+                http_request=self._request(),
+                config=config,
+            )
+        with patch(
+            "src.services.alphasift_service._enrich_candidates_with_dsa",
+            side_effect=lambda candidates: (
+                candidates,
+                {
+                    "enabled": True,
+                    "max_candidates": 3,
+                    "requested_count": min(len(candidates), 3),
+                    "enriched_count": 0,
+                    "warnings": [],
+                },
+            ),
+        ):
+            return alphasift_endpoint.alphasift_screen(
+                alphasift_endpoint.AlphaSiftScreenRequest(**kwargs),
+                http_request=self._request(),
+                config=config,
+            )
+
+    def _strategies(self, config: Config):
+        return alphasift_endpoint.alphasift_strategies(request=self._request(), config=config)
+
+    def _hotspots(self, config: Config, **kwargs):
+        return alphasift_endpoint.alphasift_hotspots(config=config, **kwargs)
+
+    def _hotspot_detail(self, config: Config, **kwargs):
+        if os.environ.get("ALPHASIFT_DATA_DIR"):
+            return alphasift_endpoint.alphasift_hotspot_detail(config=config, **kwargs)
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with patch.dict(os.environ, {"ALPHASIFT_DATA_DIR": str(Path(tmpdir) / "alphasift")}, clear=False):
+                return alphasift_endpoint.alphasift_hotspot_detail(config=config, **kwargs)
+
+    def test_default_install_spec_is_commit_pinned(self) -> None:
+        self.assertRegex(
+            DEFAULT_ALPHASIFT_TEST_SPEC,
+            r"^git\+https://github\.com/ZhuLinsen/alphasift\.git@[0-9a-f]{40}$",
+        )
+
+    def test_status_defaults_to_disabled(self) -> None:
+        config = self._config(enabled=False)
+
+        with patch("src.services.alphasift_service._call_alphasift_status", side_effect=_raise_alphasift_unavailable):
+            payload = alphasift_endpoint.alphasift_status(config=config)
+
+        self.assertEqual(payload["enabled"], False)
+        self.assertEqual(payload["available"], False)
+        self.assertEqual(payload["install_spec_is_default"], True)
+        self.assertNotIn("diagnostics", payload)
+        self.assertNotIn("install_spec", payload)
+
+    def test_status_marks_custom_install_source(self) -> None:
+        config = self._config(enabled=False, install_spec="git+https://example.com/private/alphasift.git")
+
+        with patch("src.services.alphasift_service._call_alphasift_status", side_effect=_raise_alphasift_unavailable):
+            payload = alphasift_endpoint.alphasift_status(config=config)
+
+        self.assertEqual(payload["install_spec_is_default"], False)
+        self.assertNotIn("install_spec", payload)
+
+    def test_status_includes_adapter_contract_metadata(self) -> None:
+        config = self._config(enabled=True)
+
+        with patch(
+            "src.services.alphasift_service._call_alphasift_status",
+            return_value={"available": True, "contract_version": "1", "version": "0.2.0", "strategy_count": 8},
+        ):
+            payload = alphasift_endpoint.alphasift_status(config=config)
+
+        self.assertTrue(payload["available"])
+        self.assertEqual(payload["contract_version"], "1")
+        self.assertEqual(payload["version"], "0.2.0")
+        self.assertEqual(payload["strategy_count"], 8)
+
+    def test_status_includes_alphasift_source_health_snapshot(self) -> None:
+        config = self._config(enabled=True)
+
+        with (
+            patch(
+                "src.services.alphasift_service._call_alphasift_status",
+                return_value={"available": True, "contract_version": "1", "version": "0.2.0", "strategy_count": 8},
+            ),
+            patch(
+                "src.services.alphasift_service._get_alphasift_source_health_snapshot",
+                return_value={"snapshot": {"sina": {"failures": 2, "disabled": False}}},
+            ),
+        ):
+            payload = alphasift_endpoint.alphasift_status(config=config)
+
+        self.assertEqual(payload["source_health"]["snapshot"]["sina"]["failures"], 2)
+
+    def test_status_preserves_adapter_available_false_without_diagnostics(self) -> None:
+        config = self._config(enabled=False)
+
+        with patch(
+            "src.services.alphasift_service._call_alphasift_status",
+            return_value={"available": False, "contract_version": "1", "version": "0.2.0", "strategy_count": 0},
+        ):
+            payload = alphasift_endpoint.alphasift_status(config=config)
+
+        self.assertFalse(payload["available"])
+        self.assertEqual(payload["contract_version"], "1")
+        self.assertNotIn("diagnostics", payload)
+
+    def test_status_logs_and_reports_adapter_runtime_exception_diagnostics(self) -> None:
+        config = self._config(enabled=False)
+        fake_module = _make_adapter_module(get_status=MagicMock(side_effect=RuntimeError("get_status failed")))
+
+        with (
+            patch("src.services.alphasift_service._import_alphasift", return_value=fake_module),
+            self.assertLogs("src.services.alphasift_service", level="WARNING") as captured,
+        ):
+            payload = alphasift_endpoint.alphasift_status(config=config)
+
+        self.assertFalse(payload["available"])
+        self.assertEqual(payload["diagnostics"]["reason"], "unexpected_exception")
+        self.assertEqual(payload["diagnostics"]["stage"], "get_status")
+        self.assertEqual(payload["diagnostics"]["error_type"], "RuntimeError")
+        self.assertIn("Unexpected AlphaSift get_status failure", "\n".join(captured.output))
+
+    def test_status_logs_and_reports_unexpected_import_exception_diagnostics(self) -> None:
+        config = self._config(enabled=False)
+        missing_sub_dependency = ModuleNotFoundError("No module named 'optional_dep'", name="optional_dep")
+
+        with (
+            patch("src.services.alphasift_service._prepare_alphasift_runtime_env"),
+            patch("src.services.alphasift_service.importlib.import_module", side_effect=missing_sub_dependency),
+            self.assertLogs("src.services.alphasift_service", level="WARNING") as captured,
+        ):
+            payload = alphasift_endpoint.alphasift_status(config=config)
+
+        self.assertFalse(payload["available"])
+        self.assertEqual(payload["diagnostics"]["reason"], "unexpected_exception")
+        self.assertEqual(payload["diagnostics"]["stage"], "import_adapter")
+        self.assertEqual(payload["diagnostics"]["error_type"], "ModuleNotFoundError")
+        self.assertIn("Unexpected AlphaSift import_adapter failure", "\n".join(captured.output))
+
+    def test_status_marks_missing_module_for_dependency_diagnostic(self) -> None:
+        config = self._config(enabled=True)
+        missing_module_exc = ModuleNotFoundError("No module named 'alphasift.dsa_adapter'", name="alphasift.dsa_adapter")
+
+        with (
+            patch("src.services.alphasift_service._import_alphasift", side_effect=missing_module_exc),
+            self.assertLogs("src.services.alphasift_service", level="WARNING"),
+        ):
+            payload = alphasift_endpoint.alphasift_status(config=config)
+
+        self.assertFalse(payload["available"])
+        self.assertEqual(payload["diagnostics"]["reason"], "missing_module")
+        self.assertEqual(payload["diagnostics"]["stage"], "import_adapter")
+        self.assertEqual(payload["diagnostics"]["error_type"], "ModuleNotFoundError")
+
+    def test_status_logs_and_reports_invalid_get_status_result_diagnostics(self) -> None:
+        config = self._config(enabled=False)
+        fake_module = _make_adapter_module(get_status=lambda: ["not", "a", "dict"])
+
+        with (
+            patch("src.services.alphasift_service._import_alphasift", return_value=fake_module),
+            self.assertLogs("src.services.alphasift_service", level="WARNING") as captured,
+        ):
+            payload = alphasift_endpoint.alphasift_status(config=config)
+
+        self.assertFalse(payload["available"])
+        self.assertEqual(payload["diagnostics"]["reason"], "unexpected_exception")
+        self.assertEqual(payload["diagnostics"]["stage"], "get_status_result")
+        self.assertEqual(payload["diagnostics"]["error_type"], "TypeError")
+        self.assertIn("Unexpected AlphaSift get_status_result failure", "\n".join(captured.output))
+
+    def test_status_logs_and_reports_missing_get_status_callable_diagnostics(self) -> None:
+        config = self._config(enabled=False)
+        fake_module = SimpleNamespace(list_strategies=lambda: [], screen=MagicMock(return_value=[]))
+
+        with (
+            patch("src.services.alphasift_service._import_alphasift", return_value=fake_module),
+            self.assertLogs("src.services.alphasift_service", level="WARNING") as captured,
+        ):
+            payload = alphasift_endpoint.alphasift_status(config=config)
+
+        self.assertFalse(payload["available"])
+        self.assertEqual(payload["diagnostics"]["reason"], "unexpected_exception")
+        self.assertEqual(payload["diagnostics"]["stage"], "get_status_callable")
+        self.assertEqual(payload["diagnostics"]["error_type"], "HTTPException")
+        self.assertIn("Unexpected AlphaSift get_status_callable failure", "\n".join(captured.output))
+
+    def test_strategies_returns_adapter_strategies(self) -> None:
+        config = self._config(enabled=True)
+        fake_module = _make_adapter_module(
+            list_strategies=lambda: [
+                {"id": "dual_low", "name": "双低选股", "description": "value", "category": "价值"},
+                {"id": "trend_quality", "title": "趋势质量", "description": "trend", "tag": "框架"},
+            ],
+        )
+
+        with patch("src.services.alphasift_service._import_alphasift", return_value=fake_module):
+            payload = self._strategies(config=config)
+
+        self.assertEqual(payload["enabled"], True)
+        self.assertEqual(payload["strategy_count"], 2)
+        self.assertEqual(payload["strategies"][0]["id"], "dual_low")
+        self.assertEqual(payload["strategies"][0]["name"], "双低选股")
+        self.assertEqual(payload["strategies"][1]["name"], "趋势质量")
+
+    def test_hotspots_returns_alphasift_hotspot_summaries(self) -> None:
+        config = self._config(enabled=True)
+
+        class HotspotRows(list):
+            provider_used = "akshare"
+            fallback_used = False
+            source_errors = []
+            stale = False
+            stale_age_hours = None
+
+        rows = HotspotRows([
+            {
+                "topic": "AI算力",
+                "name": "AI算力",
+                "heat_score": 88.0,
+                "change_pct": 6.2,
+                "stage": "加速主升",
+                "leaders": ["中际旭创"],
+            }
+        ])
+        discover = MagicMock(return_value=rows)
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cache_path = Path(tmpdir) / "hotspots.json"
+            with (
+                patch("src.services.alphasift_service.DSA_ALPHASIFT_HOTSPOT_CACHE_PATH", cache_path),
+                patch("src.services.alphasift_service._get_alphasift_status_snapshot", return_value=({}, True, {})),
+                patch("src.services.alphasift_service._import_alphasift_hotspot", return_value=SimpleNamespace(discover_hotspots=discover)),
+            ):
+                payload = self._hotspots(config=config, provider="akshare", top=1, refresh=True)
+
+        self.assertEqual(payload["enabled"], True)
+        self.assertEqual(payload["provider"], "akshare")
+        self.assertEqual(payload["provider_used"], "akshare")
+        self.assertEqual(payload["hotspot_count"], 1)
+        self.assertEqual(payload["hotspots"][0]["topic"], "AI算力")
+        self.assertEqual(payload["hotspots"][0]["heat_score"], 88.0)
+        discover.assert_called_once()
+        provider = discover.call_args.kwargs["provider"]
+        self.assertTrue(hasattr(provider, "stock_board_concept_name_em"))
+        self.assertTrue(hasattr(provider, "stock_board_industry_name_em"))
+        self.assertEqual(discover.call_args.kwargs["top"], 1)
+
+    def test_hotspots_default_provider_uses_dsa_eastmoney_provider(self) -> None:
+        provider_name, provider = alphasift_service._resolve_hotspot_provider("")
+
+        self.assertEqual(provider_name, "akshare")
+        self.assertIsInstance(provider, alphasift_service.DsaEastMoneyHotspotProvider)
+
+    def test_hotspots_refresh_uses_dsa_direct_rows_when_alphasift_rows_are_thin(self) -> None:
+        config = self._config(enabled=True)
+
+        class ThinRows(list):
+            provider_used = "akshare"
+            fallback_used = False
+            source_errors = []
+            stale = False
+            stale_age_hours = None
+
+        class FakeProvider(alphasift_service.DsaEastMoneyHotspotProvider):
+            def hotspot_rows(self, *, top: int = 12) -> List[Dict[str, Any]]:
+                return [
+                    {"topic": "钼", "name": "钼", "heat_score": 96.0, "change_pct": 10.0, "leaders": ["盛龙股份"]},
+                    {"topic": "铅锌", "name": "铅锌", "heat_score": 92.0, "change_pct": 9.14, "leaders": ["豫光金铅"]},
+                    {"topic": "铜", "name": "铜", "heat_score": 89.0, "change_pct": 7.03, "leaders": ["江西铜业"]},
+                ][:top]
+
+        discover = MagicMock(return_value=ThinRows([
+            {"topic": "AI算力", "name": "AI算力", "heat_score": 88.0},
+        ]))
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cache_path = Path(tmpdir) / "hotspots.json"
+            provider = FakeProvider()
+            with (
+                patch("src.services.alphasift_service.DSA_ALPHASIFT_HOTSPOT_CACHE_PATH", cache_path),
+                patch("src.services.alphasift_service._get_alphasift_status_snapshot", return_value=({}, True, {})),
+                patch("src.services.alphasift_service._resolve_hotspot_provider", return_value=("akshare", provider)),
+                patch("src.services.alphasift_service._import_alphasift_hotspot", return_value=SimpleNamespace(discover_hotspots=discover)),
+            ):
+                payload = self._hotspots(config=config, provider="akshare", top=6, refresh=True)
+
+        self.assertEqual(payload["provider_used"], "dsa_eastmoney_board_change")
+        self.assertEqual(payload["hotspot_count"], 3)
+        self.assertEqual([item["topic"] for item in payload["hotspots"][:3]], ["钼", "铅锌", "铜"])
+        self.assertTrue(payload["fallback_used"])
+
+    def test_hotspots_enriches_missing_metrics_from_dsa_provider(self) -> None:
+        config = self._config(enabled=True)
+
+        class HotspotRows(list):
+            provider_used = "akshare"
+            fallback_used = False
+            source_errors = []
+            stale = False
+            stale_age_hours = None
+
+        class FakeProvider(alphasift_service.DsaEastMoneyHotspotProvider):
+            def hotspot_rows(self, *, top: int = 12) -> List[Dict[str, Any]]:
+                return [{
+                    "topic": "铜",
+                    "name": "工业金属 · 铜",
+                    "heat_score": 92.0,
+                    "change_pct": 7.03,
+                    "trend_score": 99.0,
+                    "persistence_score": 64.3,
+                    "sample_stock_count": 11,
+                    "leaders": ["嘉元科技", "方邦股份"],
+                    "theme_group": "工业金属",
+                }]
+
+        discover = MagicMock(return_value=HotspotRows([{
+            "topic": "铜",
+            "name": "铜",
+            "heat_score": 92.0,
+            "change_pct": 7.03,
+        }]))
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cache_path = Path(tmpdir) / "hotspots.json"
+            with (
+                patch("src.services.alphasift_service.DSA_ALPHASIFT_HOTSPOT_CACHE_PATH", cache_path),
+                patch("src.services.alphasift_service._get_alphasift_status_snapshot", return_value=({}, True, {})),
+                patch("src.services.alphasift_service._resolve_hotspot_provider", return_value=("akshare", FakeProvider())),
+                patch("src.services.alphasift_service._import_alphasift_hotspot", return_value=SimpleNamespace(discover_hotspots=discover)),
+            ):
+                payload = self._hotspots(config=config, provider="akshare", top=1, refresh=True)
+
+        hotspot = payload["hotspots"][0]
+        self.assertEqual(hotspot["name"], "工业金属 · 铜")
+        self.assertEqual(hotspot["trend_score"], 99.0)
+        self.assertEqual(hotspot["persistence_score"], 64.3)
+        self.assertEqual(hotspot["sample_stock_count"], 11)
+        self.assertEqual(hotspot["leaders"], ["嘉元科技", "方邦股份"])
+
+    def test_hotspots_default_cache_miss_does_not_import_hotspot_module(self) -> None:
+        config = self._config(enabled=True)
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cache_path = Path(tmpdir) / "missing-hotspots.json"
+            import_hotspot = MagicMock(side_effect=AssertionError("default cache read must not import live hotspot module"))
+            with (
+                patch("src.services.alphasift_service.DSA_ALPHASIFT_HOTSPOT_CACHE_PATH", cache_path),
+                patch("src.services.alphasift_service._get_alphasift_status_snapshot", return_value=({}, True, {})),
+                patch("src.services.alphasift_service._import_alphasift_hotspot", import_hotspot),
+            ):
+                payload = self._hotspots(config=config, provider="akshare", top=6, refresh=False)
+
+        self.assertEqual(payload["enabled"], True)
+        self.assertEqual(payload["provider"], "akshare")
+        self.assertEqual(payload["cache_used"], False)
+        self.assertEqual(payload["hotspots"], [])
+        self.assertEqual(payload["hotspot_count"], 0)
+        self.assertEqual(payload["source_errors"], [])
+        import_hotspot.assert_not_called()
+
+    def test_hotspots_ignores_too_thin_default_cache(self) -> None:
+        config = self._config(enabled=True)
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cache_path = Path(tmpdir) / "hotspots.json"
+            cache_path.write_text(
+                json.dumps({
+                    "cached_at": "2026-06-13T08:06:50Z",
+                    "payload": {
+                        "enabled": True,
+                        "provider": "akshare",
+                        "hotspots": [{"topic": "AI算力", "name": "AI算力", "heat_score": 88.0}],
+                        "hotspot_count": 1,
+                    },
+                }),
+                encoding="utf-8",
+            )
+            import_hotspot = MagicMock(side_effect=AssertionError("default cache read must not import live hotspot module"))
+            with (
+                patch("src.services.alphasift_service.DSA_ALPHASIFT_HOTSPOT_CACHE_PATH", cache_path),
+                patch("src.services.alphasift_service._get_alphasift_status_snapshot", return_value=({}, True, {})),
+                patch("src.services.alphasift_service._import_alphasift_hotspot", import_hotspot),
+            ):
+                payload = self._hotspots(config=config, provider="akshare", top=12, refresh=False)
+
+        self.assertEqual(payload["hotspots"], [])
+        self.assertEqual(payload["hotspot_count"], 0)
+        import_hotspot.assert_not_called()
+
+
+    def test_hotspots_uses_last_success_cache_by_default(self) -> None:
+        config = self._config(enabled=True)
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cache_path = Path(tmpdir) / "hotspots.json"
+            cache_path.write_text(
+                json.dumps({
+                    "cached_at": "2026-06-07T12:00:00Z",
+                    "payload": {
+                        "enabled": True,
+                        "provider": "akshare",
+                        "provider_used": "DsaEastMoneyHotspotProvider",
+                        "fallback_used": False,
+                        "cache_used": False,
+                        "cached_at": "2026-06-07T12:00:00Z",
+                        "source_errors": [],
+                        "hotspots": [
+                            {"topic": "玻璃基板", "heat_score": 88.0},
+                            {"topic": "机器人执行器", "heat_score": 80.0},
+                        ],
+                        "hotspot_count": 2,
+                    },
+                }),
+                encoding="utf-8",
+            )
+            discover = MagicMock()
+            with (
+                patch("src.services.alphasift_service.DSA_ALPHASIFT_HOTSPOT_CACHE_PATH", cache_path),
+                patch("src.services.alphasift_service._get_alphasift_status_snapshot", return_value=({}, True, {})),
+                patch("src.services.alphasift_service._import_alphasift_hotspot", return_value=SimpleNamespace(discover_hotspots=discover)),
+            ):
+                payload = self._hotspots(config=config, provider="akshare", top=1, refresh=False)
+
+        self.assertEqual(payload["cache_used"], True)
+        self.assertEqual(payload["cached_at"], "2026-06-07T12:00:00Z")
+        self.assertEqual(payload["hotspot_count"], 1)
+        self.assertEqual(payload["hotspots"][0]["topic"], "玻璃基板")
+        discover.assert_not_called()
+
+    def test_hotspots_refresh_falls_back_to_cache_when_provider_returns_only_errors(self) -> None:
+        config = self._config(enabled=True)
+
+        class HotspotRows(list):
+            provider_used = "akshare"
+            fallback_used = False
+            source_errors = ["akshare returned no usable board rows"]
+            stale = False
+            stale_age_hours = None
+
+        rows = HotspotRows()
+        discover = MagicMock(return_value=rows)
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cache_path = Path(tmpdir) / "hotspots.json"
+            cache_path.write_text(
+                json.dumps({
+                    "cached_at": "2026-06-07T12:00:00Z",
+                    "payload": {
+                        "enabled": True,
+                        "provider": "akshare",
+                        "provider_used": "DsaEastMoneyHotspotProvider",
+                        "fallback_used": False,
+                        "cache_used": False,
+                        "cached_at": "2026-06-07T12:00:00Z",
+                        "source_errors": [],
+                        "hotspots": [
+                            {"topic": "MLCC", "heat_score": 91.0},
+                        ],
+                        "hotspot_count": 1,
+                    },
+                }),
+                encoding="utf-8",
+            )
+            provider = alphasift_service.DsaEastMoneyHotspotProvider()
+            provider.hotspot_rows = MagicMock(return_value=[])
+            with (
+                patch("src.services.alphasift_service.DSA_ALPHASIFT_HOTSPOT_CACHE_PATH", cache_path),
+                patch("src.services.alphasift_service._get_alphasift_status_snapshot", return_value=({}, True, {})),
+                patch("src.services.alphasift_service._resolve_hotspot_provider", return_value=("akshare", provider)),
+                patch("src.services.alphasift_service._import_alphasift_hotspot", return_value=SimpleNamespace(discover_hotspots=discover)),
+            ):
+                payload = self._hotspots(config=config, provider="akshare", top=1, refresh=True)
+
+        self.assertEqual(payload["cache_used"], True)
+        self.assertEqual(payload["fallback_used"], True)
+        self.assertEqual(payload["hotspot_count"], 1)
+        self.assertEqual(payload["hotspots"][0]["topic"], "MLCC")
+        self.assertIn("akshare returned no usable board rows", payload["source_errors"])
+        discover.assert_called_once()
+
+    def test_hotspots_refresh_failure_without_cache_returns_friendly_empty_payload(self) -> None:
+        config = self._config(enabled=True)
+        discover = MagicMock(side_effect=RuntimeError("RemoteDisconnected('Remote end closed connection without response')"))
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cache_path = Path(tmpdir) / "missing-hotspots.json"
+            provider = alphasift_service.DsaEastMoneyHotspotProvider()
+            with (
+                patch("src.services.alphasift_service.DSA_ALPHASIFT_HOTSPOT_CACHE_PATH", cache_path),
+                patch("src.services.alphasift_service._get_alphasift_status_snapshot", return_value=({}, True, {})),
+                patch("src.services.alphasift_service._resolve_hotspot_provider", return_value=("akshare", provider)),
+                patch("src.services.alphasift_service._import_alphasift_hotspot", return_value=SimpleNamespace(discover_hotspots=discover)),
+            ):
+                payload = self._hotspots(config=config, provider="akshare", top=1, refresh=True)
+
+        self.assertEqual(payload["hotspots"], [])
+        self.assertEqual(payload["hotspot_count"], 0)
+        self.assertEqual(payload["source_errors"], ["eastmoney_hotspot_unavailable"])
+        self.assertEqual(payload["message"], "热点源连接中断，暂无可用缓存。")
+        self.assertNotIn("RemoteDisconnected", payload["message"])
+        discover.assert_called_once()
+
+    def test_hotspots_default_refresh_degraded_eastmoney_failure_without_cache_returns_friendly_empty_payload(self) -> None:
+        config = self._config(enabled=True)
+
+        class HotspotRows(list):
+            provider_used = "DsaEastMoneyHotspotProvider"
+            fallback_used = False
+            source_errors = ["RemoteDisconnected('Remote end closed connection without response')"]
+            stale = False
+            stale_age_hours = None
+
+        discover = MagicMock(return_value=HotspotRows())
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cache_path = Path(tmpdir) / "missing-hotspots.json"
+            app = FastAPI()
+            app.include_router(alphasift_endpoint.router, prefix="/api/v1/alphasift")
+            app.dependency_overrides[alphasift_endpoint.get_config_dep] = lambda: config
+            with (
+                patch.dict(os.environ, {"INDUSTRY_PROVIDER": ""}, clear=False),
+                patch("src.services.alphasift_service.DSA_ALPHASIFT_HOTSPOT_CACHE_PATH", cache_path),
+                patch("src.services.alphasift_service._get_alphasift_status_snapshot", return_value=({}, True, {})),
+                patch("src.services.alphasift_service.DsaEastMoneyHotspotProvider.hotspot_rows", return_value=[]),
+                patch("src.services.alphasift_service._import_alphasift_hotspot", return_value=SimpleNamespace(discover_hotspots=discover)),
+            ):
+                response = TestClient(app).get("/api/v1/alphasift/hotspots?refresh=true&top=1")
+
+        self.assertEqual(response.status_code, 200)
+        payload = response.json()
+
+        self.assertEqual(payload["provider"], "akshare")
+        self.assertEqual(payload["provider_used"], "DsaEastMoneyHotspotProvider")
+        self.assertEqual(payload["hotspots"], [])
+        self.assertEqual(payload["hotspot_count"], 0)
+        self.assertEqual(payload["source_errors"], ["eastmoney_hotspot_unavailable"])
+        self.assertEqual(payload["message"], "热点源连接中断，暂无可用缓存。")
+        self.assertNotIn("RemoteDisconnected", payload["message"])
+        discover.assert_called_once()
+
+    def test_hotspots_refresh_runtime_failure_without_cache_raises_integration_error(self) -> None:
+        config = self._config(enabled=True)
+        discover = MagicMock(side_effect=RuntimeError("adapter contract returned invalid payload"))
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cache_path = Path(tmpdir) / "missing-hotspots.json"
+            provider = alphasift_service.DsaEastMoneyHotspotProvider()
+            with (
+                patch("src.services.alphasift_service.DSA_ALPHASIFT_HOTSPOT_CACHE_PATH", cache_path),
+                patch("src.services.alphasift_service._get_alphasift_status_snapshot", return_value=({}, True, {})),
+                patch("src.services.alphasift_service._resolve_hotspot_provider", return_value=("akshare", provider)),
+                patch("src.services.alphasift_service._import_alphasift_hotspot", return_value=SimpleNamespace(discover_hotspots=discover)),
+            ):
+                with self.assertRaises(HTTPException) as caught:
+                    self._hotspots(config=config, provider="akshare", top=1, refresh=True)
+
+        self.assertEqual(caught.exception.status_code, 424)
+        self.assertEqual(caught.exception.detail["error"], "alphasift_hotspot_refresh_failed")
+        self.assertIn("adapter contract returned invalid payload", caught.exception.detail["message"])
+        discover.assert_called_once()
+
+    def test_hotspots_refresh_non_akshare_failure_without_cache_raises_integration_error(self) -> None:
+        config = self._config(enabled=True)
+        discover = MagicMock(side_effect=RuntimeError("RemoteDisconnected('remote provider failed')"))
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cache_path = Path(tmpdir) / "missing-hotspots.json"
+            with (
+                patch("src.services.alphasift_service.DSA_ALPHASIFT_HOTSPOT_CACHE_PATH", cache_path),
+                patch("src.services.alphasift_service._get_alphasift_status_snapshot", return_value=({}, True, {})),
+                patch("src.services.alphasift_service._resolve_hotspot_provider", return_value=("custom", "custom")),
+                patch("src.services.alphasift_service._import_alphasift_hotspot", return_value=SimpleNamespace(discover_hotspots=discover)),
+            ):
+                with self.assertRaises(HTTPException) as caught:
+                    self._hotspots(config=config, provider="custom", top=1, refresh=True)
+
+        self.assertEqual(caught.exception.status_code, 424)
+        self.assertEqual(caught.exception.detail["error"], "alphasift_hotspot_refresh_failed")
+        self.assertIn("RemoteDisconnected", caught.exception.detail["message"])
+        discover.assert_called_once()
+
+    def test_hotspot_provider_retries_transient_eastmoney_failure(self) -> None:
+        import requests
+
+        provider = alphasift_service.DsaEastMoneyHotspotProvider()
+
+        class FakeResponse:
+            def raise_for_status(self) -> None:
+                return None
+
+            def json(self) -> Dict[str, Any]:
+                return {
+                    "data": {
+                        "diff": [
+                            {"f14": "AI算力", "f3": 4.2, "f140": "工业富联", "f104": 8, "f105": 2},
+                        ]
+                    }
+                }
+
+        get_mock = MagicMock(side_effect=[requests.exceptions.ConnectionError("Connection aborted"), FakeResponse()])
+        provider._last_request_ts = time.monotonic()
+        with (
+            patch("src.services.alphasift_service.time.sleep") as sleep_mock,
+            patch.object(provider._session, "get", get_mock),
+            patch("requests.get", side_effect=AssertionError("bare requests.get should not be used for EastMoney hotspots")) as bare_get,
+        ):
+            frame = provider._fetch_board_names(source_fs="m:90 t:3 f:!50")
+
+        self.assertFalse(frame.empty)
+        self.assertEqual(frame.iloc[0]["name"], "AI算力")
+        self.assertEqual(get_mock.call_count, 2)
+        bare_get.assert_not_called()
+        sleep_values = [call.args[0] for call in sleep_mock.call_args_list if call.args]
+        self.assertIn(0.3, sleep_values)
+        self.assertTrue(any(0 < value <= provider._min_request_interval for value in sleep_values))
+
+    def test_hotspots_respects_custom_alphasift_data_dir_for_cache_paths(self) -> None:
+        config = self._config(enabled=True)
+
+        class HotspotRows(list):
+            provider_used = "akshare"
+            fallback_used = False
+            source_errors = []
+            stale = False
+            stale_age_hours = None
+
+        rows = HotspotRows([
+            {"topic": "机器人执行器", "heat_score": 86.0, "change_pct": 4.2},
+            {"topic": "减速器", "heat_score": 82.0, "change_pct": 3.8},
+            {"topic": "铜", "heat_score": 80.0, "change_pct": 3.2},
+        ])
+        captured: Dict[str, Any] = {}
+
+        def discover(**kwargs):
+            captured.update(kwargs)
+            return rows
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            data_dir = Path(tmpdir) / "persistent-alphasift"
+            cache_path = data_dir / "hotspots.json"
+            history_path = data_dir / "hotspot.history.jsonl"
+            with (
+                patch.dict(os.environ, {"ALPHASIFT_DATA_DIR": str(data_dir)}, clear=False),
+                patch("src.services.alphasift_service._get_alphasift_status_snapshot", return_value=({}, True, {})),
+                patch(
+                    "src.services.alphasift_service._import_alphasift_hotspot",
+                    return_value=SimpleNamespace(discover_hotspots=discover),
+                ),
+            ):
+                payload = self._hotspots(config=config, provider="akshare", top=3, refresh=True)
+
+            self.assertEqual(payload["hotspots"][0]["topic"], "机器人执行器")
+            self.assertEqual(captured["history_path"], history_path)
+            self.assertEqual(captured["fallback_cache_path"], cache_path)
+            self.assertTrue(cache_path.exists())
+
+            discover_again = MagicMock()
+            with (
+                patch.dict(os.environ, {"ALPHASIFT_DATA_DIR": str(data_dir)}, clear=False),
+                patch("src.services.alphasift_service._get_alphasift_status_snapshot", return_value=({}, True, {})),
+                patch(
+                    "src.services.alphasift_service._import_alphasift_hotspot",
+                    return_value=SimpleNamespace(discover_hotspots=discover_again),
+                ),
+            ):
+                cached = self._hotspots(config=config, provider="akshare", top=1, refresh=False)
+
+            cache_payload = json.loads(cache_path.read_text(encoding="utf-8"))
+
+        self.assertEqual(cached["cache_used"], True)
+        self.assertEqual(cached["hotspots"][0]["topic"], "机器人执行器")
+        discover_again.assert_not_called()
+        self.assertEqual(cache_payload["schema_version"], 2)
+        self.assertEqual(cache_payload["hotspots"][0]["topic"], "机器人执行器")
+
+    def test_hotspots_reads_alphasift_v2_hotspot_cache(self) -> None:
+        config = self._config(enabled=True)
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cache_path = Path(tmpdir) / "hotspots.json"
+            cache_path.write_text(
+                json.dumps({
+                    "schema_version": 2,
+                    "generated_at": "2026-06-13T02:55:00Z",
+                    "source_errors": "provider timeout",
+                    "metadata": {"schema_version": 2, "provider_used": "last_good_cache"},
+                    "hotspots": [
+                        {
+                            "topic": "算力",
+                            "canonical_topic": "算力",
+                            "aliases": ["AI算力"],
+                            "heat_score": 88.0,
+                            "quality_status": "available",
+                        }
+                    ],
+                }),
+                encoding="utf-8",
+            )
+            discover = MagicMock()
+            with (
+                patch("src.services.alphasift_service.DSA_ALPHASIFT_HOTSPOT_CACHE_PATH", cache_path),
+                patch("src.services.alphasift_service._get_alphasift_status_snapshot", return_value=({}, True, {})),
+                patch("src.services.alphasift_service._import_alphasift_hotspot", return_value=SimpleNamespace(discover_hotspots=discover)),
+            ):
+                cached = self._hotspots(config=config, provider="akshare", top=1, refresh=False)
+
+        self.assertEqual(cached["cache_used"], True)
+        self.assertEqual(cached["cached_at"], "2026-06-13T02:55:00Z")
+        self.assertEqual(cached["schema_version"], 2)
+        self.assertEqual(cached["source_errors"], ["provider timeout"])
+        self.assertEqual(cached["hotspots"][0]["canonical_topic"], "算力")
+        discover.assert_not_called()
+
+    def test_hotspots_refresh_prefetches_detail_payloads(self) -> None:
+        config = self._config(enabled=True)
+
+        class HotspotRows(list):
+            provider_used = "akshare"
+            fallback_used = False
+            source_errors = []
+            stale = False
+            stale_age_hours = None
+
+        rows = HotspotRows([
+            {"topic": "Moly", "heat_score": 96.0, "change_pct": 10.0},
+            {"topic": "Copper", "heat_score": 88.0, "change_pct": 6.0},
+        ])
+
+        def detail_side_effect(*, topic: str, provider: str = "", refresh: bool = False) -> Dict[str, Any]:
+            return {
+                "enabled": True,
+                "provider": provider,
+                "topic": topic,
+                "summary": f"{topic} summary",
+                "route": [{"title": f"{topic} event", "description": f"{topic} catalyst"}],
+                "stocks": [],
+                "stock_count": 0,
+            }
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            data_dir = Path(tmpdir) / "alphasift"
+            with (
+                patch.dict(os.environ, {"ALPHASIFT_DATA_DIR": str(data_dir)}, clear=False),
+                patch("src.services.alphasift_service._get_alphasift_status_snapshot", return_value=({}, True, {})),
+                patch(
+                    "src.services.alphasift_service._import_alphasift_hotspot",
+                    return_value=SimpleNamespace(discover_hotspots=MagicMock(return_value=rows)),
+                ),
+                patch.object(alphasift_service.AlphaSiftService, "hotspot_detail", side_effect=detail_side_effect) as detail_mock,
+            ):
+                payload = self._hotspots(config=config, provider="akshare", top=2, refresh=True, include_details=True)
+
+            cache_payload = json.loads((data_dir / "hotspots.json").read_text(encoding="utf-8"))
+
+        self.assertEqual(set(payload["details"].keys()), {"Moly", "Copper"})
+        self.assertEqual(payload["details"]["Moly"]["route"][0]["title"], "Moly event")
+        self.assertEqual(cache_payload["payload"]["details"]["Copper"]["summary"], "Copper summary")
+        self.assertEqual(detail_mock.call_count, 2)
+
+    def test_hotspot_news_local_summary_extracts_event_instead_of_truncating(self) -> None:
+        text = (
+            "【股商异动】钼板块异动大涨5.64%！金钼股份涨停，机构看好行业机遇。"
+            "消息称以钼代钨带动小金属行情，市场关注材料替代和供需偏紧。"
+            "截至10:30，相关个股现价和成交额继续变化，后续建议关注供需平衡。"
+        )
+
+        summary = alphasift_service._summarize_hotspot_news_event_locally(topic="钼", text=text)
+
+        self.assertIn("以钼代钨", summary)
+        self.assertIn("小金属", summary)
+        self.assertNotIn("截至", summary)
+        self.assertNotIn("后续建议", summary)
+        self.assertLessEqual(len(summary), alphasift_service.DSA_ALPHASIFT_HOTSPOT_EVENT_SUMMARY_MAX_CHARS)
+
+    def test_hotspot_detail_uses_alphasift_contract_detail_cache(self) -> None:
+        config = self._config(enabled=True)
+        captured: Dict[str, Any] = {}
+
+        def get_hotspot_detail(topic: str, **kwargs: Any) -> Dict[str, Any]:
+            captured.update({"topic": topic, **kwargs})
+            return {
+                "summary": {
+                    "topic": topic,
+                    "name": "算力",
+                    "canonical_topic": "算力",
+                    "aliases": "AI算力",
+                    "heat_score": 88.0,
+                    "stage": "加速主升",
+                    "leaders": ["算力龙头"],
+                    "quality_status": "stale",
+                    "missing_fields": "live_stocks",
+                    "source_errors": "none: no live detail rows",
+                    "fallback_used": True,
+                    "stale": True,
+                    "stale_age_hours": 1.5,
+                    "resolver_candidates": [{"topic": "算力", "confidence": 1.0}],
+                },
+                "stocks": [{
+                    "code": "300001",
+                    "name": "算力龙头",
+                    "role": "核心龙头",
+                    "source": "last_good_cache.leader_stocks",
+                    "source_confidence": 0.65,
+                    "fallback_used": True,
+                }],
+                "timeline": [{"date": "2026-06-13", "source": "新闻", "title": "AI算力催化"}],
+            }
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            data_dir = Path(tmpdir) / "alphasift"
+            provider = alphasift_service.DsaEastMoneyHotspotProvider()
+            with (
+                patch.dict(os.environ, {"ALPHASIFT_DATA_DIR": str(data_dir)}, clear=False),
+                patch("src.services.alphasift_service._get_alphasift_status_snapshot", return_value=({}, True, {})),
+                patch("src.services.alphasift_service._resolve_hotspot_provider", return_value=("akshare", provider)),
+                patch(
+                    "src.services.alphasift_service._import_alphasift_hotspot",
+                    return_value=SimpleNamespace(get_hotspot_detail=get_hotspot_detail),
+                ),
+            ):
+                payload = self._hotspot_detail(config=config, provider="akshare", topic="AI算力")
+
+        self.assertEqual(captured["topic"], "AI算力")
+        self.assertIs(captured["provider"], provider)
+        self.assertEqual(captured["fallback_cache_path"], data_dir / "hotspots.json")
+        self.assertEqual(captured["history_path"], data_dir / "hotspot.history.jsonl")
+        self.assertEqual(payload["enabled"], True)
+        self.assertEqual(payload["provider"], "akshare")
+        self.assertEqual(payload["topic"], "AI算力")
+        self.assertEqual(payload["canonical_topic"], "算力")
+        self.assertEqual(payload["quality_status"], "stale")
+        self.assertEqual(payload["aliases"], ["AI算力"])
+        self.assertEqual(payload["missing_fields"], ["live_stocks"])
+        self.assertEqual(payload["source_errors"], ["none: no live detail rows"])
+        self.assertEqual(payload["stocks"][0]["source"], "last_good_cache.leader_stocks")
+        self.assertEqual(payload["leader_stocks"][0]["source"], "last_good_cache.leader_stocks")
+        self.assertEqual(payload["route"][0]["title"], "AI算力催化")
+
+    def test_hotspot_detail_backfills_stocks_from_contract_leader_stocks(self) -> None:
+        config = self._config(enabled=True)
+
+        def get_hotspot_detail(topic: str, **_kwargs: Any) -> Dict[str, Any]:
+            return {
+                "summary": {"topic": topic, "name": "算力"},
+                "leader_stocks": [{
+                    "code": "300001",
+                    "name": "算力龙头",
+                    "role": "核心龙头",
+                    "source": "last_good_cache.leader_stocks",
+                }],
+                "route": [{"title": "盘中发酵", "description": "真实新闻催化", "source": "news"}],
+            }
+
+        provider = alphasift_service.DsaEastMoneyHotspotProvider()
+        provider.hotspot_detail = MagicMock(side_effect=AssertionError("provider route fallback should not be used"))
+        with (
+            patch("src.services.alphasift_service._get_alphasift_status_snapshot", return_value=({}, True, {})),
+            patch("src.services.alphasift_service._resolve_hotspot_provider", return_value=("akshare", provider)),
+            patch(
+                "src.services.alphasift_service._import_alphasift_hotspot",
+                return_value=SimpleNamespace(get_hotspot_detail=get_hotspot_detail),
+            ),
+        ):
+            payload = self._hotspot_detail(config=config, provider="akshare", topic="AI算力")
+
+        self.assertEqual(payload["stocks"][0]["name"], "算力龙头")
+        self.assertEqual(payload["leader_stocks"][0]["name"], "算力龙头")
+        self.assertEqual(payload["stock_count"], 1)
+        provider.hotspot_detail.assert_not_called()
+
+    def test_hotspot_detail_compat_backfills_from_summary_detail_leader_stocks(self) -> None:
+        payload = alphasift_service._ensure_hotspot_detail_compat_fields({
+            "summary_detail": {
+                "leader_stocks": [{
+                    "code": "300001",
+                    "name": "缓存龙头",
+                    "source": "legacy.summary_detail.leader_stocks",
+                }],
+            },
+        })
+
+        self.assertEqual(payload["stocks"][0]["name"], "缓存龙头")
+        self.assertEqual(payload["leader_stocks"][0]["name"], "缓存龙头")
+        self.assertEqual(payload["stock_count"], 1)
+
+    def test_hotspot_detail_backfills_stocks_from_summary_leader_stocks(self) -> None:
+        config = self._config(enabled=True)
+
+        def get_hotspot_detail(topic: str, **_kwargs: Any) -> Dict[str, Any]:
+            return {
+                "summary": {
+                    "topic": topic,
+                    "name": "算力",
+                    "leader_stocks": [{
+                        "code": "300001",
+                        "name": "嵌套龙头",
+                        "role": "缓存龙头",
+                        "source": "last_good_cache.summary.leader_stocks",
+                    }],
+                },
+                "route": [{"title": "盘中发酵", "description": "真实新闻催化", "source": "news"}],
+            }
+
+        provider = alphasift_service.DsaEastMoneyHotspotProvider()
+        provider.hotspot_detail = MagicMock(side_effect=AssertionError("provider route fallback should not be used"))
+        with (
+            patch("src.services.alphasift_service._get_alphasift_status_snapshot", return_value=({}, True, {})),
+            patch("src.services.alphasift_service._resolve_hotspot_provider", return_value=("akshare", provider)),
+            patch(
+                "src.services.alphasift_service._import_alphasift_hotspot",
+                return_value=SimpleNamespace(get_hotspot_detail=get_hotspot_detail),
+            ),
+        ):
+            payload = self._hotspot_detail(config=config, provider="akshare", topic="AI算力")
+
+        self.assertEqual(payload["stocks"][0]["name"], "嵌套龙头")
+        self.assertEqual(payload["leader_stocks"][0]["name"], "嵌套龙头")
+        self.assertEqual(payload["stock_count"], 1)
+        provider.hotspot_detail.assert_not_called()
+
+    def test_hotspot_detail_uses_dsa_detail_cache_after_first_fetch(self) -> None:
+        config = self._config(enabled=True)
+        provider = alphasift_service.DsaEastMoneyHotspotProvider()
+        provider.hotspot_detail = MagicMock(return_value={
+            "topic": "钼",
+            "name": "小金属 · 钼",
+            "summary": "钼 当前涨跌幅 10.00%。",
+            "route": [{"title": "当日发酵", "description": "钼板块异动。", "source": "eastmoney_board_change"}],
+            "stocks": [{"code": "001257", "name": "盛龙股份"}],
+            "stock_count": 1,
+            "source_errors": [],
+        })
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with (
+                patch.dict(os.environ, {"ALPHASIFT_DATA_DIR": str(Path(tmpdir) / "alphasift")}, clear=False),
+                patch("src.services.alphasift_service._get_alphasift_status_snapshot", return_value=({}, True, {})),
+                patch("src.services.alphasift_service._resolve_hotspot_provider", return_value=("akshare", provider)),
+                patch("src.services.alphasift_service._import_alphasift_hotspot", return_value=SimpleNamespace()),
+            ):
+                first = self._hotspot_detail(config=config, provider="akshare", topic="钼")
+                second = self._hotspot_detail(config=config, provider="akshare", topic="钼")
+
+        provider.hotspot_detail.assert_called_once_with("钼")
+        self.assertFalse(first.get("cache_used", False))
+        self.assertTrue(second["cache_used"])
+        self.assertEqual(second["stocks"][0]["name"], "盛龙股份")
+        self.assertEqual(second["leader_stocks"][0]["name"], "盛龙股份")
+
+    def test_hotspot_detail_refresh_bypasses_dsa_detail_cache(self) -> None:
+        config = self._config(enabled=True)
+        provider = alphasift_service.DsaEastMoneyHotspotProvider()
+        provider.hotspot_detail = MagicMock(side_effect=[
+            {
+                "topic": "钼",
+                "summary": "旧详情",
+                "route": [{"title": "旧发酵", "description": "旧缓存", "source": "eastmoney_board_change"}],
+                "stocks": [{"code": "001257", "name": "旧龙头"}],
+                "stock_count": 1,
+                "source_errors": [],
+            },
+            {
+                "topic": "钼",
+                "summary": "新详情",
+                "route": [{"title": "新发酵", "description": "实时刷新", "source": "eastmoney_board_change"}],
+                "stocks": [{"code": "001257", "name": "新龙头"}],
+                "stock_count": 1,
+                "source_errors": [],
+            },
+        ])
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with (
+                patch.dict(os.environ, {"ALPHASIFT_DATA_DIR": str(Path(tmpdir) / "alphasift")}, clear=False),
+                patch("src.services.alphasift_service._get_alphasift_status_snapshot", return_value=({}, True, {})),
+                patch("src.services.alphasift_service._resolve_hotspot_provider", return_value=("akshare", provider)),
+                patch("src.services.alphasift_service._import_alphasift_hotspot", return_value=SimpleNamespace()),
+            ):
+                first = self._hotspot_detail(config=config, provider="akshare", topic="钼")
+                cached = self._hotspot_detail(config=config, provider="akshare", topic="钼")
+                refreshed = self._hotspot_detail(config=config, provider="akshare", topic="钼", refresh=True)
+
+        self.assertEqual(provider.hotspot_detail.call_count, 2)
+        self.assertEqual(first["stocks"][0]["name"], "旧龙头")
+        self.assertEqual(cached["stocks"][0]["name"], "旧龙头")
+        self.assertTrue(cached["cache_used"])
+        self.assertEqual(refreshed["stocks"][0]["name"], "新龙头")
+        self.assertFalse(refreshed.get("cache_used", False))
+
+    def test_hotspot_detail_adds_real_search_event_when_configured(self) -> None:
+        config = Config(alphasift_enabled=True, bocha_api_keys=["test-key"])
+        provider = alphasift_service.DsaEastMoneyHotspotProvider()
+        provider.hotspot_detail = MagicMock(return_value={
+            "topic": "钼",
+            "summary": "钼 当前涨跌幅 10.00%。",
+            "route": [{"title": "当日发酵", "description": "钼板块异动。", "source": "eastmoney_board_change"}],
+            "stocks": [],
+            "stock_count": 0,
+            "source_errors": [],
+        })
+        search_service = MagicMock()
+        search_service.search_stock_news.return_value = SimpleNamespace(
+            success=True,
+            provider="Bocha",
+            results=[
+                SimpleNamespace(
+                    title="以钼代钨带动小金属行情",
+                    snippet=(
+                        "以钼代钨带动小金属行情 2026-06-12 市场关注材料替代和供需偏紧。"
+                        "金钼股份、盛龙股份等相关个股出现异动，报道还详细列出价格、成交、"
+                        "机构观点、供需格局和完整产业链背景，后续建议继续关注供需平衡与政策动力。"
+                    ),
+                    url="https://example.com/news",
+                    source="ExampleNews",
+                    published_date="2026-06-12",
+                )
+            ],
+        )
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with (
+                patch.dict(os.environ, {"ALPHASIFT_DATA_DIR": str(Path(tmpdir) / "alphasift")}, clear=False),
+                patch("src.services.alphasift_service._get_alphasift_status_snapshot", return_value=({}, True, {})),
+                patch("src.services.alphasift_service._resolve_hotspot_provider", return_value=("akshare", provider)),
+                patch("src.services.alphasift_service._import_alphasift_hotspot", return_value=SimpleNamespace()),
+                patch("src.search_service.SearchService", return_value=search_service),
+            ):
+                payload = self._hotspot_detail(config=config, provider="akshare", topic="钼")
+
+        self.assertEqual(payload["route"][0]["source"], "ExampleNews")
+        self.assertEqual(payload["route"][0]["title"], "消息催化")
+        self.assertEqual(payload["route"][0]["date"], "2026-06-12")
+        self.assertEqual(payload["route"][0]["url"], "https://example.com/news")
+        self.assertLessEqual(len(payload["route"][0]["description"]), 93)
+        self.assertNotIn("完整产业链背景", payload["route"][0]["description"])
+        search_service.search_stock_news.assert_called_once()
+
+    def test_hotspot_detail_prefers_timeline_when_contract_route_is_empty(self) -> None:
+        config = self._config(enabled=True)
+        provider = alphasift_service.DsaEastMoneyHotspotProvider()
+        provider.hotspot_detail = MagicMock(side_effect=RuntimeError("provider fallback should not be used"))
+
+        def get_hotspot_detail(topic: str, **_kwargs: Any) -> Dict[str, Any]:
+            return {
+                "summary": {
+                    "topic": topic,
+                    "name": "算力",
+                    "canonical_topic": "算力",
+                    "quality_status": "available",
+                },
+                "stocks": [{
+                    "code": "300001",
+                    "name": "算力龙头",
+                }],
+                "timeline": [{"date": "2026-06-13", "source": "新闻", "title": "AI算力催化"}],
+                "route": [],
+            }
+
+        with (
+            patch("src.services.alphasift_service._get_alphasift_status_snapshot", return_value=({}, True, {})),
+            patch("src.services.alphasift_service._resolve_hotspot_provider", return_value=("akshare", provider)),
+            patch(
+                "src.services.alphasift_service._import_alphasift_hotspot",
+                return_value=SimpleNamespace(get_hotspot_detail=get_hotspot_detail),
+            ),
+        ):
+            payload = self._hotspot_detail(config=config, provider="akshare", topic="AI算力")
+
+        self.assertEqual(payload["route"][0]["title"], "AI算力催化")
+        self.assertEqual(payload["route"][0]["source"], "新闻")
+        provider.hotspot_detail.assert_not_called()
+
+    def test_hotspot_detail_falls_back_to_provider_when_contract_helper_fails(self) -> None:
+        config = self._config(enabled=True)
+        provider = alphasift_service.DsaEastMoneyHotspotProvider()
+        provider.hotspot_detail = MagicMock(return_value={
+            "topic": "机器人执行器",
+            "summary": "机器人执行器 盘中发酵。",
+            "route": [{"title": "盘中发酵", "description": "provider fallback route.", "source": "eastmoney_board_change"}],
+            "stocks": [{"code": "002000", "name": "旧路径个股"}],
+            "stock_count": 1,
+            "source_errors": [],
+        })
+
+        def get_hotspot_detail(topic: str, **_kwargs: Any) -> Dict[str, Any]:
+            raise RuntimeError("contract parser broken")
+
+        with (
+            patch("src.services.alphasift_service._get_alphasift_status_snapshot", return_value=({}, True, {})),
+            patch("src.services.alphasift_service._resolve_hotspot_provider", return_value=("akshare", provider)),
+            patch(
+                "src.services.alphasift_service._import_alphasift_hotspot",
+                return_value=SimpleNamespace(get_hotspot_detail=get_hotspot_detail),
+            ),
+        ):
+            payload = self._hotspot_detail(config=config, provider="akshare", topic="机器人执行器")
+
+        self.assertEqual(payload["route"][0]["title"], "盘中发酵")
+        self.assertEqual(payload["route"][0]["source"], "eastmoney_board_change")
+        provider.hotspot_detail.assert_called_once_with("机器人执行器")
+        self.assertEqual(
+            payload["source_errors"][0],
+            "alphasift_hotspot_detail_fallback: contract parser broken",
+        )
+        self.assertTrue(payload["fallback_used"])
+
+    def test_hotspot_detail_preserves_provider_route_when_contract_detail_has_no_timeline(self) -> None:
+        config = self._config(enabled=True)
+        provider = alphasift_service.DsaEastMoneyHotspotProvider()
+        provider.hotspot_detail = MagicMock(return_value={
+            "topic": "机器人执行器",
+            "summary": "机器人执行器 盘中发酵。",
+            "route": [{
+                "title": "盘中发酵",
+                "description": "机器人执行器 当前有异动记录。",
+                "source": "eastmoney_board_change",
+            }],
+            "stocks": [{"code": "002000", "name": "旧路径个股"}],
+            "stock_count": 1,
+            "source_errors": [],
+        })
+
+        def get_hotspot_detail(topic: str, **_kwargs: Any) -> Dict[str, Any]:
+            return {
+                "summary": {
+                    "topic": topic,
+                    "name": "机器人执行器",
+                    "canonical_topic": "机器人执行器",
+                    "quality_status": "available",
+                },
+                "stocks": [{
+                    "code": "300000",
+                    "name": "合约路径个股",
+                    "source": "alphasift_contract",
+                }],
+            }
+
+        with (
+            patch("src.services.alphasift_service._get_alphasift_status_snapshot", return_value=({}, True, {})),
+            patch("src.services.alphasift_service._resolve_hotspot_provider", return_value=("akshare", provider)),
+            patch(
+                "src.services.alphasift_service._import_alphasift_hotspot",
+                return_value=SimpleNamespace(get_hotspot_detail=get_hotspot_detail),
+            ),
+        ):
+            payload = self._hotspot_detail(config=config, provider="akshare", topic="机器人执行器")
+
+        self.assertEqual(payload["route"][0]["title"], "盘中发酵")
+        self.assertEqual(payload["route"][0]["source"], "eastmoney_board_change")
+        self.assertEqual(payload["stocks"][0]["name"], "合约路径个股")
+        provider.hotspot_detail.assert_called_once_with("机器人执行器")
+
+    def test_hotspot_detail_returns_route_and_concept_stocks(self) -> None:
+        config = self._config(enabled=True)
+
+        class FakeProvider(alphasift_service.DsaEastMoneyHotspotProvider):
+            def hotspot_detail(self, topic: str) -> Dict[str, Any]:
+                return {
+                    "topic": topic,
+                    "summary": f"{topic} 盘中发酵。",
+                    "route": [{"title": "盘中发酵", "description": "出现大笔买入。"}],
+                    "stocks": [{"code": "920438", "name": "戈碧迦", "role": "异动核心"}],
+                    "stock_count": 1,
+                    "source_errors": [],
+                }
+
+        with (
+            patch("src.services.alphasift_service._get_alphasift_status_snapshot", return_value=({}, True, {})),
+            patch("src.services.alphasift_service._resolve_hotspot_provider", return_value=("akshare", FakeProvider())),
+        ):
+            payload = self._hotspot_detail(config=config, provider="akshare", topic="玻璃基板")
+
+        self.assertEqual(payload["enabled"], True)
+        self.assertEqual(payload["provider"], "akshare")
+        self.assertEqual(payload["topic"], "玻璃基板")
+        self.assertEqual(payload["route"][0]["title"], "盘中发酵")
+        self.assertEqual(payload["stocks"][0]["name"], "戈碧迦")
+        self.assertEqual(payload["leader_stocks"][0]["name"], "戈碧迦")
+
+    def test_hotspot_detail_route_accepts_slash_containing_topic(self) -> None:
+        config = self._config(enabled=True)
+        app = FastAPI()
+        app.include_router(alphasift_endpoint.router, prefix="/api/v1/alphasift")
+        app.dependency_overrides[alphasift_endpoint.get_config_dep] = lambda: config
+        service = MagicMock()
+        service.hotspot_detail.return_value = {
+            "enabled": True,
+            "provider": "akshare",
+            "topic": "DRG/DIP",
+            "route": [],
+            "stocks": [],
+            "stock_count": 0,
+        }
+
+        with patch("api.v1.endpoints.alphasift._service", return_value=service):
+            response = TestClient(app).get("/api/v1/alphasift/hotspots/DRG%2FDIP?provider=akshare")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()["topic"], "DRG/DIP")
+        service.hotspot_detail.assert_called_once_with(topic="DRG/DIP", provider="akshare", refresh=False)
+
+    def test_hotspot_detail_falls_back_when_ths_constituents_fail(self) -> None:
+        import pandas as pd
+
+        config = self._config(enabled=True)
+
+        class FakeProvider(alphasift_service.DsaEastMoneyHotspotProvider):
+            def _fetch_ths_constituents(self, topic: str) -> Any:
+                raise TimeoutError("ths timeout")
+
+            def _fallback_constituents(self, topic: str) -> Any:
+                return pd.DataFrame([{
+                    "code": "300000",
+                    "name": "中际旭创",
+                    "change_pct": None,
+                    "hot_stock_score": 60.0,
+                }])
+
+            def _fetch_eastmoney_constituents(self, topic: str, *, source: str) -> Any:
+                return pd.DataFrame()
+
+            def _find_board_change(self, topic: str) -> Dict[str, Any]:
+                return {}
+
+            def _build_hotspot_route(self, topic: str, summary: Dict[str, Any]) -> Any:
+                return [{"title": "fallback", "description": topic, "source": "test"}]
+
+            def _fetch_ths_info(self, topic: str) -> Dict[str, str]:
+                return {}
+
+        with (
+            patch("src.services.alphasift_service._get_alphasift_status_snapshot", return_value=({}, True, {})),
+            patch("src.services.alphasift_service._resolve_hotspot_provider", return_value=("akshare", FakeProvider())),
+        ):
+            payload = self._hotspot_detail(config=config, provider="akshare", topic="AI算力")
+
+        self.assertEqual(payload["enabled"], True)
+        self.assertEqual(payload["provider"], "akshare")
+        self.assertEqual(payload["topic"], "AI算力")
+        self.assertEqual(payload["stocks"][0]["name"], "中际旭创")
+        self.assertEqual(payload["route"][0]["title"], "fallback")
+
+    def test_hotspot_provider_merges_constituent_sources_before_single_leader_fallback(self) -> None:
+        import pandas as pd
+
+        class FakeProvider(alphasift_service.DsaEastMoneyHotspotProvider):
+            def _fetch_eastmoney_constituents(self, topic: str, *, source: str) -> Any:
+                return pd.DataFrame([
+                    {"代码": "000001", "名称": "平安银行", "涨跌幅": 1.2},
+                    {"代码": "000002", "名称": "万科A", "涨跌幅": 0.8},
+                ])
+
+            def _fetch_ths_constituents(self, topic: str) -> Any:
+                return pd.DataFrame([
+                    {"code": "000002", "name": "万科A"},
+                    {"code": "000003", "name": "国农科技"},
+                ])
+
+            def _fallback_constituents(self, topic: str) -> Any:
+                return pd.DataFrame([{
+                    "code": "000001",
+                    "name": "平安银行",
+                    "hot_stock_score": 60.0,
+                }])
+
+        provider = FakeProvider()
+        frame = provider.stock_board_concept_cons_em("金融")
+
+        self.assertEqual(list(frame["code"]), ["000001", "000002", "000003"])
+        self.assertEqual(provider.stock_board_concept_cons_em("金融").shape[0], 3)
+
+    def test_hotspot_provider_adds_related_metal_leaders_for_narrow_topic(self) -> None:
+        import pandas as pd
+
+        provider = alphasift_service.DsaEastMoneyHotspotProvider()
+        raw = pd.DataFrame([
+            {
+                "板块名称": "钼",
+                "涨跌幅": 10.0,
+                "板块异动最频繁个股及所属类型-股票代码": "001257",
+                "板块异动最频繁个股及所属类型-股票名称": "盛龙股份",
+            },
+            {
+                "板块名称": "钴",
+                "涨跌幅": 5.9,
+                "板块异动最频繁个股及所属类型-股票代码": "300618",
+                "板块异动最频繁个股及所属类型-股票名称": "寒锐钴业",
+            },
+            {
+                "板块名称": "铜",
+                "涨跌幅": 7.0,
+                "板块异动最频繁个股及所属类型-股票代码": "600362",
+                "板块异动最频繁个股及所属类型-股票名称": "江西铜业",
+            },
+        ])
+        with patch.object(provider, "_fetch_board_changes_raw", return_value=raw):
+            frame = provider._related_hotspot_constituents("钼")
+
+        self.assertEqual(list(frame["code"]), ["001257", "300618"])
+        self.assertEqual(frame.iloc[0]["role"], "小金属活跃股")
+
+    def test_hotspot_route_is_grouped_by_daily_markers(self) -> None:
+        provider = alphasift_service.DsaEastMoneyHotspotProvider()
+        provider._fetch_ths_summary_event = MagicMock(return_value="2026-06-12：政策催化")
+        summary = {
+            "板块名称": "AI算力",
+            "涨跌幅": 4.2,
+            "板块异动总次数": 186,
+            "板块异动最频繁个股及所属类型-股票名称": "中际旭创",
+            "板块具体异动类型列表及出现次数": [{"t": 8203, "ct": 8}, {"t": 8204, "ct": 6}],
+        }
+
+        route = provider._build_hotspot_route("AI算力", summary)
+
+        self.assertLessEqual(len(route), 2)
+        self.assertEqual(route[0]["date"], datetime.now().date().isoformat())
+        self.assertEqual(route[0]["published_at"], route[0]["date"])
+        self.assertIn("当日结构", route[0]["description"])
+        self.assertEqual(route[1]["date"], "2026-06-12")
+
+    def test_hotspot_route_does_not_invent_metal_catalyst_hint(self) -> None:
+        provider = alphasift_service.DsaEastMoneyHotspotProvider()
+        provider._fetch_ths_summary_event = MagicMock(return_value="")
+
+        route = provider._build_hotspot_route("钼", {})
+
+        self.assertEqual(route[0]["source"], "fallback")
+        self.assertNotIn("以钼代钨", route[0]["description"])
+
+    def test_hotspot_detail_uses_constituent_fallback_when_board_change_summary_fails(self) -> None:
+        import pandas as pd
+
+        config = self._config(enabled=True)
+
+        class FakeProvider(alphasift_service.DsaEastMoneyHotspotProvider):
+            def _find_board_change(self, topic: str) -> Dict[str, Any]:
+                raise TimeoutError("board change timeout")
+
+            def _fetch_ths_constituents(self, topic: str) -> Any:
+                return pd.DataFrame()
+
+            def _fetch_eastmoney_constituents(self, topic: str, *, source: str) -> Any:
+                return pd.DataFrame([{
+                    "代码": "002138",
+                    "名称": "顺络电子",
+                    "涨跌幅": 3.2,
+                }])
+
+            def _fetch_ths_summary_event(self, topic: str) -> str:
+                return "需求升温"
+
+            def _fetch_ths_info(self, topic: str) -> Dict[str, str]:
+                return {}
+
+        with (
+            patch("src.services.alphasift_service._get_alphasift_status_snapshot", return_value=({}, True, {})),
+            patch("src.services.alphasift_service._resolve_hotspot_provider", return_value=("akshare", FakeProvider())),
+        ):
+            payload = self._hotspot_detail(config=config, provider="akshare", topic="MLCC")
+
+        self.assertEqual(payload["enabled"], True)
+        self.assertEqual(payload["topic"], "MLCC")
+        self.assertEqual(payload["summary"], "MLCC 当前暂无可用的板块异动摘要。")
+        self.assertEqual(payload["route"][0]["source"], "ths_summary")
+        self.assertEqual(payload["stocks"][0]["name"], "顺络电子")
+
+    def test_hotspot_detail_uses_industry_constituents_for_industry_hotspots(self) -> None:
+        import pandas as pd
+
+        config = self._config(enabled=True)
+
+        class FakeProvider(alphasift_service.DsaEastMoneyHotspotProvider):
+            def __init__(self) -> None:
+                self.constituent_sources = []
+
+            def stock_board_industry_name_em(self) -> Any:
+                return pd.DataFrame([{"name": "电池", "rank": 1}])
+
+            def _fetch_eastmoney_constituents(self, topic: str, *, source: str) -> Any:
+                self.constituent_sources.append(source)
+                if source == "industry":
+                    return pd.DataFrame([{
+                        "代码": "300750",
+                        "名称": "宁德时代",
+                        "涨跌幅": 2.6,
+                    }])
+                return pd.DataFrame()
+
+            def _fetch_ths_constituents(self, topic: str) -> Any:
+                raise AssertionError("industry hotspots must not use concept constituents")
+
+            def _find_board_change(self, topic: str) -> Dict[str, Any]:
+                return {}
+
+            def _fetch_ths_summary_event(self, topic: str) -> str:
+                return ""
+
+            def _fetch_ths_info(self, topic: str) -> Dict[str, str]:
+                return {}
+
+        provider = FakeProvider()
+        with (
+            patch("src.services.alphasift_service._get_alphasift_status_snapshot", return_value=({}, True, {})),
+            patch("src.services.alphasift_service._resolve_hotspot_provider", return_value=("akshare", provider)),
+        ):
+            payload = self._hotspot_detail(config=config, provider="akshare", topic="电池")
+
+        self.assertEqual(payload["enabled"], True)
+        self.assertEqual(payload["topic"], "电池")
+        self.assertEqual(payload["stocks"][0]["name"], "宁德时代")
+        self.assertEqual(provider.constituent_sources, ["industry"])
+
+    def test_hotspot_provider_uses_board_name_fallback_when_rankings_fail(self) -> None:
+        import pandas as pd
+
+        provider = alphasift_service.DsaEastMoneyHotspotProvider()
+        fallback = pd.DataFrame([{"板块名称": "玻璃基板", "涨跌幅": 1.8, "序号": 1}])
+        with (
+            patch.object(provider, "_fetch_board_changes", return_value=pd.DataFrame()),
+            patch.object(provider, "_fetch_rankings", side_effect=RuntimeError("ranking schema changed")),
+            patch.object(provider, "_fetch_board_names", return_value=fallback) as fetch_board_names,
+        ):
+            concept = provider.stock_board_concept_name_em()
+            industry = provider.stock_board_industry_name_em()
+
+        self.assertEqual(concept.iloc[0]["板块名称"], "玻璃基板")
+        self.assertEqual(industry.iloc[0]["板块名称"], "玻璃基板")
+        fetch_board_names.assert_any_call(source_fs="m:90 t:3 f:!50")
+        fetch_board_names.assert_any_call(source_fs="m:90 t:2 f:!50")
+
+    def test_hotspot_provider_continues_fallback_when_board_change_fails(self) -> None:
+        import pandas as pd
+
+        provider = alphasift_service.DsaEastMoneyHotspotProvider()
+        rankings = pd.DataFrame([{"name": "减速器", "change_pct": 2.2, "rank": 1}])
+        with (
+            patch.object(provider, "_fetch_board_changes", side_effect=RuntimeError("akshare timeout")),
+            patch.object(provider, "_fetch_rankings", return_value=rankings) as fetch_rankings,
+        ):
+            concept = provider.stock_board_concept_name_em()
+
+        self.assertEqual(concept.iloc[0]["name"], "减速器")
+        fetch_rankings.assert_called_once_with("concept")
+
+    def test_hotspot_provider_derives_trend_metrics_from_board_changes(self) -> None:
+        import pandas as pd
+
+        board_changes = pd.DataFrame([
+            {
+                "板块名称": "AI算力",
+                "涨跌幅": 4.2,
+                "板块异动总次数": 186,
+                "板块异动最频繁个股及所属类型-股票名称": "中际旭创",
+            },
+        ])
+
+        class _MockAkshare:
+            calls = 0
+
+            @staticmethod
+            def stock_board_change_em():
+                _MockAkshare.calls += 1
+                return board_changes
+
+        provider = alphasift_service.DsaEastMoneyHotspotProvider()
+        with patch.dict("sys.modules", {"akshare": _MockAkshare()}):
+            frame = provider._fetch_board_changes()
+            summary = provider._find_board_change("AI算力")
+
+        self.assertEqual(_MockAkshare.calls, 1)
+        self.assertEqual(frame.iloc[0]["name"], "AI算力")
+        self.assertEqual(frame.iloc[0]["stage"], "加速发酵")
+        self.assertGreater(frame.iloc[0]["trend_score"], 0)
+        self.assertGreater(frame.iloc[0]["persistence_score"], 0)
+        self.assertEqual(frame.iloc[0]["sample_stock_count"], 1)
+        self.assertEqual(frame.iloc[0]["leaders"], ["中际旭创"])
+        self.assertEqual(summary["板块名称"], "AI算力")
+
+    def test_fetch_ths_summary_event_ignores_missing_concept_name_column(self) -> None:
+        import pandas as pd
+
+        provider = alphasift_service.DsaEastMoneyHotspotProvider()
+        summary = pd.DataFrame([
+            {"日期": "2026-06-07", "驱动事件": "行业政策利好"},
+        ])
+
+        class _MockAkshare:
+            @staticmethod
+            def stock_board_concept_summary_ths():
+                return summary
+
+        with patch.dict("sys.modules", {"akshare": _MockAkshare()}):
+            text = provider._fetch_ths_summary_event("MLCC")
+
+        self.assertEqual(text, "")
+
+    def test_strategies_rejects_when_enabled_but_adapter_missing(self) -> None:
+        config = self._config(enabled=True)
+
+        with (
+            patch(
+                "src.services.alphasift_service._get_alphasift_status_snapshot",
+                return_value=({}, False, _missing_alphasift_module_diagnostics()),
+            ),
+            patch("src.services.alphasift_service._install_alphasift") as install_mock,
+        ):
+            with self.assertRaises(HTTPException) as caught:
+                self._strategies(config=config)
+
+        self.assertEqual(caught.exception.status_code, 424)
+        self.assertEqual(caught.exception.detail["error"], "alphasift_unavailable")
+        self.assertEqual(caught.exception.detail.get("diagnostics", {}).get("reason"), "missing_module")
+        install_mock.assert_not_called()
+
+    def test_screen_rejects_when_disabled(self) -> None:
+        config = self._config(enabled=False)
+
+        with self.assertRaises(HTTPException) as caught:
+            self._screen(config)
+
+        self.assertEqual(caught.exception.status_code, 403)
+        self.assertEqual(caught.exception.detail["error"], "alphasift_disabled")
+
+    def test_screen_rejects_when_alphasift_unavailable(self) -> None:
+        config = self._config(enabled=True)
+
+        with (
+            patch(
+                "src.services.alphasift_service._get_alphasift_status_snapshot",
+                return_value=({}, False, _missing_alphasift_module_diagnostics()),
+            ),
+            patch("src.services.alphasift_service._install_alphasift") as install_mock,
+        ):
+            with self.assertRaises(HTTPException) as caught:
+                self._screen(config)
+
+        self.assertEqual(caught.exception.status_code, 424)
+        self.assertEqual(caught.exception.detail["error"], "alphasift_unavailable")
+        self.assertEqual(caught.exception.detail.get("diagnostics", {}).get("reason"), "missing_module")
+        self.assertIn("pip install -r requirements.txt", caught.exception.detail["message"])
+        install_mock.assert_not_called()
+
+    def test_start_screen_task_submits_background_work(self) -> None:
+        config = self._config(enabled=True)
+        fake_queue = MagicMock()
+        fake_queue.submit_background_task.return_value = SimpleNamespace(
+            task_id="screen-task-1",
+            trace_id="screen-task-1",
+            status=QueueTaskStatus.PENDING,
+            message="AlphaSift 选股任务已提交",
+        )
+
+        with (
+            patch("api.v1.endpoints.alphasift.get_task_queue", return_value=fake_queue),
+            patch("api.v1.endpoints.alphasift.uuid.uuid4", return_value=SimpleNamespace(hex="screen-task-1")),
+            patch.object(
+                alphasift_endpoint.AlphaSiftService,
+                "screen",
+                return_value={"enabled": True, "candidates": [], "candidate_count": 0},
+            ) as screen_mock,
+        ):
+            payload = alphasift_endpoint.alphasift_start_screen_task(
+                alphasift_endpoint.AlphaSiftScreenRequest(market="cn", strategy="dual_low", max_results=3),
+                http_request=self._request(),
+                config=config,
+            )
+            run_task = fake_queue.submit_background_task.call_args.args[0]
+            result = run_task()
+
+        self.assertEqual(payload.task_id, "screen-task-1")
+        self.assertEqual(payload.max_results, 3)
+        fake_queue.submit_background_task.assert_called_once()
+        self.assertEqual(fake_queue.submit_background_task.call_args.kwargs["report_type"], "alphasift_screen")
+        screen_mock.assert_called_once_with(strategy="dual_low", market="cn", max_results=3)
+        self.assertEqual(result["candidate_count"], 0)
+        fake_queue.update_task_progress.assert_any_call(
+            "screen-task-1",
+            20,
+            "正在执行 AlphaSift 选股，外部数据源较慢时会持续后台运行",
+        )
+
+    def test_screen_task_status_returns_alphasift_result(self) -> None:
+        task = TaskInfo(
+            task_id="screen-task-1",
+            trace_id="screen-task-1",
+            stock_code="alphasift_screen",
+            status=QueueTaskStatus.COMPLETED,
+            progress=100,
+            message="任务执行完成",
+            result={"enabled": True, "candidates": [], "candidate_count": 0},
+            report_type="alphasift_screen",
+        )
+        fake_queue = MagicMock()
+        fake_queue.get_task.return_value = task
+
+        with patch("api.v1.endpoints.alphasift.get_task_queue", return_value=fake_queue):
+            payload = alphasift_endpoint.alphasift_screen_task_status("screen-task-1")
+
+        self.assertEqual(payload.status, "completed")
+        self.assertEqual(payload.result["candidate_count"], 0)
+
+    def test_screen_task_status_rejects_non_alphasift_task(self) -> None:
+        task = TaskInfo(
+            task_id="analysis-task-1",
+            stock_code="600519",
+            status=QueueTaskStatus.COMPLETED,
+            report_type="detailed",
+        )
+        fake_queue = MagicMock()
+        fake_queue.get_task.return_value = task
+
+        with patch("api.v1.endpoints.alphasift.get_task_queue", return_value=fake_queue):
+            with self.assertRaises(HTTPException) as caught:
+                alphasift_endpoint.alphasift_screen_task_status("analysis-task-1")
+
+        self.assertEqual(caught.exception.status_code, 404)
+        self.assertEqual(caught.exception.detail["error"], "alphasift_screen_task_not_found")
+
+    def test_screen_does_not_auto_install_when_adapter_runtime_unavailable(self) -> None:
+        config = self._config(enabled=True)
+
+        with (
+            patch.dict(os.environ, {"DSA_DESKTOP_MODE": "true"}, clear=False),
+            patch(
+                "src.services.alphasift_service._get_alphasift_status_snapshot",
+                return_value=(
+                    {},
+                    False,
+                    {"reason": "unexpected_exception", "stage": "get_status", "error_type": "RuntimeError"},
+                ),
+            ),
+            patch("src.services.alphasift_service._install_alphasift") as install_mock,
+        ):
+            with self.assertRaises(HTTPException) as caught:
+                self._screen(config)
+
+        self.assertEqual(caught.exception.status_code, 424)
+        self.assertEqual(caught.exception.detail["error"], "alphasift_unavailable")
+        self.assertEqual(caught.exception.detail.get("diagnostics", {}).get("resolution"), "no_auto_install")
+        self.assertEqual(
+            caught.exception.detail.get("diagnostics", {}).get("message"),
+            "请先检查后端日志并修复运行时异常，当前未触发修复安装。",
+        )
+        install_mock.assert_not_called()
+
+    def test_install_rejects_spoofed_localhost_without_admin_session(self) -> None:
+        config = self._config(enabled=True)
+        request = SimpleNamespace(
+            cookies={alphasift_service.COOKIE_NAME: "invalid-session"},
+            url=SimpleNamespace(hostname="localhost"),
+            client=SimpleNamespace(host="127.0.0.1"),
+        )
+
+        with (
+            patch.dict(os.environ, {"DSA_DESKTOP_MODE": "false"}, clear=False),
+            patch("src.services.alphasift_service.refresh_auth_state") as refresh_mock,
+            patch("src.services.alphasift_service.is_auth_enabled", return_value=True),
+            patch("src.services.alphasift_service.verify_session", return_value=False) as verify_session_mock,
+            patch("src.services.alphasift_service.subprocess.run") as run_mock,
+        ):
+            with self.assertRaises(HTTPException) as caught:
+                alphasift_endpoint.alphasift_install(request=request, config=config)
+
+        self.assertEqual(caught.exception.status_code, 401)
+        self.assertEqual(caught.exception.detail["error"], "alphasift_install_access_denied")
+        refresh_mock.assert_called_once()
+        verify_session_mock.assert_called_once_with("invalid-session")
+        run_mock.assert_not_called()
+
+    def test_install_allows_valid_admin_session_outside_desktop_mode(self) -> None:
+        config = self._config(enabled=True)
+        request = self._request({alphasift_service.COOKIE_NAME: "valid-session"})
+
+        with (
+            patch.dict(os.environ, {"DSA_DESKTOP_MODE": "false"}, clear=False),
+            patch("src.services.alphasift_service.refresh_auth_state") as refresh_mock,
+            patch("src.services.alphasift_service.is_auth_enabled", return_value=True),
+            patch("src.services.alphasift_service.verify_session", return_value=True) as verify_session_mock,
+            patch("src.services.alphasift_service._install_alphasift", return_value={"installed": True}) as install_mock,
+        ):
+            payload = alphasift_endpoint.alphasift_install(request=request, config=config)
+
+        self.assertEqual(payload["installed"], True)
+        refresh_mock.assert_called_once()
+        verify_session_mock.assert_called_once_with("valid-session")
+        install_mock.assert_called_once_with(config)
+
+    def test_install_rejects_when_disabled_without_side_effects(self) -> None:
+        config = self._config(enabled=False)
+
+        with (
+            patch.dict(os.environ, {"DSA_DESKTOP_MODE": "true"}, clear=False),
+            patch("src.services.alphasift_service.subprocess.run") as run_mock,
+            patch("src.services.alphasift_service._import_alphasift") as import_mock,
+        ):
+            with self.assertRaises(HTTPException) as caught:
+                alphasift_endpoint.alphasift_install(request=self._request(), config=config)
+
+        self.assertEqual(caught.exception.status_code, 403)
+        self.assertEqual(caught.exception.detail["error"], "alphasift_disabled")
+        import_mock.assert_not_called()
+        run_mock.assert_not_called()
+
+    def test_install_invokes_pip_when_enabled_and_missing(self) -> None:
+        config = self._config(enabled=True)
+        completed = SimpleNamespace(returncode=0, stdout="installed", stderr="")
+
+        with (
+            patch.dict(os.environ, {"DSA_DESKTOP_MODE": "true"}, clear=False),
+            patch("src.services.alphasift_service._is_alphasift_available", side_effect=[False, True]),
+            patch(
+                "src.services.alphasift_service._call_alphasift_status",
+                return_value={"available": True, "supported_markets": ["cn"], "contract_version": "1", "version": "0.2.0", "strategy_count": 1},
+            ),
+            patch("src.services.alphasift_service.subprocess.run", return_value=completed) as run_mock,
+            patch("src.services.alphasift_service._get_dsa_adapter", return_value=_make_adapter_module()),
+        ):
+            payload = alphasift_endpoint.alphasift_install(request=self._request(), config=config)
+
+        self.assertEqual(payload["installed"], True)
+        self.assertEqual(payload["already_installed"], False)
+        self.assertEqual(payload["install_spec_is_default"], True)
+        self.assertNotIn("install_spec", payload)
+        run_mock.assert_called_once()
+        install_command = run_mock.call_args.args[0]
+        self.assertIn("--upgrade", install_command)
+        self.assertIn("--force-reinstall", install_command)
+        self.assertIn(DEFAULT_ALPHASIFT_TEST_SPEC, install_command)
+
+    def test_install_rejects_when_alphasift_adapter_reports_unavailable(self) -> None:
+        config = self._config(enabled=True)
+        completed = SimpleNamespace(returncode=0, stdout="installed", stderr="")
+
+        with (
+            patch.dict(os.environ, {"DSA_DESKTOP_MODE": "true"}, clear=False),
+            patch(
+                "src.services.alphasift_service._call_alphasift_status",
+                side_effect=[
+                    {"available": False},
+                    {"available": False},
+                ],
+            ),
+            patch("src.services.alphasift_service.subprocess.run", return_value=completed) as run_mock,
+            patch("src.services.alphasift_service._get_dsa_adapter") as get_adapter_mock,
+        ):
+            with self.assertRaises(HTTPException) as caught:
+                alphasift_endpoint.alphasift_install(request=self._request(), config=config)
+
+        self.assertEqual(caught.exception.status_code, 424)
+        self.assertEqual(caught.exception.detail["error"], "alphasift_unavailable")
+        run_mock.assert_called_once()
+        get_adapter_mock.assert_not_called()
+
+    def test_install_rejects_untrusted_spec(self) -> None:
+        config = self._config(enabled=True, install_spec="git+https://example.com/private/alphasift.git")
+
+        with (
+            patch.dict(os.environ, {"DSA_DESKTOP_MODE": "true"}, clear=False),
+            patch("src.services.alphasift_service._is_alphasift_available", return_value=False),
+            patch("src.services.alphasift_service.subprocess.run") as run_mock,
+        ):
+            with self.assertRaises(HTTPException) as caught:
+                alphasift_endpoint.alphasift_install(request=self._request(), config=config)
+
+        self.assertEqual(caught.exception.status_code, 403)
+        self.assertEqual(caught.exception.detail["error"], "alphasift_install_spec_not_allowed")
+        run_mock.assert_not_called()
+
+    def test_screen_calls_dsa_adapter_and_normalizes_llm_fields(self) -> None:
+        config = self._config(enabled=True)
+        fake_module = _make_adapter_module(
+            screen=MagicMock(
+                return_value={
+                    "run_id": "run123",
+                    "strategy": "dual_low",
+                    "market": "cn",
+                    "snapshot_count": 100,
+                    "snapshot_source": "em_datacenter",
+                    "after_filter_count": 5,
+                    "llm_ranked": True,
+                    "llm_coverage": 1.0,
+                    "warnings": "fallback",
+                    "source_errors": "sina timeout",
+                    "llm_parse_errors": "retry parsed partial JSON",
+                    "deep_analysis_requested": False,
+                    "post_analyzers": ["scorecard"],
+                    "daily_enriched": True,
+                    "daily_enrich_count": 12,
+                    "risk_enabled": True,
+                    "portfolio_diversity_enabled": True,
+                    "portfolio_concentration_notes": ["sector concentration adjusted"],
+                    "candidates": [
+                        {
+                            "code": "600519",
+                            "name": "Kweichow Moutai",
+                            "score": 88.5,
+                            "llm_score": 90.0,
+                            "llm_thesis": "LLM likes the setup",
+                            "risk_level": "medium",
+                            "risk_flags": ["valuation"],
+                            "price": 1688.0,
+                            "industry": "Baijiu",
+                            "factor_scores": {"value": 88.0},
+                        }
+                    ],
+                }
+            ),
+        )
+
+        with patch("src.services.alphasift_service._import_alphasift", return_value=fake_module):
+            payload = self._screen(config, market="cn", strategy="dual_low", max_results=5)
+
+        fake_module.screen.assert_called_once_with(
+            "dual_low",
+            market="cn",
+            max_results=5,
+            use_llm=True,
+            context=ANY,
+        )
+        self.assertEqual(fake_module.screen.call_args.kwargs["context"]["llm"]["model"], "")
+        self.assertEqual(payload["run_id"], "run123")
+        self.assertEqual(payload["snapshot_count"], 100)
+        self.assertEqual(payload["snapshot_source"], "em_datacenter")
+        self.assertEqual(payload["after_filter_count"], 5)
+        self.assertEqual(payload["llm_ranked"], True)
+        self.assertEqual(payload["llm_coverage"], 1.0)
+        self.assertEqual(payload["warnings"], ["fallback"])
+        self.assertEqual(payload["source_errors"], ["sina timeout"])
+        self.assertEqual(payload["llm_parse_errors"], ["retry parsed partial JSON"])
+        self.assertEqual(payload["candidate_count"], 1)
+        self.assertEqual(payload["post_analyzers"], ["scorecard"])
+        self.assertEqual(payload["daily_enriched"], True)
+        self.assertEqual(payload["daily_enrich_count"], 12)
+        self.assertEqual(payload["portfolio_concentration_notes"], ["sector concentration adjusted"])
+        self.assertEqual(payload["candidates"][0]["code"], "600519")
+        self.assertEqual(payload["candidates"][0]["llm_score"], 90.0)
+        self.assertEqual(payload["candidates"][0]["llm_thesis"], "LLM likes the setup")
+        self.assertEqual(payload["candidates"][0]["risk_level"], "medium")
+        self.assertEqual(payload["candidates"][0]["price"], 1688.0)
+        self.assertEqual(payload["candidates"][0]["industry"], "Baijiu")
+
+    def test_screen_prefers_dsa_daily_history_for_alphasift_enrichment(self) -> None:
+        config = self._config(enabled=True)
+        parent_module = ModuleType("alphasift")
+        daily_module = ModuleType("alphasift.daily")
+        original_daily_fetch = MagicMock(side_effect=AssertionError("AlphaSift daily fetch should not run first"))
+        daily_module.fetch_daily_history = original_daily_fetch
+        parent_module.daily = daily_module
+        captured: Dict[str, Any] = {}
+
+        def screen_with_daily_fetch(strategy: str, **kwargs: Any) -> Dict[str, Any]:
+            daily_df = daily_module.fetch_daily_history(
+                "600519",
+                lookback_days=20,
+                source="akshare",
+                retries=1,
+            )
+            captured["daily_df"] = daily_df
+            captured["context"] = kwargs.get("context")
+            return {
+                "strategy": strategy,
+                "candidates": [{"code": "600519", "score": 88.0}],
+            }
+
+        fake_module = _make_adapter_module(screen=MagicMock(side_effect=screen_with_daily_fetch))
+
+        with (
+            patch.dict(sys.modules, {"alphasift": parent_module, "alphasift.daily": daily_module}),
+            patch("src.services.alphasift_service._import_alphasift", return_value=fake_module),
+            patch(
+                "src.services.alphasift_service.get_dsa_daily_history",
+                return_value=(
+                    [
+                        {
+                            "trade_date": "20260603",
+                            "close": "10.5",
+                            "vol": "123400",
+                        }
+                    ],
+                    "EfinanceFetcher",
+                ),
+            ) as dsa_history_mock,
+        ):
+            payload = self._screen(config, market="cn", strategy="dual_low", max_results=5)
+
+        daily_df = captured["daily_df"]
+        self.assertEqual(daily_df.attrs["source"], "dsa:EfinanceFetcher")
+        self.assertEqual(daily_df.loc[0, "date"], "2026-06-03")
+        self.assertEqual(daily_df.loc[0, "volume"], 123400)
+        self.assertEqual(daily_df.loc[0, "open"], 10.5)
+        self.assertEqual(payload["candidate_count"], 1)
+        self.assertIn("daily_history", captured["context"]["dsa"]["capabilities"])
+        self.assertIs(captured["context"]["dsa"]["get_daily_history"], dsa_history_mock)
+        dsa_history_mock.assert_called_once_with("600519", lookback_days=20)
+        original_daily_fetch.assert_not_called()
+        self.assertIs(daily_module.fetch_daily_history, original_daily_fetch)
+
+    def test_screen_enriches_top_candidates_with_dsa_context(self) -> None:
+        config = self._config(enabled=True)
+        fake_manager = SimpleNamespace(get_stock_name=MagicMock(return_value="贵州茅台"))
+        fake_module = _make_adapter_module(
+            screen=MagicMock(
+                return_value={
+                    "candidates": [
+                        {
+                            "code": "600519",
+                            "score": 88.5,
+                            "reason": "AlphaSift pick",
+                        }
+                    ]
+                }
+            ),
+        )
+
+        with (
+            patch("src.services.alphasift_service._import_alphasift", return_value=fake_module),
+            patch("src.services.alphasift_service._get_dsa_fetcher_manager", return_value=fake_manager),
+            patch(
+                "src.services.alphasift_service.get_dsa_realtime_quote",
+                return_value={"price": 1688.0, "change_pct": 1.2, "amount": 100000000.0},
+            ),
+            patch(
+                "src.services.alphasift_service.get_dsa_fundamental_context",
+                return_value={"market": "cn", "coverage": {"valuation": "available"}},
+            ),
+            patch(
+                "src.services.alphasift_service.search_dsa_stock_news",
+                return_value={
+                    "success": True,
+                    "provider": "test",
+                    "results": [{"title": "贵州茅台最新公告", "source": "测试源"}],
+                },
+            ),
+        ):
+            payload = self._screen(
+                config,
+                market="cn",
+                strategy="dual_low",
+                max_results=5,
+                mock_enrichment=False,
+            )
+
+        candidate = payload["candidates"][0]
+        self.assertEqual(candidate["name"], "贵州茅台")
+        self.assertEqual(candidate["price"], 1688.0)
+        self.assertTrue(candidate["dsa_context"]["enriched"])
+        self.assertEqual(candidate["dsa_news"][0]["title"], "贵州茅台最新公告")
+        self.assertIn("DSA行情", candidate["dsa_analysis_summary"])
+        self.assertEqual(payload["dsa_enrichment"]["enriched_count"], 1)
+
+    def test_screen_reuses_alphasift_dsa_context_without_refetch(self) -> None:
+        config = self._config(enabled=True)
+        fake_module = _make_adapter_module(
+            screen=MagicMock(
+                return_value={
+                    "candidates": [
+                        {
+                            "code": "600519",
+                            "name": "贵州茅台",
+                            "score": 88.5,
+                            "dsa_context": {
+                                "enriched": True,
+                                "quote": {"price": 1688.0, "change_pct": 1.2},
+                                "warnings": ["from_alphasift_provider"],
+                            },
+                            "dsa_news": [{"title": "贵州茅台最新公告", "source": "测试源"}],
+                            "dsa_analysis_summary": "DSA新闻: 贵州茅台最新公告",
+                        }
+                    ]
+                }
+            ),
+        )
+
+        with (
+            patch("src.services.alphasift_service._import_alphasift", return_value=fake_module),
+            patch("src.services.alphasift_service.get_dsa_realtime_quote") as quote_mock,
+            patch("src.services.alphasift_service.get_dsa_fundamental_context") as fundamentals_mock,
+            patch("src.services.alphasift_service.search_dsa_stock_news") as news_mock,
+        ):
+            payload = self._screen(
+                config,
+                market="cn",
+                strategy="dual_low",
+                max_results=5,
+                mock_enrichment=False,
+            )
+
+        candidate = payload["candidates"][0]
+        self.assertTrue(candidate["dsa_context"]["enriched"])
+        self.assertEqual(candidate["dsa_news"][0]["title"], "贵州茅台最新公告")
+        self.assertEqual(candidate["dsa_analysis_summary"], "DSA新闻: 贵州茅台最新公告")
+        self.assertEqual(payload["dsa_enrichment"]["enriched_count"], 1)
+        self.assertEqual(payload["dsa_enrichment"]["warnings"], ["from_alphasift_provider"])
+        quote_mock.assert_not_called()
+        fundamentals_mock.assert_not_called()
+        news_mock.assert_not_called()
+
+    def test_screen_reuses_context_news_results_without_refetch(self) -> None:
+        config = self._config(enabled=True)
+        fake_module = _make_adapter_module(
+            screen=MagicMock(
+                return_value={
+                    "candidates": [
+                        {
+                            "code": "600519",
+                            "name": "贵州茅台",
+                            "score": 88.5,
+                            "dsa_context": {
+                                "enriched": True,
+                                "quote": {"price": 1688.0, "change_pct": 1.2},
+                                "news": {
+                                    "success": True,
+                                    "summary": "DSA新闻：贵州茅台最新公告",
+                                    "results": [{"title": "贵州茅台最新公告", "source": "测试源"}],
+                                },
+                                "warnings": ["from_alphasift_provider"],
+                            },
+                            "dsa_news": [],
+                        }
+                    ]
+                }
+            ),
+        )
+
+        with (
+            patch("src.services.alphasift_service._import_alphasift", return_value=fake_module),
+            patch("src.services.alphasift_service.get_dsa_realtime_quote") as quote_mock,
+            patch("src.services.alphasift_service.get_dsa_fundamental_context") as fundamentals_mock,
+            patch("src.services.alphasift_service.search_dsa_stock_news") as news_mock,
+        ):
+            payload = self._screen(
+                config,
+                market="cn",
+                strategy="dual_low",
+                max_results=5,
+                mock_enrichment=False,
+            )
+
+        candidate = payload["candidates"][0]
+        self.assertEqual(candidate["dsa_news"][0]["title"], "贵州茅台最新公告")
+        self.assertEqual(candidate["dsa_analysis_summary"], "DSA新闻：贵州茅台最新公告")
+        self.assertEqual(payload["dsa_enrichment"]["enriched_count"], 1)
+        self.assertEqual(payload["dsa_enrichment"]["warnings"], ["from_alphasift_provider"])
+        quote_mock.assert_not_called()
+        fundamentals_mock.assert_not_called()
+        news_mock.assert_not_called()
+
+    def test_screen_completes_light_alphasift_context_with_news_only(self) -> None:
+        config = self._config(enabled=True)
+        fake_module = _make_adapter_module(
+            screen=MagicMock(
+                return_value={
+                    "candidates": [
+                        {
+                            "code": "600519",
+                            "name": "贵州茅台",
+                            "score": 88.5,
+                            "dsa_context": {
+                                "enriched": True,
+                                "profile": "pre_rank_light",
+                                "news_included": False,
+                                "quote": {"price": 1688.0, "change_pct": 1.2},
+                                "fundamentals": {"coverage": {"valuation": "available"}},
+                                "news": {
+                                    "success": False,
+                                    "skipped": True,
+                                    "reason": "pre_rank_light_context",
+                                    "results": [],
+                                },
+                            },
+                            "dsa_news": [],
+                            "dsa_analysis_summary": "DSA行情: 现价 1688.0",
+                        }
+                    ]
+                }
+            ),
+        )
+        fake_manager = SimpleNamespace(get_stock_name=MagicMock(return_value="贵州茅台"))
+
+        with (
+            patch("src.services.alphasift_service._import_alphasift", return_value=fake_module),
+            patch("src.services.alphasift_service._get_dsa_fetcher_manager", return_value=fake_manager),
+            patch("src.services.alphasift_service.get_dsa_realtime_quote") as quote_mock,
+            patch("src.services.alphasift_service.get_dsa_fundamental_context") as fundamentals_mock,
+            patch(
+                "src.services.alphasift_service.search_dsa_stock_news",
+                return_value={
+                    "success": True,
+                    "provider": "test",
+                    "results": [{"title": "贵州茅台最新公告", "source": "测试源"}],
+                },
+            ) as news_mock,
+        ):
+            payload = self._screen(
+                config,
+                market="cn",
+                strategy="dual_low",
+                max_results=5,
+                mock_enrichment=False,
+            )
+
+        candidate = payload["candidates"][0]
+        self.assertEqual(candidate["dsa_context"]["profile"], "post_rank_full")
+        self.assertTrue(candidate["dsa_context"]["news_included"])
+        self.assertEqual(candidate["dsa_context"]["quote"]["price"], 1688.0)
+        self.assertEqual(candidate["dsa_context"]["fundamentals"]["coverage"]["valuation"], "available")
+        self.assertEqual(candidate["dsa_news"][0]["title"], "贵州茅台最新公告")
+        quote_mock.assert_not_called()
+        fundamentals_mock.assert_not_called()
+        news_mock.assert_called_once()
+
+    def test_dsa_pre_rank_candidate_context_omits_news(self) -> None:
+        fake_manager = SimpleNamespace(get_stock_name=MagicMock(return_value="贵州茅台"))
+
+        with (
+            patch("src.services.alphasift_service._get_dsa_fetcher_manager", return_value=fake_manager),
+            patch(
+                "src.services.alphasift_service.get_dsa_realtime_quote",
+                return_value={"price": 1688.0, "change_pct": 1.2, "amount": 100000000.0},
+            ),
+            patch(
+                "src.services.alphasift_service.get_dsa_fundamental_context",
+                return_value={"market": "cn", "coverage": {"valuation": "available"}},
+            ),
+            patch("src.services.alphasift_service.search_dsa_stock_news") as news_mock,
+        ):
+            context = alphasift_service.get_dsa_candidate_context("600519", "贵州茅台")
+
+        self.assertEqual(context["profile"], "pre_rank_light")
+        self.assertFalse(context["news_included"])
+        self.assertTrue(context["news"]["skipped"])
+        self.assertEqual(context["quote"]["price"], 1688.0)
+        self.assertEqual(context["fundamentals"]["coverage"]["valuation"], "available")
+        news_mock.assert_not_called()
+
+    def test_screen_bridges_dsa_llm_config_into_alphasift_runtime(self) -> None:
+        config = Config(
+            alphasift_enabled=True,
+            alphasift_install_spec=DEFAULT_ALPHASIFT_TEST_SPEC,
+            litellm_model="gemini/gemini-2.5-flash",
+            litellm_fallback_models=["deepseek/deepseek-chat"],
+            llm_channels=[
+                {
+                    "name": "gemini",
+                    "protocol": "gemini",
+                    "enabled": True,
+                    "base_url": "",
+                    "api_keys": ["dsa-gemini-key"],
+                    "models": ["gemini/gemini-2.5-flash"],
+                    "extra_headers": {"x-tenant": "dsa"},
+                }
+            ],
+        )
+        captured: dict[str, object] = {}
+
+        def screen_impl(_strategy: str, **kwargs):
+            captured["env"] = {
+                "LITELLM_MODEL": alphasift_service.os.environ.get("LITELLM_MODEL"),
+                "LITELLM_FALLBACK_MODELS": alphasift_service.os.environ.get("LITELLM_FALLBACK_MODELS"),
+                "LLM_CHANNELS": alphasift_service.os.environ.get("LLM_CHANNELS"),
+                "LLM_GEMINI_PROTOCOL": alphasift_service.os.environ.get("LLM_GEMINI_PROTOCOL"),
+                "LLM_GEMINI_API_KEYS": alphasift_service.os.environ.get("LLM_GEMINI_API_KEYS"),
+                "LLM_GEMINI_EXTRA_HEADERS": alphasift_service.os.environ.get("LLM_GEMINI_EXTRA_HEADERS"),
+                "GEMINI_API_KEY": alphasift_service.os.environ.get("GEMINI_API_KEY"),
+                "LLM_CANDIDATE_CONTEXT_ENABLED": alphasift_service.os.environ.get("LLM_CANDIDATE_CONTEXT_ENABLED"),
+                "LLM_CANDIDATE_CONTEXT_PROVIDERS": alphasift_service.os.environ.get("LLM_CANDIDATE_CONTEXT_PROVIDERS"),
+                "LLM_CANDIDATE_MULTIPLIER": alphasift_service.os.environ.get("LLM_CANDIDATE_MULTIPLIER"),
+                "LLM_MAX_CANDIDATES": alphasift_service.os.environ.get("LLM_MAX_CANDIDATES"),
+                "DAILY_SOURCE": alphasift_service.os.environ.get("DAILY_SOURCE"),
+                "DAILY_FETCH_RETRIES": alphasift_service.os.environ.get("DAILY_FETCH_RETRIES"),
+                "DAILY_FETCH_MAX_WORKERS": alphasift_service.os.environ.get("DAILY_FETCH_MAX_WORKERS"),
+                "SNAPSHOT_SOURCE_PRIORITY": alphasift_service.os.environ.get("SNAPSHOT_SOURCE_PRIORITY"),
+                "ALPHASIFT_DATA_DIR": alphasift_service.os.environ.get("ALPHASIFT_DATA_DIR"),
+                "ALPHASIFT_FALLBACK_SNAPSHOT_PATH": alphasift_service.os.environ.get("ALPHASIFT_FALLBACK_SNAPSHOT_PATH"),
+                "ALPHASIFT_DAILY_HISTORY_CACHE_DIR": alphasift_service.os.environ.get("ALPHASIFT_DAILY_HISTORY_CACHE_DIR"),
+                "ALPHASIFT_INDUSTRY_PROVIDER_CACHE_DIR": alphasift_service.os.environ.get("ALPHASIFT_INDUSTRY_PROVIDER_CACHE_DIR"),
+            }
+            captured["context"] = kwargs.get("context")
+            return {"candidates": []}
+
+        fake_module = _make_adapter_module(screen=MagicMock(side_effect=screen_impl))
+
+        with (
+            patch.dict(
+                alphasift_service.os.environ,
+                {
+                    "GEMINI_API_KEY": "outer-key",
+                    "SNAPSHOT_SOURCE_PRIORITY": "",
+                    "LLM_CANDIDATE_CONTEXT_ENABLED": "true",
+                    "LLM_CANDIDATE_MULTIPLIER": "",
+                    "LLM_MAX_CANDIDATES": "",
+                    "DAILY_FETCH_RETRIES": "",
+                    "DAILY_FETCH_MAX_WORKERS": "",
+                },
+                clear=False,
+            ),
+            patch("src.services.alphasift_service._import_alphasift", return_value=fake_module),
+        ):
+            payload = self._screen(config, market="cn", strategy="dual_low", max_results=5)
+            self.assertEqual(alphasift_service.os.environ.get("GEMINI_API_KEY"), "outer-key")
+
+        runtime_env = captured["env"]
+        self.assertIsInstance(runtime_env, dict)
+        self.assertEqual(runtime_env["LITELLM_MODEL"], "gemini/gemini-2.5-flash")
+        self.assertEqual(runtime_env["LITELLM_FALLBACK_MODELS"], "deepseek/deepseek-chat")
+        self.assertEqual(runtime_env["LLM_CHANNELS"], "gemini")
+        self.assertEqual(runtime_env["LLM_GEMINI_PROTOCOL"], "gemini")
+        self.assertEqual(runtime_env["LLM_GEMINI_API_KEYS"], "dsa-gemini-key")
+        self.assertEqual(runtime_env["LLM_GEMINI_EXTRA_HEADERS"], '{"x-tenant": "dsa"}')
+        self.assertEqual(runtime_env["GEMINI_API_KEY"], "dsa-gemini-key")
+        self.assertEqual(runtime_env["LLM_CANDIDATE_CONTEXT_ENABLED"], "false")
+        self.assertEqual(runtime_env["LLM_CANDIDATE_CONTEXT_PROVIDERS"], "news,fund_flow,announcement,quote")
+        self.assertEqual(runtime_env["LLM_CANDIDATE_MULTIPLIER"], "2")
+        self.assertEqual(runtime_env["LLM_MAX_CANDIDATES"], "10")
+        self.assertEqual(runtime_env["DAILY_SOURCE"], "auto")
+        self.assertEqual(runtime_env["DAILY_FETCH_RETRIES"], "3")
+        self.assertEqual(runtime_env["DAILY_FETCH_MAX_WORKERS"], "1")
+        self.assertEqual(runtime_env["SNAPSHOT_SOURCE_PRIORITY"], "sina,efinance,akshare_em,em_datacenter")
+        self.assertEqual(runtime_env["ALPHASIFT_DATA_DIR"], str(alphasift_service.DSA_ALPHASIFT_DATA_DIR))
+        self.assertEqual(
+            runtime_env["ALPHASIFT_FALLBACK_SNAPSHOT_PATH"],
+            str(alphasift_service.DSA_ALPHASIFT_DATA_DIR / "snapshot.last_good.json"),
+        )
+        self.assertEqual(
+            runtime_env["ALPHASIFT_DAILY_HISTORY_CACHE_DIR"],
+            str(alphasift_service.DSA_ALPHASIFT_DATA_DIR / "daily_history"),
+        )
+        self.assertEqual(
+            runtime_env["ALPHASIFT_INDUSTRY_PROVIDER_CACHE_DIR"],
+            str(alphasift_service.DSA_ALPHASIFT_DATA_DIR / "industry_provider_cache"),
+        )
+        context = captured["context"]
+        self.assertIsInstance(context, dict)
+        self.assertEqual(context["llm"]["model"], "gemini/gemini-2.5-flash")
+        self.assertFalse(context["llm"]["candidate_context_enabled"])
+        self.assertEqual(context["llm"]["candidate_multiplier"], 2)
+        self.assertEqual(context["llm"]["max_candidates"], 10)
+        self.assertEqual(context["llm"]["channels"][0]["api_keys"], ["dsa-gemini-key"])
+        self.assertEqual(context["llm"]["channels"][0]["extra_headers"], {"x-tenant": "dsa"})
+        self.assertEqual(context["llm"]["model_list"][0]["litellm_params"]["extra_headers"], {"x-tenant": "dsa"})
+        self.assertIn("get_candidate_context", context["dsa"])
+        self.assertEqual(context["dsa"]["mode"], "pre_rank_light")
+        self.assertEqual(context["dsa"]["max_candidates"], 3)
+        self.assertFalse(context["dsa"]["include_news"])
+        self.assertNotIn("search_stock_news", context["dsa"])
+        self.assertEqual(payload["candidate_count"], 0)
+
+    def test_screen_injects_dsa_channel_headers_into_alphasift_litellm_calls(self) -> None:
+        config = Config(
+            alphasift_enabled=True,
+            alphasift_install_spec=DEFAULT_ALPHASIFT_TEST_SPEC,
+            litellm_model="gemini/gemini-2.5-flash",
+            llm_channels=[
+                {
+                    "name": "gemini",
+                    "protocol": "gemini",
+                    "enabled": True,
+                    "api_keys": ["dsa-gemini-key"],
+                    "models": ["gemini/gemini-2.5-flash"],
+                    "extra_headers": {"x-tenant": "dsa"},
+                }
+            ],
+        )
+        completion_calls: list[dict[str, object]] = []
+
+        def completion_impl(**kwargs):
+            completion_calls.append(kwargs)
+            return SimpleNamespace(choices=[])
+
+        fake_litellm = SimpleNamespace(completion=completion_impl)
+
+        def screen_impl(_strategy: str, **_kwargs):
+            fake_litellm.completion(
+                model="gemini/gemini-2.5-flash",
+                api_key="dsa-gemini-key",
+                messages=[{"role": "user", "content": "rank"}],
+            )
+            return {"candidates": []}
+
+        fake_module = _make_adapter_module(screen=MagicMock(side_effect=screen_impl))
+
+        with (
+            patch.dict(sys.modules, {"litellm": fake_litellm}, clear=False),
+            patch("src.services.alphasift_service._import_alphasift", return_value=fake_module),
+        ):
+            payload = self._screen(config, market="cn", strategy="dual_low", max_results=5)
+
+        self.assertEqual(payload["candidate_count"], 0)
+        self.assertEqual(completion_calls[0]["extra_headers"], {"x-tenant": "dsa"})
+        self.assertIsNot(fake_litellm.completion, completion_impl)
+        self.assertTrue(
+            getattr(fake_litellm.completion, "_alphasift_litellm_completion_bridge", False),
+        )
+
+    def test_screen_bridges_legacy_openai_fields_into_alphasift_runtime_env(self) -> None:
+        config = Config(
+            alphasift_enabled=True,
+            alphasift_install_spec=DEFAULT_ALPHASIFT_TEST_SPEC,
+            litellm_model="openai/gpt-4o-mini",
+            openai_api_keys=["dsa-openai-key"],
+            openai_base_url="https://openai-compatible.example/v1",
+        )
+        captured: dict[str, object] = {}
+
+        def screen_impl(_strategy: str, **kwargs):
+            captured["env"] = {
+                "OPENAI_API_KEY": alphasift_service.os.environ.get("OPENAI_API_KEY"),
+                "OPENAI_API_KEYS": alphasift_service.os.environ.get("OPENAI_API_KEYS"),
+                "OPENAI_BASE_URL": alphasift_service.os.environ.get("OPENAI_BASE_URL"),
+                "LITELLM_MODEL": alphasift_service.os.environ.get("LITELLM_MODEL"),
+            }
+            captured["context"] = kwargs.get("context")
+            return {"candidates": []}
+
+        fake_module = _make_adapter_module(screen=MagicMock(side_effect=screen_impl))
+
+        with (
+            patch.dict(
+                alphasift_service.os.environ,
+                {
+                    "OPENAI_API_KEY": "outer-openai-key",
+                    "OPENAI_BASE_URL": "https://outer-openai.example/v1",
+                },
+                clear=False,
+            ),
+            patch("src.services.alphasift_service._import_alphasift", return_value=fake_module),
+        ):
+            payload = self._screen(config, market="cn", strategy="dual_low", max_results=5)
+            self.assertEqual(alphasift_service.os.environ.get("OPENAI_API_KEY"), "outer-openai-key")
+            self.assertEqual(alphasift_service.os.environ.get("OPENAI_BASE_URL"), "https://outer-openai.example/v1")
+
+        runtime_env = captured["env"]
+        self.assertIsInstance(runtime_env, dict)
+        self.assertEqual(runtime_env["OPENAI_API_KEY"], "dsa-openai-key")
+        self.assertEqual(runtime_env["OPENAI_API_KEYS"], "dsa-openai-key")
+        self.assertEqual(runtime_env["OPENAI_BASE_URL"], "https://openai-compatible.example/v1")
+        self.assertEqual(runtime_env["LITELLM_MODEL"], "openai/gpt-4o-mini")
+
+        context = captured["context"]
+        self.assertIsInstance(context, dict)
+        self.assertEqual(context["llm"]["channels"], [])
+        self.assertEqual(context["llm"]["model_list"], [])
+        self.assertEqual(payload["candidate_count"], 0)
+
+    def test_screen_injects_openai_compatible_model_headers_into_alphasift_litellm_calls(self) -> None:
+        config = Config(
+            alphasift_enabled=True,
+            alphasift_install_spec=DEFAULT_ALPHASIFT_TEST_SPEC,
+            litellm_model="openai/gpt-4o-mini",
+            litellm_fallback_models=["openai/gpt-4o-mini"],
+            llm_model_list=[
+                {
+                    "model_name": "openai/gpt-4o-mini",
+                    "litellm_params": {
+                        "model": "openai/gpt-4o-mini",
+                        "api_key": "dsa-openai-key",
+                        "api_base": "https://openai-compatible.example/v1",
+                        "extra_headers": {"x-tenant": "dsa"},
+                    },
+                },
+            ],
+        )
+        completion_calls: list[dict[str, object]] = []
+
+        def completion_impl(**kwargs):
+            completion_calls.append(kwargs)
+            return SimpleNamespace(choices=[])
+
+        fake_litellm = SimpleNamespace(completion=completion_impl)
+
+        def screen_impl(_strategy: str, **_kwargs):
+            fake_litellm.completion(
+                model="openai/gpt-4o-mini",
+                api_key="dsa-openai-key",
+                api_base="https://openai-compatible.example/v1",
+                messages=[{"role": "user", "content": "rank"}],
+            )
+            return {"candidates": []}
+
+        fake_module = _make_adapter_module(screen=MagicMock(side_effect=screen_impl))
+
+        with (
+            patch.dict(sys.modules, {"litellm": fake_litellm}, clear=False),
+            patch("src.services.alphasift_service._import_alphasift", return_value=fake_module),
+        ):
+            payload = self._screen(config, market="cn", strategy="dual_low", max_results=5)
+
+        self.assertEqual(payload["candidate_count"], 0)
+        self.assertEqual(completion_calls[0]["extra_headers"], {"x-tenant": "dsa"})
+        self.assertEqual(
+            completion_calls[0]["api_base"],
+            "https://openai-compatible.example/v1",
+        )
+        self.assertIsNot(fake_litellm.completion, completion_impl)
+        self.assertTrue(
+            getattr(fake_litellm.completion, "_alphasift_litellm_completion_bridge", False),
+        )
+
+    def test_screen_bridges_openai_channel_base_url_and_headers(self) -> None:
+        config = Config(
+            alphasift_enabled=True,
+            alphasift_install_spec=DEFAULT_ALPHASIFT_TEST_SPEC,
+            litellm_model="openai/gpt-4o-mini",
+            litellm_fallback_models=["openai/gpt-4.1"],
+            llm_channels=[
+                {
+                    "name": "openai",
+                    "protocol": "openai",
+                    "enabled": True,
+                    "base_url": "https://primary-openai.example/v1",
+                    "api_keys": ["dsa-openai-primary"],
+                    "models": ["openai/gpt-4o-mini", "openai/gpt-4.1"],
+                    "extra_headers": {"x-route": "primary", "x-tenant": "dsa"},
+                }
+            ],
+        )
+        completion_calls: list[Dict[str, object]] = []
+
+        def completion_impl(**kwargs: Any) -> Any:
+            completion_calls.append(kwargs)
+            return SimpleNamespace(choices=[])
+
+        fake_litellm = SimpleNamespace(completion=completion_impl)
+
+        captured: dict[str, object] = {}
+
+        def screen_impl(_strategy: str, **kwargs: Dict[str, Any]) -> dict[str, object]:
+            captured["env"] = {
+                "OPENAI_BASE_URL": alphasift_service.os.environ.get("OPENAI_BASE_URL"),
+                "OPENAI_API_KEY": alphasift_service.os.environ.get("OPENAI_API_KEY"),
+                "OPENAI_API_KEYS": alphasift_service.os.environ.get("OPENAI_API_KEYS"),
+                "LLM_CHANNELS": alphasift_service.os.environ.get("LLM_CHANNELS"),
+                "LLM_OPENAI_BASE_URL": alphasift_service.os.environ.get("LLM_OPENAI_BASE_URL"),
+                "LLM_OPENAI_API_KEYS": alphasift_service.os.environ.get("LLM_OPENAI_API_KEYS"),
+            }
+            captured["context"] = kwargs.get("context")
+            fake_litellm.completion(
+                model="openai/gpt-4o-mini",
+                api_key="dsa-openai-primary",
+                api_base="https://primary-openai.example/v1",
+                messages=[{"role": "user", "content": "primary"}],
+            )
+            fake_litellm.completion(
+                model="openai/gpt-4.1",
+                api_key="dsa-openai-primary",
+                api_base="https://primary-openai.example/v1",
+                messages=[{"role": "user", "content": "fallback"}],
+            )
+            return {"candidates": []}
+
+        fake_module = _make_adapter_module(screen=MagicMock(side_effect=screen_impl))
+
+        with (
+            patch.dict(sys.modules, {"litellm": fake_litellm}, clear=False),
+            patch("src.services.alphasift_service._import_alphasift", return_value=fake_module),
+        ):
+            payload = self._screen(config, market="cn", strategy="dual_low", max_results=5)
+
+        self.assertEqual(payload["candidate_count"], 0)
+        self.assertEqual(len(completion_calls), 2)
+        self.assertEqual(captured["env"]["OPENAI_BASE_URL"], "https://primary-openai.example/v1")
+        self.assertEqual(captured["env"]["OPENAI_API_KEYS"], "dsa-openai-primary")
+        self.assertEqual(captured["env"]["OPENAI_API_KEY"], "dsa-openai-primary")
+        self.assertEqual(captured["env"]["LLM_CHANNELS"], "openai")
+        self.assertEqual(captured["env"]["LLM_OPENAI_BASE_URL"], "https://primary-openai.example/v1")
+        self.assertEqual(captured["env"]["LLM_OPENAI_API_KEYS"], "dsa-openai-primary")
+        self.assertEqual(completion_calls[0]["extra_headers"], {"x-route": "primary", "x-tenant": "dsa"})
+        self.assertEqual(completion_calls[1]["extra_headers"], {"x-route": "primary", "x-tenant": "dsa"})
+        context = captured["context"]
+        self.assertIsInstance(context, dict)
+        self.assertEqual(context["llm"]["channels"][0]["base_url"], "https://primary-openai.example/v1")
+        self.assertEqual(context["llm"]["channels"][0]["extra_headers"], {"x-route": "primary", "x-tenant": "dsa"})
+        self.assertEqual(context["llm"]["model_list"][0]["litellm_params"]["api_base"], "https://primary-openai.example/v1")
+        self.assertEqual(context["llm"]["fallback_models"], ["openai/gpt-4.1"])
+        self.assertEqual(payload["candidate_count"], 0)
+
+    def test_screen_injects_openai_compatible_fallback_headers_for_multiple_models(self) -> None:
+        config = Config(
+            alphasift_enabled=True,
+            alphasift_install_spec=DEFAULT_ALPHASIFT_TEST_SPEC,
+            litellm_model="openai/gpt-4o-mini",
+            litellm_fallback_models=["openai/gpt-4.1"],
+            llm_model_list=[
+                {
+                    "model_name": "openai/gpt-4o-mini",
+                    "litellm_params": {
+                        "model": "openai/gpt-4o-mini",
+                        "api_key": "dsa-openai-primary",
+                        "api_base": "https://primary.openai.example/v1",
+                        "extra_headers": {"x-route": "primary", "x-tenant": "dsa"},
+                    },
+                },
+                {
+                    "model_name": "openai/gpt-4.1",
+                    "litellm_params": {
+                        "model": "openai/gpt-4.1",
+                        "api_key": "dsa-openai-fallback",
+                        "api_base": "https://fallback.openai.example/v1",
+                        "extra_headers": {"x-route": "fallback", "x-tenant": "dsa"},
+                    },
+                },
+            ],
+        )
+        completion_calls: list[Dict[str, object]] = []
+
+        def completion_impl(**kwargs: Any) -> Any:
+            completion_calls.append(kwargs)
+            return SimpleNamespace(choices=[])
+
+        fake_litellm = SimpleNamespace(completion=completion_impl)
+
+        def screen_impl(_strategy: str, **_kwargs) -> dict[str, object]:
+            fake_litellm.completion(
+                model="openai/gpt-4o-mini",
+                api_key="dsa-openai-primary",
+                api_base="https://primary.openai.example/v1",
+                messages=[{"role": "user", "content": "rank-1"}],
+            )
+            fake_litellm.completion(
+                model="openai/gpt-4.1",
+                api_key="dsa-openai-fallback",
+                api_base="https://fallback.openai.example/v1",
+                messages=[{"role": "user", "content": "rank-2"}],
+            )
+            return {"candidates": []}
+
+        fake_module = _make_adapter_module(screen=MagicMock(side_effect=screen_impl))
+
+        with (
+            patch.dict(sys.modules, {"litellm": fake_litellm}, clear=False),
+            patch("src.services.alphasift_service._import_alphasift", return_value=fake_module),
+        ):
+            payload = self._screen(config, market="cn", strategy="dual_low", max_results=5)
+
+        self.assertEqual(payload["candidate_count"], 0)
+        primary_call = next(
+            call for call in completion_calls if call["model"] == "openai/gpt-4o-mini"
+        )
+        fallback_call = next(
+            call for call in completion_calls if call["model"] == "openai/gpt-4.1"
+        )
+        self.assertEqual(primary_call["extra_headers"], {"x-route": "primary", "x-tenant": "dsa"})
+        self.assertEqual(
+            fallback_call["extra_headers"],
+            {"x-route": "fallback", "x-tenant": "dsa"},
+        )
+        self.assertEqual(primary_call["api_base"], "https://primary.openai.example/v1")
+        self.assertEqual(fallback_call["api_base"], "https://fallback.openai.example/v1")
+        self.assertTrue(getattr(fake_litellm.completion, "_alphasift_litellm_completion_bridge", False))
+
+    def test_screen_handles_concurrent_requests_without_litellm_header_cross_pollution(self) -> None:
+        config_a = Config(
+            alphasift_enabled=True,
+            alphasift_install_spec=DEFAULT_ALPHASIFT_TEST_SPEC,
+            litellm_model="gemini/gemini-2.5-flash",
+            llm_channels=[
+                {
+                    "name": "gemini",
+                    "protocol": "gemini",
+                    "enabled": True,
+                    "api_keys": ["dsa-gemini-key-a"],
+                    "models": ["gemini/gemini-2.5-flash"],
+                    "extra_headers": {"x-tenant": "tenant-a"},
+                }
+            ],
+        )
+        config_b = Config(
+            alphasift_enabled=True,
+            alphasift_install_spec=DEFAULT_ALPHASIFT_TEST_SPEC,
+            litellm_model="gemini/gemini-2.5-flash",
+            llm_channels=[
+                {
+                    "name": "gemini",
+                    "protocol": "gemini",
+                    "enabled": True,
+                    "api_keys": ["dsa-gemini-key-b"],
+                    "models": ["gemini/gemini-2.5-flash"],
+                    "extra_headers": {"x-tenant": "tenant-b"},
+                }
+            ],
+        )
+
+        completion_calls: list[Dict[str, Any]] = []
+        thread_b_ready = threading.Event()
+        completion_lock = threading.Lock()
+
+        def completion_impl(**kwargs: Any) -> Any:
+            with completion_lock:
+                completion_calls.append(kwargs)
+            return SimpleNamespace(choices=[])
+
+        fake_litellm = SimpleNamespace(completion=completion_impl)
+
+        def screen_impl(_strategy: str, **kwargs: Any) -> Dict[str, Any]:
+            context = kwargs.get("context") or {}
+            llm = context.get("llm", {})
+            channels = llm.get("channels") or []
+            headers = (channels[0] if channels else {}).get("extra_headers", {})
+            tenant = headers.get("x-tenant")
+            if tenant == "tenant-a":
+                thread_b_ready.wait(timeout=2)
+            else:
+                thread_b_ready.set()
+            fake_litellm.completion(
+                model="gemini/gemini-2.5-flash",
+                api_key=(channels[0].get("api_keys") or [""])[0],
+                messages=[{"role": "user", "content": "rank"}],
+            )
+            return {"candidates": []}
+
+        fake_module = _make_adapter_module(screen=MagicMock(side_effect=screen_impl))
+
+        def _run_screen(config: Config) -> None:
+            self._screen(config, market="cn", strategy="dual_low", max_results=5, mock_enrichment=False)
+
+        with (
+            patch.dict(sys.modules, {"litellm": fake_litellm}, clear=False),
+            patch("src.services.alphasift_service._import_alphasift", return_value=fake_module),
+        ):
+            thread_a = threading.Thread(target=_run_screen, args=(config_a,))
+            thread_b = threading.Thread(target=_run_screen, args=(config_b,))
+            thread_a.start()
+            thread_b.start()
+            thread_a.join()
+            thread_b.join()
+
+        self.assertEqual(len(completion_calls), 2)
+        self.assertCountEqual(
+            [call.get("extra_headers", {}).get("x-tenant") for call in completion_calls],
+            ["tenant-a", "tenant-b"],
+        )
+        self.assertTrue(
+            thread_a.is_alive() is False and thread_b.is_alive() is False,
+        )
+
+    def test_screen_disabled_preserves_existing_llm_env_state(self) -> None:
+        config = self._config(enabled=False)
+        baseline_env = {
+            "OPENAI_API_KEY": "legacy-openai-key",
+            "OPENAI_BASE_URL": "https://outer.example.com/v1",
+            "LITELLM_MODEL": "openai/gpt-4o-mini",
+        }
+        original_env = {key: alphasift_service.os.environ.get(key) for key in baseline_env}
+
+        with (
+            patch.dict(alphasift_service.os.environ, baseline_env, clear=False),
+            patch("src.services.alphasift_service._build_alphasift_runtime_env") as runtime_env_mock,
+            self.assertRaises(HTTPException) as caught,
+        ):
+            self._screen(config, market="cn", strategy="dual_low", max_results=5)
+            for key, value in baseline_env.items():
+                self.assertEqual(alphasift_service.os.environ.get(key), value)
+
+        self.assertEqual(caught.exception.status_code, 403)
+        self.assertEqual(caught.exception.detail["error"], "alphasift_disabled")
+        runtime_env_mock.assert_not_called()
+        for key, value in baseline_env.items():
+            self.assertEqual(alphasift_service.os.environ.get(key), original_env[key])
+
+    def test_screen_preserves_explicit_alphasift_snapshot_source_priority(self) -> None:
+        config = self._config(enabled=True)
+        captured: dict[str, object] = {}
+
+        def screen_impl(_strategy: str, **_kwargs):
+            captured["snapshot_priority"] = alphasift_service.os.environ.get("SNAPSHOT_SOURCE_PRIORITY")
+            return {"candidates": []}
+
+        fake_module = _make_adapter_module(screen=MagicMock(side_effect=screen_impl))
+
+        with (
+            patch.dict(alphasift_service.os.environ, {"SNAPSHOT_SOURCE_PRIORITY": "tushare,em_datacenter"}, clear=False),
+            patch("src.services.alphasift_service._import_alphasift", return_value=fake_module),
+        ):
+            payload = self._screen(config, market="cn", strategy="dual_low", max_results=5)
+
+        self.assertEqual(captured["snapshot_priority"], "tushare,em_datacenter")
+        self.assertEqual(payload["candidate_count"], 0)
+
+    def test_screen_preserves_explicit_daily_source(self) -> None:
+        config = self._config(enabled=True)
+        captured: dict[str, object] = {}
+
+        def screen_impl(_strategy: str, **_kwargs):
+            captured["daily_source"] = alphasift_service.os.environ.get("DAILY_SOURCE")
+            return {"candidates": []}
+
+        fake_module = _make_adapter_module(screen=MagicMock(side_effect=screen_impl))
+
+        with (
+            patch.dict(alphasift_service.os.environ, {"DAILY_SOURCE": "akshare"}, clear=False),
+            patch("src.services.alphasift_service._import_alphasift", return_value=fake_module),
+        ):
+            payload = self._screen(config, market="cn", strategy="dual_low", max_results=5)
+
+        self.assertEqual(captured["daily_source"], "akshare")
+        self.assertEqual(payload["candidate_count"], 0)
+
+    def test_screen_preserves_explicit_openai_base_url_without_openai_channel(self) -> None:
+        config = Config(
+            alphasift_enabled=True,
+            alphasift_install_spec=DEFAULT_ALPHASIFT_TEST_SPEC,
+            litellm_model="deepseek/deepseek-chat",
+            llm_channels=[
+                {
+                    "name": "deepseek",
+                    "protocol": "deepseek",
+                    "enabled": True,
+                    "base_url": "https://api.deepseek.example/v1",
+                    "api_keys": ["runtime-deepseek-key"],
+                    "models": ["deepseek/deepseek-chat"],
+                }
+            ],
+        )
+        captured: dict[str, object] = {}
+
+        def screen_impl(_strategy: str, **_kwargs):
+            captured["openai_base_url"] = alphasift_service.os.environ.get("OPENAI_BASE_URL")
+            captured["llm_openai_base_url"] = alphasift_service.os.environ.get("LLM_OPENAI_BASE_URL")
+            captured["openai_api_key"] = alphasift_service.os.environ.get("OPENAI_API_KEY")
+            return {"candidates": []}
+
+        fake_module = _make_adapter_module(screen=MagicMock(side_effect=screen_impl))
+
+        with (
+            patch.dict(
+                alphasift_service.os.environ,
+                {
+                    "OPENAI_BASE_URL": "https://outer-openai.example/v1",
+                    "LLM_OPENAI_BASE_URL": "https://outer-openai-channel.example/v1",
+                    "OPENAI_API_KEY": "outer-openai-key",
+                },
+                clear=False,
+            ),
+            patch("src.services.alphasift_service._import_alphasift", return_value=fake_module),
+        ):
+            payload = self._screen(config, market="cn", strategy="dual_low", max_results=5)
+
+        self.assertEqual(captured["openai_base_url"], "https://outer-openai.example/v1")
+        self.assertEqual(captured["llm_openai_base_url"], "https://outer-openai-channel.example/v1")
+        self.assertEqual(captured["openai_api_key"], "outer-openai-key")
+        self.assertEqual(payload["candidate_count"], 0)
+
+    def test_alphasift_runtime_priority_puts_tushare_before_sina_when_token_exists(self) -> None:
+        config = self._config(enabled=True)
+        config.tushare_token = "token-1"
+
+        with patch.dict(alphasift_service.os.environ, {"SNAPSHOT_SOURCE_PRIORITY": ""}, clear=False):
+            env = alphasift_service._build_alphasift_runtime_env(config)
+
+        self.assertEqual(env["SNAPSHOT_SOURCE_PRIORITY"], "tushare,sina,efinance,akshare_em,em_datacenter")
+
+    def test_screen_preserves_explicit_candidate_context_provider_override(self) -> None:
+        config = self._config(enabled=True)
+        captured: dict[str, object] = {}
+
+        def screen_impl(_strategy: str, **_kwargs):
+            captured["providers"] = alphasift_service.os.environ.get("LLM_CANDIDATE_CONTEXT_PROVIDERS")
+            return {"candidates": []}
+
+        fake_module = _make_adapter_module(screen=MagicMock(side_effect=screen_impl))
+
+        with (
+            patch.dict(alphasift_service.os.environ, {"LLM_CANDIDATE_CONTEXT_PROVIDERS": "news,announcement"}, clear=False),
+            patch("src.services.alphasift_service._import_alphasift", return_value=fake_module),
+        ):
+            payload = self._screen(config, market="cn", strategy="dual_low", max_results=5)
+
+        self.assertEqual(captured["providers"], "news,announcement")
+        self.assertEqual(payload["candidate_count"], 0)
+
+    def test_screen_filters_undeclared_managed_fallbacks_for_dsa_routes(self) -> None:
+        config = Config(
+            alphasift_enabled=True,
+            alphasift_install_spec=DEFAULT_ALPHASIFT_TEST_SPEC,
+            litellm_model="gemini/gemini-3-flash-preview",
+            litellm_fallback_models=["gemini/gemini-2.5-flash"],
+            llm_channels=[
+                {
+                    "name": "gemini",
+                    "protocol": "gemini",
+                    "enabled": True,
+                    "base_url": "",
+                    "api_keys": ["dsa-gemini-key"],
+                    "models": ["gemini/gemini-3-flash-preview"],
+                },
+                {
+                    "name": "deepseek",
+                    "protocol": "deepseek",
+                    "enabled": True,
+                    "base_url": "https://api.deepseek.com",
+                    "api_keys": ["dsa-deepseek-key"],
+                    "models": ["deepseek/deepseek-chat"],
+                },
+            ],
+            llm_model_list=[
+                {
+                    "model_name": "gemini/gemini-3-flash-preview",
+                    "litellm_params": {
+                        "model": "gemini/gemini-3-flash-preview",
+                        "api_key": "dsa-gemini-key",
+                    },
+                },
+                {
+                    "model_name": "deepseek/deepseek-chat",
+                    "litellm_params": {
+                        "model": "deepseek/deepseek-chat",
+                        "api_key": "dsa-deepseek-key",
+                        "api_base": "https://api.deepseek.com",
+                    },
+                },
+            ],
+        )
+        captured: dict[str, object] = {}
+
+        def screen_impl(_strategy: str, **kwargs):
+            captured["env"] = {
+                "LITELLM_MODEL": alphasift_service.os.environ.get("LITELLM_MODEL"),
+                "LITELLM_FALLBACK_MODELS": alphasift_service.os.environ.get("LITELLM_FALLBACK_MODELS"),
+                "LLM_CHANNELS": alphasift_service.os.environ.get("LLM_CHANNELS"),
+            }
+            captured["context"] = kwargs.get("context")
+            return {"candidates": []}
+
+        fake_module = _make_adapter_module(screen=MagicMock(side_effect=screen_impl))
+
+        with patch("src.services.alphasift_service._import_alphasift", return_value=fake_module):
+            payload = self._screen(config, market="cn", strategy="dual_low", max_results=5)
+
+        runtime_env = captured["env"]
+        self.assertIsInstance(runtime_env, dict)
+        self.assertEqual(runtime_env["LITELLM_MODEL"], "gemini/gemini-3-flash-preview")
+        self.assertEqual(runtime_env["LITELLM_FALLBACK_MODELS"], "deepseek/deepseek-chat")
+        self.assertEqual(runtime_env["LLM_CHANNELS"], "gemini,deepseek")
+        context = captured["context"]
+        self.assertIsInstance(context, dict)
+        self.assertEqual(context["llm"]["fallback_models"], ["deepseek/deepseek-chat"])
+        self.assertEqual(payload["candidate_count"], 0)
+
+    def test_screen_retries_without_context_for_older_adapter_kwargs_wrappers(self) -> None:
+        config = self._config(enabled=True)
+
+        def screen_impl(_strategy: str, **kwargs):
+            if "context" in kwargs:
+                raise TypeError("unexpected keyword argument 'context'")
+            return {"candidates": []}
+
+        fake_module = _make_adapter_module(screen=MagicMock(side_effect=screen_impl))
+
+        with patch("src.services.alphasift_service._import_alphasift", return_value=fake_module):
+            payload = self._screen(config, market="cn", strategy="dual_low", max_results=5)
+
+        self.assertEqual(fake_module.screen.call_count, 2)
+        first_kwargs = fake_module.screen.call_args_list[0].kwargs
+        second_kwargs = fake_module.screen.call_args_list[1].kwargs
+        self.assertIn("context", first_kwargs)
+        self.assertNotIn("context", second_kwargs)
+        self.assertEqual(second_kwargs["market"], "cn")
+        self.assertEqual(second_kwargs["max_results"], 5)
+        self.assertEqual(second_kwargs["use_llm"], True)
+        self.assertEqual(payload["candidate_count"], 0)
+
+    def test_screen_does_not_install_when_enabled_but_adapter_missing(self) -> None:
+        config = self._config(enabled=True)
+        fake_module = _make_adapter_module(screen=MagicMock(return_value={"candidates": []}))
+
+        with (
+            patch(
+                "src.services.alphasift_service._get_alphasift_status_snapshot",
+                return_value=({}, False, _missing_alphasift_module_diagnostics()),
+            ),
+            patch("src.services.alphasift_service._install_alphasift") as install_mock,
+            patch("src.services.alphasift_service._import_alphasift", return_value=fake_module),
+        ):
+            with self.assertRaises(HTTPException) as caught:
+                self._screen(config, market="cn", strategy="dual_low", max_results=5)
+
+        self.assertEqual(caught.exception.status_code, 424)
+        self.assertEqual(caught.exception.detail.get("diagnostics", {}).get("reason"), "missing_module")
+        install_mock.assert_not_called()
+        fake_module.screen.assert_not_called()
+
+    def test_screen_normalizes_non_finite_values(self) -> None:
+        config = self._config(enabled=True)
+        fake_module = _make_adapter_module(
+            screen=MagicMock(
+                return_value={
+                    "picks": [
+                        {
+                            "code": "600519",
+                            "name": "Kweichow Moutai",
+                            "score": float("nan"),
+                            "ranking_reason": "AlphaSift pick",
+                            "nested": {"pe": float("inf"), "pb": float("-inf"), "eps": 20.5},
+                        },
+                    ],
+                }
+            ),
+        )
+
+        with patch("src.services.alphasift_service._import_alphasift", return_value=fake_module):
+            payload = self._screen(config, market="cn", strategy="dual_low", max_results=5)
+
+        self.assertIsNone(payload["candidates"][0]["score"])
+        self.assertIsNone(payload["candidates"][0]["raw"]["score"])
+        self.assertIsNone(payload["candidates"][0]["raw"]["nested"]["pe"])
+        self.assertIsNone(payload["candidates"][0]["raw"]["nested"]["pb"])
+
+    def test_screen_allows_non_listed_strategy_as_custom(self) -> None:
+        config = self._config(enabled=True)
+        fake_module = _make_adapter_module(
+            list_strategies=lambda: [{"id": "dual_low", "name": "双低选股"}],
+            screen=MagicMock(return_value={"candidates": []}),
+        )
+
+        with patch("src.services.alphasift_service._import_alphasift", return_value=fake_module):
+            payload = self._screen(config, market="cn", strategy="custom_alpha", max_results=5)
+
+        fake_module.screen.assert_called_once_with(
+            "custom_alpha",
+            market="cn",
+            max_results=5,
+            use_llm=True,
+            context=ANY,
+        )
+        self.assertEqual(payload["candidates"], [])
+        self.assertEqual(payload["candidate_count"], 0)
+
+    def test_screen_rejects_unsupported_market(self) -> None:
+        config = self._config(enabled=True)
+        fake_module = _make_adapter_module(
+            get_status=lambda: {"supported_markets": ["hk", "us"]},
+            screen=MagicMock(return_value=[]),
+        )
+
+        with patch("src.services.alphasift_service._import_alphasift", return_value=fake_module):
+            with self.assertRaises(HTTPException) as caught:
+                self._screen(config, market="cn", strategy="dual_low", max_results=5)
+
+        self.assertEqual(caught.exception.status_code, 422)
+        self.assertEqual(caught.exception.detail["error"], "alphasift_invalid_market")
+
+    def test_screen_maps_adapter_value_error_to_bad_request(self) -> None:
+        config = self._config(enabled=True)
+        fake_module = _make_adapter_module(
+            screen=MagicMock(side_effect=ValueError("Only market='cn' is currently supported")),
+        )
+
+        with patch("src.services.alphasift_service._import_alphasift", return_value=fake_module):
+            with self.assertRaises(HTTPException) as caught:
+                self._screen(config, market="cn", strategy="dual_low", max_results=5)
+
+        self.assertEqual(caught.exception.status_code, 400)
+        self.assertEqual(caught.exception.detail["error"], "alphasift_screen_rejected")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_free_source_context_integration.py
+++ b/tests/test_free_source_context_integration.py
@@ -1,0 +1,110 @@
+# -*- coding: utf-8 -*-
+"""Offline integration tests for free-source report context injection."""
+
+import os
+import sys
+import unittest
+from unittest.mock import MagicMock
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+
+class TestFreeSourceStockContext(unittest.TestCase):
+    def test_pipeline_builds_bounded_free_a_stock_context(self):
+        from src.core.pipeline import StockAnalysisPipeline
+
+        pipeline = StockAnalysisPipeline.__new__(StockAnalysisPipeline)
+        pipeline.fetcher_manager = MagicMock()
+        pipeline.fetcher_manager.get_free_announcements.return_value = [
+            {
+                "title": "年度报告",
+                "date": "2026-07-30",
+                "source": "cninfo",
+                "pdf_url": "https://static.cninfo.com.cn/test.pdf",
+            }
+        ]
+        pipeline.fetcher_manager.get_fallback_announcements.return_value = []
+        pipeline.fetcher_manager.get_fallback_fund_flow.return_value = [
+            {
+                "date": "2026-07-29",
+                "net_amount": 12345,
+                "close": 1500.5,
+                "turnover": 1.2,
+            }
+        ]
+
+        text = pipeline._build_free_a_stock_intelligence_context("SH600519", "贵州茅台")
+
+        self.assertIn("A股免费情报源补充", text)
+        self.assertIn("年度报告", text)
+        self.assertIn("免费资金流 fallback", text)
+        self.assertIn("净额 12345", text)
+        pipeline.fetcher_manager.get_fallback_announcements.assert_not_called()
+
+    def test_pipeline_falls_back_to_announcement_fallback_when_cninfo_empty(self):
+        from src.core.pipeline import StockAnalysisPipeline
+
+        pipeline = StockAnalysisPipeline.__new__(StockAnalysisPipeline)
+        pipeline.fetcher_manager = MagicMock()
+        pipeline.fetcher_manager.get_free_announcements.return_value = []
+        pipeline.fetcher_manager.get_fallback_announcements.return_value = [
+            {"title": "交易所公告", "date": "2026-07-30", "source": "szse_announcement"}
+        ]
+        pipeline.fetcher_manager.get_fallback_fund_flow.return_value = []
+
+        text = pipeline._build_free_a_stock_intelligence_context("000001", "平安银行")
+
+        self.assertIn("交易所公告", text)
+        pipeline.fetcher_manager.get_fallback_announcements.assert_called_once()
+
+
+class TestFreeSourceMarketNews(unittest.TestCase):
+    def test_market_analyzer_uses_free_news_without_search_service(self):
+        from src.market_analyzer import MarketAnalyzer
+
+        analyzer = MarketAnalyzer.__new__(MarketAnalyzer)
+        analyzer.region = "cn"
+        analyzer.search_service = None
+        analyzer.data_manager = MagicMock()
+        analyzer.data_manager.get_free_market_news.return_value = [
+            {
+                "title": "财联社快讯",
+                "content": "市场消息",
+                "source": "cls",
+                "time": "2026-07-30 10:00:00",
+                "url": "https://www.cls.cn/detail/1",
+            }
+        ]
+
+        news = analyzer.search_market_news()
+
+        self.assertEqual(len(news), 1)
+        self.assertEqual(news[0]["title"], "财联社快讯")
+        self.assertEqual(news[0]["source"], "cls")
+
+
+    def test_market_analyzer_skips_search_when_free_news_available(self):
+        from src.market_analyzer import MarketAnalyzer
+
+        analyzer = MarketAnalyzer.__new__(MarketAnalyzer)
+        analyzer.region = "cn"
+        analyzer.search_service = MagicMock()
+        analyzer.data_manager = MagicMock()
+        analyzer.data_manager.get_free_market_news.return_value = [
+            {
+                "title": "CLS flash",
+                "content": "market message",
+                "source": "cls",
+                "time": "2026-07-30 10:00:00",
+                "url": "https://www.cls.cn/detail/1",
+            }
+        ]
+
+        news = analyzer.search_market_news()
+
+        self.assertEqual(len(news), 1)
+        analyzer.search_service.search_stock_news.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_market_low_noise_mode.py
+++ b/tests/test_market_low_noise_mode.py
@@ -1,0 +1,135 @@
+# -*- coding: utf-8 -*-
+"""Regression tests for low-noise market-review data routing."""
+
+import os
+import sys
+import types
+import unittest
+from unittest.mock import patch
+
+import pandas as pd
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+
+class TestMarketLowNoiseMode(unittest.TestCase):
+    def _fetcher(self):
+        from data_provider.akshare_fetcher import AkshareFetcher
+
+        fetcher = AkshareFetcher.__new__(AkshareFetcher)
+        fetcher._set_random_user_agent = lambda: None
+        fetcher._enforce_rate_limit = lambda: None
+        return fetcher
+
+    def test_market_stats_prefers_sina_and_skips_eastmoney(self):
+        calls = {"eastmoney": 0, "sina": 0}
+
+        fake_ak = types.SimpleNamespace()
+
+        def stock_zh_a_spot_em():
+            calls["eastmoney"] += 1
+            raise AssertionError("Eastmoney should be skipped in low-noise mode")
+
+        def stock_zh_a_spot():
+            calls["sina"] += 1
+            return pd.DataFrame(
+                [
+                    {"代码": "600000", "名称": "A", "最新价": 11.0, "昨收": 10.0, "成交额": 1000},
+                    {"代码": "000001", "名称": "B", "最新价": 9.0, "昨收": 10.0, "成交额": 1000},
+                ]
+            )
+
+        fake_ak.stock_zh_a_spot_em = stock_zh_a_spot_em
+        fake_ak.stock_zh_a_spot = stock_zh_a_spot
+
+        with patch.dict(os.environ, {"FREE_A_STOCK_LOW_NOISE_MODE": "true"}), patch.dict(
+            sys.modules, {"akshare": fake_ak}
+        ):
+            stats = self._fetcher().get_market_stats()
+
+        self.assertEqual(calls["eastmoney"], 0)
+        self.assertEqual(calls["sina"], 1)
+        self.assertEqual(stats["up_count"], 1)
+        self.assertEqual(stats["down_count"], 1)
+
+    def test_sector_rankings_prefers_sina_and_skips_eastmoney(self):
+        calls = {"eastmoney": 0, "sina": 0}
+
+        fake_ak = types.SimpleNamespace()
+
+        def stock_board_industry_name_em():
+            calls["eastmoney"] += 1
+            raise AssertionError("Eastmoney should be skipped in low-noise mode")
+
+        def stock_sector_spot(indicator="行业"):
+            calls["sina"] += 1
+            return pd.DataFrame(
+                [
+                    {"板块": "行业A", "涨跌幅": 2.0},
+                    {"板块": "行业B", "涨跌幅": -1.0},
+                    {"板块": "行业C", "涨跌幅": 0.5},
+                ]
+            )
+
+        fake_ak.stock_board_industry_name_em = stock_board_industry_name_em
+        fake_ak.stock_sector_spot = stock_sector_spot
+
+        with patch.dict(os.environ, {"FREE_A_STOCK_LOW_NOISE_MODE": "true"}), patch.dict(
+            sys.modules, {"akshare": fake_ak}
+        ):
+            top, bottom = self._fetcher().get_sector_rankings(1)
+
+        self.assertEqual(calls["eastmoney"], 0)
+        self.assertEqual(calls["sina"], 1)
+        self.assertEqual(top[0]["name"], "行业A")
+        self.assertEqual(bottom[0]["name"], "行业B")
+
+    def test_chip_distribution_skips_eastmoney_in_low_noise_mode(self):
+        calls = {"cyq": 0}
+
+        fake_ak = types.SimpleNamespace()
+
+        def stock_cyq_em(symbol):
+            calls["cyq"] += 1
+            raise AssertionError("Eastmoney chip distribution should be skipped in low-noise mode")
+
+        fake_ak.stock_cyq_em = stock_cyq_em
+
+        with patch.dict(os.environ, {"FREE_A_STOCK_LOW_NOISE_MODE": "true"}), patch.dict(
+            sys.modules, {"akshare": fake_ak}
+        ):
+            chip = self._fetcher().get_chip_distribution("600000")
+
+        self.assertIsNone(chip)
+        self.assertEqual(calls["cyq"], 0)
+
+    def test_data_fetcher_manager_skips_chip_distribution_in_low_noise_mode(self):
+        from data_provider.base import DataFetcherManager
+
+        manager = DataFetcherManager.__new__(DataFetcherManager)
+        manager._get_fetchers_snapshot = lambda: (_ for _ in ()).throw(
+            AssertionError("fetcher loop should not run in low-noise mode")
+        )
+
+        with patch.dict(os.environ, {"FREE_A_STOCK_LOW_NOISE_MODE": "true"}):
+            chip = manager.get_chip_distribution("600000")
+
+        self.assertIsNone(chip)
+
+    def test_data_fetcher_manager_skips_concept_rankings_in_low_noise_mode(self):
+        from data_provider.base import DataFetcherManager
+
+        manager = DataFetcherManager.__new__(DataFetcherManager)
+        manager._get_fetchers_snapshot = lambda: (_ for _ in ()).throw(
+            AssertionError("fetcher loop should not run in low-noise mode")
+        )
+
+        with patch.dict(os.environ, {"FREE_A_STOCK_LOW_NOISE_MODE": "true"}):
+            top, bottom = manager.get_concept_rankings(5)
+
+        self.assertEqual(top, [])
+        self.assertEqual(bottom, [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!--
For Chinese contributors: 请直接用中文填写。
For English contributors: please fill in English. All fields marked (EN) accept English.
-->

## PR Type

- [ ] fix
- [ ] feat
- [ ] refactor
- [ ] docs
- [ ] chore
- [ ] test

## Background And Problem

请描述当前问题、影响范围与触发场景。  
*(EN) Describe the problem, its impact, and what triggers it.*

## Scope Of Change

请列出本 PR 修改的模块和文件范围。  
*(EN) List the modules and files changed in this PR.*

> 注意：请按实际 `git diff` 全量列出文件范围（建议注明文件总数），避免遗漏文档/后端/API/前端文件导致描述不一致。

> 若本 PR 修改了 `.github/PULL_REQUEST_TEMPLATE.md`、`.github/copilot-instructions.md`、`AGENTS.md`、`.github/instructions/*` 或 `.claude/skills/**` 等协作与治理文件，请补充“变更原因 + 影响面 + 回滚方式（默认 revert）”到 Summary / Compatibility / Rollback，避免 Scope 与描述不一致。

> 建议先执行并粘贴以下命令输出，避免与实际 diff 不一致：

```bash
BASE_REF=$(git merge-base HEAD origin/main)
git diff --stat "$BASE_REF"..HEAD
git diff --name-only "$BASE_REF"..HEAD
```

- 文件总数 / 变更行数（建议粘贴 `git diff --stat "$BASE_REF"..HEAD`）：
- 文件清单（按实际 diff 全量，逐项列出）：
- 文档更新文件（`docs/*`）：

## Issue Link

必须填写以下之一 / Fill in one of:
- `Fixes #<issue_number>`
- `Refs #<issue_number>`
- 无 Issue 时说明原因与验收标准 / If no issue, explain the motivation and acceptance criteria

## Verification Commands And Results

请填写你实际执行过的命令和关键结果（不要只写"已测试"）。  
*(EN) Paste the commands you actually ran and their key output (don't just write "tested"):*

```bash
# example
./scripts/ci_gate.sh
python -m pytest -m "not network"
```

> `Full-suite note` 必须与当次 PR 的当前 Head CI 结果保持一致；若本地复现存在环境相关失败，请明确标注“本地环境差异”并给出 GitHub CI 的结论与链接。  
> 请避免保留与本 PR 无关的历史失败措辞，按本次实际结果填报。
> 如历史描述中仍保留 `./scripts/ci_gate.sh` 失败记录，请先改为当前 Head CI 状态或说明与 Head CI 的差异来源。
> 若 `Full-suite note` 与当前 Head CI 不一致，PR 文本不完整，请先更新 PR 描述后再提交。

- 请在下面按实际结果填写并与 `Full-suite note` 保持一致（任一未填视为信息缺失）：
  - ai-governance：`pass` / `fail`，附链接
  - backend-gate：`pass` / `fail`，附链接
  - docker-build：`pass` / `fail`，附链接
  - web-gate：`pass` / `fail`，附链接
  - 若本 PR 修改 `.github/PULL_REQUEST_TEMPLATE.md` 等流程模板协作文件，请先说明变更必要性、影响边界，并明确回滚方式（默认 `revert this PR`）；否则请在下一版中拆为单独 chore PR。

关键输出/结论 / Key output & conclusion:

- 【必填】当前 Head CI：`ai-governance:pass / backend-gate:pass / docker-build:pass / web-gate:pass`（按实际结果替换）并附对应链接。  
- 若需保留本地失败现象，请在同段写明“本地环境差异 + 当前 CI 通过/失败结果 + CI 链接”。  
- 若全部通过，需补充一句：`当前状态：全部通过（pass）`，并明确 Head CI 全部为 pass。  

- 建议将本行直接粘贴到 PR 描述正文首段：`当前 Head CI：ai-governance:pass / backend-gate:pass / docker-build:pass / web-gate:pass`（仅示例，按实际结果替换）。

> 若上述核验项与 PR 文本冲突，建议先更新 PR 描述再提交，避免审查因状态不一致被阻塞。

## Visual Evidence (if applicable)

【必填】若本 PR 修改报告格式、报告渲染效果或 Web UI 界面，请在此处附受影响报告 / 页面截图；涉及前后差异时，优先附前后对比。Issue / PR 过程截图、审查截图、一次性验收截图和临时可视证据请放在 PR 描述、PR 评论、GitHub 附件、Actions artifact 或外部可访问链接中，不要作为仓库文件合入。
*(EN) If this PR changes report formatting, report rendering, or Web UI, attach screenshots of the affected report/page here; before/after screenshots are preferred when relevant. Issue/PR process screenshots, review screenshots, one-off acceptance screenshots, and temporary visual evidence should be linked from the PR body/comments, GitHub attachments, Actions artifacts, or external accessible evidence; do not commit them as repository files.)*

> 如截图无法获取，请在“原因”中明确写明替代证据（如 Playwright/e2e 产物路径、审查链接）及其可追溯命令，不得留空。涉及 Web 设置/报告渲染变更时，需确保截图或替代证据明确指向变更项。
>
> 若本 PR 修改 Web UI，建议至少补一条可复现路径，例如（优先 settings page）：
>
> - Playwright 截图产物：`apps/dsa-web/e2e/smoke.spec.ts`（`cd apps/dsa-web && npx playwright test e2e/smoke.spec.ts --grep "settings page renders title and save actions after login"`）
> - 审查证据链接：可直接使用 Actions 产物、GitHub 评论附件或外部可访问链接。

> 替代证据模板（设置页变更建议）：
> - 命令：`cd apps/dsa-web && npx playwright test e2e/smoke.spec.ts --grep "settings page"`
> - 产物路径：`apps/dsa-web/test-results/**/smoke-settings-page-*.png`
> - 说明：截图中应可见本次修改的系统设置项（字段、标签、帮助文案）

- 截图链接 / Screenshot links（Web UI/报告改动项必填，未提供请在下方“不适用原因”给出替代证据）：
- settings 页建议命名：`smoke-settings-page-zh` / `smoke-settings-page-en`
- 前后对比 / Before & After（如有）：
- settings 字段变更说明：截图或产物应明确包含 `MARKET_REVIEW_REGION` 字段与帮助文案区块（中文/英文）。
- 不适用原因 / Reason if not applicable（若未附截图，此项务必填写，且包含可复现证据与命令）：
  - Playwright 命令（无截图时）：`cd apps/dsa-web && npx playwright test e2e/smoke.spec.ts --grep "settings page"`
  - 产物路径（无截图时）：`apps/dsa-web/test-results/**/smoke-settings-page-*.png`
  - 说明：截图（或产物）必须可见本次修改的设置字段文案与帮助信息。

> 若本 PR 修改 Web 设置字段（字段、文案或帮助文案），截图或替代证据必须可定位到对应设置项区域并可追溯至变更项；该项为必填。

> 若本 PR 修改 Web UI 或报告展示且无法获取截图，原因栏必须给出可复现替代证据（例如 Playwright 截图产物路径 + 命令），且不得留空。

## Compatibility And Risk

请说明兼容性影响、潜在风险（如无请写 `None`）。  
*(EN) Describe compatibility impact and potential risks (write `None` if not applicable).*

- 若本 PR 修改第三方模型 / API 的兼容语义、请求参数、路由前缀或 provider fallback，请提供**官方来源链接或公告**，并说明这是长期约束、当前运行时约束还是临时兼容处理。  
  请在下方补充所影响外部 API/服务、回归范围与回退方式。  
  *(EN) If this PR changes third-party model/API compatibility, request parameters, routing prefixes, or provider fallback behavior, include an **official source link or announcement** and clarify whether the rule is permanent, runtime-specific, or a temporary compatibility workaround.)*
- 若本 PR 未触及第三方模型/API、provider/model/base URL 或运行时配置保存/清理/迁移逻辑，请在此段直接按以下文案确认（无须再次展开）：  
  `本 PR 未变更 provider/model/base URL、运行时配置清理迁移语义；历史配置保持不变；回滚方式为 revert 本提交。`
- 若本 PR 修改 `.github/PULL_REQUEST_TEMPLATE.md` / PR 流程模板类文件，请在此明确：仅影响协作流程与模板维护，不改 runtime 行为；回退方式为 revert；并补充是否影响自动化提交流程。  
  *(EN) If this PR changes `.github/PULL_REQUEST_TEMPLATE.md` or other PR workflow files, state that it only affects contribution governance templates (no runtime behavior), provide rollback by revert, and note any CI/checklist impact.)*
- 若本 PR 依赖特定运行时 / 锁定依赖窗口（例如 LiteLLM 版本范围、OpenAI-compatible 路由、YAML alias 行为），请写明当前验证过的兼容范围与覆盖路径。  
  *(EN) If this PR depends on a specific runtime or pinned dependency window (for example a LiteLLM version range, OpenAI-compatible routing, or YAML alias behavior), state the compatibility window you verified and which code paths were covered.)*
- 若本 PR 触及运行时配置保存、清理、迁移或回填逻辑，请明确说明旧配置是否会被自动改写、清空、迁移或保持不变，以及用户如何恢复原行为。  
  *(EN) If this PR touches runtime config save/cleanup/migration/backfill logic, explicitly describe whether existing config is rewritten, cleared, migrated, or left intact, and how users can restore the previous behavior.)*
- 若本 PR **未触及** provider/model/base URL 或运行时配置保存/清理/迁移逻辑（本条仅作为声明），请明确写：`本 PR 未变更 provider/model/base URL、运行时配置清理迁移语义；历史配置保持不变；回滚方式为 revert 本提交。`

## Rollback Plan

请至少写一句可执行的回滚方案（必填）。  
*(EN) Provide at least one actionable rollback step (required).*

- 如果是兼容性修复，默认应写出**最小回滚方式**（例如 `revert this PR`），并说明是否需要额外回滚配置或数据迁移。  
  *(EN) For compatibility fixes, include the **minimal rollback path** (for example `revert this PR`) and whether any additional config or data rollback is required.)*

## EXTRACT_PROMPT Change (if applicable)

若本 PR 修改了 `src/services/image_stock_extractor.py` 中的 `EXTRACT_PROMPT`，请在此处粘贴完整变更后的 prompt。  
*If this PR changes `EXTRACT_PROMPT` in `src/services/image_stock_extractor.py`, paste the full updated prompt here:*

<details>
<summary>展开 / Expand: Full EXTRACT_PROMPT</summary>

```
(paste full prompt here)
```

</details>

## Checklist

- [ ] 本 PR 有明确动机和业务价值 / This PR has a clear motivation and value
- [ ] 已提供可复现的验证命令与结果 / Reproducible verification commands and results are included
- [ ] 已评估兼容性与风险 / Compatibility and risk have been assessed
- [ ] 已提供回滚方案 / A rollback plan is provided
- [ ] 若修改报告格式或 Web UI 界面，已在 PR 描述/评论附受影响报告 / 页面截图，且未把一次性验收截图作为仓库文件合入 / If report formatting or Web UI changed, affected report/page screenshots are linked in the PR body/comments and one-off acceptance screenshots are not committed as repository files
- [ ] 若本 PR 修改 Web 设置字段（字段、文案或帮助文本），请补充设置页截图；无法截图时需提供替代可视证据（命令 + 产物路径），并指向对应变更项 / If Web settings fields changed (labels or help text), screenshots of the settings page are required; if unavailable, provide alternative visual evidence with command + artifact path that points to the changed item.
- [ ] 若涉及用户可见变更，已同步更新相关文档与 `docs/CHANGELOG.md`；`README.md` 仅在首页级信息变化时更新，细节优先写入 `docs/*.md` / If user-visible changes are included, relevant docs and `docs/CHANGELOG.md` are updated; `README.md` is updated only for homepage-level changes, with details kept in `docs/*.md`
