### PR TITLE
fix: 修复 yfinance TTM 测试时间基准冲突

### DIFF
--- a/tests/test_yfinance_fundamental_adapter.py
+++ b/tests/test_yfinance_fundamental_adapter.py
@@ -8,17 +8,23 @@ graceful degradation when yfinance is unavailable.
 """
 from __future__ import annotations
 
-from datetime import datetime, timezone
 import unittest
-from datetime import datetime, timedelta
+from datetime import datetime, timezone
 from unittest.mock import patch, MagicMock
 
 import pandas as pd
-import pytz
 
 from data_provider.yfinance_fundamental_adapter import (
     YfinanceFundamentalAdapter,
     _convert_to_yf_symbol,
+)
+
+
+_DIVIDEND_EVENT_DATES = (
+    "2025-08-11",
+    "2025-11-10",
+    "2026-02-09",
+    "2026-05-11",
 )
 
 
@@ -82,14 +88,6 @@ class TestYfinanceFundamentalAdapter(unittest.TestCase):
             "trailingAnnualDividendRate": 1.04,
             "dividendYield": 0.36,
         }
-        income_df = pd.DataFrame(
-            {
-                pd.Timestamp("2026-03-31"): {"Total Revenue": 1.11e11, "Net Income": 2.95e10},
-                pd.Timestamp("2025-12-31"): {"Total Revenue": 1.24e11, "Net Income": 3.62e10},
-                pd.Timestamp("2025-09-30"): {"Total Revenue": 9.49e10, "Net Income": 2.49e10},
-                pd.Timestamp("2025-06-30"): {"Total Revenue": 9.40e10, "Net Income": 2.34e10},
-            }
-        )
         # Need at least 5 columns to trigger statement-derived YoY.
         income_df_with_yoy = pd.DataFrame(
             {
@@ -106,18 +104,10 @@ class TestYfinanceFundamentalAdapter(unittest.TestCase):
                 pd.Timestamp("2025-12-31"): {"Operating Cash Flow": 3.5e10},
             }
         )
-        # Use dates relative to now so the 365-day TTM window always
-        # contains all 4 events regardless of when the test runs (#2204).
-        now_ny = datetime.now(pytz.timezone("America/New_York"))
         dividends = pd.Series(
             [0.26, 0.26, 0.26, 0.27],
             index=pd.DatetimeIndex(
-                [
-                    (now_ny - timedelta(days=330)).strftime("%Y-%m-%d"),
-                    (now_ny - timedelta(days=240)).strftime("%Y-%m-%d"),
-                    (now_ny - timedelta(days=150)).strftime("%Y-%m-%d"),
-                    (now_ny - timedelta(days=60)).strftime("%Y-%m-%d"),
-                ],
+                _DIVIDEND_EVENT_DATES,
                 tz="America/New_York",
             ),
             name="Dividends",
@@ -147,6 +137,7 @@ class TestYfinanceFundamentalAdapter(unittest.TestCase):
         # info.dividendYield (0.36) is intentionally ignored when TTM cash exists.
         self.assertAlmostEqual(div["ttm_dividend_yield_pct"], 0.3762, places=4)
         self.assertEqual(div["currency"], "USD")
+        self.assertEqual(div["events"][0]["ex_dividend_date"], "2026-05-11")
         self.assertEqual(
             bundle["belong_boards"],
             [
@@ -160,15 +151,8 @@ class TestYfinanceFundamentalAdapter(unittest.TestCase):
         # Series. Without coercion, `.items()` yields (column_name, Series), every event
         # is dropped, and TTM silently falls back to the annual-rate estimate — the real
         # bug seen on live US/HK/JP/KR/TW reports (24.0 / "0 次" instead of the true sum).
-        # Use dates relative to now so the 365-day TTM window is always satisfied (#2204).
-        now_ny = datetime.now(pytz.timezone("America/New_York"))
         idx = pd.DatetimeIndex(
-            [
-                (now_ny - timedelta(days=330)).strftime("%Y-%m-%d"),
-                (now_ny - timedelta(days=240)).strftime("%Y-%m-%d"),
-                (now_ny - timedelta(days=150)).strftime("%Y-%m-%d"),
-                (now_ny - timedelta(days=60)).strftime("%Y-%m-%d"),
-            ],
+            _DIVIDEND_EVENT_DATES,
             tz="America/New_York",
         )
         dividends_df = pd.DataFrame({"Dividends": [0.26, 0.26, 0.26, 0.27]}, index=idx)
@@ -191,7 +175,7 @@ class TestYfinanceFundamentalAdapter(unittest.TestCase):
 
     def test_ttm_dividend_window_uses_as_of_date_cutoff(self) -> None:
         idx = pd.DatetimeIndex(
-            ["2025-08-11", "2025-11-10", "2026-02-09", "2026-05-11"],
+            _DIVIDEND_EVENT_DATES,
             tz="America/New_York",
         )
         dividends = pd.Series([0.26, 0.26, 0.26, 0.27], index=idx, name="Dividends")


### PR DESCRIPTION
## PR Type

- [x] fix
- [ ] feat
- [ ] refactor
- [ ] docs
- [ ] chore
- [ ] test

## Background And Problem

PR #2206 made the dividend fixtures relative to the real current time. PR #2211 then froze only the adapter's `as_of` time at 2026-08-14 while keeping those dynamic fixtures and changing the expected TTM count to 3.

On the merged `main` tree, all four dynamically generated events fall after the frozen cutoff date (2025-08-14), so two assertions deterministically fail with `4 != 3`. Each PR passed independently, but their combined tree was not exercised by post-merge CI.

## Scope Of Change

- 文件总数 / 变更行数：1 file, `+13 / -29`
- 文件清单：
  - `tests/test_yfinance_fundamental_adapter.py`
- 文档更新文件：None。This is a test-only correction with no user-visible or runtime behavior change.

Changes:

- Keep PR #2211's frozen `as_of` time and restore fixed dividend event dates so the cutoff boundary is deterministic.
- Reuse one fixed event-date fixture across the Series, single-column DataFrame, and cutoff tests.
- Consolidate datetime imports and remove unused `timedelta`, `pytz`, and `income_df` setup.
- Restore the latest dividend event ordering assertion removed by PR #2206.

## Issue Link

Refs #2211 and #2206.

No new issue was opened because this is a direct integration follow-up. Acceptance criteria: the current `main` failure reproduces before the patch, all yfinance adapter tests pass after the patch, and the test no longer depends on wall-clock time.

## Verification Commands And Results

Baseline reproduction on `origin/main` (`294210883`):

```bash
python -m pytest tests/test_yfinance_fundamental_adapter.py -q
```

- Result before fix: `2 failed, 11 passed`
- Both failures were `ttm_event_count: 4 != 3`.

Fix validation:

```bash
./scripts/ci_gate.sh flake8
python -m pytest tests/test_yfinance_fundamental_adapter.py -q
./scripts/ci_gate.sh
python -m pytest tests/test_intelligence_service.py::IntelligenceServiceTestCase::test_fetch_enabled_sources_is_fail_open -vv
```

- flake8 critical checks: pass (`0`)
- yfinance targeted tests: pass (`13 passed`)
- full local backend gate: completed with `5766 passed, 1 failed, 4 deselected, 501 subtests passed`
- the sole local full-suite failure was unrelated to this one-file test patch: `test_fetch_enabled_sources_is_fail_open`; its immediate isolated rerun passed (`1 passed`), indicating an existing intermittent/order-dependent failure
- [PR Head CI](https://github.com/ZhuLinsen/daily_stock_analysis/actions/runs/31809777117): `ai-governance:pass / backend-gate:pass / backend-tests (1/3):pass / backend-tests (2/3):pass / backend-tests (3/3):pass / docker-build:skipped / web-gate:skipped`
- 当前状态：全部适用检查通过（pass）；Docker/Web/Desktop 因仅修改后端测试文件按路径规则跳过。

## Visual Evidence (if applicable)

Not applicable. This PR only changes deterministic backend test fixtures and assertions; it does not modify report rendering or Web UI.

## Compatibility And Risk

- API / Web / Desktop: no impact
- Runtime behavior: no impact; production yfinance adapter code is unchanged
- Test behavior: removes wall-clock dependence and restores coverage for descending dividend-event ordering
- Configuration / Docker / GitHub Actions: no change
- Main risk: fixed fixture dates must remain aligned with the frozen 2026-08-14 `as_of`; both now share one explicit deterministic contract in the same test module

本 PR 未变更 provider/model/base URL、运行时配置清理迁移语义；历史配置保持不变；回滚方式为 revert 本提交。

## Rollback Plan

Revert this PR. No configuration, data, or dependency rollback is required.

## EXTRACT_PROMPT Change (if applicable)

Not applicable.

## Checklist

- [x] 本 PR 有明确动机和业务价值 / This PR has a clear motivation and value
- [x] 已提供可复现的验证命令与结果 / Reproducible verification commands and results are included
- [x] 已评估兼容性与风险 / Compatibility and risk have been assessed
- [x] 已提供回滚方案 / A rollback plan is provided
- [x] 不涉及报告格式、Web UI 或设置字段，无需可视证据
