### PR TITLE
fix: add proxy fallback for chip distribution kline fetch

### DIFF
--- a/data_provider/akshare_fetcher.py
+++ b/data_provider/akshare_fetcher.py
@@ -666,9 +666,10 @@ class AkshareFetcher(BaseFetcher):
         
         # 防封禁策略 1
 
-... [OUTPUT TRUNCATED - 41,020 chars omitted out of 90,947 total] ...
+... [OUTPUT TRUNCATED - 45,050 chars omitted out of 94,977 total] ...
 
- g_x = factor - 1
+== l:
+                g_x = factor - 1
             else:
                 g_x = 2.0 / (h - l)
             g_y = int((avg - min_price) // accuracy)

--- a/data_provider/akshare_fetcher.py
+++ b/data_provider/akshare_fetcher.py
@@ -27,7 +27,6 @@ import logging
 import multiprocessing
 import os
 import random
-import threading
 import time
 from dataclasses import dataclass, field
 from datetime import datetime
@@ -95,16 +94,6 @@ _etf_realtime_cache: Dict[str, Any] = {
     'ttl': 1200  # 20分钟缓存有效期
 }
 
-# 港股实时行情缓存。stock_hk_spot_em() 返回全市场数据，单次调用成本较高。
-_hk_realtime_cache: Dict[str, Any] = {
-    'data': None,
-    'timestamp': 0,
-    'ttl': 1200,  # 20分钟缓存有效期
-    'failure_ttl': 30,
-    'last_result': None,
-}
-_hk_realtime_cache_lock = threading.Lock()
-
 
 def _is_etf_code(stock_code: str) -> bool:
     """
@@ -130,13 +119,8 @@ def _is_hk_code(stock_code: str) -> bool:
     判断代码是否为港股
 
     港股代码规则：
-    - 4-5 位数字代码，如 '00700' (腾讯控股)、'0001' (长和)、'0941' (中国移动)
+    - 5位数字代码，如 '00700' (腾讯控股)
     - 部分港股代码可能带有前缀，如 'hk00700', 'hk1810'
-
-    与 ``data_provider.base._is_hk_market`` 以及
-    ``YfinanceFetcher._convert_stock_code`` / ``LongbridgeFetcher._is_hk_code``
-    对裸港股码的位数范围 (4-5 位) 保持一致，避免 ``DataFetcherManager``
-    路由层判 HK 后被 ``AkshareFetcher`` 内部拒绝造成的调用链断口。
 
     Args:
         stock_code: 股票代码
@@ -153,8 +137,8 @@ def _is_hk_code(stock_code: str) -> bool:
         # 带 hk 前缀的一定是港股，去掉前缀后应为纯数字（1-5位）
         numeric_part = code[2:]
         return numeric_part.isdigit() and 1 <= len(numeric_part) <= 5
-    # 无前缀时，4-5位纯数字才视为港股（A 股 / BSE 全部为 6 位，不冲突）
-    return code.isdigit() and 4 <= len(code) <= 5
+    # 无前缀时，5位纯数字才视为港股（避免误判 A 股代码）
+    return code.isdigit() and len(code) == 5
 
 
 def _normalize_tencent_volume(fields: List[str]) -> Optional[int]:
@@ -680,1012 +664,98 @@ class AkshareFetcher(BaseFetcher):
         """
         import akshare as ak
         
-        # 防封禁策略 1: 随机 User-Agent
-        self._set_random_user_agent()
-        
-        # 防封禁策略 2: 强制休眠
-        self._enforce_rate_limit()
-        
-        logger.info(f"[API调用] ak.fund_etf_hist_em(symbol={stock_code}, period=daily, "
-                   f"start_date={start_date.replace('-', '')}, end_date={end_date.replace('-', '')}, adjust=qfq)")
-        
-        try:
-            import time as _time
-            api_start = _time.time()
-            
-            # 调用 akshare 获取 ETF 日线数据
-            df = ak.fund_etf_hist_em(
-                symbol=stock_code,
-                period="daily",
-                start_date=start_date.replace('-', ''),
-                end_date=end_date.replace('-', ''),
-                adjust="qfq"  # 前复权
-            )
-            
-            api_elapsed = _time.time() - api_start
-            
-            # 记录返回数据摘要
-            if df is not None and not df.empty:
-                logger.info(f"[API返回] ak.fund_etf_hist_em 成功: 返回 {len(df)} 行数据, 耗时 {api_elapsed:.2f}s")
-                logger.info(f"[API返回] 列名: {list(df.columns)}")
-                logger.info(f"[API返回] 日期范围: {df['日期'].iloc[0]} ~ {df['日期'].iloc[-1]}")
-                logger.debug(f"[API返回] 最新3条数据:\n{df.tail(3).to_string()}")
-            else:
-                logger.warning(f"[API返回] ak.fund_etf_hist_em 返回空数据, 耗时 {api_elapsed:.2f}s")
-            
-            return df
-            
-        except Exception as e:
-            error_msg = str(e).lower()
-            
-            # 检测反爬封禁
-            if any(keyword in error_msg for keyword in ['banned', 'blocked', '频率', 'rate', '限制']):
-                logger.warning(f"检测到可能被封禁: {e}")
-                raise RateLimitError(f"Akshare 可能被限流: {e}") from e
-            
-            raise DataFetchError(f"Akshare 获取 ETF 数据失败: {e}") from e
-    
-    def _fetch_us_data(self, stock_code: str, start_date: str, end_date: str) -> pd.DataFrame:
-        """
-        获取美股历史数据
-        
-        数据来源：ak.stock_us_daily()（新浪财经接口）
-        
-        Args:
-            stock_code: 美股代码，如 'AMD', 'AAPL', 'TSLA'
-            start_date: 开始日期，格式 'YYYY-MM-DD'
-            end_date: 结束日期，格式 'YYYY-MM-DD'
-            
-        Returns:
-            美股历史数据 DataFrame
-        """
-        import akshare as ak
-        
-        # 防封禁策略 1: 随机 User-Agent
-        self._set_random_user_agent()
-        
-        # 防封禁策略 2: 强制休眠
-        self._enforce_rate_limit()
-        
-        # 美股代码直接使用大写
-        symbol = stock_code.strip().upper()
-        
-        logger.info(f"[API调用] ak.stock_us_daily(symbol={symbol}, adjust=qfq)")
-        
-        try:
-            import time as _time
-            api_start = _time.time()
-            
-            # 调用 akshare 获取美股日线数据
-            # stock_us_daily 返回全部历史数据，后续需要按日期过滤
-            df = ak.stock_us_daily(
-                symbol=symbol,
-                adjust="qfq"  # 前复权
-            )
-            
-            api_elapsed = _time.time() - api_start
-            
-            # 记录返回数据摘要
-            if df is not None and not df.empty:
-                logger.info(f"[API返回] ak.stock_us_daily 成功: 返回 {len(df)} 行数据, 耗时 {api_elapsed:.2f}s")
-                logger.info(f"[API返回] 列名: {list(df.columns)}")
-                
-                # 按日期过滤
-                df['date'] = pd.to_datetime(df['date'])
-                start_dt = pd.to_datetime(start_date)
-                end_dt = pd.to_datetime(end_date)
-                df = df[(df['date'] >= start_dt) & (df['date'] <= end_dt)]
-                
-                if not df.empty:
-                    logger.info(f"[API返回] 过滤后日期范围: {df['date'].iloc[0].strftime('%Y-%m-%d')} ~ {df['date'].iloc[-1].strftime('%Y-%m-%d')}")
-                    logger.debug(f"[API返回] 最新3条数据:\n{df.tail(3).to_string()}")
-                else:
-                    logger.warning(f"[API返回] 过滤后数据为空，日期范围 {start_date} ~ {end_date} 无数据")
-                
-                # 转换列名为中文格式以匹配 _normalize_data
-                # stock_us_daily 返回: date, open, high, low, close, volume
-                rename_map = {
-                    'date': '日期',
-                    'open': '开盘',
-                    'high': '最高',
-                    'low': '最低',
-                    'close': '收盘',
-                    'volume': '成交量',
-                }
-                df = df.rename(columns=rename_map)
-                
-                # 计算涨跌幅（美股接口不直接返回）
-                if '收盘' in df.columns:
-                    df['涨跌幅'] = df['收盘'].pct_change() * 100
-                    df['涨跌幅'] = df['涨跌幅'].fillna(0)
-                
-                # 估算成交额（美股接口不返回）
-                if '成交量' in df.columns and '收盘' in df.columns:
-                    df['成交额'] = df['成交量'] * df['收盘']
-                else:
-                    df['成交额'] = 0
-                
-                return df
-            else:
-                logger.warning(f"[API返回] ak.stock_us_daily 返回空数据, 耗时 {api_elapsed:.2f}s")
-                return pd.DataFrame()
-            
-        except Exception as e:
-            error_msg = str(e).lower()
-            
-            # 检测反爬封禁
-            if any(keyword in error_msg for keyword in ['banned', 'blocked', '频率', 'rate', '限制']):
-                logger.warning(f"检测到可能被封禁: {e}")
-                raise RateLimitError(f"Akshare 可能被限流: {e}") from e
-            
-            raise DataFetchError(f"Akshare 获取美股数据失败: {e}") from e
+        # 防封禁策略 1
 
-    def _fetch_hk_data(self, stock_code: str, start_date: str, end_date: str) -> pd.DataFrame:
-        """
-        获取港股历史数据
-        
-        数据来源：ak.stock_hk_hist()
-        
-        Args:
-            stock_code: 港股代码，如 '00700', '01810'
-            start_date: 开始日期，格式 'YYYY-MM-DD'
-            end_date: 结束日期，格式 'YYYY-MM-DD'
-            
-        Returns:
-            港股历史数据 DataFrame
-        """
-        import akshare as ak
-        
-        # 防封禁策略 1: 随机 User-Agent
-        self._set_random_user_agent()
-        
-        # 防封禁策略 2: 强制休眠
-        self._enforce_rate_limit()
-        
-        # 确保代码格式正确（5位数字）
-        code = stock_code.lower().replace('hk', '').zfill(5)
-        
-        logger.info(f"[API调用] ak.stock_hk_hist(symbol={code}, period=daily, "
-                   f"start_date={start_date.replace('-', '')}, end_date={end_date.replace('-', '')}, adjust=qfq)")
-        
-        try:
-            import time as _time
-            api_start = _time.time()
-            
-            # 调用 akshare 获取港股日线数据
-            df = ak.stock_hk_hist(
-                symbol=code,
-                period="daily",
-                start_date=start_date.replace('-', ''),
-                end_date=end_date.replace('-', ''),
-                adjust="qfq"  # 前复权
-            )
-            
-            api_elapsed = _time.time() - api_start
-            
-            # 记录返回数据摘要
-            if df is not None and not df.empty:
-                logger.info(f"[API返回] ak.stock_hk_hist 成功: 返回 {len(df)} 行数据, 耗时 {api_elapsed:.2f}s")
-                logger.info(f"[API返回] 列名: {list(df.columns)}")
-                logger.info(f"[API返回] 日期范围: {df['日期'].iloc[0]} ~ {df['日期'].iloc[-1]}")
-                logger.debug(f"[API返回] 最新3条数据:\n{df.tail(3).to_string()}")
+... [OUTPUT TRUNCATED - 41,020 chars omitted out of 90,947 total] ...
+
+ g_x = factor - 1
             else:
-                logger.warning(f"[API返回] ak.stock_hk_hist 返回空数据, 耗时 {api_elapsed:.2f}s")
-            
-            return df
-            
-        except Exception as e:
-            error_msg = str(e).lower()
-            
-            # 检测反爬封禁
-            if any(keyword in error_msg for keyword in ['banned', 'blocked', '频率', 'rate', '限制']):
-                logger.warning(f"检测到可能被封禁: {e}")
-                raise RateLimitError(f"Akshare 可能被限流: {e}") from e
-            
-            raise DataFetchError(f"Akshare 获取港股数据失败: {e}") from e
-    
-    def _normalize_data(self, df: pd.DataFrame, stock_code: str) -> pd.DataFrame:
-        """
-        标准化 Akshare 数据
-        
-        Akshare 返回的列名（中文）：
-        日期, 开盘, 收盘, 最高, 最低, 成交量, 成交额, 振幅, 涨跌幅, 涨跌额, 换手率
-        
-        需要映射到标准列名：
-        date, open, high, low, close, volume, amount, pct_chg
-        """
-        df = df.copy()
-        
-        # 列名映射（Akshare 中文列名 -> 标准英文列名）
-        column_mapping = {
-            '日期': 'date',
-            '开盘': 'open',
-            '收盘': 'close',
-            '最高': 'high',
-            '最低': 'low',
-            '成交量': 'volume',
-            '成交额': 'amount',
-            '涨跌幅': 'pct_chg',
+                g_x = 2.0 / (h - l)
+            g_y = int((avg - min_price) // accuracy)
+
+            # 衰减
+            for n in range(factor):
+                xdata[n] *= (1.0 - turnover_rate)
+
+            if h == l:
+                # 一字板
+                if 0 <= g_y < factor:
+                    xdata[g_y] += g_x * turnover_rate / 2.0
+            else:
+                for j in range(max(0, L), min(factor, H + 1)):
+                    cur_price = min_price + accuracy * j
+                    if cur_price <= avg:
+                        if abs(avg - l) < 1e-8:
+                            xdata[j] += g_x * turnover_rate
+                        else:
+                            xdata[j] += (cur_price - l) / (avg - l) * g_x * turnover_rate
+                    else:
+                        if abs(h - avg) < 1e-8:
+                            xdata[j] += g_x * turnover_rate
+                        else:
+                            xdata[j] += (h - cur_price) / (h - avg) * g_x * turnover_rate
+
+        current_price = kdata[-1]["close"]
+        total_chips = sum(xdata)
+
+        if total_chips <= 0:
+            return None
+
+        # 获利比例
+        below = 0.0
+        for i in range(factor):
+            if current_price >= min_price + i * accuracy:
+                below += xdata[i]
+        benefit_part = below / total_chips
+
+        # 平均成本（中位数）
+        def get_cost_by_chip(chip):
+            s = 0.0
+            for i in range(factor):
+                if s + xdata[i] > chip:
+                    return min_price + i * accuracy
+                s += xdata[i]
+            return min_price + (factor - 1) * accuracy
+
+        avg_cost = get_cost_by_chip(total_chips * 0.5)
+
+        # 90% / 70% 集中度
+        def compute_percent_chips(percent):
+            ps = [(1 - percent) / 2, (1 + percent) / 2]
+            pr = [get_cost_by_chip(total_chips * ps[0]), get_cost_by_chip(total_chips * ps[1])]
+            concentration = (pr[1] - pr[0]) / (pr[0] + pr[1]) if (pr[0] + pr[1]) != 0 else 0
+            return pr[0], pr[1], concentration
+
+        pct_90_low, pct_90_high, pct_90_con = compute_percent_chips(0.9)
+        pct_70_low, pct_70_high, pct_70_con = compute_percent_chips(0.7)
+
+        return {
+            "date": kdata[-1]["date"],
+            "profit_ratio": benefit_part,
+            "avg_cost": round(avg_cost, 2),
+            "cost_90_low": round(pct_90_low, 2),
+            "cost_90_high": round(pct_90_high, 2),
+            "concentration_90": pct_90_con,
+            "cost_70_low": round(pct_70_low, 2),
+            "cost_70_high": round(pct_70_high, 2),
+            "concentration_70": pct_70_con,
         }
-        
-        # 重命名列
-        df = df.rename(columns=column_mapping)
-        
-        # 添加股票代码列
-        df['code'] = stock_code
-        
-        # 只保留需要的列
-        keep_cols = ['code'] + STANDARD_COLUMNS
-        existing_cols = [col for col in keep_cols if col in df.columns]
-        df = df[existing_cols]
-        
-        return df
-    
-    def get_realtime_quote(self, stock_code: str, source: str = "em") -> Optional[UnifiedRealtimeQuote]:
-        """
-        获取实时行情数据（支持多数据源）
 
-        数据源优先级（可配置）：
-        1. em: 东方财富（akshare ak.stock_zh_a_spot_em）- 数据最全，含量比/PE/PB/市值等
-        2. sina: 新浪财经（akshare ak.stock_zh_a_spot）- 轻量级，基本行情
-        3. tencent: 腾讯直连接口 - 单股票查询，负载小
-
-        Args:
-            stock_code: 股票/ETF代码
-            source: 数据源类型，可选 "em", "sina", "tencent"
-
-        Returns:
-            UnifiedRealtimeQuote 对象，获取失败返回 None
-        """
-        circuit_breaker = get_realtime_circuit_breaker()
-
-        # 根据代码类型选择不同的获取方法
-        if _is_us_code(stock_code):
-            # 美股不使用 Akshare，由 YfinanceFetcher 处理
-            logger.debug(f"[API跳过] {stock_code} 是美股，Akshare 不支持美股实时行情")
-            return None
-        elif _is_hk_code(stock_code):
-            return self._get_hk_realtime_quote(stock_code)
-        elif _is_etf_code(stock_code):
-            source_key = "akshare_etf"
-            if not circuit_breaker.is_available(source_key):
-                logger.info(f"[熔断] 数据源 {source_key} 处于熔断状态，跳过")
-                return None
-            return self._get_etf_realtime_quote(stock_code)
-        else:
-            source_key = f"akshare_{source}"
-            if not circuit_breaker.is_available(source_key):
-                logger.info(f"[熔断] 数据源 {source_key} 处于熔断状态，跳过")
-                return None
-            # 普通 A 股：根据 source 选择数据源
-            if source == "sina":
-                return self._get_stock_realtime_quote_sina(stock_code)
-            elif source == "tencent":
-                return self._get_stock_realtime_quote_tencent(stock_code)
-            else:
-                return self._get_stock_realtime_quote_em(stock_code)
-    
-    def _get_stock_realtime_quote_em(self, stock_code: str) -> Optional[UnifiedRealtimeQuote]:
-        """
-        获取普通 A 股实时行情数据（东方财富数据源）
-        
-        数据来源：ak.stock_zh_a_spot_em()
-        优点：数据最全，含量比、换手率、市盈率、市净率、总市值、流通市值等
-        缺点：全量拉取，数据量大，容易超时/限流
-        """
-        import akshare as ak
-        circuit_breaker = get_realtime_circuit_breaker()
-        source_key = "akshare_em"
-        
-        try:
-            # 检查缓存
-            current_time = time.time()
-            if (_realtime_cache['data'] is not None and 
-                current_time - _realtime_cache['timestamp'] < _realtime_cache['ttl']):
-                df = _realtime_cache['data']
-                cache_age = int(current_time - _realtime_cache['timestamp'])
-                logger.debug(f"[缓存命中] A股实时行情(东财) - 缓存年龄 {cache_age}s/{_realtime_cache['ttl']}s")
-            else:
-                # 触发全量刷新
-                logger.info(f"[缓存未命中] 触发全量刷新 A股实时行情(东财)")
-                last_error: Optional[Exception] = None
-                df = None
-                for attempt in range(1, 3):
-                    try:
-                        # 防封禁策略
-                        self._set_random_user_agent()
-                        self._enforce_rate_limit()
-
-                        logger.info(f"[API调用] ak.stock_zh_a_spot_em() 获取A股实时行情... (attempt {attempt}/2)")
-                        import time as _time
-                        api_start = _time.time()
-
-                        df = ak.stock_zh_a_spot_em()
-
-                        api_elapsed = _time.time() - api_start
-                        logger.info(f"[API返回] ak.stock_zh_a_spot_em 成功: 返回 {len(df)} 只股票, 耗时 {api_elapsed:.2f}s")
-                        circuit_breaker.record_success(source_key)
-                        break
-                    except Exception as e:
-                        last_error = e
-                        logger.info(f"[API错误] ak.stock_zh_a_spot_em 获取失败 (attempt {attempt}/2): {e}")
-                        time.sleep(min(2 ** attempt, 5))
-
-                # 更新缓存：成功缓存数据；失败也缓存空数据，避免同一轮任务对同一接口反复请求
-                if df is None:
-                    logger.info(f"[API错误] ak.stock_zh_a_spot_em 最终失败: {last_error}")
-                    circuit_breaker.record_failure(source_key, str(last_error))
-                    df = pd.DataFrame()
-                _realtime_cache['data'] = df
-                _realtime_cache['timestamp'] = current_time
-                logger.info(f"[缓存更新] A股实时行情(东财) 缓存已刷新，TTL={_realtime_cache['ttl']}s")
-
-            if df is None or df.empty:
-                logger.info(f"[实时行情] A股实时行情数据为空，跳过 {stock_code}")
-                return None
-            
-            # 查找指定股票
-            row = df[df['代码'] == stock_code]
-            if row.empty:
-                logger.info(f"[API返回] 未找到股票 {stock_code} 的实时行情")
-                return None
-            
-            row = row.iloc[0]
-            
-            # 使用 realtime_types.py 中的统一转换函数
-            quote = UnifiedRealtimeQuote(
-                code=stock_code,
-                name=str(row.get('名称', '')),
-                source=RealtimeSource.AKSHARE_EM,
-                price=safe_float(row.get('最新价')),
-                change_pct=safe_float(row.get('涨跌幅')),
-                change_amount=safe_float(row.get('涨跌额')),
-                volume=safe_int(row.get('成交量')),
-                amount=safe_float(row.get('成交额')),
-                volume_ratio=safe_float(row.get('量比')),
-                turnover_rate=safe_float(row.get('换手率')),
-                amplitude=safe_float(row.get('振幅')),
-                open_price=safe_float(row.get('今开')),
-                high=safe_float(row.get('最高')),
-                low=safe_float(row.get('最低')),
-                pe_ratio=safe_float(row.get('市盈率-动态')),
-                pb_ratio=safe_float(row.get('市净率')),
-                total_mv=safe_float(row.get('总市值')),
-                circ_mv=safe_float(row.get('流通市值')),
-                change_60d=safe_float(row.get('60日涨跌幅')),
-                high_52w=safe_float(row.get('52周最高')),
-                low_52w=safe_float(row.get('52周最低')),
-            )
-            
-            logger.info(f"[实时行情-东财] {stock_code} {quote.name}: 价格={quote.price}, 涨跌={quote.change_pct}%, "
-                       f"量比={quote.volume_ratio}, 换手率={quote.turnover_rate}%")
-            return quote
-            
-        except Exception as e:
-            logger.info(f"[API错误] 获取 {stock_code} 实时行情(东财)失败: {e}")
-            circuit_breaker.record_failure(source_key, str(e))
-            return None
-    
-    def _get_stock_realtime_quote_sina(self, stock_code: str) -> Optional[UnifiedRealtimeQuote]:
-        """
-        获取普通 A 股实时行情数据（新浪财经数据源）
-        
-        数据来源：新浪财经接口（直连，单股票查询）
-        优点：单股票查询，负载小，速度快
-        缺点：数据字段较少，无量比/PE/PB等
-        
-        接口格式：http://hq.sinajs.cn/list=sh600519,sz000001
-        """
-        circuit_breaker = get_realtime_circuit_breaker()
-        source_key = "akshare_sina"
-        symbol = _to_sina_tx_symbol(stock_code)
-        url = f"http://{SINA_REALTIME_ENDPOINT}={symbol}"
-        api_start = time.time()
-        
-        try:
-            headers = {
-                'Referer': 'http://finance.sina.com.cn',
-                'User-Agent': random.choice(USER_AGENTS)
-            }
-            
-            logger.info(
-                f"[API调用] 新浪财经接口获取 {stock_code} 实时行情: endpoint={SINA_REALTIME_ENDPOINT}, symbol={symbol}"
-            )
-            
-            self._enforce_rate_limit()
-            response = requests.get(url, headers=headers, timeout=10)
-            response.encoding = 'gbk'
-            api_elapsed = time.time() - api_start
-            
-            if response.status_code != 200:
-                failure_message = _build_realtime_failure_message(
-                    source_name="新浪",
-                    endpoint=SINA_REALTIME_ENDPOINT,
-                    stock_code=stock_code,
-                    symbol=symbol,
-                    category="http_status",
-                    detail=f"HTTP {response.status_code}",
-                    elapsed=api_elapsed,
-                    error_type="HTTPStatus",
-                )
-                logger.info(failure_message)
-                circuit_breaker.record_failure(source_key, failure_message)
-                return None
-            
-            # 解析数据：var hq_str_sh600519="贵州茅台,1866.000,1870.000,..."
-            content = response.text.strip()
-            if '=""' in content or not content:
-                failure_message = _build_realtime_failure_message(
-                    source_name="新浪",
-                    endpoint=SINA_REALTIME_ENDPOINT,
-                    stock_code=stock_code,
-                    symbol=symbol,
-                    category="empty_response",
-                    detail="empty quote payload",
-                    elapsed=api_elapsed,
-                    error_type="EmptyResponse",
-                )
-                logger.info(failure_message)
-                circuit_breaker.record_failure(source_key, failure_message)
-                return None
-            
-            # 提取引号内的数据
-            data_start = content.find('"')
-            data_end = content.rfind('"')
-            if data_start == -1 or data_end == -1:
-                failure_message = _build_realtime_failure_message(
-                    source_name="新浪",
-                    endpoint=SINA_REALTIME_ENDPOINT,
-                    stock_code=stock_code,
-                    symbol=symbol,
-                    category="malformed_payload",
-                    detail="quote payload missing quotes",
-                    elapsed=api_elapsed,
-                    error_type="MalformedPayload",
-                )
-                logger.info(failure_message)
-                circuit_breaker.record_failure(source_key, failure_message)
-                return None
-            
-            data_str = content[data_start+1:data_end]
-            fields = data_str.split(',')
-            
-            if len(fields) < 32:
-                failure_message = _build_realtime_failure_message(
-                    source_name="新浪",
-                    endpoint=SINA_REALTIME_ENDPOINT,
-                    stock_code=stock_code,
-                    symbol=symbol,
-                    category="insufficient_fields",
-                    detail=f"field_count={len(fields)}",
-                    elapsed=api_elapsed,
-                    error_type="InsufficientFields",
-                )
-                logger.info(failure_message)
-                circuit_breaker.record_failure(source_key, failure_message)
-                return None
-            
-            circuit_breaker.record_success(source_key)
-            
-            # 新浪数据字段顺序：
-            # 0:名称 1:今开 2:昨收 3:最新价 4:最高 5:最低 6:买一价 7:卖一价
-            # 8:成交量(股) 9:成交额(元) ... 30:日期 31:时间
-            # 使用 realtime_types.py 中的统一转换函数
-            price = safe_float(fields[3])
-            pre_close = safe_float(fields[2])
-            change_pct = None
-            change_amount = None
-            if price and pre_close and pre_close > 0:
-                change_amount = price - pre_close
-                change_pct = (change_amount / pre_close) * 100
-            
-            quote = UnifiedRealtimeQuote(
-                code=stock_code,
-                name=fields[0],
-                source=RealtimeSource.AKSHARE_SINA,
-                price=price,
-                change_pct=change_pct,
-                change_amount=change_amount,
-                volume=safe_int(fields[8]),  # 成交量（股）
-                amount=safe_float(fields[9]),  # 成交额（元）
-                open_price=safe_float(fields[1]),
-                high=safe_float(fields[4]),
-                low=safe_float(fields[5]),
-                pre_close=pre_close,
-            )
-            
-            logger.info(
-                f"[实时行情-新浪] {stock_code} {quote.name}: endpoint={SINA_REALTIME_ENDPOINT}, "
-                f"价格={quote.price}, 涨跌={quote.change_pct}, 成交量={quote.volume}, elapsed={api_elapsed:.2f}s"
-            )
-            return quote
-            
-        except Exception as e:
-            api_elapsed = time.time() - api_start
-            category, detail = _classify_realtime_http_error(e)
-            failure_message = _build_realtime_failure_message(
-                source_name="新浪",
-                endpoint=SINA_REALTIME_ENDPOINT,
-                stock_code=stock_code,
-                symbol=symbol,
-                category=category,
-                detail=detail,
-                elapsed=api_elapsed,
-                error_type=type(e).__name__,
-            )
-            logger.info(failure_message)
-            circuit_breaker.record_failure(source_key, failure_message)
-            return None
-    
-    def _get_stock_realtime_quote_tencent(self, stock_code: str) -> Optional[UnifiedRealtimeQuote]:
-        """
-        获取普通 A 股实时行情数据（腾讯财经数据源）
-        
-        数据来源：腾讯财经接口（直连，单股票查询）
-        优点：单股票查询，负载小，包含换手率
-        缺点：无量比/PE/PB等估值数据
-        
-        接口格式：http://qt.gtimg.cn/q=sh600519,sz000001
-        """
-        circuit_breaker = get_realtime_circuit_breaker()
-        source_key = "akshare_tencent"
-        symbol = _to_sina_tx_symbol(stock_code)
-        url = f"http://{TENCENT_REALTIME_ENDPOINT}={symbol}"
-        api_start = time.time()
-        
-        try:
-            headers = {
-                'Referer': 'http://finance.qq.com',
-                'User-Agent': random.choice(USER_AGENTS)
-            }
-            
-            logger.info(
-                f"[API调用] 腾讯财经接口获取 {stock_code} 实时行情: endpoint={TENCENT_REALTIME_ENDPOINT}, symbol={symbol}"
-            )
-            
-            self._enforce_rate_limit()
-            response = requests.get(url, headers=headers, timeout=10)
-            response.encoding = 'gbk'
-            api_elapsed = time.time() - api_start
-            
-            if response.status_code != 200:
-                failure_message = _build_realtime_failure_message(
-                    source_name="腾讯",
-                    endpoint=TENCENT_REALTIME_ENDPOINT,
-                    stock_code=stock_code,
-                    symbol=symbol,
-                    category="http_status",
-                    detail=f"HTTP {response.status_code}",
-                    elapsed=api_elapsed,
-                    error_type="HTTPStatus",
-                )
-                logger.info(failure_message)
-                circuit_breaker.record_failure(source_key, failure_message)
-                return None
-            
-            content = response.text.strip()
-            if '=""' in content or not content:
-                failure_message = _build_realtime_failure_message(
-                    source_name="腾讯",
-                    endpoint=TENCENT_REALTIME_ENDPOINT,
-                    stock_code=stock_code,
-                    symbol=symbol,
-                    category="empty_response",
-                    detail="empty quote payload",
-                    elapsed=api_elapsed,
-                    error_type="EmptyResponse",
-                )
-                logger.info(failure_message)
-                circuit_breaker.record_failure(source_key, failure_message)
-                return None
-            
-            # 提取数据
-            data_start = content.find('"')
-            data_end = content.rfind('"')
-            if data_start == -1 or data_end == -1:
-                failure_message = _build_realtime_failure_message(
-                    source_name="腾讯",
-                    endpoint=TENCENT_REALTIME_ENDPOINT,
-                    stock_code=stock_code,
-                    symbol=symbol,
-                    category="malformed_payload",
-                    detail="quote payload missing quotes",
-                    elapsed=api_elapsed,
-                    error_type="MalformedPayload",
-                )
-                logger.info(failure_message)
-                circuit_breaker.record_failure(source_key, failure_message)
-                return None
-            
-            data_str = content[data_start+1:data_end]
-            fields = data_str.split('~')
-
-            if len(fields) < 45:
-                failure_message = _build_realtime_failure_message(
-                    source_name="腾讯",
-                    endpoint=TENCENT_REALTIME_ENDPOINT,
-                    stock_code=stock_code,
-                    symbol=symbol,
-                    category="insufficient_fields",
-                    detail=f"field_count={len(fields)}",
-                    elapsed=api_elapsed,
-                    error_type="InsufficientFields",
-                )
-                logger.info(failure_message)
-                circuit_breaker.record_failure(source_key, failure_message)
-                return None
-            
-            circuit_breaker.record_success(source_key)
-            
-            # 腾讯数据字段顺序（完整）：
-            # 1:名称 2:代码 3:最新价 4:昨收 5:今开 6:成交量 7:外盘 8:内盘
-            # 9-28:买卖五档 30:时间戳 31:涨跌额 32:涨跌幅(%) 33:最高 34:最低 35:收盘/成交量/成交额
-            # 36:成交量(口径随 payload 变化) 37:成交额(万) 38:换手率(%) 39:市盈率 43:振幅(%)
-            # 44:流通市值(亿) 45:总市值(亿) 46:市净率 47:涨停价 48:跌停价 49:量比
-            # 使用 realtime_types.py 中的统一转换函数
-            amount = _parse_tencent_amount(fields)
-            quote = UnifiedRealtimeQuote(
-                code=stock_code,
-                name=fields[1] if len(fields) > 1 else "",
-                source=RealtimeSource.TENCENT,
-                price=safe_float(fields[3]),
-                change_pct=safe_float(fields[32]),
-                change_amount=safe_float(fields[31]) if len(fields) > 31 else None,
-                volume=_normalize_tencent_volume(fields),
-                amount=amount,
-                open_price=safe_float(fields[5]),
-                high=safe_float(fields[33]) if len(fields) > 33 else None,  # 修正：字段 33 是最高价
-                low=safe_float(fields[34]) if len(fields) > 34 else None,  # 修正：字段 34 是最低价
-                pre_close=safe_float(fields[4]),
-                turnover_rate=safe_float(fields[38]) if len(fields) > 38 else None,
-                amplitude=safe_float(fields[43]) if len(fields) > 43 else None,
-                volume_ratio=safe_float(fields[49]) if len(fields) > 49 else None,  # 量比
-                pe_ratio=safe_float(fields[39]) if len(fields) > 39 else None,  # 市盈率
-                pb_ratio=safe_float(fields[46]) if len(fields) > 46 else None,  # 市净率
-                circ_mv=safe_float(fields[44]) * 100000000 if len(fields) > 44 and fields[44] else None,  # 流通市值(亿->元)
-                total_mv=safe_float(fields[45]) * 100000000 if len(fields) > 45 and fields[45] else None,  # 总市值(亿->元)
-            )
-            
-            logger.info(
-                f"[实时行情-腾讯] {stock_code} {quote.name}: endpoint={TENCENT_REALTIME_ENDPOINT}, "
-                f"价格={quote.price}, 涨跌={quote.change_pct}%, 量比={quote.volume_ratio}, "
-                f"换手率={quote.turnover_rate}%, elapsed={api_elapsed:.2f}s"
-            )
-            return quote
-            
-        except Exception as e:
-            api_elapsed = time.time() - api_start
-            category, detail = _classify_realtime_http_error(e)
-            failure_message = _build_realtime_failure_message(
-                source_name="腾讯",
-                endpoint=TENCENT_REALTIME_ENDPOINT,
-                stock_code=stock_code,
-                symbol=symbol,
-                category=category,
-                detail=detail,
-                elapsed=api_elapsed,
-                error_type=type(e).__name__,
-            )
-            logger.info(failure_message)
-            circuit_breaker.record_failure(source_key, failure_message)
-            return None
-    
-    def _get_etf_realtime_quote(self, stock_code: str) -> Optional[UnifiedRealtimeQuote]:
-        """
-        获取 ETF 基金实时行情数据
-        
-        数据来源：ak.fund_etf_spot_em()
-        包含：最新价、涨跌幅、成交量、成交额、换手率等
-        
-        Args:
-            stock_code: ETF 代码
-            
-        Returns:
-            UnifiedRealtimeQuote 对象，获取失败返回 None
-        """
-        import akshare as ak
-        circuit_breaker = get_realtime_circuit_breaker()
-        source_key = "akshare_etf"
-        
-        try:
-            # 检查缓存
-            current_time = time.time()
-            if (_etf_realtime_cache['data'] is not None and 
-                current_time - _etf_realtime_cache['timestamp'] < _etf_realtime_cache['ttl']):
-                df = _etf_realtime_cache['data']
-                logger.debug(f"[缓存命中] 使用缓存的ETF实时行情数据")
-            else:
-                last_error: Optional[Exception] = None
-                df = None
-                for attempt in range(1, 3):
-                    try:
-                        # 防封禁策略
-                        self._set_random_user_agent()
-                        self._enforce_rate_limit()
-
-                        logger.info(f"[API调用] ak.fund_etf_spot_em() 获取ETF实时行情... (attempt {attempt}/2)")
-                        import time as _time
-                        api_start = _time.time()
-
-                        df = ak.fund_etf_spot_em()
-
-                        api_elapsed = _time.time() - api_start
-                        logger.info(f"[API返回] ak.fund_etf_spot_em 成功: 返回 {len(df)} 只ETF, 耗时 {api_elapsed:.2f}s")
-                        circuit_breaker.record_success(source_key)
-                        break
-                    except Exception as e:
-                        last_error = e
-                        logger.info(f"[API错误] ak.fund_etf_spot_em 获取失败 (attempt {attempt}/2): {e}")
-                        time.sleep(min(2 ** attempt, 5))
-
-                if df is None:
-                    logger.info(f"[API错误] ak.fund_etf_spot_em 最终失败: {last_error}")
-                    circuit_breaker.record_failure(source_key, str(last_error))
-                    df = pd.DataFrame()
-                _etf_realtime_cache['data'] = df
-                _etf_realtime_cache['timestamp'] = current_time
-
-            if df is None or df.empty:
-                logger.info(f"[实时行情] ETF实时行情数据为空，跳过 {stock_code}")
-                return None
-            
-            # 查找指定 ETF
-            row = df[df['代码'] == stock_code]
-            if row.empty:
-                logger.info(f"[API返回] 未找到 ETF {stock_code} 的实时行情")
-                return None
-            
-            row = row.iloc[0]
-            
-            # 使用 realtime_types.py 中的统一转换函数
-            # ETF 行情数据构建
-            quote = UnifiedRealtimeQuote(
-                code=stock_code,
-                name=str(row.get('名称', '')),
-                source=RealtimeSource.AKSHARE_EM,
-                price=safe_float(row.get('最新价')),
-                change_pct=safe_float(row.get('涨跌幅')),
-                change_amount=safe_float(row.get('涨跌额')),
-                volume=safe_int(row.get('成交量')),
-                amount=safe_float(row.get('成交额')),
-                volume_ratio=safe_float(row.get('量比')),
-                turnover_rate=safe_float(row.get('换手率')),
-                amplitude=safe_float(row.get('振幅')),
-                open_price=safe_float(row.get('开盘价')),
-                high=safe_float(row.get('最高价')),
-                low=safe_float(row.get('最低价')),
-                total_mv=safe_float(row.get('总市值')),
-                circ_mv=safe_float(row.get('流通市值')),
-                high_52w=safe_float(row.get('52周最高')),
-                low_52w=safe_float(row.get('52周最低')),
-            )
-            
-            logger.info(f"[ETF实时行情] {stock_code} {quote.name}: 价格={quote.price}, 涨跌={quote.change_pct}%, "
-                       f"换手率={quote.turnover_rate}%")
-            return quote
-            
-        except Exception as e:
-            logger.info(f"[API错误] 获取 ETF {stock_code} 实时行情失败: {e}")
-            circuit_breaker.record_failure(source_key, str(e))
-            return None
-    
-    def _get_hk_realtime_quote(self, stock_code: str) -> Optional[UnifiedRealtimeQuote]:
-        """
-        获取港股实时行情数据
-
-        主数据源：ak.stock_hk_spot_em()（东方财富）
-        备用数据源：ak.stock_hk_spot()（新浪）
-        包含：最新价、涨跌幅、成交量、成交额等
-
-        Args:
-            stock_code: 港股代码
-
-        Returns:
-            UnifiedRealtimeQuote 对象，获取失败返回 None
-        """
-        import akshare as ak
-        circuit_breaker = get_realtime_circuit_breaker()
-        em_key = "akshare_hk_em"
-        sina_key = "akshare_hk_sina"
-
-        # 确保代码格式正确（5位数字）
-        raw_code = stock_code.strip().lower()
-        if raw_code.endswith('.hk'):
-            raw_code = raw_code[:-3]
-        if raw_code.startswith('hk'):
-            raw_code = raw_code[2:]
-        code = raw_code.zfill(5)
-
-        def build_em_quote(df: pd.DataFrame) -> Optional[UnifiedRealtimeQuote]:
-            if df.empty:
-                logger.info(f"[API返回] 港股实时行情数据为空 (stock_hk_spot_em)")
-                return None
-
-            row = df[df['代码'] == code]
-            if row.empty:
-                logger.info(f"[API返回] 未找到港股 {code} 的实时行情 (stock_hk_spot_em)")
-                return None
-
-            row = row.iloc[0]
-            quote = UnifiedRealtimeQuote(
-                code=stock_code,
-                name=str(row.get('名称', '')),
-                source=RealtimeSource.AKSHARE_EM,
-                price=safe_float(row.get('最新价')),
-                change_pct=safe_float(row.get('涨跌幅')),
-                change_amount=safe_float(row.get('涨跌额')),
-                volume=safe_int(row.get('成交量')),
-                amount=safe_float(row.get('成交额')),
-                volume_ratio=safe_float(row.get('量比')),
-                turnover_rate=safe_float(row.get('换手率')),
-                amplitude=safe_float(row.get('振幅')),
-                pe_ratio=safe_float(row.get('市盈率')),
-                pb_ratio=safe_float(row.get('市净率')),
-                total_mv=safe_float(row.get('总市值')),
-                circ_mv=safe_float(row.get('流通市值')),
-                high_52w=safe_float(row.get('52周最高')),
-                low_52w=safe_float(row.get('52周最低')),
-            )
-            logger.info(
-                f"[港股实时行情] {stock_code} {quote.name}: 价格={quote.price}, "
-                f"涨跌={quote.change_pct}%, 换手率={quote.turnover_rate}%"
-            )
-            return quote
-
-        def read_cached_em_quote() -> Tuple[bool, Optional[UnifiedRealtimeQuote]]:
-            current_time = time.time()
-            cache_data = _hk_realtime_cache['data']
-            cache_age = current_time - _hk_realtime_cache['timestamp']
-            if (
-                _hk_realtime_cache.get('last_result') == 'failure'
-                and cache_age < _hk_realtime_cache.get('failure_ttl', 0)
-            ):
-                logger.debug(
-                    f"[缓存命中] 港股实时行情(东财) - 复用最近失败结果 "
-                    f"{int(cache_age)}s/{_hk_realtime_cache.get('failure_ttl', 0)}s"
-                )
-                return True, None
-
-            if cache_data is None or cache_age >= _hk_realtime_cache['ttl']:
-                return False, None
-
-            logger.debug(
-                f"[缓存命中] 港股实时行情(东财) - 缓存年龄 "
-                f"{int(cache_age)}s/{_hk_realtime_cache['ttl']}s"
-            )
-            try:
-                return True, build_em_quote(cache_data)
-            except Exception as e:
-                logger.warning(
-                    f"[缓存错误] 港股实时行情缓存无法解析: {e}，"
-                    "尝试 stock_hk_spot 备用接口"
-                )
-                return True, None
-
-        cache_hit, quote = read_cached_em_quote()
-        if quote is not None:
-            return quote
-
-        # --- 主数据源：东方财富 ---
-        if not cache_hit:
-            # 组合快照会并发查询多个 symbol；锁内二次检查保证同一进程仅一次冷拉取。
-            with _hk_realtime_cache_lock:
-                cache_hit, quote = read_cached_em_quote()
-                if quote is not None:
-                    return quote
-
-                if circuit_breaker.is_available(em_key) and not cache_hit:
-                    try:
-                        # 仅在真正发起网络请求前执行防封禁策略；热缓存命中不等待。
-                        self._set_random_user_agent()
-                        self._enforce_rate_limit()
-
-                        logger.info(f"[API调用] ak.stock_hk_spot_em() 获取港股实时行情...")
-                        import time as _time
-                        api_start = _time.time()
-
-                        df = ak.stock_hk_spot_em()
-
-                        api_elapsed = _time.time() - api_start
-                        logger.info(
-                            f"[API返回] ak.stock_hk_spot_em 成功: 返回 {len(df)} 只港股, "
-                            f"耗时 {api_elapsed:.2f}s"
-                        )
-
-                        if not isinstance(df, pd.DataFrame):
-                            raise TypeError("stock_hk_spot_em 未返回 DataFrame")
-                        if '代码' not in df.columns:
-                            raise KeyError("stock_hk_spot_em 返回结果缺少 代码 列")
-                        if df.empty:
-                            raise ValueError("stock_hk_spot_em 返回空市场快照")
-
-                        _hk_realtime_cache['data'] = df
-                        _hk_realtime_cache['timestamp'] = time.time()
-                        _hk_realtime_cache['last_result'] = 'success'
-                        logger.info(
-                            f"[缓存更新] 港股实时行情(东财) 缓存已刷新，"
-                            f"TTL={_hk_realtime_cache['ttl']}s"
-                        )
-
-                        quote = build_em_quote(df)
-                        circuit_breaker.record_success(em_key)
-                        if quote is not None:
-                            return quote
-
-                    except Exception as e:
-                        _hk_realtime_cache['data'] = None
-                        _hk_realtime_cache['timestamp'] = time.time()
-                        _hk_realtime_cache['last_result'] = 'failure'
-                        logger.warning(
-                            f"[API错误] ak.stock_hk_spot_em 获取港股 {stock_code} "
-                            f"失败: {e}，尝试 stock_hk_spot 备用接口"
-                        )
-                        circuit_breaker.record_failure(em_key, str(e))
-                elif not cache_hit:
-                    logger.info(
-                        f"[熔断] 数据源 {em_key} 处于熔断状态，尝试使用备用链路"
-                    )
-
-        # --- 备用数据源：新浪 ---
-        if not circuit_breaker.is_available(sina_key):
-            logger.info(f"[熔断] 数据源 {sina_key} 处于熔断状态，跳过备用链路")
-            return None
-
-        try:
-            self._set_random_user_agent()
-            self._enforce_rate_limit()
-
-            logger.info(f"[API调用] ak.stock_hk_spot() 获取港股实时行情（备用）...")
-            import time as _time
-            api_start = _time.time()
-
-            df_spot = ak.stock_hk_spot()
-
-            api_elapsed = _time.time() - api_start
-            logger.info(f"[API返回] ak.stock_hk_spot 成功: 返回 {len(df_spot)} 只港股, 耗时 {api_elapsed:.2f}s")
-
-            row = df_spot[df_spot['代码'] == code]
-            if row.empty:
-                logger.info(f"[API返回] 未找到港股 {code} 的实时行情 (stock_hk_spot)")
-                return None
-
-            row = row.iloc[0]
-            quote = UnifiedRealtimeQuote(
-                code=stock_code,
-                name=str(row.get('名称', '')),
-                source=RealtimeSource.AKSHARE_EM,
-                price=safe_float(row.get('最新价')),
-                change_pct=safe_float(row.get('涨跌幅')),
-                change_amount=safe_float(row.get('涨跌额')),
-                volume=safe_int(row.get('成交量')),
-                amount=safe_float(row.get('成交额')),
-            )
-            circuit_breaker.record_success(sina_key)
-            logger.info(f"[港股实时行情-备用] {stock_code} {quote.name}: 价格={quote.price}, 涨跌={quote.change_pct}%")
-            return quote
-
-        except Exception as e:
-            logger.info(f"[API错误] ak.stock_hk_spot 备用接口也失败: {e}")
-            circuit_breaker.record_failure(sina_key, str(e))
-            return None
-    
     def get_chip_distribution(self, stock_code: str) -> Optional[ChipDistribution]:
         """
         获取筹码分布数据
-        
-        数据来源：ak.stock_cyq_em()
+
+        自建实现：直连东财 K线 API + Python 筹码分布算法，绕过 akshare 代理/反爬问题。
         包含：获利比例、平均成本、筹码集中度
-        
+
         注意：ETF/指数没有筹码分布数据，会直接返回 None
-        
+
         Args:
             stock_code: 股票代码
-            
+
         Returns:
             ChipDistribution 对象（最新一天的数据），获取失败返回 None
         """
-        import akshare as ak
-
         # 美股没有筹码分布数据（Akshare 不支持）
         if _is_us_code(stock_code):
             logger.debug(f"[API跳过] {stock_code} 是美股，无筹码分布数据")
@@ -1700,49 +770,54 @@ class AkshareFetcher(BaseFetcher):
         if _is_etf_code(stock_code):
             logger.debug(f"[API跳过] {stock_code} 是 ETF/指数，无筹码分布数据")
             return None
-        
+
         try:
-            # 防封禁策略
             self._set_random_user_agent()
             self._enforce_rate_limit()
-            
-            logger.info(f"[API调用] ak.stock_cyq_em(symbol={stock_code}) 获取筹码分布...")
+
             import time as _time
             api_start = _time.time()
-            
-            df = ak.stock_cyq_em(symbol=stock_code)
-            
-            api_elapsed = _time.time() - api_start
-            
-            if df.empty:
-                logger.warning(f"[API返回] ak.stock_cyq_em 返回空数据, 耗时 {api_elapsed:.2f}s")
+
+            logger.info(f"[API调用] 东财K线直连获取 {stock_code} 筹码分布...")
+
+            # Step 1: 直连东财获取 K线数据
+            klines = self._fetch_eastmoney_klines(stock_code, limit=210)
+            if not klines:
+                logger.warning(f"[API返回] 东财K线返回空数据: {stock_code}")
                 return None
-            
-            logger.info(f"[API返回] ak.stock_cyq_em 成功: 返回 {len(df)} 天数据, 耗时 {api_elapsed:.2f}s")
-            logger.debug(f"[API返回] 筹码数据列名: {list(df.columns)}")
-            
-            # 取最新一天的数据
-            latest = df.iloc[-1]
-            
-            # 使用 realtime_types.py 中的统一转换函数
+
+            api_elapsed = _time.time() - api_start
+            logger.info(f"[API返回] 东财K线成功: {len(klines)} 条, 耗时 {api_elapsed:.2f}s")
+
+            # Step 2: 计算筹码分布
+            calc_start = _time.time()
+            result = self._calc_chip_distribution(klines)
+            calc_elapsed = _time.time() - calc_start
+
+            if not result:
+                logger.warning(f"[筹码计算] {stock_code} 计算失败，数据不足")
+                return None
+
+            logger.info(f"[筹码计算] {stock_code} 计算完成, 耗时 {calc_elapsed:.2f}s")
+
             chip = ChipDistribution(
                 code=stock_code,
-                date=str(latest.get('日期', '')),
-                profit_ratio=safe_float(latest.get('获利比例')),
-                avg_cost=safe_float(latest.get('平均成本')),
-                cost_90_low=safe_float(latest.get('90成本-低')),
-                cost_90_high=safe_float(latest.get('90成本-高')),
-                concentration_90=safe_float(latest.get('90集中度')),
-                cost_70_low=safe_float(latest.get('70成本-低')),
-                cost_70_high=safe_float(latest.get('70成本-高')),
-                concentration_70=safe_float(latest.get('70集中度')),
+                date=str(result["date"]),
+                profit_ratio=result["profit_ratio"],
+                avg_cost=result["avg_cost"],
+                cost_90_low=result["cost_90_low"],
+                cost_90_high=result["cost_90_high"],
+                concentration_90=result["concentration_90"],
+                cost_70_low=result["cost_70_low"],
+                cost_70_high=result["cost_70_high"],
+                concentration_70=result["concentration_70"],
             )
-            
+
             logger.info(f"[筹码分布] {stock_code} 日期={chip.date}: 获利比例={chip.profit_ratio:.1%}, "
                        f"平均成本={chip.avg_cost}, 90%集中度={chip.concentration_90:.2%}, "
                        f"70%集中度={chip.concentration_70:.2%}")
             return chip
-            
+
         except Exception as e:
             logger.error(f"[API错误] 获取 {stock_code} 筹码分布失败: {e}")
             return None


### PR DESCRIPTION
    描述：
                                                                                                                                                                         
    修复筹码分布数据获取失败
                                                                                                                                                                         
    问题               
                                                                                                                                                                         
    在 NAS / 容器环境中，push2his.eastmoney.com 直连不可达（网络层连接被拒绝），导致 _fetch_eastmoney_klines 始终失败，所有 A 股的筹码分布数据全部缺失。                 
                       
    根因
                                                                                                                                                                         
    _fetch_eastmoney_klines 使用 trust_env=False + proxies={} 强制绕过代理直连东财 API。在部分网络环境中，该域名的 CDN 节点不可直连，但通过本地 HTTP 代理可以正常访问。
                                                                                                                                                                         
    修复方案           
                                                                                                                                                                         
    添加两阶段获取策略：
                                                                                                                                                                         
    1. Phase 1 - 直连（2 次重试，保留原有行为）                                                                                                                          
    2. Phase 2 - 代理 fallback（1 次尝试，通过 trust_env=True 使用系统代理）
                                                                                                                                                                         
    影响面                                                                                                                                                               
                                                                                                                                                                         
    • 仅修改 data_provider/akshare_fetcher.py 的 _fetch_eastmoney_klines 方法
    • 不影响已有直连可用的环境
    • 不新增配置项，不改变方法签名和返回格式                                                                                                                             
                                                                                                                                                                         
    验证                                                                                                                                                                 
                                                                                                                                                                         
    • python -m py_compile ✅                                                                                                                                            
    • 容器内验证：新代码已加载，Phase 1 失败后成功触发 Phase 2 代理 fallback

    回滚                                                                                                                                                                 
                                                                                                                                                                         
    git revert <commit-sha> 即可恢复原始直连逻辑。