### PR TITLE
fix: split level-one headings without recursion

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -50,6 +50,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - [文档] FAQ 补充 macOS 桌面应用被 Gatekeeper quarantine 阻止启动时的受信任安装包临时放行步骤（refs #2113）。
 - [新功能] LLM 渠道新增显式 Chat Completions / Responses API Surface，支持 Anspire GPT-5.6 系列等 Responses-only 模型，并统一连接测试、主分析、筛选、图片识别与状态诊断路由；所有运行路径先按同一规则解析协议再校验 Surface，混合 Surface 的同名路由按未知能力保守处理；显式 Anspire 渠道独占共享 Key，非法 Surface 或协议不匹配时不会把该 Key 回退为旧版 Chat 部署，同时保留无关的 Gemini/OpenAI 等 legacy provider；本地 loopback 渠道可在图片识别路径继续无 Key 调用，远端渠道仍要求凭据；禁用渠道不会因残留 Surface 配置阻断其他兼容 fallback；Web 编辑器不会静默改写非法历史值，并允许将 Hermes 非法 Surface 修复为 Chat Completions。
 - [修复] 将 Responses 渠道的协议、模型 provider、公开 route alias 与 wire-model 构造收敛为统一路由契约，保存校验、运行时加载、状态诊断、选股入口和 Web 编辑器共同使用当前安装的 LiteLLM provider registry，拒绝 `openai` 协议下显式非 OpenAI provider 的模型、拒绝同一 alias 混用 Chat/Responses，并保留 OpenAI-compatible 网关自有的带斜杠模型 ID。
+- [修复] 长通知包含一级 Markdown 标题时按对应标题边界正确分片，避免错误递归耗尽长度预算并中断发送。
 
 ## [3.29.0] - 2026-08-02
 

--- a/src/formatters.py
+++ b/src/formatters.py
@@ -947,8 +947,8 @@ def _chunk_by_separators(content: str) -> tuple[list[str], str]:
         separator = "\n---\n"
     elif "\n# " in content:
         # 按 # 分割 (兼容一级标题)
-        parts = content.split("\n## ")
-        sections = [parts[0]] + [f"## {p}" for p in parts[1:]]
+        parts = content.split("\n# ")
+        sections = [parts[0]] + [f"# {p}" for p in parts[1:]]
         separator = "\n"
     elif "\n## " in content:
         # 按 ## 分割 (兼容二级标题)

--- a/src/formatters.py
+++ b/src/formatters.py
@@ -1059,6 +1059,8 @@ def chunk_content_by_max_words(
                 # 先保存当前积累的内容
                 if current_chunk:
                     chunks.append("".join(current_chunk))
+                    current_chunk = []
+                    current_word_len = 0
 
                 # 强制截断这个超长 section
                 section_chunks = _chunk(

--- a/tests/test_formatters.py
+++ b/tests/test_formatters.py
@@ -65,6 +65,14 @@ class TestChunkContentByMaxWords(unittest.TestCase):
         joined = "".join(result).replace(TRUNCATION_SUFFIX, "")
         self.assertEqual(joined, text)
 
+    def test_long_level_one_section_does_not_duplicate_buffered_preamble(self):
+        text = "Intro\n# Section\n" + "B" * 2500
+
+        result = chunk_content_by_max_words(text, 2000)
+
+        joined = "".join(result).replace(TRUNCATION_SUFFIX, "")
+        self.assertEqual(joined, text)
+
     def test_long_content_without_separators_gets_force_split_with_suffix(self):
         long_text = "X" * 200
         result = chunk_content_by_max_words(long_text, 50)

--- a/tests/test_formatters.py
+++ b/tests/test_formatters.py
@@ -54,6 +54,17 @@ class TestChunkContentByMaxWords(unittest.TestCase):
         self.assertGreaterEqual(len(result), 2)
         self.assertEqual("".join(result), text)
 
+    def test_level_one_heading_content_splits_without_recursive_failure(self):
+        part_a = "A" * 40
+        part_b = "B" * 40
+        text = f"{part_a}\n# Section\n{part_b}"
+
+        result = chunk_content_by_max_words(text, 60)
+
+        self.assertGreaterEqual(len(result), 2)
+        joined = "".join(result).replace(TRUNCATION_SUFFIX, "")
+        self.assertEqual(joined, text)
+
     def test_long_content_without_separators_gets_force_split_with_suffix(self):
         long_text = "X" * 200
         result = chunk_content_by_max_words(long_text, 50)
@@ -130,6 +141,17 @@ class TestChunkContentByMaxBytes(unittest.TestCase):
         part_b = "B" * 150
         text = f"{part_a}\n---\n{part_b}"
         result = chunk_content_by_max_bytes(text, 200)
+        self.assertGreaterEqual(len(result), 2)
+        joined = "".join(result).replace(TRUNCATION_SUFFIX, "")
+        self.assertEqual(joined, text)
+
+    def test_level_one_heading_content_splits_without_recursive_failure(self):
+        part_a = "A" * 80
+        part_b = "B" * 80
+        text = f"{part_a}\n# Section\n{part_b}"
+
+        result = chunk_content_by_max_bytes(text, 100)
+
         self.assertGreaterEqual(len(result), 2)
         joined = "".join(result).replace(TRUNCATION_SUFFIX, "")
         self.assertEqual(joined, text)


### PR DESCRIPTION
## PR Type

- [x] fix
- [ ] feat
- [ ] refactor
- [ ] docs
- [ ] chore
- [ ] test

## Background And Problem

长通知包含一级 Markdown 标题（`\n# `）时，按字节或按字符分片会反复缩小长度预算，最终抛出 `ValueError` 并中断通知发送。该路径会影响复用公共分片函数的通知渠道。

根因是一级标题分支虽然检测 `\n# `，却错误地按 `\n## ` 分割并重建为二级标题，导致超长内容始终无法在已经识别出的一级标题边界处分段。进一步审查还发现，word 分片路径在输出标题前的已缓冲内容后未清空缓冲状态；当后续 H1 section 本身超长时，前言和标题会在结果末尾重复。

## Scope Of Change

- 文件总数 / 变更行数：3 files changed, 35 insertions(+), 2 deletions(-)
- 文件清单：
  - `src/formatters.py`：修正一级标题的分割标记与重建前缀，并在递归拆分超长 section 前清空已输出的 word 分片缓冲状态。
  - `tests/test_formatters.py`：增加按字节、按字符两个公共入口的一级标题回归，以及“短前言 + 超长 H1 section”不重复内容的审查反例回归。
  - `docs/CHANGELOG.md`：记录用户可见的通知分片修复。
- 文档更新文件：`docs/CHANGELOG.md`

## Issue Link

无关联 Issue：本修复来自对通知分片边界条件的确定性复现。验收标准是同一一级标题输入在修复前稳定抛出 `ValueError`，修复后可拆为至少两个分片；对于短前言后接超长 H1 section 的输入，移除既有截断标记后必须无损还原原文且不得重复前言或标题。

## Verification Commands And Results

当前 Head CI：[CI run 31285564056](https://github.com/ZhuLinsen/daily_stock_analysis/actions/runs/31285564056) 为 `action_required`，尚未创建任何 job，需要上游维护者批准来自 fork 的工作流后才会执行。下列本地验证已全部通过；此状态不是测试失败，也未将尚未运行的 Head CI 误报为 pass。

```bash
.venv/bin/python -m pytest tests/test_formatters.py::TestChunkContentByMaxBytes::test_level_one_heading_content_splits_without_recursive_failure -q
# original regression before: 1 failed; after: 1 passed

.venv/bin/python -m pytest tests/test_formatters.py::TestChunkContentByMaxWords::test_long_level_one_section_does_not_duplicate_buffered_preamble -q
# review regression before: 1 failed; after: 1 passed

.venv/bin/python -m pytest tests/test_formatters.py -q
# 45 passed

PATH="$PWD/.venv/bin:$PATH" ./scripts/ci_gate.sh
# 5743 passed, 4 deselected, 47 warnings, 501 subtests

.venv/bin/python -m py_compile src/formatters.py tests/test_formatters.py
git diff --check
# both passed
```

- ai-governance：`not started`（等待维护者批准 [CI run](https://github.com/ZhuLinsen/daily_stock_analysis/actions/runs/31285564056)）
- backend-gate：`not started`（等待维护者批准 [CI run](https://github.com/ZhuLinsen/daily_stock_analysis/actions/runs/31285564056)）
- docker-build：`not started`（等待维护者批准 [CI run](https://github.com/ZhuLinsen/daily_stock_analysis/actions/runs/31285564056)）
- web-gate：`not started`（等待维护者批准 [CI run](https://github.com/ZhuLinsen/daily_stock_analysis/actions/runs/31285564056)）
- Full-suite note：本地 `./scripts/ci_gate.sh` 全部通过；当前 Head CI 等待上游批准且尚无 job，因此没有可报告的 pass/fail 结论。

## Visual Evidence (if applicable)

- 截图链接：不适用。
- 前后对比：不适用。
- 不适用原因：本 PR 仅修复后端字符串分片逻辑及单元测试，不修改报告格式、报告渲染或 Web UI。可复现替代证据为上述精确 pytest 命令及 `tests/test_formatters.py` 中的三个一级标题回归用例。

## Compatibility And Risk

改动只影响内容中存在一级 Markdown 标题时的分片边界，以及 word 分片器在输出已缓冲内容后递归拆分超长 section 的状态清理；段落、分隔线、二级至四级标题及无分隔符的既有分片路径保持不变。风险集中在标题重建与跨递归边界的内容顺序，三个公共入口/反例回归均验证了无损还原。

本 PR 未变更 provider/model/base URL、运行时配置清理迁移语义；历史配置保持不变；回滚方式为 revert 本 PR 的两个提交。

## Rollback Plan

如出现兼容性回归，revert 本 PR 的两个提交即可；不涉及配置回滚、依赖变更或数据迁移。

## EXTRACT_PROMPT Change (if applicable)

不适用；本 PR 未修改 `src/services/image_stock_extractor.py` 或 `EXTRACT_PROMPT`。

## Checklist

- [x] 本 PR 有明确动机和业务价值 / This PR has a clear motivation and value
- [x] 已提供可复现的验证命令与结果 / Reproducible verification commands and results are included
- [x] 已评估兼容性与风险 / Compatibility and risk have been assessed
- [x] 已提供回滚方案 / A rollback plan is provided
- [x] 若修改报告格式或 Web UI 界面，已在 PR 描述/评论附受影响报告 / 页面截图，且未把一次性验收截图作为仓库文件合入 / If report formatting or Web UI changed, affected report/page screenshots are linked in the PR body/comments and one-off acceptance screenshots are not committed as repository files
- [x] 若本 PR 修改 Web 设置字段（字段、文案或帮助文本），请补充设置页截图；无法截图时需提供替代可视证据（命令 + 产物路径），并指向对应变更项 / If Web settings fields changed (labels or help text), screenshots of the settings page are required; if unavailable, provide alternative visual evidence with command + artifact path that points to the changed item.
- [x] 若涉及用户可见变更，已同步更新相关文档与 `docs/CHANGELOG.md`；`README.md` 仅在首页级信息变化时更新，细节优先写入 `docs/*.md` / If user-visible changes are included, relevant docs and `docs/CHANGELOG.md` are updated; `README.md` is updated only for homepage-level changes, with details kept in `docs/*.md`
