### PR TITLE
fix: share DataFetcherManager singleton to avoid chip fetch race

### DIFF
--- a/data_provider/base.py
+++ b/data_provider/base.py
@@ -615,6 +615,36 @@ class DataFetcherManager:
     - 所有数据源都失败时抛出异常
     """
 
+    _shared_instance: Optional["DataFetcherManager"] = None
+    _shared_instance_lock = RLock()
+
+    @classmethod
+    def get_instance(cls) -> "DataFetcherManager":
+        """Return the process-wide shared DataFetcherManager (lazy init).
+
+        Creating a new manager on every use re-runs Tushare token detection and
+        API initialization (~1-2 s of network round-trips). Under concurrent
+        analysis tasks (MAX_WORKERS > 1), requests issued while another task's
+        manager is still initializing miss the Tushare entry (priority -1) and
+        fall back to lower-priority sources (e.g. AkShare), causing chip
+        distribution to fail even though TUSHARE_TOKEN is valid.
+        """
+        if cls._shared_instance is None:
+            with cls._shared_instance_lock:
+                if cls._shared_instance is None:
+                    cls._shared_instance = cls()
+        return cls._shared_instance
+
+    @classmethod
+    def reset_instance(cls) -> None:
+        """Drop the shared instance so the next get_instance() re-initializes.
+
+        Used after runtime config reloads (e.g. API key changes) so a stale
+        fetcher list is not kept forever.
+        """
+        with cls._shared_instance_lock:
+            cls._shared_instance = None
+
     _DAILY_MARKET_FETCHER_SUPPORT = {
         "EfinanceFetcher": {"cn"},
         "TencentFetcher": {"cn"},

--- a/src/agent/events.py
+++ b/src/agent/events.py
@@ -263,7 +263,7 @@ class EventMonitor:
     def _fetch_realtime_quote(self, stock_code: str) -> Any:
         from data_provider import DataFetcherManager
 
-        return DataFetcherManager().get_realtime_quote(stock_code)
+        return DataFetcherManager.get_instance().get_realtime_quote(stock_code)
 
     async def _get_realtime_quote(self, stock_code: str) -> Any:
         return await asyncio.to_thread(self._fetch_realtime_quote, stock_code)
@@ -338,7 +338,7 @@ class EventMonitor:
             def _fetch_daily_data():
                 from data_provider import DataFetcherManager
 
-                fm = DataFetcherManager()
+                fm = DataFetcherManager.get_instance()
                 return fm.get_daily_data(rule.stock_code, days=20)
 
             result = await asyncio.to_thread(_fetch_daily_data)

--- a/src/agent/tools/data_tools.py
+++ b/src/agent/tools/data_tools.py
@@ -62,7 +62,7 @@ def _get_fetcher_manager():
     if _fetcher_manager_singleton is None:
         with _fetcher_manager_lock:
             if _fetcher_manager_singleton is None:
-                _fetcher_manager_singleton = DataFetcherManager()
+                _fetcher_manager_singleton = DataFetcherManager.get_instance()
     return _fetcher_manager_singleton
 
 
@@ -71,6 +71,8 @@ def reset_fetcher_manager() -> None:
     global _fetcher_manager_singleton
     with _fetcher_manager_lock:
         _fetcher_manager_singleton = None
+    from data_provider import DataFetcherManager
+    DataFetcherManager.reset_instance()
 
 
 def _get_db():

--- a/src/agent/tools/market_tools.py
+++ b/src/agent/tools/market_tools.py
@@ -23,7 +23,7 @@ _MARKET_READ_POLICY = ToolPolicy.declared(
 def _get_fetcher_manager():
     """Lazy import to avoid circular deps."""
     from data_provider import DataFetcherManager
-    return DataFetcherManager()
+    return DataFetcherManager.get_instance()
 
 
 # ============================================================

--- a/src/analyzer.py
+++ b/src/analyzer.py
@@ -1648,7 +1648,7 @@ def get_stock_name_multi_source(
     if data_manager is None:
         try:
             from data_provider.base import DataFetcherManager
-            data_manager = DataFetcherManager()
+            data_manager = DataFetcherManager.get_instance()
         except Exception as e:
             logger.debug(f"无法初始化 DataFetcherManager: {e}")
 

--- a/src/core/pipeline.py
+++ b/src/core/pipeline.py
@@ -254,7 +254,7 @@ class StockAnalysisPipeline:
         
         # 初始化各模块
         self.db = get_db()
-        self.fetcher_manager = DataFetcherManager()
+        self.fetcher_manager = DataFetcherManager.get_instance()
         # 不再单独创建 akshare_fetcher，统一使用 fetcher_manager 获取增强数据
         self.trend_analyzer = StockTrendAnalyzer()  # 技术分析器
         self.analyzer = GeminiAnalyzer(config=self.config, skills=self.analysis_skills)

--- a/src/market_analyzer.py
+++ b/src/market_analyzer.py
@@ -146,7 +146,7 @@ class MarketAnalyzer:
         self.config = config or get_config()
         self.search_service = search_service
         self.analyzer = analyzer
-        self.data_manager = DataFetcherManager()
+        self.data_manager = DataFetcherManager.get_instance()
         self.region = region if region in ("cn", "us", "hk", "jp", "kr") else "cn"
         self.profile: MarketProfile = get_profile(self.region)
         self.strategy = get_market_strategy_blueprint(self.region)

--- a/src/services/alert_service.py
+++ b/src/services/alert_service.py
@@ -438,7 +438,7 @@ class AlertService:
         def _fetch_daily_data():
             from data_provider import DataFetcherManager
 
-            return DataFetcherManager().get_daily_data(rule.stock_code, days=20)
+            return DataFetcherManager.get_instance().get_daily_data(rule.stock_code, days=20)
 
         try:
             result = await asyncio.to_thread(_fetch_daily_data)
@@ -533,7 +533,7 @@ class AlertService:
         def _fetch_daily_data():
             from data_provider import DataFetcherManager
 
-            return DataFetcherManager().get_daily_data(rule.stock_code, days=requested_days)
+            return DataFetcherManager.get_instance().get_daily_data(rule.stock_code, days=requested_days)
 
         try:
             if daily_cache is not None and cache_key in daily_cache:

--- a/src/services/backtest_service.py
+++ b/src/services/backtest_service.py
@@ -840,7 +840,7 @@ class BacktestService:
 
             # fetch a window that covers start + forward bars
             end_date = analysis_date + timedelta(days=max(eval_window_days * 2, 30))
-            manager = DataFetcherManager()
+            manager = DataFetcherManager.get_instance()
             df, source = manager.get_daily_data(
                 stock_code=refill_code,
                 start_date=analysis_date.strftime("%Y-%m-%d"),

--- a/src/services/history_loader.py
+++ b/src/services/history_loader.py
@@ -53,7 +53,7 @@ def _get_fetcher_manager():
         with _fetcher_lock:
             if _fetcher_singleton is None:
                 from data_provider import DataFetcherManager
-                _fetcher_singleton = DataFetcherManager()
+                _fetcher_singleton = DataFetcherManager.get_instance()
     return _fetcher_singleton
 
 

--- a/src/services/market_hotspot_service.py
+++ b/src/services/market_hotspot_service.py
@@ -55,7 +55,7 @@ class MarketHotspotService:
         failure_cache_ttl_seconds: Optional[float] = None,
         success_cache_ttl_seconds: Optional[float] = None,
     ) -> None:
-        self.fetcher_manager = fetcher_manager or DataFetcherManager()
+        self.fetcher_manager = fetcher_manager or DataFetcherManager.get_instance()
         self._ranking_fetch_timeout_seconds = ranking_fetch_timeout_seconds
         self._failure_cache_ttl_seconds = self._coerce_cache_ttl(
             DEFAULT_RANKING_CACHE_FAILURE_TTL_SECONDS

--- a/src/services/market_structure_service.py
+++ b/src/services/market_structure_service.py
@@ -43,7 +43,7 @@ class MarketStructureService:
         fetcher_manager: Optional[DataFetcherManager] = None,
         hotspot_service: Optional[MarketHotspotService] = None,
     ) -> None:
-        self.fetcher_manager = fetcher_manager or DataFetcherManager()
+        self.fetcher_manager = fetcher_manager or DataFetcherManager.get_instance()
         self.hotspot_service = hotspot_service or MarketHotspotService(
             fetcher_manager=self.fetcher_manager,
         )

--- a/src/services/portfolio_risk_service.py
+++ b/src/services/portfolio_risk_service.py
@@ -457,7 +457,7 @@ class PortfolioRiskService:
         try:
             from data_provider import DataFetcherManager
 
-            self._data_manager = DataFetcherManager()
+            self._data_manager = DataFetcherManager.get_instance()
             return self._data_manager
         except Exception as exc:  # pragma: no cover - fail-open initialization
             self._data_manager_init_error = str(exc)

--- a/src/services/portfolio_service.py
+++ b/src/services/portfolio_service.py
@@ -1199,7 +1199,7 @@ class PortfolioService:
             try:
                 from data_provider.base import DataFetcherManager
 
-                DataFetcherManager().prefetch_realtime_quotes(unique_symbols)
+                DataFetcherManager.get_instance().prefetch_realtime_quotes(unique_symbols)
             except Exception as exc:
                 logger.warning("Failed to prefetch realtime portfolio quotes: %s", exc)
 
@@ -1229,7 +1229,7 @@ class PortfolioService:
         try:
             from data_provider.base import DataFetcherManager
 
-            fetcher_manager = DataFetcherManager()
+            fetcher_manager = DataFetcherManager.get_instance()
             quote = fetcher_manager.get_realtime_quote(symbol, log_final_failure=False)
         except Exception as exc:
             logger.warning("Failed to fetch realtime portfolio price for %s: %s", symbol, exc)

--- a/src/services/screening_service.py
+++ b/src/services/screening_service.py
@@ -3267,7 +3267,7 @@ def _get_dsa_fetcher_manager() -> Any:
             if _DSA_FETCHER_MANAGER is None:
                 from data_provider import DataFetcherManager
 
-                _DSA_FETCHER_MANAGER = DataFetcherManager()
+                _DSA_FETCHER_MANAGER = DataFetcherManager.get_instance()
     return _DSA_FETCHER_MANAGER
 
 

--- a/src/services/stock_service.py
+++ b/src/services/stock_service.py
@@ -43,7 +43,7 @@ class StockService:
             # 调用数据获取器获取实时行情
             from data_provider.base import DataFetcherManager
             
-            manager = DataFetcherManager()
+            manager = DataFetcherManager.get_instance()
             quote = manager.get_realtime_quote(stock_code)
             
             if quote is None:
@@ -116,7 +116,7 @@ class StockService:
             # 调用数据获取器获取历史数据
             from data_provider.base import DataFetcherManager
             
-            manager = DataFetcherManager()
+            manager = DataFetcherManager.get_instance()
             df, source = manager.get_daily_data(stock_code, days=days)
             
             if df is None or df.empty:


### PR DESCRIPTION
## Problem

Chip distribution (筹码分布) intermittently fails for stocks even when `TUSHARE_TOKEN` is valid and the Tushare API initializes successfully.

### Root cause

`DataFetcherManager()` is constructed **per use** in 16 call sites across the codebase (pipeline, analyzer, agent tools, alert/backtest/portfolio/stock services). Each constructor re-runs Tushare token detection and `pro_api` initialization (~1–2s of network round-trips).

Under concurrent analysis tasks (`MAX_WORKERS > 1`, e.g. `MAX_WORKERS=3`), a chip request issued while **another task's** manager is still initializing sees a fetcher snapshot without the Tushare entry (priority -1). It then falls back to lower-priority sources — typically `AkshareFetcher.stock_cyq_em` (Eastmoney), which is prone to `RemoteDisconnected`. The result is `所有数据源均失败` (all sources failed) for that request, even though a parallel task succeeds through Tushare moments later.

Observed in production logs (2026-08-10):

```
18:43 批次：全部走 TushareFetcher(P-1) 成功
19:08:25 [API调用] ak.stock_cyq_em(symbol=001317) 获取筹码分布...   <- Tushare 未就绪，落回 AkShare
19:08:26 Tushare API 初始化成功 / 已初始化 7 个数据源: TushareFetcher(P-1)  <- 晚 1 秒
19:08:27 [API错误] RemoteDisconnected / 所有数据源均失败
```

The repo already had three *module-local* singletons (`data_tools.py`, `history_loader.py`, `screening_service.py`) acknowledging the re-init overhead, but the main analysis pipeline (`pipeline.py:257`) still constructed a fresh manager per task — so the race persisted on the hot path.

## Fix

Promote the singleton to the class level and route all call sites through it:

- `DataFetcherManager.get_instance()` — process-wide shared instance, lazily initialized with a double-checked `RLock` guard. All fetchers (including Tushare) are initialized exactly once per process, so concurrent tasks never see a half-initialized snapshot.
- `DataFetcherManager.reset_instance()` — drops the shared instance so runtime config reloads (e.g. API key changes) take effect; `reset_fetcher_manager()` in `data_tools.py` now calls it too.
- All 16 `DataFetcherManager()` construction sites updated to `DataFetcherManager.get_instance()`.

## Verification

- Unit tests: 63 fetcher-related tests pass; full offline suite (excluding `network` marker) passes.
- Live smoke test with real TUSHARE_TOKEN: `get_chip_distribution("001317")` and `("600784")` both succeed via `TushareFetcher` (获利比例 98.3% / 97.7%) — the exact stocks that failed on 2026-08-10 19:08.
- Concurrent access: 6 threads calling `get_instance()` return the identical instance; priority order confirmed `TushareFetcher(P-1)` first.

## Risk

Low. The shared manager keeps the same fetcher set and priority ordering; per-instance locks (`_fetcher_call_locks`) are preserved. The only behavior change is that Tushare initialization happens once instead of once-per-task. If a fetcher is intentionally configured differently between services, that config now resolves to the shared instance — `reset_instance()` remains available for reloads.
