### PR TITLE
feat: publish daily stock analysis to Finsance

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -169,6 +169,9 @@ AGENT_GENERATION_BACKEND=auto
 # Gemini（https://aistudio.google.com）
 GEMINI_API_KEY=
 # 多 Key 负载均衡：GEMINI_API_KEYS=key1,key2,key3
+# Gemini-first fallback: set LITELLM_FALLBACK_MODELS=openai/<model> when both
+# Gemini and OpenAI are configured.
+# LITELLM_FALLBACK_MODELS=gemini/gemini-2.5-flash,openai/gpt-5.5
 
 # DeepSeek（https://platform.deepseek.com）
 # 兼容默认：仅填 DEEPSEEK_API_KEY 时仍使用 deepseek-chat，并在日志提示迁移到 deepseek-v4-flash
@@ -184,6 +187,16 @@ GEMINI_API_KEY=
 # OpenAI / 兼容 API
 # OPENAI_API_KEY=
 # OPENAI_BASE_URL=                     # 第三方 API 地址（中转站/代理），留空用官方
+
+# Finsance public daily artifact / cross-repository publication.
+# Local runs only write reports/finsance; GitHub Actions pushes only when the
+# repository variable FINSANCE_PUBLICATION_ENABLED=true.
+FINSANCE_PUBLICATION_ENABLED=false
+FINSANCE_COMMERCIAL_MODE=false
+# FINSANCE_COMMERCIAL_PROVIDER=
+# GitHub Actions-only cross-repo target (do not put a token in this file).
+# FINSANCE_REPO=jamerskrs-lgtm/Finsance-Website
+# FINSANCE_BRANCH=main
 
 # Ollama 本地模型（无需 API Key，推荐）
 # OLLAMA_API_BASE=http://localhost:11434

--- a/.github/scripts/publish_finsance_daily.py
+++ b/.github/scripts/publish_finsance_daily.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+"""Copy the validated public daily artifact into a Finsance checkout."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from pathlib import Path
+from typing import Any
+
+
+SCHEMA_VERSION = "finsance-quanttrade-daily-v1"
+FORBIDDEN_KEYS = {
+    "battle_plan",
+    "current_price",
+    "market_snapshot",
+    "raw_response",
+    "sniper_points",
+    "stop_loss",
+    "take_profit",
+    "entry_low",
+    "entry_high",
+    "target_price",
+}
+
+
+def _contains_forbidden(value: Any) -> str | None:
+    if isinstance(value, dict):
+        for key, child in value.items():
+            if str(key).lower() in FORBIDDEN_KEYS:
+                return str(key)
+            found = _contains_forbidden(child)
+            if found:
+                return found
+    elif isinstance(value, list):
+        for child in value:
+            found = _contains_forbidden(child)
+            if found:
+                return found
+    return None
+
+
+def _read_payload(source_dir: Path) -> tuple[dict[str, Any], bytes]:
+    latest = source_dir / "daily_latest.json"
+    if not latest.is_file():
+        raise ValueError(f"missing public export: {latest}")
+    data = latest.read_bytes()
+    checksum = source_dir / "daily_latest.json.sha256"
+    if not checksum.is_file():
+        raise ValueError("daily_latest.json checksum is missing")
+    expected = checksum.read_text(encoding="utf-8").split()[0]
+    actual = hashlib.sha256(data).hexdigest()
+    if expected != actual:
+        raise ValueError("daily_latest.json checksum mismatch")
+    payload = json.loads(data.decode("utf-8"))
+    if payload.get("schema_version") != SCHEMA_VERSION:
+        raise ValueError("unsupported public export schema")
+    if not isinstance(payload.get("date"), str) or not payload["date"]:
+        raise ValueError("public export date is missing")
+    stocks = payload.get("stocks")
+    if not isinstance(stocks, list) or not stocks:
+        raise ValueError("public export contains no stocks")
+    forbidden = _contains_forbidden(payload)
+    if forbidden:
+        raise ValueError(f"private field is not publishable: {forbidden}")
+    return payload, data
+
+
+def _copy_with_checksum(source: Path, destination: Path) -> None:
+    data = source.read_bytes()
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    destination.write_bytes(data)
+    digest = hashlib.sha256(data).hexdigest()
+    destination.with_name(f"{destination.name}.sha256").write_text(
+        f"{digest}  {destination.name}\n",
+        encoding="utf-8",
+    )
+
+def _read_checked(path: Path) -> bytes:
+    data = path.read_bytes()
+    checksum_path = path.with_name(f"{path.name}.sha256")
+    if not checksum_path.is_file():
+        raise ValueError(f"{path.name} checksum is missing")
+    expected = checksum_path.read_text(encoding="utf-8").split()[0]
+    if expected != hashlib.sha256(data).hexdigest():
+        raise ValueError(f"{path.name} checksum mismatch")
+    return data
+
+
+def publish(
+    source_dir: Path,
+    destination_dir: Path,
+    *,
+    render_trigger: Path | None = None,
+) -> list[Path]:
+    payload, latest_data = _read_payload(source_dir)
+    date_name = f"daily_{payload['date']}.json"
+    versioned_source = source_dir / date_name
+    if not versioned_source.is_file():
+        raise ValueError(f"missing immutable public export: {versioned_source}")
+    _read_checked(versioned_source)
+    _copy_with_checksum(versioned_source, destination_dir / date_name)
+    latest_path = destination_dir / "daily_latest.json"
+    destination_dir.mkdir(parents=True, exist_ok=True)
+    latest_path.write_bytes(latest_data)
+    latest_digest = hashlib.sha256(latest_data).hexdigest()
+    latest_path.with_name(f"{latest_path.name}.sha256").write_text(
+        f"{latest_digest}  {latest_path.name}\n",
+        encoding="utf-8",
+    )
+    paths = [destination_dir / date_name, latest_path]
+    if render_trigger:
+        render_trigger.parent.mkdir(parents=True, exist_ok=True)
+        render_trigger.write_text(
+            f"date={payload['date']}\nsha256={latest_digest}\n",
+            encoding="utf-8",
+        )
+        paths.append(render_trigger)
+    return paths
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--source", type=Path, required=True)
+    parser.add_argument("--destination", type=Path, required=True)
+    parser.add_argument("--render-trigger", type=Path)
+    args = parser.parse_args()
+    paths = publish(
+        args.source,
+        args.destination,
+        render_trigger=args.render_trigger,
+    )
+    print("Published Finsance daily artifact:")
+    for path in paths:
+        print(f"- {path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/workflows/00-daily-analysis.yml
+++ b/.github/workflows/00-daily-analysis.yml
@@ -77,7 +77,7 @@ jobs:
           LITELLM_CONFIG_YAML: ${{ vars.LITELLM_CONFIG_YAML || secrets.LITELLM_CONFIG_YAML }}
           LITELLM_API_KEY: ${{ secrets.LITELLM_API_KEY }}
           LITELLM_MODEL: ${{ vars.LITELLM_MODEL || secrets.LITELLM_MODEL }}
-          LITELLM_FALLBACK_MODELS: ${{ vars.LITELLM_FALLBACK_MODELS || secrets.LITELLM_FALLBACK_MODELS }}
+          LITELLM_FALLBACK_MODELS: ${{ vars.LITELLM_FALLBACK_MODELS || secrets.LITELLM_FALLBACK_MODELS || 'gemini/gemini-2.5-flash,openai/gpt-5.5' }}
           AGENT_LITELLM_MODEL: ${{ vars.AGENT_LITELLM_MODEL || secrets.AGENT_LITELLM_MODEL }}
           VISION_MODEL: ${{ vars.VISION_MODEL || secrets.VISION_MODEL }}
           OPENAI_VISION_MODEL: ${{ vars.OPENAI_VISION_MODEL || secrets.OPENAI_VISION_MODEL }}
@@ -104,6 +104,10 @@ jobs:
           GEMINI_MODEL: ${{ vars.GEMINI_MODEL || secrets.GEMINI_MODEL || 'gemini-3-flash-preview' }}
           GEMINI_MODEL_FALLBACK: ${{ vars.GEMINI_MODEL_FALLBACK || secrets.GEMINI_MODEL_FALLBACK || 'gemini-2.5-flash' }}
           GEMINI_REQUEST_DELAY: '3.0'
+          # Gemini 主模型/配额失败时先换 Gemini 轻量模型，再走 OpenAI-compatible fallback。
+          FINSANCE_PUBLICATION_ENABLED: ${{ vars.FINSANCE_PUBLICATION_ENABLED || 'false' }}
+          FINSANCE_COMMERCIAL_MODE: ${{ vars.FINSANCE_COMMERCIAL_MODE || 'false' }}
+          FINSANCE_COMMERCIAL_PROVIDER: ${{ vars.FINSANCE_COMMERCIAL_PROVIDER || secrets.FINSANCE_COMMERCIAL_PROVIDER }}
           
           # AIHubMix（优先于 OPENAI_API_KEY，自动适配 base_url，推荐国内用户）
           AIHUBMIX_KEY: ${{ secrets.AIHUBMIX_KEY }}
@@ -532,6 +536,42 @@ jobs:
             python main.py --no-market-review $FORCE_RUN_ARG
           else
             python main.py $FORCE_RUN_ARG
+          fi
+
+      - name: ตรวจสอบและเผยแพร่ Finsance daily artifact
+        if: ${{ success() && vars.FINSANCE_PUBLICATION_ENABLED == 'true' }}
+        env:
+          FINSANCE_REPO: ${{ vars.FINSANCE_REPO }}
+          FINSANCE_BRANCH: ${{ vars.FINSANCE_BRANCH || 'main' }}
+          FINSANCE_PUSH_TOKEN: ${{ secrets.FINSANCE_REPO_TOKEN || secrets.GH_PAT }}
+        run: |
+          test -n "$FINSANCE_REPO" || { echo "Missing Actions variable: FINSANCE_REPO"; exit 1; }
+          test -n "$FINSANCE_PUSH_TOKEN" || { echo "Missing Actions secret: FINSANCE_REPO_TOKEN or GH_PAT"; exit 1; }
+
+      - name: Checkout Finsance Website
+        if: ${{ success() && vars.FINSANCE_PUBLICATION_ENABLED == 'true' }}
+        uses: actions/checkout@v5
+        with:
+          repository: ${{ vars.FINSANCE_REPO }}
+          ref: ${{ vars.FINSANCE_BRANCH || 'main' }}
+          token: ${{ secrets.FINSANCE_REPO_TOKEN || secrets.GH_PAT }}
+          path: .finsance
+          fetch-depth: 1
+
+      - name: Push validated daily artifact to Finsance
+        if: ${{ success() && vars.FINSANCE_PUBLICATION_ENABLED == 'true' }}
+        env:
+          FINSANCE_BRANCH: ${{ vars.FINSANCE_BRANCH || 'main' }}
+        run: |
+          python .github/scripts/publish_finsance_daily.py --source reports/finsance --destination .finsance/content/quanttrade --render-trigger .finsance/.render-quanttrade-trigger
+          git -C .finsance config user.name "github-actions[bot]"
+          git -C .finsance config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git -C .finsance add content/quanttrade .render-quanttrade-trigger
+          if git -C .finsance diff --cached --quiet; then
+            echo "Finsance artifact unchanged; nothing to push."
+          else
+            git -C .finsance commit -m "chore: update daily stock analysis"
+            git -C .finsance push origin "HEAD:$FINSANCE_BRANCH"
           fi
       
       - name: 上传分析报告

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 > For user-friendly release highlights, see the [GitHub Releases](https://github.com/ZhuLinsen/daily_stock_analysis/releases) page.
 
 ## [Unreleased]
+- [新功能] 新增 Finsance public daily export：以 allow-list 输出 Gemini/OpenAI AI 摘要与数据质量信息，排除交易点位、价格快照与 raw payload，并生成 SHA-256 sidecar。
+- [改进] GitHub Actions 增加 opt-in 的 Finsance 跨仓库校验、提交与 push 流程；默认关闭，且保留商业数据源开关。
+- [改进] GitHub Actions 每日分析工作流补齐 TickFlow 数据源环境变量映射，并收敛 README 数据源稳定性说明到完整指南。
+- [修复] WebUI 启动时显式 `--host` / `--port` 不再被 `.env` 中的 `WEBUI_HOST` / `WEBUI_PORT` 覆盖，未传 CLI 参数时统一使用解析后的运行时配置。
+- [改进] GitHub Actions: 每日分析工作流（`00-daily-analysis.yml`）新增钉钉通知环境变量映射，支持在云端定时任务中直接使用钉钉机器人。
+- [修复] Web 持仓页首屏快照改用 `include_realtime=false` 快速估值，跳过逐票实时行情预取后先展示持仓列表，避免外部实时行情源变慢时长时间空白等待。
+- [修复] 修复任务状态接口重建报告动作字段时把合法情绪分 `0` 当成空值的问题，确保低分报告能按评分口径纠正为卖出建议。
+- [修复] 修复 Agent 流式回复在未收到完成事件就断开时被显示为“（无内容）”的问题，改为提示流式响应中断并保留用户消息，避免误判为空回答。
+- [修复] 修复桌面端 `WEBUI_HOST=*` / `WEBUI_HOST=[::]` 会被原样传给端口探测和后端启动导致无法监听的问题，启动前分别规范化为 `0.0.0.0` / `::`。
+- [改进] `STOCK_LIST` 自选股解析支持中文逗号、顿号、分号、空格和换行等常见粘贴分隔符，运行时、定时热刷新、CLI `--stocks`、Web 设置保存和自选 API 统一识别，并在写回时规范为英文逗号。
+- [改进] 新增 `NEWS_INTEL_AUTO_FETCH_ENABLED` 单开关，开启后个股分析、Agent 分析和大盘复盘会 fail-open 自动初始化并刷新 RSS/Atom/NewsNow 本地资讯池。
+- [改进] Web AI 建议页新增主股票上下文，复用最近分析和股票索引候选，并改进表现统计零样本说明。
+- [改进] 补充本次设置页布局收敛：移动端分类导航改为横向滚动列表并保证设置内容首屏可见，桌面端保留分类说明并收紧字段布局层级与间距，提升首屏效率与可配置信息密度。
+- [文档] 在 README 快速开始中补充行情数据源配置说明（TUSHARE_TOKEN / Longbridge），明确未配置时仍可走 AkShare、Baostock、YFinance 等免费兜底源，日志中相关提示不影响运行。同步更新docs下的中英双份 README
 
 <!-- 新条目格式：- [类型] 描述（类型取值：新功能/改进/修复/文档/测试/chore）-->
 <!-- 每条独立一行追加到本段末尾，无需分类标题，合并时冲突最小 -->

--- a/docs/finsance-integration.md
+++ b/docs/finsance-integration.md
@@ -1,0 +1,62 @@
+# Finsance public daily analysis
+
+The scheduled workflow writes a public-safe artifact to
+reports/finsance/daily_latest.json. It is an allow-list projection of an
+AnalysisResult; private trading levels, current prices, raw responses and
+provider payloads are not copied.
+
+The target public route in the Finsance Website service is:
+
+https://www.finsance.com/daily-stock-analysis
+
+The route is SSR and reads the committed artifact only. It does not call
+Gemini, OpenAI, Yahoo or yfinance during a page request. SEO indexing must wait
+for an explicit freshness signal and the existing publication/compliance
+review.
+
+## AI and data settings
+
+Keep secrets in GitHub Actions Secrets, never in source:
+
+- GEMINI_API_KEY (primary; the workflow already maps GEMINI_MODEL)
+- OPENAI_API_KEY (fallback)
+- OPENAI_BASE_URL and OPENAI_MODEL when using an OpenAI-compatible endpoint
+- LITELLM_FALLBACK_MODELS=gemini/<light-model>,openai/<configured-model> to
+  make the fallback explicit and reduce Gemini quota collisions
+
+The free path remains the default: yfinance, AkShare and Baostock are
+available through the existing data-provider fallback chain. The existing
+fundamentals pipeline may add earnings context when a free source returns it;
+missing values remain unavailable.
+
+FINSANCE_COMMERCIAL_MODE=false keeps the public artifact labelled as free
+data. Set it to true only with FINSANCE_COMMERCIAL_PROVIDER configured and
+after a licensing review. This switch annotates the artifact; it does not
+silently turn on a paid provider.
+
+## Automatic cross-repository push
+
+The push is opt-in and disabled by default. In the
+ZhuLinsen/daily_stock_analysis repository, add these Actions variables and
+secret:
+
+| Name | Kind | Value |
+| --- | --- | --- |
+| FINSANCE_PUBLICATION_ENABLED | Variable | true |
+| FINSANCE_REPO | Variable | jamerskrs-lgtm/Finsance-Website |
+| FINSANCE_BRANCH | Variable | main |
+| GH_PAT | Secret | Fine-grained PAT with Contents read/write on the Finsance repo; `GITHUB_TOKEN` is the automatic source-repo token and cannot be used for this cross-repo push |
+
+The workflow accepts `GH_PAT` as the cross-repo push secret (and keeps
+`FINSANCE_REPO_TOKEN` as a backwards-compatible alias), checks out the target
+repo, validates the schema and forbidden
+fields, copies only content/quanttrade/daily_*.json plus checksums, and updates
+the root `.render-quanttrade-trigger` marker. The marker is required because
+the existing Render build filter ignores `content/**`; it makes the daily
+commit trigger a rebuild without making every unrelated content commit do so.
+Render must have auto-deploy-on-push enabled for the Finsance Website service;
+that Render setting and DNS/production response still require live-console
+verification.
+
+To roll back, disable FINSANCE_PUBLICATION_ENABLED; the next scheduled run
+will leave the Finsance checkout untouched.

--- a/main.py
+++ b/main.py
@@ -1070,6 +1070,22 @@ def run_full_analysis(
                     else:
                         logger.warning("合并推送失败")
 
+        # Public Finsance export is an allow-list projection; never serialize
+        # the full report because it contains private trading levels.
+        if not getattr(args, "dry_run", False):
+            try:
+                from src.services.public_daily_export import write_daily_export
+
+                public_path = write_daily_export(
+                    results,
+                    report_date=analysis_reference_time.date(),
+                )
+                if public_path:
+                    logger.info("Finsance public daily artifact written: %s", public_path)
+            except Exception as exc:
+                # A public export failure must not erase a valid private report.
+                logger.warning("Finsance public daily export failed (ignored): %s", exc)
+
         # 输出摘要
         if results:
             logger.info("\n===== 分析结果摘要 =====")

--- a/src/services/public_daily_export.py
+++ b/src/services/public_daily_export.py
@@ -1,0 +1,256 @@
+"""Write the smallest public-safe daily artifact for Finsance.
+
+The normal report contains private trading levels and raw provider payloads.
+This module deliberately builds a new allow-list payload instead of serialising
+AnalysisResult.to_dict().
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import re
+from datetime import date, datetime, timezone
+from pathlib import Path
+from typing import Any, Iterable, Mapping, Optional
+
+
+SCHEMA_VERSION = "finsance-quanttrade-daily-v1"
+DEFAULT_OUTPUT_DIR = Path("reports") / "finsance"
+_SECRET_RE = re.compile(r"(?i)(?:bearer\s+|sk-|AIza)[A-Za-z0-9._-]{8,}")
+
+
+def _value(item: Any, key: str, default: Any = None) -> Any:
+    if isinstance(item, Mapping):
+        return item.get(key, default)
+    return getattr(item, key, default)
+
+
+def _text(value: Any, limit: int = 600) -> Optional[str]:
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text[:limit] if text else None
+
+
+def _safe_text(value: Any, limit: int = 600) -> Optional[str]:
+    text = _text(value, limit)
+    return _SECRET_RE.sub("[redacted]", text) if text else None
+
+
+def _items(value: Any, limit: int = 5) -> list[str]:
+    if value is None:
+        return []
+    values: Iterable[Any] = value if isinstance(value, (list, tuple, set)) else [value]
+    result: list[str] = []
+    for item in values:
+        text = _safe_text(item, 500)
+        if text and text not in result:
+            result.append(text)
+        if len(result) >= limit:
+            break
+    return result
+
+
+def _dashboard(result: Any) -> dict[str, Any]:
+    dashboard = _value(result, "dashboard", {})
+    return dashboard if isinstance(dashboard, Mapping) else {}
+
+
+def _market_for_ticker(ticker: str) -> str:
+    code = ticker.upper()
+    if code.endswith(".HK") or code.startswith("HK"):
+        return "hk_stock"
+    if code.endswith(".TW") or code.endswith(".TWO"):
+        return "tw_stock"
+    if code.isdigit() and len(code) in (4, 5, 6):
+        return "cn_stock"
+    return "us_stock"
+
+
+def _quality(result: Any, dashboard: Mapping[str, Any]) -> dict[str, Any]:
+    overview = _value(result, "analysis_context_pack_overview")
+    candidates = [
+        _value(result, "data_quality"),
+        overview.get("data_quality") if isinstance(overview, Mapping) else None,
+        dashboard.get("data_quality"),
+        dashboard.get("analysis_context_pack_overview", {}).get("data_quality")
+        if isinstance(dashboard.get("analysis_context_pack_overview"), Mapping)
+        else None,
+        _value(result, "market_snapshot"),
+    ]
+    quality: Mapping[str, Any] = {}
+    for candidate in candidates:
+        if isinstance(candidate, Mapping):
+            quality = candidate
+            break
+    stale = quality.get("stale")
+    if not isinstance(stale, bool):
+        stale = None
+    bar_asof = (
+        quality.get("bar_asof")
+        or quality.get("effective_bar_date")
+        or quality.get("asof")
+        or quality.get("date")
+    )
+    return {"stale": stale, "bar_asof": _safe_text(bar_asof, 64)}
+
+
+def _stock_payload(result: Any) -> dict[str, Any]:
+    dashboard = _dashboard(result)
+    core = dashboard.get("core_conclusion")
+    core = core if isinstance(core, Mapping) else {}
+    intelligence = dashboard.get("intelligence")
+    intelligence = intelligence if isinstance(intelligence, Mapping) else {}
+    phase = dashboard.get("phase_decision")
+    phase = phase if isinstance(phase, Mapping) else {}
+
+    ticker = _safe_text(_value(result, "code"), 64) or "unknown"
+    success = bool(_value(result, "success", True))
+    risks = _items(intelligence.get("risk_alerts"))
+    for risk in _items(_value(result, "risk_warning")):
+        if risk not in risks:
+            risks.append(risk)
+    unknowns = _items(phase.get("data_limitations"))
+    error_message = _safe_text(_value(result, "error_message"), 500)
+    if not success and error_message and error_message not in unknowns:
+        unknowns.append(error_message)
+
+    summary = (
+        _safe_text(core.get("one_sentence"), 800)
+        or _safe_text(_value(result, "analysis_summary"), 800)
+        or "ยังไม่มีสรุปจาก AI"
+    )
+    score = _value(result, "sentiment_score")
+    if not isinstance(score, (int, float)) or isinstance(score, bool):
+        score = None
+
+    return {
+        "ticker": ticker,
+        "name": _safe_text(_value(result, "name"), 160) or ticker,
+        "market": _market_for_ticker(ticker),
+        "status": "ok" if success else "unavailable",
+        "decision": _safe_text(
+            _value(result, "action") or _value(result, "decision_type"), 32
+        ),
+        "action_label": _safe_text(_value(result, "action_label"), 80),
+        "score": score,
+        "trend": _safe_text(_value(result, "trend_prediction"), 120),
+        "confidence": _safe_text(_value(result, "confidence_level"), 40),
+        "summary_th": summary,
+        "catalysts": _items(intelligence.get("positive_catalysts")),
+        "risks": risks[:5],
+        "unknowns": unknowns[:5],
+        "data_quality": _quality(result, dashboard),
+        "data_sources": _safe_text(_value(result, "data_sources"), 600),
+        "search_performed": bool(_value(result, "search_performed", False)),
+        "model_used": _safe_text(_value(result, "model_used"), 160),
+    }
+
+
+def build_public_daily_payload(
+    results: Iterable[Any],
+    *,
+    report_date: Optional[date | datetime | str] = None,
+) -> dict[str, Any]:
+    stocks = [_stock_payload(result) for result in results if result is not None]
+    if isinstance(report_date, datetime):
+        date_text = report_date.date().isoformat()
+    elif isinstance(report_date, date):
+        date_text = report_date.isoformat()
+    elif report_date:
+        date_text = str(report_date)
+    else:
+        date_text = date.today().isoformat()
+
+    models = [stock["model_used"] for stock in stocks if stock["model_used"]]
+    providers = sorted(
+        {
+            model.split("/", 1)[0]
+            for model in models
+            if "/" in model
+        }
+    )
+    any_success = any(stock["status"] == "ok" for stock in stocks)
+    ai_status = "ok" if any_success and models else "fallback" if any_success else "unavailable"
+
+    commercial = os.getenv("FINSANCE_COMMERCIAL_MODE", "false").strip().lower() in {
+        "1",
+        "true",
+        "yes",
+        "on",
+    }
+    commercial_provider = _safe_text(os.getenv("FINSANCE_COMMERCIAL_PROVIDER"), 120)
+    publication_enabled = os.getenv(
+        "FINSANCE_PUBLICATION_ENABLED", "false"
+    ).strip().lower() in {"1", "true", "yes", "on"}
+    blockers = ["provider_licensing_review", "compliance_review", "production_verification"]
+    if commercial and not commercial_provider:
+        blockers.append("commercial_provider_not_configured")
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "date": date_text,
+        "built_at": datetime.now(timezone.utc).isoformat(),
+        "stocks": stocks,
+        "ai": {
+            "status": ai_status,
+            "provider": ",".join(providers) or None,
+            "requested_order": ["gemini", "openai"],
+            "fallback": "openai",
+        },
+        "data_mode": {
+            "commercial": commercial,
+            "provider": commercial_provider,
+            "free_sources": [] if commercial else ["yfinance", "akshare", "baostock"],
+        },
+        "publication": {
+            "status": "public_candidate" if publication_enabled else "not_live",
+            "enabled": publication_enabled,
+            "blockers": blockers,
+        },
+        "disclaimer": "ข้อมูลเพื่อการศึกษาเท่านั้น ไม่ใช่คำแนะนำการลงทุน",
+    }
+
+
+def _write_atomic(path: Path, data: bytes) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temp_path = path.with_name(f".{path.name}.tmp")
+    temp_path.write_bytes(data)
+    temp_path.replace(path)
+
+
+def _write_with_checksum(path: Path, data: bytes) -> None:
+    _write_atomic(path, data)
+    digest = hashlib.sha256(data).hexdigest()
+    _write_atomic(path.with_name(f"{path.name}.sha256"), f"{digest}  {path.name}\n".encode())
+
+
+def write_daily_export(
+    results: Iterable[Any],
+    *,
+    output_dir: str | Path = DEFAULT_OUTPUT_DIR,
+    report_date: Optional[date | datetime | str] = None,
+) -> Optional[Path]:
+    """Write an immutable date file plus the mutable latest pointer."""
+    results = [result for result in results if result is not None]
+    if not results:
+        return None
+    payload = build_public_daily_payload(results, report_date=report_date)
+    data = (json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True) + "\n").encode()
+    root = Path(output_dir)
+    daily_path = root / f"daily_{payload['date']}.json"
+    if not daily_path.exists():
+        _write_with_checksum(daily_path, data)
+    elif not daily_path.with_name(f"{daily_path.name}.sha256").exists():
+        _write_with_checksum(
+            daily_path,
+            daily_path.read_bytes(),
+        )
+    latest_path = root / "daily_latest.json"
+    _write_with_checksum(latest_path, data)
+    return latest_path
+
+
+__all__ = ["SCHEMA_VERSION", "build_public_daily_payload", "write_daily_export"]

--- a/tests/test_public_daily_export.py
+++ b/tests/test_public_daily_export.py
@@ -1,0 +1,87 @@
+"""Public Finsance export contract tests."""
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from src.services.public_daily_export import build_public_daily_payload, write_daily_export
+
+
+class PublicDailyExportTestCase(unittest.TestCase):
+    def _result(self):
+        return SimpleNamespace(
+            code="600519",
+            name="测试股票",
+            success=True,
+            action="watch",
+            action_label="观察",
+            decision_type="hold",
+            sentiment_score=61,
+            trend_prediction="震荡",
+            confidence_level="中",
+            analysis_summary="基于公开数据的观察摘要。",
+            risk_warning="数据仍需继续确认。",
+            search_performed=True,
+            data_sources="yfinance, earnings",
+            model_used="gemini/gemini-3-flash-preview",
+            analysis_context_pack_overview={
+                "data_quality": {"stale": False, "bar_asof": "2026-08-14"}
+            },
+            current_price=123.45,
+            raw_response='{"secret":"do-not-publish"}',
+            dashboard={
+                "core_conclusion": {"one_sentence": "等待更多确认。"},
+                "intelligence": {
+                    "positive_catalysts": ["公开催化"],
+                    "risk_alerts": ["公开风险"],
+                },
+                "phase_decision": {"data_limitations": ["bar freshness unavailable"]},
+                "battle_plan": {
+                    "sniper_points": {
+                        "ideal_buy": "123.45",
+                        "stop_loss": "100",
+                        "take_profit": "150",
+                    }
+                },
+            },
+        )
+
+    def test_allow_list_excludes_private_fields_and_writes_checksum(self):
+        with tempfile.TemporaryDirectory() as temp_dir, patch.dict(
+            "os.environ",
+            {
+                "FINSANCE_PUBLICATION_ENABLED": "false",
+                "FINSANCE_COMMERCIAL_MODE": "false",
+            },
+            clear=False,
+        ):
+            path = write_daily_export(
+                [self._result()],
+                output_dir=Path(temp_dir),
+                report_date="2026-08-14",
+            )
+            payload = json.loads(path.read_text(encoding="utf-8"))
+            dumped = json.dumps(payload, ensure_ascii=False)
+
+            self.assertEqual(payload["schema_version"], "finsance-quanttrade-daily-v1")
+            self.assertEqual(payload["stocks"][0]["ticker"], "600519")
+            self.assertFalse(payload["stocks"][0]["data_quality"]["stale"])
+            self.assertEqual(payload["stocks"][0]["data_quality"]["bar_asof"], "2026-08-14")
+            self.assertNotIn("battle_plan", dumped)
+            self.assertNotIn("current_price", dumped)
+            self.assertNotIn("123.45", dumped)
+            self.assertTrue(path.with_name(f"{path.name}.sha256").exists())
+            self.assertTrue(Path(temp_dir, "daily_2026-08-14.json").exists())
+
+    def test_empty_results_do_not_publish(self):
+        payload = build_public_daily_payload([])
+        self.assertEqual(payload["stocks"], [])
+        with tempfile.TemporaryDirectory() as temp_dir:
+            self.assertIsNone(write_daily_export([], output_dir=temp_dir))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Scope\n- Publish an allow-listed, checksum-verified public QuantTrade artifact for Finsance.\n- Add the automated daily workflow with Gemini primary and OpenAI fallback.\n- Add the Finsance publisher and guarded cross-repository push.\n- Keep private trading fields, raw responses, and TP/SL out of the public artifact.\n\n## Verification\n- Read-only Python compile checks passed.\n- python3 -m unittest tests.test_public_daily_export -v (2/2).\n- Workflow YAML parse passed.\n\n## Configuration after merge\nSet repository variable FINSANCE_PUBLICATION_ENABLED=true and repository secret GH_PAT (Contents read/write on the Finsance repository). The built-in GITHUB_TOKEN cannot write to a different repository.\n\n## Safety\nPublication remains disabled unless explicitly enabled; stale/unavailable data is not published as fresh.