### PR TITLE
fix(web): 修复手机端个股栏无法滚动的问题

### DIFF
--- a/apps/dsa-web/src/components/history/StockBar.tsx
+++ b/apps/dsa-web/src/components/history/StockBar.tsx
@@ -74,7 +74,7 @@ export const StockBar: React.FC<StockBarProps> = ({
   }, [onDeleteStock, selectedCodes]);
 
   return (
-    <aside className={`glass-card overflow-hidden flex flex-col ${className}`}>
+    <aside className={`glass-card overflow-hidden flex flex-col min-h-0 ${className}`}>
       <ScrollArea
         viewportClassName="p-4"
         testId="home-stock-bar-scroll"


### PR DESCRIPTION
## 问题描述

Issue #2166: 首页个股栏在手机浏览器里面不能滚动。

## 根因分析

`StockBar.tsx` 的外层 `<aside>` 元素使用了 `flex flex-col overflow-hidden`，但缺少 `min-h-0`。在移动端布局中，这个 aside 嵌套在固定高度的 drawer 容器内，flex 子项默认 `min-height: auto`，导致高度无法收缩，ScrollArea 的视口高度为 0，用户手势无法触发滚动。

## 修复内容

给 `<aside>` 添加 `min-h-0`，使其在 flex 容器中能够正确收缩到可用高度，让 ScrollArea 有明确的滚动区域。

```diff
-    <aside className={`glass-card overflow-hidden flex flex-col ${className}`}>
+    <aside className={`glass-card overflow-hidden flex flex-col min-h-0 ${className}`}>
```

## 验证

- 修复后，在移动端浏览器中，抽屉内的个股栏可以正常上下滚动
- 桌面端布局不受影响（md 以上屏幕使用侧边栏布局）