### PR TITLE
[feat] Web Chat 意图识别与股票解析增强

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -482,6 +482,10 @@ AGENT_SKILLS=
 # 自定义策略目录（可选，放置自定义 YAML 策略文件；环境变量名沿用内部 skill 命名）
 # AGENT_SKILL_DIR=./strategies
 
+# Web Chat 意图识别层（默认 true）：在 SSE 流中优先解析意图并发出 intent_resolved 事件；
+# 低置信度或一名多候选股票时返回 action_required 让用户确认，不直接执行分析
+# AGENT_WEB_INTENT_ENABLED=true
+
 # Agent 架构模式（默认 single；multi 为多 Agent 编排模式）
 # AGENT_ARCH=single
 

--- a/api/v1/endpoints/agent.py
+++ b/api/v1/endpoints/agent.py
@@ -481,6 +481,15 @@ async def agent_chat_stream(
     """
     Chat with the AI Agent, streaming progress via SSE.
     Each SSE event is a JSON object with a 'type' field:
+      - accepted: 请求已被接收（流协议提交边界，始终为第一条事件，
+        包括意图确认分支）；在意图识别与 prepare_turn 之前立即发出，
+        前端收到后立刻渲染用户消息气泡，无需等待意图解析或 AI 分析
+      - intent_resolved: Web 意图层已完成消息分类（在 accepted 之后发出）
+      - action_required: 意图层判定需要用户确认后执行（多候选股票
+        或低置信度）；客户端应展示确认界面，用户确认后重新发消息。
+        该事件后紧跟一个 'done' 事件，其 'content' 字段携带澄清问题文本。
+        确认分支的完整事件序列为 accepted → intent_resolved →
+        action_required → done（不发 accepted 会被 Web store 判为协议错误）
       - thinking: AI is deciding next action
       - stage_start: an agent or orchestrator stage has begun
       - stage_done: an agent or orchestrator stage finished
@@ -569,16 +578,202 @@ async def agent_chat_stream(
 
     async def event_generator():
         fut = None
+
+        def _accepted_event() -> dict:
+            # accepted 是流协议的第一条事件（提交边界）：Web store 只有在收到
+            # 它之后才会渲染用户消息气泡，因此必须在任何耗时准备之前发出——
+            # 意图解析的 LLM 兜底（8s 超时 + 一次重试）、AkShare 扩展下载、
+            # executor 构建与 prepare_turn 持久化都发生在它之后。否则用户输入
+            # （如"分析三花"触发 LLM 兜底时）要等解析完成才显示气泡。
+            return {
+                "type": "accepted",
+                "backend": backend_id,
+                "request_id": request_id,
+                "session_id": session_id,
+            }
+
         try:
+            # accepted 首事件立即送达：前端无需等待意图识别或 AI 分析即可
+            # 渲染用户消息。后续所有分支（正常执行 / 确认短路 / 确认失败 /
+            # 准备失败）都只消费这一个 accepted，绝不重复发出。
+            yield "data: " + json.dumps(_accepted_event(), ensure_ascii=False) + "\n\n"
+
             try:
                 executor = await asyncio.to_thread(_build_executor, config, skills or None)
-                turn = await asyncio.to_thread(
-                    executor.prepare_turn,
-                    message=request.message,
-                    session_id=session_id,
-                    context=stream_ctx,
-                    selected_skill_ids=selected_skill_ids,
-                )
+
+                # ============================================================
+                # Web 意图识别层（issue #1125 需求方向）
+                # 在 Agent 编排前对用户消息做意图分类，发 intent_resolved 事件；
+                # 需用户确认时（多候选股票 / 低置信度）短路返回 action_required，避免未确认即执行分析。
+                # getattr 默认值 False：测试/机器人等临时 Config 走原有路径；
+                # 正式环境 Config（settings.json / env）默认开启此开关。
+                # 必须位于 prepare_turn 之前：解析注入的 stock_code/web_intent
+                # 写入 stream_ctx 后，prepare_agent_chat 在 prepare 阶段才会固化股票作用域。
+                # accepted 首事件已在此块之前发出：意图解析即使触发 LLM 兜底
+                # （8s 超时 + 一次重试）也不会推迟前端用户气泡的渲染。
+                # ============================================================
+                intent_confirmed = False
+                web_intent_session: Any = None
+                web_intent_resolution: Any = None
+                if getattr(config, "agent_web_intent_enabled", False):
+                    try:
+                        # ---- 延迟 import，避免非 Web 场景加载意图模块 ----
+                        from src.agent.conversation import conversation_manager
+                        from src.agent.web_intent_resolver import (
+                            WebIntentResolver,              # 意图解析器：分类 + 股票消歧
+                            apply_resolution_to_session,    # 将解析结果写入会话上下文
+                            build_action_required_event,    # 构建“需用户确认”SSE 事件
+                            build_clarification_message,    # 构建澄清问题文本
+                            build_intent_resolved_event,    # 构建“意图已解析”SSE 事件
+                            clear_pending_actions,          # 确认流程失败时清理待确认状态
+                        )
+                        # 获取或创建当前会话（session_id 唯一标识一次对话）
+                        web_intent_session = conversation_manager.get_or_create(session_id)
+
+                        def _resolve_web_intent() -> Any:
+                            # 意图解析可能触发 LLM 兜底（同步网络调用：8s 超时 +
+                            # 一次重试）或 AkShare 扩展下载，必须在工作线程执行，
+                            # 否则会阻塞 SSE 事件循环。
+
+                            return WebIntentResolver(config).resolve(
+                                request.message,              # 用户原始输入
+                                session_context=web_intent_session.context,  # 会话历史上下文
+                                request_context=stream_ctx,       # 请求级上下文（skills 等）
+                            )
+
+                        web_intent_resolution = await asyncio.to_thread(_resolve_web_intent)
+
+                        # ---- 需要用户确认的分支 ----
+                        if web_intent_resolution.needs_confirmation:
+                            # 一旦判定需要确认，立即短路：确认分支内任何一步失败
+                            # 都绝不退回 Agent 执行，否则会绕过“未确认不执行”安全门，
+                            # 对歧义请求直接分析。
+                            intent_confirmed = True
+                            try:
+                                # 构建澄清问题文本（如“您是指招商银行还是招商证券？”）
+                                clarification = build_clarification_message(web_intent_resolution)
+                                # 将用户原始消息和澄清回复写入会话历史（本地 SQLite 写，
+                                # 移出事件循环线程，与意图解析保持一致）
+                                await asyncio.to_thread(
+                                    conversation_manager.add_message,
+                                    session_id,
+                                    "user",
+                                    request.message,
+                                )
+                                await asyncio.to_thread(
+                                    conversation_manager.add_message,
+                                    session_id,
+                                    "assistant",
+                                    clarification,
+                                )
+                                # 确认分支的服务器持久化（user + assistant 会话历史）
+                                # 已成功，此时才把意图层上下文写入会话，保证 Web 状态
+                                # 与服务器持久化共享同一提交点。
+                                apply_resolution_to_session(web_intent_session, web_intent_resolution)
+                                # accepted 首事件已在流开头发出（首事件契约），
+                                # 确认分支只需按序补发后续事件；确认分支已处于
+                                # 事件循环线程内：直接同步入队，保证
+                                # intent_resolved → action_required → done 顺序送达。
+                                # 不能用 progress_callback：其 run_coroutine_threadsafe
+                                # 只是调度，会被紧随其后的 done 抢先消费，导致
+                                # action_required 永远到不了前端确认界面。
+                                await queue.put(build_intent_resolved_event(web_intent_resolution))
+                                await queue.put(build_action_required_event(web_intent_resolution))
+                                # 发送 done 事件结束本次 SSE 流（content 携带澄清文本）
+                                await queue.put({
+                                    "type": "done",
+                                    "success": True,
+                                    "content": clarification,
+                                    "error": None,
+                                    "total_steps": 0,       # 未执行分析步骤
+                                    "session_id": session_id,
+                                })
+                            except Exception:
+                                # 确认分支失败（如会话历史写入异常）仍保持短路：
+                                # 绝不执行未确认的歧义请求，发兜底终端事件结束流。
+                                # 同时清空已写入会话的待确认动作，避免下一轮消息
+                                # 被误当成本轮失败确认流程的回复而执行旧歧义请求。
+                                # 清理本身失败也只记警告，不改变"确认失败仅 error
+                                # 终态"的短路契约。
+                                try:
+                                    clear_pending_actions(web_intent_session)
+                                except Exception:
+                                    logger.warning(
+                                        "Failed to clear pending intent actions "
+                                        "after confirmation branch failure",
+                                        exc_info=True,
+                                    )
+                                logger.warning(
+                                    "Web intent confirmation branch failed, "
+                                    "skipping analysis of unconfirmed request",
+                                    exc_info=True,
+                                )
+                                await queue.put({
+                                    "type": "error",
+                                    "message": "无法完成该请求的确认流程，请稍后重试",
+                                    "error_code": "confirmation_failed",
+                                    "backend": backend_id,
+                                    "request_id": request_id,
+                                })
+
+                        # ---- 意图已确定，无需确认的分支 ----
+                        else:
+                            # 推送意图解析结果事件到 SSE 流（非确认分支经后续
+                            # await to_thread 挂起点被执行，仍按序送达）
+                            progress_callback(build_intent_resolved_event(web_intent_resolution))
+                            # 将解析出的主股票代码注入上下文（#1619 股票作用域锁定），
+                            # 后续追问或仅提股票名的消息自动锁定同一只股票。
+                            primary_code = web_intent_resolution.primary_stock_code
+                            if primary_code and not stream_ctx.get("stock_code"):
+                                # 仅在上下文未指定 stock_code 时才覆盖（显式传入优先）
+                                stream_ctx["stock_code"] = primary_code
+                            # 将解析出的意图类型写入上下文，供编排器按意图分流策略
+                            stream_ctx["web_intent"] = web_intent_resolution.intent
+                            # 确认消费轮的多股比较：确认回复本身（如"港股"）不带
+                            # 任何代码，primary_stock_code 又为空串；已解析的比较对
+                            # 与原始请求必须显式注入本轮上下文，否则 prepare_turn
+                            # 只看到裸确认回复，无法构建比较作用域，工具调用不再
+                            # 受比较对约束，退化为泛市场追问或单股回答。
+                            if web_intent_resolution.source == "confirmation":
+                                resolved_codes = [
+                                    stock.code
+                                    for stock in web_intent_resolution.stocks
+                                    if getattr(stock, "code", "")
+                                ]
+                                if len(resolved_codes) >= 2:
+                                    stream_ctx["resolved_stock_codes"] = resolved_codes
+                                    if web_intent_resolution.original_request:
+                                        stream_ctx["web_intent_original_request"] = (
+                                            web_intent_resolution.original_request
+                                        )
+                    except Exception:
+                        # 意图解析失败时降级：记录警告，继续走原有编排流程
+                        logger.warning(
+                            "Web intent resolution failed, continuing without it",
+                            exc_info=True,
+                        )
+
+                if not intent_confirmed:
+                    turn = await asyncio.to_thread(
+                        executor.prepare_turn,
+                        message=request.message,
+                        session_id=session_id,
+                        context=stream_ctx,
+                        selected_skill_ids=selected_skill_ids,
+                    )
+                    # prepare_turn 是服务端持久化提交点：意图层上下文必须等它
+                    # 成功后才写入会话。若 prepare_turn 失败，上面的异常路径只发
+                    # request_not_accepted，会话 recent_stocks / last_intent 保持
+                    # 不变，避免被拒绝的请求污染后续追问解释。
+                    if web_intent_session is not None and web_intent_resolution is not None:
+                        try:
+                            apply_resolution_to_session(web_intent_session, web_intent_resolution)
+                        except Exception:
+                            logger.warning(
+                                "Failed to persist web intent session context "
+                                "after turn preparation; continuing without it",
+                                exc_info=True,
+                            )
             except asyncio.CancelledError:
                 raise
             except Exception as exc:
@@ -593,17 +788,10 @@ async def agent_chat_stream(
                 yield "data: " + json.dumps(event, ensure_ascii=False) + "\n\n"
                 return
 
-            accepted_event = {
-                "type": "accepted",
-                "backend": backend_id,
-                "request_id": request_id,
-                "session_id": session_id,
-            }
-            yield "data: " + json.dumps(accepted_event, ensure_ascii=False) + "\n\n"
-
-            # Backend execution starts only after the accepted event has been
-            # yielded, so Web state and server persistence share one commit point.
-            fut = loop.run_in_executor(None, run_sync, executor, turn)
+            if not intent_confirmed:
+                # accepted 首事件已在流开头发出；prepare_turn 完成（含会话
+                # 持久化）后才启动后端执行，提交边界语义保持不变。
+                fut = loop.run_in_executor(None, run_sync, executor, turn)
             while True:
                 try:
                     if backend_id == "codex_app_server":

--- a/api/v1/endpoints/agent.py
+++ b/api/v1/endpoints/agent.py
@@ -578,6 +578,9 @@ async def agent_chat_stream(
 
     async def event_generator():
         fut = None
+        intent_confirmed = False
+        web_intent_session: Any = None
+        web_intent_resolution: Any = None
 
         def _accepted_event() -> dict:
             # accepted 是流协议的第一条事件（提交边界）：Web store 只有在收到
@@ -612,9 +615,6 @@ async def agent_chat_stream(
                 # accepted 首事件已在此块之前发出：意图解析即使触发 LLM 兜底
                 # （8s 超时 + 一次重试）也不会推迟前端用户气泡的渲染。
                 # ============================================================
-                intent_confirmed = False
-                web_intent_session: Any = None
-                web_intent_resolution: Any = None
                 if getattr(config, "agent_web_intent_enabled", False):
                     try:
                         # ---- 延迟 import，避免非 Web 场景加载意图模块 ----
@@ -625,7 +625,7 @@ async def agent_chat_stream(
                             build_action_required_event,    # 构建“需用户确认”SSE 事件
                             build_clarification_message,    # 构建澄清问题文本
                             build_intent_resolved_event,    # 构建“意图已解析”SSE 事件
-                            clear_pending_actions,          # 确认流程失败时清理待确认状态
+                            clear_pending_actions,          # 确认流程失败/新请求被拒时清理待确认状态
                         )
                         # 获取或创建当前会话（session_id 唯一标识一次对话）
                         web_intent_session = conversation_manager.get_or_create(session_id)
@@ -764,7 +764,9 @@ async def agent_chat_stream(
                     # prepare_turn 是服务端持久化提交点：意图层上下文必须等它
                     # 成功后才写入会话。若 prepare_turn 失败，上面的异常路径只发
                     # request_not_accepted，会话 recent_stocks / last_intent 保持
-                    # 不变，避免被拒绝的请求污染后续追问解释。
+                    # 不变，避免被拒绝的请求污染后续追问解释；上一轮遗留的
+                    # pending_actions 会在外层 except 中清空，确认窗口随本轮
+                    # 新请求关闭。
                     if web_intent_session is not None and web_intent_resolution is not None:
                         try:
                             apply_resolution_to_session(web_intent_session, web_intent_resolution)
@@ -777,6 +779,23 @@ async def agent_chat_stream(
             except asyncio.CancelledError:
                 raise
             except Exception as exc:
+                # 新请求被拒（request_not_accepted）同样意味着上一轮遗留的
+                # 确认窗口已关闭：只要本轮意图解析成功且不是确认回复，就清掉
+                # 旧的 pending_actions，避免下一轮无关消息被误消费为陈旧确认。
+                if (
+                    web_intent_session is not None
+                    and web_intent_resolution is not None
+                    and getattr(web_intent_resolution, "source", None) != "confirmation"
+                ):
+                    try:
+                        from src.agent.web_intent_resolver import clear_pending_actions
+                        clear_pending_actions(web_intent_session)
+                    except Exception:
+                        logger.warning(
+                            "Failed to clear stale pending intent actions "
+                            "after request_not_accepted",
+                            exc_info=True,
+                        )
                 logger.error("Agent request preparation failed: %s", exc, exc_info=True)
                 event = {
                     "type": "error",

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - [改进] AIHubMix 注册与引流链接统一使用 inferera.com，改善中国大陆网络直连体验。
 - [修复] 单股推送模式在未配置通知渠道时仍会落盘本地个股报告；CLI 启动分析若因空股票列表、个股结果全失败或本地报告保存失败而未生成报告，会显式返回失败并记录原因。
 - [修复] 合并推送模式下即使个股汇总报告落盘失败，仍会先发送已有的合并通知；仅启用大盘复盘但最终未生成任何复盘内容时，分析任务会显式返回失败。
+- [新功能] Web Chat SSE 流新增意图识别层 src/agent/web_intent_resolver.py：覆盖 stock_research/portfolio_review/market_overview/history_followup/general_chat 五类意图，复用和增强 name_to_code 解析，流式优先发出 intent_resolved 事件，低置信度或多候选股票时短路返回 action_required 让用户确认，新增 AGENT_WEB_INTENT_ENABLED 开关（默认开启）
+- [改进] Web Chat 意图识别：AkShare 全量 A 股扩展统一提前至分词管道 Step 6 前执行（首次扩展并入新条目返回 true、已扩展不需要再扩展返回 false），库外真实 A 股由规则路径直接解析，LLM 提及解析不再重复扩展
 
 - [新功能] Agent 工具调用支持按类别（data/search/analysis/action/market）配置默认超时，并允许单工具声明 `timeout_seconds`；有效超时按 first-wins 优先级解析（显式 per-run `tool_call_timeout_seconds` > 单工具显式 `timeout_seconds` > 类别默认 > 无限制），剩余 wall-clock 预算仅作不可突破的外层 cap，超时后返回结构化 `{"timeout": true}` 错误（标记 `retriable: false` 并写入 `non_retriable_tool_results` 防重试重复执行）供 Agent 继续执行而非中断循环（fixes #1890）。
 - [修复] Agent 工具注册表（`src/agent/factory.get_tool_registry`）由模块级缓存改为按「类别超时映射的值」比对失效，规避 CPython 回收对象后地址复用（`id(config)` 相同）导致配置 reload 后的 `Config` 被误判为未变、沿用过期超时的真 bug；新增 `_coerce_config_timeout` 类型白名单，使调用方传入 `MagicMock` / 缺属性 stub / 脏字符串（如 `float(MagicMock())` 静默得到 1.0）时降级为「无类别限制」而非崩溃或强加 1 秒超时；`build_agent_executor(config)` / `build_agent_chat_executor(config)` 现已把调用方 `config` 透传给 `get_tool_registry(config)`（不再无参调用冻结首构 registry）；`main._reload_runtime_config` 与 `SystemConfigService._reload_runtime_singletons`（及 `update()`→`reload_now` 路径）在配置热重载时调用 `reset_tool_registry()` 强制重建；回归测试补充「传入新 config 后 registry 重建」「reload 后新超时应生效」及「builder 透传 config」三类场景（#1890 的 review follow-up，闭环 OR-COM-dd1e8fa7 / OR-COM-bff42110）

--- a/docs/agent-stream-events.md
+++ b/docs/agent-stream-events.md
@@ -42,6 +42,9 @@ Unknown event types should be ignored or displayed with a generic fallback.
 
 | Type | Producer | Meaning | Important Fields |
 | --- | --- | --- | --- |
+| `accepted` | SSE endpoint | The stream commit boundary and mandatory first event. It is emitted immediately, before executor construction, web intent resolution (`intent_resolved` LLM fallback / stock-name downloads) and `prepare_turn`, so the Web store renders the user message bubble right away instead of waiting for intent resolution or agent analysis. | `backend`, `request_id`, `session_id` |
+| `intent_resolved` | web intent resolver (SSE endpoint) | The web intent layer classified the message before any agent work started. Emitted after `accepted` (the stream commit boundary) when `AGENT_WEB_INTENT_ENABLED=true`. | `intent`, `confidence`, `source`, `stock_codes`, `candidates`, `inherited_stock_code`, `needs_confirmation` |
+| `action_required` | web intent resolver (SSE endpoint) | The intent layer will not execute yet: the user must confirm an ambiguous stock pick or a low-confidence intent. A `done` event with the clarification question as `content` follows immediately. The confirmation branch emits the full sequence `accepted` → `intent_resolved` → `action_required` → `done`; `accepted` remains the mandatory first event so existing Web stores do not treat clarification as a protocol error. | `action`, `intent`, `reason`, `candidates`, `unresolved_names`, `message` |
 | `stage_start` | single-agent loop, multi-agent orchestrator | An agent or pipeline stage has started. | `stage`, `message` |
 | `stage_done` | single-agent loop, multi-agent orchestrator | An agent or pipeline stage has completed. | `stage`, `status`, `duration` |
 | `thinking` | single-agent loop | The agent is deciding the next action. | `step`, `message` |
@@ -83,7 +86,7 @@ are mock identifiers only.
 Recommended checks for changes to this contract:
 
 ```bash
-python -m pytest tests/test_agent_stream_events.py tests/test_agent_sse_cleanup.py
+python -m pytest tests/test_agent_stream_events.py tests/test_agent_sse_cleanup.py tests/test_web_intent_resolver.py tests/test_agent_chat_intent_stream.py
 ```
 
 ```bash

--- a/src/agent/executor.py
+++ b/src/agent/executor.py
@@ -583,8 +583,8 @@ def prepare_agent_chat(
             )
         )
 
+    context_parts = []
     if effective_context:
-        context_parts = []
         if effective_context.get("stock_code"):
             context_parts.append(f"股票代码: {effective_context['stock_code']}")
         if effective_context.get("stock_name"):
@@ -613,19 +613,32 @@ def prepare_agent_chat(
         )
         if market_structure_section:
             context_parts.append(market_structure_section.strip())
-        if context_parts:
-            history_messages.extend(
-                [
-                    {
-                        "role": "user",
-                        "content": "[系统提供的历史分析上下文，可供参考对比]\n" + "\n".join(context_parts),
-                    },
-                    {
-                        "role": "assistant",
-                        "content": "好的，我已了解该股票的历史分析数据。请告诉我你想了解什么？",
-                    },
-                ]
-            )
+    # 确认消费轮注入的已解析比较对：确认回复（如"港股"）不含代码，
+    # 工具作用域又只放行这些代码，必须显式告知后端本轮标的与原始请求
+    resolved_stock_codes = [
+        str(code).strip()
+        for code in ((context or {}).get("resolved_stock_codes") or [])
+        if isinstance(code, str) and code.strip()
+    ]
+    if resolved_stock_codes:
+        confirmed_line = "本轮已确认的分析标的: " + "、".join(resolved_stock_codes)
+        original_request = str((context or {}).get("web_intent_original_request") or "").strip()
+        if original_request:
+            confirmed_line += f"（原始请求：{original_request}）"
+        context_parts.append(confirmed_line)
+    if context_parts:
+        history_messages.extend(
+            [
+                {
+                    "role": "user",
+                    "content": "[系统提供的历史分析上下文，可供参考对比]\n" + "\n".join(context_parts),
+                },
+                {
+                    "role": "assistant",
+                    "content": "好的，我已了解该股票的历史分析数据。请告诉我你想了解什么？",
+                },
+            ]
+        )
 
     return PreparedAgentChat(
         system_prompt=system_prompt,

--- a/src/agent/stock_scope.py
+++ b/src/agent/stock_scope.py
@@ -189,14 +189,23 @@ def resolve_stock_scope(
     current_code = _normalize_stock_code(original_context.get("stock_code"))
     invalid_context_code = bool(current_code and _is_denied_candidate(current_code, message_text))
     original_context.pop("allowed_stock_codes", None)
+    # 意图层已解析的股票（确认消费轮的多股比较对）：确认回复（如"港股"）
+    # 本身不含任何代码，这些代码作为显式候选参与作用域推导，且不得流入
+    # 下游 effective_context。
+    resolved_codes: List[str] = []
+    for code in (original_context.pop("resolved_stock_codes", None) or []):
+        normalized = _normalize_stock_code(code)
+        if normalized and normalized not in resolved_codes:
+            resolved_codes.append(normalized)
     if invalid_context_code:
         original_context.pop("stock_code", None)
         original_context.pop("stock_name", None)
         current_code = ""
 
     if not current_code:
-        if invalid_context_code or strict_initial_scope:
+        if invalid_context_code or strict_initial_scope or resolved_codes:
             candidates = extract_stock_codes(message_text)
+            candidates.extend(code for code in resolved_codes if code not in candidates)
             if strict_initial_scope and not invalid_context_code and not candidates:
                 return StockScopeResolution(
                     effective_context=_with_skills(original_context, skills),
@@ -223,6 +232,7 @@ def resolve_stock_scope(
         )
 
     candidates = extract_stock_codes(message_text)
+    candidates.extend(code for code in resolved_codes if code not in candidates)
     new_candidates = [code for code in candidates if code != current_code]
     mode = "maintain"
     effective_context = dict(original_context)

--- a/src/agent/web_intent_resolver.py
+++ b/src/agent/web_intent_resolver.py
@@ -1,0 +1,1830 @@
+# -*- coding: utf-8 -*-
+"""
+Web Chat 意图识别层（Intent Resolution Layer）。
+
+== 模块定位 ==
+本模块与 Bot 分发器（``bot/dispatcher.py``）的自然语言路由并行工作，
+在 Web Chat 的 SSE 流（``POST /api/v1/agent/chat/stream``）中插入一步意图识别。
+
+== 支持的意图类型 ==
+- ``stock_research``     — 个股研究/分析
+- ``portfolio_review``   — 持仓回顾
+- ``market_overview``    — 大盘行情
+- ``history_followup``   — 对上一轮分析的追问
+- ``general_chat``       — 闲聊/与股票分析无关的问题
+
+== 设计边界 ==
+这不是一个完整的 Agent 规划器。意图识别只产生一个轻量级标签 + 股票上下文，
+由 SSE 层据此行动：
+  1. 先发送 ``intent_resolved`` 事件；
+  2. 当置信度低或股票名称歧义时，发送 ``action_required`` 事件中断流程等待用户澄清；
+  3. 将解析出的 ``stock_code`` 传递给 #1619 股票范围（stock-scope）机制。
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any, Dict, List, Optional, Tuple
+
+from src.agent.stream_events import stream_event  # SSE 事件工厂
+from src.agent.stock_scope import extract_stock_codes  # 代码格式校验（不查库）
+from src.services.name_to_code_resolver import (
+    Stock,  # (code/name/market)
+    US_stock_code_match,  # 美股代码匹配
+    extend_AkShare,  # AkShare 全量 A 股扩展（30 分钟缓存，_preprocess_text Step 6 前调用）
+    is_known_stock_name,
+    resolver_name_to_code_list,
+    stockDB,  # 全局名称库（code→name，可被 AkShare 原地扩充）
+)
+from src.data.stock_mapping import STOCK_NAME_MAP  # 代码→名称映射
+
+logger = logging.getLogger(__name__)
+
+
+# =========================================================================
+# 意图常量定义
+# =========================================================================
+
+class WebIntent(str, Enum):
+    """意图标签枚举（str 子类，成员可直接与字符串比较）。"""
+
+    STOCK_RESEARCH = "stock_research"       # 个股研究
+    PORTFOLIO_REVIEW = "portfolio_review"   # 持仓回顾
+    MARKET_OVERVIEW = "market_overview"     # 大盘行情
+    HISTORY_FOLLOWUP = "history_followup"   # 对上一轮分析的追问（未提及新股票）
+    GENERAL_CHAT = "general_chat"           # 闲聊
+
+
+# 所有合法意图（字符串形式），校验 LLM/session 返回
+ALL_WEB_INTENTS = frozenset(w.value for w in WebIntent)
+
+
+# =========================================================================
+# Token 语义标签常量 — 5 大类 20 个标签，近义词归入同一标签，供正则匹配使用
+# =========================================================================
+
+# --- 股票识别 ---
+TAG_UNKNOWN_CODE = "unknown_code"      # 待验证的代码形字符串，Step 2 提取，后续辨认为 stock_code/wrong_code，或保留交由下游 LLM 判断
+TAG_UNKNOWN_NUMBER = "unknown_number"  # ≤4 位裸数字（年份/月份/日期/价格…），非代码候选，Step 2 直接标记，不进入代码校验
+TAG_STOCK_CODE = "stock_code"          # 已验证有效的股票代码（高置信度格式/本地库命中）
+TAG_WRONG_CODE = "wrong_code"          # 无效/非法代码形字符串
+TAG_STOCK_NAME = "stock_name"          # 股票实体（全名或一对一缩写），Step 3 仅全名精确匹配、Step 6 多策略匹配提取
+TAG_CODE_NAME = "code_name"            # 空 tag 经 name_code_list 解析为股票名称后打此标签
+
+# --- 意图主题 ---
+TAG_SUBJECT_RESEARCH = "subject_research"       # 研究主题（走势/趋势/技术面/基本面/筹码）
+TAG_SUBJECT_PORTFOLIO = "subject_portfolio"     # 持仓主题（持仓/仓位/自选股/盈亏）
+TAG_SUBJECT_MARKET = "subject_market"           # 市场标识（A股/港股/美股/沪市…）
+TAG_SUBJECT_MARKET_BROAD = "subject_market_broad"  # 泛市场概念（大盘/行情/指数/两市）
+TAG_SUBJECT_INDEX = "subject_index"             # 具体指数（上证/恒生/纳斯达克/沪深300…）
+
+# --- 动作 ---
+TAG_REQUEST = "request"                 # 分析动作词（分析/看看/研究/诊断/查一下/评估）
+TAG_ACTION_RESEARCH = "action_research"     # 研究决策（能买/可以买/止损/目标价/buy/sell）
+TAG_ACTION_PORTFOLIO = "action_portfolio"   # 持仓操作（加仓/减仓/调仓/满仓/空仓）
+
+# --- 辅助 ---
+TAG_FOLLOWUP = "followup"               # 追问延续（继续/刚才/这只/它/上面/上次/该股）
+TAG_QUESTION = "question"               # 疑问（怎么看/怎么样/涨还是跌/怎么/为何/吗/呢）
+TAG_COMPARISON = "comparison"           # 对比（对比/比较/哪个好/vs/pk/二选一）
+TAG_SECTOR = "sector"                   # 板块/行业（新能源/半导体/消费/医药/AI…）
+TAG_TIME = "time"                       # 时间指示（今天/本周/交易日/实时）
+TAG_FILLER = "filler"                   # 回复填充词（单字独立匹配：的/买/卖/选/那/这…）
+
+# 所有合法 tag 的不可变集合
+_ALL_TAGS = frozenset({
+    TAG_UNKNOWN_CODE, TAG_UNKNOWN_NUMBER, TAG_STOCK_CODE, TAG_WRONG_CODE, TAG_STOCK_NAME, TAG_CODE_NAME,
+    TAG_SUBJECT_RESEARCH, TAG_SUBJECT_PORTFOLIO, TAG_SUBJECT_MARKET,
+    TAG_SUBJECT_MARKET_BROAD, TAG_SUBJECT_INDEX,
+    TAG_REQUEST, TAG_ACTION_RESEARCH, TAG_ACTION_PORTFOLIO,
+    TAG_FOLLOWUP, TAG_QUESTION, TAG_COMPARISON, TAG_SECTOR, TAG_TIME, TAG_FILLER,
+})
+
+
+class Market(str, Enum):
+    """市场标识枚举（str 子类，成员可直接与字符串比较）。"""
+
+    A = "a"    # A 股
+    HK = "hk"  # 港股
+    US = "us"  # 美股
+
+# 执行类意图：会触发 Agent 工作流，低置信度/股票歧义时必须先经用户确认
+_EXECUTING_INTENTS = frozenset({
+    WebIntent.STOCK_RESEARCH,
+    WebIntent.PORTFOLIO_REVIEW,
+    WebIntent.MARKET_OVERVIEW,
+})
+
+# 执行类意图低于此置信度 → 转用户确认
+CONFIRMATION_CONFIDENCE_THRESHOLD = 0.6
+
+# LLM 兜底路径的置信度上限（规则路径 0.8~0.9，LLM 统一压低，避免过度自信）
+LLM_CONFIDENCE_CAP = 0.75
+
+# 会话上下文最多保留的"最近关注股票"数量
+MAX_RECENT_STOCKS = 10
+
+# apply_resolution_to_session() 写入会话上下文时使用的 key
+RECENT_STOCKS_KEY = "recent_stocks"       # 最近关注股票代码列表
+PENDING_ACTIONS_KEY = "pending_actions"   # 待确认动作列表（仅 confirm_stock）
+LAST_INTENT_KEY = "last_intent"           # 上一轮意图标签
+
+
+# =========================================================================
+# Tag → 关键词列表 — 所有中文关键词的唯一定义处
+# =========================================================================
+# 后续正则全部从这里编译，不手写中文关键词；TAG_SUBJECT_MARKET 由 _MARKET_KEYWORD_MAP 派生。
+# 排除项：多 token 跨词模式（和.*比…）→ extra 参数；"值得" → 与股票名"值得买"冲突，已删除
+
+_MARKET_KEYWORD_MAP: Dict[Market, tuple] = {
+    Market.A: ("a股", "大a", "沪市", "深市", "沪深"),
+    Market.HK: ("港股", "h股", "香港"),
+    Market.US: ("美股", "美国"),
+}
+
+# 关键词分两池：clean 无歧义可直接分词；extend 可能与股票名混淆，增加分词多样性。
+# _TAG_KEYWORD_LISTS 由两者合并，下游逻辑不变
+
+_TAG_KEYWORD_LISTS_CLEAN: Dict[str, List[str]] = {
+    TAG_REQUEST: [
+        "分析", "看看", "研究", "诊断", "评估", "查一下", "查下",
+        "analyze", "analyse", "research",
+    ],
+    TAG_SUBJECT_RESEARCH: [
+        "走势", "走向", "趋势", "技术面", "基本面", "筹码", "后市", "trend",
+    ],
+    TAG_ACTION_RESEARCH: [
+        "能买", "可以买", "目标价", "止损", "买点", "卖点", "抄底", "buy", "sell",
+    ],
+    TAG_QUESTION: [
+        "涨还是跌", "怎么看", "怎么样", "怎么", "是否",
+        "为何", "为什么", "还会", "要不要",
+        "能否", "能不能", "如何", "吗", "？", "?",
+    ],
+    TAG_SUBJECT_PORTFOLIO: [
+        "持仓", "仓位", "我的股票", "自选股", "盈亏", "成本价",
+        "portfolio", "position",
+    ],
+    TAG_ACTION_PORTFOLIO: [
+        "加仓", "减仓", "调仓", "满仓", "空仓",
+    ],
+    TAG_SUBJECT_MARKET_BROAD: [
+        "大盘", "行情", "两市", "北向", "股市", "market", "sector", "指数",
+    ],
+    TAG_SUBJECT_INDEX: [
+        "上证", "深证", "创业板", "科创板",
+        "恒指", "纳斯达克", "纳指",
+        "标普", "道琼斯", "道指", "沪深300",
+        "沪指", "深成指", "深证成指", "创业板指", 
+        "科创50", "科创", "index", "indices",
+    ],
+    TAG_FOLLOWUP: [
+        "继续", "接着", "刚才", "上面", "上次", "这只", "该股", "它", "他",
+        "然后",
+    ],
+    TAG_COMPARISON: [
+        "哪个好", "哪个", "哪只", "谁更", "二选一",
+        "差别", "区别", "优劣", "pk",
+    ],
+    TAG_TIME: [
+        "今天", "本周", "交易日", "实时", "最近", 
+    ],
+    TAG_FILLER: [
+        "那个", "这个", "一只", "一下", "帮我", "我要", "我想", "以及", 
+        "其他", "其它",
+    ],
+}
+
+_TAG_KEYWORD_LISTS_EXTEND: Dict[str, List[str]] = {
+    TAG_SUBJECT_INDEX: [
+        "恒生",  # 与股票名"恒生电子"混淆
+    ],
+    TAG_COMPARISON: [
+        "对比", "比较", "多选", "选哪",
+    ],
+    TAG_SECTOR: [
+        "板块", "行业", "赛道", "概念", "题材", "龙头",
+        "新能源", "半导体", "消费", "医药", "白酒",
+        "军工", "银行", "地产", "保险", "券商",
+        "煤炭", "有色", "钢铁", "汽车", "光伏", "锂电",
+        "芯片", "人工智能", "互联网", "金融", "科技股", "AI",
+    ],
+    TAG_FILLER: [
+        "和", "下", "是", "再",
+        "的", "买", "卖", "选", "了", "吧", "呢",
+        "那", "这", "只", "支", "啊", "呀", "咯",
+        "哦", "嘛", "么", "就", "请", "第", "个",
+    ],
+}
+
+_TAG_KEYWORD_LISTS: Dict[str, List[str]] = {}
+for _tag in set(_TAG_KEYWORD_LISTS_CLEAN) | set(_TAG_KEYWORD_LISTS_EXTEND):
+    _TAG_KEYWORD_LISTS[_tag] = (
+        _TAG_KEYWORD_LISTS_CLEAN.get(_tag, []) +
+        _TAG_KEYWORD_LISTS_EXTEND.get(_tag, [])
+    )
+
+# 市场标识关键词 → tag（从 _MARKET_KEYWORD_MAP 派生）
+_MARKET_KW_TAG_MAP: Dict[str, str] = {
+    kw: TAG_SUBJECT_MARKET
+    for keywords in _MARKET_KEYWORD_MAP.values()
+    for kw in keywords
+}
+
+# market keyword → Market 枚举（反转，O(1) 查询）
+_KW_TO_MARKET: Dict[str, Market] = {
+    kw: mkt for mkt, keywords in _MARKET_KEYWORD_MAP.items() for kw in keywords
+}
+
+# keyword → tag（反转 + 市场词合并，供 _classify_keyword O(1) 查询）
+_KEYWORD_TAG_MAP: Dict[str, str] = {
+    kw: tag for tag, kws in _TAG_KEYWORD_LISTS.items() for kw in kws
+}
+_KEYWORD_TAG_MAP.update(_MARKET_KW_TAG_MAP)
+
+
+
+# =========================================================================
+# 正则编译工具 — 全部从 _TAG_KEYWORD_LISTS 编译
+# =========================================================================
+
+def _compile_kw_fragment(kw: str) -> str:
+    """单个关键词 → regex 片段：ASCII 包裹 (?i:)，CJK 直接 escape。"""
+    if re.search(r"[A-Za-z]", kw):
+        return f"(?i:{re.escape(kw)})"
+    return re.escape(kw)
+
+
+def _compile_kw_pattern(*tags: str, extra: str = "") -> re.Pattern:
+    """从指定 tag 列表提取所有关键词，编译为单个正则。
+
+    按长度降序排列确保长关键词优先（"沪深300" 不被 "沪深" 截断）。
+    extra 参数可追加原生 regex 片段（如 vs 词边界、多 token 跨词模式）。
+    """
+    kws: List[str] = []
+    for tag in tags:
+        if tag == TAG_SUBJECT_MARKET:
+            kws.extend(_MARKET_KW_TAG_MAP.keys())
+        else:
+            kws.extend(_TAG_KEYWORD_LISTS.get(tag, []))
+    fragments = sorted(
+        ({_compile_kw_fragment(k) for k in kws} |
+         ({extra} if extra else set())),
+        key=len, reverse=True,
+    )
+    return re.compile("|".join(fragments))
+
+
+# Step 5 关键词分词正则（排除市场类 tag，Step 4 独立处理，避免 "大港股份" 消歧失效）
+_NON_MARKET_TAGS = frozenset({
+    TAG_REQUEST, TAG_SUBJECT_RESEARCH, TAG_ACTION_RESEARCH, TAG_QUESTION,
+    TAG_SUBJECT_PORTFOLIO, TAG_ACTION_PORTFOLIO,
+    TAG_FOLLOWUP, TAG_COMPARISON, TAG_SECTOR, TAG_TIME, TAG_FILLER,
+})
+
+
+def _compile_clean_kw_pattern(*tags: str) -> re.Pattern:
+    """仅用 _TAG_KEYWORD_LISTS_CLEAN 编译正则，排除可能混淆股票名的扩展关键词。"""
+    kws: List[str] = []
+    for tag in tags:
+        kws.extend(_TAG_KEYWORD_LISTS_CLEAN.get(tag, []))
+    fragments = sorted({_compile_kw_fragment(k) for k in kws}, key=len, reverse=True)
+    return re.compile("|".join(fragments))
+
+
+# Step 5 无歧义关键词分词正则（如"分析""走势""持仓"等不可能混淆股票名的词）
+_CLEAN_KEYWORDS_PATTERN = _compile_clean_kw_pattern(*_NON_MARKET_TAGS)
+
+
+# 纯标点/空白过滤：至少含一个 CJK/字母/数字
+_HAS_CONTENT_PATTERN = re.compile(r"[\u3400-\u9fffA-Za-z0-9]")
+
+# 特殊标点集合（Step 1 分词边界）。排除 * - .：可能出现在股票名/代码中（ST*、600519.SH）
+_SPECIAL_PUNCT_CHARS = (
+    "\uff0c\u3002\uff01\uff1f\uff1b\uff1a\u3001\u201c\u201d\u2018\u2019"
+    "\uff08\uff09\u3010\u3011\u300a\u300b\u2026\uff5e\u2014\uff0f\uff20"
+    "\uff03\uff04\uff05\uff3e\uff06\uff0b\uff1d"
+    ",!?;:\"'()[]{}<>/@#$%^&+=~`|\\\\"
+)
+_SPECIAL_PUNCT_RE = re.compile("[" + re.escape(_SPECIAL_PUNCT_CHARS) + "]")
+
+
+def _classify_keyword(token_text: str) -> str:
+    """查 _KEYWORD_TAG_MAP 取语义标签；混合大小写 token 做 lower() 回退；未命中返回空串。"""
+    tag = _KEYWORD_TAG_MAP.get(token_text)
+    if tag:
+        return tag
+    lowered = token_text.lower()
+    if lowered != token_text:
+        return _KEYWORD_TAG_MAP.get(lowered, "")
+    return ""
+
+
+# =========================================================================
+# LLM 意图分类 Prompt — 仅在规则无法判定时调用
+# =========================================================================
+
+_INTENT_PARSE_PROMPT = """\
+You are the intent classifier for a stock-analysis assistant web chat.
+
+Classify the user message into exactly one intent:
+- "stock_research": research/analyze specific stock(s) — price, trend,
+  buy/sell advice, technicals, fundamentals, news
+- "portfolio_review": review the user's own holdings / positions / P&L
+- "market_overview": overall market, indices, sectors
+- "history_followup": follow-up about the previous analysis turn, with no
+  new stock mentioned
+- "general_chat": chit-chat or questions unrelated to stock analysis
+
+Also extract every stock mentioned in the message into "stock_mentions".
+Resolve each mention to its canonical code using the "Stock mapping" section
+appended below whenever the stock appears there, and use the code exactly as
+written in the mapping — do NOT add exchange prefixes like "HK" or "SH", and
+do NOT invent codes that are not listed. When a mentioned stock is absent from
+the mapping, fall back to its Chinese name (e.g. "贵州茅台"); when only a
+ticker or English name is known, return it as written (e.g. "TSLA", "Tesla").
+
+The user message may be followed by a "Conversation context" section listing:
+- previous_intent: the intent of the previous turn
+- recent_stocks: stock codes recently discussed
+- current_focus_stock: the stock currently locked in the UI
+Use it ONLY to resolve pronouns and ellipsis ("它", "这只", "还会涨吗"):
+choose "history_followup" only when the message continues the previous
+analysis subject and names no new stock; if the message names a different
+stock, choose "stock_research" and extract that name instead.
+
+Return a JSON object and NOTHING else:
+{"intent": "...", "stock_mentions": ["canonical code or Chinese name or ticker", ...], "confidence": 0.0-1.0, "market": "a"/"hk"/"us"/null}
+
+The "market" field indicates which market the user is referring to, 
+set null if no specific market or not applicable (portfolio_review, general_chat, etc.)
+For market_overview, always infer the market if possible (e.g. "大盘" → "a", "港股行情" → "hk", "美股走势" → "us"). 
+For stock_research, infer from the stock mentioned or conversation context.
+
+Examples:
+User: "帮我分析一下贵州茅台"
+{"intent":"stock_research","stock_mentions":["600519"],"confidence":0.9,"market":"a"}
+
+User: "研究一下腾讯最近的走势"
+{"intent":"stock_research","stock_mentions":["00700"],"confidence":0.9,"market":"hk"}
+
+User: "我的持仓今天怎么样"
+{"intent":"portfolio_review","stock_mentions":[],"confidence":0.9,"market":null}
+
+User: "今天大盘走势如何"
+{"intent":"market_overview","stock_mentions":[],"confidence":0.9,"market":"a"}
+
+User: "港股最近行情怎么样"
+{"intent":"market_overview","stock_mentions":[],"confidence":0.9,"market":"hk"}
+
+User: "它还能涨吗"
+{"intent":"history_followup","stock_mentions":[],"confidence":0.8,"market":null}
+
+User: "你好，在吗"
+{"intent":"general_chat","stock_mentions":[],"confidence":0.95,"market":null}
+
+User: "compare AAPL and TSLA"
+{"intent":"stock_research","stock_mentions":["AAPL","TSLA"],"confidence":0.9,"market":"us"}
+"""
+
+
+# =========================================================================
+# WebIntentResolution — 单次意图识别的完整结果
+# =========================================================================
+
+@dataclass
+class WebIntentResolution:
+    """一次 Web Chat 意图识别流程的完整产出。
+
+    各字段的含义：
+    - ``intent``: 最终的意图标签（来自 ALL_WEB_INTENTS 之一）
+    - ``confidence``: 置信度 [0.0, 1.0]，影响是否需要用户确认。
+      注意：本层输出的置信度是**按决策路径赋的常量**（显式代码 0.9、关键词独高
+      0.85、LLM 上限 0.75…），用于表达"这条路径的可靠程度"，并非从打分分差
+      导出的校准概率；前端展示时不应将其解读为统计意义的成功概率。
+    - ``source``: 意图来源标识
+        - ``"rule"`` — 正则/规则直接判定
+        - ``"llm"`` — LLM 分类结果
+        - ``"context"`` — 从会话上下文中继承（如继承 current_stock 推断为追问）
+        - ``"confirmation"`` — 用户对上一个待确认动作的响应
+    - ``stocks``: 能精确解析出的股票列表（已去重），每项为 Stock(code, name, market)
+    - ``candidates``: 能解析名字，但股票名称有歧义时的候选列表，每项为 Stock(code, name, market)
+    - ``unresolved_names``: 无法解析为任何代码的股票名称（用户可能拼错了）
+    - ``inherited_stock_code``: 从会话/请求上下文中继承的当前股票代码（#1619 机制）
+    - ``needs_confirmation``: True 表示该意图需要用户确认后才能执行
+    - ``reason``: 需要确认时的原因说明（如 "ambiguous_stock_name" / "low_confidence" / "stock_unresolved"）
+    - ``pending_action``: 需要用户执行的确认动作描述，供 SSE 层发送 action_required 事件
+    - ``market``: LLM 推断的市场上下文（Market 枚举），无法推断时为 None。
+      主要用于 market_overview 指定市场范围，以及辅助跨市场股票名称消歧。
+    """
+
+    intent: WebIntent
+    confidence: float
+    source: str = "rule"       # 默认为规则来源
+    stocks: List[Stock] = field(default_factory=list)
+    candidates: List[Stock] = field(default_factory=list)
+    unresolved_names: List[str] = field(default_factory=list)
+    inherited_stock_code: str = ""
+    needs_confirmation: bool = False
+    reason: str = ""
+    pending_action: Optional[Dict[str, Any]] = None
+    market: Optional[Market] = None      # LLM 市场推断，无法推断时为 None
+    original_request: str = ""           # 确认消费轮：待确认动作对应的原请求文本
+
+    def __post_init__(self) -> None:
+        """将 stocks/candidates 中的字符串或 dict 条目统一转为 Stock。"""
+        self.stocks = [
+            Stock(code=s) if isinstance(s, str) else s
+            for s in self.stocks
+        ]
+        self.candidates = [
+            Stock(code=c["code"], name=c.get("name", ""), market=c.get("market", ""))
+            if isinstance(c, dict) else c
+            for c in self.candidates
+        ]
+
+    @property
+    def primary_stock_code(self) -> str:
+        """返回注入 stock-scope 的主股票代码。
+
+        单代码直接返回；多代码（比较场景）返回空串交执行端处理——绝不能返回
+        继承代码，否则"对比000858和300750"会错误锁定上一轮的 600519；
+        无代码时返回继承代码保持锁定。
+        """
+        if len(self.stocks) == 1:
+            return self.stocks[0].code
+        if len(self.stocks) >= 2:
+            return ""
+        return self.inherited_stock_code
+
+
+# =========================================================================
+# 意图决策辅助
+# =========================================================================
+
+def _log_resolution(path: str, resolution: "WebIntentResolution") -> None:
+    """记录意图决策 info 日志（一行），打分明细在 debug 级。"""
+    logger.info(
+        "[WebIntent] resolved via %s: intent=%s confidence=%.2f source=%s reason=%s codes=%s inherited=%s confirm=%s",
+        path,
+        resolution.intent,
+        resolution.confidence,
+        resolution.source,
+        resolution.reason or "-",
+        ",".join(s.code for s in resolution.stocks) or "-",
+        resolution.inherited_stock_code or "-",
+        resolution.needs_confirmation,
+    )
+
+
+# =========================================================================
+# Token — 分词结构体，text + tag
+# =========================================================================
+
+
+@dataclass(frozen=True)
+class Token:
+    """分词结构体：文本 + 语义标签 + 可选的已解析股票实体。
+
+    frozen=True 使 Token 可哈希；tag 为空表示未识别；stocks 透传已解析实体避免下游重复解析。
+    """
+    text: str
+    tag: str = ""
+    stocks: Optional[List["Stock"]] = None
+
+
+def _extract_markets_from_tokens(tokens: List[Token]) -> List[Market]:
+    """从 token 中提取市场枚举（唯一提取点）：TAG_SUBJECT_MARKET → _KW_TO_MARKET，
+    另识别 ASCII 简写 "us"/"hk"。消歧已在 _split_market_tokens 完成，此处仅映射。"""
+    markets: List[Market] = []
+    seen: set = set()
+    for t in tokens:
+        if t.tag == TAG_SUBJECT_MARKET:
+            mkt = _KW_TO_MARKET.get(t.text.lower())
+            if mkt and mkt not in seen:
+                markets.append(mkt)
+                seen.add(mkt)
+        elif t.text.strip().lower() in ("us", "hk"):
+            mkt = Market(t.text.strip().lower())
+            if mkt not in seen:
+                markets.append(mkt)
+                seen.add(mkt)
+    return markets
+
+
+def _detect_markets(text: str) -> List[str]:
+    """文本级市场检测（确认流程快速回复用）。
+
+    整条消息为 "us"/"hk" → 直接返回；否则扫描中文市场关键词。英文句中的代词
+    "us"（"tell us"）不做子串匹配，不会误命中。
+    """
+    stripped = (text or "").strip()
+    lowered = stripped.lower()
+    if lowered in ("us", "hk"):
+        return [lowered]
+    markets: List[str] = []
+    seen: set = set()
+    for kw, mkt in _KW_TO_MARKET.items():
+        if kw in stripped and mkt.value not in seen:
+            markets.append(mkt.value)
+            seen.add(mkt.value)
+    return markets
+
+
+def _recognition_rate(tokens: List[Token]) -> float:
+    """已打标签 token 占全部 token 的比例，低则升级 LLM 兜底。"""
+    if not tokens:
+        return 0.0
+    return sum(1 for t in tokens if t.tag) / len(tokens)
+
+
+def _dedup_stocks(stocks: List[Stock]) -> List[Stock]:
+    """按 code 去重并保持出现顺序。"""
+    seen: set = set()
+    result: List[Stock] = []
+    for s in stocks:
+        if s.code not in seen:
+            seen.add(s.code)
+            result.append(s)
+    return result
+
+
+def _research_request_with_unresolved(tokens: List[Token]) -> bool:
+    """研究请求中是否仍有未识别 token。
+
+    股票名千变万化，名称库覆盖有限：研究请求（分析/看看…）下未识别的 token 很可能
+    就是研究对象（"再分析一下你好股份"中的"你好股份"），规则无法定论 → 升级 LLM，
+    不能误判为对上一轮股票的追问。
+    """
+    has_request = False
+    has_unresolved = False
+    for t in tokens:
+        if t.tag == TAG_REQUEST:
+            has_request = True
+        elif not t.tag or t.tag == TAG_UNKNOWN_NUMBER:  # 空tag/None 未识别；4位裸数字（年份/日期/价格）同样不落规则，交给LLM
+            has_unresolved = True
+    return has_request and has_unresolved
+
+
+# =========================================================================
+# _preprocess_text 六步管道辅助函数
+# =========================================================================
+
+# 市场分词 pattern = 市场相关 tag 关键词 union。"股"+"份" 消歧见 _split_market_tokens，
+# 避免 "大港股份" 中的 "港股" 子串被误提取
+_MARKET_TOKEN_PATTERN = _compile_kw_pattern(
+    TAG_SUBJECT_MARKET, TAG_SUBJECT_MARKET_BROAD, TAG_SUBJECT_INDEX,
+)
+
+
+# ---- _CODE_CANDIDATE_PATTERNS — 代码形字符串候选正则（_split_by_codes 专用） ----
+# 宽松匹配（宁多勿漏）：找出所有"看起来像股票代码"的片段打 TAG_UNKNOWN_CODE，
+# 合法性交给下游 _identify_stock_codes。唯一例外：≤4 位裸数字由 _split_by_codes
+# 直接标记为 TAG_UNKNOWN_NUMBER，不进入代码校验。
+# 设计要点：纯文本匹配不查库；同位置多正则命中取最长；不做市场推断。
+# 覆盖形态：
+#   1. 交易所前缀+数字        SH600519 / HK88888（SH/SZ/BJ/HK）
+#   2. 数字.交易所后缀        123456.HK / 235454354.sh
+#   3. 裸数字                 600519 / 12（≤4 位 → unknown_number）
+#   4. 美股连续大写 ticker    BABA / TSLA（左右不紧邻字母数字）
+#   5. 连续字母 + .us 后缀    aapl.us / BABA.US（大小写不敏感）
+_CODE_CANDIDATE_PATTERNS: List[Tuple[str, int]] = [
+    # 1. 交易所前缀 + 任意位数字: SH600519, HK88888, SZ123
+    (r'(?<![a-zA-Z])(?:SH|SZ|BJ|HK)\d{1,}(?!\d)', re.IGNORECASE),
+    # 2. 数字.交易所后缀: 123456.HK, 235454354.sh
+    (r'(?<!\d)\d{1,}\.(?:SH|SZ|BJ|HK)(?!\d)', re.IGNORECASE),
+    # 3. 裸任意位数字: 600519, 12, 6005199（≤4 位裸数字可能并非代码意图，会在 _split_by_codes 直接标记为 unknown_number）
+    (r'(?<!\d)\d{1,}(?!\d)', 0),
+    # 4. 美股连续大写 ticker: BABA, TSLA（左右边界为汉字/标点，不得紧邻小写字母）
+    (r'(?<![A-Za-z0-9.])([A-Z]{2,5})(?![A-Za-z0-9])', 0),
+    # 5. 连续字母 + .us 后缀（大小写不敏感）: aapl.us, BABA.US, Tsla.us
+    (r'(?<![A-Za-z0-9.])([A-Za-z]{1,5}\.us)(?![A-Za-z0-9])', re.IGNORECASE),
+]
+
+
+def _split_by_codes(text: str) -> List[Token]:
+    """宽口径代码形字符串提取（Step 2 对空 tag token 调用）。
+
+    扫描 5 类正则命中"像代码"的片段 → TAG_UNKNOWN_CODE，间隙文本保留为空 tag token。
+    此阶段只做形态匹配与最大连续合并，不校验合法性、不推断市场：
+      "600519"/"HK3294384923"/"TSLA" → unknown_code；"12" → unknown_number
+
+    不复用 extract_stock_codes：它内置首码白名单（0/3/6/4/8），会丢弃 777777 这类
+    非法代码；本函数保留非法代码形字符串，供下游 SSE 二次确认。
+    """
+    if not text:
+        return []
+
+    # 阶段 1：全部正则独立扫描收集 span，重叠/嵌套交由阶段 2 合并
+    spans: List[Tuple[int, int]] = []
+    for pattern, flags in _CODE_CANDIDATE_PATTERNS:
+        for m in re.finditer(pattern, text, flags):
+            spans.append((m.start(), m.end()))
+
+    # 无命中 → 整段文本作为一个空 tag token 返回
+    if not spans:
+        return [Token(text)]
+
+    # 阶段 2：最大连续合并。重叠 span 扩展右边界取最长字母/数字片段
+    # （"HK3294384923" 的 (0,12)/(2,12) → (0,12)，不被子串截断）
+    spans.sort()
+    merged: List[Tuple[int, int]] = []
+    for s, e in spans:
+        if merged and s < merged[-1][1]:
+            if e > merged[-1][1]:
+                merged[-1] = (merged[-1][0], e)
+        else:
+            merged.append((s, e))
+
+    # 阶段 3：按合并后 span 切分：候选 → unknown_code；间隙 → 空 tag token
+    tokens: List[Token] = []
+    pos = 0
+    for s, e in merged:
+        if pos < s:
+            gap = text[pos:s].strip()
+            if gap:
+                tokens.append(Token(gap))
+        span_text = text[s:e]
+        if span_text.isdigit() and len(span_text) <= 4:
+            # ≤4 位裸数字 → unknown_number（纯数字 span 只可能来自裸数字正则）
+            tokens.append(Token(span_text, TAG_UNKNOWN_NUMBER))
+        else:
+            tokens.append(Token(span_text, TAG_UNKNOWN_CODE))
+        pos = e
+    tail = text[pos:].strip()
+    if tail:
+        tokens.append(Token(tail))
+    return tokens
+
+
+def _apply_code_extraction(tokens: List[Token]) -> List[Token]:
+    """Step 2: 对空 tag token 做代码形提取（已识别 token 受保护）。"""
+    result: List[Token] = []
+    for t in tokens:
+        if _is_identified_token(t):
+            result.append(t)
+        else:
+            result.extend(_split_by_codes(t.text))
+    return result
+
+
+def _market_of_code(code: str) -> str:
+    """从代码形态推断市场：6 位→a、5 位→hk、字母 ticker→us（与
+    name_to_code_resolver._infer_code_market 语义一致）。"""
+    c = (code or "").strip().upper()
+    if not c:
+        return ""
+    if c.isdigit():
+        if len(c) == 5:
+            return "hk"
+        if len(c) == 6:
+            return "a"
+        return ""
+    if re.match(r"^[A-Z]{1,5}(\.[A-Z])?$", c):
+        return "us"
+    return ""
+
+
+def _build_entity_index() -> Tuple[List[str], Dict[str, List[Tuple[str, str]]]]:
+    """构建实体扫描用的名称索引：全名去重保序列表 + 全名 → [(code, market)]。
+
+    每个待扫描 token 重建一次（stockDB 可能被 AkShare 扩充，不能跨消息缓存）。
+    AkShare 扩展统一在 _preprocess_text Step 6 前执行（extend_AkShare）；
+    本函数只读当时的 stockDB，绝不主动发起扩展。
+    """
+    names: List[str] = []
+    name_codes: Dict[str, List[Tuple[str, str]]] = {}
+    for code, name in stockDB.items():
+        if not name or not code:
+            continue
+        if name not in name_codes:
+            names.append(name)
+            name_codes[name] = []
+        market = _market_of_code(code)
+        if market:
+            name_codes[name].append((code, market))
+    return names, name_codes
+
+
+# 实体扫描窗口长度：固定 4~3 字精确匹配；超过 4 字的名字由 Step 6
+# resolver_name_to_code_list 承接
+_MAX_ENTITY_LEN = 4
+
+
+def _split_by_stock_entities(text: str) -> List[Token]:
+    """Step 3 子函数：多股票实体扫描（仅全名精确匹配，最长优先、非重叠）。
+
+    逐位置尝试 4~3 字窗口：窗口必须整体等于库中股票全名，禁止子串/拼音/模糊
+    等其它形式；一对一缩写（"茅台""三花"）非全名不做匹配，交由 Step 6 多策略
+    匹配承接。
+      - 窗口恰好等于库中全名且唯一 1 只 → TAG_STOCK_NAME 确定实体；
+      - 跨市场同名多只（"阿里巴巴"→hk 09988/us BABA）→ TAG_STOCK_NAME
+        携带多候选，下游 _classify_by_rules 走歧义确认；
+    未命中片段保留为空 tag token 交后续步骤（宁可不做也不做错）。
+    """
+    if not text:
+        return []
+    if not any("\u3400" <= ch <= "\u9fff" for ch in text):
+        return [Token(text)]  # 纯英文段由 Step 6 DFS（拼音/美股代码）兜底
+    names, name_codes = _build_entity_index()
+    max_len = min(_MAX_ENTITY_LEN, max((len(n) for n in names), default=0))
+    tokens: List[Token] = []
+    i, gap_start, n = 0, 0, len(text)
+    while i < n:
+        matched = False
+        for length in range(max_len, 2, -1):
+            if i + length > n:
+                continue
+            window = text[i:i + length]
+            if not any("\u3400" <= ch <= "\u9fff" for ch in window):
+                continue  # 不含 CJK 的窗口不扫描（代码/ASCII 由其他步骤处理）
+            pairs = name_codes.get(window)  # 仅全名精确匹配：窗口必须整体等于库中股票全名
+            if pairs:
+                stocks = [
+                    Stock(code=code, name=window, market=market)
+                    for code, market in pairs
+                ]
+                if gap_start < i:
+                    tokens.append(Token(text[gap_start:i]))
+                tokens.append(Token(window, TAG_STOCK_NAME, stocks=stocks))
+                i += length
+                gap_start = i
+                matched = True
+                break
+        if not matched:
+            i += 1
+    if gap_start < n:
+        tokens.append(Token(text[gap_start:]))
+    return tokens
+
+
+def _apply_full_name_extraction(tokens: List[Token]) -> List[Token]:
+    """Step 3: 对非代码 token 做多股票全名精确匹配扫描（仅全名）。
+
+    一对一缩写（"茅台""三花"）非全名不做匹配，交由 Step 6 多策略匹配承接；
+    已识别 token（代码/已知名称）保持原样，未被前序步骤识别的 token 交给
+    _split_by_stock_entities 做仅全名精确匹配扫描。
+    """
+    result: List[Token] = []
+    for t in tokens:
+        if _is_identified_token(t):
+            result.append(t)
+        else:
+            result.extend(_split_by_stock_entities(t.text))
+    return result
+
+
+def _split_market_tokens(text: str) -> List[Token]:
+    """Step 4 子函数：提取市场关键词打 tag。"股"后接"份"（股票名后缀）跳过不上报。"""
+    if not text:
+        return []
+    tokens: List[Token] = []
+    pos = 0
+    for m in _MARKET_TOKEN_PATTERN.finditer(text):
+        s, e = m.start(), m.end()
+        matched = m.group()
+        if matched.endswith("股") and e < len(text) and text[e] == "份":
+            continue
+        if pos < s:
+            gap = text[pos:s].strip()
+            if gap:
+                tokens.append(Token(gap))
+        tag = _classify_keyword(matched)
+        tokens.append(Token(matched, tag))
+        pos = e
+    tail = text[pos:].strip()
+    if tail:
+        tokens.append(Token(tail))
+    return tokens
+
+
+def _apply_market_extraction(tokens: List[Token]) -> List[Token]:
+    """Step 4: 对非代码/非全名 token 做市场关键词提取 + 股份消歧。"""
+    result: List[Token] = []
+    for t in tokens:
+        if _is_identified_token(t):
+            result.append(t)
+        else:
+            result.extend(_split_market_tokens(t.text))
+    return result
+
+
+# ── Step 5: 无歧义关键词提取 ──────────────────────────────────────────────
+
+def _tokenize_by_clean_keywords(text: str) -> List[Token]:
+    """Step 5 子函数：无歧义关键词分词，间隙保留为空 tag token 交 Step 6。"""
+    tokens: List[Token] = []
+    pos = 0
+    for m in _CLEAN_KEYWORDS_PATTERN.finditer(text):
+        gap = text[pos:m.start()].strip()
+        if gap:
+            tokens.append(Token(gap))
+        tokens.append(Token(m.group(), _classify_keyword(m.group())))
+        pos = m.end()
+    tail = text[pos:].strip()
+    if tail:
+        tokens.append(Token(tail))
+    return tokens
+
+
+def _apply_clean_keyword_extraction(tokens: List[Token]) -> List[Token]:
+    """Step 5: 对未识别 token 用无歧义关键词（如"分析""走势""怎样"）分词。"""
+    result: List[Token] = []
+    for t in tokens:
+        if _is_identified_token(t):
+            result.append(t)
+        else:
+            result.extend(_tokenize_by_clean_keywords(t.text))
+    return result
+
+
+# ── Step 6 调用入口 — 直接走多策略智能匹配 ──────────────────
+
+
+def _isAlpha(s: str) -> bool:
+    """检测字符串是否为纯英文字母（a-z, A-Z）。"""
+    return bool(s) and all(c.isascii() and c.isalpha() for c in s)
+
+
+def _dfs_match(text: str) -> Optional[List[Token]]:
+    """深度优先全匹配：0 位置起匹配关键词/股票名并递归剩余文本；无法全匹配返回 None（宁可不做也不做错）。"""
+    if len(text) == 0:
+        return []
+    
+    # 以字母开头：提取连续英文字母组成的单词
+    if _isAlpha(text[0]):
+        # 直接组成连续的最大单词 例如 "Alibaba的基本面" → "Alibaba", "的基本面"
+        i = 1
+        while i < len(text) and _isAlpha(text[i]):
+            i += 1
+        segment = text[:i]
+        # 纯英文 做 股票名拼音检测 和 美国股票代码检测
+        stock_list = resolver_name_to_code_list(segment) + US_stock_code_match(segment)
+        if stock_list:
+            rest = _dfs_match(text[i:])
+            if rest is not None:
+                return [Token(segment, TAG_STOCK_NAME, stocks=stock_list)] + rest
+
+    # 尝试连续 2~4 汉字片段（优先长匹配）
+    for length in (4, 3, 2, 1):
+        if length > len(text):
+            continue
+        segment = text[:length]
+
+        # 不分割连续的字母
+        if _isAlpha(segment[-1]) and length < len(text) and _isAlpha(text[length]):
+            continue
+
+        # 递归搜索匹配，策略不变
+        tag = _classify_keyword(segment)  # 全部关键词（clean + extend）
+        stock_list = []
+        if not tag:
+            stock_list = resolver_name_to_code_list(segment)
+        if tag or len(stock_list) > 0:
+            rest = _dfs_match(text[length:])
+            if rest is not None:
+                return [Token(segment, tag or TAG_STOCK_NAME, stocks=stock_list or None)] + rest
+
+    return None
+
+
+# 动态混合匹配文本
+def _multi_match(text: str) -> List[Token]:
+    """多策略智能匹配：DFS 匹配 2~4 字关键词/名字子串；无法完全匹配则原样返回（宁可不做也不做错）。"""
+    if not text:
+        return []
+    result = _dfs_match(text)
+    return result if result is not None else [Token(text)]
+
+def _apply_multi_extraction(tokens: List[Token]) -> List[Token]:
+    """Step 6: 对每个空 tag token 做多策略智能匹配，已打 tag 的 token 受保护。"""
+    result: List[Token] = []
+    for t in tokens:
+        if t.tag:
+            result.append(t)
+        else:
+            result.extend(_multi_match(t.text))
+    return result
+
+
+def _is_identified_token(token: Token) -> bool:
+    """Token 是否已被前序步骤识别（有 tag 或是已知股票名/代码）。"""
+    if token.tag:
+        return True
+    if is_known_stock_name(token.text):
+        return True
+    return False
+
+
+def _split_by_special_punct(text: str) -> List[Token]:
+    """按特殊标点边界切分（排除 * 和 -）；标点本身留作空 tag token，后续 _HAS_CONTENT_PATTERN 过滤。"""
+    if not text:
+        return []
+    tokens: List[Token] = []
+    pos = 0
+    for m in _SPECIAL_PUNCT_RE.finditer(text):
+        if pos < m.start():
+            gap = text[pos:m.start()].strip()
+            if gap:
+                tokens.append(Token(gap))
+        tokens.append(Token(m.group()))
+        pos = m.end()
+    tail = text[pos:].strip()
+    if tail:
+        tokens.append(Token(tail))
+    return tokens
+
+
+def _preprocess_text(text: str) -> Tuple[str, List[Token]]:
+    """六步管道分词，返回 (原文本, token列表)。
+
+    Step 1 标点切分 → Step 2 代码形（unknown_code，≤4 位裸数字 → unknown_number）→
+    Step 3 多股票实体扫描（全名精确匹配）→ Step 4 市场关键词 → Step 5 无歧义
+    关键词 → Step 6 多策略匹配。unknown_code 由 _identify_stock_codes 辨认为
+    stock_code/wrong_code，或保留交 LLM。
+
+    Step 6 前先用 AkShare 全量 A 股扩充本地名称库（extend_AkShare，30 分钟缓存，
+    全模块唯一的扩展调用点）：首次扩展并入新条目（返回 True）时，对未识别 token
+    重跑 Step 3 全名精确扫描，库外真实 A 股（酒鬼酒/三花智控等）以确定实体标签
+    进入 Step 6；已扩展过（返回 False）直接跳过，零网络、零重复遍历。
+    """
+    # ---- 六步管道 ----
+    tokens = _split_by_special_punct(text)          # Step 1: 特殊标点符号提取和分词（排除 * - .）
+    tokens = _apply_code_extraction(tokens)         # Step 2: 代码形字符串（unknown_code）
+    tokens = _apply_full_name_extraction(tokens)    # Step 3: 股票全名匹配（本地静态库）
+    tokens = _apply_market_extraction(tokens)       # Step 4: 市场关键词
+    tokens = _apply_clean_keyword_extraction(tokens)  # Step 5: 无歧义关键词
+    # Step 6 前：AkShare 扩展本地名称库。首次扩展并入新条目（True）时对未识别
+    # token 重跑全名精确扫描，扩展名以确定实体标签进入 Step 6；已扩展（False）跳过。
+    if extend_AkShare():
+        tokens = _apply_full_name_extraction(tokens)
+    tokens = _apply_multi_extraction(tokens)        # Step 6: 多策略子串智能匹配
+
+    # 过滤纯标点/空白 token
+    tokens = [t for t in tokens if t.text.strip() and _HAS_CONTENT_PATTERN.search(t.text)]
+
+    return text, tokens
+
+def _validate_code_candidate(text: str) -> Optional[bool]:
+    """单个代码形字符串的合法性校验（_identify_stock_codes 专用）。
+
+    数字代码沿用 extract_stock_codes 格式判定（6 位 A 股 0/3/6/4/8 首码、5 位港股、
+    显式交易所形态 → stock_code；777777/SH1 等 → wrong_code）。
+    美股 ticker 仅本地库命中（US_stock_code_match）→ stock_code；库外（SOFI）→
+    None 保留 unknown_code 交 LLM，绝不硬猜。
+    ≤4 位裸数字不会到达本函数（已在 _split_by_codes 标记为 unknown_number）。
+
+    Returns: True → stock_code；False → wrong_code；None → 保持 unknown_code
+    """
+    if any(ch.isdigit() for ch in text):
+        # 数字代码：沿用原 extract_stock_codes 格式判定（不查库，纯格式）
+        return True if extract_stock_codes(text) else False
+
+    # 纯字母 → 美股 ticker（含 .us/.X 后缀）：仅本地库命中才认可，
+    # 库外美股（如 SOFI）保留 unknown_code 交由下游 LLM 判断。
+    ticker = text.split(".", 1)[0].upper()
+    return True if US_stock_code_match(ticker) else None
+
+
+def _identify_stock_codes(tokens: List[Token]) -> List[Token]:
+    """对 TAG_UNKNOWN_CODE 做格式校验 → stock_code / wrong_code，或保留 unknown_code 交 LLM。"""
+    result: List[Token] = []
+    for t in tokens:
+        if t.tag != TAG_UNKNOWN_CODE:
+            result.append(t)
+            continue
+        verdict = _validate_code_candidate(t.text)
+        if verdict is True:
+            result.append(Token(t.text, TAG_STOCK_CODE))
+        elif verdict is False:
+            result.append(Token(t.text, TAG_WRONG_CODE))
+        else:
+            result.append(t)  # 存疑：保持 unknown_code，交由下游 LLM 判断
+    return result
+
+
+def _normalize_intent_label(value: Any) -> Optional[str]:
+    """规范化 LLM 返回的意图标签（去首尾空白、转小写、连字符/空格统一为下划线、去尾部标点）。"""
+    if not isinstance(value, str):
+        return None
+    label = value.strip().lower().replace(" ", "_").replace("-", "_")
+    label = label.strip(".,;:!?。，；：！？")
+    return label or None
+
+
+def _extract_json_object(text: str) -> Optional[str]:
+    """从 LLM 噪声输出中提取第一个完整 JSON 对象（处理嵌套与字符串内花括号）。"""
+    start = text.find("{")
+    if start < 0:
+        return None
+    depth = 0
+    in_string = False
+    escaped = False
+    for i in range(start, len(text)):
+        ch = text[i]
+        if in_string:
+            if escaped:
+                escaped = False
+            elif ch == "\\":
+                escaped = True
+            elif ch == '"':
+                in_string = False
+        elif ch == '"':
+            in_string = True
+        elif ch == "{":
+            depth += 1
+        elif ch == "}":
+            depth -= 1
+            if depth == 0:
+                return text[start:i + 1]
+    return None
+
+
+def _load_json_object(text: str) -> Any:
+    """先严格 json.loads，失败再回退到提取内容中的 JSON 对象。"""
+    try:
+        return json.loads(text)
+    except json.JSONDecodeError:
+        pass
+    fragment = _extract_json_object(text)
+    if fragment is None:
+        return None
+    try:
+        return json.loads(fragment)
+    except json.JSONDecodeError:
+        return None
+
+
+def _parse_llm_payload(raw: str) -> Optional[Dict[str, Any]]:
+    """解析 LLM 返回的 JSON 负载：处理空串/BOM/markdown 围栏/夹杂文字，
+    规范化 market（变体统一为 Market 枚举）与 stock_mentions（字符串转列表、
+    过滤空白）。无 intent 字段或解析失败 → 记告警返回 None。
+    """
+
+    # market 字段规范化：LLM 各种变体 → Market 枚举
+    _MARKET_NORMALIZE: Dict[str, Optional[Market]] = {
+        "a": Market.A, "a_share": Market.A, "a股": Market.A,
+        "ashare": Market.A, "a-share": Market.A, "ashares": Market.A,
+        "shanghai": Market.A, "shenzhen": Market.A,
+        "hk": Market.HK, "港股": Market.HK,
+        "hongkong": Market.HK, "hong_kong": Market.HK,
+        "h-share": Market.HK, "hshare": Market.HK,
+        "us": Market.US, "美股": Market.US,
+        "american": Market.US, "america": Market.US, "usa": Market.US,
+    }
+
+    cleaned = (raw or "").strip().lstrip("\ufeff")
+    if not cleaned:
+        return None
+    # 处理 LLM 常见的 markdown 代码块包裹（可能带 ```json 前缀，或结尾夹带解释文字）
+    if "```" in cleaned:
+        cleaned = re.sub(r"```(?:json|JSON)?\s*", "", cleaned).strip()
+    result = _load_json_object(cleaned)
+    if result is None:
+        logger.warning("[WebIntent] unparseable LLM payload: %s", cleaned[:200])
+        return None
+    # 最终校验：必须是一个包含 "intent" 键的字典
+    if isinstance(result, dict) and "intent" in result:
+        # 规范化 market 字段
+        if "market" in result and result["market"]:
+            raw_market = str(result["market"]).strip().lower()
+            result["market"] = _MARKET_NORMALIZE.get(raw_market)
+        else:
+            result["market"] = None
+        # 规范化 stock_mentions：字符串单提及 → 列表；过滤非字符串/空白条目
+        mentions = result.get("stock_mentions")
+        if isinstance(mentions, str):
+            mentions = [mentions]
+        if isinstance(mentions, list):
+            result["stock_mentions"] = [
+                m.strip() for m in mentions if isinstance(m, str) and m.strip()
+            ]
+        else:
+            result["stock_mentions"] = []
+        return result
+    logger.warning("[WebIntent] unexpected LLM payload: %s", cleaned[:200])
+    return None
+
+
+def _has_competing_intent(tokens: List[Token], candidate_codes: set) -> bool:
+    """弱子串确认的守卫：消息是否携带与"确认"竞争的意图锚点。
+
+    仅"包含"候选名称的消息若同时带研究/追问/对比/提问等意图关键词，或提及
+    候选以外的股票（代码/名称），说明它不是纯粹的确认回复（如"再分析下阿里
+    巴巴最近走势"、"阿里巴巴和腾讯对比一下"），应按新消息重新分类，绝不静默
+    确认候选列表中的第一只。
+    """
+    for t in tokens:
+        if t.tag in (
+            TAG_REQUEST, TAG_SUBJECT_RESEARCH, TAG_ACTION_RESEARCH,
+            TAG_FOLLOWUP, TAG_COMPARISON, TAG_QUESTION,
+        ):
+            return True
+        if t.tag in (TAG_STOCK_CODE, TAG_WRONG_CODE):
+            if t.text.lower() not in candidate_codes:
+                return True
+        elif t.tag == TAG_STOCK_NAME and t.stocks:
+            if any(s.code.lower() not in candidate_codes for s in t.stocks):
+                return True
+    return False
+
+
+# =========================================================================
+# WebIntentResolver — 核心意图解析器
+# =========================================================================
+
+class WebIntentResolver:
+    """Web Chat 单条消息的意图解析器。
+
+    == 整体流程（六步管道）==
+    resolve() 采用"廉价优先、逐层升级"的级联架构：
+
+      1. 空消息短路 → general_chat（置信度 1.0），最廉价、最确定的短路路径。
+      2. 分词 + 实体识别（_preprocess_text 六步管道）：
+         产出代码（stock_code/wrong_code）、已知名称（含歧义候选）、
+         市场、意图关键词等 token 与实体信号。
+      3. 消费待确认动作：用户对上一轮 action_required 的回复（选代码/名称/
+         市场）直接确认，仅消费紧邻的下一轮。
+      4. 基于 token 的规则分类：证据充分（识别率全 + 置信度高）时直接定论
+         返回，绝不调用 LLM；证据不足时返回 None 升级 LLM。
+      5. LLM 兜底：仅规则无解时调用，单次、超时即止损，超时/失败静默降级。
+      6. 规则兜底：规则与 LLM 均无法判定时，返回最保守的 general_chat，
+         不阻塞对话、不改变原有行为。
+    """
+
+    def __init__(self, config: Any = None, *, llm_adapter: Any = None, llm_timeout: float = 8.0):
+        """config: 全局配置（懒加载 LLM 适配器）；llm_adapter: 预建适配器（测试注入）；
+        llm_timeout: 意图分类超时秒数（在首 token 延迟关键路径上，超时自动降级规则兜底）。"""
+        self._config = config
+        self._llm_adapter = llm_adapter        # 可注入的 LLM 适配器（便于测试）
+        self.llm_timeout = llm_timeout
+
+    # ------------------------------------------------------------------
+    # resolve() — 主入口
+    # ------------------------------------------------------------------
+
+    def resolve(
+        self,
+        message: str,
+        *,
+        session_context: Optional[Dict[str, Any]] = None,
+        request_context: Optional[Dict[str, Any]] = None,
+    ) -> WebIntentResolution:
+        """解析一条用户消息的意图（模块主入口，SSE 层调用后据此执行/确认/提示）。
+
+        session_context: 会话级上下文（pending_actions / recent_stocks）。
+        request_context: 单次请求上下文，stock_code 为 #1619 当前锁定值，优先级高于 session。
+        """
+        # ===== 输入规范化 =====
+
+        # None → 空串并去空白
+        text = (message or "").strip()
+        # 防御非 dict 的调用方
+        session_context = session_context if isinstance(session_context, dict) else {}
+        request_context = request_context if isinstance(request_context, dict) else {}
+
+        # ===== 步骤 1: 空消息短路 → 闲聊（最廉价、最确定的路径） =====
+
+        if not text:
+            empty = WebIntentResolution(
+                intent=WebIntent.GENERAL_CHAT,
+                confidence=1.0,          # 无歧义，置信度最高
+                reason="empty_message",
+            )
+            _log_resolution("empty", empty)
+            return empty
+
+        # ===== 步骤 2: 分词 + 实体识别（六步管道） =====
+        text, tokens = _preprocess_text(text)
+        tokens = _identify_stock_codes(tokens)  # 可能耗时
+
+        # ===== 步骤 3: 消费待确认动作（仅紧邻的下一轮，未命中按新消息处理） =====
+        confirmed = self._consume_pending_action(text, tokens, session_context)
+        if confirmed is not None:
+            _log_resolution("confirmation", confirmed)
+            return confirmed
+
+        # ===== 步骤 4: 规则分类（证据充分直接定论，否则升级 LLM） =====
+        logger.debug(
+            "[WebIntent] tokens=%s rate=%.2f",
+            [t.text for t in tokens], _recognition_rate(tokens),
+        )
+        rule_result = self._classify_by_rules(tokens, text, session_context, request_context)
+        if rule_result is not None:
+            _log_resolution("rule", rule_result)
+            return rule_result
+
+        # ===== 步骤 5: LLM 兜底（单次、超时即止损） =====
+        llm_result = self._classify_by_llm(text, session_context, request_context)
+        if llm_result is not None:
+            _log_resolution("llm", llm_result)
+            return llm_result
+
+        # ===== 步骤 6: 静默降级 → 最保守 general_chat，不阻塞对话 =====
+        fallback = WebIntentResolution(
+            intent=WebIntent.GENERAL_CHAT,
+            confidence=0.6,
+            reason="rule_fallback",
+        )
+        _log_resolution("fallback", fallback)
+        return fallback
+
+    # ------------------------------------------------------------------
+    # 步骤 3 辅助 — 待确认动作消费
+    # ------------------------------------------------------------------
+
+    def _consume_pending_action(
+        self,
+        text: str,
+        tokens: List[Token],
+        session_context: Dict[str, Any],
+    ) -> Optional[WebIntentResolution]:
+        """消费上一轮遗留的 confirm_stock 待确认动作。
+
+        判定顺序（证据强度递减）：
+          1. 整条回复精确等于候选代码 → 直接确认；
+          2. 整条回复精确等于候选名称 → 名称在候选中唯一时确认
+             （同名跨市场候选无法靠名称区分，不确认）；
+          3. 市场词把候选收窄到唯一一只 → 确认（优先于弱子串匹配，
+             "美股阿里巴巴"不会被"阿里巴巴"子串抢先命中成 09988）；
+          4. 回复仅"包含"候选名称 → 仅当其不含其他意图锚点（研究/追问/
+             对比/提问/其他股票）时才视为确认，否则按新消息重新分类
+             （"阿里巴巴和腾讯对比一下"、"再分析下阿里巴巴最近走势"），
+             绝不静默选第一只。
+        未命中返回 None，动作按新消息自然清空。
+        """
+        pending = session_context.get(PENDING_ACTIONS_KEY) or []
+        if not pending:
+            return None
+        action = pending[0]
+        if not isinstance(action, dict) or action.get("action") != "confirm_stock":
+            return None
+        candidates = [
+            Stock(c["code"], c.get("name", ""), c.get("market", ""))
+            for c in (action.get("candidates") or [])
+            if isinstance(c, dict) and c.get("code")
+        ]
+        # 原请求中已解析的股票（如"对比阿里巴巴和腾讯控股"中的腾讯 00700）在
+        # 确认后必须保留，否则确认消费只注入被选中的候选，比较/多股语义丢失
+        resolved_stocks = [
+            Stock(c["code"], c.get("name", ""), c.get("market", ""))
+            for c in (action.get("resolved_stocks") or [])
+            if isinstance(c, dict) and c.get("code")
+        ]
+        if not candidates:
+            # 低置信度确认（无候选）→ 用户的下一条消息按新消息重新分类
+            return None
+        original_request = action.get("original_request") or ""
+        stripped = text.strip()
+
+        # 1) 整条消息精确等于候选代码 → 无歧义，直接确认
+        for cand in candidates:
+            if stripped.lower() == cand.code.lower():
+                return self._confirmed_resolution(cand, resolved_stocks, original_request)
+
+        # 2) 整条消息精确等于候选名称 → 仅当该名称在候选中唯一（同名跨市场
+        #    候选如 09988/BABA 都叫"阿里巴巴"无法靠名称区分，不确认）
+        named = [c for c in candidates if c.name and stripped == c.name]
+        if len(named) == 1:
+            return self._confirmed_resolution(named[0], resolved_stocks, original_request)
+
+        # 3) 市场词收窄：回复含明确市场信号且收窄到唯一候选 → 确认。
+        #    必须优先于"名称子串"匹配，否则"美股阿里巴巴"会被第一只候选
+        #    的"阿里巴巴"子串抢先确认，忽略美股提示。
+        #    同时必须跳过带竞争意图锚点的消息（研究/追问/对比/其他股票），
+        #    否则"帮我分析一下港股腾讯"会被"港股"抢先确认成 09988，把用户
+        #    对腾讯的新请求吞掉（与分支 4 一致）。
+        markets = _detect_markets(text)
+        if markets and not _has_competing_intent(tokens, {c.code.lower() for c in candidates}):
+            filtered = [c for c in candidates if c.market in markets]
+            if len(filtered) == 1:
+                return self._confirmed_resolution(filtered[0], resolved_stocks, original_request)
+
+        # 4) 弱子串匹配：消息包含候选名称 → 仅当无竞争意图锚点时才视为确认；
+        #    含研究/追问/对比/提问/其他股票 → 按新消息重新分类，绝不静默猜第一只
+        if not _has_competing_intent(tokens, {c.code.lower() for c in candidates}):
+            for cand in candidates:
+                if cand.name and cand.name in text:
+                    same_name = [c for c in candidates if c.name == cand.name]
+                    if len(same_name) > 1:
+                        # 同名跨市场候选无法由名称区分 → 不确认，交由重分类
+                        return None
+                    return self._confirmed_resolution(cand, resolved_stocks, original_request)
+        return None
+
+    @staticmethod
+    def _confirmed_resolution(
+        cand: Stock,
+        resolved_stocks: List[Stock],
+        original_request: str = "",
+    ) -> WebIntentResolution:
+        """用户确认候选股票后的确定性结果。
+
+        确认的候选与原请求中已解析的股票合并保留（如"对比阿里巴巴和腾讯控股"
+        确认港股阿里后仍保留腾讯 00700，多股比较语义不丢失）；original_request
+        携带原请求文本，供 SSE 层把比较语义显式传入本轮执行。
+        """
+        stocks = _dedup_stocks([cand] + list(resolved_stocks))
+        return WebIntentResolution(
+            intent=WebIntent.STOCK_RESEARCH,
+            confidence=0.95,
+            source="confirmation",
+            stocks=stocks,
+            reason="confirmed_stock",
+            original_request=original_request,
+        )
+
+    # ------------------------------------------------------------------
+    # 步骤 4 辅助 — 规则分类
+    # ------------------------------------------------------------------
+
+    def _classify_by_rules(
+        self,
+        tokens: List[Token],
+        text: str,
+        session_context: Dict[str, Any],
+        request_context: Dict[str, Any],
+    ) -> Optional[WebIntentResolution]:
+        """基于 token 的规则分类，按证据强度递减判定。
+
+        命中明确证据即返回定论（置信度为路径常量）；无证据返回 None 交 LLM。规则路径绝不产生模糊结果。
+        """
+        # 持仓优先级最高
+        if any(t.tag in (TAG_SUBJECT_PORTFOLIO, TAG_ACTION_PORTFOLIO) for t in tokens):
+            return WebIntentResolution(
+                intent=WebIntent.PORTFOLIO_REVIEW,
+                confidence=0.85,           # 关键词命中
+                reason="portfolio_keyword",
+            )
+
+        # 存疑代码 token（unknown_code）且带研究/追问等股票锚点 → 规则无法安全定论，
+        # 升级 LLM（宁可不做也不做错）；纯板块/市场语境不升级
+        if any(t.tag == TAG_UNKNOWN_CODE for t in tokens):
+            has_stock_anchor = any(
+                t.tag in (TAG_REQUEST, TAG_FOLLOWUP, TAG_STOCK_CODE, TAG_WRONG_CODE, TAG_STOCK_NAME)
+                for t in tokens
+            )
+            has_market_context = any(
+                t.tag in (TAG_SECTOR, TAG_SUBJECT_MARKET_BROAD, TAG_SUBJECT_INDEX)
+                for t in tokens
+            )
+            if has_stock_anchor and not has_market_context:
+                return None
+
+        stocks: List[Stock] = []
+        candidates: List[Stock] = []
+        wrong_codes: List[str] = []
+        for t in tokens:
+            if t.tag == TAG_STOCK_CODE:
+                stocks.append(Stock(t.text))
+            elif t.tag == TAG_STOCK_NAME and t.stocks:
+                if len(t.stocks) == 1:
+                    stocks.append(t.stocks[0])
+                else:
+                    candidates.extend(t.stocks)
+            elif t.tag == TAG_WRONG_CODE:
+                wrong_codes.append(t.text)
+
+        # 名称歧义 → 待确认
+        if candidates:
+            candidates = _dedup_stocks(candidates)
+            stocks = _dedup_stocks(stocks)
+            pending = {
+                "action": "confirm_stock",
+                "candidates": _candidates_to_dicts(candidates),
+            }
+            if stocks:
+                # 原请求中已解析的股票（如"对比阿里巴巴和腾讯控股"中的腾讯 00700）
+                # 必须在确认后保留，否则确认消费只注入被选中的候选、比较语义丢失
+                pending["resolved_stocks"] = _candidates_to_dicts(stocks)
+            if text:
+                # 保留原始请求文本，确认消费后执行端可据此还原多股比较语义
+                pending["original_request"] = text
+            return WebIntentResolution(
+                intent=WebIntent.STOCK_RESEARCH,
+                confidence=0.85,
+                stocks=stocks,
+                candidates=candidates,
+                needs_confirmation=True,
+                reason="ambiguous_stock_name",
+                pending_action=pending,
+            )
+
+        # 显式代码/唯一已解析名称 → 直接定论个股研究
+        if stocks:
+            return WebIntentResolution(
+                intent=WebIntent.STOCK_RESEARCH,
+                confidence=0.9,            # 显式代码
+                stocks=_dedup_stocks(stocks),
+                reason="explicit_stock",
+            )
+
+        # 无效代码/裸数字 → 个股研究但无法解析，需确认；旁有市场/指数上下文
+        # （"沪深300" 被拆成 沪深+300）→ 大盘行情；无市场上下文不触发确认，绝不把数字当股票代码
+        if wrong_codes or any(t.tag == TAG_UNKNOWN_NUMBER for t in tokens):
+            if any(t.tag in (TAG_SUBJECT_MARKET, TAG_SUBJECT_MARKET_BROAD, TAG_SUBJECT_INDEX) for t in tokens):
+                markets = _extract_markets_from_tokens(tokens)
+                return WebIntentResolution(
+                    intent=WebIntent.MARKET_OVERVIEW,
+                    confidence=0.85,
+                    reason="market_keyword",
+                    market=markets[0] if markets else None,
+                )
+            if wrong_codes:
+                return WebIntentResolution(
+                    intent=WebIntent.STOCK_RESEARCH,
+                    confidence=0.8,
+                    unresolved_names=wrong_codes,
+                    needs_confirmation=True,
+                    reason="stock_unresolved",
+                    pending_action={"action": "confirm_stock", "unresolved_names": wrong_codes},
+                )
+
+        # 市场/指数/板块关键词 → 大盘行情
+        if any(t.tag in (TAG_SUBJECT_MARKET_BROAD, TAG_SUBJECT_INDEX, TAG_SECTOR) for t in tokens):
+            markets = _extract_markets_from_tokens(tokens)
+            return WebIntentResolution(
+                intent=WebIntent.MARKET_OVERVIEW,
+                confidence=0.85,
+                reason="market_keyword",
+                market=markets[0] if markets else None,
+            )
+
+        # 追问/研究 + 继承股票 → 对上一轮分析的追问
+        inherited = self._inherit_current_stock(session_context, request_context)
+        if inherited and any(
+            t.tag in (TAG_FOLLOWUP, TAG_REQUEST) for t in tokens
+        ):
+            # 例外：研究请求含未识别 token（如"你好股份"）→ 升级 LLM，不误继承当前股票
+            if _research_request_with_unresolved(tokens):
+                return None
+            return WebIntentResolution(
+                intent=WebIntent.HISTORY_FOLLOWUP,
+                confidence=0.8,
+                inherited_stock_code=inherited,
+                reason="followup_inherit",
+            )
+
+        # 完全无识别：无上下文 → 闲聊；有上下文（可能追问）→ 升级 LLM
+        if _recognition_rate(tokens) == 0.0:
+            if not self._inherit_current_stock(session_context, request_context) \
+                    and not session_context.get(LAST_INTENT_KEY):
+                return WebIntentResolution(
+                    intent=WebIntent.GENERAL_CHAT,
+                    confidence=0.9,
+                    reason="no_signal",
+                )
+            return None
+
+        # 证据不足 → 升级 LLM
+        return None
+
+    @staticmethod
+    def _inherit_current_stock(
+        session_context: Dict[str, Any],
+        request_context: Dict[str, Any],
+    ) -> str:
+        """继承当前关注股票：#1619 请求级 stock_code 优先，其次 session recent_stocks 首位。
+        规则分类的股票分支在前，天然排除本轮显式代码。"""
+        code = (request_context.get("stock_code") or "").strip()
+        if code:
+            return code
+        recent = session_context.get(RECENT_STOCKS_KEY) or []
+        return recent[0] if recent and isinstance(recent[0], str) else ""
+
+    # ------------------------------------------------------------------
+    # 步骤 5 辅助 — LLM 兜底
+    # ------------------------------------------------------------------
+
+    def _get_llm_adapter(self) -> Any:
+        """懒加载 LLM 适配器（仅规则无解时才创建，避免无谓初始化 litellm）。"""
+        if self._llm_adapter is None and self._config is not None:
+            from src.agent.llm_adapter import LLMToolAdapter
+            self._llm_adapter = LLMToolAdapter(self._config)
+        return self._llm_adapter
+
+    def _classify_by_llm(
+        self,
+        text: str,
+        session_context: Dict[str, Any],
+        request_context: Dict[str, Any],
+    ) -> Optional[WebIntentResolution]:
+        """LLM 意图分类兜底：单次调用、超时即止损，任何失败返回 None 静默降级。"""
+        adapter = self._get_llm_adapter()
+        if adapter is None:
+            return None
+        try:
+            # is_available 在真实适配器上是 property（返回 bool），
+            # 兼容方法形态（旧版/测试桩）两种接口
+            available = getattr(adapter, "is_available", True)
+            if callable(available):
+                available = available()
+            if not available:
+                return None
+            ctx_lines = []
+            prev = session_context.get(LAST_INTENT_KEY)
+            if prev:
+                ctx_lines.append(f"- previous_intent: {prev}")
+            recent = session_context.get(RECENT_STOCKS_KEY) or []
+            if recent:
+                ctx_lines.append(f"- recent_stocks: {', '.join(str(c) for c in recent[:5])}")
+            focus = (request_context.get("stock_code") or "").strip()
+            if focus:
+                ctx_lines.append(f"- current_focus_stock: {focus}")
+            user_content = f"User: {text}"
+            if ctx_lines:
+                user_content += "\n\nConversation context:\n" + "\n".join(ctx_lines)
+
+            # 将 src.data.stock_mapping 的 STOCK_NAME_MAP，塞进 prompt 辅助命名实体识别(槽位识别)
+            system_prompt = _INTENT_PARSE_PROMPT + "\n\nStock mapping (code - name):\n" + json.dumps(STOCK_NAME_MAP, ensure_ascii=False)
+
+            resp = self._call_llm_with_retry(adapter, system_prompt, user_content)
+            payload = _parse_llm_payload(resp.content)
+            if payload is None:
+                return None
+            return self._build_llm_resolution(payload, session_context, request_context)
+        except Exception as exc:
+            # 静默降级：只记一行告警（异常类型即可），不输出完整堆栈，不阻塞对话
+            logger.warning("[WebIntent] LLM classification failed (%s), falling back to rules", exc.__class__.__name__)
+            return None
+
+    def _call_llm_with_retry(
+        self,
+        adapter: Any,
+        system_prompt: str,
+        user_content: str,
+    ) -> Any:
+        """单次意图分类调用，瞬断（超时）错误重试一次；鉴权/配置等永久性错误不重试。"""
+        messages = [
+            {"role": "system", "content": system_prompt},
+            {"role": "user", "content": user_content},
+        ]
+        for attempt in range(2):
+            resp = adapter.call_text(messages, timeout=self.llm_timeout)
+            if not self._is_transient_llm_error(resp):
+                return resp
+            if attempt == 0:
+                logger.warning(
+                    "[WebIntent] LLM call transient failure, retrying once: %s",
+                    (getattr(resp, "content", "") or "")[:120],
+                )
+        return resp
+
+    @staticmethod
+    def _is_transient_llm_error(resp: Any) -> bool:
+        """判断 LLM 响应是否为可重试的瞬断错误（连接/读写超时）。"""
+        if resp is None or getattr(resp, "provider", "") != "error":
+            return False
+        text = (getattr(resp, "content", "") or "").lower()
+        return "timeout" in text or "timed out" in text
+
+    def _build_llm_resolution(
+        self,
+        payload: Dict[str, Any],
+        session_context: Dict[str, Any],
+        request_context: Dict[str, Any],
+    ) -> Optional[WebIntentResolution]:
+        """将 LLM JSON 负载组装为 WebIntentResolution。
+
+        意图标签规范化；置信度封顶 LLM_CONFIDENCE_CAP（非数值按 0.5）；执行类意图
+        低置信度（<0.6）转确认；提及歧义/解析不出进 unresolved（AkShare 全量 A 股
+        已在分词阶段并入本地库，此处只查库，绝不虚构代码）；追问意图未提及新股票
+        时继承当前股票。
+        """
+        intent = _normalize_intent_label(payload.get("intent"))
+        if intent not in ALL_WEB_INTENTS:
+            logger.warning("[WebIntent] LLM returned invalid intent %r", payload.get("intent"))
+            return None
+        try:
+            confidence = min(float(payload.get("confidence") or 0.5), LLM_CONFIDENCE_CAP)
+        except (TypeError, ValueError):
+            confidence = min(0.5, LLM_CONFIDENCE_CAP)
+        # stock_mentions 已是 LLM 识别结果，本地库解析只做规范化与消歧增强
+        market = payload.get("market")
+        stocks, candidates, unresolved = self._resolve_mentions(
+            payload.get("stock_mentions") or []
+        )
+        # 用 LLM 市场推断打破跨市场同名歧义：候选恰好只有一只与推断市场一致时直接采纳
+        if market and candidates and not stocks:
+            market_filtered = [c for c in candidates if c.market == market]
+            if len(market_filtered) == 1:
+                candidates = []
+                stocks = market_filtered
+        resolution = WebIntentResolution(
+            intent=WebIntent(intent),
+            confidence=confidence,
+            source="llm",
+            stocks=stocks,
+            candidates=candidates,
+            unresolved_names=unresolved,
+            market=payload.get("market"),
+        )
+        if (
+            resolution.intent == WebIntent.HISTORY_FOLLOWUP
+            and not stocks
+            and not candidates
+        ):
+            # 追问且未提及新股票：继承当前股票，保持 #1619 股票锁定
+            resolution.inherited_stock_code = self._inherit_current_stock(
+                session_context, request_context
+            )
+        if resolution.intent in _EXECUTING_INTENTS and confidence < CONFIRMATION_CONFIDENCE_THRESHOLD:
+            resolution.needs_confirmation = True
+            resolution.reason = "low_confidence"
+            resolution.pending_action = {"action": "confirm_stock", "reason": "low_confidence"}
+        elif (
+            resolution.intent == WebIntent.STOCK_RESEARCH
+            and (candidates or unresolved)
+        ):
+            # 与规则路径（_classify_by_rules 歧义分支）保持同一契约：提及有歧义/
+            # 未解析股票即转确认，且已解析的股票一并保留在 pending_action 中，
+            # 确认消费后与所选候选合并，不静默丢失多股比较的其它标的。
+            resolution.needs_confirmation = True
+            resolution.reason = "ambiguous_stock_name" if candidates else "stock_unresolved"
+            pending = {
+                "action": "confirm_stock",
+                "candidates": _candidates_to_dicts(candidates),
+                "unresolved_names": unresolved,
+            }
+            if stocks:
+                pending["resolved_stocks"] = _candidates_to_dicts(stocks)
+            resolution.pending_action = pending
+        return resolution
+
+    @staticmethod
+    def _resolve_mentions(
+        mentions: List[str],
+    ) -> Tuple[List[Stock], List[Stock], List[str]]:
+        """将 LLM 提取的股票提及转为 (唯一股票, 歧义候选, 未解析名称)。
+
+        AkShare 全量 A 股已在分词阶段（_preprocess_text Step 6 前）并入本地库，
+        这里只查库、不再次扩展；解析不出进 unresolved，绝不虚构代码。
+        """
+        stocks: List[Stock] = []
+        candidates: List[Stock] = []
+        unresolved: List[str] = []
+        for mention in mentions:
+            mention = (mention or "").strip()
+            if not mention:
+                continue
+            codes = extract_stock_codes(mention)
+            if codes:
+                stocks.extend(Stock(code) for code in codes)
+                continue
+            matches = resolver_name_to_code_list(mention) + US_stock_code_match(mention)
+            if len(matches) == 1:
+                stocks.append(matches[0])
+            elif len(matches) > 1:
+                candidates.extend(matches)
+            else:
+                unresolved.append(mention)
+        return _dedup_stocks(stocks), _dedup_stocks(candidates), unresolved
+        
+
+# =========================================================================
+# 会话上下文持久化（conversation.py 的 session sink）
+# =========================================================================
+
+
+def apply_resolution_to_session(session: Any, resolution: WebIntentResolution) -> None:
+    """将意图识别结果写入会话上下文（供下一轮步骤 3/4 读取）。
+
+    - recent_stocks: 新代码 + 继承代码 + 已有代码，去重取前 MAX_RECENT_STOCKS 条，
+      新代码在前保证最近使用的优先被继承。
+    - last_intent: 本轮意图标签。
+    - pending_actions: needs_confirmation 时写入确认动作，否则清空。
+    session 用鸭子类型（getattr），避免循环依赖。
+    """
+
+    # 鸭子类型检测：确保 session 有 context 属性且为 dict
+    context = getattr(session, "context", None)
+    if not isinstance(context, dict):
+        return  # 不兼容的 session 对象，静默跳过
+
+    # 过滤非法元素后取已有最近股票
+    existing = [
+        code
+        for code in (context.get(RECENT_STOCKS_KEY) or [])
+        if isinstance(code, str) and code
+    ]
+
+    # 新代码 + 继承代码
+    new_codes = [s.code for s in resolution.stocks]
+    if resolution.inherited_stock_code:
+        new_codes.append(resolution.inherited_stock_code)
+
+    # 去重合并（保持插入顺序，新代码在前）
+    merged: List[str] = []
+    for code in new_codes + existing:
+        if code not in merged:
+            merged.append(code)
+
+    # 写入上下文并裁剪上限
+    session.update_context(RECENT_STOCKS_KEY, merged[:MAX_RECENT_STOCKS])
+    session.update_context(LAST_INTENT_KEY, resolution.intent)
+
+    # 待确认动作：有则写入覆盖，无则清空
+    if resolution.needs_confirmation and resolution.pending_action:
+        session.update_context(PENDING_ACTIONS_KEY, [resolution.pending_action])
+    else:
+        session.update_context(PENDING_ACTIONS_KEY, [])
+
+
+def clear_pending_actions(session: Any) -> None:
+    """清除会话中残留的待确认动作（确认流程失败时的清理入口）。
+
+    apply_resolution_to_session 在 needs_confirmation 时先把 pending_actions
+    写入会话；若随后澄清文本构建 / 会话历史写入失败，端点短路返回错误，
+    必须同步清掉已写入的待确认状态，否则下一轮消息会被 _consume_pending_action
+    误当成上一轮失败确认流程的回复，执行旧的歧义请求。
+    """
+    context = getattr(session, "context", None)
+    if not isinstance(context, dict):
+        return
+    session.update_context(PENDING_ACTIONS_KEY, [])
+
+
+# =========================================================================
+# SSE 事件构建器（#1871 叠加合约）
+# =========================================================================
+
+
+def _candidates_to_dicts(candidates: List[Stock]) -> List[Dict[str, str]]:
+    """将 Stock 候选列表转为前端可序列化的 dict 列表。"""
+    return [{"code": stock.code, "name": stock.name, "market": stock.market} for stock in candidates]
+
+
+def build_intent_resolved_event(resolution: WebIntentResolution) -> Dict[str, Any]:
+    """构建 intent_resolved SSE 事件（Agent 开始工作前发送给前端）。
+
+    约定：空列表字段序列化为 None 减少体积；confidence 保留两位小数去噪。
+    """
+
+    return stream_event(
+        "intent_resolved",
+        intent=resolution.intent,
+        confidence=round(resolution.confidence, 2),
+        source=resolution.source,
+        stock_codes=[s.code for s in resolution.stocks] or None,
+        candidates=_candidates_to_dicts(resolution.candidates) or None,
+        inherited_stock_code=resolution.inherited_stock_code or None,
+        needs_confirmation=resolution.needs_confirmation or None,
+        market=resolution.market or None,
+    )
+
+
+def build_action_required_event(resolution: WebIntentResolution) -> Dict[str, Any]:
+    """构建 action_required SSE 事件（needs_confirmation=True 时发送，前端展示确认界面）。
+
+    message 由 build_clarification_message 生成，可直接展示给用户。
+    """
+
+    return stream_event(
+        "action_required",
+        action="confirm_stock",
+        intent=resolution.intent,
+        reason=resolution.reason or None,
+        candidates=_candidates_to_dicts(resolution.candidates) or None,
+        unresolved_names=resolution.unresolved_names or None,
+        message=build_clarification_message(resolution),
+    )
+
+
+# 市场 → 中文标签（澄清提示用）
+_MARKET_LABELS: Dict[Market, str] = {Market.A: "A股", Market.HK: "港股", Market.US: "美股"}
+
+
+def build_clarification_message(resolution: WebIntentResolution) -> str:
+    """构建面向用户的澄清提示文本。
+
+    按优先级：1) 名称歧义 → 列出候选（最多 5 个）；2) 名称无法识别 → 提示检查拼写；
+    3) 低置信度 → 引导补充意图方向；4) 默认 → 引导提供股票名称/代码。
+    """
+
+    # 场景 1: 歧义候选
+    if resolution.candidates:
+        lines = ["你说的股票可能指以下几只，请回复股票代码或名称确认："]
+        for cand in resolution.candidates[:5]:  # 最多 5 个，避免信息过载
+            label = _MARKET_LABELS.get(cand.market, cand.market)
+            suffix = f"（{label}）" if label else ""
+            lines.append(f"- {cand.code} {cand.name or ''}{suffix}".rstrip())
+        return "\n".join(lines)
+
+    # 场景 2: 名称无法识别
+    if resolution.unresolved_names:
+        names = "、".join(resolution.unresolved_names)
+        return (
+            f"没有查到「{names}」对应的股票，请确认名称是否正确，"
+            "或直接提供股票代码（如 600519、hk00700、AAPL）。"
+        )
+
+    # 场景 3: 低置信度
+    if resolution.reason == "low_confidence":
+        return "我没有完全理解你的需求，请补充说明：想分析具体股票、查看持仓，还是了解大盘行情？"
+
+    # 场景 4: 默认兜底
+    return "请补充你想分析的股票名称或代码（如 600519、hk00700、AAPL）。"

--- a/src/agent/web_intent_resolver.py
+++ b/src/agent/web_intent_resolver.py
@@ -1735,12 +1735,14 @@ def apply_resolution_to_session(session: Any, resolution: WebIntentResolution) -
 
 
 def clear_pending_actions(session: Any) -> None:
-    """清除会话中残留的待确认动作（确认流程失败时的清理入口）。
+    """清除会话中残留的待确认动作（确认流程失败/新请求被拒时的清理入口）。
 
     apply_resolution_to_session 在 needs_confirmation 时先把 pending_actions
     写入会话；若随后澄清文本构建 / 会话历史写入失败，端点短路返回错误，
     必须同步清掉已写入的待确认状态，否则下一轮消息会被 _consume_pending_action
-    误当成上一轮失败确认流程的回复，执行旧的歧义请求。
+    误当成上一轮失败确认流程的回复，执行旧的歧义请求。同样地，当一条全新请求
+    被服务端拒绝（request_not_accepted）时，上一轮遗留的确认窗口也已关闭，
+    端点也会调用本函数清理陈旧 pending_actions。
     """
     context = getattr(session, "context", None)
     if not isinstance(context, dict):

--- a/src/config.py
+++ b/src/config.py
@@ -1005,6 +1005,7 @@ class Config:
     agent_skills: List[str] = field(default_factory=list)
     agent_skill_dir: Optional[str] = None
     agent_nl_routing: bool = False  # Enable natural language routing in bot dispatcher
+    agent_web_intent_enabled: bool = True  # Enable intent recognition layer in web chat SSE stream
     agent_arch: str = "single"     # Agent architecture: 'single' (legacy) or 'multi' (orchestrator)
     agent_orchestrator_mode: str = "standard"  # Orchestrator mode: quick/standard/full/specialist
     agent_orchestrator_timeout_s: int = 600  # Cooperative timeout budget for the whole multi-agent pipeline
@@ -1921,6 +1922,7 @@ class Config:
             agent_skills=[s.strip() for s in os.getenv('AGENT_SKILLS', '').split(',') if s.strip()],
             agent_skill_dir=os.getenv('AGENT_SKILL_DIR') or os.getenv('AGENT_STRATEGY_DIR'),
             agent_nl_routing=os.getenv('AGENT_NL_ROUTING', 'false').lower() == 'true',
+            agent_web_intent_enabled=os.getenv('AGENT_WEB_INTENT_ENABLED', 'true').lower() == 'true',
             agent_arch=os.getenv('AGENT_ARCH', 'single').lower(),
             agent_orchestrator_mode=os.getenv('AGENT_ORCHESTRATOR_MODE', 'standard').lower(),
             agent_orchestrator_timeout_s=parse_env_int(

--- a/src/services/name_to_code_resolver.py
+++ b/src/services/name_to_code_resolver.py
@@ -4,15 +4,18 @@
 Name-to-Code Resolution Engine
 ===================================
 
-Resolve stock name to code: local mapping + pinyin + AkShare fallback + fuzzy matching.
+Resolve stock name to code: local mapping + list resolution (exact/substring/
+pinyin/fuzzy) over an AkShare-extended stock database.
 """
 
 from __future__ import annotations
 
 import difflib
 import logging
+import re
 import time
-from typing import Dict, Optional, Set, Tuple
+from dataclasses import dataclass
+from typing import Dict, List, Optional, Set, Tuple
 
 from src.data.stock_mapping import STOCK_NAME_MAP
 from src.services.stock_code_utils import is_code_like, normalize_code
@@ -22,6 +25,10 @@ logger = logging.getLogger(__name__)
 # AkShare result cache: (timestamp, name_to_code_dict)
 _akshare_cache: Optional[tuple[float, Dict[str, str]]] = None
 _AKSHARE_CACHE_TTL = 1800  # 30 MIN
+
+# AkShare merge guard: _get_akshare_name_to_code() 返回同一缓存 dict（30 分钟 TTL）。
+# 已合并过该对象则直接跳过，避免对同一份数据重复遍历/扩展。
+_akshare_merged: object = None
 
 
 def _contains_cjk(text: str) -> bool:
@@ -55,37 +62,6 @@ def _build_reverse_map_no_duplicates(
         name_to_codes[name].add(code)
     # Only include names with exactly one code
     return {name: next(iter(codes)) for name, codes in name_to_codes.items() if len(codes) == 1}
-
-
-def _build_local_name_indexes(code_to_name: Dict[str, str]) -> Tuple[Dict[str, str], Set[str]]:
-    """
-    Build cached local lookup structures:
-    - unique name -> code
-    - ambiguous names that should fail fast
-    """
-    name_to_codes: Dict[str, Set[str]] = {}
-    for code, name in code_to_name.items():
-        if not name or not code:
-            continue
-        normalized_name = name.strip()
-        if not normalized_name:
-            continue
-        name_to_codes.setdefault(normalized_name, set()).add(code)
-
-    unique_names = {
-        name: next(iter(codes))
-        for name, codes in name_to_codes.items()
-        if len(codes) == 1
-    }
-    ambiguous_names = {
-        name
-        for name, codes in name_to_codes.items()
-        if len(codes) > 1
-    }
-    return unique_names, ambiguous_names
-
-
-_LOCAL_REVERSE_MAP, _LOCAL_AMBIGUOUS_NAMES = _build_local_name_indexes(STOCK_NAME_MAP)
 
 
 def _get_akshare_name_to_code() -> Optional[Dict[str, str]]:
@@ -122,6 +98,124 @@ def _get_akshare_name_to_code() -> Optional[Dict[str, str]]:
         return None
 
 
+# =========================================================================
+# Stock dataclass — code/name/market triple, dict-compatible for back compat
+# =========================================================================
+
+
+@dataclass
+class Stock:
+    """Stock entry with code, name, market.
+
+    Supports dict-style access (``s["code"]``) and equality with dict/str.
+    """
+
+    code: str
+    name: str = ""
+    market: str = ""
+
+    def __getitem__(self, key: str) -> str:
+        if key == "code":
+            return self.code
+        if key == "name":
+            return self.name
+        if key == "market":
+            return self.market
+        raise KeyError(key)
+
+    def __eq__(self, other: object) -> bool:
+        if isinstance(other, Stock):
+            return (self.code, self.name, self.market) == (other.code, other.name, other.market)
+        if isinstance(other, dict):
+            return (self.code, self.name, self.market) == (
+                other.get("code", ""), other.get("name", ""), other.get("market", "")
+            )
+        if isinstance(other, str):
+            return self.code == other
+        return NotImplemented
+
+
+# =========================================================================
+# stockDB — global stock database, initialized from STOCK_NAME_MAP
+# =========================================================================
+
+stockDB: Dict[str, str] = dict(STOCK_NAME_MAP)
+
+_MARKET_ORDER: Dict[str, int] = {"a": 0, "hk": 1, "us": 2}
+
+
+def extend_AkShare() -> bool:
+    """用 AkShare 全量 A 股数据扩充 stockDB（30 分钟缓存）。
+
+    返回值契约（供 _preprocess_text 决定是否重跑全名扫描）：
+      - True  — 首次扩展：stockDB 实际并入了新条目（下游名称/拼音缓存已同步失效）；
+      - False — 不需要再扩展：同一份缓存数据已合并过（幂等短路），或 AkShare
+                获取失败/返回空数据/无任何新条目（数据库未发生变化）。
+    已扩展后重复调用零网络开销（命中内存缓存），TTL 过期后才重新拉取。
+    """
+    global _akshare_merged
+    akshare_map = _get_akshare_name_to_code()
+    if not akshare_map:
+        return False  # 获取失败/空数据：无可扩展
+    if _akshare_merged is akshare_map:
+        return False  # 同一份缓存已合并过：不需要再扩展（幂等）
+    added = 0
+    # _get_akshare_name_to_code() 返回 name→code 反向映射，而 stockDB 是
+    # code→name：按名称遍历、以代码为键写入，保持方向一致。
+    for name, code in akshare_map.items():
+        if code not in stockDB:
+            stockDB[code] = name
+            added += 1
+    _akshare_merged = akshare_map
+    if not added:
+        return False  # 缓存数据无新条目：数据库未变化，无需重扫
+    # stockDB 原地扩充，模块内按对象身份缓存的名称列表/拼音列表已失效，
+    # 需重置，否则 resolver_name_to_code_list 等下游看不到新增名称。
+    _database_names_cache[:] = [None, None, None]
+    return True
+
+
+# =========================================================================
+# Name matching helpers
+# =========================================================================
+
+
+_database_names_cache: List = [None, None, None]  # [database_obj, names_list, pinyins_list]
+
+
+def _database_names(database: Dict[str, str]) -> List[str]:
+    """Deduplicated, order-preserving list of stock names from a database (cached by object identity)."""
+    if _database_names_cache[0] is database:
+        return _database_names_cache[1]
+    names = list(dict.fromkeys(database.values()))
+    _database_names_cache[0] = database
+    _database_names_cache[1] = names
+    _database_names_cache[2] = None
+    return names
+
+
+def _database_pinyins(database: Dict[str, str]) -> List[str]:
+    """Lowercased full pinyin of every name, aligned with ``_database_names`` (cached)."""
+    pinyins = _database_names_cache[2]
+    if pinyins is None:
+        try:
+            from pypinyin import lazy_pinyin
+
+            pinyins = [
+                "".join(lazy_pinyin(name)).lower()
+                for name in _database_names(database)
+            ]
+        except (ImportError, Exception):
+            pinyins = [""] * len(_database_names(database))
+        _database_names_cache[2] = pinyins
+    return pinyins
+
+
+def _is_exact_name_hit(query: str, name: str) -> bool:
+    """Case-insensitive exact equality between a query and a stock name."""
+    return name.strip().lower() == query.strip().lower()
+
+
 def _is_single_char_typo(input_name: str, candidate_name: str) -> bool:
     """Return True when two names only differ by one character position."""
     if not input_name or not candidate_name:
@@ -135,23 +229,266 @@ def _is_single_char_typo(input_name: str, candidate_name: str) -> bool:
     return diff == 1
 
 
+def _fix_name(fragment: str, database: Dict[str, str]) -> List[str]:
+    """Resolve a name fragment to full stock names.
+
+    Strategy chain (inherits the original resolve_name_to_code flow):
+    1. Exact match (case-insensitive)
+    2. Substring match (case-insensitive; only for fragments with >= 2 CJK
+       chars, e.g. 茅台 -> 贵州茅台)
+    3. Pinyin-based matching (lazy_pinyin on both sides, substring comparison;
+       same method as the original backup)
+    4. difflib fuzzy match (cutoff 0.8, plus a conservative single-char-typo
+       fallback at 0.7; same method as the original backup)
+    """
+    if not fragment:
+        return []
+    fragment_lower = fragment.lower()
+    names = _database_names(database)
+
+    # 1. Exact match (case-insensitive)
+    for name in names:
+        if name.lower() == fragment_lower:
+            return [name]
+
+    matches: List[str] = []
+
+    # 2. Substring match (case-insensitive, fragments with >= 2 CJK chars,
+    #    e.g. 茅台 ⊂ 贵州茅台)
+    if sum(1 for ch in fragment if '\u3400' <= ch <= '\u9fff') >= 2:
+        matches = [name for name in names if fragment_lower in name.lower()]
+        if matches:
+            return matches
+
+    # 3. Pinyin-based matching (lazy_pinyin on both sides, substring,
+    #    case-insensitive; e.g. "maotai" ⊂ "guizhoumaotai" 贵州茅台)
+    try:
+        from pypinyin import lazy_pinyin
+
+        fragment_pinyin = "".join(lazy_pinyin(fragment)).lower()
+    except (ImportError, Exception):
+        fragment_pinyin = ""
+    if fragment_pinyin:
+        for name, name_pinyin in zip(names, _database_pinyins(database)):
+            if fragment_pinyin in name_pinyin:
+                matches.append(name)
+        if matches:
+            return matches
+
+    # 4. difflib fuzzy match (only for fragments > 2 chars; strict cutoff 0.8,
+    #    plus a single-char-typo fallback at 0.7, e.g. "贵州茅苔" -> 贵州茅台)
+    if len(fragment) > 2:
+        dl_matches = difflib.get_close_matches(fragment, names, n=5, cutoff=0.8)
+        if dl_matches:
+            return dl_matches
+        typo_matches = difflib.get_close_matches(fragment, names, n=5, cutoff=0.7)
+        typo_hits = [m for m in typo_matches if _is_single_char_typo(fragment, m)]
+        if typo_hits:
+            return typo_hits
+
+    return []
+
+
+def _infer_code_market(code: str) -> Optional[str]:
+    """Infer market from code format: 6-digit→a, 5-digit→hk, letters→us."""
+    if not code:
+        return None
+    c = code.strip().upper()
+    if c.isdigit():
+        if len(c) == 5:
+            return "hk"
+        if len(c) == 6:
+            return "a"
+        return None
+    if re.match(r"^[A-Z]{1,5}(\.[A-Z])?$", c):
+        return "us"
+    return None
+
+
+def _find_codes_for_name(name: str, database: Dict[str, str]) -> List[Tuple[str, str]]:
+    """Find all (code, market) pairs for a given stock name in the database."""
+    results: List[Tuple[str, str]] = []
+    seen: Set[str] = set()
+    for code, mapped_name in database.items():
+        if mapped_name == name:
+            m = _infer_code_market(code)
+            if m and code not in seen:
+                results.append((code, m))
+                seen.add(code)
+    return results
+
+
+# =========================================================================
+# is_known_stock_name — lightweight boolean check (no network)
+# =========================================================================
+
+
+def is_known_stock_name(fragment: str) -> bool:
+    """Check whether *fragment* is a real stock name (or substring of one) in the local database.
+
+    Cheap, pure-local, no network. Only exact/substring match — no pinyin, no fuzzy,
+    no AkShare. Safe to call per-message in rule paths.
+    """
+    if not fragment or not isinstance(fragment, str):
+        return False
+    s = fragment.strip()
+    if len(s) < 2:
+        return False
+    names = _database_names(stockDB)
+    return any(s in name for name in names)
+
+
+# =========================================================================
+# Public API
+# =========================================================================
+
+
+def _stocks_for_name(name: str) -> List[Stock]:
+    """Resolve a known stock name to its Stock objects (code + name + market)."""
+    return [
+        Stock(code=code, name=name, market=market)
+        for code, market in _find_codes_for_name(name, stockDB)
+    ]
+
+
+def extract_stock_name(text: str) -> List[Tuple[str, Optional[List[Stock]]]]:
+    """Segment *text* into (fragment, stocks_or_none) pairs.
+
+    Uses the global ``stockDB`` to identify stock names. Longer names are matched
+    first to prevent partial matches (e.g. "贵州茅台" before "茅台").
+    Each matched name is resolved to ``Stock`` objects via ``_find_codes_for_name``.
+
+    Returns:
+        List of ``(fragment, stocks_or_none)`` tuples.  *stocks_or_none* is a
+        ``List[Stock]`` when the fragment was matched as a known stock name,
+        ``None`` otherwise.
+    """
+    if not text or not isinstance(text, str):
+        return []
+
+    names = _database_names(stockDB)
+    names_sorted = sorted(names, key=len, reverse=True)
+
+    # Collect all non-overlapping matches with resolved Stock objects
+    matches: List[Tuple[int, int, str, List[Stock]]] = []  # (start, end, name, stocks)
+
+    for name in names_sorted:
+        start = 0
+        while True:
+            idx = text.find(name, start)
+            if idx < 0:
+                break
+            end = idx + len(name)
+            if not any(
+                m_start < end and idx < m_end
+                for m_start, m_end, _, _ in matches
+            ):
+                matches.append((idx, end, name, _stocks_for_name(name)))
+            start = idx + 1
+
+    if not matches:
+        return [(text, None)] if text else []
+
+    matches.sort(key=lambda x: x[0])
+
+    segments: List[Tuple[str, Optional[List[Stock]]]] = []
+    pos = 0
+    for start, end, name, stocks in matches:
+        if start > pos:
+            segments.append((text[pos:start], None))
+        segments.append((name, stocks))
+        pos = end
+    if pos < len(text):
+        segments.append((text[pos:], None))
+
+    return segments
+
+
+def resolver_name_to_code_list(name: str) -> List[Stock]:
+    """Resolve a stock name to a list of matching ``Stock`` entries (max 5).
+
+    Only processes pure Chinese names. The name is matched against the global
+    ``stockDB`` via exact, substring, pinyin, and fuzzy matching.
+
+    Results are sorted A-share → HK → US.
+
+    Examples:
+        "阿里巴巴"  → [Stock("09988", "阿里巴巴", "hk"), Stock("BABA", "阿里巴巴", "us")]
+        "阿里"      → [Stock("09988", "阿里巴巴", "hk"), Stock("BABA", "阿里巴巴", "us")]
+        "茅台"      → [Stock("600519", "贵州茅台", "a")]
+        "你好世界"   → []
+    """
+    if not name or not isinstance(name, str):
+        return []
+    s = name.strip()
+    if not s:
+        return []
+    # 单个汉字不可能是股票名称，直接短路避免后续无意义的查表
+    if len(s) == 1 and '\u4e00' <= s <= '\u9fff':
+        return []
+
+    full_names = _fix_name(s, stockDB)
+    if not full_names:
+        return []
+
+    results: List[Stock] = []
+    seen: Set[str] = set()
+    for full_name in full_names:
+        for code, market in _find_codes_for_name(full_name, stockDB):
+            if code in seen:
+                continue
+            seen.add(code)
+            results.append(Stock(code=code, name=full_name, market=market))
+
+    results.sort(key=lambda r: _MARKET_ORDER.get(r.market, 99))
+    return results[:5]
+
+
+def US_stock_code_match(segment: str) -> List[Stock]:
+    """匹配美国股票代码：1~5 个大写英文字母组成的 ticker symbol。
+
+    仅在股票数据库中存在对应代码时才返回结果，避免将普通英文单词误判为股票代码。
+    返回 Stock 列表，market 固定为 "us"。
+    """
+    if not segment or not segment.isascii() or not segment.isalpha():
+        return []
+    if not (1 <= len(segment) <= 5):
+        return []
+    upper = segment.upper()
+    name = stockDB.get(upper, "")
+    if name:
+        return [Stock(code=upper, name=name, market="us")]
+    return []
+
+
+# =========================================================================
+# Single-code resolution — thin orchestration over the list resolver
+# =========================================================================
+
+
 def resolve_name_to_code(name: str) -> Optional[str]:
     """
     Resolve stock name to code.
 
     Strategy (in order):
     1. If input looks like a code (5-6 digits or 1-5 letters), return it normalized.
-    2. Local STOCK_NAME_MAP reverse (exclude ambiguous names).
-    3. Pinyin match against local names.
-    4. AkShare online fallback (A-shares).
-    5. Fuzzy match (difflib).
-    6. Return None.
+    2. Resolve via ``resolver_name_to_code_list`` against the current ``stockDB``.
+       Any multi-candidate result (exact duplicate names, substring, pinyin,
+       fuzzy matches, e.g. "阿里巴巴" -> BABA/09988 or "阿里" -> BABA/09988)
+       returns None so callers ask the user to disambiguate. A singleton from
+       an exact name match is trusted as-is; a singleton from substring/
+       pinyin/fuzzy matching may be a local near-match, so it must first
+       yield to an exact AkShare-only A-share name before being returned.
+    3. Extend ``stockDB`` with AkShare A-share data (idempotent), then
+       resolve again — ``_fix_name`` prefers the exact name, so an exact
+       AkShare entry beats the local near-match; otherwise the local
+       near-match singleton is kept.
 
     Args:
         name: Stock name or code string.
 
     Returns:
-        Resolved stock code, or None if ambiguous/failed.
+        Resolved stock code, or None if unresolved/ambiguous.
     """
     if not name or not isinstance(name, str):
         return None
@@ -163,61 +500,55 @@ def resolve_name_to_code(name: str) -> Optional[str]:
     if _is_code_like(s):
         return _normalize_code(s)
 
-    # 2. Local reverse map (no duplicates)
-    local_reverse = _LOCAL_REVERSE_MAP
-    if s in local_reverse:
-        return local_reverse[s]
-    if s in _LOCAL_AMBIGUOUS_NAMES:
-        logger.debug(f"[NameResolver] 命中本地歧义名称，快速返回 None: {s}")
-        return None
+    # 2. List resolution against the current stockDB (local data first).
+    stocks = resolver_name_to_code_list(s)
+    if stocks:
+        # 任何多候选结果（精确同名多市场、子串、拼音、模糊匹配）都是歧义：
+        # 单代码入口绝不静默挑选排序后的第一只，返回 None 交由调用方澄清。
+        # 此前仅拦截精确同名歧义，子串/拼音/模糊产生的多候选会直接落到
+        # stocks[0].code，例如"阿里"→09988、"银行"→000001。
+        if len(stocks) > 1:
+            logger.debug(
+                f"[NameResolver] 命中歧义名称（{len(stocks)} 个候选），返回 None: {s}"
+            )
+            return None
+        singleton = stocks[0]
+        # 本地非精确 singleton（子串/拼音/模糊命中）可能只是近似：本地库缺失、
+        # AkShare 独有的精确 A 股名必须先于本地近似名胜出，否则会被解析到
+        # 相近的本地股票（OR-COR-a2d5f6b9）。_fix_name 精确优先，扩展重解析
+        # 后精确名自然置顶；AkShare 无精确名时维持本地近似结果（保留既有
+        # 容错行为）。extend_AkShare() 返回 False 表示数据未变，无需重解析。
+        if (
+            not _is_exact_name_hit(s, singleton.name)
+            and _contains_cjk(s)
+            and extend_AkShare()
+        ):
+            retry = resolver_name_to_code_list(s)
+            exact_hits = [st for st in retry if _is_exact_name_hit(s, st.name)]
+            if len(exact_hits) == 1:
+                return exact_hits[0].code
+        return singleton.code
 
-    # 3. Pinyin match (exact)
-    try:
-        from pypinyin import lazy_pinyin
-
-        input_pinyin = "".join(lazy_pinyin(s)).lower()
-        for local_name, code in local_reverse.items():
-            local_pinyin = "".join(lazy_pinyin(local_name)).lower()
-            if input_pinyin == local_pinyin:
-                return code
-    except ImportError:
-        pass
-    except Exception as e:
-        logger.debug(f"[NameResolver] Pinyin match failed: {e}")
-
-    # Skip AkShare/fuzzy fallback for non-CJK free text such as random Latin noise.
-    # These paths are expensive and only meaningfully help Chinese stock names.
+    # Non-CJK input can never be helped by AkShare A-share data (all Chinesenames); 
+    # skip the fetch and the retry for random Latin free text.
     if not _contains_cjk(s):
-        logger.debug(f"[NameResolver] Skip CJK-only fallbacks for non-CJK input: {s}")
+        logger.debug(f"[NameResolver] Skip AkShare extension for non-CJK input: {s}")
         return None
 
-    # 4. AkShare fallback
-    akshare_map = _get_akshare_name_to_code()
-    if akshare_map and s in akshare_map:
-        logger.debug(f"[NameResolver] 命中 AkShare 映射: {s} -> {akshare_map[s]}")
-        return akshare_map[s]
-
-    # 5. Fuzzy match (local + akshare, local takes precedence)
-    all_name_to_code = dict(local_reverse)
-    if akshare_map:
-        all_name_to_code.update(akshare_map)
-    # Skip fuzzy matching for very short inputs (<=2 chars) to avoid false positives,
-    # e.g. '中国' matching arbitrary company names in a pool of 5000+ stocks.
-    # Use a higher cutoff (0.8) to reduce mis-hits on longer inputs as well.
-    if len(s) > 2:
-        names = list(all_name_to_code.keys())
-        matches = difflib.get_close_matches(s, names, n=1, cutoff=0.8)
-        if matches:
-            logger.debug(f"[NameResolver] 命中模糊匹配: input={s}, matched={matches[0]}")
-            return all_name_to_code[matches[0]]
-
-        # Conservative fallback for one-character typo in medium/long names.
-        # This keeps the strict default threshold while fixing obvious misspellings
-        # such as "贵州茅苔" -> "贵州茅台".
-        typo_matches = difflib.get_close_matches(s, names, n=1, cutoff=0.7)
-        if typo_matches and _is_single_char_typo(s, typo_matches[0]):
-            logger.debug(f"[NameResolver] 命中单字误写兜底: input={s}, matched={typo_matches[0]}")
-            return all_name_to_code[typo_matches[0]]
+    # 3. Extend the local DB with AkShare A-share data (idempotent)
+    extend_AkShare()
+    
+    # 4. resolve again — the retry sees A-share names beyond the local map.
+    stocks = resolver_name_to_code_list(s)
+    if stocks:
+        # 与本地解析一致的歧义契约：AkShare 扩展后出现多候选（如子串命中
+        # 多只 A 股）同样返回 None，绝不静默取第一只。
+        if len(stocks) > 1:
+            logger.debug(
+                f"[NameResolver] AkShare 扩展后仍歧义（{len(stocks)} 个候选），返回 None: {s}"
+            )
+            return None
+        return stocks[0].code
 
     logger.debug(f"[NameResolver] 解析失败: {s}")
     return None

--- a/tests/test_agent_chat_api.py
+++ b/tests/test_agent_chat_api.py
@@ -423,10 +423,18 @@ def test_agent_models_does_not_hide_unexpected_backend_resolution_errors() -> No
         asyncio.run(agent_endpoint.get_agent_models())
 
 
-def test_stream_prepares_and_persists_before_accepted_then_starts_backend() -> None:
+def test_stream_emits_accepted_before_preparing_then_starts_backend() -> None:
+    """accepted 必须是首事件，且先于 prepare_turn 发出。
+
+    前端 store 只在收到 accepted 后才把用户消息渲染成气泡；若 accepted 被
+    延迟到意图解析（LLM 兜底 8s 超时 + 一次重试）或 prepare_turn 之后才发，
+    用户输入的气泡会被拖到解析/准备完成后才显示。本测试锁定新契约：
+    首事件为 accepted、且此刻 prepare_turn 尚未被调用；prepare/持久化仍
+    发生在 execute_turn 之前（提交边界语义不变）。
+    """
     executor = _executor(_result(backend="codex_app_server"))
 
-    async def exercise() -> dict:
+    async def exercise() -> tuple[dict, list[dict]]:
         with patch("api.v1.endpoints.agent.asyncio.to_thread", side_effect=_immediate_to_thread), \
              patch("api.v1.endpoints.agent.get_config", return_value=_codex_config()), \
              patch("api.v1.endpoints.agent._get_agent_chat_status", side_effect=AssertionError("status probe repeated")), \
@@ -442,24 +450,31 @@ def test_stream_prepares_and_persists_before_accepted_then_starts_backend() -> N
             )
             iterator = response.body_iterator
             first = json.loads((await anext(iterator)).removeprefix("data: ").strip())
-            executor.prepare_turn.assert_called_once_with(
-                message="分析 AAPL",
-                session_id="accepted-session",
-                context={"stock_code": "AAPL", "report_language": "zh"},
-                selected_skill_ids=None,
-            )
+            # 首事件先于 prepare_turn：此刻生成器只 yield 了 accepted，
+            # executor 构建 / prepare_turn 均尚未执行。
+            executor.prepare_turn.assert_not_called()
             executor.execute_turn.assert_not_called()
-            await iterator.aclose()
-            return first
+            rest = [
+                json.loads(chunk.removeprefix("data: ").strip())
+                async for chunk in iterator
+            ]
+            return first, rest
 
-    first_event = asyncio.run(exercise())
+    first_event, rest_events = asyncio.run(exercise())
     assert first_event == {
         "type": "accepted",
         "backend": "codex_app_server",
         "request_id": "accepted-request",
         "session_id": "accepted-session",
     }
-    executor.execute_turn.assert_not_called()
+    assert [event["type"] for event in rest_events] == ["done"]
+    executor.prepare_turn.assert_called_once_with(
+        message="分析 AAPL",
+        session_id="accepted-session",
+        context={"stock_code": "AAPL", "report_language": "zh"},
+        selected_skill_ids=None,
+    )
+    executor.execute_turn.assert_called_once()
 
 
 def test_stream_forwards_normalized_skill_selection_to_prepare_turn() -> None:
@@ -564,7 +579,13 @@ def test_codex_stream_skill_resolution_failure_does_not_register_request() -> No
 
 
 @pytest.mark.parametrize("failure", ["context preparation failed", "database write failed"])
-def test_stream_preparation_failure_emits_no_accepted_and_never_starts_backend(failure: str) -> None:
+def test_stream_preparation_failure_keeps_accepted_first_and_never_starts_backend(failure: str) -> None:
+    """准备失败时 accepted 首事件契约保持不变，且绝不启动后端执行。
+
+    accepted 是流协议的首事件，即使 prepare_turn 失败也必须先发出
+    （前端先渲染用户气泡，再消费随后的 error 终态）；失败路径序列为
+    accepted → error（error_code=request_not_accepted），execute_turn 绝不执行。
+    """
     executor = _executor()
     executor.prepare_turn.side_effect = RuntimeError(failure)
 
@@ -582,8 +603,9 @@ def test_stream_preparation_failure_emits_no_accepted_and_never_starts_backend(f
             ]
 
     events = asyncio.run(exercise())
-    assert [event["type"] for event in events] == ["error"]
-    assert events[0]["error_code"] == "request_not_accepted"
+    assert [event["type"] for event in events] == ["accepted", "error"]
+    assert events[0]["type"] == "accepted"
+    assert events[1]["error_code"] == "request_not_accepted"
     executor.execute_turn.assert_not_called()
 
 

--- a/tests/test_agent_chat_intent_stream.py
+++ b/tests/test_agent_chat_intent_stream.py
@@ -389,7 +389,8 @@ def test_prepare_turn_failure_keeps_session_context_unchanged() -> None:
     意图解析器在 prepare_turn 之前已完成分类（例如"分析一下贵州茅台" →
     600519 / stock_research），但 prepare_turn 失败时端点只发送
     request_not_accepted 终态；该请求不应被视作已接受的会话边界，因此
-    recent_stocks / last_intent / pending_actions 必须保持解析前的状态，
+    recent_stocks / last_intent 必须保持解析前的状态；上一轮遗留的
+    pending_actions 则会被清空（本用例预置为空，所以整体快照仍不变），
     否则下一轮追问（如"它还能涨吗"）会继承一个被拒绝请求的股票上下文。
     """
     config = _intent_config()
@@ -427,6 +428,63 @@ def test_prepare_turn_failure_keeps_session_context_unchanged() -> None:
     assert executor.prepare_turn.call_args.kwargs["context"]["stock_code"] == "600519"
     # 但会话上下文必须保持解析前的快照：被拒绝的请求不得成为后续追问的上下文
     assert session.context == context_before
+
+
+def test_prepare_turn_failure_clears_stale_confirm_pending() -> None:
+    """prepare_turn 失败且本轮为新请求时，必须清空上一轮遗留 pending_actions。
+
+    复现：第 1 轮歧义请求写入 confirm_stock 待确认动作；第 2 轮新请求
+    （如"分析一下贵州茅台"）被意图层判定为显式股票，但 prepare_turn 抛错
+    走到 request_not_accepted。若不清空 pending_actions，第 3 轮无关消息
+    会被 _consume_pending_action 误当成第 1 轮的确认回复，执行旧的歧义股票。
+    """
+    config = _intent_config()
+    executor = _executor(_result())
+    executor.prepare_turn.side_effect = RuntimeError("prepare_turn failed")
+    session = ConversationSession(session_id="prepare-fail-stale-pending-session")
+    session.update_context("recent_stocks", ["000001"])
+    session.update_context("last_intent", WebIntent.GENERAL_CHAT)
+    stale_pending = _ambiguous_resolution().pending_action
+    session.update_context("pending_actions", [stale_pending])
+
+    async def exercise() -> list[dict]:
+        with patch("api.v1.endpoints.agent.get_config", return_value=config), \
+             patch("api.v1.endpoints.agent.asyncio.to_thread", side_effect=_immediate_to_thread), \
+             patch("src.agent.conversation.conversation_manager") as cm, \
+             patch("src.agent.web_intent_resolver.WebIntentResolver") as resolver_cls, \
+             patch("api.v1.endpoints.agent._build_executor", return_value=executor):
+            cm.get_or_create.return_value = session
+            resolver_cls.return_value.resolve.return_value = _simple_resolution()
+            return await _collect_stream_events(
+                agent_endpoint.ChatRequest(
+                    message="分析一下贵州茅台",
+                    session_id=session.session_id,
+                )
+            )
+
+    events = asyncio.run(exercise())
+
+    assert [event["type"] for event in events] == ["accepted", "error"]
+    terminal = events[-1]
+    assert terminal["type"] == "error"
+    assert terminal["error_code"] == "request_not_accepted"
+    executor.execute_turn.assert_not_called()
+    # 意图解析确实发生在 prepare_turn 之前（stock_code 已注入请求上下文）
+    assert executor.prepare_turn.call_args.kwargs["context"]["stock_code"] == "600519"
+    # 被拒的新请求不污染 recent_stocks / last_intent
+    assert session.context["recent_stocks"] == ["000001"]
+    assert session.context["last_intent"] == WebIntent.GENERAL_CHAT
+    # 但上一轮遗留的确认窗口必须关闭
+    assert session.context["pending_actions"] == []
+
+    # 复核反馈反例：后续无关消息不再被消费为确认回复
+    follow_up = WebIntentResolver(None).resolve(
+        "港股",
+        session_context=session.context,
+        request_context={},
+    )
+    assert follow_up.source != "confirmation"
+    assert not follow_up.needs_confirmation
 
 
 def test_prepare_turn_success_commits_intent_context() -> None:

--- a/tests/test_agent_chat_intent_stream.py
+++ b/tests/test_agent_chat_intent_stream.py
@@ -1,0 +1,652 @@
+# -*- coding: utf-8 -*-
+"""Web 意图层 SSE 流集成回归测试。
+
+覆盖两类行为约束：
+- 规则无解时意图解析会同步调用 LLM（8s 超时 + 一次重试），必须移出事件
+  循环线程，不能阻塞 SSE 首包；
+- 确认分支必须保持 accepted 提交边界（accepted 为首事件），否则 Web
+  store 会把澄清场景判成协议错误。
+
+终态契约回归：
+- 确认分支失败（api/v1/endpoints/agent.py 会话历史写入异常、
+  src/agent/web_intent_resolver.py 构建器异常）时，流只以唯一终态
+  error（error_code=confirmation_failed）收尾，绝不再发 done ——
+  前端统一消费策略按"读到终态事件（done/error）即收尾"工作，
+  本文件显式锁定"确认失败仅 error 终态、不走 done"的行为。
+"""
+
+import asyncio
+import json
+import threading
+import time
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from src.agent.conversation import ConversationSession
+from src.agent.web_intent_resolver import (
+    WebIntent, WebIntentResolution, WebIntentResolver,
+)
+from src.config import Config
+from src.services.agent_chat_session_service import AgentChatSessionService
+from src.services.name_to_code_resolver import Stock
+from src.storage import DatabaseManager
+
+import api.v1.endpoints.agent as agent_endpoint
+
+
+@pytest.fixture(autouse=True)
+def _restore_resolver_state():
+    """快照/还原 name_to_code_resolver 模块级可变状态，防止本文件集成用例
+    触发真实 AkShare 扩展（extend_AkShare 合并全局 stockDB 并置位
+    _akshare_merged）后泄漏给同进程内后续运行的测试文件。"""
+    from src.services import name_to_code_resolver as resolver_mod
+
+    db = dict(resolver_mod.stockDB)
+    cache = resolver_mod._akshare_cache
+    merged = resolver_mod._akshare_merged
+    yield
+    resolver_mod.stockDB.clear()
+    resolver_mod.stockDB.update(db)
+    resolver_mod._akshare_cache = cache
+    resolver_mod._akshare_merged = merged
+    # stockDB 原地增删，按对象身份缓存的名称/拼音列表可能已陈旧，强制重建
+    resolver_mod._database_names_cache[:] = [None, None, None]
+
+
+def setup_function() -> None:
+    DatabaseManager.reset_instance()
+    Config.reset_instance()
+
+
+def teardown_function() -> None:
+    DatabaseManager.reset_instance()
+    Config.reset_instance()
+
+
+def _intent_config(**overrides):
+    values = {
+        "agent_backend": "auto",
+        "is_agent_available": lambda: True,
+        "report_language": "zh",
+        "agent_web_intent_enabled": True,
+    }
+    values.update(overrides)
+    return SimpleNamespace(**values)
+
+
+def _result(*, backend: str = "litellm", success: bool = True):
+    return SimpleNamespace(
+        success=success,
+        content="ok" if success else "",
+        error=None,
+        total_steps=1,
+        backend=backend,
+        error_code=None,
+    )
+
+
+def _executor(result=None) -> MagicMock:
+    executor = MagicMock()
+    executor.prepare_turn.return_value = object()
+    executor.execute_turn.return_value = result or _result()
+    return executor
+
+
+def _ambiguous_resolution() -> WebIntentResolution:
+    """多候选股票（hk 09988 / us BABA）→ 需要用户确认。"""
+    return WebIntentResolution(
+        intent=WebIntent.STOCK_RESEARCH,
+        confidence=0.85,
+        source="rule",
+        candidates=[
+            Stock("09988", "阿里巴巴", "hk"),
+            Stock("BABA", "阿里巴巴", "us"),
+        ],
+        needs_confirmation=True,
+        reason="ambiguous_stock_name",
+        pending_action={
+            "action": "confirm_stock",
+            "candidates": [
+                {"code": "09988", "name": "阿里巴巴", "market": "hk"},
+                {"code": "BABA", "name": "阿里巴巴", "market": "us"},
+            ],
+        },
+    )
+
+
+def _simple_resolution() -> WebIntentResolution:
+    """唯一已解析股票（600519）→ 无需确认。"""
+    return WebIntentResolution(
+        intent=WebIntent.STOCK_RESEARCH,
+        confidence=0.9,
+        source="rule",
+        stocks=[Stock("600519", "贵州茅台", "a")],
+        reason="explicit_stock",
+    )
+
+
+async def _immediate_to_thread(func, /, *args, **kwargs):
+    """测试替身：把 to_thread 变成同步直调，避免真实线程池。"""
+    return func(*args, **kwargs)
+
+
+async def _collect_stream_events(request: "agent_endpoint.ChatRequest") -> list[dict]:
+    response = await agent_endpoint.agent_chat_stream(
+        request,
+        session_service=AgentChatSessionService(),
+    )
+    return [
+        json.loads(chunk.removeprefix("data: ").strip())
+        async for chunk in response.body_iterator
+    ]
+
+
+def test_confirmation_branch_keeps_accepted_commit_boundary() -> None:
+    """确认分支必须保持 accepted 提交边界。
+
+    Web store 要求第一条事件必须是 accepted（否则抛协议错误），因此确认分支
+    的事件序列必须是 accepted → intent_resolved → action_required → done。
+    """
+    executor = _executor(_result())
+    config = _intent_config()
+    captured: dict = {}
+
+    async def exercise() -> None:
+        with patch("api.v1.endpoints.agent.get_config", return_value=config), \
+             patch("api.v1.endpoints.agent.asyncio.to_thread", side_effect=_immediate_to_thread), \
+             patch("src.agent.conversation.conversation_manager") as cm, \
+             patch("src.agent.web_intent_resolver.WebIntentResolver") as resolver_cls, \
+             patch("api.v1.endpoints.agent._build_executor", return_value=executor):
+            session = ConversationSession(session_id="confirm-session")
+            cm.get_or_create.return_value = session
+            resolver_cls.return_value.resolve.return_value = _ambiguous_resolution()
+            captured["events"] = await _collect_stream_events(
+                agent_endpoint.ChatRequest(
+                    message="阿里巴巴",
+                    session_id="confirm-session",
+                )
+            )
+            captured["cm"] = cm
+
+    asyncio.run(exercise())
+    events = captured["events"]
+    cm = captured["cm"]
+    assert [event["type"] for event in events] == [
+        "accepted",
+        "intent_resolved",
+        "action_required",
+        "done",
+    ]
+    assert events[0]["backend"] == "litellm"
+    assert events[1]["intent"] == "stock_research"
+    assert events[2]["action"] == "confirm_stock"
+    assert "阿里巴巴" in events[3]["content"]
+    assert events[3]["success"] is True
+    # 确认分支短路：不进入 Agent 编排
+    executor.prepare_turn.assert_not_called()
+    executor.execute_turn.assert_not_called()
+    # 会话历史写入 user 消息 + 澄清回复
+    cm.add_message.assert_any_call("confirm-session", "user", "阿里巴巴")
+    cm.add_message.assert_any_call("confirm-session", "assistant", events[3]["content"])
+
+
+def _assert_confirmation_failure_terminal(events: list[dict], executor: MagicMock) -> None:
+    """确认失败终态契约：accepted → error，绝无 done，且不进入 Agent 编排。
+
+    前端统一消费策略按事件类型分发、读到终态事件（done/error）即收尾：
+    确认失败后流必须以唯一终态 error 结束，绝不追加 done —— 否则前端会
+    把 done 当"分析成功"消费，歧义请求被静默放行；也不得退回 Agent 执行
+    未确认的歧义请求，否则绕过"未确认不执行"安全门。
+    """
+    types = [event["type"] for event in events]
+    assert types == ["accepted", "error"]
+    assert "done" not in types
+    assert not any(event["type"] == "intent_resolved" for event in events)
+    assert not any(event["type"] == "action_required" for event in events)
+    terminal = events[-1]
+    assert terminal["type"] == "error"
+    assert terminal["error_code"] == "confirmation_failed"
+    assert terminal["message"] == "无法完成该请求的确认流程，请稍后重试"
+    assert terminal["backend"] == "litellm"
+    # 确认失败仍保持短路：绝不执行未确认的歧义请求
+    executor.prepare_turn.assert_not_called()
+    executor.execute_turn.assert_not_called()
+
+
+def test_confirmation_failure_sends_only_error_terminal_no_done() -> None:
+    """确认分支失败（agent.py 异常路径：会话历史写入抛错）仅发 error 终态。
+
+    模拟 conversation_manager.add_message 写入 SQLite 失败：确认分支的
+    except 必须保持短路，流事件序列为 accepted → error（唯一终态），
+    绝不追加 done、绝不退回 Agent 编排执行未确认的歧义请求。
+    """
+    config = _intent_config()
+    executor = _executor(_result())
+
+    async def exercise() -> list[dict]:
+        with patch("api.v1.endpoints.agent.get_config", return_value=config), \
+             patch("api.v1.endpoints.agent.asyncio.to_thread", side_effect=_immediate_to_thread), \
+             patch("src.agent.conversation.conversation_manager") as cm, \
+             patch("src.agent.web_intent_resolver.WebIntentResolver") as resolver_cls, \
+             patch("api.v1.endpoints.agent._build_executor", return_value=executor):
+            cm.get_or_create.return_value = ConversationSession(session_id="confirm-fail-session")
+            cm.add_message.side_effect = RuntimeError("session history write failed")
+            resolver_cls.return_value.resolve.return_value = _ambiguous_resolution()
+            return await _collect_stream_events(
+                agent_endpoint.ChatRequest(
+                    message="阿里巴巴",
+                    session_id="confirm-fail-session",
+                )
+            )
+
+    events = asyncio.run(exercise())
+    _assert_confirmation_failure_terminal(events, executor)
+
+
+def test_confirmation_failure_via_intent_builder_only_error_terminal() -> None:
+    """确认分支失败（web_intent_resolver.py 异常路径：澄清构建器抛错）仅发 error 终态。
+
+    build_clarification_message 属于 web_intent_resolver.py 的构建函数，
+    是确认分支内最先被调用的模块函数：它抛错时同样必须保持短路终态契约
+    （accepted → error，无 done），与会话历史写入失败的路径行为一致，
+    保证前端统一消费策略对"确认失败"只有一种终态可收。
+    """
+    config = _intent_config()
+    executor = _executor(_result())
+
+    async def exercise() -> list[dict]:
+        # build_clarification_message 在 agent_chat_stream 函数内延迟 import，
+        # 需在源模块 src.agent.web_intent_resolver 上打补丁才能影响确认分支
+        # （patch 窗口内函数体的 from ... import 会绑定被替换的属性）
+        with patch("api.v1.endpoints.agent.get_config", return_value=config), \
+             patch("api.v1.endpoints.agent.asyncio.to_thread", side_effect=_immediate_to_thread), \
+             patch("src.agent.conversation.conversation_manager") as cm, \
+             patch("src.agent.web_intent_resolver.WebIntentResolver") as resolver_cls, \
+             patch("src.agent.web_intent_resolver.build_clarification_message",
+                   side_effect=RuntimeError("clarification build failed")), \
+             patch("api.v1.endpoints.agent._build_executor", return_value=executor):
+            cm.get_or_create.return_value = ConversationSession(session_id="clarify-fail-session")
+            resolver_cls.return_value.resolve.return_value = _ambiguous_resolution()
+            return await _collect_stream_events(
+                agent_endpoint.ChatRequest(
+                    message="阿里巴巴",
+                    session_id="clarify-fail-session",
+                )
+            )
+
+    events = asyncio.run(exercise())
+    _assert_confirmation_failure_terminal(events, executor)
+
+
+def test_confirmed_compare_turn_reaches_prepare_turn_with_compare_scope() -> None:
+    """确认消费轮的多股比较必须把比较对带入 prepare_turn（OR-COR-1f4c2d7a）。
+
+    "对比阿里巴巴和腾讯控股" 触发歧义确认（阿里 09988/BABA）后，用户回复
+    "港股"：确认轮的 primary_stock_code 为空串，若端点只转发该单码字段，
+    prepare_turn 只能看到裸确认回复（"港股"），既无比较股票也无原始请求，
+    工具调用不再受比较对约束。端点必须把已解析比较对 + 原始请求注入
+    请求上下文。
+    """
+    config = _intent_config()
+    executor = _executor(_result())
+    confirmed_resolution = WebIntentResolution(
+        intent=WebIntent.STOCK_RESEARCH,
+        confidence=0.95,
+        source="confirmation",
+        stocks=[
+            Stock("09988", "阿里巴巴", "hk"),
+            Stock("00700", "腾讯控股", "hk"),
+        ],
+        reason="confirmed_stock",
+        original_request="对比阿里巴巴和腾讯控股",
+    )
+
+    async def exercise() -> list[dict]:
+        with patch("api.v1.endpoints.agent.get_config", return_value=config), \
+             patch("api.v1.endpoints.agent.asyncio.to_thread", side_effect=_immediate_to_thread), \
+             patch("src.agent.conversation.conversation_manager") as cm, \
+             patch("src.agent.web_intent_resolver.WebIntentResolver") as resolver_cls, \
+             patch("api.v1.endpoints.agent._build_executor", return_value=executor):
+            cm.get_or_create.return_value = ConversationSession(
+                session_id="confirm-compare-session"
+            )
+            resolver_cls.return_value.resolve.return_value = confirmed_resolution
+            return await _collect_stream_events(
+                agent_endpoint.ChatRequest(
+                    message="港股",
+                    session_id="confirm-compare-session",
+                )
+            )
+
+    events = asyncio.run(exercise())
+    assert [event["type"] for event in events] == ["accepted", "intent_resolved", "done"]
+    executor.execute_turn.assert_called_once()
+    kwargs = executor.prepare_turn.call_args.kwargs
+    # 历史保真：本轮用户消息仍是确认回复本身，不被改写
+    assert kwargs["message"] == "港股"
+    # 已解析比较对与原始请求进入本轮上下文，prepare_agent_chat 才能构建
+    # 比较作用域（否则工具调用不受比较对约束）
+    assert kwargs["context"]["resolved_stock_codes"] == ["09988", "00700"]
+    assert kwargs["context"]["web_intent_original_request"] == "对比阿里巴巴和腾讯控股"
+    # 多股比较轮绝不锁定单一主股票
+    assert not kwargs["context"].get("stock_code")
+
+
+def test_confirmation_failure_clears_stale_pending_actions() -> None:
+    """确认分支失败必须清空会话 pending_actions。
+
+    修复前：apply_resolution_to_session 先写入 pending_actions，随后会话历史
+    写入抛错，except 只发 error 终态、不清会话状态；下一轮 resolve() 会把
+    用户的新消息（如"港股"）误当成上一轮失败确认流程的回复直接确认
+    （source="confirmation"，股票 09988）。
+    修复后：失败路径同步清空 pending_actions，下一轮按新消息重新分类。
+    """
+    config = _intent_config()
+    executor = _executor(_result())
+    captured: dict = {}
+
+    async def exercise() -> list[dict]:
+        with patch("api.v1.endpoints.agent.get_config", return_value=config), \
+             patch("api.v1.endpoints.agent.asyncio.to_thread", side_effect=_immediate_to_thread), \
+             patch("src.agent.conversation.conversation_manager") as cm, \
+             patch("src.agent.web_intent_resolver.WebIntentResolver") as resolver_cls, \
+             patch("api.v1.endpoints.agent._build_executor", return_value=executor):
+            session = ConversationSession(session_id="confirm-fail-state-session")
+            cm.get_or_create.return_value = session
+            cm.add_message.side_effect = RuntimeError("session history write failed")
+            resolver_cls.return_value.resolve.return_value = _ambiguous_resolution()
+            events = await _collect_stream_events(
+                agent_endpoint.ChatRequest(
+                    message="阿里巴巴",
+                    session_id="confirm-fail-state-session",
+                )
+            )
+            captured["session"] = session
+            return events
+
+    events = asyncio.run(exercise())
+    _assert_confirmation_failure_terminal(events, executor)
+
+    # 会话中不得残留待确认动作
+    session: ConversationSession = captured["session"]
+    assert session.context.get("pending_actions") == []
+
+    # 复核反馈反例：失败后同会话的下一轮消息不得被误消费为确认回复
+    follow_up = WebIntentResolver(None).resolve(
+        "港股",
+        session_context=session.context,
+        request_context={},
+    )
+    assert follow_up.source != "confirmation"
+    assert not follow_up.needs_confirmation
+
+
+def test_prepare_turn_failure_keeps_session_context_unchanged() -> None:
+    """prepare_turn 失败时，意图层不得提前污染会话上下文。
+
+    意图解析器在 prepare_turn 之前已完成分类（例如"分析一下贵州茅台" →
+    600519 / stock_research），但 prepare_turn 失败时端点只发送
+    request_not_accepted 终态；该请求不应被视作已接受的会话边界，因此
+    recent_stocks / last_intent / pending_actions 必须保持解析前的状态，
+    否则下一轮追问（如"它还能涨吗"）会继承一个被拒绝请求的股票上下文。
+    """
+    config = _intent_config()
+    executor = _executor(_result())
+    executor.prepare_turn.side_effect = RuntimeError("prepare_turn failed")
+    session = ConversationSession(session_id="prepare-fail-intent-session")
+    session.update_context("recent_stocks", ["000001"])
+    session.update_context("last_intent", WebIntent.GENERAL_CHAT)
+    session.update_context("pending_actions", [])
+    context_before = dict(session.context)
+
+    async def exercise() -> list[dict]:
+        with patch("api.v1.endpoints.agent.get_config", return_value=config), \
+             patch("api.v1.endpoints.agent.asyncio.to_thread", side_effect=_immediate_to_thread), \
+             patch("src.agent.conversation.conversation_manager") as cm, \
+             patch("src.agent.web_intent_resolver.WebIntentResolver") as resolver_cls, \
+             patch("api.v1.endpoints.agent._build_executor", return_value=executor):
+            cm.get_or_create.return_value = session
+            resolver_cls.return_value.resolve.return_value = _simple_resolution()
+            return await _collect_stream_events(
+                agent_endpoint.ChatRequest(
+                    message="分析一下贵州茅台",
+                    session_id=session.session_id,
+                )
+            )
+
+    events = asyncio.run(exercise())
+
+    assert [event["type"] for event in events] == ["accepted", "error"]
+    terminal = events[-1]
+    assert terminal["type"] == "error"
+    assert terminal["error_code"] == "request_not_accepted"
+    executor.execute_turn.assert_not_called()
+    # 意图解析确实发生在 prepare_turn 之前（stock_code 已注入请求上下文）
+    assert executor.prepare_turn.call_args.kwargs["context"]["stock_code"] == "600519"
+    # 但会话上下文必须保持解析前的快照：被拒绝的请求不得成为后续追问的上下文
+    assert session.context == context_before
+
+
+def test_prepare_turn_success_commits_intent_context() -> None:
+    """prepare_turn 成功后才提交意图上下文，保证成功路径不回退。
+
+    修复将 apply_resolution_to_session 从意图解析线程挪到 prepare_turn
+    成功之后；本用例锁定成功路径仍会写入 recent_stocks / last_intent。
+    """
+    config = _intent_config()
+    executor = _executor(_result())
+    session = ConversationSession(session_id="prepare-ok-intent-session")
+
+    async def exercise() -> list[dict]:
+        with patch("api.v1.endpoints.agent.get_config", return_value=config), \
+             patch("api.v1.endpoints.agent.asyncio.to_thread", side_effect=_immediate_to_thread), \
+             patch("src.agent.conversation.conversation_manager") as cm, \
+             patch("src.agent.web_intent_resolver.WebIntentResolver") as resolver_cls, \
+             patch("api.v1.endpoints.agent._build_executor", return_value=executor):
+            cm.get_or_create.return_value = session
+            resolver_cls.return_value.resolve.return_value = _simple_resolution()
+            return await _collect_stream_events(
+                agent_endpoint.ChatRequest(
+                    message="分析一下贵州茅台",
+                    session_id=session.session_id,
+                )
+            )
+
+    events = asyncio.run(exercise())
+
+    assert [event["type"] for event in events] == [
+        "accepted",
+        "intent_resolved",
+        "done",
+    ]
+    assert session.context == {
+        "recent_stocks": ["600519"],
+        "last_intent": WebIntent.STOCK_RESEARCH,
+        "pending_actions": [],
+    }
+
+
+def test_intent_llm_fallback_does_not_block_event_loop() -> None:
+    """规则无解 + LLM 兜底（同步阻塞调用）不得阻塞 SSE 事件循环。
+
+    slow_resolve 模拟同步 LLM 调用阻塞 0.5s；断言 heartbeat 协程在 resolve 的
+    阻塞窗口内仍能 tick。修复前 resolve 在事件循环线程内同步执行，阻塞期间
+    事件循环无法调度任何协程，窗口内没有 heartbeat；修复后 resolve 走
+    asyncio.to_thread，事件循环空闲，窗口内正常 tick。
+    """
+    config = _intent_config()
+    executor = _executor(_result())
+    heartbeats: list = []
+    observed: dict = {}
+
+    def slow_resolve(self, message, *, session_context=None, request_context=None):
+        # 模拟规则无解时的同步 LLM 兜底调用（最多 8s 超时 + 一次重试）
+        observed["resolve_start"] = time.monotonic()
+        time.sleep(0.5)
+        observed["resolve_end"] = time.monotonic()
+        return _simple_resolution()
+
+    async def exercise() -> list[dict]:
+        with patch("api.v1.endpoints.agent.get_config", return_value=config), \
+             patch("src.agent.conversation.conversation_manager") as cm, \
+             patch.object(WebIntentResolver, "resolve", slow_resolve), \
+             patch("api.v1.endpoints.agent._build_executor", return_value=executor):
+            cm.get_or_create.return_value = ConversationSession(session_id="hb-session")
+
+            async def heartbeat() -> None:
+                for _ in range(20):
+                    await asyncio.sleep(0.05)
+                    heartbeats.append(time.monotonic())
+
+            hb_task = asyncio.create_task(heartbeat())
+            events = await _collect_stream_events(
+                agent_endpoint.ChatRequest(
+                    message="分析一下你好股份",
+                    session_id="hb-session",
+                )
+            )
+            await hb_task
+            return events
+
+    events = asyncio.run(exercise())
+    # heartbeat 必须在 resolve 的同步阻塞窗口内完成至少一次，才能证明事件循环
+    # 未被 LLM 兜底调用卡住（旧行为下窗口内无 tick，此断言会失败）
+    within_window = any(
+        observed["resolve_start"] <= tick <= observed["resolve_end"]
+        for tick in heartbeats
+    )
+    assert within_window, "event loop was blocked during intent LLM fallback"
+    assert [event["type"] for event in events] == [
+        "accepted",
+        "intent_resolved",
+        "done",
+    ]
+    assert events[1]["intent"] == "stock_research"
+
+
+def test_intent_resolution_runs_off_event_loop_thread() -> None:
+    """意图解析（含 LLM 兜底与 AkShare 扩展）在工作线程执行，不在事件循环线程。"""
+    config = _intent_config()
+    executor = _executor(_result())
+    main_thread_id = threading.get_ident()
+    observed: dict = {}
+
+    def fake_resolve(self, message, *, session_context=None, request_context=None):
+        observed["thread_id"] = threading.get_ident()
+        observed["message"] = message
+        return _simple_resolution()
+
+    async def exercise() -> list[dict]:
+        with patch("api.v1.endpoints.agent.get_config", return_value=config), \
+             patch("src.agent.conversation.conversation_manager") as cm, \
+             patch.object(WebIntentResolver, "resolve", fake_resolve), \
+             patch("api.v1.endpoints.agent._build_executor", return_value=executor):
+            cm.get_or_create.return_value = ConversationSession(session_id="thread-session")
+            return await _collect_stream_events(
+                agent_endpoint.ChatRequest(
+                    message="分析一下你好股份",
+                    session_id="thread-session",
+                )
+            )
+
+    events = asyncio.run(exercise())
+    assert observed["thread_id"] != main_thread_id
+    assert observed["message"] == "分析一下你好股份"
+    assert [event["type"] for event in events] == [
+        "accepted",
+        "intent_resolved",
+        "done",
+    ]
+
+
+def test_accepted_first_event_does_not_wait_for_intent_resolution() -> None:
+    """accepted 首事件不得等待意图解析完成（用户气泡即时渲染回归）。
+
+    修复前 accepted 在意图解析之后才发出：解析触发 LLM 兜底（8s 超时 + 一次
+    重试）或 AkShare 扩展下载时，Web store 收不到 accepted，用户输入（如
+    "分析三花"）的气泡要等解析完成后才显示。修复后 accepted 立即送达，
+    解析仍阻塞在工作线程时前端就能渲染用户消息。
+    """
+    config = _intent_config()
+    executor = _executor(_result())
+    release = threading.Event()
+    resolve_started = threading.Event()
+    resolve_finished = threading.Event()
+
+    def blocking_resolve(self, message, *, session_context=None, request_context=None):
+        resolve_started.set()
+        release.wait(timeout=5)
+        resolve_finished.set()
+        return _simple_resolution()
+
+    captured: dict = {}
+
+    async def exercise() -> None:
+        with patch("api.v1.endpoints.agent.get_config", return_value=config), \
+             patch("src.agent.conversation.conversation_manager") as cm, \
+             patch.object(WebIntentResolver, "resolve", blocking_resolve), \
+             patch("api.v1.endpoints.agent._build_executor", return_value=executor):
+            cm.get_or_create.return_value = ConversationSession(session_id="early-accept-session")
+            response = await agent_endpoint.agent_chat_stream(
+                agent_endpoint.ChatRequest(
+                    message="分析三花",
+                    session_id="early-accept-session",
+                ),
+                session_service=AgentChatSessionService(),
+            )
+            iterator = response.body_iterator
+            # 解析仍在阻塞时必须能读到首事件；若 accepted 等解析完成才发，
+            # 此 anext 会阻塞直到 wait_for 超时。
+            captured["first"] = json.loads(
+                (await asyncio.wait_for(anext(iterator), timeout=5)).removeprefix("data: ").strip()
+            )
+            captured["resolved_before_first"] = resolve_finished.is_set()
+            release.set()
+            captured["rest"] = [
+                json.loads(chunk.removeprefix("data: ").strip())
+                async for chunk in iterator
+            ]
+
+    async def main() -> None:
+        task = asyncio.create_task(exercise())
+        deadline = time.monotonic() + 5
+        while not resolve_started.is_set() and time.monotonic() < deadline:
+            await asyncio.sleep(0.01)
+        assert resolve_started.is_set(), "intent resolution never started"
+        await task
+
+    asyncio.run(main())
+    first = captured["first"]
+    rest = captured["rest"]
+    assert first["type"] == "accepted"
+    assert not captured["resolved_before_first"], (
+        "accepted was emitted only after intent resolution finished"
+    )
+    assert [event["type"] for event in rest] == ["intent_resolved", "done"]
+    assert rest[0]["intent"] == "stock_research"
+
+
+def test_intent_layer_default_off_keeps_legacy_stream() -> None:
+    """未声明 agent_web_intent_enabled 的临时 Config 走原路径（无意图事件）。"""
+    config = SimpleNamespace(
+        agent_backend="auto",
+        is_agent_available=lambda: True,
+        report_language="zh",
+    )
+    executor = _executor(_result())
+
+    async def exercise() -> list[dict]:
+        with patch("api.v1.endpoints.agent.get_config", return_value=config), \
+             patch("api.v1.endpoints.agent.asyncio.to_thread", side_effect=_immediate_to_thread), \
+             patch("api.v1.endpoints.agent._build_executor", return_value=executor):
+            return await _collect_stream_events(
+                agent_endpoint.ChatRequest(
+                    message="分析 600519",
+                    session_id="legacy-session",
+                )
+            )
+
+    events = asyncio.run(exercise())
+    assert [event["type"] for event in events] == ["accepted", "done"]

--- a/tests/test_agent_executor.py
+++ b/tests/test_agent_executor.py
@@ -281,6 +281,46 @@ class TestAgentExecutor(unittest.TestCase):
         assert messages[-1] == {"role": "user", "content": "当前问题"}
         assert captured["stock_scope"].expected_stock_code == "600519"
 
+    def test_chat_confirmed_compare_turn_renders_resolved_codes_and_scope(self):
+        """确认消费轮（OR-COR-1f4c2d7a）：确认回复"港股"不含任何代码，
+        意图层注入的已解析比较对必须同时进入上下文渲染与工具作用域，
+        否则范围守卫无范围可依、后端也不知道本轮该分析哪些标的。
+        """
+        registry = _make_registry_with_echo()
+        adapter = _make_mock_adapter()
+        adapter._config = MagicMock()
+        executor = AgentExecutor(registry, adapter, max_steps=2)
+        captured = {}
+
+        def fake_run_loop(messages, tool_decls, parse_dashboard, progress_callback=None, stock_scope=None):
+            captured["messages"] = messages
+            captured["stock_scope"] = stock_scope
+            return AgentResult(success=True, content="assistant reply")
+
+        with patch.object(executor, "_run_loop", side_effect=fake_run_loop):
+            with patch(
+                "src.agent.executor.build_agent_chat_context_bundle",
+                return_value=SimpleNamespace(context_messages=[], diagnostics={}),
+            ):
+                with patch("src.agent.conversation.conversation_manager.get_or_create"):
+                    with patch("src.agent.conversation.conversation_manager.add_message"):
+                        executor.chat(
+                            "港股",
+                            "session-confirm-compare",
+                            context={
+                                "resolved_stock_codes": ["09988", "00700"],
+                                "web_intent_original_request": "对比阿里巴巴和腾讯控股",
+                            },
+                        )
+
+        context_message = captured["messages"][1]["content"]
+        assert "本轮已确认的分析标的: 09988、00700" in context_message
+        assert "原始请求：对比阿里巴巴和腾讯控股" in context_message
+        scope = captured["stock_scope"]
+        assert scope.mode == "compare"
+        assert scope.expected_stock_code == ""
+        assert scope.allowed_stock_codes == {"HK09988", "HK00700"}
+
     def test_chat_switches_effective_context_and_clears_previous_stock_fields(self):
         registry = _make_registry_with_echo()
         adapter = _make_mock_adapter()
@@ -421,6 +461,35 @@ class TestAgentExecutor(unittest.TestCase):
         self.assertEqual(result.stock_scope.mode, "maintain")
         self.assertEqual(result.effective_context["stock_code"], "600519")
         self.assertEqual(result.stock_scope.allowed_stock_codes, {"600519"})
+
+    def test_resolved_stock_codes_build_compare_scope_without_message_codes(self):
+        # 确认消费轮：确认回复（如"港股"）不含代码，意图层注入的已解析
+        # 比较对必须独立构建比较作用域（默认与 strict 初始模式行为一致）
+        context = {"resolved_stock_codes": ["09988", "00700"]}
+
+        for strict in (False, True):
+            with self.subTest(strict=strict):
+                result = resolve_stock_scope("港股", context, strict_initial_scope=strict)
+
+                self.assertEqual(result.stock_scope.mode, "compare")
+                self.assertEqual(result.stock_scope.expected_stock_code, "")
+                # 5 位港股代码按守卫规范格式（HK 前缀）进入允许集合
+                self.assertEqual(result.stock_scope.allowed_stock_codes, {"HK09988", "HK00700"})
+                # 注入键只参与作用域推导，不得流入下游 effective_context
+                self.assertNotIn("resolved_stock_codes", result.effective_context)
+
+    def test_resolved_stock_codes_merge_with_message_codes(self):
+        # 确认回复顺带提及其他显式代码时，与注入比较对合并且范围不缩水
+        result = resolve_stock_scope(
+            "顺带看下600519",
+            {"resolved_stock_codes": ["09988", "00700"]},
+        )
+
+        self.assertEqual(result.stock_scope.mode, "compare")
+        self.assertEqual(
+            result.stock_scope.allowed_stock_codes,
+            {"HK09988", "HK00700", "600519"},
+        )
 
     def test_run_agent_loop_does_not_persist_agent_usage_without_provider_usage(self):
         registry = _make_registry_with_echo()

--- a/tests/test_name_to_code_resolver.py
+++ b/tests/test_name_to_code_resolver.py
@@ -8,17 +8,56 @@ Covers:
 - AkShare fallback (mocked)
 - Fuzzy match (difflib)
 - Ambiguous names return None
+- List resolver (resolver_name_to_code_list: exact/substring/sorting/limits)
+- US ticker match (US_stock_code_match)
+- Stock dataclass (dict-style access, equality)
+- is_known_stock_name / extract_stock_name (pure-local name recognition)
+- extend_AkShare (stockDB merge + idempotency)
 """
 
 import pytest
 from unittest.mock import patch
 
+import src.services.name_to_code_resolver as resolver_mod
+
 from src.services.name_to_code_resolver import (
     resolve_name_to_code,
+    resolver_name_to_code_list,
+    US_stock_code_match,
+    Stock,
+    is_known_stock_name,
+    extract_stock_name,
+    extend_AkShare,
     _is_code_like,
     _normalize_code,
     _build_reverse_map_no_duplicates,
 )
+
+
+def _pypinyin_available() -> bool:
+    try:
+        import pypinyin  # noqa: F401
+        return True
+    except ImportError:
+        return False
+
+
+@pytest.fixture(autouse=True)
+def _restore_name_resolver_state():
+    """Snapshot and restore module-level mutable state around each test.
+
+    name_to_code_resolver keeps a process-wide stockDB plus an AkShare
+    cache/merge guard; tests that mock AkShare data would otherwise leak
+    entries into the shared database and break later tests.
+    """
+    db = dict(resolver_mod.stockDB)
+    cache = resolver_mod._akshare_cache
+    merged = resolver_mod._akshare_merged
+    yield
+    resolver_mod.stockDB.clear()
+    resolver_mod.stockDB.update(db)
+    resolver_mod._akshare_cache = cache
+    resolver_mod._akshare_merged = merged
 
 
 # ---------------------------------------------------------------------------
@@ -131,6 +170,41 @@ class TestResolveNameToCode:
         # "阿里巴巴" maps to both BABA and 09988 in STOCK_NAME_MAP
         assert resolve_name_to_code("阿里巴巴") is None
 
+    def test_ambiguous_substring_multi_candidate_returns_none(self):
+        # 子串匹配产生的多候选同样必须返回 None：
+        # 修复前仅拦截精确同名歧义，以下输入会静默返回排序后第一只
+        # （"阿里"→09988、"银行"→000001、"汽车"→09868）。
+        assert resolve_name_to_code("阿里") is None
+        assert resolve_name_to_code("银行") is None
+        assert resolve_name_to_code("汽车") is None
+
+    @patch("src.services.name_to_code_resolver._get_akshare_name_to_code")
+    def test_akshare_extension_multi_candidate_returns_none(self, mock_akshare):
+        # AkShare 扩展后子串命中多只 → 同样必须返回 None，绝不取第一只
+        # （本地库外的名称只有扩展后才出现多候选）。
+        mock_akshare.return_value = {
+            "测试银行甲": "999990",
+            "测试银行乙": "999991",
+        }
+        assert resolve_name_to_code("测试银行") is None
+
+    @patch("src.services.name_to_code_resolver._get_akshare_name_to_code")
+    def test_akshare_exact_name_beats_local_fuzzy_singleton(self, mock_akshare, monkeypatch):
+        # OR-COR-a2d5f6b9：本地库里的近似名（单字之差）不得抢占本地缺失、
+        # AkShare 独有的精确 A 股名——修复前"测试银行乙"被本地模糊匹配
+        # 静默解析到"测试银行甲"的代码，AkShare 精确条目永远没机会胜出。
+        monkeypatch.setattr(resolver_mod, "stockDB", {"111111": "测试银行甲"})
+        mock_akshare.return_value = {"测试银行乙": "222222"}
+        assert resolve_name_to_code("测试银行乙") == "222222"
+
+    @patch("src.services.name_to_code_resolver._get_akshare_name_to_code")
+    def test_local_fuzzy_singleton_kept_when_akshare_lacks_exact_name(self, mock_akshare, monkeypatch):
+        # 反向保护：AkShare 没有精确名时，本地模糊 singleton 容错行为保留
+        # （与 test_fuzzy_match_fallback 的"贵州茅苔"→600519 契约一致）。
+        monkeypatch.setattr(resolver_mod, "stockDB", {"111111": "测试银行甲"})
+        mock_akshare.return_value = {"无关个股": "333333"}
+        assert resolve_name_to_code("测试银行乙") == "111111"
+
     @patch("src.services.name_to_code_resolver._get_akshare_name_to_code")
     def test_akshare_fallback_when_not_in_local(self, mock_akshare):
         mock_akshare.return_value = {"平安银行": "000001"}
@@ -160,3 +234,207 @@ class TestResolveNameToCode:
         result = resolve_name_to_code("aaaaaaa")
         assert result is None
         mock_akshare.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Pinyin match (skipped when pypinyin is unavailable)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.skipif(not _pypinyin_available(), reason="pypinyin not installed")
+class TestPinyinMatch:
+    def test_resolves_full_pinyin(self):
+        # maotai ⊂ guizhoumaotai (贵州茅台)
+        assert resolve_name_to_code("maotai") == "600519"
+
+    def test_resolves_concatenated_pinyin(self):
+        assert resolve_name_to_code("guizhoumaotai") == "600519"
+
+    def test_list_resolver_pinyin(self):
+        stocks = resolver_name_to_code_list("maotai")
+        assert [(s.code, s.market) for s in stocks] == [("600519", "a")]
+
+    def test_list_resolver_pinyin_case_insensitive(self):
+        stocks = resolver_name_to_code_list("MAOTAI")
+        assert [(s.code, s.market) for s in stocks] == [("600519", "a")]
+
+
+# ---------------------------------------------------------------------------
+# resolver_name_to_code_list
+# ---------------------------------------------------------------------------
+
+class TestResolverNameToCodeList:
+    def test_exact_name_single_result(self):
+        stocks = resolver_name_to_code_list("贵州茅台")
+        assert [(s.code, s.market) for s in stocks] == [("600519", "a")]
+
+    def test_substring_match(self):
+        # 茅台 ⊂ 贵州茅台
+        stocks = resolver_name_to_code_list("茅台")
+        assert [(s.code, s.market) for s in stocks] == [("600519", "a")]
+
+    def test_ambiguous_exact_name_all_candidates_sorted(self):
+        # Sorted A → HK → US: 09988(hk) before BABA(us)
+        stocks = resolver_name_to_code_list("阿里巴巴")
+        assert [(s.code, s.market) for s in stocks] == [("09988", "hk"), ("BABA", "us")]
+
+    def test_ambiguous_substring_all_candidates_sorted(self):
+        stocks = resolver_name_to_code_list("阿里")
+        assert [(s.code, s.market) for s in stocks] == [("09988", "hk"), ("BABA", "us")]
+
+    def test_single_cjk_char_short_circuits(self):
+        assert resolver_name_to_code_list("好") == []
+
+    def test_empty_and_none_input(self):
+        assert resolver_name_to_code_list("") == []
+        assert resolver_name_to_code_list(None) == []
+        assert resolver_name_to_code_list("   ") == []
+
+    def test_truncates_to_five_results(self, monkeypatch):
+        fake_db = {f"1{i:05d}": "多码股" for i in range(1, 9)}
+        monkeypatch.setattr(resolver_mod, "stockDB", fake_db)
+        stocks = resolver_name_to_code_list("多码股")
+        assert len(stocks) == 5
+        assert all(s.market == "a" for s in stocks)
+
+
+# ---------------------------------------------------------------------------
+# US_stock_code_match
+# ---------------------------------------------------------------------------
+
+class TestUSStockCodeMatch:
+    def test_known_ticker(self):
+        stocks = US_stock_code_match("TSLA")
+        assert [(s.code, s.market) for s in stocks] == [("TSLA", "us")]
+
+    def test_lowercase_ticker_uppercased(self):
+        stocks = US_stock_code_match("tsla")
+        assert [(s.code, s.market) for s in stocks] == [("TSLA", "us")]
+
+    def test_unknown_ticker_not_in_db(self):
+        assert US_stock_code_match("SOFI") == []
+
+    def test_ordinary_word_not_treated_as_code(self):
+        assert US_stock_code_match("OK") == []
+
+    def test_rejects_invalid_format(self):
+        assert US_stock_code_match("AAPL1") == []  # not pure alpha
+        assert US_stock_code_match("ABCDEF") == []  # > 5 letters
+        assert US_stock_code_match("") == []
+        assert US_stock_code_match("   ") == []
+
+
+# ---------------------------------------------------------------------------
+# Stock dataclass
+# ---------------------------------------------------------------------------
+
+class TestStockDataclass:
+    def test_dict_style_access(self):
+        stock = Stock("600519", "贵州茅台", "a")
+        assert stock["code"] == "600519"
+        assert stock["name"] == "贵州茅台"
+        assert stock["market"] == "a"
+
+    def test_key_error_on_unknown_key(self):
+        with pytest.raises(KeyError):
+            _ = Stock("600519", "贵州茅台", "a")["unknown"]
+
+    def test_equality(self):
+        stock = Stock("600519", "贵州茅台", "a")
+        assert stock == Stock("600519", "贵州茅台", "a")
+        assert stock == {"code": "600519", "name": "贵州茅台", "market": "a"}
+        assert stock == "600519"
+
+    def test_inequality(self):
+        stock = Stock("600519", "贵州茅台", "a")
+        assert stock != Stock("00700", "腾讯控股", "hk")
+        assert stock != {"code": "00700", "name": "腾讯控股", "market": "hk"}
+        assert stock != "00700"
+        assert stock != 123
+
+    def test_repr(self):
+        assert repr(Stock("600519", "贵州茅台", "a")) == "Stock(code='600519', name='贵州茅台', market='a')"
+
+
+# ---------------------------------------------------------------------------
+# is_known_stock_name
+# ---------------------------------------------------------------------------
+
+class TestIsKnownStockName:
+    def test_exact_name(self):
+        assert is_known_stock_name("贵州茅台") is True
+
+    def test_substring_of_stock_name(self):
+        assert is_known_stock_name("茅台") is True
+
+    def test_unknown_name(self):
+        assert is_known_stock_name("你好股份") is False
+
+    def test_invalid_inputs(self):
+        assert is_known_stock_name("") is False
+        assert is_known_stock_name("   ") is False
+        assert is_known_stock_name("贵") is False  # too short
+        assert is_known_stock_name(None) is False
+        assert is_known_stock_name(123) is False
+
+
+# ---------------------------------------------------------------------------
+# extract_stock_name
+# ---------------------------------------------------------------------------
+
+class TestExtractStockName:
+    def test_segments_known_and_unknown(self):
+        segments = extract_stock_name("分析下贵州茅台")
+        assert segments[0] == ("分析下", None)
+        fragment, stocks = segments[1]
+        assert fragment == "贵州茅台"
+        assert [(s.code, s.market) for s in stocks] == [("600519", "a")]
+
+    def test_longest_name_matched_first(self):
+        # 茅台 is not a standalone entry, only the full 贵州茅台 is matched
+        segments = extract_stock_name("贵州茅台怎么样")
+        assert [(f, [(s.code, s.market) for s in st] if st else None) for f, st in segments] == [
+            ("贵州茅台", [("600519", "a")]),
+            ("怎么样", None),
+        ]
+
+    def test_no_match_passthrough(self):
+        assert extract_stock_name("你好呀") == [("你好呀", None)]
+
+    def test_empty_input(self):
+        assert extract_stock_name("") == []
+        assert extract_stock_name(None) == []
+
+
+# ---------------------------------------------------------------------------
+# extend_AkShare
+# ---------------------------------------------------------------------------
+
+class TestExtendAkShare:
+    @patch("src.services.name_to_code_resolver._get_akshare_name_to_code")
+    def test_adds_new_entries(self, mock_get):
+        mock_get.return_value = {"新股票": "888888"}
+        assert extend_AkShare() is True
+        assert resolver_mod.stockDB.get("888888") == "新股票"
+
+    @patch("src.services.name_to_code_resolver._get_akshare_name_to_code")
+    def test_idempotent_same_data(self, mock_get):
+        data = {"新股票": "888888"}
+        mock_get.return_value = data
+        assert extend_AkShare() is True
+        assert extend_AkShare() is False  # same dict object already merged
+
+    @patch("src.services.name_to_code_resolver._get_akshare_name_to_code")
+    def test_no_data_returns_false(self, mock_get):
+        mock_get.return_value = None
+        assert extend_AkShare() is False
+        mock_get.return_value = {}
+        assert extend_AkShare() is False
+
+    @patch("src.services.name_to_code_resolver._get_akshare_name_to_code")
+    def test_refreshed_cache_without_new_entries_returns_false(self, mock_get):
+        mock_get.return_value = {"新股票": "888888"}
+        assert extend_AkShare() is True
+        # TTL 过期后重新拉取返回新 dict 但无新条目：不需要再扩展 → False
+        mock_get.return_value = dict({"新股票": "888888"})
+        assert extend_AkShare() is False
+        assert resolver_mod.stockDB.get("888888") == "新股票"

--- a/tests/test_search_performance.py
+++ b/tests/test_search_performance.py
@@ -12,6 +12,26 @@ import pytest
 from unittest.mock import patch
 from src.services.name_to_code_resolver import resolve_name_to_code
 
+
+@pytest.fixture(autouse=True)
+def _restore_resolver_state():
+    """快照/还原 name_to_code_resolver 模块级可变状态，防止基准用例的
+    AkShare mock 数据（extend_AkShare 合并进全局 stockDB 并置位
+    _akshare_merged）泄漏给同进程内后续运行的测试文件。"""
+    from src.services import name_to_code_resolver as resolver_mod
+
+    db = dict(resolver_mod.stockDB)
+    cache = resolver_mod._akshare_cache
+    merged = resolver_mod._akshare_merged
+    yield
+    resolver_mod.stockDB.clear()
+    resolver_mod.stockDB.update(db)
+    resolver_mod._akshare_cache = cache
+    resolver_mod._akshare_merged = merged
+    # stockDB 原地增删，按对象身份缓存的名称/拼音列表可能已陈旧，强制重建
+    resolver_mod._database_names_cache[:] = [None, None, None]
+
+
 class TestSearchPerformance:
     """Benchmark tests for stock search resolution."""
 

--- a/tests/test_web_intent_resolver.py
+++ b/tests/test_web_intent_resolver.py
@@ -1,0 +1,551 @@
+# -*- coding: utf-8 -*-
+"""web_intent_resolver 规则路径回归测试。
+
+只测 _classify_by_rules 规则层（WebIntentResolver(None)：无 LLM 适配器、
+无 config，resolve() 不会发起任何 LLM 调用）。规则无法定论的消息会走
+rule_fallback（general_chat），因此断言以"不等于误判的意图"为主。
+
+分词管道 Step 6 前的 AkShare 扩展在测试中 mock 为最小全量 A 股数据
+（_MOCK_AKSHARE_A_SHARES），保证离线确定性；mock 之外的库外名称仍走
+规则不定论路径。
+"""
+
+import os
+import sys
+from unittest.mock import patch
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+import pytest
+
+from src.agent.web_intent_resolver import (
+    WebIntent, WebIntentResolver,
+    _split_by_codes, TAG_UNKNOWN_CODE, TAG_UNKNOWN_NUMBER, Token,
+)
+
+INHERIT_CTX = {"recent_stocks": ["600519"], "last_intent": "stock_research"}
+
+# 上一轮"再分析下阿里最近的走势"遗留的待确认动作（hk 09988 / us BABA）
+CONFIRM_CTX = {
+    "pending_actions": [
+        {
+            "action": "confirm_stock",
+            "candidates": [
+                {"code": "09988", "name": "阿里巴巴", "market": "hk"},
+                {"code": "BABA", "name": "阿里巴巴", "market": "us"},
+            ],
+        }
+    ]
+}
+
+
+# AkShare 扩展在分词管道 Step 6 前统一执行（extend_AkShare，30 分钟缓存）。
+# 规则路径测试 mock 一份最小全量 A 股数据：确定、离线、不依赖真实网络；
+# mock 之外的库外名称（你好股份/SOFI 等）仍走"规则不定论"原路径。
+_MOCK_AKSHARE_A_SHARES = {
+    "酒鬼酒": "000799",
+    "三花智控": "002050",
+    "中大力德": "002896",
+}
+
+
+@pytest.fixture(autouse=True)
+def _mock_akshare_extension():
+    with patch(
+        "src.services.name_to_code_resolver._get_akshare_name_to_code",
+        return_value=_MOCK_AKSHARE_A_SHARES,
+    ):
+        yield
+
+
+@pytest.fixture(autouse=True)
+def _restore_resolver_state():
+    """快照/还原 name_to_code_resolver 模块级可变状态，用例间互不泄漏。"""
+    from src.services import name_to_code_resolver as resolver_mod
+
+    db = dict(resolver_mod.stockDB)
+    cache = resolver_mod._akshare_cache
+    merged = resolver_mod._akshare_merged
+    yield
+    resolver_mod.stockDB.clear()
+    resolver_mod.stockDB.update(db)
+    resolver_mod._akshare_cache = cache
+    resolver_mod._akshare_merged = merged
+    # stockDB 原地增删，按对象身份缓存的名称/拼音列表可能已陈旧，强制重建
+    resolver_mod._database_names_cache[:] = [None, None, None]
+
+
+@pytest.fixture(scope="module")
+def resolver():
+    # config=None + 无 llm_adapter → resolve() 不创建 LLM，规则层可独立判定
+    return WebIntentResolver(None)
+
+
+def _resolve(resolver, message, session=INHERIT_CTX):
+    return resolver.resolve(message, session_context=session, request_context={})
+
+
+class TestResearchRequestWithUnresolvedToken:
+    """研究请求中含未识别 token（关键位置解析失败，如"你好股份"）时，
+    规则不得定论为对当前股票的追问，应升级 LLM 兜底。"""
+
+    def test_unknown_name_after_request(self, resolver):
+        res = _resolve(resolver, "再分析一下你好股份基本面")
+        assert res.intent != WebIntent.HISTORY_FOLLOWUP
+
+    def test_unknown_name_before_request(self, resolver):
+        res = _resolve(resolver, "你好股份分析一下")
+        assert res.intent != WebIntent.HISTORY_FOLLOWUP
+
+    def test_unknown_name_with_research_subject(self, resolver):
+        res = _resolve(resolver, "研究一下你好股份的基本面")
+        assert res.intent != WebIntent.HISTORY_FOLLOWUP
+
+
+class TestFollowupPreserved:
+    """真正的追问（无新股票名称）仍走 followup 规则路径，不回归。"""
+
+    def test_re_analysis(self, resolver):
+        res = _resolve(resolver, "再分析一下")
+        assert res.intent == WebIntent.HISTORY_FOLLOWUP
+        assert res.inherited_stock_code == "600519"
+
+    def test_continue_analysis(self, resolver):
+        res = _resolve(resolver, "继续分析")
+        assert res.intent == WebIntent.HISTORY_FOLLOWUP
+
+    def test_pronoun_anchor(self, resolver):
+        res = _resolve(resolver, "它还能涨吗")
+        assert res.intent == WebIntent.HISTORY_FOLLOWUP
+
+    def test_re_analysis_with_topic(self, resolver):
+        res = _resolve(resolver, "再分析一下它的基本面")
+        assert res.intent == WebIntent.HISTORY_FOLLOWUP
+
+    def test_no_inherited_stock_not_followup(self, resolver):
+        res = _resolve(resolver, "再分析一下", session={})
+        assert res.intent != WebIntent.HISTORY_FOLLOWUP
+
+
+class TestUsTickerIdentification:
+    """美股识别优化：本地库命中的 ticker 才辨认为 stock_code；
+    库外美股保留 unknown_code 交由下游 LLM 判断（宁可不做也不做错）。
+
+    resolver 无 LLM 适配器，升级 LLM 的消息会降级 rule_fallback(general_chat)，
+    因此断言以"不等于误判的意图"为主。
+    """
+
+    def test_us_ticker_in_db_is_stock(self, resolver):
+        res = _resolve(resolver, "研究一下TSLA", session={})
+        assert res.intent == WebIntent.STOCK_RESEARCH
+        assert res.stocks and res.stocks[0].code == "TSLA"
+
+    def test_us_ticker_with_us_suffix_in_db(self, resolver):
+        res = _resolve(resolver, "看看AAPL.us", session={})
+        assert res.intent == WebIntent.STOCK_RESEARCH
+        assert res.stocks and res.stocks[0].code == "AAPL.us"
+
+    def test_us_ticker_not_in_db_not_stock(self, resolver):
+        # SOFI 不在本地库：不得辨认为股票，规则无法定论 → 无 LLM 时降级 general_chat
+        res = _resolve(resolver, "研究一下SOFI", session={})
+        assert res.intent != WebIntent.STOCK_RESEARCH
+
+    def test_english_word_not_stock(self, resolver):
+        # 普通英文单词（OK）不得被当成美股代码 → 不能是 stock_research
+        res = _resolve(resolver, "OK", session={})
+        assert res.intent != WebIntent.STOCK_RESEARCH
+
+    def test_us_ticker_outside_db_with_inherited_not_followup(self, resolver):
+        # 库外美股 + 追问锚点 + 继承股票：不得误判为对 600519 的追问
+        res = _resolve(resolver, "再分析一下SOFI", session=INHERIT_CTX)
+        assert res.intent != WebIntent.HISTORY_FOLLOWUP
+
+    def test_us_ticker_not_poisoning_explicit_code(self, resolver):
+        # 有效代码 + 库外美股比较：升级 LLM，规则不定论（不静默丢弃存疑股）
+        res = _resolve(resolver, "600519和SOFI哪个好", session={})
+        assert res.intent != WebIntent.HISTORY_FOLLOWUP
+
+
+class TestNumericCodeIdentificationPreserved:
+    """A 股/港股数字代码识别保持原行为，不回归。"""
+
+    def test_ashare_6digit(self, resolver):
+        res = _resolve(resolver, "分析一下600519", session={})
+        assert res.intent == WebIntent.STOCK_RESEARCH
+        assert res.stocks and res.stocks[0].code == "600519"
+
+    def test_hk_5digit_bare(self, resolver):
+        # 5 位裸数字（港股 00700）原行为：直接辨认为股票代码
+        res = _resolve(resolver, "分析一下00700", session={})
+        assert res.intent == WebIntent.STOCK_RESEARCH
+        assert res.stocks and res.stocks[0].code == "00700"
+
+    def test_hk_suffix_form(self, resolver):
+        res = _resolve(resolver, "00700.HK分析一下", session={})
+        assert res.intent == WebIntent.STOCK_RESEARCH
+        assert res.stocks and res.stocks[0].code == "00700.HK"
+
+    def test_wrong_code_still_unresolved(self, resolver):
+        # 明确非法代码形字符串仍走 wrong_code → 待确认流程
+        res = _resolve(resolver, "看一下777777的趋势", session={})
+        assert res.intent == WebIntent.STOCK_RESEARCH
+        assert res.needs_confirmation
+        assert "777777" in (res.unresolved_names or [])
+
+
+class TestBareShortNumberTag:
+    """≤4 位裸数字在 _split_by_codes 阶段直接打 unknown_number。"""
+
+    def test_year_tag(self):
+        assert _split_by_codes("2024") == [Token("2024", TAG_UNKNOWN_NUMBER)]
+
+    def test_month_tag(self):
+        assert _split_by_codes("12") == [Token("12", TAG_UNKNOWN_NUMBER)]
+
+    def test_bare_4digit_tag(self):
+        assert _split_by_codes("0070") == [Token("0070", TAG_UNKNOWN_NUMBER)]
+
+    def test_bare_5digit_still_unknown_code(self):
+        assert _split_by_codes("00700") == [Token("00700", TAG_UNKNOWN_CODE)]
+
+    def test_bare_6digit_still_unknown_code(self):
+        assert _split_by_codes("600519") == [Token("600519", TAG_UNKNOWN_CODE)]
+
+    def test_bare_7digit_still_unknown_code(self):
+        assert _split_by_codes("6005199") == [Token("6005199", TAG_UNKNOWN_CODE)]
+
+    def test_hk_suffix_still_unknown_code(self):
+        assert _split_by_codes("1234.HK") == [Token("1234.HK", TAG_UNKNOWN_CODE)]
+
+    def test_sz_suffix_still_unknown_code(self):
+        assert _split_by_codes("0070.SZ") == [Token("0070.SZ", TAG_UNKNOWN_CODE)]
+
+    def test_hk_prefix_still_unknown_code(self):
+        assert _split_by_codes("HK12") == [Token("HK12", TAG_UNKNOWN_CODE)]
+
+    def test_date_splits_into_three_number_tokens(self):
+        tokens = _split_by_codes("2024-08-12")
+        assert [t.tag for t in tokens if t.tag] == [TAG_UNKNOWN_NUMBER] * 3
+
+
+class TestBareShortNumberNotStock:
+    """≤4 位裸数字（年份/月份/日期/价格）不得触发 stock_unresolved 确认流程。"""
+
+    def test_year_alone_no_confirmation(self, resolver):
+        res = _resolve(resolver, "2024", session={})
+        assert res.intent != WebIntent.STOCK_RESEARCH
+        assert not res.needs_confirmation
+
+    def test_year_with_request_word_no_confirmation(self, resolver):
+        res = _resolve(resolver, "看一下2024", session={})
+        assert res.intent != WebIntent.STOCK_RESEARCH
+        assert not res.needs_confirmation
+
+    def test_year_with_research_subject_and_inherited_stock(self, resolver):
+        res = _resolve(resolver, "2024年走势怎么样", session=INHERIT_CTX)
+        assert res.intent != WebIntent.STOCK_RESEARCH
+        assert res.intent != WebIntent.HISTORY_FOLLOWUP
+        assert not res.needs_confirmation
+
+    def test_month_no_confirmation(self, resolver):
+        res = _resolve(resolver, "12月", session={})
+        assert not res.needs_confirmation
+
+    def test_date_no_confirmation(self, resolver):
+        res = _resolve(resolver, "2024-08-12", session={})
+        assert not res.needs_confirmation
+
+    def test_csi300_index_still_market_overview(self, resolver):
+        # "沪深300" 的 300 现在是 unknown_number，仍必须命中 market_keyword → 大盘行情
+        res = _resolve(resolver, "沪深300", session={})
+        assert res.intent == WebIntent.MARKET_OVERVIEW
+
+
+class TestStockResearchExamples:
+    """个股研究样例的规则路径回归：歧义待确认、真实股票名守卫、
+    多股比较、ASCII 市场词边界、确认消费、唯一名称直判。"""
+
+    def test_ambiguous_name_needs_confirmation(self, resolver):
+        # "再分析下阿里最近的走势"：阿里 → hk 09988 / us BABA 多候选 → 待确认
+        res = _resolve(resolver, "再分析下阿里最近的走势", session={})
+        assert res.intent == WebIntent.STOCK_RESEARCH
+        assert res.needs_confirmation
+        assert res.pending_action and res.pending_action.get("action") == "confirm_stock"
+        codes = [c["code"] for c in res.pending_action["candidates"]]
+        assert codes == ["09988", "BABA"]
+
+    def test_real_stock_name_not_followup_guard(self, resolver):
+        # 追问短路真实股票名守卫：上一轮研究茅台后"比亚迪怎么样？" → 个股研究
+        res = _resolve(resolver, "比亚迪怎么样？", session=INHERIT_CTX)
+        assert res.intent == WebIntent.STOCK_RESEARCH
+        assert res.intent != WebIntent.HISTORY_FOLLOWUP
+        assert res.stocks and res.stocks[0].code == "002594"
+
+    def test_multi_stock_comparison_no_inherited_code(self, resolver):
+        # 多股比较：primary_stock_code 返回空串，绝不注入继承码 600519
+        res = _resolve(resolver, "对比000858和300750", session=INHERIT_CTX)
+        assert res.intent == WebIntent.STOCK_RESEARCH
+        assert [s.code for s in (res.stocks or [])] == ["000858", "300750"]
+        assert res.primary_stock_code == ""
+
+    def test_ascii_market_word_boundary(self, resolver):
+        # ASCII 市场词边界：英文句中的代词 "us" 不误判为美股指示，由 TSLA 显式代码定论
+        res = _resolve(resolver, "tell us about TSLA", session={})
+        assert res.intent == WebIntent.STOCK_RESEARCH
+        assert res.stocks and res.stocks[0].code == "TSLA"
+
+    def test_confirmation_consumed_by_market_word(self, resolver):
+        # 步骤 3 消费确认："港股"市场词把候选收窄到唯一一只 → 确认港股阿里
+        res = _resolve(resolver, "港股阿里", session=CONFIRM_CTX)
+        assert res.source == "confirmation"
+        assert res.confidence == 0.95
+        assert res.stocks and res.stocks[0].code == "09988"
+
+    def test_ambiguity_preserves_resolved_stocks_in_pending(self, resolver):
+        # 混合歧义 + 已解析股票："对比阿里巴巴和腾讯控股"中的腾讯 00700 必须
+        # 保留在 stocks 和 pending_action.resolved_stocks 中，确认后不得丢失
+        res = _resolve(resolver, "对比阿里巴巴和腾讯控股", session={})
+        assert res.intent == WebIntent.STOCK_RESEARCH
+        assert res.needs_confirmation
+        assert [s.code for s in res.stocks] == ["00700"]
+        assert res.pending_action["action"] == "confirm_stock"
+        assert {c["code"] for c in res.pending_action["candidates"]} == {"09988", "BABA"}
+        assert [s["code"] for s in res.pending_action["resolved_stocks"]] == ["00700"]
+        assert res.pending_action["original_request"] == "对比阿里巴巴和腾讯控股"
+
+    def test_confirmation_merges_selected_candidate_with_resolved(self, resolver):
+        # 确认消费后重放比较请求：选中港股阿里 09988 时，必须与已解析的
+        # 腾讯 00700 合并，primary_stock_code 保持空串（多股比较语义）；
+        # original_request 必须随确认结果带出，供 SSE 层恢复比较语义
+        ctx = {
+            "pending_actions": [
+                {
+                    "action": "confirm_stock",
+                    "candidates": [
+                        {"code": "09988", "name": "阿里巴巴", "market": "hk"},
+                        {"code": "BABA", "name": "阿里巴巴", "market": "us"},
+                    ],
+                    "resolved_stocks": [
+                        {"code": "00700", "name": "腾讯控股", "market": "hk"}
+                    ],
+                    "original_request": "对比阿里巴巴和腾讯控股",
+                }
+            ]
+        }
+        res = _resolve(resolver, "港股", session=ctx)
+        assert res.source == "confirmation"
+        assert res.confidence == 0.95
+        assert [s.code for s in res.stocks] == ["09988", "00700"]
+        assert res.primary_stock_code == ""
+        assert res.original_request == "对比阿里巴巴和腾讯控股"
+
+    def test_unique_known_name_direct(self, resolver):
+        # 唯一已解析名称（腾讯 → 00700）显式名称分支直接定论
+        res = _resolve(resolver, "研究一下腾讯基本面以及它最近的走势", session={})
+        assert res.intent == WebIntent.STOCK_RESEARCH
+        assert res.stocks and res.stocks[0].code == "00700"
+
+
+class TestConfirmationConsumptionNegative:
+    """待确认动作消费的反例回归（OR-COR-91d4de84）。
+
+    上一轮遗留的歧义候选（hk 09988 / us BABA 都叫"阿里巴巴"）在用户下一条
+    消息中再次出现时，不得静默确认第一只 09988：
+      - 带市场提示（"美股阿里巴巴"）必须按市场收窄 → BABA；
+      - 带新请求（"再分析下阿里巴巴最近走势"）或比较（"阿里巴巴和腾讯对比
+        一下"）必须按新消息重新分类，跳过确认消费。
+    """
+
+    def test_market_hint_narrows_cross_market_candidate(self, resolver):
+        # "美股"提示必须把候选收窄到唯一美股 BABA，而不是子串抢先命中 09988
+        res = _resolve(resolver, "美股阿里巴巴", session=CONFIRM_CTX)
+        assert res.source == "confirmation"
+        assert res.stocks and res.stocks[0].code == "BABA"
+
+    def test_research_request_with_ambiguous_name_reclassified(self, resolver):
+        # 研究请求 + 歧义名称再次出现 → 按新消息重新分类，不消费为确认
+        res = _resolve(resolver, "再分析下阿里巴巴最近走势", session=CONFIRM_CTX)
+        assert res.source != "confirmation"
+        assert not (res.stocks and res.stocks[0].code == "09988")
+
+    def test_comparison_with_ambiguous_name_reclassified(self, resolver):
+        # 比较请求 + 歧义名称再次出现 → 按新消息重新分类，不消费为确认
+        res = _resolve(resolver, "阿里巴巴和腾讯对比一下", session=CONFIRM_CTX)
+        assert res.source != "confirmation"
+        assert not (res.stocks and res.stocks[0].code == "09988")
+
+    def test_new_request_with_market_word_not_hijacked(self, resolver):
+        # 新研究请求 + 市场词 + 其他股票（"帮我分析一下港股腾讯"）不得被市场词
+        # 收窄分支抢先确认成 09988（港股阿里），必须按新消息重新分类解析腾讯
+        res = _resolve(resolver, "帮我分析一下港股腾讯", session=CONFIRM_CTX)
+        assert res.source != "confirmation"
+        assert res.stocks and res.stocks[0].code == "00700"
+
+    def test_market_word_plus_same_name_still_confirms(self, resolver):
+        # 同一歧义股票 + 市场词（"看一下港股阿里巴巴"）仍是确认：按市场收窄 → 09988
+        res = _resolve(resolver, "看一下港股阿里巴巴", session=CONFIRM_CTX)
+        assert res.source == "confirmation"
+        assert res.stocks and res.stocks[0].code == "09988"
+
+
+class TestMultiStockEntityRecognition:
+    """多股票实体识别：一句话识别多只股票（全名 + 一对一缩写），
+    与单 token 多候选的歧义（阿里）严格区分。
+
+    - 多只确定实体 → stocks（primary_stock_code 为空串，绝不注入继承码）；
+    - 单 token 多候选 → candidates + needs_confirmation（歧义确认路径）。
+    Step 3 仅做全名精确匹配（窗口必须整体等于库中股票全名），一对一缩写
+    （茅台/比亚迪）非全名，交由 Step 6 多策略匹配承接。
+    分词管道 Step 6 前统一执行 AkShare 扩展（extend_AkShare，全模块唯一
+    调用点；本测试模块 mock 为最小全量 A 股数据，见 _MOCK_AKSHARE_A_SHARES）：
+    酒鬼酒/三花智控/中大力德等本地静态库外真实 A 股由此在规则路径直接定论；
+    mock 之外的库外名称（你好股份等）仍升级 LLM（无 LLM 时降级 rule_fallback），
+    绝不静默解析成唯一单只或误判为对上一轮的追问。
+    """
+
+    def test_extended_full_name_resolved_by_rule_path(self, resolver):
+        # "酒鬼酒"本地映射外、AkShare 扩展后全名精确命中（Step 3 重扫）：
+        # 与茅台一起由规则直接定论双股比较，不再升级 LLM
+        res = _resolve(resolver, "对比茅台和酒鬼酒的基本面", session={})
+        assert res.intent == WebIntent.STOCK_RESEARCH
+        assert [s.code for s in (res.stocks or [])] == ["600519", "000799"]
+        assert not res.needs_confirmation
+
+    def test_extended_abbreviation_resolved_by_multi_match(self, resolver):
+        # "三花/中大力德"本地库外一对一缩写：Step 6 多策略匹配在扩展库命中，
+        # 规则直接定论双股比较，不再升级 LLM
+        res = _resolve(resolver, "对比三花和中大力德的趋势", session={})
+        assert res.intent == WebIntent.STOCK_RESEARCH
+        assert [s.code for s in (res.stocks or [])] == ["002050", "002896"]
+        assert not res.needs_confirmation
+
+    def test_extended_names_no_inherited_code(self, resolver):
+        # 扩展库命中双股：primary_stock_code 为空串，绝不注入上一轮继承码
+        # 600519，也不误判为对它的追问
+        res = _resolve(resolver, "对比茅台和酒鬼酒的基本面", session=INHERIT_CTX)
+        assert res.intent == WebIntent.STOCK_RESEARCH
+        assert res.primary_stock_code == ""
+        assert [s.code for s in (res.stocks or [])] == ["600519", "000799"]
+
+    def test_single_abbreviation_is_definite(self, resolver):
+        # 一对一缩写（茅台→600519）直接定论，不触发确认
+        res = _resolve(resolver, "帮我看看茅台", session={})
+        assert res.intent == WebIntent.STOCK_RESEARCH
+        assert [s.code for s in (res.stocks or [])] == ["600519"]
+        assert not res.needs_confirmation
+
+    def test_local_unique_name_direct(self, resolver):
+        # "东方"在本地库唯一解析为东方财富（东方雨虹/东方航空/京东方A 在库外，
+        # 真实歧义交由 LLM 兜底路径处理）→ 唯一已解析名称直接定论
+        res = _resolve(resolver, "研究一下东方", session={})
+        assert res.intent == WebIntent.STOCK_RESEARCH
+        assert [s.code for s in (res.stocks or [])] == ["300059"]
+        assert not res.needs_confirmation
+
+    def test_ambiguous_alias_still_confirmation(self, resolver):
+        # 既有歧义回归：阿里 → hk09988 / us BABA 仍是歧义确认，不回归
+        res = _resolve(resolver, "再分析下阿里最近的走势", session={})
+        assert res.intent == WebIntent.STOCK_RESEARCH
+        assert res.needs_confirmation
+        codes = [c["code"] for c in res.pending_action["candidates"]]
+        assert codes == ["09988", "BABA"]
+
+    def test_multi_stock_with_comparison_keyword(self, resolver):
+        res = _resolve(resolver, "茅台和比亚迪哪个好", session={})
+        assert res.intent == WebIntent.STOCK_RESEARCH
+        assert [s.code for s in (res.stocks or [])] == ["600519", "002594"]
+
+    def test_common_suffix_not_silently_definite(self, resolver):
+        # 通用后缀"股份"命中多只（伊利股份/凌云股份）→ 歧义确认，
+        # 绝不静默解析成唯一命中的单只股票
+        res = _resolve(resolver, "再分析一下你好股份基本面", session=INHERIT_CTX)
+        assert res.intent != WebIntent.HISTORY_FOLLOWUP
+        assert not (res.stocks and [s.code for s in res.stocks] == ["600887"])
+
+
+class TestPortfolioReviewExamples:
+    """持仓回顾样例：持仓关键词优先级最高，即使与疑问词/显式代码并存。"""
+
+    def test_portfolio_with_question_word(self, resolver):
+        res = _resolve(resolver, "我的持仓今天怎么样", session={})
+        assert res.intent == WebIntent.PORTFOLIO_REVIEW
+        assert res.reason == "portfolio_keyword"
+
+    def test_portfolio_wins_over_explicit_code(self, resolver):
+        # 持仓词 + 显式代码并存：持仓意图胜出（持仓分支在代码分支之前）
+        res = _resolve(resolver, "看看我的持仓 600519", session={})
+        assert res.intent == WebIntent.PORTFOLIO_REVIEW
+
+
+class TestMarketOverviewExamples:
+    """大盘行情样例：指数词/板块语境/市场词 → market_overview，携带市场推断。"""
+
+    def test_index_keyword(self, resolver):
+        res = _resolve(resolver, "上证指数今天涨了多少", session={})
+        assert res.intent == WebIntent.MARKET_OVERVIEW
+        assert res.reason == "market_keyword"
+
+    def test_sector_context_unknown_code(self, resolver):
+        # "AI" 是库外 unknown_code，但带板块语境 → 升级保护豁免 → 大盘行情
+        res = _resolve(resolver, "AI板块怎么样", session={})
+        assert res.intent == WebIntent.MARKET_OVERVIEW
+
+    def test_market_word_with_market_inference(self, resolver):
+        res = _resolve(resolver, "港股最近行情和趋势怎么样", session={})
+        assert res.intent == WebIntent.MARKET_OVERVIEW
+        assert res.market == "hk"
+
+
+class TestHistoryFollowupExamples:
+    """追问样例：追问锚点 + 继承代码，含研究决策词但无 request 词时不误升级。"""
+
+    def test_followup_with_decision_word(self, resolver):
+        res = _resolve(resolver, "那它在支撑位可以抄底吗", session=INHERIT_CTX)
+        assert res.intent == WebIntent.HISTORY_FOLLOWUP
+        assert res.inherited_stock_code == "600519"
+        assert res.primary_stock_code == "600519"
+
+
+class TestGeneralChatExamples:
+    """闲聊样例：无信号与空消息短路。"""
+
+    def test_no_signal(self, resolver):
+        res = _resolve(resolver, "你好", session={})
+        assert res.intent == WebIntent.GENERAL_CHAT
+        assert res.reason == "no_signal"
+
+    def test_empty_message_short_circuit(self, resolver):
+        res = _resolve(resolver, "", session={})
+        assert res.intent == WebIntent.GENERAL_CHAT
+        assert res.confidence == 1.0
+        assert res.reason == "empty_message"
+
+
+class TestAkShareExtensionSinglePoint:
+    """AkShare 扩展是全模块唯一调用点：只在分词管道 Step 6 前执行；
+    LLM 提及解析（_resolve_mentions）只查已扩充的库，绝不再次扩展。"""
+
+    def test_preprocess_extension_reaches_rule_path(self, resolver):
+        # 首次解析触发扩展（mock 数据并入 stockDB），库外全名在规则路径直接定论；
+        # 重复解析零新条目、幂等，不改变定论
+        res = _resolve(resolver, "对比茅台和酒鬼酒的基本面", session={})
+        assert res.intent == WebIntent.STOCK_RESEARCH
+        assert [s.code for s in (res.stocks or [])] == ["600519", "000799"]
+        res2 = _resolve(resolver, "对比茅台和酒鬼酒的基本面", session={})
+        assert res2.intent == WebIntent.STOCK_RESEARCH
+        assert [s.code for s in (res2.stocks or [])] == ["600519", "000799"]
+
+    def test_resolve_mentions_never_fetches_akshare(self, monkeypatch):
+        from src.services import name_to_code_resolver as resolver_mod
+
+        calls = {"n": 0}
+
+        def fake_get():
+            calls["n"] += 1
+            return {"酒鬼酒": "000799"}
+
+        monkeypatch.setattr(resolver_mod, "_get_akshare_name_to_code", fake_get)
+        stocks, candidates, unresolved = WebIntentResolver._resolve_mentions(["酒鬼酒"])
+        assert calls["n"] == 0  # 库外名称也只查库，绝不发起 AkShare 拉取
+        assert not stocks and not candidates
+        assert unresolved == ["酒鬼酒"]


### PR DESCRIPTION
## PR Type

- [ ] fix
- [x] feat
- [ ] refactor
- [ ] docs
- [ ] chore
- [ ] test

## Background And Problem

**问题**：Web Chat 的 SSE 流（`POST /api/v1/agent/chat/stream`）在 Agent 开始工作前没有任何意图理解层，用户消息直接进入 Agent 编排执行：

1. 无法在 Agent 工作前先理解用户意图（个股研究 / 持仓回顾 / 大盘行情 / 追问 / 闲聊），编排器没有意图信号可供分流；
2. 股票名称歧义（如"阿里巴巴" → hk 09988 / us BABA）或低置信度意图时，无法先让用户确认再执行，可能直接分析错误的股票；

**影响范围**：Web Chat SSE 流；新增意图层与 Bot 分发器（`bot/dispatcher.py`）的 NL 路由平行运行，互不干扰（Web 端与 Bot 端路由策略相互独立）。

**触发场景**：多候选股票名（"阿里巴巴"）、多轮对话的股票识别(上一轮询问"茅台",此轮询问"三花")、对上一轮分析的追问（"它还能涨吗"）等输入，在旧流程中均无法区分或确认。

<img width="1169" height="680" alt="image" src="https://github.com/user-attachments/assets/b6236eb0-c0ed-480c-b70f-9ab9cc80c645" />



**验收边界（五条）**：

- **完备性**：任意输入（空串 / None / 乱码 / 闲聊 / 多股比较）都必须返回合法的 `WebIntentResolution`，绝不返回 None、绝不抛异常 —— 这是"SSE 层不会因意图层卡死"的硬底线。
- **可执行性**：产出必须足以让 SSE 层决策 —— 意图 ∈ 5 类标签、`confidence / source / reason` 齐全；股票要么解析成确定的 code，要么明确标歧义/未解析并携带 `needs_confirmation + pending_action + 澄清文本`，保证"能跑就跑、不能跑必确认，绝不猜"。
- **节省性**：分词与实体识别结果清晰，规则路径直接定论，尽量避免 LLM 调用；仅当规则无解才升级 LLM，且单次、8 秒超时即止损、超时类瞬断错误重试一次。
- **上下文正确性**：继承遵循 `request > session` 优先级并排除本轮显式代码；待确认动作只消费紧邻的下一轮，未被消费即清除，不残留影响后续轮次。
- **降级性**：LLM 不可用 / 超时 / 识别失败时静默降级规则兜底，任何异常不阻塞对话、不改变原有行为。

## Scope Of Change

基准 `BASE_REF = git merge-base HEAD origin/main` = `3b98aa1d`。文件总数 **9**，变更 **+2698 / -90**。以下为 `git diff --stat` 实际输出：

```text
 .env.example                          |    4 +
 api/v1/endpoints/agent.py             |  119 ++-
 docs/CHANGELOG.md                     |    1 +
 docs/agent-stream-events.md           |    4 +-
 src/agent/web_intent_resolver.py      | 1639 +++++++++++++++++++++++++++++++++
 src/config.py                         |    2 +
 src/services/name_to_code_resolver.py |  460 +++++++--
 tests/test_name_to_code_resolver.py   |  234 +++++
 tests/test_web_intent_resolver.py     |  325 +++++++
 9 files changed, 2698 insertions(+), 90 deletions(-)
```

**文件清单（按实际 diff 全量，逐项列出）**：

1. **`src/agent/web_intent_resolver.py`**（新增 1639 行，核心模块）
   - `WebIntent` 5 类意图标签：`stock_research / portfolio_review / market_overview / history_followup / general_chat`（str 枚举，`ALL_WEB_INTENTS` 用于校验 LLM / session 返回）；
   - 20 个 token 语义标签（5 大类），关键词分 clean / extend 两池，所有正则与反转映射从关键词表编译生成；
   - `WebIntentResolution` 数据类（`intent / confidence / source / stocks / candidates / unresolved_names / inherited_stock_code / needs_confirmation / reason / pending_action / market`，`source ∈ rule / llm / context / confirmation`）；`primary_stock_code` 决定注入 #1619 的代码：恰好 1 只 → 该代码；≥2 只（多股比较）→ 空串且绝不返回继承代码（修复"对比000858和300750"错误锁定上一轮 600519 的问题）；0 只（追问/继承）→ 继承代码，保持 UI 股票锁定；
   - 六步分词管道（标点切分 → 代码形提取 → 股票全名 → 市场词 → 无歧义关键词 → 多策略 DFS 匹配）＋ `_validate_code_candidate` 三态校验（stock_code / wrong_code / 保留 unknown_code）；≤4 位裸数字打 `unknown_number` 标签（年份/日期/价格等，绝不触发股票确认）；
   - `resolve()` 六步级联主流程：① 空消息短路 → ② 分词 + 实体识别 → ③ 消费待确认动作（仅消费紧邻下一轮，候选精确匹配或市场词收窄唯一）→ ④ 基于 token 的规则分类（证据充分直接定论，绝不调用 LLM）→ ⑤ LLM 兜底（懒加载适配器、单次、8 秒超时、瞬断重试一次、失败静默降级）→ ⑥ 规则兜底（最保守 general_chat）；
   - `_classify_by_rules` 规则判定链（9 分支，证据强度递减、命中即返回常量置信度，绝不产出模糊结果）；
   - `apply_resolution_to_session()`（写入 `recent_stocks`（上限 10）/ `last_intent` / `pending_actions`，鸭子类型检测避免循环依赖）；
   - `build_intent_resolved_event / build_action_required_event / build_clarification_message` SSE 事件与澄清文本工厂函数。
2. **`api/v1/endpoints/agent.py`**（+102 / -17）在 `agent_chat_stream()` 的 run_sync 中集成意图层：延迟 import 意图模块与 conversation_manager（`getattr` 默认 False，测试/机器人等临时 Config 走原路径）；`resolve` + `apply_resolution_to_session`；`needs_confirmation` 时在事件循环线程内直接 `await queue.put` 按序发送 `intent_resolved → action_required → done` 短路返回（不能用 progress_callback：其 run_coroutine_threadsafe 只是调度，会被紧随其后的 done 抢先消费）；非确认分支经 progress_callback 发 `intent_resolved`，注入 `stream_ctx["stock_code"]`（#1619 机制，仅上下文未显式指定时覆盖）与 `stream_ctx["web_intent"]`；`intent_confirmed` 跳过 `prepare_turn` 与 accepted 事件；整个意图层 try/except 包裹，任何异常仅记警告、不阻塞正常对话。
3. **`src/services/name_to_code_resolver.py`**（+388 / -72）名称解析引擎增强（全库统一解析服务，`api/v1/endpoints/analysis.py`、`bot/dispatcher.py`、`src/services/import_parser.py` 与本模块均引用）：`Stock` 结构体、`stockDB` 全局名称库、`is_known_stock_name`、`extract_stock_name`（最长名称优先切分）、`resolver_name_to_code_list`（精确/子串/拼音/difflib 模糊四级匹配 + 保守单字错别字兜底，A→HK→US 排序，最多 5 条）、`US_stock_code_match`（1~5 位大写 ticker 仅库中存在时返回）、`extend_AkShare`（30 分钟缓存 + `_akshare_merged` 幂等守卫）、`resolve_name_to_code` 单代码编排；复用 `src/services/stock_code_utils` 共享代码格式校验。
4. **`tests/test_web_intent_resolver.py`**（新增 325 行，48 条用例 / 11 组）规则路径回归测试：研究请求含未识别 token 不得误判为追问、真追问仍走 followup、美股识别（库内 TSLA→stock_research / 库外 SOFI 宁可不做也不做错 / 普通英文词不当代码）、数字代码不回归、≤4 位裸数字标签与不触发确认、真实股票名追问短路守卫、多股比较无继承码、ASCII 市场词边界等。
5. **`tests/test_name_to_code_resolver.py`**（+234 行，新增 32 条，总计 55 条）：Stock 数据类相等/dict 访问、四级匹配与跨市场排序、拼音子串匹配、`US_stock_code_match`、`extend_AkShare` 幂等、模块级可变状态 autouse fixture 快照/还原。
6. **`src/config.py`**（+2 行）`Config` 新增 `agent_web_intent_enabled: bool = True`；`from_env()` 从 `AGENT_WEB_INTENT_ENABLED` 读取（"true"/"false"）。
7. **`.env.example`**（+4 行）新增 `AGENT_WEB_INTENT_ENABLED` 注释项（默认 true，含功能说明）。
8. **`docs/agent-stream-events.md`**（+3 / -1）事件类型表新增 `intent_resolved`、`action_required` 两行；测试命令补充 `tests/test_web_intent_resolver.py`。
9. **`docs/CHANGELOG.md`**（+1 行）新增 1 条 changelog 条目：`[新功能] Web Chat SSE 流新增意图识别层 src/agent/web_intent_resolver.py：覆盖五类意图，复用和增强 name_to_code 解析，流式优先发出 intent_resolved 事件，低置信度或多候选股票时短路返回 action_required 让用户确认，新增 AGENT_WEB_INTENT_ENABLED 开关（默认开启）`。

**文档更新文件（`docs/*`）**：`docs/agent-stream-events.md`、`docs/CHANGELOG.md`。

## Issue Link

- `Refs #1125` 意图识别与实体解析前置

## Verification Commands And Results

已实际执行（本地 Windows 11 / Python 3.13.3 / pytest 9.1.1）：

```bash
python -m pytest tests/test_web_intent_resolver.py -q
# 48 passed in 6.21s

python -m pytest tests/test_name_to_code_resolver.py -q
# 55 passed in 0.78s

python -m pytest tests/test_name_to_code_resolver.py tests/test_agent_stream_events.py tests/test_agent_sse_cleanup.py -q
# 65 passed in 9.36s
```

- 关键输出/结论：上述本地测试全绿。`WebIntentResolver(None)`（无 LLM 适配器、无 config）resolve 不会发起任何 LLM 调用，规则无解时降级 `rule_fallback`（general_chat），断言以"不等于误判的意图"为主。

## Visual Evidence (if applicable)

- 不适用原因：本 PR **未修改报告格式或 Web UI 页面渲染**；前端"意图状态展示 / 确认界面"为已完成的前端改动（独立于本 PR，见 web_intent 说明"前端部分已完成"）。SSE 事件契约变更已由 `docs/agent-stream-events.md` 同步更新，并有测试覆盖，可复现替代证据如下：
  - 命令：`python -m pytest tests/test_web_intent_resolver.py tests/test_agent_stream_events.py tests/test_agent_sse_cleanup.py -q`（65 passed）
  - 产物/说明：事件类型新增 `intent_resolved` / `action_required`，由事件契约文档与单测断言覆盖；前端交互截图属于独立前端 PR，如需展示请另行补充。

## Compatibility And Risk

- **兼容性**：
  - 新增配置开关 `AGENT_WEB_INTENT_ENABLED`（默认 true）；`agent.py` 以 `getattr(config, "agent_web_intent_enabled", False)` 读取，测试 / 机器人等临时 Config（未声明该字段）自动走原有路径，兼容既有调用方。
  - 新增 SSE 事件类型 `intent_resolved` / `action_required`：`docs/agent-stream-events.md` 已声明未知事件类型应忽略或用通用兜底展示，旧前端兼容。
  - LLM 兜底：`adapter.call_text(..., timeout=8)` 单次调用、超时类瞬断错误（连接/读写超时）重试一次、其余失败静默降级规则兜底；任何异常不阻塞对话。
  - 本 PR 未变更 provider/model/base URL、运行时配置清理迁移语义；历史配置保持不变；回滚方式为 revert 本提交。
- **风险**：
  - 意图误分类风险：误判为 `general_chat` 走闲聊兜底、不执行分析（不产生错误操作）；误判为执行类意图受"低置信度（<0.6）或股票歧义 → 用户确认"机制约束；多层降级保证行为不劣于原流程。
  - 多股比较继承码、追问短路、ASCII 市场词边界等易错边界已由 48 条回归用例覆盖。
  - 无第三方模型 / API 语义变更，无依赖窗口锁定。

## 意图分类对后续流程的影响与无负面影响说明

**意图层落点（四个通道）**：
`WebIntentResolver.resolve()` 的分类结果不直接改写 Agent 内部逻辑，而是通过四个通道作用于 SSE 流与后续编排：

1. **确认/执行分流**（agent.py `needs_confirmation` 分支）：需确认（多候选股票 / 低置信度）时在事件循环线程内按序发送 `intent_resolved → action_required → done`（content 携带澄清文本、`total_steps=0`），置 `intent_confirmed` 短路——跳过 `prepare_turn`、不发出 `accepted`、不进入 Agent 编排；用户消息与澄清文本写入会话历史后结束本轮。无需确认时经 progress_callback 发 `intent_resolved` 后照常进入 `prepare_turn → accepted → 后端执行`。
2. **股票作用域注入**（`primary_stock_code → stream_ctx["stock_code"]`）：仅在上下文未显式指定时覆盖（显式传入优先，agent.py `if primary_code and not stream_ctx.get("stock_code")`）；注入后由 `resolve_stock_scope()`（executor.py）按 maintain / switch / compare 三种模式产出 `StockScope`，进而影响系统提示的 `market_role / market_guidelines`、上下文片段"股票代码: xxx"、research 子问题的 stock_hint 与工具 `allowed_stock_codes / expected_stock_code` 作用域。多股比较（≥2 只）时返回空串、绝不注入继承代码，不污染执行端比较模式。
3. **会话持久化**（`apply_resolution_to_session`）：写入 `recent_stocks`（去重保序、新代码在前、上限 10）/ `last_intent` / `pending_actions`，供下一轮 `resolve()` 的追问继承、候选收窄与 LLM 上下文注入；待确认动作只消费紧邻下一轮、未消费即清空，不残留。
4. **SSE 事件**：`intent_resolved`（携带 market 推断）先行发出让前端尽早展示状态；空列表/空串/False 字段序列化为 None 减体积；新事件类型由 `docs/agent-stream-events.md` 声明"未知事件类型应忽略或用通用兜底展示"，旧前端兼容。

**关于 `web_intent` 字段的如实说明**：
agent.py 将意图标签写入 `stream_ctx["web_intent"]`，目前无后续消费代码，即"按意图分流"是预留的扩展点，本 PR 未接线；
故而意图标签本身不改变 Agent 内部的任何行为，只作信息记录，为后续迭代提供信号。

**兼容性**：

- 开关隔离：`AGENT_WEB_INTENT_ENABLED` 默认 true，但 agent.py 以 `getattr(config, "agent_web_intent_enabled", False)` 读取，测试 / 机器人等未声明该字段的临时 Config 自动走原有路径，行为与 PR 前完全一致；
- 异常降级：整个意图层 try/except 包裹，任何异常仅记 warning、继续走原有编排，SSE 流绝不因意图层卡死；
- LLM 兜底克制：规则能定论绝不调用 LLM（意图分类位于首 token 延迟关键路径，litellm 适配器懒加载避免无谓初始化）；仅规则无解才升级，单次、8 秒超时即止损、超时类瞬断错误重试一次、其余失败静默降级；
- 注入保守：`stock_code` 仅在上下文未显式指定时覆盖，显式传入优先；多股比较返回空串，不污染 `resolve_stock_scope` 的比较模式；
- 生命周期干净：待确认动作只消费紧邻下一轮、未命中即被 `apply_resolution_to_session` 清空，不残留影响后续轮次；
- 不改既有路径：未修改 provider/model/base URL 与运行时配置清理迁移语义；事件类型为新增，旧前端兼容；回滚方式为 revert 本提交，或设 `AGENT_WEB_INTENT_ENABLED=false` 重启服务即可恢复原行为。

## name_to_code_resolver.py 改动说明

**定位**：全库统一的名称解析服务，`api/v1/endpoints/analysis.py`、`bot/dispatcher.py`、`src/services/import_parser.py` 与本 PR 的 web_intent_resolver 均引用。本 PR 改动 +388 / -72，从"代码/名称索引 + 单代码解析"扩展为完整解析引擎：

- **`Stock` 数据类**：code / name / market 三元组，支持 dict 式 `[]` 访问，与 dict / str 相等比较（向后兼容既有调用方）；
- **`stockDB` 全局名称库**：初始化自 `STOCK_NAME_MAP`，可被 AkShare 数据原地扩充；
- **`is_known_stock_name()`**：轻量布尔检查（精确/子串、纯本地无网络），供规则路径逐消息安全调用；
- **`extract_stock_name()`**：按最长名称优先切分文本为（片段, Stock 列表）对；
- **`resolver_name_to_code_list()`**：名称→Stock 列表（精确 / 子串 / 拼音 / difflib 模糊四级匹配 + 保守单字错别字兜底，如"贵州茅苔"→贵州茅台），结果按 A 股→港股→美股排序、最多 5 条，单个汉字直接短路；
- **`US_stock_code_match()`**：1~5 位大写 ticker → Stock，仅库中存在时返回，避免普通英文单词误判；
- **`extend_AkShare()`**：用 AkShare 全量 A 股数据扩充 stockDB（30 分钟缓存 + `_akshare_merged` 幂等守卫，同一份缓存 dict 只合并一次，避免重复遍历）；
- **`resolve_name_to_code()`**：单代码编排（形如代码直接规范化返回；歧义名称返回 None 交由调用方澄清；非 CJK 输入跳过 AkShare 扩展，否则扩展后重试），保持既有入口与返回语义；
- 内部重构：`_build_local_name_indexes` 收敛为 `_build_local_ambiguous_names`，新增 `_database_names / _database_pinyins / _fix_name / _infer_code_market / _find_codes_for_name / _stocks_for_name` 辅助函数；复用 `src/services/stock_code_utils`（`is_code_like / normalize_code` 共享代码格式校验，内部依赖 data_provider 的 `canonical_stock_code`）。

**兼容性**：

对外接口（`resolve_name_to_code` 入口与返回语义、`stockDB` 全局库）保持兼容，新增函数均为追加；
模块级可变状态由测试 fixture 快照/还原，用例间互不泄漏。

## Rollback Plan

- 最小回滚：`revert 本 PR`（`git revert <本 PR 合并提交>`），无需额外配置回滚或数据迁移。
- 运行时逃生开关：设置 `AGENT_WEB_INTENT_ENABLED=false` 后重启服务即可关闭意图层，SSE 流恢复原行为，无需代码回滚。

## EXTRACT_PROMPT Change (if applicable)

不适用：本 PR 未修改 `src/services/image_stock_extractor.py` 中的 `EXTRACT_PROMPT`。

## Checklist

- [x] 本 PR 有明确动机和业务价值 / This PR has a clear motivation and value
- [x] 已提供可复现的验证命令与结果（本地 48 / 55 / 65 用例全绿；CI 结果待补充）/ Reproducible verification commands and results are included
- [x] 已评估兼容性与风险 / Compatibility and risk have been assessed
- [x] 已提供回滚方案 / A rollback plan is provided
- [x] 若修改报告格式或 Web UI 界面，已在 PR 描述/评论附受影响报告 / 页面截图 —— 本 PR 未修改报告格式与 Web UI 渲染，见 Visual Evidence 不适用原因
- [x] 若本 PR 修改 Web 设置字段（字段、文案或帮助文本）—— 本 PR 未修改 Web 设置字段（仅新增服务端 `.env` / Config 开关）
- [x] 若涉及用户可见变更，已同步更新相关文档与 `docs/CHANGELOG.md` —— CHANGELOG 已新增 1 条，与 web_intent 说明一致
