### PR TITLE
feat: add cost-bounded stock analysis modes

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -25,11 +25,45 @@ description: "分析股票和市场。当用户想要分析单个或多个股票
 
 **参考:** [`Config`](src/config.py)
 
+## 推荐入口与运行模式
+
+优先使用 `run_stock_analysis()`，并明确选择运行模式。该入口返回统一的
+`StockAnalysisRunResult`，会标明本次是否允许网络、LLM 和通知能力。
+
+1. **`check`（默认）**：只检查本地配置与依赖，不访问行情、不调用 LLM、不推送。
+2. **`data`**：只获取并保存行情数据，不调用 LLM、不搜索新闻、不推送。
+3. **`full`**：执行原有的行情、新闻、AI 分析流程；只有显式传入 `notifier` 才推送。
+
+```python
+from src.services.analyzer_service import run_stock_analysis
+
+# 先做零成本本地体检
+check = run_stock_analysis("600519", mode="check")
+
+# 体检通过后，仅验证行情链路
+market_data = run_stock_analysis("600519", mode="data")
+
+# 用户明确需要完整报告时再调用 LLM
+full = run_stock_analysis("600519", mode="full", full_report=True)
+analysis = full.analysis if full.success else None
+```
+
+也可以使用文件式命令行入口，避免交互式标准输入触发部分行情库的多进程问题：
+在项目根目录执行；如果存在 `.venv/bin/python`，始终优先使用它，避免误用缺少项目依赖的系统 Python。
+
+```bash
+.venv/bin/python -m src.services.analyzer_service 600519 --mode check
+.venv/bin/python -m src.services.analyzer_service 600519 --mode data
+.venv/bin/python -m src.services.analyzer_service 600519 --mode full --full-report
+```
+
+除非用户明确要求完整 AI 分析，否则先运行 `check`；需要验证行情源时再运行 `data`。
+
 ## 函数
 
 ### 1. 分析单只股票
 
-**描述:** 分析单只股票并返回分析结果。
+**描述:** 向后兼容的完整 AI 分析入口，分析单只股票并返回分析结果。
 
 **何时使用:** 当用户要求分析特定股票时。
 
@@ -59,7 +93,7 @@ if result:
 
 ### 2. 分析多只股票
 
-**描述:** 分析一个股票列表并返回分析结果列表。
+**描述:** 向后兼容的完整 AI 分析入口，分析一个股票列表并返回分析结果列表。
 
 **何时使用:** 当用户想要一次分析多只股票时。
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 <!-- 新条目格式：- [类型] 描述（类型取值：新功能/改进/修复/文档/测试/chore）-->
 <!-- 每条独立一行追加到本段末尾，无需分类标题，合并时冲突最小 -->
 
+- [新功能] 股票分析服务 CLI 新增 `check`、`data`、`full` 模式，明确本地配置体检、行情获取、LLM 分析与显式通知边界。
+
 ## [3.30.0] - 2026-08-09
 
 ### 发布亮点

--- a/src/services/analyzer_service.py
+++ b/src/services/analyzer_service.py
@@ -128,7 +128,45 @@ def _module_available(module_name: str) -> bool:
         return False
 
 
-def _build_readiness_details(config: "Config") -> Dict[str, Any]:
+_NOTIFICATION_CONFIG_FIELD_PREFIXES = (
+    "WECHAT_",
+    "FEISHU_",
+    "DINGTALK_",
+    "TELEGRAM_",
+    "EMAIL_",
+    "PUSHOVER_",
+    "NTFY_",
+    "GOTIFY_",
+    "PUSHPLUS_",
+    "SERVERCHAN",
+    "CUSTOM_WEBHOOK_",
+    "ASTRBOT_",
+    "DISCORD_",
+    "SLACK_",
+    "NOTIFICATION_",
+)
+
+
+def _config_issue_is_optional_for_check(
+    field: str,
+    *,
+    explicit_stock_code: bool,
+    notification_requested: bool,
+) -> bool:
+    normalized_field = field.strip().upper()
+    if explicit_stock_code and normalized_field in {"STOCK_LIST", "STOCK_GROUP_N"}:
+        return True
+    return not notification_requested and normalized_field.startswith(
+        _NOTIFICATION_CONFIG_FIELD_PREFIXES
+    )
+
+
+def _build_readiness_details(
+    config: "Config",
+    *,
+    stock_code: str = "",
+    notification_requested: bool = False,
+) -> Dict[str, Any]:
     pipeline_available = _module_available("src.core.pipeline")
     pandas_available = _module_available("pandas")
     litellm_available = _module_available("litellm")
@@ -151,11 +189,18 @@ def _build_readiness_details(config: "Config") -> Dict[str, Any]:
                 severity = str(getattr(issue, "severity", "error")).lower()
                 if severity not in {"error", "warning", "info"}:
                     severity = "error"
+                field = str(getattr(issue, "field", "") or "")
+                if severity == "error" and _config_issue_is_optional_for_check(
+                    field,
+                    explicit_stock_code=bool(stock_code.strip()),
+                    notification_requested=notification_requested,
+                ):
+                    severity = "warning"
                 validation_issues.append(
                     {
                         "severity": severity,
                         "message": str(getattr(issue, "message", issue)),
-                        "field": str(getattr(issue, "field", "") or ""),
+                        "field": field,
                         "code": str(getattr(issue, "code", "") or ""),
                     }
                 )
@@ -222,7 +267,11 @@ def run_stock_analysis(
         )
 
     if normalized_mode is StockAnalysisMode.CHECK:
-        details = _build_readiness_details(resolved_config)
+        details = _build_readiness_details(
+            resolved_config,
+            stock_code=code,
+            notification_requested=notifier is not None,
+        )
         success = bool(details["full_analysis_ready"])
         return StockAnalysisRunResult(
             stock_code=code,

--- a/src/services/analyzer_service.py
+++ b/src/services/analyzer_service.py
@@ -11,23 +11,287 @@ A股自选股智能分析系统 - 分析服务层
 4. 统一管理分析流程和配置
 """
 
-import uuid
-from typing import List, Optional
+from __future__ import annotations
 
-from src.analyzer import AnalysisResult
-from src.core.market_review import run_market_review
-from src.core.pipeline import StockAnalysisPipeline
-from src.config import Config, get_config
-from src.enums import ReportType
-from src.notification import NotificationService
+import argparse
+import importlib.util
+import json
+import sys
+import uuid
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Sequence, Union
+
+if TYPE_CHECKING:
+    from src.analyzer import AnalysisResult
+    from src.config import Config
+    from src.core.pipeline import StockAnalysisPipeline
+    from src.notification import NotificationService
+
+
+class StockAnalysisMode(str, Enum):
+    """Controls which expensive capabilities a service call may use."""
+
+    CHECK = "check"
+    DATA = "data"
+    FULL = "full"
+
+    @classmethod
+    def from_value(cls, value: Union["StockAnalysisMode", str]) -> "StockAnalysisMode":
+        if isinstance(value, cls):
+            return value
+
+        normalized = str(value or "").strip().lower().replace("_", "-")
+        aliases = {
+            "check": cls.CHECK,
+            "health": cls.CHECK,
+            "preflight": cls.CHECK,
+            "data": cls.DATA,
+            "fetch": cls.DATA,
+            "fetch-only": cls.DATA,
+            "dry-run": cls.DATA,
+            "full": cls.FULL,
+            "analysis": cls.FULL,
+            "ai": cls.FULL,
+        }
+        try:
+            return aliases[normalized]
+        except KeyError as exc:
+            supported = ", ".join(mode.value for mode in cls)
+            raise ValueError(f"不支持的分析模式 {value!r}，可选值: {supported}") from exc
+
+
+@dataclass
+class StockAnalysisRunResult:
+    """Structured outcome shared by check, data-only, and full analysis modes."""
+
+    stock_code: str
+    mode: StockAnalysisMode
+    success: bool
+    query_id: str
+    analysis: Optional["AnalysisResult"] = None
+    error: Optional[str] = None
+    network_allowed: bool = False
+    llm_allowed: bool = False
+    notification_allowed: bool = False
+    details: Dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self, include_analysis: bool = True) -> Dict[str, Any]:
+        payload: Dict[str, Any] = {
+            "stock_code": self.stock_code,
+            "mode": self.mode.value,
+            "success": self.success,
+            "query_id": self.query_id,
+            "error": self.error,
+            "capabilities": {
+                "network": self.network_allowed,
+                "llm": self.llm_allowed,
+                "notification": self.notification_allowed,
+            },
+            "details": dict(self.details),
+        }
+        if include_analysis:
+            if self.analysis is None:
+                payload["analysis"] = None
+            elif hasattr(self.analysis, "to_dict"):
+                payload["analysis"] = self.analysis.to_dict()
+            else:
+                payload["analysis"] = self.analysis
+        return payload
+
+
+def _resolve_config(config: Optional["Config"]) -> "Config":
+    if config is not None:
+        return config
+
+    from src.config import get_config
+
+    return get_config()
+
+
+def _build_pipeline(config: "Config", query_id: str) -> "StockAnalysisPipeline":
+    from src.core.pipeline import StockAnalysisPipeline
+
+    return StockAnalysisPipeline(
+        config=config,
+        query_id=query_id,
+        query_source="cli",
+    )
+
+
+def _module_available(module_name: str) -> bool:
+    if module_name in sys.modules:
+        return True
+    try:
+        return importlib.util.find_spec(module_name) is not None
+    except (AttributeError, ImportError, ValueError):
+        return False
+
+
+def _build_readiness_details(config: "Config") -> Dict[str, Any]:
+    pipeline_available = _module_available("src.core.pipeline")
+    pandas_available = _module_available("pandas")
+    litellm_available = _module_available("litellm")
+    data_mode_ready = pipeline_available and pandas_available
+    full_analysis_ready = data_mode_ready and litellm_available
+    return {
+        "config_loaded": True,
+        "pipeline_module_available": pipeline_available,
+        "market_data_runtime_available": pandas_available,
+        "llm_runtime_available": litellm_available,
+        "data_mode_ready": data_mode_ready,
+        "full_analysis_ready": full_analysis_ready,
+        "generation_backend": getattr(config, "generation_backend", None),
+        "realtime_source_priority": getattr(config, "realtime_source_priority", None),
+        "max_workers": getattr(config, "max_workers", None),
+    }
+
+
+def run_stock_analysis(
+    stock_code: str,
+    *,
+    mode: Union[StockAnalysisMode, str] = StockAnalysisMode.CHECK,
+    config: Optional["Config"] = None,
+    full_report: bool = False,
+    notifier: Optional["NotificationService"] = None,
+    force_refresh: bool = False,
+) -> StockAnalysisRunResult:
+    """Run one stock with explicit network, LLM, and notification boundaries.
+
+    ``check`` only validates local readiness. ``data`` fetches and stores market
+    data without analysis or notification. ``full`` preserves the existing AI
+    analysis flow and only sends a notification when a notifier is provided.
+    """
+    normalized_mode = StockAnalysisMode.from_value(mode)
+    code = str(stock_code or "").strip()
+    query_id = uuid.uuid4().hex
+
+    if not code:
+        return StockAnalysisRunResult(
+            stock_code=code,
+            mode=normalized_mode,
+            success=False,
+            query_id=query_id,
+            error="股票代码不能为空",
+        )
+
+    try:
+        resolved_config = _resolve_config(config)
+    except Exception as exc:
+        return StockAnalysisRunResult(
+            stock_code=code,
+            mode=normalized_mode,
+            success=False,
+            query_id=query_id,
+            error=f"配置加载失败: {exc}",
+        )
+
+    if normalized_mode is StockAnalysisMode.CHECK:
+        details = _build_readiness_details(resolved_config)
+        success = bool(details["full_analysis_ready"])
+        return StockAnalysisRunResult(
+            stock_code=code,
+            mode=normalized_mode,
+            success=success,
+            query_id=query_id,
+            details=details,
+            error=None if success else "本地运行环境不完整",
+        )
+
+    try:
+        pipeline = _build_pipeline(resolved_config, query_id)
+    except Exception as exc:
+        return StockAnalysisRunResult(
+            stock_code=code,
+            mode=normalized_mode,
+            success=False,
+            query_id=query_id,
+            network_allowed=True,
+            llm_allowed=normalized_mode is StockAnalysisMode.FULL,
+            notification_allowed=normalized_mode is StockAnalysisMode.FULL and notifier is not None,
+            error=f"分析流水线初始化失败: {exc}",
+        )
+
+    if normalized_mode is StockAnalysisMode.DATA:
+        success, error = pipeline.fetch_and_save_stock_data(
+            code,
+            force_refresh=force_refresh,
+        )
+        return StockAnalysisRunResult(
+            stock_code=code,
+            mode=normalized_mode,
+            success=success,
+            query_id=query_id,
+            network_allowed=True,
+            error=error,
+            details={"force_refresh": force_refresh, "data_ready": success},
+        )
+
+    if notifier is not None:
+        pipeline.notifier = notifier
+
+    from src.enums import ReportType
+
+    report_type = ReportType.FULL if full_report else ReportType.SIMPLE
+    result = pipeline.process_single_stock(
+        code=code,
+        skip_analysis=False,
+        single_stock_notify=notifier is not None,
+        report_type=report_type,
+    )
+    success = result is not None and bool(getattr(result, "success", True))
+    error = None
+    if result is None:
+        error = "分析未返回结果"
+    elif not success:
+        error = getattr(result, "error_message", None) or "分析未成功完成"
+
+    return StockAnalysisRunResult(
+        stock_code=code,
+        mode=normalized_mode,
+        success=success,
+        query_id=query_id,
+        analysis=result,
+        error=error,
+        network_allowed=True,
+        llm_allowed=True,
+        notification_allowed=notifier is not None,
+        details={"report_type": report_type.value},
+    )
+
+
+def run_stock_analyses(
+    stock_codes: Sequence[str],
+    *,
+    mode: Union[StockAnalysisMode, str] = StockAnalysisMode.CHECK,
+    config: Optional["Config"] = None,
+    full_report: bool = False,
+    notifier: Optional["NotificationService"] = None,
+    force_refresh: bool = False,
+) -> List[StockAnalysisRunResult]:
+    """Run multiple stocks while retaining a result for every requested code."""
+    if not stock_codes:
+        return []
+
+    return [
+        run_stock_analysis(
+            stock_code,
+            mode=mode,
+            config=config,
+            full_report=full_report,
+            notifier=notifier,
+            force_refresh=force_refresh,
+        )
+        for stock_code in stock_codes
+    ]
 
 
 def analyze_stock(
     stock_code: str,
-    config: Config = None,
+    config: Optional["Config"] = None,
     full_report: bool = False,
-    notifier: Optional[NotificationService] = None,
-) -> Optional[AnalysisResult]:
+    notifier: Optional["NotificationService"] = None,
+) -> Optional["AnalysisResult"]:
     """
     分析单只股票
 
@@ -40,40 +304,22 @@ def analyze_stock(
     Returns:
         分析结果对象
     """
-    if config is None:
-        config = get_config()
-
-    # 创建分析流水线
-    pipeline = StockAnalysisPipeline(
+    outcome = run_stock_analysis(
+        stock_code,
+        mode=StockAnalysisMode.FULL,
         config=config,
-        query_id=uuid.uuid4().hex,
-        query_source="cli"
+        full_report=full_report,
+        notifier=notifier,
     )
-
-    # 使用通知服务（如果提供）
-    if notifier:
-        pipeline.notifier = notifier
-
-    # 根据full_report参数设置报告类型
-    report_type = ReportType.FULL if full_report else ReportType.SIMPLE
-
-    # 运行单只股票分析
-    result = pipeline.process_single_stock(
-        code=stock_code,
-        skip_analysis=False,
-        single_stock_notify=notifier is not None,
-        report_type=report_type,
-    )
-
-    return result
+    return outcome.analysis
 
 
 def analyze_stocks(
     stock_codes: List[str],
-    config: Config = None,
+    config: Optional["Config"] = None,
     full_report: bool = False,
-    notifier: Optional[NotificationService] = None,
-) -> List[AnalysisResult]:
+    notifier: Optional["NotificationService"] = None,
+) -> List["AnalysisResult"]:
     """
     分析多只股票
 
@@ -87,7 +333,7 @@ def analyze_stocks(
         分析结果列表
     """
     if config is None:
-        config = get_config()
+        config = _resolve_config(config)
 
     results = []
     for stock_code in stock_codes:
@@ -99,8 +345,8 @@ def analyze_stocks(
 
 
 def perform_market_review(
-    config: Config = None,
-    notifier: Optional[NotificationService] = None,
+    config: Optional["Config"] = None,
+    notifier: Optional["NotificationService"] = None,
 ) -> Optional[str]:
     """
     执行大盘复盘
@@ -112,18 +358,15 @@ def perform_market_review(
     Returns:
         复盘报告内容
     """
-    if config is None:
-        config = get_config()
+    config = _resolve_config(config)
 
     # 创建分析流水线以获取analyzer和search_service
-    pipeline = StockAnalysisPipeline(
-        config=config,
-        query_id=uuid.uuid4().hex,
-        query_source="cli",
-    )
+    pipeline = _build_pipeline(config, uuid.uuid4().hex)
 
     # 使用提供的通知服务或创建新的
     review_notifier = notifier or pipeline.notifier
+
+    from src.core.market_review import run_market_review
 
     # 调用大盘复盘函数
     return run_market_review(
@@ -133,3 +376,55 @@ def perform_market_review(
         config=config,
         trigger_source="service",
     )
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    """File-based CLI that avoids interactive-stdin multiprocessing issues."""
+    parser = argparse.ArgumentParser(description="按成本边界运行股票分析")
+    parser.add_argument("stock_codes", nargs="+", help="股票代码，例如 600519 AAPL 00700.HK")
+    parser.add_argument(
+        "--mode",
+        choices=[mode.value for mode in StockAnalysisMode],
+        default=StockAnalysisMode.CHECK.value,
+        help="check=本地体检，data=仅拉取行情，full=完整 AI 分析",
+    )
+    parser.add_argument("--full-report", action="store_true", help="full 模式生成完整报告")
+    parser.add_argument("--force-refresh", action="store_true", help="data 模式忽略本地行情缓存")
+    parser.add_argument("--notify", action="store_true", help="full 模式启用已配置通知渠道")
+    args = parser.parse_args(argv)
+
+    mode = StockAnalysisMode.from_value(args.mode)
+    if args.notify and mode is not StockAnalysisMode.FULL:
+        parser.error("--notify 只能与 --mode full 一起使用")
+    if args.full_report and mode is not StockAnalysisMode.FULL:
+        parser.error("--full-report 只能与 --mode full 一起使用")
+    if args.force_refresh and mode is not StockAnalysisMode.DATA:
+        parser.error("--force-refresh 只能与 --mode data 一起使用")
+
+    notifier = None
+    if args.notify:
+        from src.notification import NotificationService
+
+        notifier = NotificationService()
+
+    outcomes = run_stock_analyses(
+        args.stock_codes,
+        mode=mode,
+        full_report=args.full_report,
+        notifier=notifier,
+        force_refresh=args.force_refresh,
+    )
+    include_analysis = mode is StockAnalysisMode.FULL
+    print(
+        json.dumps(
+            [outcome.to_dict(include_analysis=include_analysis) for outcome in outcomes],
+            ensure_ascii=False,
+            indent=2,
+            default=str,
+        )
+    )
+    return 0 if all(outcome.success for outcome in outcomes) else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/services/analyzer_service.py
+++ b/src/services/analyzer_service.py
@@ -132,10 +132,45 @@ def _build_readiness_details(config: "Config") -> Dict[str, Any]:
     pipeline_available = _module_available("src.core.pipeline")
     pandas_available = _module_available("pandas")
     litellm_available = _module_available("litellm")
+    validation_issues: List[Dict[str, str]] = []
+    validate_structured = getattr(config, "validate_structured", None)
+    if callable(validate_structured):
+        try:
+            raw_issues = validate_structured()
+        except Exception as exc:
+            validation_issues.append(
+                {
+                    "severity": "error",
+                    "message": f"配置校验失败: {exc}",
+                    "field": "",
+                    "code": "config_validation_failed",
+                }
+            )
+        else:
+            for issue in raw_issues:
+                severity = str(getattr(issue, "severity", "error")).lower()
+                if severity not in {"error", "warning", "info"}:
+                    severity = "error"
+                validation_issues.append(
+                    {
+                        "severity": severity,
+                        "message": str(getattr(issue, "message", issue)),
+                        "field": str(getattr(issue, "field", "") or ""),
+                        "code": str(getattr(issue, "code", "") or ""),
+                    }
+                )
+
+    validation_errors = [
+        issue for issue in validation_issues if issue["severity"] == "error"
+    ]
+    config_valid = not validation_errors
     data_mode_ready = pipeline_available and pandas_available
-    full_analysis_ready = data_mode_ready and litellm_available
+    full_analysis_ready = data_mode_ready and litellm_available and config_valid
     return {
         "config_loaded": True,
+        "config_valid": config_valid,
+        "config_validation_issues": validation_issues,
+        "config_validation_errors": validation_errors,
         "pipeline_module_available": pipeline_available,
         "market_data_runtime_available": pandas_available,
         "llm_runtime_available": litellm_available,
@@ -195,7 +230,7 @@ def run_stock_analysis(
             success=success,
             query_id=query_id,
             details=details,
-            error=None if success else "本地运行环境不完整",
+            error=None if success else "本地配置或运行环境不完整",
         )
 
     try:

--- a/src/services/analyzer_service.py
+++ b/src/services/analyzer_service.py
@@ -161,6 +161,71 @@ def _config_issue_is_optional_for_check(
     )
 
 
+def _generation_backend_error_details(error: Exception) -> Dict[str, str]:
+    error_code = getattr(error, "error_code", "unknown_backend_error")
+    details = getattr(error, "details", {}) or {}
+    return {
+        "error_code": str(getattr(error_code, "value", error_code)),
+        "message": str(error),
+        "backend": str(getattr(error, "backend", "") or ""),
+        "stage": str(getattr(error, "stage", "configuration") or "configuration"),
+        "reason": str(details.get("reason", "") or ""),
+    }
+
+
+def _check_generation_backend(
+    config: "Config",
+    *,
+    litellm_available: bool,
+) -> tuple[str, bool, Optional[Dict[str, str]]]:
+    from src.llm.backend_registry import (
+        LITELLM_BACKEND_ID,
+        LOCAL_CLI_GENERATION_BACKEND_IDS,
+        resolve_generation_backend_id,
+    )
+    from src.llm.generation_backend import GenerationError
+
+    try:
+        backend_id = resolve_generation_backend_id(config)
+    except GenerationError as exc:
+        return str(exc.backend or ""), False, _generation_backend_error_details(exc)
+
+    if backend_id == LITELLM_BACKEND_ID:
+        if litellm_available:
+            return backend_id, True, None
+        return backend_id, False, {
+            "error_code": "runtime_unavailable",
+            "message": "litellm runtime module is unavailable",
+            "backend": backend_id,
+            "stage": "configuration",
+            "reason": "module_not_found",
+        }
+
+    if backend_id in LOCAL_CLI_GENERATION_BACKEND_IDS:
+        from src.llm.local_cli_backend import (
+            LocalCliGenerationBackend,
+            resolve_local_cli_preset,
+        )
+
+        backend = LocalCliGenerationBackend(
+            config,
+            preset_id=backend_id,
+            preset=resolve_local_cli_preset(backend_id),
+        )
+        error = backend.get_config_error()
+        if error is not None:
+            return backend_id, False, _generation_backend_error_details(error)
+        return backend_id, True, None
+
+    return backend_id, False, {
+        "error_code": "backend_not_configured",
+        "message": f"unsupported generation backend: {backend_id}",
+        "backend": backend_id,
+        "stage": "configuration",
+        "reason": "unsupported_generation_backend",
+    }
+
+
 def _build_readiness_details(
     config: "Config",
     *,
@@ -210,7 +275,15 @@ def _build_readiness_details(
     ]
     config_valid = not validation_errors
     data_mode_ready = pipeline_available and pandas_available
-    full_analysis_ready = data_mode_ready and litellm_available and config_valid
+    (
+        generation_backend,
+        generation_backend_ready,
+        generation_backend_config_error,
+    ) = _check_generation_backend(
+        config,
+        litellm_available=litellm_available,
+    )
+    full_analysis_ready = data_mode_ready and generation_backend_ready and config_valid
     return {
         "config_loaded": True,
         "config_valid": config_valid,
@@ -221,7 +294,9 @@ def _build_readiness_details(
         "llm_runtime_available": litellm_available,
         "data_mode_ready": data_mode_ready,
         "full_analysis_ready": full_analysis_ready,
-        "generation_backend": getattr(config, "generation_backend", None),
+        "generation_backend": generation_backend,
+        "generation_backend_ready": generation_backend_ready,
+        "generation_backend_config_error": generation_backend_config_error,
         "realtime_source_priority": getattr(config, "realtime_source_priority", None),
         "max_workers": getattr(config, "max_workers", None),
     }

--- a/tests/test_analyzer_service_modes.py
+++ b/tests/test_analyzer_service_modes.py
@@ -59,6 +59,66 @@ def test_check_mode_never_builds_pipeline_or_allows_external_calls():
     assert outcome.details["pipeline_module_available"] is True
 
 
+def test_check_mode_fails_on_structured_config_errors():
+    config = _config()
+    config.validate_structured = MagicMock(
+        return_value=[
+            SimpleNamespace(
+                severity="error",
+                message="未配置可用的 LLM 渠道",
+                field="LLM_CHANNELS",
+                code="missing_llm_channel",
+            ),
+            SimpleNamespace(
+                severity="warning",
+                message="搜索增强未配置",
+                field="TAVILY_API_KEY",
+                code="",
+            ),
+        ]
+    )
+
+    with patch("src.services.analyzer_service._module_available", return_value=True):
+        outcome = run_stock_analysis("600519", mode="check", config=config)
+
+    config.validate_structured.assert_called_once_with()
+    assert outcome.success is False
+    assert outcome.error == "本地配置或运行环境不完整"
+    assert outcome.details["config_valid"] is False
+    assert outcome.details["full_analysis_ready"] is False
+    assert outcome.details["config_validation_errors"] == [
+        {
+            "severity": "error",
+            "message": "未配置可用的 LLM 渠道",
+            "field": "LLM_CHANNELS",
+            "code": "missing_llm_channel",
+        }
+    ]
+    assert len(outcome.details["config_validation_issues"]) == 2
+
+
+def test_check_mode_keeps_warnings_visible_without_failing():
+    config = _config()
+    config.validate_structured = MagicMock(
+        return_value=[
+            SimpleNamespace(
+                severity="warning",
+                message="搜索增强未配置",
+                field="TAVILY_API_KEY",
+                code="",
+            )
+        ]
+    )
+
+    with patch("src.services.analyzer_service._module_available", return_value=True):
+        outcome = run_stock_analysis("600519", mode="check", config=config)
+
+    assert outcome.success is True
+    assert outcome.details["config_valid"] is True
+    assert outcome.details["config_validation_errors"] == []
+    assert outcome.details["config_validation_issues"][0]["severity"] == "warning"
+
+
 def test_data_mode_fetches_only_without_analysis_or_notification():
     pipeline = MagicMock()
     pipeline.fetch_and_save_stock_data.return_value = (True, None)

--- a/tests/test_analyzer_service_modes.py
+++ b/tests/test_analyzer_service_modes.py
@@ -119,6 +119,73 @@ def test_check_mode_keeps_warnings_visible_without_failing():
     assert outcome.details["config_validation_issues"][0]["severity"] == "warning"
 
 
+def test_check_mode_downgrades_errors_unrelated_to_explicit_no_notify_run():
+    config = _config()
+    config.validate_structured = MagicMock(
+        return_value=[
+            SimpleNamespace(
+                severity="error",
+                message="未配置 STOCK_LIST",
+                field="STOCK_LIST",
+                code="",
+            ),
+            SimpleNamespace(
+                severity="error",
+                message="Telegram 通知配置不完整",
+                field="TELEGRAM_CHAT_ID",
+                code="",
+            ),
+            SimpleNamespace(
+                severity="error",
+                message="通知时区配置无效",
+                field="NOTIFICATION_TIMEZONE",
+                code="",
+            ),
+        ]
+    )
+
+    with patch("src.services.analyzer_service._module_available", return_value=True):
+        outcome = run_stock_analysis("600519", mode="check", config=config)
+
+    assert outcome.success is True
+    assert outcome.details["config_valid"] is True
+    assert outcome.details["config_validation_errors"] == []
+    assert {
+        issue["field"]: issue["severity"]
+        for issue in outcome.details["config_validation_issues"]
+    } == {
+        "STOCK_LIST": "warning",
+        "TELEGRAM_CHAT_ID": "warning",
+        "NOTIFICATION_TIMEZONE": "warning",
+    }
+
+
+def test_check_mode_keeps_notification_errors_blocking_when_requested():
+    config = _config()
+    config.validate_structured = MagicMock(
+        return_value=[
+            SimpleNamespace(
+                severity="error",
+                message="Telegram 通知配置不完整",
+                field="TELEGRAM_CHAT_ID",
+                code="",
+            )
+        ]
+    )
+
+    with patch("src.services.analyzer_service._module_available", return_value=True):
+        outcome = run_stock_analysis(
+            "600519",
+            mode="check",
+            config=config,
+            notifier=object(),
+        )
+
+    assert outcome.success is False
+    assert outcome.details["config_valid"] is False
+    assert outcome.details["config_validation_errors"][0]["field"] == "TELEGRAM_CHAT_ID"
+
+
 def test_data_mode_fetches_only_without_analysis_or_notification():
     pipeline = MagicMock()
     pipeline.fetch_and_save_stock_data.return_value = (True, None)

--- a/tests/test_analyzer_service_modes.py
+++ b/tests/test_analyzer_service_modes.py
@@ -186,6 +186,42 @@ def test_check_mode_keeps_notification_errors_blocking_when_requested():
     assert outcome.details["config_validation_errors"][0]["field"] == "TELEGRAM_CHAT_ID"
 
 
+def test_check_mode_fails_when_selected_local_cli_is_missing():
+    config = _config()
+    config.generation_backend = "codex_cli"
+
+    with patch(
+        "src.services.analyzer_service._module_available",
+        return_value=True,
+    ), patch("src.llm.local_cli_backend.shutil.which", return_value=None):
+        outcome = run_stock_analysis("600519", mode="check", config=config)
+
+    assert outcome.success is False
+    assert outcome.details["generation_backend"] == "codex_cli"
+    assert outcome.details["generation_backend_ready"] is False
+    assert outcome.details["generation_backend_config_error"]["error_code"] == "command_not_found"
+    assert outcome.details["generation_backend_config_error"]["reason"] == "executable_not_found"
+
+
+def test_check_mode_local_cli_does_not_require_litellm_runtime():
+    config = _config()
+    config.generation_backend = "codex_cli"
+
+    with patch(
+        "src.services.analyzer_service._module_available",
+        side_effect=lambda module_name: module_name != "litellm",
+    ), patch(
+        "src.llm.local_cli_backend.shutil.which",
+        return_value="/usr/local/bin/codex",
+    ), patch("src.llm.local_cli_backend.os.access", return_value=True):
+        outcome = run_stock_analysis("600519", mode="check", config=config)
+
+    assert outcome.success is True
+    assert outcome.details["llm_runtime_available"] is False
+    assert outcome.details["generation_backend_ready"] is True
+    assert outcome.details["generation_backend_config_error"] is None
+
+
 def test_data_mode_fetches_only_without_analysis_or_notification():
     pipeline = MagicMock()
     pipeline.fetch_and_save_stock_data.return_value = (True, None)

--- a/tests/test_analyzer_service_modes.py
+++ b/tests/test_analyzer_service_modes.py
@@ -1,0 +1,179 @@
+# -*- coding: utf-8 -*-
+"""Focused coverage for the cost-bounded stock analyzer service entrypoint."""
+
+import sys
+from types import SimpleNamespace
+from unittest.mock import MagicMock, call, patch
+
+import pytest
+
+from src.enums import ReportType
+from src.services.analyzer_service import (
+    StockAnalysisMode,
+    StockAnalysisRunResult,
+    _module_available,
+    analyze_stock,
+    analyze_stocks,
+    run_stock_analysis,
+)
+
+
+def _config() -> SimpleNamespace:
+    return SimpleNamespace(
+        generation_backend="litellm",
+        realtime_source_priority="tencent,efinance",
+        max_workers=2,
+    )
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        ("check", StockAnalysisMode.CHECK),
+        ("preflight", StockAnalysisMode.CHECK),
+        ("dry-run", StockAnalysisMode.DATA),
+        ("fetch_only", StockAnalysisMode.DATA),
+        ("ai", StockAnalysisMode.FULL),
+    ],
+)
+def test_mode_aliases(value, expected):
+    assert StockAnalysisMode.from_value(value) is expected
+
+
+def test_module_probe_accepts_an_already_loaded_test_double(monkeypatch):
+    monkeypatch.setitem(sys.modules, "stubbed_runtime", SimpleNamespace(__spec__=None))
+
+    assert _module_available("stubbed_runtime") is True
+
+
+def test_check_mode_never_builds_pipeline_or_allows_external_calls():
+    with patch("src.services.analyzer_service._build_pipeline") as build_pipeline:
+        outcome = run_stock_analysis("600519", mode="check", config=_config())
+
+    build_pipeline.assert_not_called()
+    assert outcome.success is True
+    assert outcome.network_allowed is False
+    assert outcome.llm_allowed is False
+    assert outcome.notification_allowed is False
+    assert outcome.details["config_loaded"] is True
+    assert outcome.details["pipeline_module_available"] is True
+
+
+def test_data_mode_fetches_only_without_analysis_or_notification():
+    pipeline = MagicMock()
+    pipeline.fetch_and_save_stock_data.return_value = (True, None)
+
+    with patch("src.services.analyzer_service._build_pipeline", return_value=pipeline):
+        outcome = run_stock_analysis(
+            "600519",
+            mode="data",
+            config=_config(),
+            force_refresh=True,
+            notifier=object(),
+        )
+
+    pipeline.fetch_and_save_stock_data.assert_called_once_with("600519", force_refresh=True)
+    pipeline.process_single_stock.assert_not_called()
+    assert outcome.success is True
+    assert outcome.network_allowed is True
+    assert outcome.llm_allowed is False
+    assert outcome.notification_allowed is False
+    assert outcome.details == {"force_refresh": True, "data_ready": True}
+
+
+def test_data_mode_keeps_fetch_error_visible():
+    pipeline = MagicMock()
+    pipeline.fetch_and_save_stock_data.return_value = (False, "provider unavailable")
+
+    with patch("src.services.analyzer_service._build_pipeline", return_value=pipeline):
+        outcome = run_stock_analysis("600519", mode="data", config=_config())
+
+    assert outcome.success is False
+    assert outcome.error == "provider unavailable"
+    assert outcome.details["data_ready"] is False
+
+
+def test_full_mode_preserves_pipeline_contract_and_explicit_notification():
+    analysis = SimpleNamespace(success=True)
+    pipeline = MagicMock()
+    pipeline.process_single_stock.return_value = analysis
+    notifier = object()
+
+    with patch("src.services.analyzer_service._build_pipeline", return_value=pipeline):
+        outcome = run_stock_analysis(
+            "600519",
+            mode="full",
+            config=_config(),
+            full_report=True,
+            notifier=notifier,
+        )
+
+    assert pipeline.notifier is notifier
+    pipeline.process_single_stock.assert_called_once_with(
+        code="600519",
+        skip_analysis=False,
+        single_stock_notify=True,
+        report_type=ReportType.FULL,
+    )
+    assert outcome.analysis is analysis
+    assert outcome.success is True
+    assert outcome.network_allowed is True
+    assert outcome.llm_allowed is True
+    assert outcome.notification_allowed is True
+
+
+def test_legacy_analyze_stock_still_returns_analysis_result():
+    analysis = object()
+    outcome = StockAnalysisRunResult(
+        stock_code="600519",
+        mode=StockAnalysisMode.FULL,
+        success=True,
+        query_id="q1",
+        analysis=analysis,
+    )
+    config = _config()
+    notifier = object()
+
+    with patch("src.services.analyzer_service.run_stock_analysis", return_value=outcome) as run:
+        result = analyze_stock("600519", config, True, notifier)
+
+    assert result is analysis
+    run.assert_called_once_with(
+        "600519",
+        mode=StockAnalysisMode.FULL,
+        config=config,
+        full_report=True,
+        notifier=notifier,
+    )
+
+
+def test_legacy_analyze_stocks_keeps_positional_per_stock_calls_and_filters_none():
+    first = object()
+    second = object()
+    config = _config()
+    notifier = object()
+
+    with patch(
+        "src.services.analyzer_service.analyze_stock",
+        side_effect=[first, None, second],
+    ) as analyze:
+        results = analyze_stocks(["600519", "000001", "AAPL"], config, True, notifier)
+
+    assert results == [first, second]
+    assert analyze.call_args_list == [
+        call("600519", config, True, notifier),
+        call("000001", config, True, notifier),
+        call("AAPL", config, True, notifier),
+    ]
+
+
+def test_blank_stock_code_fails_before_config_or_pipeline_loading():
+    with patch("src.services.analyzer_service._resolve_config") as resolve_config, patch(
+        "src.services.analyzer_service._build_pipeline"
+    ) as build_pipeline:
+        outcome = run_stock_analysis("  ", mode="full")
+
+    resolve_config.assert_not_called()
+    build_pipeline.assert_not_called()
+    assert outcome.success is False
+    assert outcome.error == "股票代码不能为空"


### PR DESCRIPTION
## PR Type

- [ ] fix
- [x] feat
- [ ] refactor
- [x] docs
- [ ] chore
- [x] test

## Background And Problem

现有 skill 入口默认直接进入完整分析，缺少清晰的成本与副作用边界，容易在仅做可用性检查时意外触发行情网络、LLM 或通知。本 PR 增加显式的 check / data / full 三种模式，并保持原有分析函数兼容。

验收标准：
- check 仅检查本地配置与依赖，不访问网络、不调用 LLM、不推送。
- data 仅拉取并保存行情，不调用 LLM、不推送。
- full 显式执行完整 AI 分析，只有传入 notifier 才允许推送。
- 原 analyze_stock / analyze_stocks 调用方式继续可用。

## Scope Of Change

- 文件总数 / 变更行数：4 files changed, 770 insertions(+), 49 deletions(-)
- `SKILL.md`：补充推荐入口、运行模式与虚拟环境命令。
- `src/services/analyzer_service.py`：增加统一模式、结构化结果、批量入口和文件式 CLI；重依赖改为延迟加载。
- `tests/test_analyzer_service_modes.py`：覆盖模式别名、副作用边界、结构化配置错误、单股/通知校验范围、旧接口兼容与模块探测。
- `docs/CHANGELOG.md`：在 `Unreleased` 记录新增 CLI 模式及成本/通知边界。
- `SKILL.md`：补充推荐入口、运行模式与虚拟环境命令。

## Issue Link

无关联 Issue。本 PR 的动机与验收标准已在 Background And Problem 中列明。

## Verification Commands And Results

```bash
.venv/bin/python -m src.services.analyzer_service 600519 --mode check
# success=true; config_valid=true; network=false; llm=false; notification=false

.venv/bin/python -m src.services.analyzer_service 600519 --mode data --force-refresh
# success=true; network=true; llm=false; notification=false

.venv/bin/python -m src.services.analyzer_service 600519 --mode full
# success=true; model_used=openai/qwen-plus; notification=false

.venv/bin/python -m pytest tests/test_agent_pipeline.py tests/test_analysis_api_contract.py tests/test_analyzer_service_modes.py tests/test_pipeline_daily_market_context.py tests/test_pipeline_market_phase_context.py tests/test_realtime_quote_fallback_logging.py tests/test_pipeline_single_stock_notify.py -q
# 241 passed, 1 existing dependency deprecation warning

.venv/bin/python -m pytest tests/test_config_validate_structured.py -q
# 76 passed, 1 existing dependency deprecation warning

git diff --check
# pass
```

当前 Head CI：已生成运行 #4245，状态为 `action_required`，尚未启动任何 Job；这是外部分支首次运行等待上游维护者批准，并非测试失败。PR 已转为正式评审。

## Visual Evidence (if applicable)

不适用。本 PR 未修改 Web UI、报告格式或报告渲染，仅增加服务层调用模式、CLI 与 skill 文档。可复现证据为上述 CLI 与 pytest 命令。

## Compatibility And Risk

- 原 `analyze_stock`、`analyze_stocks`、`perform_market_review` 入口保持兼容。
- `check` 是本地零成本体检；只有当前运行需要的 `Config.validate_structured()` error 会阻断。显式股票代码会将 `STOCK_LIST` 错误降为 warning，未请求通知时会将通知专属错误降为 warning；全部 issue 仍保留在 details。不承诺验证远端行情源或模型服务实时可用性。
- 真实验收中部分公开行情/搜索源发生限流或代理失败，现有备用源与降级逻辑成功完成报告；本 PR 未改变这些数据源策略。
- 本 PR 未变更 provider/model/base URL、运行时配置清理迁移语义；历史配置保持不变；回滚方式为 revert 本提交。
- 本 PR 未修改运行时配置保存、清理、迁移或回填逻辑。

## Rollback Plan

Revert this PR 即可恢复原服务入口；无需回滚配置、数据库或行情数据。

## EXTRACT_PROMPT Change (if applicable)

不适用。

## Checklist

- [x] 本 PR 有明确动机和业务价值
- [x] 已提供可复现的验证命令与结果
- [x] 已评估兼容性与风险
- [x] 已提供回滚方案
- [x] 未修改报告格式或 Web UI
- [x] 未修改 Web 设置字段
- [x] 用户可见的 skill 使用说明已同步更新
