### PR TITLE
docs: update AIHubMix referral links to InferEra

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -174,7 +174,7 @@ GEMINI_API_KEY=
 # 兼容默认：仅填 DEEPSEEK_API_KEY 时仍使用 deepseek-chat，并在日志提示迁移到 deepseek-v4-flash
 # DEEPSEEK_API_KEY=
 
-# AIHubmix 聚合（https://aihubmix.com/?aff=CfMq）
+# AIHubmix 聚合（https://inferera.com/?aff=CfMq）
 # 一个 Key 用 GPT/Claude/Gemini/GLM/Qwen 等模型，无需科学上网
 # AIHUBMIX_KEY=
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@
 
 | 类型 | 支持 |
 |------|------|
-| AI 模型 | [Anspire](https://open.anspire.cn/dsa?share_code=QFBC0FYC)、[AIHubMix](https://aihubmix.com/?aff=CfMq)、Gemini、OpenAI 兼容、DeepSeek、通义千问、Claude、Ollama 本地模型等 |
+| AI 模型 | [Anspire](https://open.anspire.cn/dsa?share_code=QFBC0FYC)、[AIHubMix](https://inferera.com/?aff=CfMq)、Gemini、OpenAI 兼容、DeepSeek、通义千问、Claude、Ollama 本地模型等 |
 | 行情数据 | [TickFlow](https://tickflow.org/auth/register?ref=WDSGSPS5XC)、AkShare、Tushare、Pytdx、Baostock、YFinance、Longbridge |
 | 新闻搜索 | [Anspire](https://open.anspire.cn/dsa/?share_code=QFBC0FYC)、[SerpAPI](https://serpapi.com/baidu-search-api?utm_source=github_daily_stock_analysis)、[Tavily](https://tavily.com/)、[Bocha](https://open.bocha.cn/)、[Brave](https://brave.com/search/api/)、[MiniMax](https://platform.minimaxi.com/)、SearXNG |
 | 社交舆情 | [Stock Sentiment API](https://api.adanos.org/docs)（Reddit / X / Polymarket，仅美股，可选） |
@@ -82,7 +82,7 @@
 | Secret 名称 | 说明 | 必填 |
 |------------|------|:----:|
 | `ANSPIRE_API_KEYS` | [Anspire](https://open.anspire.cn/dsa?share_code=QFBC0FYC) API Key，一Key同时启用全球热门大模型和联网搜索，本项目新用户提供30元等额的免费额度（GLM5.2、GPT等模型特惠中） | **推荐** |
-| `AIHUBMIX_KEY` | [AIHubMix](https://aihubmix.com/?aff=CfMq) API Key，一Key切换使用全系模型，无需科学上网，本项目可享 10% 优惠 | **推荐** |
+| `AIHUBMIX_KEY` | [AIHubMix](https://inferera.com/?aff=CfMq) API Key，一Key切换使用全系模型，无需科学上网，本项目可享 10% 优惠 | **推荐** |
 | `GEMINI_API_KEY` | Google Gemini API Key | 可选 |
 | `ANTHROPIC_API_KEY` | Anthropic Claude API Key | 可选 |
 | `OPENAI_API_KEY` | OpenAI 兼容 API Key（支持 DeepSeek、通义千问等） | 可选 |

--- a/apps/dsa-web/src/components/settings/__tests__/llmProviderTemplates.test.ts
+++ b/apps/dsa-web/src/components/settings/__tests__/llmProviderTemplates.test.ts
@@ -84,6 +84,13 @@ describe('llmProviderTemplates', () => {
     expect(LLM_PROVIDER_TEMPLATE_BY_ID.openai.configHint).toBeUndefined();
   });
 
+  it('uses the mainland-accessible AIHubmix referral without changing its API base URL', () => {
+    expect(LLM_PROVIDER_TEMPLATE_BY_ID.aihubmix).toMatchObject({
+      baseUrl: 'https://aihubmix.com/v1',
+      officialSources: [{ label: 'AIHubmix', url: 'https://inferera.com/?aff=CfMq' }],
+    });
+  });
+
   it('keeps basic metadata on non-custom provider templates', () => {
     for (const template of LLM_PROVIDER_TEMPLATES.filter((item) => item.channelId !== 'custom')) {
       expect(template.capabilities.length).toBeGreaterThan(0);

--- a/apps/dsa-web/src/components/settings/llmProviderTemplates.ts
+++ b/apps/dsa-web/src/components/settings/llmProviderTemplates.ts
@@ -56,7 +56,7 @@ export const LLM_PROVIDER_TEMPLATES: LLMProviderTemplate[] = [
     baseUrl: 'https://aihubmix.com/v1',
     placeholderModels: 'gpt-5.5,claude-sonnet-4-6,gemini-3.1-pro-preview',
     capabilities: ['openai-compatible', 'aggregator'],
-    officialSources: [{ label: 'AIHubmix', url: 'https://aihubmix.com/' }],
+    officialSources: [{ label: 'AIHubmix', url: 'https://inferera.com/?aff=CfMq' }],
   },
   {
     channelId: 'anspire',

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 <!-- 新条目格式：- [类型] 描述（类型取值：新功能/改进/修复/文档/测试/chore）-->
 <!-- 每条独立一行追加到本段末尾，无需分类标题，合并时冲突最小 -->
+- [改进] AIHubMix 注册与引流链接统一使用 inferera.com，改善中国大陆网络直连体验。
 
 ## [3.30.0] - 2026-08-09
 

--- a/docs/README_CHT.md
+++ b/docs/README_CHT.md
@@ -55,7 +55,7 @@
 
 | 類型 | 支援 |
 |------|------|
-| AI 模型 | [Anspire](https://open.anspire.cn/?share_code=QFBC0FYC)、[AIHubMix](https://aihubmix.com/?aff=CfMq)、Gemini、OpenAI 兼容、DeepSeek、通義千問、Claude、Ollama 本地模型等 |
+| AI 模型 | [Anspire](https://open.anspire.cn/?share_code=QFBC0FYC)、[AIHubMix](https://inferera.com/?aff=CfMq)、Gemini、OpenAI 兼容、DeepSeek、通義千問、Claude、Ollama 本地模型等 |
 | 行情數據 | [TickFlow](https://tickflow.org/auth/register?ref=WDSGSPS5XC)、AkShare、Tushare、Pytdx、Baostock、YFinance、Longbridge |
 | 新聞搜尋 | [Anspire](https://open.anspire.cn/?share_code=QFBC0FYC)、[SerpAPI](https://serpapi.com/baidu-search-api?utm_source=github_daily_stock_analysis)、[Tavily](https://tavily.com/)、[Bocha](https://open.bocha.cn/)、[Brave](https://brave.com/search/api/)、[MiniMax](https://platform.minimaxi.com/)、SearXNG |
 | 社交輿情 | [Stock Sentiment API](https://api.adanos.org/docs)（Reddit / X / Polymarket，僅美股，可選） |
@@ -83,7 +83,7 @@
 | Secret 名稱 | 說明 | 必填 |
 |-------------|------|:----:|
 | `ANSPIRE_API_KEYS` | [Anspire](https://open.anspire.cn/?share_code=QFBC0FYC) API Key，一 Key 同時啟用全球熱門大模型和聯網搜尋，含本項目免費額度 | **推薦** |
-| `AIHUBMIX_KEY` | [AIHubMix](https://aihubmix.com/?aff=CfMq) API Key，一 Key 切換使用全系模型，本項目可享 10% 優惠 | **推薦** |
+| `AIHUBMIX_KEY` | [AIHubMix](https://inferera.com/?aff=CfMq) API Key，一 Key 切換使用全系模型，本項目可享 10% 優惠 | **推薦** |
 | `GEMINI_API_KEY` | Google Gemini API Key | 可選 |
 | `ANTHROPIC_API_KEY` | Anthropic Claude API Key | 可選 |
 | `OPENAI_API_KEY` | OpenAI 兼容 API Key（支援 DeepSeek、通義千問等） | 可選 |

--- a/docs/README_EN.md
+++ b/docs/README_EN.md
@@ -55,7 +55,7 @@ English | [简体中文](../README.md) | [繁體中文](README_CHT.md)
 
 | Type | Supported |
 |------|-----------|
-| AI Models | [Anspire](https://open.anspire.cn/?share_code=QFBC0FYC), [AIHubMix](https://aihubmix.com/?aff=CfMq), Gemini, OpenAI-compatible providers, DeepSeek, Qwen, Claude, Ollama |
+| AI Models | [Anspire](https://open.anspire.cn/?share_code=QFBC0FYC), [AIHubMix](https://inferera.com/?aff=CfMq), Gemini, OpenAI-compatible providers, DeepSeek, Qwen, Claude, Ollama |
 | Market Data | [TickFlow](https://tickflow.org/auth/register?ref=WDSGSPS5XC), AkShare, Tushare, Pytdx, Baostock, YFinance, Longbridge |
 | News Search | [Anspire](https://open.anspire.cn/?share_code=QFBC0FYC), [SerpAPI](https://serpapi.com/baidu-search-api?utm_source=github_daily_stock_analysis), [Tavily](https://tavily.com/), [Bocha](https://open.bocha.cn/), [Brave](https://brave.com/search/api/), [MiniMax](https://platform.minimaxi.com/), SearXNG |
 | Social Sentiment | [Stock Sentiment API](https://api.adanos.org/docs) for Reddit / X / Polymarket, US stocks only |
@@ -83,7 +83,7 @@ Start with one provider and one API key. For multi-model routing, image recognit
 | Secret Name | Description | Required |
 |-------------|-------------|:--------:|
 | `ANSPIRE_API_KEYS` | [Anspire](https://open.anspire.cn/?share_code=QFBC0FYC) API key, one key for popular LLMs and web search with free quota for this project | **Recommended** |
-| `AIHUBMIX_KEY` | [AIHubMix](https://aihubmix.com/?aff=CfMq) API key, one key for multiple model families and a 10% top-up discount for this project | **Recommended** |
+| `AIHUBMIX_KEY` | [AIHubMix](https://inferera.com/?aff=CfMq) API key, one key for multiple model families and a 10% top-up discount for this project | **Recommended** |
 | `GEMINI_API_KEY` | Google Gemini API key | Optional |
 | `ANTHROPIC_API_KEY` | Anthropic Claude API key | Optional |
 | `OPENAI_API_KEY` | OpenAI-compatible API key, including DeepSeek and Qwen-compatible services | Optional |

--- a/docs/beginner-client-setup.md
+++ b/docs/beginner-client-setup.md
@@ -9,7 +9,7 @@
 1. Windows 或 macOS 电脑。
 2. 一个模型服务密钥（Key），推荐从下面任选一个：
    - [Anspire Open](https://open.anspire.cn/?share_code=QFBC0FYC)：支持全球主流模型，一个 Key 可同时用于模型和新闻搜索，第一次配置最省事。
-   - [AIHubMix](https://aihubmix.com/?aff=CfMq)：支持全球主流模型，适合想在一个平台切换多种模型的用户。
+   - [AIHubMix](https://inferera.com/?aff=CfMq)：支持全球主流模型，适合想在一个平台切换多种模型的用户。
 3. 想分析的股票代码，例如 `600519,hk00700,AAPL`。
 
 ## 1. 下载客户端
@@ -59,7 +59,7 @@ macOS 用户升级前建议先在客户端设置里导出一次配置备份。
 
 ### 方案 B：AIHubMix
 
-1. 打开 [AIHubMix](https://aihubmix.com/?aff=CfMq)，注册 / 登录后创建 API Key。
+1. 打开 [AIHubMix](https://inferera.com/?aff=CfMq)，注册 / 登录后创建 API Key。
 2. 回到客户端，在快速添加渠道里选择 `AIHubmix（聚合平台）`。
 3. 粘贴 API Key。
 4. 模型名选择控制台里已开通的模型；不确定就先选控制台推荐模型。

--- a/docs/full-guide.md
+++ b/docs/full-guide.md
@@ -58,7 +58,7 @@ daily_stock_analysis/
 | Secret 名称 | 说明 | 必填 |
 |------------|------|:----:|
 | `ANSPIRE_API_KEYS` | [Anspire](https://open.anspire.cn/?share_code=QFBC0FYC) API Key，一 Key 同时启用大模型和中文优化联网搜索，含本项目免费额度 | 推荐 |
-| `AIHUBMIX_KEY` | [AIHubMix](https://aihubmix.com/?aff=CfMq) API Key，一 Key 切换使用全系模型，本项目可享 10% 优惠 | 推荐 |
+| `AIHUBMIX_KEY` | [AIHubMix](https://inferera.com/?aff=CfMq) API Key，一 Key 切换使用全系模型，本项目可享 10% 优惠 | 推荐 |
 | `GEMINI_API_KEY` | [Google AI Studio](https://aistudio.google.com/) 获取免费 Key | 可选 |
 | `ANTHROPIC_API_KEY` | Anthropic Claude API Key | 可选 |
 | `OPENAI_API_KEY` | OpenAI 兼容 API Key（支持 DeepSeek、通义千问等） | 可选 |
@@ -197,7 +197,7 @@ daily_stock_analysis/
 
 如果你想快速开始，最少需要配置以下项：
 
-1. **AI 模型**：`ANSPIRE_API_KEYS`（一 Key 同时启用大模型和搜索）、`AIHUBMIX_KEY`（[AIHubmix](https://aihubmix.com/?aff=CfMq)，一 Key 多模型）、`GEMINI_API_KEY` 或 `OPENAI_API_KEY`
+1. **AI 模型**：`ANSPIRE_API_KEYS`（一 Key 同时启用大模型和搜索）、`AIHUBMIX_KEY`（[AIHubmix](https://inferera.com/?aff=CfMq)，一 Key 多模型）、`GEMINI_API_KEY` 或 `OPENAI_API_KEY`
 2. **通知渠道**：至少配置一个，如 `WECHAT_WEBHOOK_URL` 或 `EMAIL_SENDER` + `EMAIL_PASSWORD`
 3. **股票列表**：`STOCK_LIST`（必填）
 4. **搜索 API**：`ANSPIRE_API_KEYS` 或 `SERPAPI_API_KEYS`（推荐，用于新闻与舆情搜索）
@@ -264,7 +264,7 @@ daily_stock_analysis/
 | `LLM_USAGE_HMAC_SECRET` | LLM 用量遥测 message HMAC 密钥；留空时自动使用数据目录中的本地密钥文件 | - | 否 |
 | `LLM_USAGE_HMAC_KEY_VERSION` | LLM 用量遥测 HMAC 密钥版本标签，轮换密钥时同步更新 | `local-v1` | 否 |
 | `ANSPIRE_API_KEYS` | [Anspire](https://open.anspire.cn/?share_code=QFBC0FYC) API Key，一 Key 同时启用大模型网关和搜索 | - | 可选 |
-| `AIHUBMIX_KEY` | [AIHubmix](https://aihubmix.com/?aff=CfMq) API Key，一 Key 切换使用全系模型，无需额外配置 Base URL | - | 可选 |
+| `AIHUBMIX_KEY` | [AIHubmix](https://inferera.com/?aff=CfMq) API Key，一 Key 切换使用全系模型，无需额外配置 Base URL | - | 可选 |
 | `GEMINI_API_KEY` | Google Gemini API Key | - | 可选 |
 | `GEMINI_MODEL` | 主模型名称（legacy，`LITELLM_MODEL` 优先） | `gemini-3.1-pro-preview` | 否 |
 | `GEMINI_MODEL_FALLBACK` | 备选模型（legacy） | `gemini-3-flash-preview` | 否 |

--- a/docs/full-guide_EN.md
+++ b/docs/full-guide_EN.md
@@ -58,7 +58,7 @@ Go to your forked repo → `Settings` → `Secrets and variables` → `Actions` 
 | Secret Name | Description | Required |
 |------------|------|:----:|
 | `ANSPIRE_API_KEYS` | [Anspire](https://open.anspire.cn/?share_code=QFBC0FYC) API key, one key for popular LLMs and Chinese-optimized web search with free quota for this project | Recommended |
-| `AIHUBMIX_KEY` | [AIHubMix](https://aihubmix.com/?aff=CfMq) API key, one key for multiple model families and a 10% top-up discount for this project | Recommended |
+| `AIHUBMIX_KEY` | [AIHubMix](https://inferera.com/?aff=CfMq) API key, one key for multiple model families and a 10% top-up discount for this project | Recommended |
 | `GEMINI_API_KEY` | Get free key from [Google AI Studio](https://aistudio.google.com/) | Optional |
 | `ANTHROPIC_API_KEY` | Anthropic Claude API Key | Optional |
 | `OPENAI_API_KEY` | OpenAI-compatible API Key (supports DeepSeek, Qwen, etc.) | Optional |
@@ -232,7 +232,7 @@ Default schedule: Every weekday at **18:00 (Beijing Time)** automatic execution.
 | `LLM_USAGE_HMAC_SECRET` | Secret for LLM usage telemetry message HMACs; leave empty to use a generated local data-dir secret file | - | No |
 | `LLM_USAGE_HMAC_KEY_VERSION` | Version label for the LLM usage HMAC key; update it when rotating the secret | `local-v1` | No |
 | `ANSPIRE_API_KEYS` | [Anspire](https://open.anspire.cn/?share_code=QFBC0FYC) API key, one key for the LLM gateway and search | - | Optional |
-| `AIHUBMIX_KEY` | [AIHubMix](https://aihubmix.com/?aff=CfMq) API key, one key for multiple model families | - | Optional |
+| `AIHUBMIX_KEY` | [AIHubMix](https://inferera.com/?aff=CfMq) API key, one key for multiple model families | - | Optional |
 | `GEMINI_API_KEY` | Google Gemini API Key | - | Optional |
 | `GEMINI_MODEL` | Primary model name (legacy, `LITELLM_MODEL` preferred) | `gemini-3.1-pro-preview` | No |
 | `GEMINI_MODEL_FALLBACK` | Fallback model (legacy) | `gemini-3-flash-preview` | No |

--- a/src/core/config_registry.py
+++ b/src/core/config_registry.py
@@ -633,7 +633,7 @@ _FIELD_DEFINITIONS: Dict[str, Dict[str, Any]] = {
     },
     "AIHUBMIX_KEY": {
         "title": "AIHubmix Key",
-        "description": "AIHubmix one-stop API key – access all mainstream models with a single key, no VPN required. Auto-sets base URL to aihubmix.com/v1. Get key: https://aihubmix.com/?aff=CfMq",
+        "description": "AIHubmix one-stop API key – access all mainstream models with a single key, no VPN required. Auto-sets base URL to aihubmix.com/v1. Get key: https://inferera.com/?aff=CfMq",
         "category": "ai_model",
         "data_type": "string",
         "ui_control": "password",

--- a/tests/test_config_registry.py
+++ b/tests/test_config_registry.py
@@ -194,6 +194,15 @@ class TestLLMUsageHMACFieldsRegistered(unittest.TestCase):
         self.assertEqual(field["help_key"], "settings.ai_model.LLM_USAGE_HMAC_KEY_VERSION")
 
 
+class TestAIHubMixReferralMetadata(unittest.TestCase):
+    def test_uses_mainland_accessible_referral_without_changing_api_base_hint(self):
+        description = get_field_definition("AIHUBMIX_KEY")["description"]
+
+        self.assertIn("Get key: https://inferera.com/?aff=CfMq", description)
+        self.assertIn("Auto-sets base URL to aihubmix.com/v1", description)
+        self.assertNotIn("Get key: https://aihubmix.com/", description)
+
+
 class TestGenerationBackendFieldsRegistered(unittest.TestCase):
     def test_analysis_backend_fields_are_ai_model_selects(self):
         expected = {


### PR DESCRIPTION
## PR Type

- [ ] fix
- [ ] feat
- [ ] refactor
- [x] docs
- [ ] chore
- [ ] test

## Background And Problem

AIHubMix 的注册和推广链接仍指向 `aihubmix.com/?aff=CfMq`。在中国大陆网络环境中，该域名可能无法直接连接；新增的 `inferera.com` 域名可直接访问，并会根据用户网络环境处理后续跳转。

本地验证中，`https://inferera.com/?aff=CfMq` 返回 HTTP 200，而 `https://aihubmix.com/?aff=CfMq` 在 21 秒后连接超时。

## Scope Of Change

- 文件总数 / 变更行数：12 files changed, 33 insertions(+), 16 deletions(-)
- 更新 `.env.example`、README 及中/英/繁文档中的 AIHubMix 注册与推广链接
- 更新后端配置元数据和 Web Provider 模板中的官网入口
- 补充后端与 Web 回归测试，锁定“引流链接使用 InferEra、API Base URL 保持不变”的边界
- 更新 `docs/CHANGELOG.md`

## Issue Link

无关联 Issue。验收标准：

- 已跟踪文件中不再残留 `https://aihubmix.com/?aff=CfMq`
- AIHubMix 注册/推广入口统一为 `https://inferera.com/?aff=CfMq`
- `aihubmix.com/v1` / `api.aihubmix.com/v1` API Base URL 和运行时域名识别逻辑保持不变
- 相关后端与 Web 测试通过

## Verification Commands And Results

- `curl.exe -sS -D - -o NUL --max-redirs 0 'https://inferera.com/?aff=CfMq'`：HTTP 200
- `curl.exe ... 'https://aihubmix.com/?aff=CfMq'`：当前网络连接超时
- `python -X utf8 -m pytest tests/test_config_registry.py -q`：59 passed
- `npm test -- src/components/settings/__tests__/llmProviderTemplates.test.ts`：9 passed
- `python -m py_compile src/core/config_registry.py tests/test_config_registry.py`：pass
- `python -m flake8 ... --select=E9,F63,F7,F82`：0 errors
- `npm ci && npm run lint && npm run build`：pass
- `git diff --check`：pass
- tracked stale referral check：0 matches

完整 `scripts/ci_gate.sh` 在本地 Windows + Git Bash 环境通过 syntax 与 flake8 后，于 `scripts/test.sh` 的“代码识别”阶段异常退出；该环境同时缺少 yfinance、akshare。未观察到测试断言失败，等待当前 Head GitHub CI 给出最终门禁结论。

当前 Head CI：ai-governance:pending / backend-gate:pending / docker-build:pending / web-gate:pending

## Visual Evidence

不适用：本 PR 仅改变链接目标，不改变页面布局、标签或可见样式。可复现替代证据为：

`cd apps/dsa-web && npm test -- src/components/settings/__tests__/llmProviderTemplates.test.ts`

该测试断言 AIHubMix 官网入口为 `inferera.com/?aff=CfMq`，同时 Base URL 仍为 `aihubmix.com/v1`。

## Compatibility And Risk

本 PR 未变更 provider/model/base URL、运行时配置清理迁移语义；历史配置保持不变；回滚方式为 revert 本提交。

- 仅注册、推广和官网入口切换到 InferEra
- 模型请求仍使用原有 AIHubMix API Base URL
- 未在 VPN 环境复现自动重定向到 aihubmix.com；该行为由服务端控制，不影响本次链接替换
- 无数据迁移或配置迁移

## Rollback Plan

Revert this PR 即可恢复旧引流链接，无需回滚配置或数据。

## Checklist

- [x] 本 PR 有明确动机和业务价值
- [x] 已提供可复现的验证命令与结果
- [x] 已评估兼容性与风险
- [x] 已提供回滚方案
- [x] 用户可见文档与 `docs/CHANGELOG.md` 已同步更新
