### PR TITLE
fix: 修复大盘复盘摘要显示 Markdown 原文及服务重启端口占用问题

### DIFF
--- a/main.py
+++ b/main.py
@@ -1118,6 +1118,7 @@ def start_api_server(host: str, port: int, config: Config) -> None:
 
     probe = socket.socket(socket.AF_INET6 if ":" in host else socket.AF_INET, socket.SOCK_STREAM)
     try:
+        probe.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
         probe.bind((host, port))
     except OSError as exc:
         raise RuntimeError(f"FastAPI port is not available: {host}:{port}") from exc

--- a/src/services/history_service.py
+++ b/src/services/history_service.py
@@ -557,6 +557,26 @@ class HistoryService:
         return display_points
 
     @staticmethod
+    def _market_review_summary_excerpt(markdown: str, limit: int = 120) -> str:
+        """Return a short plain-text excerpt for summary display."""
+        lines = []
+        for line in markdown.splitlines():
+            stripped = line.strip()
+            if not stripped or stripped.startswith("[dsa-market-region]"):
+                continue
+            stripped = stripped.lstrip("#").strip()
+            if stripped.startswith(">"):
+                stripped = stripped.lstrip(">").strip()
+            stripped = stripped.lstrip("-*+").strip()
+            stripped = stripped.replace("**", "").replace("`", "").replace("|", " ")
+            lines.append(stripped)
+        text = " ".join(lines)
+        text = " ".join(text.split())
+        if len(text) > limit:
+            text = text[:limit].rstrip() + "\u2026"
+        return text
+
+    @staticmethod
     def _extract_market_review_content(record, raw_result: Any) -> Optional[str]:
         """Return persisted market review content from raw_result or news_content."""
         if isinstance(raw_result, dict):
@@ -603,7 +623,7 @@ class HistoryService:
             "report_type": record.report_type,
             "created_at": self._serialize_created_at(record.created_at),
             "model_used": model_used,
-            "analysis_summary": market_review_content or record.analysis_summary,
+            "analysis_summary": record.analysis_summary or (self._market_review_summary_excerpt(market_review_content) if market_review_content else None),
             "operation_advice": record.operation_advice,
             "action": action_fields["action"],
             "action_label": action_fields["action_label"],


### PR DESCRIPTION
## 问题描述
1. Web 大盘复盘详情页「复盘摘要」卡片显示 Markdown 原文（含 `[dsa-market-region]` 内部标记、`#`、表格符号），而不是一句话摘要。
2. FastAPI 服务重启时可能因残留 TIME_WAIT 连接导致端口探测失败（`FastAPI port is not available`），服务陷入重启循环。

## 根因
- 历史详情接口将大盘复盘完整 Markdown（`raw_response`/`market_review_report`）作为 `analysis_summary` 返回，前端摘要卡片直接展示。
- `main.py` 端口探测 socket 未设置 `SO_REUSEADDR`，绑定 `0.0.0.0:PORT` 与 TIME_WAIT 连接冲突时报 `EADDRINUSE`。

## 修复内容
- `src/services/history_service.py`：详情接口 `analysis_summary` 优先使用数据库短摘要；缺失时用 `_market_review_summary_excerpt` 将 Markdown 转为纯文本并截断（默认 120 字符），避免前端显示原文。
- `main.py`：端口探测前设置 `SO_REUSEADDR`。

## 验证
- 生产环境复现并验证：修复后详情摘要返回数据库短摘要，服务可正常重启并监听端口；前端渲染链路无需改动。