### PR TITLE
fix(ui): use overflow-visible for mobile touch scrolling in StockBar and HomeStockWorkspace

### DIFF
--- a/apps/dsa-web/src/components/history/StockBar.tsx
+++ b/apps/dsa-web/src/components/history/StockBar.tsx
@@ -74,7 +74,7 @@ export const StockBar: React.FC<StockBarProps> = ({
   }, [onDeleteStock, selectedCodes]);
 
   return (
-    <aside className={`glass-card overflow-hidden flex flex-col ${className}`}>
+    <aside className={`glass-card overflow-visible flex flex-col ${className}`}>
       <ScrollArea
         viewportClassName="p-4"
         testId="home-stock-bar-scroll"

--- a/apps/dsa-web/src/components/watchlist/HomeStockWorkspace.tsx
+++ b/apps/dsa-web/src/components/watchlist/HomeStockWorkspace.tsx
@@ -357,14 +357,14 @@ export const HomeStockWorkspace: React.FC<HomeStockWorkspaceProps> = ({
           onItemClick={onHistoryItemClick}
           onDeleteStock={onDeleteStock}
           isDeleting={isDeleting}
-          className="flex-1 overflow-hidden"
+          className="flex-1 overflow-visible"
         />
       </div>
     );
   }
 
   return (
-    <aside className={`glass-card flex min-h-0 flex-1 flex-col overflow-hidden ${className}`}>
+    <aside className={`glass-card flex min-h-0 flex-1 flex-col overflow-visible ${className}`}>
       <div className="space-y-2.5 border-b border-subtle px-3 py-3 sm:px-4">
         {renderTabs}
 


### PR DESCRIPTION
fix: resolve mobile touch scrolling blocked by outer overflow-hidden containers.

Three CSS changes:
1. StockBar.tsx: aside overflow-hidden -> overflow-visible
2. HomeStockWorkspace.tsx: outer aside overflow-hidden -> overflow-visible
3. HomeStockWorkspace.tsx: StockBar className overflow-hidden -> overflow-visible

The ScrollArea internal pattern (overflow-hidden wrapping overflow-y-auto) is correct and unchanged. Only the two outermost containers that intercepted touch-scroll events on mobile are modified.

Fixes #2166