### PR TITLE
fix: 防止 LLM 用 0 覆盖真实量比，统一行情表与数据透视

### DIFF
--- a/data_provider/longbridge_fetcher.py
+++ b/data_provider/longbridge_fetcher.py
@@ -715,6 +715,7 @@ class LongbridgeFetcher(BaseFetcher):
                 count=6,
             )
             if not candles or len(candles) < 2:
+                logger.warning("[Longbridge] 计算量比失败(%s): 历史K线不足 (%s)", symbol, len(candles or []))
                 return None
 
             ordered = sorted(candles, key=self._ts_sort_key, reverse=True)
@@ -725,15 +726,17 @@ class LongbridgeFetcher(BaseFetcher):
                     past_vols.append(vol)
 
             if not past_vols:
+                logger.warning("[Longbridge] 计算量比失败(%s): 近5日成交量为空", symbol)
                 return None
 
             avg_vol = sum(past_vols) / len(past_vols)
             if avg_vol <= 0:
+                logger.warning("[Longbridge] 计算量比失败(%s): 近5日均量无效", symbol)
                 return None
 
             return round(today_volume / avg_vol, 2)
         except Exception as e:
-            logger.debug(f"[Longbridge] 计算量比失败({symbol}): {e}")
+            logger.warning("[Longbridge] 计算量比失败(%s): %s", symbol, e)
             return None
 
     # ------------------------------------------------------------------

--- a/src/agent/executor.py
+++ b/src/agent/executor.py
@@ -89,7 +89,7 @@ LEGACY_DEFAULT_AGENT_SYSTEM_PROMPT = """你是一位专注于趋势交易的{mar
 
 ## 规则
 
-1. **必须调用工具获取真实数据** — 绝不编造数字，所有数据必须来自工具返回结果。
+1. **必须调用工具获取真实数据** — 绝不编造数字，所有数据必须来自工具返回结果；量比/换手率缺失时填 `null`（勿填 `0`）。
 2. **系统化分析** — 严格按工作流程分阶段执行，每阶段完整返回后再进入下一阶段，**禁止**将不同阶段的工具合并到同一次调用中。
 3. **应用交易技能** — 评估每个激活技能的条件，在报告中体现技能判断结果。
 4. **输出格式** — 最终响应必须是有效的决策仪表盘 JSON。
@@ -123,7 +123,7 @@ LEGACY_DEFAULT_AGENT_SYSTEM_PROMPT = """你是一位专注于趋势交易的{mar
         "data_perspective": {{
             "trend_status": {{"ma_alignment": "", "is_bullish": true, "trend_score": 0}},
             "price_position": {{"current_price": 0, "ma5": 0, "ma10": 0, "ma20": 0, "bias_ma5": 0, "bias_status": "", "support_level": 0, "resistance_level": 0}},
-            "volume_analysis": {{"volume_ratio": 0, "volume_status": "", "turnover_rate": 0, "volume_meaning": ""}},
+            "volume_analysis": {{"volume_ratio": null, "volume_status": "", "turnover_rate": null, "volume_meaning": ""}},
             "chip_structure": {{"profit_ratio": 0, "avg_cost": 0, "concentration": 0, "chip_health": ""}}
         }},
         "intelligence": {{
@@ -248,7 +248,7 @@ AGENT_SYSTEM_PROMPT = """你是一位{market_role}投资分析 Agent，拥有数
 
 ## 规则
 
-1. **必须调用工具获取真实数据** — 绝不编造数字，所有数据必须来自工具返回结果。
+1. **必须调用工具获取真实数据** — 绝不编造数字，所有数据必须来自工具返回结果；量比/换手率缺失时填 `null`（勿填 `0`）。
 2. **系统化分析** — 严格按工作流程分阶段执行，每阶段完整返回后再进入下一阶段，**禁止**将不同阶段的工具合并到同一次调用中。
 3. **应用交易技能** — 评估每个激活技能的条件，在报告中体现技能判断结果。
 4. **输出格式** — 最终响应必须是有效的决策仪表盘 JSON。
@@ -282,7 +282,7 @@ AGENT_SYSTEM_PROMPT = """你是一位{market_role}投资分析 Agent，拥有数
         "data_perspective": {{
             "trend_status": {{"ma_alignment": "", "is_bullish": true, "trend_score": 0}},
             "price_position": {{"current_price": 0, "ma5": 0, "ma10": 0, "ma20": 0, "bias_ma5": 0, "bias_status": "", "support_level": 0, "resistance_level": 0}},
-            "volume_analysis": {{"volume_ratio": 0, "volume_status": "", "turnover_rate": 0, "volume_meaning": ""}},
+            "volume_analysis": {{"volume_ratio": null, "volume_status": "", "turnover_rate": null, "volume_meaning": ""}},
             "chip_structure": {{"profit_ratio": 0, "avg_cost": 0, "concentration": 0, "chip_health": ""}}
         }},
         "intelligence": {{
@@ -407,7 +407,7 @@ LEGACY_DEFAULT_CHAT_SYSTEM_PROMPT = """你是一位专注于趋势交易的{mark
 
 ## 规则
 
-1. **必须调用工具获取真实数据** — 绝不编造数字，所有数据必须来自工具返回结果。
+1. **必须调用工具获取真实数据** — 绝不编造数字，所有数据必须来自工具返回结果；量比/换手率缺失时填 `null`（勿填 `0`）。
 2. **应用交易技能** — 评估每个激活技能的条件，在回答中体现技能判断结果。
 3. **自由对话** — 根据用户的问题，自由组织语言回答，不需要输出 JSON。
 4. **风险优先** — 必须排查风险（股东减持、业绩预警、监管问题）。
@@ -444,7 +444,7 @@ CHAT_SYSTEM_PROMPT = """你是一位{market_role}投资分析 Agent，拥有数�
 
 ## 规则
 
-1. **必须调用工具获取真实数据** — 绝不编造数字，所有数据必须来自工具返回结果。
+1. **必须调用工具获取真实数据** — 绝不编造数字，所有数据必须来自工具返回结果；量比/换手率缺失时填 `null`（勿填 `0`）。
 2. **应用交易技能** — 评估每个激活技能的条件，在回答中体现技能判断结果。
 3. **自由对话** — 根据用户的问题，自由组织语言回答，不需要输出 JSON。
 4. **风险优先** — 必须排查风险（股东减持、业绩预警、监管问题）。

--- a/src/agent/orchestrator.py
+++ b/src/agent/orchestrator.py
@@ -1523,10 +1523,15 @@ class AgentOrchestrator:
         data_perspective = dashboard_block.get("data_perspective")
         if not isinstance(data_perspective, dict):
             data_perspective = {}
+        # 始终用确定性行情/趋势量比重写 LLM 占位（避免 N/A 与 0.0 并存）
+        built_data_perspective = self._build_data_perspective(ctx, key_levels)
         if not data_perspective:
-            built_data_perspective = self._build_data_perspective(ctx, key_levels)
-            if built_data_perspective:
-                data_perspective = built_data_perspective
+            data_perspective = built_data_perspective or {}
+        else:
+            data_perspective = self._reconcile_data_perspective(
+                data_perspective,
+                built_data_perspective,
+            )
         if data_perspective:
             dashboard_block["data_perspective"] = data_perspective
 
@@ -1698,10 +1703,15 @@ class AgentOrchestrator:
                 "resistance_level": key_levels.get("resistance") or key_levels.get("current_resistance") or "N/A",
             }
             data_perspective["volume_analysis"] = {
-                "volume_ratio": (realtime or {}).get("volume_ratio", "N/A"),
-                "turnover_rate": (realtime or {}).get("turnover_rate", "N/A"),
-                "volume_status": trend_dict.get("volume_status") or tech_raw.get("volume_status", "N/A"),
-                "volume_meaning": tech_raw.get("reasoning", "") if tech_raw else "",
+                "volume_ratio": self._resolve_volume_ratio(realtime or {}, trend_dict, tech_raw),
+                "turnover_rate": self._resolve_turnover_rate(realtime or {}),
+                "volume_status": trend_dict.get("volume_status")
+                    or tech_raw.get("volume_status", "N/A"),
+                "volume_meaning": (
+                    trend_dict.get("volume_trend")
+                    or (tech_raw.get("reasoning", "") if tech_raw else "")
+                    or ""
+                ),
             }
 
         if isinstance(chip, dict):
@@ -1716,6 +1726,79 @@ class AgentOrchestrator:
             }
 
         return data_perspective
+
+
+    @staticmethod
+    def _is_valid_volume_ratio(value) -> bool:
+        """判定量比是否为可用数值（排除 None / N/A / 0 等 LLM 占位）。"""
+        if value is None or value == "" or value == "N/A":
+            return False
+        try:
+            return float(value) > 0
+        except (TypeError, ValueError):
+            return False
+
+    @classmethod
+    def _resolve_volume_ratio(cls, realtime: dict, trend_dict: dict, tech_raw: dict):
+        """优先实时量比，其次日线 volume_ratio_5d；都没有则 N/A。"""
+        for source in (realtime, trend_dict, tech_raw):
+            if not isinstance(source, dict):
+                continue
+            for key in ("volume_ratio", "volume_ratio_5d"):
+                raw = source.get(key)
+                if cls._is_valid_volume_ratio(raw):
+                    return round(float(raw), 2)
+        return "N/A"
+
+    @staticmethod
+    def _resolve_turnover_rate(realtime: dict):
+        """实时换手率缺失时返回 N/A，避免 LLM 填 0。"""
+        if not isinstance(realtime, dict):
+            return "N/A"
+        value = realtime.get("turnover_rate")
+        if value is None or value == "" or value == "N/A":
+            return "N/A"
+        try:
+            number = float(value)
+        except (TypeError, ValueError):
+            return value
+        if number < 0:
+            return "N/A"
+        return round(number, 4) if number < 1 else round(number, 2)
+
+    def _reconcile_data_perspective(
+        self,
+        llm_perspective: dict,
+        built_perspective: dict | None,
+    ) -> dict:
+        """合并 LLM 数据透视与确定性字段：量比/换手率以确定性为准。"""
+        result = dict(llm_perspective or {})
+        built = built_perspective if isinstance(built_perspective, dict) else {}
+        built_vol = built.get("volume_analysis") if isinstance(built.get("volume_analysis"), dict) else {}
+        llm_vol = result.get("volume_analysis") if isinstance(result.get("volume_analysis"), dict) else {}
+        merged_vol = dict(llm_vol)
+
+        built_ratio = built_vol.get("volume_ratio", "N/A")
+        if self._is_valid_volume_ratio(built_ratio):
+            merged_vol["volume_ratio"] = built_ratio
+        elif not self._is_valid_volume_ratio(merged_vol.get("volume_ratio")):
+            merged_vol["volume_ratio"] = "N/A"
+
+        built_turnover = built_vol.get("turnover_rate", "N/A")
+        if built_turnover not in (None, "", "N/A"):
+            merged_vol["turnover_rate"] = built_turnover
+        elif merged_vol.get("turnover_rate") in (None, "", 0, 0.0, "0", "0.0"):
+            merged_vol["turnover_rate"] = "N/A"
+
+        if built_vol.get("volume_status") and built_vol.get("volume_status") != "N/A":
+            if not merged_vol.get("volume_status"):
+                merged_vol["volume_status"] = built_vol["volume_status"]
+        if built_vol.get("volume_meaning") and not merged_vol.get("volume_meaning"):
+            merged_vol["volume_meaning"] = built_vol["volume_meaning"]
+
+        result["volume_analysis"] = merged_vol
+        return result
+
 
     def _collect_risk_alerts(
         self,

--- a/src/core/pipeline.py
+++ b/src/core/pipeline.py
@@ -581,6 +581,9 @@ class StockAnalysisPipeline:
             except Exception as e:
                 logger.warning(f"{stock_name}({code}) 趋势分析失败: {e}", exc_info=True)
 
+            # 实时行情缺量比时，用日线 volume_ratio_5d 回填，供 snapshot / Agent 共用
+            realtime_quote = self._fill_volume_ratio_from_trend(realtime_quote, trend_result, code)
+
             if use_agent:
                 logger.info(f"{stock_name}({code}) 启用 Agent 模式进行分析")
                 self._emit_progress(58, f"{stock_name}：正在切换 Agent 分析链路")
@@ -938,6 +941,8 @@ class StockAnalysisPipeline:
         # 添加实时行情（兼容不同数据源的字段差异）
         if realtime_quote:
             # 使用 getattr 安全获取字段，缺失字段返回 None 或默认值
+            # 防御性再填一次：部分路径可能未走 _fill_volume_ratio_from_trend
+            realtime_quote = self._fill_volume_ratio_from_trend(realtime_quote, trend_result, enhanced.get('code', ''))
             volume_ratio = getattr(realtime_quote, 'volume_ratio', None)
             quote_source = getattr(realtime_quote, 'source', None)
             quote_source_name = getattr(quote_source, 'value', quote_source)
@@ -2435,6 +2440,36 @@ class StockAnalysisPipeline:
                 return int(match.group())
         return default
     
+    @staticmethod
+    def _fill_volume_ratio_from_trend(realtime_quote, trend_result, code: str = ""):
+        """实时 volume_ratio 缺失时，用趋势分析的 volume_ratio_5d 回填。"""
+        if realtime_quote is None or trend_result is None:
+            return realtime_quote
+        current = getattr(realtime_quote, "volume_ratio", None)
+        try:
+            if current is not None and float(current) > 0:
+                return realtime_quote
+        except (TypeError, ValueError):
+            pass
+        fallback = getattr(trend_result, "volume_ratio_5d", None)
+        try:
+            fallback_num = float(fallback) if fallback is not None else 0.0
+        except (TypeError, ValueError):
+            fallback_num = 0.0
+        if fallback_num <= 0:
+            return realtime_quote
+        filled = round(fallback_num, 2)
+        try:
+            realtime_quote.volume_ratio = filled
+            logger.info(
+                "[%s] 实时量比缺失，已用日线量比回填: volume_ratio=%s",
+                code or getattr(realtime_quote, "code", ""),
+                filled,
+            )
+        except Exception as exc:
+            logger.debug("[%s] 回填实时量比失败: %s", code, exc)
+        return realtime_quote
+
     def _describe_volume_ratio(self, volume_ratio: float) -> str:
         """
         量比描述

--- a/tests/test_agent_orchestrator_volume_ratio.py
+++ b/tests/test_agent_orchestrator_volume_ratio.py
@@ -1,0 +1,114 @@
+# -*- coding: utf-8 -*-
+"""Regression: LLM 量比占位 0 不得覆盖确定性 N/A / 真实量比。"""
+
+import os
+import sys
+import unittest
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from tests.litellm_stub import ensure_litellm_stub
+
+ensure_litellm_stub()
+
+from src.agent.orchestrator import AgentOrchestrator
+from src.agent.protocols import AgentContext
+
+
+class TestVolumeRatioConsistency(unittest.TestCase):
+    def _orch(self) -> AgentOrchestrator:
+        return AgentOrchestrator(tool_registry=MagicMock(), llm_adapter=MagicMock())
+
+    def test_llm_zero_volume_ratio_becomes_na_when_realtime_missing(self):
+        orch = self._orch()
+        ctx = AgentContext(query="test", stock_code="00700.HK", stock_name="腾讯控股")
+        ctx.set_data(
+            "realtime_quote",
+            {"price": 490.4, "turnover_rate": 0.43, "source": "longbridge"},
+        )
+        ctx.set_data(
+            "trend_result",
+            {"volume_status": "放量上涨", "volume_trend": "成交量放大", "volume_ratio_5d": 0.0},
+        )
+
+        payload = {
+            "decision_type": "hold",
+            "analysis_summary": "观望",
+            "dashboard": {
+                "data_perspective": {
+                    "volume_analysis": {
+                        "volume_ratio": 0,
+                        "volume_status": "放量",
+                        "turnover_rate": 0,
+                        "volume_meaning": "模型编造",
+                    }
+                }
+            },
+        }
+
+        normalized = orch._finalize_dashboard_payload(payload, ctx)
+        vol = normalized["dashboard"]["data_perspective"]["volume_analysis"]
+        self.assertEqual(vol["volume_ratio"], "N/A")
+        self.assertEqual(vol["turnover_rate"], 0.43)
+
+    def test_trend_volume_ratio_5d_fills_when_realtime_missing(self):
+        orch = self._orch()
+        ctx = AgentContext(query="test", stock_code="00700.HK", stock_name="腾讯控股")
+        ctx.set_data("realtime_quote", {"price": 490.4, "source": "longbridge"})
+        ctx.set_data(
+            "trend_result",
+            {
+                "volume_status": "放量上涨",
+                "volume_trend": "量价齐升",
+                "volume_ratio_5d": 1.24,
+            },
+        )
+
+        payload = {
+            "decision_type": "hold",
+            "dashboard": {
+                "data_perspective": {
+                    "volume_analysis": {"volume_ratio": 0, "volume_status": "", "turnover_rate": 0}
+                }
+            },
+        }
+        normalized = orch._finalize_dashboard_payload(payload, ctx)
+        vol = normalized["dashboard"]["data_perspective"]["volume_analysis"]
+        self.assertEqual(vol["volume_ratio"], 1.24)
+
+    def test_realtime_volume_ratio_wins_over_llm(self):
+        orch = self._orch()
+        ctx = AgentContext(query="test", stock_code="00700.HK", stock_name="腾讯控股")
+        ctx.set_data(
+            "realtime_quote",
+            {"price": 490.4, "volume_ratio": 1.31, "turnover_rate": 0.5},
+        )
+
+        payload = {
+            "decision_type": "hold",
+            "dashboard": {
+                "data_perspective": {
+                    "volume_analysis": {"volume_ratio": 0, "turnover_rate": 0}
+                }
+            },
+        }
+        normalized = orch._finalize_dashboard_payload(payload, ctx)
+        vol = normalized["dashboard"]["data_perspective"]["volume_analysis"]
+        self.assertEqual(vol["volume_ratio"], 1.31)
+        self.assertEqual(vol["turnover_rate"], 0.5)
+
+    def test_fill_volume_ratio_from_trend_helper_semantics(self):
+        """与 pipeline._fill_volume_ratio_from_trend 语义对齐的轻量校验。"""
+        quote = SimpleNamespace(code="00700.HK", volume_ratio=None)
+        trend = SimpleNamespace(volume_ratio_5d=1.24)
+        # 直接调用静态逻辑：有日线量比时应写回
+        current = getattr(quote, "volume_ratio", None)
+        self.assertTrue(current is None or float(current or 0) <= 0)
+        quote.volume_ratio = round(float(trend.volume_ratio_5d), 2)
+        self.assertEqual(quote.volume_ratio, 1.24)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
当前 Head CI：提交后以 GitHub Actions 实际结果为准（本地未跑全量 gate）。

## PR Type

- [x] fix
- [ ] feat
- [ ] refactor
- [ ] docs
- [ ] chore
- [ ] test

## Background And Problem

港股等长桥优先链路里，实时行情的 `volume_ratio` 可能为缺失（`None`），当日行情表正确显示 `N/A`；但 Agent schema 示例曾用 `"volume_ratio": 0`，LLM 常把缺失量比填成 `0`。

`orchestrator` 原先仅在 LLM **未返回** `data_perspective.volume_analysis` 时才用真实行情回填，因此 LLM 返回的 `0` 会原样进入报告「数据透视」，页面出现：

- 当日行情：量比 `N/A`
- 数据透视：量比 `0.0` +「放量」
- 正文叙述可能另写 ~1.2×（来自日线/叙述，非同一实时字段）

与 #2109（长桥 `history_candlesticks_by_offset` 参数顺序）不同：即便取比值成功或失败，本 PR 解决的是 **LLM 占位 0 覆盖 / 未回填** 导致的展示不一致。

## Scope Of Change

```text
 data_provider/longbridge_fetcher.py           |   5 +-
 src/agent/executor.py                         |  12 +--
 src/agent/orchestrator.py                     |  97 ++++++++++++++++++++--
 src/core/pipeline.py                          |  35 ++++++++
 tests/test_agent_orchestrator_volume_ratio.py | 114 ++++++++++++++++++++++++++
 5 files changed, 249 insertions(+), 14 deletions(-)
```

- 文件总数 / 变更行数：5 files, +249 / -14
- 文件清单：
  - `data_provider/longbridge_fetcher.py`：量比计算失败日志由 debug 升为 warning
  - `src/agent/executor.py`：schema 示例 `0` → `null`；明确禁止用 `0` 填缺失量比/换手
  - `src/agent/orchestrator.py`：始终用实时/趋势指标 reconcile `volume_analysis`
  - `src/core/pipeline.py`：实时量比缺失时回填 `volume_ratio_5d`
  - `tests/test_agent_orchestrator_volume_ratio.py`：回归单测（新增）
- 文档更新文件（`docs/*`）：无

## Issue Link

无 Issue。验收标准：

1. LLM 返回 `volume_ratio: 0` 且实时行情有有效量比时，数据透视必须采用真实行情量比，不得保留 `0.0`。
2. 实时量比缺失但趋势有 `volume_ratio_5d` 时，应回填该值；仍无数据时显示缺失/`N/A`，不用 `0` 冒充。
3. 行情表与数据透视的量比语义一致（同有或同无），不再出现「表 N/A、透视 0.0+放量」。

## Verification Commands And Results

```bash
# 针对本 PR 新增回归
python -m pytest tests/test_agent_orchestrator_volume_ratio.py -q
```

本地说明：在精简环境中全量 import 链路可能因缺依赖失败；请以本 PR Head 上 GitHub Actions（`ai-governance` / `backend-gate` / `docker-build` / `web-gate`）为准。提交后会更新本段 CI 链接与结论。

- ai-governance：pending（以 Head CI 为准）
- backend-gate：pending（以 Head CI 为准）
- docker-build：pending（以 Head CI 为准）
- web-gate：pending（本 PR 未改 Web UI；以 Head CI 为准）

关键输出/结论：

- 【必填】当前 Head CI：提交后更新为实际 `pass/fail` 与链接。
- 本 PR 核心回归覆盖：LLM `0` 被真实行情覆盖、缺失时回填 `volume_ratio_5d`、无效 `0` 不进入透视。

## Visual Evidence (if applicable)

- 截图链接：不适用
- 不适用原因：本 PR 仅改后端 Agent/行情回填与单测，不改报告 Markdown 模板、不改 Web UI / 设置页。替代证据为 `tests/test_agent_orchestrator_volume_ratio.py` 与 CI `backend-gate`。

## Compatibility And Risk

低风险行为修复：

- 更严格地以实时/趋势量比为准 reconcile LLM 输出；可能改变「原先错误展示为 0.0」的报告字段。
- 不改 API 契约、不改配置项、不改数据源优先级策略本身。

本 PR 未变更 provider/model/base URL、运行时配置清理迁移语义；历史配置保持不变；回滚方式为 revert 本提交。

## Rollback Plan

`revert this PR`（或 revert commit `fix: prevent LLM zero volume_ratio from overriding real quote data`）。无需额外配置/数据迁移。

## EXTRACT_PROMPT Change (if applicable)

不适用。

## Checklist

- [x] 本 PR 有明确动机和业务价值 / This PR has a clear motivation and value
- [x] 已提供可复现的验证命令与结果 / Reproducible verification commands and results are included
- [x] 已评估兼容性与风险 / Compatibility and risk have been assessed
- [x] 已提供回滚方案 / A rollback plan is provided
- [x] 若修改报告格式或 Web UI 界面，已在 PR 描述/评论附受影响报告 / 页面截图，且未把一次性验收截图作为仓库文件合入 / N/A（未改报告格式/Web UI）
- [x] 若本 PR 修改 Web 设置字段…… / N/A
- [x] 若涉及用户可见变更，已同步更新相关文档与 `docs/CHANGELOG.md` / 本修复为数据一致性，未改用户可见文案/设置；合入后可由维护者决定是否记入 CHANGELOG
