### PR TITLE
fix: feed agent-discovered news back into AnalysisContextPack

### DIFF
--- a/src/agent/tools/search_tools.py
+++ b/src/agent/tools/search_tools.py
@@ -8,10 +8,48 @@ Tools:
 """
 
 import logging
+import threading
 
 from src.agent.tools.registry import ToolParameter, ToolDefinition, ToolPolicy
 
 logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Agent-mode news_context echo registry.
+#
+# In Agent mode the pipeline skips the traditional Step-4 news search and the
+# agent discovers news itself through the search_comprehensive_intel tool.
+# Those tool results were previously only returned to the LLM and persisted to
+# news_intel; they were never written back into the AnalysisContextPack
+# news_context, so every Agent-mode report surfaced ``news_context_missing``
+# (upstream #1602 only fixed the UI wording, not the data flow).
+#
+# This module-level registry lets the pipeline read back exactly what the
+# agent actually consumed and feed it into the context pack / history news
+# content. Keyed by canonical stock code; guarded by a lock because multiple
+# analysis workers run concurrently (MAX_WORKERS=3).
+# ---------------------------------------------------------------------------
+_AGENT_NEWS_REGISTRY: dict = {}
+_AGENT_NEWS_LOCK = threading.Lock()
+
+
+def record_agent_news_context(stock_code: str, news_context: str) -> None:
+    """Store the agent-visible news report for later pipeline write-back."""
+    if not stock_code or not news_context:
+        return
+    key = _canonical_search_code(stock_code)
+    with _AGENT_NEWS_LOCK:
+        _AGENT_NEWS_REGISTRY[key] = news_context
+
+
+def pop_agent_news_context(stock_code: str) -> str:
+    """Consume (and remove) the stored news report for a stock code."""
+    if not stock_code:
+        return ""
+    key = _canonical_search_code(stock_code)
+    with _AGENT_NEWS_LOCK:
+        return _AGENT_NEWS_REGISTRY.pop(key, "") or ""
+
 
 _NEWS_READ_POLICY = ToolPolicy.declared(
     read_only=True,
@@ -167,6 +205,17 @@ def _handle_search_comprehensive_intel(stock_code: str, stock_name: str) -> dict
 
     # Format into readable report
     report = service.format_intel_report(intel_results, stock_name)
+
+    # Echo the agent-visible news report so the pipeline can write it back
+    # into the AnalysisContextPack news_context (upstream #1602 only fixed
+    # the UI wording; the data flow still left news_context empty in Agent
+    # mode). Only dimensions with results are echoed to avoid a report that
+    # is all "未找到相关信息".
+    if any(
+        resp and resp.success and resp.results
+        for resp in intel_results.values()
+    ):
+        record_agent_news_context(stock_code, report)
 
     # Also return structured data
     dimensions = {}

--- a/src/core/pipeline.py
+++ b/src/core/pipeline.py
@@ -49,6 +49,7 @@ from src.report_language import (
     normalize_report_language,
 )
 from src.search_service import SearchService
+from src.agent.tools.search_tools import pop_agent_news_context
 from src.analysis_context_pack_prompt import format_analysis_context_pack_prompt_section
 from src.analysis_context_pack_overview import render_analysis_context_pack_overview
 from src.market_phase_summary import MARKET_PHASE_SUMMARY_KEY, render_market_phase_summary
@@ -254,7 +255,7 @@ class StockAnalysisPipeline:
         
         # 初始化各模块
         self.db = get_db()
-        self.fetcher_manager = DataFetcherManager()
+        self.fetcher_manager = DataFetcherManager.get_instance()
         # 不再单独创建 akshare_fetcher，统一使用 fetcher_manager 获取增强数据
         self.trend_analyzer = StockTrendAnalyzer()  # 技术分析器
         self.analyzer = GeminiAnalyzer(config=self.config, skills=self.analysis_skills)
@@ -1476,6 +1477,42 @@ class StockAnalysisPipeline:
             )
             if result:
                 result.query_id = query_id
+            # Agent-mode news_context write-back.
+            # The agent searches news via search_comprehensive_intel while the
+            # pipeline itself skipped Step-4 news search (Agent branch returns
+            # early). The tool echoed its report into a registry; consume it
+            # here so the AnalysisContextPack news block and saved history
+            # actually reflect the news the agent consumed. Without this every
+            # Agent-mode report showed ``news_context_missing`` (upstream #1602
+            # only adjusted the UI wording, not the data flow).
+            agent_news_context = pop_agent_news_context(code)
+            if agent_news_context:
+                initial_context["news_context"] = agent_news_context
+                # Rebuild the pack overview so the news block flips to
+                # AVAILABLE and downstream consumers (guardrail, snapshot,
+                # history) see the real news evidence.
+                (
+                    analysis_context_pack_summary,
+                    analysis_context_pack_overview,
+                ) = self._build_analysis_context_pack_outputs(
+                    self._build_agent_analysis_artifacts(
+                        code=code,
+                        stock_name=stock_name,
+                        market=market,
+                        phase=market_phase_context,
+                        initial_context=initial_context,
+                        fundamental_context=fundamental_context,
+                        query_id=query_id,
+                        base_context=analysis_context,
+                        portfolio_context=portfolio_context,
+                    ),
+                    report_language=report_language,
+                    code=code,
+                    query_id=query_id,
+                )
+                if analysis_context_pack_summary:
+                    initial_context["analysis_context_pack_summary"] = analysis_context_pack_summary
+                logger.info(f"[{code}] Agent mode: news_context written back ({len(agent_news_context)} chars)")
             # Agent weak integrity: placeholder fill only, no LLM retry
             if result and getattr(self.config, "report_integrity_enabled", False):
                 from src.analyzer import check_content_integrity, apply_placeholder_fill
@@ -1677,7 +1714,7 @@ class StockAnalysisPipeline:
                         result=result,
                         query_id=query_id,
                         report_type=report_type.value,
-                        news_content=None,
+                        news_content=initial_context.get("news_context"),
                         context_snapshot=agent_context_snapshot,
                         save_snapshot=self.save_context_snapshot,
                     )

--- a/tests/test_agent_news_context_writeback.py
+++ b/tests/test_agent_news_context_writeback.py
@@ -1,0 +1,194 @@
+# -*- coding: utf-8 -*-
+"""Tests for Agent-mode news_context write-back (upstream #1602 gap).
+
+The pipeline's Agent branch skips the traditional Step-4 news search and the
+agent discovers news through search_comprehensive_intel. Previously those tool
+results were only returned to the LLM and persisted to news_intel; the
+AnalysisContextPack news block stayed empty and every Agent-mode report
+surfaced ``news_context_missing``.
+
+This module covers the fix:
+1. ``record_agent_news_context`` / ``pop_agent_news_context`` registry unit
+   behaviour (thread-safe, consume-once, canonical code keys).
+2. ``_handle_search_comprehensive_intel`` echoes its report into the registry
+   only when at least one dimension has results.
+3. Pipeline write-back consumes the registry entry and rebuilds the pack
+   overview so the news block flips from MISSING to AVAILABLE, and the saved
+   history news_content is populated.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any, Dict, Optional
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from src.services.analysis_context_builder import (
+    AnalysisContextBuilder,
+    PipelineAnalysisArtifacts,
+)
+from src.schemas.analysis_context_pack import ContextFieldStatus
+
+
+# ---------------------------------------------------------------------------
+# 1. Registry unit tests
+# ---------------------------------------------------------------------------
+
+class TestAgentNewsRegistry:
+    def test_record_then_pop_roundtrip(self):
+        from src.agent.tools.search_tools import (
+            record_agent_news_context,
+            pop_agent_news_context,
+        )
+        record_agent_news_context("605090", "【九丰能源 情报搜索结果】...")
+        assert pop_agent_news_context("605090") == "【九丰能源 情报搜索结果】..."
+
+    def test_pop_is_consume_once(self):
+        from src.agent.tools.search_tools import (
+            record_agent_news_context,
+            pop_agent_news_context,
+        )
+        record_agent_news_context("605090", "news")
+        assert pop_agent_news_context("605090") == "news"
+        assert pop_agent_news_context("605090") == ""
+
+    def test_pop_unknown_returns_empty(self):
+        from src.agent.tools.search_tools import pop_agent_news_context
+        assert pop_agent_news_context("999999") == ""
+
+    def test_record_empty_is_noop(self):
+        from src.agent.tools.search_tools import (
+            record_agent_news_context,
+            pop_agent_news_context,
+        )
+        record_agent_news_context("", "news")
+        record_agent_news_context("605090", "")
+        assert pop_agent_news_context("605090") == ""
+
+    def test_canonical_key_normalisation(self):
+        from src.agent.tools.search_tools import (
+            record_agent_news_context,
+            pop_agent_news_context,
+        )
+        # 605090 and 605090.SH / SH605090 should resolve to the same key.
+        record_agent_news_context("605090", "news-a")
+        assert pop_agent_news_context("605090.SH") == "news-a"
+
+
+# ---------------------------------------------------------------------------
+# 2. Tool echo behaviour
+# ---------------------------------------------------------------------------
+
+class TestToolEcho:
+    def _intel_result(self, success: bool, results: Optional[list]) -> Any:
+        resp = MagicMock()
+        resp.success = success
+        resp.results = results if results is not None else []
+        resp.query = "q"
+        resp.provider = "Brave"
+        return resp
+
+    def _call_handler(self, intel_results: Dict[str, Any]) -> Dict[str, Any]:
+        from src.agent.tools import search_tools
+        with patch.object(search_tools, "_get_search_service") as svc_mock:
+            svc = MagicMock()
+            svc.is_available = True
+            svc.search_comprehensive_intel.return_value = intel_results
+            svc.format_intel_report.return_value = "【xx 情报搜索结果】formatted"
+            svc_mock.return_value = svc
+            return search_tools._handle_search_comprehensive_intel("605090", "九丰能源")
+
+    @pytest.fixture(autouse=True)
+    def _clean_registry(self):
+        from src.agent.tools import search_tools
+        with search_tools._AGENT_NEWS_LOCK:
+            search_tools._AGENT_NEWS_REGISTRY.clear()
+        yield
+        with search_tools._AGENT_NEWS_LOCK:
+            search_tools._AGENT_NEWS_REGISTRY.clear()
+
+    def test_echo_written_when_results_present(self):
+        from src.agent.tools import search_tools
+        intel = {"latest_news": self._intel_result(True, [MagicMock()])}
+        out = self._call_handler(intel)
+        assert "report" in out
+        assert search_tools.pop_agent_news_context("605090") == "【xx 情报搜索结果】formatted"
+
+    def test_echo_skipped_when_no_dimension_has_results(self):
+        from src.agent.tools import search_tools
+        intel = {
+            "latest_news": self._intel_result(False, []),
+            "risk_check": self._intel_result(True, []),
+        }
+        out = self._call_handler(intel)
+        assert "report" in out  # tool still returns a report for the LLM
+        assert search_tools.pop_agent_news_context("605090") == ""
+
+
+# ---------------------------------------------------------------------------
+# 3. Pipeline write-back → pack news block AVAILABLE
+# ---------------------------------------------------------------------------
+
+class TestPipelineWriteBack:
+    def test_news_block_available_after_write_back(self):
+        """End-to-end of the pack builder: with news_context populated, the
+        news block must be AVAILABLE (not MISSING)."""
+        artifacts = PipelineAnalysisArtifacts(
+            code="605090",
+            stock_name="九丰能源",
+            market="cn",
+            phase=None,
+            base_context={
+                "code": "605090",
+                "stock_name": "九丰能源",
+                "today": {},
+                "yesterday": {},
+            },
+            enhanced_context={},
+            realtime_quote=None,
+            trend_result=None,
+            chip_data=None,
+            fundamental_context=None,
+            news_context="【九丰能源 情报搜索结果】📰 最新消息...",
+            news_result_count=6,
+            metadata={"query_id": "q1", "trigger_source": "manual"},
+        )
+        pack = AnalysisContextBuilder.build(artifacts)
+        news_block = pack.blocks.get("news")
+        assert news_block is not None
+        assert news_block.status == ContextFieldStatus.AVAILABLE
+        content_item = news_block.items.get("content")
+        assert content_item is not None
+        assert content_item.value == "【九丰能源 情报搜索结果】📰 最新消息..."
+
+    def test_news_block_missing_without_news_context(self):
+        """Regression guard: without the write-back the pack still reports
+        news_context_missing, proving the diagnostic is accurate."""
+        artifacts = PipelineAnalysisArtifacts(
+            code="605090",
+            stock_name="九丰能源",
+            market="cn",
+            phase=None,
+            base_context={
+                "code": "605090",
+                "stock_name": "九丰能源",
+                "today": {},
+                "yesterday": {},
+            },
+            enhanced_context={},
+            realtime_quote=None,
+            trend_result=None,
+            chip_data=None,
+            fundamental_context=None,
+            news_context=None,
+            news_result_count=None,
+            metadata={"query_id": "q1", "trigger_source": "manual"},
+        )
+        pack = AnalysisContextBuilder.build(artifacts)
+        news_block = pack.blocks.get("news")
+        assert news_block is not None
+        assert news_block.status == ContextFieldStatus.MISSING
+        content_item = news_block.items.get("content")
+        assert content_item.missing_reason == "news_context_missing"


### PR DESCRIPTION
# PR: Fix Agent-mode news_context missing — feed agent-discovered news back into AnalysisContextPack

## Problem

In Agent mode (config `AGENT_MODE=true`, or non-empty `AGENT_SKILLS`), every A-share
analysis report shows `news_context_missing` under "输入数据块 / Analysis Context":

> 新闻未进入本次 LLM 分析，结论未使用新闻上下文；报告页相关资讯由独立接口补充，
> 显示与否不代表已进入本次分析。(诊断码: news_context_missing)

The diagnostic is **accurate**: the news the agent consumed was never written into
the AnalysisContextPack `news_context` field, so the report's context block honestly
reports MISSING, and the saved history `news_content` is `NULL`.

Upstream #1602 identified the same symptom and fixed only the **UI wording** (the
report page now explains that "相关资讯/后续检索" is loaded separately). The data-flow
gap itself was left open: Agent-mode reports still never receive the news the agent
actually used.

## Root cause

Two independent causes combine in Agent mode:

1. **Step-4 news search is skipped.** `StockAnalysisPipeline.analyze_stock`
   (`src/core/pipeline.py`) checks `use_agent` and returns early into
   `_analyze_with_agent(...)` **before** the traditional Step-4
   `search_comprehensive_intel` block runs. So the pipeline-side `news_context`
   variable stays `None` for every Agent-mode run.

2. **Agent tool results are not written back.** The agent discovers news itself
   through the `search_comprehensive_intel` tool
   (`src/agent/tools/search_tools.py`, `max_searches=6`). Those results are:
   - returned to the LLM (tool output),
   - persisted to `news_intel` (via `_persist_news_response`),
   - but **never** echoed back into `initial_context["news_context"]`.

   `_build_agent_analysis_artifacts` then builds the pack with
   `news_context=initial_context.get("news_context")` → `None`, and the
   `AnalysisContextBuilder._build_news_block` marks the block
   `news_context_missing`.

The same gap explains the correlated symptom of **many 39-score results**: the risk
agent's evidence inputs (`news_context` among them) are empty, so its conservative
downgrade path triggers more often, and `_adjust_sentiment_score(score, "sell")` clamps
the score to (0, 39).

### Why this appears "only after changing config"

It is **not** a configuration error. The default profile (no `AGENT_MODE`, empty
`AGENT_SKILLS`) uses the traditional path where Step-4 fills `news_context` normally.
Enabling `AGENT_MODE=true` (front-end label: **「启用 Agent 策略问股」**) or setting a
non-empty `AGENT_SKILLS` switches every analysis to the Agent branch, which
necessarily exposes this pre-existing data-flow bug.

## Reproduction

1. `.env`: set `AGENT_MODE=true` (and optionally `AGENT_SKILLS=bull_trend,...`).
2. Analyse any A-share stock (e.g. `605090 九丰能源`) from the UI.
3. Open the report → Analysis Context (输入数据块): news shows
   `news_context_missing` even though the "相关资讯" panel below displays news items.
4. Backend log shows the agent's 6-dimension searches all succeed
   (`[情报搜索] ... 原始=6条, 过滤后=2条` and `Agent news intel persisted`), and
   **no** `情报搜索完成` line from the pipeline (Step-4 never ran).

## Fix

Write the agent-discovered news back into the context pack and saved history.

### `src/agent/tools/search_tools.py`
- Add a small thread-safe module-level registry (`record_agent_news_context` /
  `pop_agent_news_context`) keyed by canonical stock code, guarded by a lock
  (analysis workers run concurrently, `MAX_WORKERS=3`).
- In `_handle_search_comprehensive_intel`, after `format_intel_report` succeeds and
  at least one dimension has results, echo the formatted report into the registry.

### `src/core/pipeline.py`
- Import `pop_agent_news_context`.
- In `_analyze_with_agent`, immediately after the agent finishes and the result is
  converted, consume the registry entry for this stock:
  - inject it into `initial_context["news_context"]`,
  - **rebuild** the AnalysisContextPack overview with the now-populated artifacts
    (the builder is a pure function, safe to re-invoke), so the news block flips
    from MISSING to AVAILABLE and downstream consumers (phase guardrail, context
    snapshot, history) see the real news evidence,
  - pass the real news content to `save_analysis_history` (`news_content` was
    previously hard-coded `None`).

## Verification

- New tests `tests/test_agent_news_context_writeback.py` (9 cases):
  - registry round-trip / consume-once / canonical-key normalisation / empty no-op;
  - tool echoes report only when a dimension has results;
  - pipeline write-back makes the pack news block `AVAILABLE`;
  - regression guard: without news_context the pack still reports
    `news_context_missing` (the diagnostic stays honest).
- Related suites rerun green: `test_analysis_context_pack_overview/prompt/builder`
  (37), `test_agent_tool_surface` + `test_search_tools_persistence` (38), plus the 9
  new tests — 84 passed, 0 failed (`-m "not network"`).

## Notes / Risks

- Registry is consume-once and bounded by active analysis tasks; entries are popped
  right after the agent finishes, so no unbounded growth.
- `_build_analysis_context_pack_outputs` re-invocation is idempotent (pure
  builder), and only happens when the registry actually has news for this stock.
- No UI/CLI changes; no config changes; backend-only, compatible with existing
  reports and DB schema.

Refs: #1602 (symptom, UI-only fix), #396 (prior Agent-mode news persistence gap).
