### PR TITLE
fix: report actual market review backend

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 ## [Unreleased]
 
 - [修复] Electron 桌面端恢复历史个股报告、市场复盘和完整报告的“分享”入口，复用安装包自带 Chromium 从本机受限 HTML 生成 PNG；Web 与桌面端在未配置自定义品牌时统一使用随包分发的小红书二维码，并在二维码下展示昵称 `@霸天土小豆`。
+- [修复] 大盘复盘流程按实际执行的生成后端和模型记录诊断，避免 Codex CLI 被误显示为 LiteLLM 模型。
 - [新功能] Agent Chat 按会话持久化 Skill 选择，支持刷新和会话切换恢复，并区分省略 `skills`、显式空列表与非空选择；无持久化状态的历史会话继续使用运行时默认且不会被静默转为显式选择，复用分析 `context` 中残留的 legacy `skills` / `strategies` 也不会覆盖顶层三态或会话状态，非空但全部无效的 Skill 请求不会被当成显式空列表并清空既有选择
 - [改进] 后端 CI 在不跳过离线测试的前提下按完整测试文件分成三个独立 runner 并行执行，由单一 `backend-gate` 汇总门禁结果；实测文件耗时和首分片静态检查成本共同参与负载平衡，新测试文件自动纳入，现有 pip 安装和测试参数保持不变，避免 xdist 进程内并发的全局状态竞态。
 - [测试] 后端 CI 默认覆盖所有非 Web 改动，仅对已证明安全的纯 Web 路径跳过，并将整个 Web public 目录及前端渠道模板、设置帮助视为跨层运行合同；补充纯 Web、共享 Web 资产及 Web/非 Web 混合改动的过滤语义回归，明确 `predicate-quantifier: every` 按单文件匹配全部规则、再以任一匹配文件触发门禁。Docker CI 继续按构建输入过滤。离线测试保留稳定的串行执行与慢用例摘要，并移除重复用例和测试内真实等待。

--- a/src/analyzer.py
+++ b/src/analyzer.py
@@ -16,7 +16,7 @@ import math
 import re
 import time
 from dataclasses import dataclass
-from typing import Optional, Dict, Any, List, Tuple, Callable
+from typing import Optional, Dict, Any, List, Tuple, Callable, Union
 
 import litellm
 from json_repair import repair_json
@@ -62,6 +62,7 @@ from src.llm.generation_backend import (
     GenerationBackend,
     GenerationError,
     GenerationErrorCode,
+    GenerationResult,
 )
 from src.llm.usage import (
     attach_legacy_message_stability_audit,
@@ -2980,7 +2981,8 @@ class GeminiAnalyzer:
         stream_progress_callback: Optional[Callable[[int], None]] = None,
         response_validator: Optional[Callable[[str], None]] = None,
         audit_context: Optional[Dict[str, Any]] = None,
-    ) -> Tuple[str, str, Dict[str, Any]]:
+        return_generation_result: bool = False,
+    ) -> Union[Tuple[str, str, Dict[str, Any]], GenerationResult]:
         """Compatibility wrapper around the configured generation backend."""
         preflight_error = self.get_generation_backend_config_error()
         if preflight_error is not None and not self._can_use_generation_fallback(preflight_error):
@@ -3078,6 +3080,8 @@ class GeminiAnalyzer:
                         "fallback_error": str(fallback_exc),
                     },
                 ) from fallback_exc
+        if return_generation_result:
+            return result
         return result.text, result.model, result.usage
 
     def _call_litellm_impl(
@@ -3352,6 +3356,38 @@ class GeminiAnalyzer:
             raise
         except Exception as exc:
             logger.error("[generate_text] LLM call failed: %s", exc)
+            return None
+
+    def get_generation_backend_identity(self) -> Tuple[str, str]:
+        """Return the configured primary backend identity for live diagnostics."""
+        backend_id, _fallback_backend_id = self._resolve_generation_backend_config()
+        if backend_id in LOCAL_CLI_GENERATION_BACKEND_IDS:
+            return backend_id, backend_id
+        config = self._get_runtime_config()
+        return backend_id, str(getattr(config, "litellm_model", "") or "")
+
+    def generate_text_with_metadata(
+        self,
+        prompt: str,
+        max_tokens: int = 2048,
+        temperature: float = 0.7,
+    ) -> Optional[GenerationResult]:
+        """Generate text and return the actual backend/model used for diagnostics."""
+        try:
+            result = self._call_litellm(
+                prompt,
+                generation_config={"max_tokens": max_tokens, "temperature": temperature},
+                return_generation_result=True,
+            )
+            if not isinstance(result, GenerationResult):
+                raise TypeError("generation backend returned an invalid result")
+            if should_persist_usage_telemetry(result.usage):
+                persist_llm_usage(result.usage, result.model, call_type="market_review")
+            return result
+        except GenerationError:
+            raise
+        except Exception as exc:
+            logger.error("[generate_text_with_metadata] LLM call failed: %s", exc)
             return None
 
     def analyze(

--- a/src/market_analyzer.py
+++ b/src/market_analyzer.py
@@ -669,8 +669,8 @@ Focus on index trend, liquidity, and sector rotation to shape the next-session t
             )
             record_llm_run(
                 success=False,
-                provider="litellm",
-                model=getattr(self.config, "litellm_model", None),
+                provider=backend_error.provider or backend_error.backend,
+                model=backend_error.backend,
                 call_type="market_review",
                 error_type=type(backend_error).__name__,
                 error_message=backend_error,
@@ -688,20 +688,29 @@ Focus on index trend, liquidity, and sector rotation to shape the next-session t
         prompt = self._build_review_prompt(overview, news)
 
         logger.info("[大盘] %s action=generate_review status=start", self._log_context())
-        # Use the public generate_text() entry point - never access private analyzer attributes.
+        # Use public analyzer APIs so diagnostics reflect the actual execution backend.
         llm_started_at = time.perf_counter()
+        provider, model = self.analyzer.get_generation_backend_identity()
         try:
             record_llm_run_started(
-                provider="litellm",
-                model=getattr(self.config, "litellm_model", None),
+                provider=provider,
+                model=model,
                 call_type="market_review",
             )
-            review = self.analyzer.generate_text(prompt, max_tokens=8192, temperature=0.7)
+            generation_result = self.analyzer.generate_text_with_metadata(
+                prompt,
+                max_tokens=8192,
+                temperature=0.7,
+            )
+            review = generation_result.text if generation_result else None
+            if generation_result is not None:
+                provider = generation_result.provider or generation_result.backend or provider
+                model = generation_result.model or model
         except Exception as exc:
             record_llm_run(
                 success=False,
-                provider="litellm",
-                model=getattr(self.config, "litellm_model", None),
+                provider=getattr(exc, "provider", None) or getattr(exc, "backend", None) or provider,
+                model=getattr(exc, "backend", None) or model,
                 call_type="market_review",
                 duration_ms=int((time.perf_counter() - llm_started_at) * 1000),
                 error_type=type(exc).__name__,
@@ -711,8 +720,8 @@ Focus on index trend, liquidity, and sector rotation to shape the next-session t
 
         record_llm_run(
             success=bool(review),
-            provider="litellm",
-            model=getattr(self.config, "litellm_model", None),
+            provider=provider,
+            model=model,
             call_type="market_review",
             duration_ms=int((time.perf_counter() - llm_started_at) * 1000),
             error_type=None if review else "EmptyResponse",

--- a/tests/test_market_analyzer_generate_text.py
+++ b/tests/test_market_analyzer_generate_text.py
@@ -206,6 +206,27 @@ class TestAnalyzerGenerateText:
         assert result == "复盘"
         mock_persist.assert_not_called()
 
+    def test_generate_text_with_metadata_returns_actual_backend_result(self):
+        from src.llm.generation_backend import GenerationResult
+
+        analyzer = self._make_analyzer()
+        generation_result = GenerationResult(
+            text="复盘",
+            provider="codex_cli",
+            model="codex_cli",
+            backend="codex_cli",
+            usage={"usage_available": False, "usage_source": "unavailable"},
+        )
+        with patch.object(analyzer, "_call_litellm", return_value=generation_result) as mock_call:
+            result = analyzer.generate_text_with_metadata("写一份复盘")
+
+        assert result is generation_result
+        mock_call.assert_called_once_with(
+            "写一份复盘",
+            generation_config={"max_tokens": 2048, "temperature": 0.7},
+            return_generation_result=True,
+        )
+
     @pytest.mark.parametrize(
         ("generation_backend", "executable_name"),
         [
@@ -2621,7 +2642,21 @@ class TestMarketAnalyzerBypassFix:
             analyzer._router = None
             analyzer._litellm_available = True
             analyzer._config_override = cfg
-            analyzer.generate_text = MagicMock(return_value=return_value)
+            analyzer.get_generation_backend_identity = MagicMock(
+                return_value=("litellm", cfg.litellm_model)
+            )
+            analyzer.generate_text_with_metadata = MagicMock(
+                return_value=(
+                    None
+                    if return_value is None
+                    else SimpleNamespace(
+                        text=return_value,
+                        provider="litellm",
+                        model=cfg.litellm_model,
+                        backend="litellm",
+                    )
+                )
+            )
 
             ma = MarketAnalyzer.__new__(MarketAnalyzer)
             ma.analyzer = analyzer
@@ -2632,16 +2667,15 @@ class TestMarketAnalyzerBypassFix:
             return ma
 
     def test_no_access_to_private_model_attribute(self):
-        """generate_text() must be called; _model must never be accessed."""
+        """The public metadata API must be called; _model must never be accessed."""
         ma = self._make_market_analyzer_with_mock_generate_text("复盘结果")
         # Ensure _model attribute does not exist (simulates PR #494 state)
         assert not hasattr(ma.analyzer, "_model") or ma.analyzer._model is None, (
             "_model should not be set on the LiteLLM-based analyzer"
         )
-        # generate_text is a MagicMock, so calling it won't crash
-        result = ma.analyzer.generate_text("prompt")
-        assert isinstance(result, str) and len(result) > 0
-        ma.analyzer.generate_text.assert_called_once()
+        result = ma.analyzer.generate_text_with_metadata("prompt")
+        assert result.text == "复盘结果"
+        ma.analyzer.generate_text_with_metadata.assert_called_once()
 
     def test_generate_text_none_falls_back_to_template(self):
         """generate_market_review() falls back to template when generate_text returns None."""
@@ -2662,7 +2696,7 @@ class TestMarketAnalyzerBypassFix:
         )
         result = ma.generate_market_review(overview, [])
         assert isinstance(result, str) and len(result) > 0
-        ma.analyzer.generate_text.assert_called_once()
+        ma.analyzer.generate_text_with_metadata.assert_called_once()
 
     def test_generation_backend_config_error_does_not_template_fallback(self):
         from src.llm.generation_backend import GenerationError
@@ -2691,7 +2725,7 @@ class TestMarketAnalyzerBypassFix:
         assert exc_info.value.details["field"] == "GENERATION_BACKEND"
         assert exc_info.value.details["requested_backend"] == "codex"
         template_review.assert_not_called()
-        ma.analyzer.generate_text.assert_not_called()
+        ma.analyzer.generate_text_with_metadata.assert_not_called()
         mock_record_llm_run.assert_called_once()
         diagnostic = mock_record_llm_run.call_args.kwargs
         assert diagnostic["success"] is False
@@ -2704,7 +2738,7 @@ class TestMarketAnalyzerBypassFix:
         from src.market_analyzer import MarketOverview, MarketIndex
 
         ma = self._make_market_analyzer_with_mock_generate_text(return_value=None)
-        ma.analyzer.generate_text.side_effect = GenerationError(
+        ma.analyzer.generate_text_with_metadata.side_effect = GenerationError(
             error_code=GenerationErrorCode.COMMAND_NOT_FOUND,
             stage="configuration",
             retryable=False,
@@ -2792,10 +2826,52 @@ class TestMarketAnalyzerBypassFix:
         result = ma.generate_market_review(overview, [])
 
         assert isinstance(result, str) and len(result) > 0
-        ma.analyzer.generate_text.assert_called_once()
-        _, kwargs = ma.analyzer.generate_text.call_args
+        ma.analyzer.generate_text_with_metadata.assert_called_once()
+        _, kwargs = ma.analyzer.generate_text_with_metadata.call_args
         assert kwargs["max_tokens"] == 8192
         assert kwargs["temperature"] == 0.7
+
+    def test_market_review_records_actual_codex_backend(self):
+        from src.market_analyzer import MarketOverview
+
+        ma = self._make_market_analyzer_with_mock_generate_text("复盘结果")
+        ma.analyzer.get_generation_backend_identity.return_value = ("codex_cli", "codex_cli")
+        ma.analyzer.generate_text_with_metadata.return_value = SimpleNamespace(
+            text="复盘结果",
+            provider="codex_cli",
+            model="codex_cli",
+            backend="codex_cli",
+        )
+
+        with patch("src.market_analyzer.record_llm_run_started") as started, \
+             patch("src.market_analyzer.record_llm_run") as recorded:
+            ma.generate_market_review(MarketOverview(date="2026-03-05"), [])
+
+        assert started.call_args.kwargs["provider"] == "codex_cli"
+        assert started.call_args.kwargs["model"] == "codex_cli"
+        assert recorded.call_args.kwargs["provider"] == "codex_cli"
+        assert recorded.call_args.kwargs["model"] == "codex_cli"
+
+    def test_market_review_records_actual_litellm_fallback(self):
+        from src.market_analyzer import MarketOverview
+
+        ma = self._make_market_analyzer_with_mock_generate_text("复盘结果")
+        ma.analyzer.get_generation_backend_identity.return_value = ("codex_cli", "codex_cli")
+        ma.analyzer.generate_text_with_metadata.return_value = SimpleNamespace(
+            text="复盘结果",
+            provider="openai",
+            model="openai/qwen3.7-max",
+            backend="litellm",
+        )
+
+        with patch("src.market_analyzer.record_llm_run_started") as started, \
+             patch("src.market_analyzer.record_llm_run") as recorded:
+            ma.generate_market_review(MarketOverview(date="2026-03-05"), [])
+
+        assert started.call_args.kwargs["provider"] == "codex_cli"
+        assert started.call_args.kwargs["model"] == "codex_cli"
+        assert recorded.call_args.kwargs["provider"] == "openai"
+        assert recorded.call_args.kwargs["model"] == "openai/qwen3.7-max"
 
     def test_generate_template_review_uses_english_shell_for_cn_when_report_language_is_en(self):
         from src.market_analyzer import MarketOverview, MarketIndex


### PR DESCRIPTION
## What changed
- Record the actual generation provider and model for market-review diagnostics.
- Keep the configured primary backend in the live start event, then update it with the backend that actually completed the request.
- Add regression coverage for Codex CLI success and LiteLLM fallback.

## Root cause
Market review called the configured generation backend but wrote diagnostic events with provider `litellm` and the configured LiteLLM model unconditionally. This made Codex CLI runs appear as LiteLLM in the flow UI.

## Validation
- `python -m py_compile src/analyzer.py src/market_analyzer.py`
- `.venv\\Scripts\\python.exe -m pytest tests/test_market_analyzer_generate_text.py tests/test_run_flow.py -q` (139 passed)

## Risk and rollback
The change only affects the public analyzer metadata handoff and market-review diagnostics. Revert commit `6bdbc652` to restore the prior behavior.