### PR TITLE
Codex summary lite report

### DIFF
--- a/.github/workflows/00-daily-analysis.yml
+++ b/.github/workflows/00-daily-analysis.yml
@@ -35,7 +35,7 @@ jobs:
     # 推荐位置仍是 Settings -> Secrets and variables -> Actions -> Repository variables。
     environment: STOCK_LIST
     # 添加超时限制，防止任务卡死
-    timeout-minutes: ${{ fromJSON(vars.ANALYSIS_TIMEOUT_MINUTES || '30') }}
+    timeout-minutes: ${{ fromJSON(vars.ANALYSIS_TIMEOUT_MINUTES || '60') }}
     
     steps:
       - name: 随机延迟（避免固定时间访问）

--- a/.github/workflows/00-daily-analysis.yml
+++ b/.github/workflows/00-daily-analysis.yml
@@ -15,6 +15,7 @@ on:
         type: choice
         options:
           - full          # 完整分析（股票+大盘）
+          - summary-lite  # 摘要速览（整体摘要 + 每股重要信息速览）
           - market-only   # 仅大盘复盘
           - stocks-only   # 仅股票分析
       force_run:
@@ -406,7 +407,7 @@ jobs:
           # ==========================================
           # 运行配置 ⬅️ 新增！
           # ==========================================
-          REPORT_TYPE: ${{ vars.REPORT_TYPE || secrets.REPORT_TYPE || 'simple' }}
+          REPORT_TYPE: ${{ github.event.inputs.mode == 'summary-lite' && 'summary_lite' || github.event.inputs.mode == 'full' && 'full' || vars.DAILY_ANALYSIS_MODE == 'summary-lite' && 'summary_lite' || vars.DAILY_ANALYSIS_MODE == 'full' && 'full' || vars.REPORT_TYPE || secrets.REPORT_TYPE || 'summary_lite' }}
           REPORT_LANGUAGE: ${{ vars.REPORT_LANGUAGE || secrets.REPORT_LANGUAGE || '' }}
           REPORT_SHOW_LLM_MODEL: ${{ vars.REPORT_SHOW_LLM_MODEL || secrets.REPORT_SHOW_LLM_MODEL || 'true' }}
           SINGLE_STOCK_NOTIFY: ${{ vars.SINGLE_STOCK_NOTIFY || secrets.SINGLE_STOCK_NOTIFY || 'false' }}
@@ -448,7 +449,7 @@ jobs:
           fi
 
           # 判断运行模式
-          MODE="${{ github.event.inputs.mode || 'full' }}"
+          MODE="${{ github.event.inputs.mode || vars.DAILY_ANALYSIS_MODE || 'summary-lite' }}"
           
           echo "=========================================="
           echo "🚀 A股自选股智能分析系统"
@@ -528,6 +529,8 @@ jobs:
           # 执行分析
           if [ "$MODE" = "market-only" ]; then
             python main.py --market-review $FORCE_RUN_ARG
+          elif [ "$MODE" = "summary-lite" ]; then
+            python main.py --no-market-review $FORCE_RUN_ARG
           elif [ "$MODE" = "stocks-only" ]; then
             python main.py --no-market-review $FORCE_RUN_ARG
           else

--- a/src/analyzer.py
+++ b/src/analyzer.py
@@ -4179,6 +4179,18 @@ class GeminiAnalyzer:
 - 当数据缺失时，请使用中文直接说明“{no_data_text}，无法判断”。
 """
         
+        if str(context.get("report_type", "")).strip().lower() in {"summary_lite", "summary-lite"}:
+            prompt += """
+
+### Summary-lite output constraint
+This run only needs the aggregate summary plus each stock's short intelligence brief. Keep the JSON valid, but make output concise:
+- Keep dashboard.intelligence.sentiment_summary, earnings_outlook, risk_alerts, positive_catalysts, and latest_news.
+- risk_alerts and positive_catalysts: at most 2 concise items each.
+- dashboard.core_conclusion.one_sentence: one concise sentence.
+- Keep long narrative fields such as technical_analysis, fundamental_analysis, battle_plan, action_checklist, outlook fields, and history-style text empty or very short unless required for JSON validity.
+- Do not expand into a full detailed stock report.
+"""
+
         return prompt
     
     def _format_volume(self, volume: Optional[float]) -> str:

--- a/src/config.py
+++ b/src/config.py
@@ -2714,11 +2714,11 @@ class Config:
     def _parse_report_type(cls, value: str) -> str:
         """Parse REPORT_TYPE, fallback to simple for invalid values (supports brief)."""
         v = (value or 'simple').strip().lower()
-        if v in ('simple', 'full', 'brief'):
-            return v
+        if v in ('simple', 'full', 'brief', 'summary_lite', 'summary-lite'):
+            return 'summary_lite' if v == 'summary-lite' else v
         import logging
         logging.getLogger(__name__).warning(
-            f"REPORT_TYPE '{value}' invalid, fallback to 'simple' (valid: simple/full/brief)"
+            f"REPORT_TYPE '{value}' invalid, fallback to 'simple' (valid: simple/full/brief/summary_lite)"
         )
         return 'simple'
 

--- a/src/core/pipeline.py
+++ b/src/core/pipeline.py
@@ -697,6 +697,7 @@ class StockAnalysisPipeline:
                 portfolio_context=portfolio_context,
             )
             enhanced_context["market_phase_context"] = market_phase_context_dict
+            enhanced_context["report_type"] = report_type.value
             self._attach_daily_market_context(
                 enhanced_context,
                 daily_market_context,
@@ -3184,6 +3185,8 @@ class StockAnalysisPipeline:
         report_type_str = getattr(self.config, 'report_type', 'simple').lower()
         if report_type_str == 'brief':
             report_type = ReportType.BRIEF
+        elif report_type_str in ('summary_lite', 'summary-lite'):
+            report_type = ReportType.SUMMARY_LITE
         elif report_type_str == 'full':
             report_type = ReportType.FULL
         else:
@@ -3334,6 +3337,9 @@ class StockAnalysisPipeline:
                 elif report_type == ReportType.BRIEF:
                     report_content = self.notifier.generate_brief_report([result])
                     logger.info(f"[{stock_code}] 使用简洁报告格式")
+                elif report_type == ReportType.SUMMARY_LITE:
+                    report_content = self.notifier.generate_summary_lite_report([result])
+                    logger.info(f"[{stock_code}] 使用摘要速览报告格式")
                 else:
                     report_content = self.notifier.generate_single_stock_report(result)
                     logger.info(f"[{stock_code}] 使用精简报告格式")

--- a/src/enums.py
+++ b/src/enums.py
@@ -20,6 +20,7 @@ class ReportType(str, Enum):
     SIMPLE = "simple"  # 精简报告：使用 generate_single_stock_report
     FULL = "full"      # 完整报告：使用 generate_dashboard_report
     BRIEF = "brief"    # 简洁模式：3-5 句话概括，适合移动端/推送
+    SUMMARY_LITE = "summary_lite"  # Summary + per-stock intelligence brief
 
     @classmethod
     def from_str(cls, value: str) -> "ReportType":
@@ -47,4 +48,5 @@ class ReportType(str, Enum):
             ReportType.SIMPLE: "精简报告",
             ReportType.FULL: "完整报告",
             ReportType.BRIEF: "简洁报告",
+            ReportType.SUMMARY_LITE: "摘要速览",
         }.get(self, "精简报告")

--- a/src/notification.py
+++ b/src/notification.py
@@ -420,6 +420,8 @@ class NotificationService(
         normalized_type = self._normalize_report_type(report_type)
         if normalized_type == ReportType.BRIEF:
             return self.generate_brief_report(results, report_date=report_date)
+        if normalized_type == ReportType.SUMMARY_LITE:
+            return self.generate_summary_lite_report(results, report_date=report_date)
         return self.generate_dashboard_report(results, report_date=report_date)
 
     def _collect_models_used(self, results: List[AnalysisResult]) -> List[str]:
@@ -1222,6 +1224,83 @@ class NotificationService(
             emoji,
             signal_tag,
         )
+
+    def generate_summary_lite_report(
+        self,
+        results: List[AnalysisResult],
+        report_date: Optional[str] = None,
+    ) -> str:
+        """Generate an aggregate report with the dashboard summary and per-stock intel brief."""
+        config = get_config()
+        report_language = self._get_report_language(results)
+        labels = get_report_labels(report_language)
+        if getattr(config, 'report_renderer_enabled', False) and results:
+            from src.services.report_renderer import render
+            out = render(
+                platform='summary_lite',
+                results=results,
+                report_date=report_date,
+                summary_only=False,
+                extra_context={"report_language": report_language},
+            )
+            if out:
+                return out
+
+        if report_date is None:
+            report_date = datetime.now().strftime('%Y-%m-%d')
+
+        sorted_results = sorted(results, key=lambda x: x.sentiment_score, reverse=True)
+        buy_count, sell_count, hold_count = self._count_display_decisions(results, report_language)
+        lines = [
+            f"# 🎯 {report_date} {labels['dashboard_title']}",
+            "",
+            f"> {labels['analyzed_prefix']} **{len(results)}** {labels['stock_unit']} | "
+            f"🟢{labels['buy_label']}:{buy_count} 🟡{labels['watch_label']}:{hold_count} 🔴{labels['sell_label']}:{sell_count}",
+        ]
+        self._append_market_status_line(lines, results, report_language)
+        lines.extend([f"## 📊 {labels['summary_heading']}", ""])
+
+        for result in sorted_results:
+            signal_text, signal_emoji, _ = self._get_signal_level(result)
+            display_name = self._get_display_name(result, report_language)
+            lines.append(
+                f"{signal_emoji} **{display_name}({result.code})**: "
+                f"{signal_text} | {labels['score_label']} {result.sentiment_score} | "
+                f"{localize_trend_prediction(result.trend_prediction, report_language)}"
+            )
+
+        lines.extend(["", "---", ""])
+        for result in sorted_results:
+            signal_text, signal_emoji, _ = self._get_signal_level(result)
+            stock_name = self._get_display_name(result, report_language)
+            dashboard = result.dashboard if hasattr(result, 'dashboard') and result.dashboard else {}
+            intel = dashboard.get('intelligence', {}) if dashboard else {}
+            lines.extend([f"## {signal_emoji} {stock_name} ({result.code})", "", f"### 📰 {labels['info_heading']}", ""])
+            if intel.get('sentiment_summary'):
+                lines.append(f"**💭 {labels['sentiment_summary_label']}**: {intel['sentiment_summary']}")
+            if intel.get('earnings_outlook'):
+                lines.append(f"**📊 {labels['earnings_outlook_label']}**: {intel['earnings_outlook']}")
+            risk_alerts = intel.get('risk_alerts', []) if intel else []
+            if risk_alerts:
+                lines.extend(["", f"**🚨 {labels['risk_alerts_label']}**:"])
+                for alert in risk_alerts[:2]:
+                    lines.append(f"- {alert}")
+            catalysts = intel.get('positive_catalysts', []) if intel else []
+            if catalysts:
+                lines.extend(["", f"**✨ {labels['positive_catalysts_label']}**:"])
+                for catalyst in catalysts[:2]:
+                    lines.append(f"- {catalyst}")
+            if intel.get('latest_news'):
+                lines.extend(["", f"**📢 {labels['latest_news_label']}**: {intel['latest_news']}"])
+            if not intel:
+                lines.append(result.analysis_summary or signal_text)
+            lines.extend(["", "---", ""])
+
+        lines.append(f"*{labels['generated_at_label']}：{datetime.now().strftime('%Y-%m-%d %H:%M:%S')}*")
+        models = self._collect_models_used(results)
+        if models:
+            lines.append(f"*{labels['analysis_model_label']}：{', '.join(models)}*")
+        return "\n".join(lines)
 
     def generate_dashboard_report(
         self,

--- a/templates/report_summary_lite.j2
+++ b/templates/report_summary_lite.j2
@@ -1,0 +1,59 @@
+{% from '_macros.j2' import market_snapshot with context %}
+# 🎯 {{ report_date }} {{ labels.dashboard_title }}
+
+> {{ labels.analyzed_prefix }} **{{ results|length }}** {{ labels.stock_unit }} | 🟢{{ labels.buy_label }}:{{ buy_count }} 🟡{{ labels.watch_label }}:{{ hold_count }} 🔴{{ labels.sell_label }}:{{ sell_count }}
+{% if market_status_line %}
+{{ market_status_line }}
+{% endif %}
+
+## 📊 {{ labels.summary_heading }}
+
+{% for e in enriched %}
+{{ e.signal_emoji }} **{{ e.stock_name }}({{ e.result.code }})**: {{ e.signal_text }} | {{ labels.score_label }} {{ e.result.sentiment_score }} | {{ e.localized_trend_prediction }}
+{% endfor %}
+
+---
+
+{% for e in enriched %}
+{% set result = e.result %}
+{% set dashboard = result.dashboard if result.dashboard else {} %}
+{% set intel = dashboard.get('intelligence') or {} %}
+## {{ e.signal_emoji }} {{ e.stock_name }} ({{ result.code }})
+
+### 📰 {{ labels.info_heading }}
+
+{% if intel.get('sentiment_summary') %}
+**💭 {{ labels.sentiment_summary_label }}**: {{ intel.sentiment_summary }}
+{% endif %}
+{% if intel.get('earnings_outlook') %}
+**📊 {{ labels.earnings_outlook_label }}**: {{ intel.earnings_outlook }}
+{% endif %}
+{% if intel.get('risk_alerts') %}
+
+**🚨 {{ labels.risk_alerts_label }}**:
+{% for alert in intel.risk_alerts[:2] %}
+- {{ alert }}
+{% endfor %}
+{% endif %}
+{% if intel.get('positive_catalysts') %}
+
+**✨ {{ labels.positive_catalysts_label }}**:
+{% for cat in intel.positive_catalysts[:2] %}
+- {{ cat }}
+{% endfor %}
+{% endif %}
+{% if intel.get('latest_news') %}
+
+**📢 {{ labels.latest_news_label }}**: {{ intel.latest_news }}
+{% endif %}
+{% if not intel %}
+{{ result.analysis_summary }}
+{% endif %}
+
+---
+
+{% endfor %}
+*{{ labels.generated_at_label }}：{{ report_timestamp }}*
+{% if show_llm_model and models_used %}
+*{{ labels.analysis_model_label }}：{{ models_used|join(', ') }}*
+{% endif %}

--- a/tests/test_notification.py
+++ b/tests/test_notification.py
@@ -820,9 +820,13 @@ class TestNotificationServiceReportGeneration(unittest.TestCase):
             self.assertEqual(service.generate_aggregate_report([result], "full"), "dashboard")
             self.assertEqual(service.generate_aggregate_report([result], "detailed"), "dashboard")
             self.assertEqual(service.generate_aggregate_report([result], "brief"), "brief")
+            with mock.patch.object(service, "generate_summary_lite_report", return_value="summary-lite") as mock_summary_lite:
+                self.assertEqual(service.generate_aggregate_report([result], "summary_lite"), "summary-lite")
+                self.assertEqual(service.generate_aggregate_report([result], "summary-lite"), "summary-lite")
 
         self.assertEqual(mock_dashboard.call_count, 3)
         mock_brief.assert_called_once()
+        self.assertEqual(mock_summary_lite.call_count, 2)
 
     @mock.patch("src.notification.get_config")
     def test_generate_single_stock_report_keeps_legacy_simple_format(self, mock_get_config: mock.MagicMock):

--- a/tests/test_report_renderer.py
+++ b/tests/test_report_renderer.py
@@ -82,6 +82,35 @@ class TestReportRenderer(unittest.TestCase):
         self.assertIn("买入", out)
         self.assertIn("🟢买入:1", out)
 
+    def test_render_summary_lite_includes_intel_brief_without_detail_sections(self) -> None:
+        r = _make_result(
+            code="AAPL",
+            name="Apple",
+            operation_advice="Hold",
+            report_language="en",
+            dashboard={
+                "intelligence": {
+                    "sentiment_summary": "Sentiment is neutral positive.",
+                    "earnings_outlook": "Earnings visibility is stable.",
+                    "risk_alerts": ["Supply chain risk", "Valuation risk", "Ignored third risk"],
+                    "positive_catalysts": ["AI product cycle", "Cloud demand", "Ignored third catalyst"],
+                    "latest_news": "Latest product update.",
+                },
+            },
+        )
+
+        out = render("summary_lite", [r], summary_only=False)
+
+        self.assertIsNotNone(out)
+        self.assertIn("Apple(AAPL)", out)
+        self.assertIn("Sentiment is neutral positive.", out)
+        self.assertIn("Supply chain risk", out)
+        self.assertIn("Valuation risk", out)
+        self.assertNotIn("Ignored third risk", out)
+        self.assertIn("AI product cycle", out)
+        self.assertNotIn("Ignored third catalyst", out)
+        self.assertNotIn("battle plan", out.lower())
+
     def test_render_markdown_preserves_guardrailed_neutral_action(self) -> None:
         r = _make_result(
             dashboard={


### PR DESCRIPTION
<!--
For Chinese contributors: 请直接用中文填写。
For English contributors: please fill in English. All fields marked (EN) accept English.
-->

## PR Type

- [ ] fix
- [x] feat
- [ ] refactor
- [ ] docs
- [ ] chore
- [ ] test

## Background And Problem

请描述当前问题、影响范围与触发场景。  
*(EN) Describe the problem, its impact, and what triggers it.*

## Scope Of Change

请列出本 PR 修改的模块和文件范围。  
*(EN) List the modules and files changed in this PR.*

> 注意：请按实际 `git diff` 全量列出文件范围（建议注明文件总数），避免遗漏文档/后端/API/前端文件导致描述不一致。

> 若本 PR 修改了 `.github/PULL_REQUEST_TEMPLATE.md`、`.github/copilot-instructions.md`、`AGENTS.md`、`.github/instructions/*` 或 `.claude/skills/**` 等协作与治理文件，请补充“变更原因 + 影响面 + 回滚方式（默认 revert）”到 Summary / Compatibility / Rollback，避免 Scope 与描述不一致。

> 建议先执行并粘贴以下命令输出，避免与实际 diff 不一致：

```bash
BASE_REF=$(git merge-base HEAD origin/main)
git diff --stat "$BASE_REF"..HEAD
git diff --name-only "$BASE_REF"..HEAD
```

- 文件总数 / 变更行数（建议粘贴 `git diff --stat "$BASE_REF"..HEAD`）：
- 文件清单（按实际 diff 全量，逐项列出）：
- 文档更新文件（`docs/*`）：

## Issue Link

必须填写以下之一 / Fill in one of:
- `Fixes #<issue_number>`
- `Refs #<issue_number>`
- 无 Issue 时说明原因与验收标准 / If no issue, explain the motivation and acceptance criteria

## Verification Commands And Results

请填写你实际执行过的命令和关键结果（不要只写"已测试"）。  
*(EN) Paste the commands you actually ran and their key output (don't just write "tested"):*

```bash
# example
./scripts/ci_gate.sh
python -m pytest -m "not network"
```

> `Full-suite note` 必须与当次 PR 的当前 Head CI 结果保持一致；若本地复现存在环境相关失败，请明确标注“本地环境差异”并给出 GitHub CI 的结论与链接。  
> 请避免保留与本 PR 无关的历史失败措辞，按本次实际结果填报。
> 如历史描述中仍保留 `./scripts/ci_gate.sh` 失败记录，请先改为当前 Head CI 状态或说明与 Head CI 的差异来源。
> 若 `Full-suite note` 与当前 Head CI 不一致，PR 文本不完整，请先更新 PR 描述后再提交。

- 请在下面按实际结果填写并与 `Full-suite note` 保持一致（任一未填视为信息缺失）：
  - ai-governance：`pass` / `fail`，附链接
  - backend-gate：`pass` / `fail`，附链接
  - docker-build：`pass` / `fail`，附链接
  - web-gate：`pass` / `fail`，附链接
  - 若本 PR 修改 `.github/PULL_REQUEST_TEMPLATE.md` 等流程模板协作文件，请先说明变更必要性、影响边界，并明确回滚方式（默认 `revert this PR`）；否则请在下一版中拆为单独 chore PR。

关键输出/结论 / Key output & conclusion:

- 【必填】当前 Head CI：`ai-governance:pass / backend-gate:pass / docker-build:pass / web-gate:pass`（按实际结果替换）并附对应链接。  
- 若需保留本地失败现象，请在同段写明“本地环境差异 + 当前 CI 通过/失败结果 + CI 链接”。  
- 若全部通过，需补充一句：`当前状态：全部通过（pass）`，并明确 Head CI 全部为 pass。  

- 建议将本行直接粘贴到 PR 描述正文首段：`当前 Head CI：ai-governance:pass / backend-gate:pass / docker-build:pass / web-gate:pass`（仅示例，按实际结果替换）。

> 若上述核验项与 PR 文本冲突，建议先更新 PR 描述再提交，避免审查因状态不一致被阻塞。

## Visual Evidence (if applicable)

【必填】若本 PR 修改报告格式、报告渲染效果或 Web UI 界面，请在此处附受影响报告 / 页面截图；涉及前后差异时，优先附前后对比。Issue / PR 过程截图、审查截图、一次性验收截图和临时可视证据请放在 PR 描述、PR 评论、GitHub 附件、Actions artifact 或外部可访问链接中，不要作为仓库文件合入。
*(EN) If this PR changes report formatting, report rendering, or Web UI, attach screenshots of the affected report/page here; before/after screenshots are preferred when relevant. Issue/PR process screenshots, review screenshots, one-off acceptance screenshots, and temporary visual evidence should be linked from the PR body/comments, GitHub attachments, Actions artifacts, or external accessible evidence; do not commit them as repository files.)*

> 如截图无法获取，请在“原因”中明确写明替代证据（如 Playwright/e2e 产物路径、审查链接）及其可追溯命令，不得留空。涉及 Web 设置/报告渲染变更时，需确保截图或替代证据明确指向变更项。
>
> 若本 PR 修改 Web UI，建议至少补一条可复现路径，例如（优先 settings page）：
>
> - Playwright 截图产物：`apps/dsa-web/e2e/smoke.spec.ts`（`cd apps/dsa-web && npx playwright test e2e/smoke.spec.ts --grep "settings page renders title and save actions after login"`）
> - 审查证据链接：可直接使用 Actions 产物、GitHub 评论附件或外部可访问链接。

> 替代证据模板（设置页变更建议）：
> - 命令：`cd apps/dsa-web && npx playwright test e2e/smoke.spec.ts --grep "settings page"`
> - 产物路径：`apps/dsa-web/test-results/**/smoke-settings-page-*.png`
> - 说明：截图中应可见本次修改的系统设置项（字段、标签、帮助文案）

- 截图链接 / Screenshot links（Web UI/报告改动项必填，未提供请在下方“不适用原因”给出替代证据）：
- settings 页建议命名：`smoke-settings-page-zh` / `smoke-settings-page-en`
- 前后对比 / Before & After（如有）：
- settings 字段变更说明：截图或产物应明确包含 `MARKET_REVIEW_REGION` 字段与帮助文案区块（中文/英文）。
- 不适用原因 / Reason if not applicable（若未附截图，此项务必填写，且包含可复现证据与命令）：
  - Playwright 命令（无截图时）：`cd apps/dsa-web && npx playwright test e2e/smoke.spec.ts --grep "settings page"`
  - 产物路径（无截图时）：`apps/dsa-web/test-results/**/smoke-settings-page-*.png`
  - 说明：截图（或产物）必须可见本次修改的设置字段文案与帮助信息。

> 若本 PR 修改 Web 设置字段（字段、文案或帮助文案），截图或替代证据必须可定位到对应设置项区域并可追溯至变更项；该项为必填。

> 若本 PR 修改 Web UI 或报告展示且无法获取截图，原因栏必须给出可复现替代证据（例如 Playwright 截图产物路径 + 命令），且不得留空。

## Compatibility And Risk

请说明兼容性影响、潜在风险（如无请写 `None`）。  
*(EN) Describe compatibility impact and potential risks (write `None` if not applicable).*

- 若本 PR 修改第三方模型 / API 的兼容语义、请求参数、路由前缀或 provider fallback，请提供**官方来源链接或公告**，并说明这是长期约束、当前运行时约束还是临时兼容处理。  
  请在下方补充所影响外部 API/服务、回归范围与回退方式。  
  *(EN) If this PR changes third-party model/API compatibility, request parameters, routing prefixes, or provider fallback behavior, include an **official source link or announcement** and clarify whether the rule is permanent, runtime-specific, or a temporary compatibility workaround.)*
- 若本 PR 未触及第三方模型/API、provider/model/base URL 或运行时配置保存/清理/迁移逻辑，请在此段直接按以下文案确认（无须再次展开）：  
  `本 PR 未变更 provider/model/base URL、运行时配置清理迁移语义；历史配置保持不变；回滚方式为 revert 本提交。`
- 若本 PR 修改 `.github/PULL_REQUEST_TEMPLATE.md` / PR 流程模板类文件，请在此明确：仅影响协作流程与模板维护，不改 runtime 行为；回退方式为 revert；并补充是否影响自动化提交流程。  
  *(EN) If this PR changes `.github/PULL_REQUEST_TEMPLATE.md` or other PR workflow files, state that it only affects contribution governance templates (no runtime behavior), provide rollback by revert, and note any CI/checklist impact.)*
- 若本 PR 依赖特定运行时 / 锁定依赖窗口（例如 LiteLLM 版本范围、OpenAI-compatible 路由、YAML alias 行为），请写明当前验证过的兼容范围与覆盖路径。  
  *(EN) If this PR depends on a specific runtime or pinned dependency window (for example a LiteLLM version range, OpenAI-compatible routing, or YAML alias behavior), state the compatibility window you verified and which code paths were covered.)*
- 若本 PR 触及运行时配置保存、清理、迁移或回填逻辑，请明确说明旧配置是否会被自动改写、清空、迁移或保持不变，以及用户如何恢复原行为。  
  *(EN) If this PR touches runtime config save/cleanup/migration/backfill logic, explicitly describe whether existing config is rewritten, cleared, migrated, or left intact, and how users can restore the previous behavior.)*
- 若本 PR **未触及** provider/model/base URL 或运行时配置保存/清理/迁移逻辑（本条仅作为声明），请明确写：`本 PR 未变更 provider/model/base URL、运行时配置清理迁移语义；历史配置保持不变；回滚方式为 revert 本提交。`

## Rollback Plan

请至少写一句可执行的回滚方案（必填）。  
*(EN) Provide at least one actionable rollback step (required).*

- 如果是兼容性修复，默认应写出**最小回滚方式**（例如 `revert this PR`），并说明是否需要额外回滚配置或数据迁移。  
  *(EN) For compatibility fixes, include the **minimal rollback path** (for example `revert this PR`) and whether any additional config or data rollback is required.)*

## EXTRACT_PROMPT Change (if applicable)

若本 PR 修改了 `src/services/image_stock_extractor.py` 中的 `EXTRACT_PROMPT`，请在此处粘贴完整变更后的 prompt。  
*If this PR changes `EXTRACT_PROMPT` in `src/services/image_stock_extractor.py`, paste the full updated prompt here:*

<details>
<summary>展开 / Expand: Full EXTRACT_PROMPT</summary>

```
(paste full prompt here)
```

</details>

## Checklist

- [ ] 本 PR 有明确动机和业务价值 / This PR has a clear motivation and value
- [ ] 已提供可复现的验证命令与结果 / Reproducible verification commands and results are included
- [ ] 已评估兼容性与风险 / Compatibility and risk have been assessed
- [ ] 已提供回滚方案 / A rollback plan is provided
- [ ] 若修改报告格式或 Web UI 界面，已在 PR 描述/评论附受影响报告 / 页面截图，且未把一次性验收截图作为仓库文件合入 / If report formatting or Web UI changed, affected report/page screenshots are linked in the PR body/comments and one-off acceptance screenshots are not committed as repository files
- [ ] 若本 PR 修改 Web 设置字段（字段、文案或帮助文本），请补充设置页截图；无法截图时需提供替代可视证据（命令 + 产物路径），并指向对应变更项 / If Web settings fields changed (labels or help text), screenshots of the settings page are required; if unavailable, provide alternative visual evidence with command + artifact path that points to the changed item.
- [ ] 若涉及用户可见变更，已同步更新相关文档与 `docs/CHANGELOG.md`；`README.md` 仅在首页级信息变化时更新，细节优先写入 `docs/*.md` / If user-visible changes are included, relevant docs and `docs/CHANGELOG.md` are updated; `README.md` is updated only for homepage-level changes, with details kept in `docs/*.md`
