### PR TITLE
test: 修复单股报告文件名日期夹具

### DIFF
--- a/tests/test_pipeline_single_stock_notify.py
+++ b/tests/test_pipeline_single_stock_notify.py
@@ -9,6 +9,7 @@ import sys
 import threading
 import time
 import unittest
+from datetime import datetime
 from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
@@ -49,7 +50,7 @@ class _TrackingNotifier:
 
     def _save_report_to_file(self, content, filename=None):
         self.saved_reports.append((content, filename))
-        return f"/tmp/{filename or 'report_20260814.md'}"
+        return f"/tmp/{filename or 'report.md'}"
 
     def _send(
         self,
@@ -89,6 +90,8 @@ def _make_result(code: str, success: bool = True) -> AnalysisResult:
 
 
 class TestPipelineSingleStockNotify(unittest.TestCase):
+    _FROZEN_REPORT_TIME = datetime(2030, 1, 2, 12, 0, 0)
+
     @staticmethod
     def _build_batch_pipeline() -> StockAnalysisPipeline:
         pipeline = StockAnalysisPipeline.__new__(StockAnalysisPipeline)
@@ -146,19 +149,21 @@ class TestPipelineSingleStockNotify(unittest.TestCase):
         pipeline.analyze_stock = MagicMock(return_value=_make_result("600519"))
         pipeline.notifier = _TrackingNotifier()
 
-        result = pipeline.process_single_stock(
-            code="600519",
-            skip_analysis=False,
-            single_stock_notify=True,
-            report_type=ReportType.BRIEF,
-            analysis_query_id="query-1",
-        )
+        with patch("src.core.pipeline.datetime") as mock_datetime:
+            mock_datetime.now.return_value = self._FROZEN_REPORT_TIME
+            result = pipeline.process_single_stock(
+                code="600519",
+                skip_analysis=False,
+                single_stock_notify=True,
+                report_type=ReportType.BRIEF,
+                analysis_query_id="query-1",
+            )
 
         self.assertIsNotNone(result)
         pipeline.notifier.generate_brief_report.assert_called_once_with([result])
         save_call = pipeline.notifier.save_report_to_file.call_args
         self.assertEqual(save_call.args[0], "brief:600519")
-        self.assertEqual(save_call.kwargs["filename"], "report_20260814_600519.md")
+        self.assertEqual(save_call.kwargs["filename"], "report_20300102_600519.md")
         pipeline.notifier.send.assert_called_once_with(
             "brief:600519",
             email_stock_codes=["600519"],
@@ -175,18 +180,20 @@ class TestPipelineSingleStockNotify(unittest.TestCase):
         pipeline.notifier = _TrackingNotifier()
         pipeline.notifier.is_available.return_value = False
 
-        result = pipeline.process_single_stock(
-            code="600519",
-            skip_analysis=False,
-            single_stock_notify=True,
-            report_type=ReportType.SIMPLE,
-            analysis_query_id="query-1",
-        )
+        with patch("src.core.pipeline.datetime") as mock_datetime:
+            mock_datetime.now.return_value = self._FROZEN_REPORT_TIME
+            result = pipeline.process_single_stock(
+                code="600519",
+                skip_analysis=False,
+                single_stock_notify=True,
+                report_type=ReportType.SIMPLE,
+                analysis_query_id="query-1",
+            )
 
         self.assertIsNotNone(result)
         save_call = pipeline.notifier.save_report_to_file.call_args
         self.assertEqual(save_call.args[0], "single:600519")
-        self.assertEqual(save_call.kwargs["filename"], "report_20260814_600519.md")
+        self.assertEqual(save_call.kwargs["filename"], "report_20300102_600519.md")
         pipeline.notifier.send.assert_not_called()
 
     def test_process_single_stock_updates_saved_diagnostics_after_notification(self):


### PR DESCRIPTION
当前 Head CI：ai-governance:pass / backend-tests:pass（3/3） / docker-build:skipped / web-gate:skipped。当前状态：全部适用检查通过（pass）。CI run：https://github.com/ZhuLinsen/daily_stock_analysis/actions/runs/31887742949

## PR Type

- [ ] fix
- [ ] feat
- [ ] refactor
- [ ] docs
- [ ] chore
- [x] test

## Background And Problem

Issue #2220 中的两个单股通知测试把提交当天日期 `20260814` 写死在期望文件名中，而生产代码按运行时 `datetime.now()` 生成 `report_YYYYMMDD_<stock>.md`。因此测试只会在 2026-08-14 通过，从次日起稳定失败；生产行为本身没有问题。

本 PR 用固定时间驱动被测生产路径，并继续精确断言完整文件名。没有改成在断言处读取“今天”，从而避免午夜跨日导致的 TOCTOU 波动。

## Scope Of Change

- 文件总数 / 变更行数：`1 file changed, 24 insertions(+), 17 deletions(-)`
- 文件清单：
  - `tests/test_pipeline_single_stock_notify.py`
- 变更内容：
  - 为两个文件名断言冻结 `src.core.pipeline.datetime.now()` 为 `2030-01-02 12:00:00`
  - 继续断言精确文件名 `report_20300102_600519.md`
  - 移除测试 notifier 未使用 fallback 中的历史日期
- 文档更新文件：无；仅修复测试夹具，不改变用户可见行为、报告格式或运行时契约。

## Issue Link

Fixes #2220

## Verification Commands And Results

```bash
.venv/bin/python -m pytest tests/test_pipeline_single_stock_notify.py -q
# 9 passed

PATH="/tmp/dsa-issue-2220-fix/.venv/bin:$PATH" ./scripts/ci_gate.sh
# 5766 passed, 1 failed, 4 deselected, 501 subtests passed
# 唯一失败：tests/test_intelligence_service.py::...::test_fetch_enabled_sources_is_fail_open
# 与本 PR 文件和日期逻辑无关；全量顺序下 good-feed mock 被既有全局状态污染。

.venv/bin/python -m pytest   tests/test_intelligence_service.py::IntelligenceServiceTestCase::test_fetch_enabled_sources_is_fail_open -q
# 1 passed

.venv/bin/python -m pytest tests/test_intelligence_service.py -q
# 25 passed

git diff --check
# pass
```

Full-suite note：本地全量门禁的目标文件 9/9 通过；唯一无关失败在单用例和完整所属文件复跑中均通过，属于全量顺序相关的既有波动。当前 Head 的 GitHub CI 三个后端分片全部通过，包括 Issue #2220 原失败所在的 `backend-tests (2/3)`。

- ai-governance：pass — https://github.com/ZhuLinsen/daily_stock_analysis/actions/runs/31887742949/job/95019403217
- backend-gate：pass（本次工作流以三个 backend-tests shards 执行）：
  - 1/3 pass — https://github.com/ZhuLinsen/daily_stock_analysis/actions/runs/31887742949/job/95019422745
  - 2/3 pass — https://github.com/ZhuLinsen/daily_stock_analysis/actions/runs/31887742949/job/95019422749
  - 3/3 pass — https://github.com/ZhuLinsen/daily_stock_analysis/actions/runs/31887742949/job/95019422737
- docker-build：skipped（仅测试文件变更）— https://github.com/ZhuLinsen/daily_stock_analysis/actions/runs/31887742949/job/95019423190
- web-gate：skipped（无 Web 变更）— https://github.com/ZhuLinsen/daily_stock_analysis/actions/runs/31887742949/job/95019423002

当前状态：全部适用的 Head CI 检查通过（pass）。

## Visual Evidence (if applicable)

- 不适用原因：仅修改测试夹具，未修改报告格式、报告渲染、Web UI 或设置字段。
- 可复现证据：`.venv/bin/python -m pytest tests/test_pipeline_single_stock_notify.py -q`（9 passed）

## Compatibility And Risk

- 生产代码、API、CLI、Web、Desktop、报告输出和持久化行为均未改变。
- 固定时间只在两个测试的 patch 上下文中生效。
- 风险较低：若生产路径未来不再通过 `src.core.pipeline.datetime.now()` 生成文件名，这两个精确断言会主动失败并提示更新契约。
- 本 PR 未变更 provider/model/base URL、运行时配置清理迁移语义；历史配置保持不变；回滚方式为 revert 本提交。

## Rollback Plan

Revert commit `51d70c816` 或 revert 本 PR；无需配置、数据或迁移回滚。

## EXTRACT_PROMPT Change (if applicable)

不适用。

## Checklist

- [x] 本 PR 有明确动机和业务价值
- [x] 已提供可复现的验证命令与结果
- [x] 已评估兼容性与风险
- [x] 已提供回滚方案
- [x] 报告格式和 Web UI 未修改，无需截图
- [x] Web 设置字段未修改，无需截图
- [x] 无用户可见变更，无需更新文档与 `docs/CHANGELOG.md`
