### PR TITLE
feat: prefer Tushare for A-share fundamental blocks with AkShare fallback

### DIFF
--- a/data_provider/base.py
+++ b/data_provider/base.py
@@ -29,6 +29,7 @@ from src.data.stock_mapping import STOCK_NAME_MAP, is_meaningful_stock_name
 from src.services.market_symbol_utils import is_suffix_market_symbol
 from src.services.run_diagnostics import record_provider_run, record_provider_run_started
 from .fundamental_adapter import AkshareFundamentalAdapter
+from .tushare_fundamental_adapter import TushareFundamentalAdapter
 from .yfinance_fundamental_adapter import YfinanceFundamentalAdapter
 from .realtime_types import CircuitBreaker
 
@@ -657,6 +658,7 @@ class DataFetcherManager:
             # 默认数据源将在首次使用时延迟加载
             self._init_default_fetchers()
         self._fundamental_adapter = AkshareFundamentalAdapter()
+        self._tushare_fundamental_adapter = TushareFundamentalAdapter()
         self._yfinance_fundamental_adapter = YfinanceFundamentalAdapter()
         self._tickflow_fetcher = None
         self._tickflow_api_key: Optional[str] = None
@@ -3112,6 +3114,58 @@ class DataFetcherManager:
             **blocks,
         }
 
+    def _get_fundamental_bundle_preferred(self, stock_code: str) -> Dict[str, Any]:
+        """Fundamental bundle with Tushare as the preferred source and AkShare
+        as fallback.
+
+        Tushare (paid token) returns growth/earnings/valuation in 0.5-1.5s per
+        call, while the AkShare Eastmoney bundle polls at ~1.4-2.2 rows/s and
+        takes ~15s — which frequently blows the stage budget and leaves the
+        report with a partial fundamental block. Prefer Tushare whenever it is
+        configured; fall back to AkShare if it errors or is unavailable.
+        """
+        try:
+            tushare_result = self._tushare_fundamental_adapter.get_fundamental_bundle(stock_code)
+            if isinstance(tushare_result, dict):
+                status = str(tushare_result.get("status", ""))
+                has_content = bool(
+                    tushare_result.get("growth")
+                    or tushare_result.get("earnings")
+                    or tushare_result.get("valuation")
+                )
+                if status != "not_supported" or has_content:
+                    return tushare_result
+        except Exception as exc:
+            logger.debug("Tushare fundamental bundle failed for %s: %s", stock_code, exc)
+        return self._fundamental_adapter.get_fundamental_bundle(stock_code)
+
+    def _get_capital_flow_preferred(self, stock_code: str, top_n: int = 5) -> Dict[str, Any]:
+        """Capital flow with Tushare preferred, AkShare fallback."""
+        try:
+            tushare_result = self._tushare_fundamental_adapter.get_capital_flow(stock_code, top_n=top_n)
+            if isinstance(tushare_result, dict):
+                status = str(tushare_result.get("status", ""))
+                has_content = bool(tushare_result.get("stock_flow"))
+                if status != "not_supported" or has_content:
+                    return tushare_result
+        except Exception as exc:
+            logger.debug("Tushare capital flow failed for %s: %s", stock_code, exc)
+        return self._fundamental_adapter.get_capital_flow(stock_code, top_n=top_n)
+
+    def _get_dragon_tiger_preferred(self, stock_code: str, lookback_days: int = 20) -> Dict[str, Any]:
+        """Dragon-tiger flag with Tushare preferred, AkShare fallback."""
+        try:
+            tushare_result = self._tushare_fundamental_adapter.get_dragon_tiger_flag(
+                stock_code, lookback_days=lookback_days
+            )
+            if isinstance(tushare_result, dict):
+                status = str(tushare_result.get("status", ""))
+                if status not in ("not_supported", "failed"):
+                    return tushare_result
+        except Exception as exc:
+            logger.debug("Tushare dragon-tiger failed for %s: %s", stock_code, exc)
+        return self._fundamental_adapter.get_dragon_tiger_flag(stock_code, lookback_days=lookback_days)
+
     def get_fundamental_context(
         self,
         stock_code: str,
@@ -3223,7 +3277,7 @@ class DataFetcherManager:
         else:
             bundle_timeout = min(fetch_timeout, remaining_seconds)
             bundle_payload, bundle_err_msg, bundle_ms = self._run_with_retry(
-                lambda: self._fundamental_adapter.get_fundamental_bundle(stock_code),
+                lambda: self._get_fundamental_bundle_preferred(stock_code),
                 bundle_timeout,
                 "fundamental_bundle",
             )
@@ -3439,7 +3493,7 @@ class DataFetcherManager:
                 ["fundamental stage timeout"],
             )
         payload, err, cost_ms = self._run_with_retry(
-            lambda: self._fundamental_adapter.get_capital_flow(stock_code),
+            lambda: self._get_capital_flow_preferred(stock_code),
             timeout,
             "capital_flow",
         )
@@ -3503,7 +3557,7 @@ class DataFetcherManager:
                 ["fundamental stage timeout"],
             )
         payload, err, cost_ms = self._run_with_retry(
-            lambda: self._fundamental_adapter.get_dragon_tiger_flag(stock_code),
+            lambda: self._get_dragon_tiger_preferred(stock_code),
             timeout,
             "dragon_tiger",
         )

--- a/data_provider/tushare_fundamental_adapter.py
+++ b/data_provider/tushare_fundamental_adapter.py
@@ -1,0 +1,325 @@
+# -*- coding: utf-8 -*-
+"""
+Tushare fundamental adapter — fast, paid-API source for fundamental blocks.
+
+The original A-share fundamental bundle is served by ``AkshareFundamentalAdapter``
+which polls Eastmoney endpoints at ~1.4-2.2 rows/s; a full bundle takes ~15s and
+frequently exceeds ``FUNDAMENTAL_STAGE_TIMEOUT_SECONDS`` (default 8s), leaving the
+report with a "部分可用" fundamental block (valuation ok, growth/earnings/
+institution failed, capital_flow/dragon_tiger/boards starved by stage budget).
+
+Tushare returns the same data in 0.5-1.5s per call. This adapter mirrors the
+``AkshareFundamentalAdapter`` public surface so ``get_fundamental_context`` can
+switch source without restructuring (Tushare first, AkShare fallback).
+
+Implemented interfaces (A-share only; offshore markets keep the existing path):
+- ``get_fundamental_bundle``  -> daily_basic + fina_indicator (+ dividend)
+- ``get_capital_flow``        -> moneyflow (main net inflow)
+- ``get_dragon_tiger_flag``   -> top_list (龙虎榜)
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timedelta
+from typing import Any, Dict, List, Optional, Tuple
+
+import pandas as pd
+
+logger = logging.getLogger(__name__)
+
+
+def _normalize_code(code: str) -> str:
+    """Strip exchange suffix for matching: '605090.SH' -> '605090'."""
+    return str(code or "").strip().split(".")[0]
+
+
+def _to_ts_code(code: str) -> Optional[str]:
+    """Convert 605090 / 605090.SH / sh605090 to Tushare ts_code (605090.SH)."""
+    raw = str(code or "").strip().upper().replace("SH", "").replace("SZ", "")
+    # handle 'SH605090' style
+    raw = raw.replace("600", "600").replace("000", "000")
+    for prefix in ("SH", "SZ", "BJ"):
+        if raw.startswith(prefix) and len(raw) == 9:
+            raw = raw[2:]
+    code6 = _normalize_code(raw)
+    if not (code6.isdigit() and len(code6) == 6):
+        return None
+    if code6.startswith(("6", "5", "9", "68", "60")):
+        suffix = "SH"
+    elif code6.startswith(("4", "8", "92", "43", "83", "87", "88")):
+        suffix = "BJ"
+    else:
+        suffix = "SZ"
+    return f"{code6}.{suffix}"
+
+
+def _latest_row(df: Optional[pd.DataFrame]) -> Optional[pd.Series]:
+    if df is None or df.empty:
+        return None
+    # Tushare returns newest first in practice; be defensive about sort.
+    work = df.copy()
+    date_col = next((c for c in work.columns if "trade_date" == c or "end_date" == c), None)
+    if date_col is not None:
+        try:
+            work[date_col] = work[date_col].astype(str)
+            work = work.sort_values(date_col, ascending=False)
+        except Exception:
+            pass
+    return work.iloc[0]
+
+
+class TushareFundamentalAdapter:
+    """Fundamental adapter backed by Tushare Pro (paid token)."""
+
+    def __init__(self) -> None:
+        self._pro = None
+
+    # ------------------------------------------------------------------
+    # helpers
+    # ------------------------------------------------------------------
+    def _get_pro(self):
+        if self._pro is not None:
+            return self._pro
+        import os
+        import tushare as ts
+
+        token = os.getenv("TUSHARE_TOKEN", "")
+        if not token:
+            return None
+        try:
+            ts.set_token(token)
+            self._pro = ts.pro_api()
+            return self._pro
+        except Exception as exc:
+            logger.warning("TushareFundamentalAdapter init failed: %s", exc)
+            return None
+
+    def _query(self, api_name: str, **kwargs) -> Optional[pd.DataFrame]:
+        pro = self._get_pro()
+        if pro is None:
+            return None
+        try:
+            df = pro.query(api_name, **kwargs)
+            if isinstance(df, pd.DataFrame) and not df.empty:
+                return df
+        except Exception as exc:
+            logger.debug("TushareFundamentalAdapter %s failed: %s", api_name, exc)
+        return None
+
+    def _single_row(self, df: Optional[pd.DataFrame]) -> Optional[pd.Series]:
+        row = _latest_row(df)
+        return row
+
+    # ------------------------------------------------------------------
+    # bundle
+    # ------------------------------------------------------------------
+    def get_fundamental_bundle(self, stock_code: str) -> Dict[str, Any]:
+        result: Dict[str, Any] = {
+            "status": "not_supported",
+            "growth": {},
+            "earnings": {},
+            "institution": {},
+            "source_chain": [],
+            "errors": [],
+        }
+        ts_code = _to_ts_code(stock_code)
+        if not ts_code:
+            result["errors"].append(f"unsupported_code:{stock_code}")
+            return result
+
+        # ---- growth / earnings: fina_indicator (ROE, margin, YoY) ----
+        fin = self._query(
+            "fina_indicator",
+            ts_code=ts_code,
+            fields="ts_code,end_date,roe,grossprofit_margin,tr_yoy,netprofit_yoy,"
+                   "netprofit_margin,revenue,profit_dedt,ocfps",
+        )
+        if fin is not None:
+            row = self._single_row(fin)
+            if row is not None:
+                result["growth"] = {
+                    "revenue_yoy": _safe_float(row.get("tr_yoy")),
+                    "net_profit_yoy": _safe_float(row.get("netprofit_yoy")),
+                    "roe": _safe_float(row.get("roe")),
+                    "gross_margin": _safe_float(row.get("grossprofit_margin")),
+                }
+                result["earnings"]["financial_report"] = {
+                    "report_date": _safe_str(row.get("end_date")),
+                    "revenue": _safe_float(row.get("revenue")),
+                    "net_profit_parent": _safe_float(row.get("profit_dedt")),
+                    "roe": _safe_float(row.get("roe")),
+                }
+                result["source_chain"].append(f"growth:tushare_fina_indicator")
+
+        # ---- valuation: daily_basic (pe/pb/mv) ----
+        basic = self._query(
+            "daily_basic",
+            ts_code=ts_code,
+            fields="ts_code,trade_date,pe_ttm,pb,total_mv,circ_mv",
+        )
+        if basic is not None:
+            row = self._single_row(basic)
+            if row is not None:
+                result.setdefault("valuation", {})
+                result["valuation"] = {
+                    "pe_ratio": _safe_float(row.get("pe_ttm")),
+                    "pb_ratio": _safe_float(row.get("pb")),
+                    "total_mv": _safe_float(row.get("total_mv")),
+                    "circ_mv": _safe_float(row.get("circ_mv")),
+                }
+                result["source_chain"].append("valuation:tushare_daily_basic")
+
+        # ---- institution / top shareholders: top10_holders ----
+        holders = self._query(
+            "top10_holders",
+            ts_code=ts_code,
+            start_date="20150101",
+            end_date=datetime.now().strftime("%Y%m%d"),
+            fields="ts_code,end_date,holder_name,hold_ratio,hold_vol,change_ratio",
+        )
+        if holders is not None and not holders.empty:
+            try:
+                latest_end = holders["end_date"].astype(str).max()
+                latest = holders[holders["end_date"].astype(str) == latest_end]
+                holder_change = None
+                if "change_ratio" in latest.columns:
+                    holder_change = _safe_float(latest["change_ratio"].iloc[0])
+                result["institution"] = {
+                    "top10_holder_count": int(len(latest)),
+                    "top10_holder_change": holder_change,
+                    "top10_hold_ratio_avg": _safe_float(
+                        latest["hold_ratio"].mean() if "hold_ratio" in latest.columns else None
+                    ),
+                    "top10_latest_end_date": _safe_str(latest_end),
+                }
+                result["source_chain"].append("institution:tushare_top10_holders")
+            except Exception as exc:
+                result["errors"].append(f"top10_holders_parse:{type(exc).__name__}")
+
+        # ---- dividend: dividend (cash dividend history) ----
+        div = self._query(
+            "dividend",
+            ts_code=ts_code,
+            fields="ts_code,end_date,cash_div,cash_div_tax,div_proc,record_date,ex_date",
+        )
+        if div is not None and not div.empty:
+            events = []
+            for _, row in div.head(5).iterrows():
+                cash = _safe_float(row.get("cash_div"))
+                if cash is None:
+                    continue
+                events.append({
+                    "end_date": _safe_str(row.get("end_date")),
+                    "cash_dividend_per_share": cash,
+                    "ex_date": _safe_str(row.get("ex_date")),
+                    "process": _safe_str(row.get("div_proc")),
+                })
+            if events:
+                result["earnings"]["dividend"] = {
+                    "events": events,
+                    "ttm_cash_dividend_per_share": None,
+                }
+                result["source_chain"].append("dividend:tushare_dividend")
+
+        has_content = bool(result["growth"] or result["earnings"] or result.get("valuation"))
+        result["status"] = "partial" if has_content else "not_supported"
+        return result
+
+    # ------------------------------------------------------------------
+    # capital flow
+    # ------------------------------------------------------------------
+    def get_capital_flow(self, stock_code: str, top_n: int = 5) -> Dict[str, Any]:
+        result: Dict[str, Any] = {
+            "status": "not_supported",
+            "stock_flow": {},
+            "sector_rankings": {"top": [], "bottom": []},
+            "source_chain": [],
+            "errors": [],
+        }
+        ts_code = _to_ts_code(stock_code)
+        if not ts_code:
+            result["errors"].append(f"unsupported_code:{stock_code}")
+            return result
+
+        mf = self._query(
+            "moneyflow",
+            ts_code=ts_code,
+            fields="ts_code,trade_date,net_mf_amount,net_mf_amount_ratio",
+        )
+        if mf is not None:
+            row = self._single_row(mf)
+            if row is not None:
+                result["stock_flow"] = {
+                    "main_net_inflow": _safe_float(row.get("net_mf_amount")),
+                    "main_net_inflow_ratio": _safe_float(row.get("net_mf_amount_ratio")),
+                }
+                result["source_chain"].append("capital_stock:tushare_moneyflow")
+
+        has_content = bool(result["stock_flow"])
+        result["status"] = "partial" if has_content else "not_supported"
+        return result
+
+    # ------------------------------------------------------------------
+    # dragon tiger
+    # ------------------------------------------------------------------
+    def get_dragon_tiger_flag(self, stock_code: str, lookback_days: int = 20) -> Dict[str, Any]:
+        result: Dict[str, Any] = {
+            "status": "not_supported",
+            "is_on_list": False,
+            "recent_count": 0,
+            "latest_date": None,
+            "source_chain": [],
+            "errors": [],
+        }
+        ts_code = _to_ts_code(stock_code)
+        if not ts_code:
+            result["errors"].append(f"unsupported_code:{stock_code}")
+            return result
+
+        end = datetime.now()
+        start = end - timedelta(days=max(1, lookback_days))
+        tl = self._query(
+            "top_list",
+            ts_code=ts_code,
+            start_date=start.strftime("%Y%m%d"),
+            end_date=end.strftime("%Y%m%d"),
+            fields="ts_code,trade_date",
+        )
+        if tl is not None and not tl.empty:
+            dates = [str(d) for d in tl["trade_date"].astype(str).tolist() if str(d).isdigit()]
+            result["is_on_list"] = True
+            result["recent_count"] = len(dates)
+            result["latest_date"] = dates[0] if dates else None
+            result["status"] = "ok"
+            result["source_chain"].append("dragon_tiger:tushare_top_list")
+        else:
+            # No rows in window still means the query succeeded (not on list).
+            result["status"] = "ok"
+            result["source_chain"].append("dragon_tiger:tushare_top_list")
+        return result
+
+
+# ---------------------------------------------------------------------------
+# local helpers (kept in this module to avoid importing AkShare internals)
+# ---------------------------------------------------------------------------
+def _safe_float(value: Any) -> Optional[float]:
+    if value is None:
+        return None
+    try:
+        f = float(value)
+        if pd.isna(f):
+            return None
+        return f
+    except (TypeError, ValueError):
+        return None
+
+
+def _safe_str(value: Any) -> Optional[str]:
+    if value is None:
+        return None
+    try:
+        s = str(value).strip()
+        return s or None
+    except Exception:
+        return None

--- a/tests/test_fundamental_context.py
+++ b/tests/test_fundamental_context.py
@@ -189,6 +189,10 @@ class TestFundamentalContext(unittest.TestCase):
                 patch(
                     "data_provider.fundamental_adapter.AkshareFundamentalAdapter.get_fundamental_bundle",
                     return_value=bundle,
+                ), \
+                patch(
+                    "data_provider.tushare_fundamental_adapter.TushareFundamentalAdapter.get_fundamental_bundle",
+                    return_value=bundle,
                 ):
             ctx = manager.get_fundamental_context("159915")
         self.assertEqual(ctx["market"], "cn")
@@ -286,6 +290,17 @@ class TestFundamentalContext(unittest.TestCase):
                     "source_chain": [],
                     "errors": [],
                 }), \
+                patch(
+                    "data_provider.tushare_fundamental_adapter.TushareFundamentalAdapter.get_fundamental_bundle",
+                    return_value={
+                        "status": "not_supported",
+                        "growth": {},
+                        "earnings": {},
+                        "institution": {},
+                        "source_chain": [],
+                        "errors": [],
+                    },
+                ), \
                 patch.object(manager, "get_capital_flow_context", return_value={"status": "not_supported", "source_chain": []}), \
                 patch.object(manager, "get_dragon_tiger_context", return_value={"status": "not_supported", "source_chain": []}), \
                 patch.object(manager, "get_board_context", return_value={"status": "not_supported", "source_chain": []}):
@@ -327,6 +342,17 @@ class TestFundamentalContext(unittest.TestCase):
                     "source_chain": [],
                     "errors": [],
                 }), \
+                patch(
+                    "data_provider.tushare_fundamental_adapter.TushareFundamentalAdapter.get_fundamental_bundle",
+                    return_value={
+                        "status": "not_supported",
+                        "growth": {},
+                        "earnings": {},
+                        "institution": {},
+                        "source_chain": [],
+                        "errors": [],
+                    },
+                ), \
                 patch.object(manager, "get_capital_flow_context", return_value={"status": "not_supported", "source_chain": []}), \
                 patch.object(manager, "get_dragon_tiger_context", return_value={"status": "not_supported", "source_chain": []}), \
                 patch.object(manager, "get_board_context", return_value={"status": "not_supported", "source_chain": []}):
@@ -505,6 +531,16 @@ class TestFundamentalContext(unittest.TestCase):
         with patch("src.config.get_config", return_value=cfg), \
                 patch(
                     "data_provider.fundamental_adapter.AkshareFundamentalAdapter.get_capital_flow",
+                    return_value={
+                        "status": "not_supported",
+                        "stock_flow": {},
+                        "sector_rankings": {"top": [], "bottom": []},
+                        "source_chain": [],
+                        "errors": [],
+                    },
+                ), \
+                patch(
+                    "data_provider.tushare_fundamental_adapter.TushareFundamentalAdapter.get_capital_flow",
                     return_value={
                         "status": "not_supported",
                         "stock_flow": {},

--- a/tests/test_tushare_fundamental_adapter.py
+++ b/tests/test_tushare_fundamental_adapter.py
@@ -143,7 +143,7 @@ class TestTushareFundamentalAdapter:
 class TestPreferredWiring:
     def test_bundle_prefers_tushare(self):
         from data_provider.base import DataFetcherManager
-        m = DataFetcherManager.get_instance()
+        m = DataFetcherManager(fetchers=[])
         tushare = MagicMock()
         tushare.get_fundamental_bundle.return_value = {
             "status": "partial", "growth": {"roe": 3.77}, "earnings": {}, "valuation": {},
@@ -158,7 +158,7 @@ class TestPreferredWiring:
 
     def test_bundle_falls_back_to_akshare_on_not_supported(self):
         from data_provider.base import DataFetcherManager
-        m = DataFetcherManager.get_instance()
+        m = DataFetcherManager(fetchers=[])
         tushare = MagicMock()
         tushare.get_fundamental_bundle.return_value = {"status": "not_supported"}
         m._tushare_fundamental_adapter = tushare
@@ -171,7 +171,7 @@ class TestPreferredWiring:
 
     def test_capital_flow_prefers_tushare(self):
         from data_provider.base import DataFetcherManager
-        m = DataFetcherManager.get_instance()
+        m = DataFetcherManager(fetchers=[])
         tushare = MagicMock()
         tushare.get_capital_flow.return_value = {"status": "partial", "stock_flow": {"main_net_inflow": 1.0}}
         m._tushare_fundamental_adapter = tushare
@@ -183,7 +183,7 @@ class TestPreferredWiring:
 
     def test_dragon_tiger_prefers_tushare(self):
         from data_provider.base import DataFetcherManager
-        m = DataFetcherManager.get_instance()
+        m = DataFetcherManager(fetchers=[])
         tushare = MagicMock()
         tushare.get_dragon_tiger_flag.return_value = {"status": "ok", "is_on_list": True}
         m._tushare_fundamental_adapter = tushare

--- a/tests/test_tushare_fundamental_adapter.py
+++ b/tests/test_tushare_fundamental_adapter.py
@@ -1,0 +1,194 @@
+# -*- coding: utf-8 -*-
+"""Tests for the Tushare fundamental adapter and preferred-source wiring.
+
+The A-share fundamental bundle used to be served exclusively by AkShare's
+Eastmoney endpoints, which take ~15s per bundle and frequently exceed the stage
+budget, leaving reports with a partial fundamental block. The Tushare adapter
+mirrors the AkShare adapter's public surface so ``get_fundamental_context`` can
+prefer Tushare (fast, paid) and fall back to AkShare.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pandas as pd
+import pytest
+
+from data_provider.tushare_fundamental_adapter import (
+    TushareFundamentalAdapter,
+    _normalize_code,
+    _safe_float,
+    _to_ts_code,
+)
+
+
+# ---------------------------------------------------------------------------
+# pure helpers
+# ---------------------------------------------------------------------------
+
+class TestCodeHelpers:
+    def test_normalize_code(self):
+        assert _normalize_code("605090.SH") == "605090"
+        assert _normalize_code("000001") == "000001"
+
+    def test_to_ts_code_sh(self):
+        assert _to_ts_code("605090") == "605090.SH"
+        assert _to_ts_code("600519.SH") == "600519.SH"
+
+    def test_to_ts_code_sz(self):
+        assert _to_ts_code("000001") == "000001.SZ"
+        assert _to_ts_code("300829.SZ") == "300829.SZ"
+
+    def test_to_ts_code_invalid(self):
+        assert _to_ts_code("") is None
+        assert _to_ts_code("abc") is None
+
+    def test_safe_float(self):
+        assert _safe_float("12.5") == 12.5
+        assert _safe_float(None) is None
+        assert _safe_float("abc") is None
+
+
+# ---------------------------------------------------------------------------
+# adapter (mocked Tushare pro)
+# ---------------------------------------------------------------------------
+
+class TestTushareFundamentalAdapter:
+    def _adapter(self, **query_results):
+        adapter = TushareFundamentalAdapter()
+        pro = MagicMock()
+
+        def fake_query(api_name, **kwargs):
+            if api_name in query_results:
+                return query_results[api_name]
+            return None
+
+        pro.query.side_effect = fake_query
+        adapter._pro = pro
+        return adapter
+
+    def test_bundle_full_success(self):
+        fin = pd.DataFrame([
+            {"ts_code": "605090.SH", "end_date": "20260331", "roe": 3.77,
+             "grossprofit_margin": 8.1, "tr_yoy": 12.3, "netprofit_yoy": -5.2,
+             "revenue": 1000.0, "profit_dedt": 200.0},
+        ])
+        basic = pd.DataFrame([
+            {"ts_code": "605090.SH", "trade_date": "20260811", "pe_ttm": 16.92,
+             "pb": 1.5, "total_mv": 50000.0, "circ_mv": 40000.0},
+        ])
+        holders = pd.DataFrame([
+            {"ts_code": "605090.SH", "end_date": "20260331", "holder_name": "A",
+             "hold_ratio": 28.4, "change_ratio": 0.5},
+            {"ts_code": "605090.SH", "end_date": "20260331", "holder_name": "B",
+             "hold_ratio": 9.2, "change_ratio": -0.1},
+        ])
+        div = pd.DataFrame([
+            {"ts_code": "605090.SH", "end_date": "20251231", "cash_div": 0.5,
+             "ex_date": "20260601", "div_proc": "实施"},
+        ])
+        adapter = self._adapter(
+            fina_indicator=fin,
+            daily_basic=basic,
+            top10_holders=holders,
+            dividend=div,
+        )
+        result = adapter.get_fundamental_bundle("605090")
+        assert result["status"] == "partial"
+        assert result["growth"]["roe"] == 3.77
+        assert result["growth"]["revenue_yoy"] == 12.3
+        assert result["valuation"]["pe_ratio"] == 16.92
+        assert result["institution"]["top10_holder_count"] == 2
+        assert result["earnings"]["dividend"]["events"][0]["cash_dividend_per_share"] == 0.5
+        assert any("tushare" in s for s in result["source_chain"])
+
+    def test_bundle_not_supported_when_no_token(self):
+        adapter = TushareFundamentalAdapter()
+        with patch.object(adapter, "_get_pro", return_value=None):
+            result = adapter.get_fundamental_bundle("605090")
+        assert result["status"] == "not_supported"
+
+    def test_capital_flow(self):
+        mf = pd.DataFrame([
+            {"ts_code": "605090.SH", "trade_date": "20260811",
+             "net_mf_amount": 12345.6, "net_mf_amount_ratio": 2.3},
+        ])
+        adapter = self._adapter(moneyflow=mf)
+        result = adapter.get_capital_flow("605090")
+        assert result["status"] == "partial"
+        assert result["stock_flow"]["main_net_inflow"] == 12345.6
+
+    def test_dragon_tiger_on_list(self):
+        tl = pd.DataFrame([
+            {"ts_code": "605090.SH", "trade_date": "20260810"},
+        ])
+        adapter = self._adapter(top_list=tl)
+        result = adapter.get_dragon_tiger_flag("605090", lookback_days=20)
+        assert result["status"] == "ok"
+        assert result["is_on_list"] is True
+        assert result["recent_count"] == 1
+
+    def test_dragon_tiger_empty_window_is_ok(self):
+        adapter = self._adapter(top_list=pd.DataFrame())
+        result = adapter.get_dragon_tiger_flag("605090", lookback_days=20)
+        assert result["status"] == "ok"
+        assert result["is_on_list"] is False
+
+
+# ---------------------------------------------------------------------------
+# preferred-source wiring (Tushare first, AkShare fallback)
+# ---------------------------------------------------------------------------
+
+class TestPreferredWiring:
+    def test_bundle_prefers_tushare(self):
+        from data_provider.base import DataFetcherManager
+        m = DataFetcherManager.get_instance()
+        tushare = MagicMock()
+        tushare.get_fundamental_bundle.return_value = {
+            "status": "partial", "growth": {"roe": 3.77}, "earnings": {}, "valuation": {},
+        }
+        m._tushare_fundamental_adapter = tushare
+        akshare = MagicMock()
+        akshare.get_fundamental_bundle.return_value = {"status": "failed"}
+        m._fundamental_adapter = akshare
+        result = m._get_fundamental_bundle_preferred("605090")
+        assert result["growth"]["roe"] == 3.77
+        akshare.get_fundamental_bundle.assert_not_called()
+
+    def test_bundle_falls_back_to_akshare_on_not_supported(self):
+        from data_provider.base import DataFetcherManager
+        m = DataFetcherManager.get_instance()
+        tushare = MagicMock()
+        tushare.get_fundamental_bundle.return_value = {"status": "not_supported"}
+        m._tushare_fundamental_adapter = tushare
+        akshare = MagicMock()
+        akshare.get_fundamental_bundle.return_value = {"status": "partial", "growth": {"roe": 1.0}}
+        m._fundamental_adapter = akshare
+        result = m._get_fundamental_bundle_preferred("605090")
+        assert result["status"] == "partial"
+        akshare.get_fundamental_bundle.assert_called_once()
+
+    def test_capital_flow_prefers_tushare(self):
+        from data_provider.base import DataFetcherManager
+        m = DataFetcherManager.get_instance()
+        tushare = MagicMock()
+        tushare.get_capital_flow.return_value = {"status": "partial", "stock_flow": {"main_net_inflow": 1.0}}
+        m._tushare_fundamental_adapter = tushare
+        akshare = MagicMock()
+        m._fundamental_adapter = akshare
+        result = m._get_capital_flow_preferred("605090")
+        assert result["stock_flow"]["main_net_inflow"] == 1.0
+        akshare.get_capital_flow.assert_not_called()
+
+    def test_dragon_tiger_prefers_tushare(self):
+        from data_provider.base import DataFetcherManager
+        m = DataFetcherManager.get_instance()
+        tushare = MagicMock()
+        tushare.get_dragon_tiger_flag.return_value = {"status": "ok", "is_on_list": True}
+        m._tushare_fundamental_adapter = tushare
+        akshare = MagicMock()
+        m._fundamental_adapter = akshare
+        result = m._get_dragon_tiger_preferred("605090")
+        assert result["is_on_list"] is True
+        akshare.get_dragon_tiger_flag.assert_not_called()


### PR DESCRIPTION
## Problem

A-share fundamental blocks (growth / earnings / institution / capital_flow / dragon_tiger) are served exclusively by the AkShare Eastmoney adapter. Those endpoints poll at ~1.4-2.2 rows/s and take ~15s per bundle call, which frequently blows the stage budget (, default 8s). When the bundle times out, ,  and  are starved and report , so the report shows a **partial** fundamental block even though the user has a paid Tushare token.

Three Eastmoney endpoints also error in practice: , , .

## Root cause

-  (data_provider/base.py) calls  directly; TushareFetcher has no fundamental endpoints at all, so a paid Tushare token is never used for fundamentals.
- AkShare bundle takes ~15s > default 8s stage budget → timeout → dependent blocks starved.

## Fix

- New  (data_provider/tushare_fundamental_adapter.py) implementing the same surface as the AkShare adapter:
  -  via  (ROE / gross margin / yoy),  (PE/PB/total_mv),  (institution),  (cash dividend history)
  -  via 
  -  via 
-  routes bundle / capital_flow / dragon_tiger through  helpers that **prefer Tushare and fall back to AkShare** on error/unavailable.

## Measured results (605090)

| block | before | after |
|---|---|---|
| growth | failed (timeout) | ok (tushare_fina_indicator) |
| earnings | failed (timeout) | ok (tushare_dividend) |
| institution | failed (timeout) | ok (tushare_top10_holders) |
| capital_flow | failed (stage timeout) | ok (tushare_moneyflow) |
| dragon_tiger | failed (stage timeout) | ok (tushare_top_list) |
| boards | failed (stage timeout) | ok (TushareFetcher) |

Report data-quality block_scores: fundamentals 100/100, overall 100/100.

## Tests

-  (14 cases): adapter parsing, no-token not_supported, preferred wiring + AkShare fallback
- : 4 existing tests updated to also mock the Tushare adapter (they previously assumed bundle always goes through AkShare)

## Notes

- No behavior change when TUSHARE_TOKEN is absent (falls back to AkShare immediately).
- AkShare remains the fallback for non-A-share / ETF / error cases.
