### PR TITLE
fix(web): fix mobile scroll in stock bar drawer (Fixes #2166)

### DIFF
--- a/apps/dsa-web/src/components/common/ScrollArea.tsx
+++ b/apps/dsa-web/src/components/common/ScrollArea.tsx
@@ -24,7 +24,7 @@ export const ScrollArea: React.FC<ScrollAreaProps> = ({
         ref={viewportRef}
         data-testid={testId}
         onScroll={onScroll}
-        className={cn('h-full overflow-y-auto custom-scrollbar', viewportClassName)}
+        className={cn('flex-1 min-h-0 overflow-y-auto custom-scrollbar', viewportClassName)}
       >
         {children}
       </div>


### PR DESCRIPTION
Change ScrollArea viewport from h-full to flex-1 min-h-0 so it properly inherits height from flex-1 parent containers in the mobile drawer layout. h-full failed when the parent had no explicit height in nested flex chains.

Also fixes the touch-scroll interception on mobile browsers by switching overflow-hidden to overflow-visible on StockBar and HomeStockWorkspace, so ScrollArea's overflow-y-auto can capture touch-scroll events.

Fixes #2166