### PR TITLE
ci: accelerate selective test gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,8 @@ jobs:
     name: 🔎 Change Detection
     runs-on: ubuntu-latest
     outputs:
+      backend: ${{ steps.backend-filter.outputs.backend_non_web == 'true' || steps.filter.outputs.backend_web_contract == 'true' }}
+      docker: ${{ steps.filter.outputs.docker }}
       frontend: ${{ steps.filter.outputs.frontend }}
       futu_packaging: ${{ steps.filter.outputs.futu_packaging }}
     steps:
@@ -23,6 +25,24 @@ jobs:
         uses: dorny/paths-filter@v3
         with:
           filters: |
+            backend_web_contract:
+              # Public assets are shared runtime inputs: Python loaders and
+              # packaged deployments may consume them outside the Web app.
+              - 'apps/dsa-web/public/**'
+              - 'apps/dsa-web/src/components/settings/llmProviderTemplates.ts'
+              - 'apps/dsa-web/src/locales/settingsHelp.ts'
+            docker:
+              - '*.py'
+              - 'api/**'
+              - 'bot/**'
+              - 'data_provider/**'
+              - 'src/**'
+              - 'strategies/**'
+              - 'apps/dsa-web/**'
+              - 'docker/**'
+              - 'requirements.txt'
+              - '.dockerignore'
+              - '.github/workflows/ci.yml'
             frontend:
               - 'apps/dsa-web/**'
             futu_packaging:
@@ -37,6 +57,15 @@ jobs:
               - 'apps/dsa-desktop/**'
               - '.github/workflows/ci.yml'
               - '.github/workflows/desktop-release.yml'
+      - name: 🧭 Filter backend-safe frontend paths
+        id: backend-filter
+        uses: dorny/paths-filter@v3
+        with:
+          predicate-quantifier: every
+          filters: |
+            backend_non_web:
+              - '**'
+              - '!apps/dsa-web/**'
 
   ai-governance:
     name: ai-governance
@@ -54,7 +83,8 @@ jobs:
   backend-gate:
     name: backend-gate
     runs-on: ubuntu-latest
-    needs: [ai-governance]
+    needs: [changes, ai-governance]
+    if: needs.changes.outputs.backend == 'true'
     steps:
       - name: 📥 Checkout
         uses: actions/checkout@v5
@@ -94,7 +124,8 @@ jobs:
   docker-build:
     name: docker-build
     runs-on: ubuntu-latest
-    needs: [ai-governance]
+    needs: [changes, ai-governance]
+    if: needs.changes.outputs.docker == 'true'
     steps:
       - name: 📥 Checkout
         uses: actions/checkout@v5

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+- [测试] 后端 CI 默认覆盖所有非 Web 改动，仅对已证明安全的纯 Web 路径跳过，并将整个 Web public 目录及前端渠道模板、设置帮助视为跨层运行合同；补充纯 Web、共享 Web 资产及 Web/非 Web 混合改动的过滤语义回归，明确 `predicate-quantifier: every` 按单文件匹配全部规则、再以任一匹配文件触发门禁。Docker CI 继续按构建输入过滤。离线测试保留稳定的串行执行与慢用例摘要，并移除重复用例和测试内真实等待。
+
 - [修复] Web 分享图改为用户点击“分享”后才按需生成，不再在报告加载时自动请求
 - [修复] 将 `SCREENING_ENABLED` 及 Web 选股功能开关归入“基础设置”，选股导航入口继续由该开关控制
 - [修复] 飞书交互机器人在 `FEISHU_DOMAIN=lark` 时让 Stream 长连接与消息回复统一使用 Lark 国际版 API 域名，避免 SDK 默认连接飞书国内域名并返回 `Incorrect domain name`（fixes #937）。

--- a/scripts/ci_gate.sh
+++ b/scripts/ci_gate.sh
@@ -35,7 +35,8 @@ offline_test_suite() {
   # workflow timeout.
   python -m pytest -m "not network" \
     --timeout=120 -o timeout_method=thread \
-    -o faulthandler_timeout=300
+    -o faulthandler_timeout=300 \
+    --durations=30 --durations-min=0.5
 }
 
 run_all() {

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,7 +20,7 @@ exclude =
 ignore = E501,W503,E203,E402
 
 [tool:pytest]
-testpaths = .
+testpaths = tests
 python_files = test_*.py
 python_functions = test_*
 addopts = -v --tb=short

--- a/tests/test_anspire_search.py
+++ b/tests/test_anspire_search.py
@@ -49,6 +49,7 @@ from src.config import Config, get_config
 from src.search_service import (
     AnspireSearchProvider,
     SearchService,
+    _get_with_retry,
     get_search_service,
     reset_search_service,
 )
@@ -274,11 +275,18 @@ class TestAnspireSearchProvider(unittest.TestCase):
             
         mock_requests.get = MagicMock(side_effect=timeout_exc())
         
-        response = self.provider.search("测试查询", max_results=3)
+        with patch.object(_get_with_retry.retry, "sleep", return_value=None) as mock_sleep:
+            response = self.provider.search("测试查询", max_results=3)
         
         self.assertFalse(response.success)
         self.assertEqual(response.provider, "Anspire")
         self.assertEqual(len(response.results), 0)
+        self.assertEqual(mock_requests.get.call_count, 3)
+        self.assertEqual(mock_sleep.call_count, 2)
+        self.assertEqual(
+            [float(item.args[0]) for item in mock_sleep.call_args_list],
+            [1.0, 2.0],
+        )
         # 错误消息检查
         self.assertTrue("超时" in response.error_message or "Timeout" in response.error_message)
     
@@ -295,11 +303,18 @@ class TestAnspireSearchProvider(unittest.TestCase):
 
         mock_requests.get = MagicMock(side_effect=conn_exc())
         
-        response = self.provider.search("测试查询", max_results=3)
+        with patch.object(_get_with_retry.retry, "sleep", return_value=None) as mock_sleep:
+            response = self.provider.search("测试查询", max_results=3)
         
         self.assertFalse(response.success)
         self.assertEqual(response.provider, "Anspire")
         self.assertEqual(len(response.results), 0)
+        self.assertEqual(mock_requests.get.call_count, 3)
+        self.assertEqual(mock_sleep.call_count, 2)
+        self.assertEqual(
+            [float(item.args[0]) for item in mock_sleep.call_args_list],
+            [1.0, 2.0],
+        )
         self.assertTrue("网络" in response.error_message or "Connection" in response.error_message)
     
     @patch('src.search_service.requests')

--- a/tests/test_ci_workflow_contract.py
+++ b/tests/test_ci_workflow_contract.py
@@ -1,0 +1,108 @@
+# -*- coding: utf-8 -*-
+"""Contracts for selective CI gates and their cross-layer inputs."""
+
+from __future__ import annotations
+
+from fnmatch import fnmatchcase
+from pathlib import Path
+
+import yaml
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _read(relative_path: str) -> str:
+    return (REPO_ROOT / relative_path).read_text(encoding="utf-8")
+
+
+def _workflow(relative_path: str) -> dict:
+    return yaml.load(_read(relative_path), Loader=yaml.BaseLoader)
+
+
+def _change_filters(ci: dict) -> tuple[dict, dict, dict]:
+    changes_job = ci["jobs"]["changes"]
+    filter_step = next(
+        step for step in changes_job["steps"] if step.get("id") == "filter"
+    )
+    backend_filter_step = next(
+        step for step in changes_job["steps"] if step.get("id") == "backend-filter"
+    )
+    return changes_job, filter_step, backend_filter_step
+
+
+def test_heavy_ci_jobs_are_path_filtered_without_parallel_test_workers() -> None:
+    ci = _workflow(".github/workflows/ci.yml")
+    changes_job, filter_step, backend_filter_step = _change_filters(ci)
+    filters = str(filter_step["with"]["filters"])
+    parsed_filters = yaml.load(filters, Loader=yaml.BaseLoader)
+    backend_contract_paths = set(parsed_filters["backend_web_contract"])
+    backend_filters = yaml.load(
+        str(backend_filter_step["with"]["filters"]),
+        Loader=yaml.BaseLoader,
+    )
+
+    assert changes_job["outputs"]["backend"] == (
+        "${{ steps.backend-filter.outputs.backend_non_web == 'true' || "
+        "steps.filter.outputs.backend_web_contract == 'true' }}"
+    )
+    assert changes_job["outputs"]["docker"] == "${{ steps.filter.outputs.docker }}"
+    assert backend_filter_step["with"]["predicate-quantifier"] == "every"
+    assert backend_filters["backend_non_web"] == ["**", "!apps/dsa-web/**"]
+    assert "docker:" in filters
+    assert "docker/**" in filters
+    assert {
+        "apps/dsa-web/public/**",
+        "apps/dsa-web/src/components/settings/llmProviderTemplates.ts",
+        "apps/dsa-web/src/locales/settingsHelp.ts",
+    } == backend_contract_paths
+
+    backend_job = ci["jobs"]["backend-gate"]
+    docker_job = ci["jobs"]["docker-build"]
+    assert backend_job["needs"] == ["changes", "ai-governance"]
+    assert docker_job["needs"] == ["changes", "ai-governance"]
+    assert backend_job["if"] == "needs.changes.outputs.backend == 'true'"
+    assert docker_job["if"] == "needs.changes.outputs.docker == 'true'"
+    requirements = _read(".github/requirements-ci.txt")
+    ci_gate = _read("scripts/ci_gate.sh")
+    assert "pytest-xdist" not in requirements
+    assert "PYTEST_WORKERS" not in ci_gate
+    assert '--durations=30' in ci_gate
+
+
+def test_backend_filter_covers_mixed_changes_and_shared_web_assets() -> None:
+    """Model the complete backend output, including shared Web-owned assets."""
+    ci = _workflow(".github/workflows/ci.yml")
+    _, filter_step, backend_filter_step = _change_filters(ci)
+    backend_web_contract = yaml.load(
+        str(filter_step["with"]["filters"]),
+        Loader=yaml.BaseLoader,
+    )["backend_web_contract"]
+    backend_filters = yaml.load(
+        str(backend_filter_step["with"]["filters"]),
+        Loader=yaml.BaseLoader,
+    )["backend_non_web"]
+
+    def matches_every_rule(path: str) -> bool:
+        return all(
+            not fnmatchcase(path, rule[1:])
+            if rule.startswith("!")
+            else fnmatchcase(path, rule)
+            for rule in backend_filters
+        )
+
+    def backend_output(changed_paths: list[str]) -> bool:
+        backend_non_web = any(matches_every_rule(path) for path in changed_paths)
+        web_contract_hit = any(
+            fnmatchcase(path, rule)
+            for path in changed_paths
+            for rule in backend_web_contract
+        )
+        return backend_non_web or web_contract_hit
+
+    assert backend_filter_step["with"]["predicate-quantifier"] == "every"
+    assert backend_output(["apps/dsa-web/src/App.tsx"]) is False
+    assert backend_output(["apps/dsa-web/src/App.tsx", "src/config.py"]) is True
+    assert backend_output(["apps/dsa-web/src/App.tsx", "docs/CHANGELOG.md"]) is True
+    assert backend_output(["apps/dsa-web/public/stocks.index.json"]) is True
+    assert backend_output(["apps/dsa-web/public/runtime/new-asset.json"]) is True

--- a/tests/test_feishu_stream.py
+++ b/tests/test_feishu_stream.py
@@ -108,6 +108,11 @@ def test_invalid_stream_domain_falls_back_to_feishu(caplog):
 
 
 def test_reply_text_chunked_keeps_reply_and_at_user(monkeypatch):
+    sleep_calls = []
+    monkeypatch.setattr(
+        "bot.platforms.feishu_stream.time.sleep",
+        lambda seconds: sleep_calls.append(seconds),
+    )
     client = DummyFeishuReplyClient(max_bytes=1000)
 
     message_id = "msg_123"
@@ -119,6 +124,7 @@ def test_reply_text_chunked_keeps_reply_and_at_user(monkeypatch):
     assert result is True
     # Should produce multiple chunks
     assert len(client.calls) >= 2
+    assert sleep_calls == [1] * (len(client.calls) - 1)
 
     for call in client.calls:
         assert call["message_id"] == message_id
@@ -138,6 +144,11 @@ def test_reply_text_uses_legacy_feishu_markdown_formatter():
 
 
 def test_send_to_chat_chunked_uses_chat_id(monkeypatch):
+    sleep_calls = []
+    monkeypatch.setattr(
+        "bot.platforms.feishu_stream.time.sleep",
+        lambda seconds: sleep_calls.append(seconds),
+    )
     client = DummyFeishuReplyClient(max_bytes=1000)
 
     chat_id = "chat_123"
@@ -147,6 +158,7 @@ def test_send_to_chat_chunked_uses_chat_id(monkeypatch):
 
     assert result is True
     assert len(client.calls) >= 2
+    assert sleep_calls == [1] * (len(client.calls) - 1)
 
     for call in client.calls:
         assert call["message_id"] is None

--- a/tests/test_image_stock_extractor_litellm.py
+++ b/tests/test_image_stock_extractor_litellm.py
@@ -404,6 +404,10 @@ class TestExtractStockCodesFromImage:
         jpeg = _make_jpeg_bytes()
         with patch("src.services.image_stock_extractor.get_config", return_value=cfg), \
              patch("src.services.image_stock_extractor.litellm.completion",
-                   side_effect=RuntimeError("network down")):
+                   side_effect=RuntimeError("network down")) as mock_completion, \
+             patch("src.services.image_stock_extractor.time.sleep") as mock_sleep:
             with pytest.raises(ValueError, match="Vision API 调用失败"):
                 extract_stock_codes_from_image(jpeg, "image/jpeg")
+
+        assert mock_completion.call_count == 3
+        assert [item.args[0] for item in mock_sleep.call_args_list] == [1, 2]

--- a/tests/test_intelligence_service.py
+++ b/tests/test_intelligence_service.py
@@ -220,7 +220,13 @@ class IntelligenceServiceTestCase(unittest.TestCase):
             if "bad" in url:
                 raise RuntimeError("network token=secret should not leak")
             return self._mock_response()
-        with patch("src.services.intelligence_service.requests.get", side_effect=fake_get):
+        # This case verifies batch fail-open behavior and request isolation. URL/DNS
+        # validation has dedicated coverage below; keeping it out of this test also
+        # avoids coupling the aggregation contract to process-global DNS patching.
+        with patch.object(self.service, "_validate_url"), patch(
+            "src.services.intelligence_service.requests.get",
+            side_effect=fake_get,
+        ):
             result = self.service.fetch_enabled_sources()
         self.assertEqual(result["source_count"], 2)
         self.assertEqual(result["saved_count"], 2)

--- a/tests/test_notification.py
+++ b/tests/test_notification.py
@@ -2141,9 +2141,15 @@ class TestNotificationServiceReportGeneration(unittest.TestCase):
         self.assertTrue(ok)
         mock_post.assert_called_once()
         
+    @mock.patch("src.notification_sender.feishu_sender.time.sleep")
     @mock.patch("src.notification.get_config")
     @mock.patch("requests.post")
-    def test_send_to_feishu_via_notification_service_requires_chunking(self, mock_post: mock.MagicMock, mock_get_config: mock.MagicMock):
+    def test_send_to_feishu_via_notification_service_requires_chunking(
+        self,
+        mock_post: mock.MagicMock,
+        mock_get_config: mock.MagicMock,
+        mock_sleep: mock.MagicMock,
+    ):
         cfg = _make_config(feishu_webhook_url="https://feishu.example", feishu_max_bytes=2000)
         mock_get_config.return_value = cfg
         mock_post.return_value = _make_response(200, {"code": 0})
@@ -2155,6 +2161,7 @@ class TestNotificationServiceReportGeneration(unittest.TestCase):
 
         self.assertTrue(ok)
         self.assertAlmostEqual(mock_post.call_count, 4, delta=1)
+        self.assertEqual(mock_sleep.call_count, mock_post.call_count - 1)
 
     @mock.patch("src.notification.get_config")
     @mock.patch("requests.post")
@@ -2437,9 +2444,15 @@ class TestNotificationServiceReportGeneration(unittest.TestCase):
         self.assertTrue(ok)
         mock_post.assert_called_once()
 
+    @mock.patch("src.notification_sender.wechat_sender.time.sleep")
     @mock.patch("src.notification.get_config")
     @mock.patch("requests.post")
-    def test_send_to_wechat_via_notification_service_requires_chunking(self, mock_post: mock.MagicMock, mock_get_config: mock.MagicMock):
+    def test_send_to_wechat_via_notification_service_requires_chunking(
+        self,
+        mock_post: mock.MagicMock,
+        mock_get_config: mock.MagicMock,
+        mock_sleep: mock.MagicMock,
+    ):
         cfg = _make_config(wechat_webhook_url="https://wechat.example", wechat_max_bytes=2000)
         mock_get_config.return_value = cfg
         mock_post.return_value = _make_response(200, {"errcode": 0})
@@ -2451,6 +2464,7 @@ class TestNotificationServiceReportGeneration(unittest.TestCase):
 
         self.assertTrue(ok)
         self.assertAlmostEqual(mock_post.call_count, 4, delta=1)
+        self.assertEqual(mock_sleep.call_count, mock_post.call_count - 1)
 
 
 if __name__ == "__main__":

--- a/tests/test_notification_sender.py
+++ b/tests/test_notification_sender.py
@@ -578,11 +578,16 @@ class TestFeishuSender(unittest.TestCase):
         sender = FeishuSender(cfg)
 
         with mock.patch.object(FeishuSender, "_ensure_app_client", return_value=object()), \
-             mock.patch.object(FeishuSender, "_app_send_raw", return_value=False) as mock_raw:
+             mock.patch.object(FeishuSender, "_app_send_raw", return_value=False) as mock_raw, \
+             mock.patch("src.notification_sender.feishu_sender.time.sleep") as mock_sleep:
             result = sender.send_to_feishu("A" * 500)
 
         self.assertFalse(result)  # All chunks fail
         self.assertGreater(mock_raw.call_count, 1)
+        self.assertEqual(
+            [item.args[0] for item in mock_sleep.call_args_list],
+            [1, 1, 1],
+        )
 
     @mock.patch.object(FeishuSender, "_app_send_raw", return_value=True)
     def test_app_bot_request_shape_interactive(self, mock_raw):

--- a/tests/test_pipeline_notification_image_routing.py
+++ b/tests/test_pipeline_notification_image_routing.py
@@ -461,38 +461,6 @@ class TestPipelineReportRouteFiltering(unittest.TestCase):
         pipeline.notifier.record_noise_control.assert_not_called()
         pipeline.notifier.release_noise_control.assert_not_called()
 
-    def test_dingtalk_context_only_delivery_skips_static_channels_in_aggregate_path(self):
-        pipeline = StockAnalysisPipeline.__new__(StockAnalysisPipeline)
-        pipeline.notifier = _FakeRoutedNotifier([NotificationChannel.TELEGRAM])
-        pipeline.notifier.send_to_context.return_value = True
-        pipeline.notifier.should_broadcast_static_channels = MagicMock(return_value=False)
-        pipeline.config = SimpleNamespace(stock_email_groups=[])
-        results = [SimpleNamespace(code="000001")]
-
-        pipeline._send_notifications(results, ReportType.SIMPLE)
-
-        pipeline.notifier.should_broadcast_static_channels.assert_called_once_with()
-        pipeline.notifier.send_to_telegram.assert_not_called()
-        pipeline.notifier.evaluate_noise_control.assert_not_called()
-        pipeline.notifier.record_noise_control.assert_not_called()
-        pipeline.notifier.release_noise_control.assert_not_called()
-
-    def test_telegram_context_only_delivery_skips_static_channels_in_aggregate_path(self):
-        pipeline = StockAnalysisPipeline.__new__(StockAnalysisPipeline)
-        pipeline.notifier = _FakeRoutedNotifier([NotificationChannel.TELEGRAM])
-        pipeline.notifier.send_to_context.return_value = True
-        pipeline.notifier.should_broadcast_static_channels = MagicMock(return_value=False)
-        pipeline.config = SimpleNamespace(stock_email_groups=[])
-        results = [SimpleNamespace(code="000001")]
-
-        pipeline._send_notifications(results, ReportType.SIMPLE)
-
-        pipeline.notifier.should_broadcast_static_channels.assert_called_once_with()
-        pipeline.notifier.send_to_telegram.assert_not_called()
-        pipeline.notifier.evaluate_noise_control.assert_not_called()
-        pipeline.notifier.record_noise_control.assert_not_called()
-        pipeline.notifier.release_noise_control.assert_not_called()
-
     def test_send_notifications_records_each_channel_run_rather_than_aggregating(self):
         token = activate_run_diagnostic_context(trace_id="trace-notify")
         try:


### PR DESCRIPTION
## PR Type

- [x] ci
- [x] test

## Background And Problem

`backend-gate` 是主 CI 的主要耗时路径。目标是在不削弱跨层合同覆盖的前提下，仅跳过已证明安全的纯 Web 改动，并移除测试中的真实等待。

早期版本采用后端资产白名单，review 反复暴露文档、许可证、桌面安装器等漏项。当前实现已整体重构为保守模型：所有非 Web 文件默认触发 backend gate；Web 目录内再以目录级共享资产边界和少量明确跨层合同识别后端输入。

## Scope Of Change

- 所有非 `apps/dsa-web/**` 改动默认触发 backend gate；纯 Web 私有实现默认跳过。
- backend filter 使用 `dorny/paths-filter@v3` 的逐文件 `predicate-quantifier: every` 语义：每个候选文件必须同时匹配 `**` 与 `!apps/dsa-web/**`，只要任一非 Web 文件匹配，filter 就输出 `true`。因此 Web + `src/docs/scripts/.github` 的混合 PR 仍会运行 backend gate。
- 整个 `apps/dsa-web/public/**` 视为共享运行资产并触发 backend gate；这覆盖 Python 股票索引加载器当前消费的 `stocks.index.json`，也保护未来新增的 public 运行资产。
- 前端 provider 模板和设置帮助是被后端测试直接读取的两个源码级 Web 合同例外，修改它们时也运行 backend gate。
- Docker、Web 与 Futu 桌面打包仍按各自构建输入独立过滤。
- 离线测试保持串行执行，输出最慢 30 项摘要；不引入 xdist 并发不稳定性。
- mock retry/backoff/chunk sleep，同时保留调用次数、退避序列和分片间隔断言。
- pytest 只从 `tests/` 收集；删除两个语义重复的通知路由用例。
- 通用 CI 合同集中在独立的 `tests/test_ci_workflow_contract.py`，覆盖纯 Web、共享 public 资产、Web + backend、Web + docs，并验证目录级 public 边界；Futu 发行合同保持独立。
- 同步 `docs/CHANGELOG.md`。
- 基于最新 `main` 重建为单一语义完整提交。

官方语义依据：[dorny/paths-filter v3 README](https://github.com/dorny/paths-filter/tree/v3#usage)。其说明 `every` 是让“一个文件匹配全部 patterns 才被纳入 filter”，不是要求 PR 中所有变更文件都满足 patterns；filter 命中判断仍是是否存在被纳入的变更文件。

## Verification Commands And Results

```bash
PYTHONUTF8=1 python -m pytest   tests/test_stock_index_loader.py   tests/test_futu_distribution_contract.py -q
# 18 passed

PYTHONUTF8=1 python -m pytest   tests/test_anspire_search.py   tests/test_feishu_stream.py   tests/test_futu_distribution_contract.py   tests/test_image_stock_extractor_litellm.py   tests/test_intelligence_service.py   tests/test_notification.py   tests/test_notification_sender.py   tests/test_pipeline_notification_image_routing.py -q
# 328 passed, 2 skipped, 7 failed
```

7 个失败全部位于飞书 App Bot 测试，原因是本机未安装可选 `lark_oapi` SDK；与本 PR 的 CI filter 或等待 mock 无关。当前最终 Head 的 GitHub Actions CI（run 4191）已全部通过：ai-governance、Change Detection、backend-gate、docker-build、Windows/macOS Futu desktop package 均为 success；web-gate 按路径过滤结果正确 skipped。

```bash
python -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('.github/workflows/ci.yml').read_text())"
git diff --check
# pass
```

当前 Head：`bed115e15e67cd4b6cf43e4215e9da09fc8b23b0`  
本地/远端 tree：`becf5e4b85f9264fa0d335cf963abd42c75a7edf`

## Visual Evidence

不适用：仅修改 CI、测试配置与测试代码，不涉及报告或 Web UI。

## Compatibility And Risk

- 不修改运行时业务逻辑或用户数据。
- backend filter 采用“任一非 Web 文件即触发”的保守模型；新增非 Web 目录无需更新白名单。
- Web public 目录整体按共享资产处理；即使其中某些文件仅供前端使用，也只会保守地多跑 backend gate，不会漏跑。
- 纯 Web 源码若未来新增被后端直接读取的资产，需要放入共享 public 目录或显式加入源码级合同例外。
- 如 branch protection 不接受 skipped job，可回滚 job 条件，不影响业务代码。

## Rollback Plan

revert 本 PR 即可完整回滚；无需配置或数据迁移。