### PR TITLE
Agent/intraday ai picker v1

### DIFF
--- a/docs/intraday-picker.md
+++ b/docs/intraday-picker.md
@@ -1,0 +1,154 @@
+# 盘中实时 AI 选股
+
+盘中选股是一个独立、无 UI 依赖的后台流程。它不会改变原有 DSA 单股分析、AlphaSift Web 选股或桌面端交互。
+
+## 流程
+
+```text
+09:35 / 09:45 / 09:55
+        ↓
+AlphaSift deterministic screen
+capital_heat + volume_breakout
+balanced_alpha 仅作为质量参考
+        ↓
+stock_analysis 风格确认规则
+        ↓
+通达信 5 分钟数据
+        ↓
+过去 20 个交易日同一时点 RVOL_TIME
+        ↓
+透明盘中评分
+        ↓
+Top10 立即推送
+        ↓
+DSA TaskQueue 后台 brief / intraday 分析
+notify=false，避免 10 条个股推送
+        ↓
+65% 盘中分 + 35% DSA 分
+        ↓
+Top5 汇总推送
+```
+
+## 模块边界
+
+业务层在 `src/services/intraday_picker/`：
+
+- `models.py`：纯数据结构。
+- `metrics.py`：RVOL、价格强度、日内位置等纯计算。
+- `scoring.py`：透明评分与惩罚。
+- `stock_analysis_rules.py`：候选确认规则，不做第二次全市场扫描。
+- `orchestrator.py`：只编排 Port，不直接 import AlphaSift/Pytdx/TaskQueue/通知实现。
+- `final_ranker.py`：盘中分与 DSA 分合成。
+
+现有系统只能通过 `adapters/` 接入：
+
+- `alphasift_adapter.py`
+- `tdx_intraday_adapter.py`
+- `sqlite_history_repository.py`
+- `dsa_task_queue_adapter.py`
+- `notification_adapter.py`
+- `run_state_repository.py`
+
+修改某个 concrete provider 时，不应修改 `metrics.py` / `scoring.py` / `orchestrator.py`。
+
+## 配置
+
+将以下内容加入本地 `.env`：
+
+```bash
+INTRADAY_PICKER_ENABLED=true
+INTRADAY_PICKER_PROFILE=strong_start
+INTRADAY_PICKER_TIMES=09:35,09:45,09:55
+INTRADAY_PICKER_TOP_N=10
+INTRADAY_FINAL_TOP_N=5
+INTRADAY_BASELINE_DAYS=20
+INTRADAY_DSA_ENABLED=true
+INTRADAY_DSA_REPORT_TYPE=brief
+INTRADAY_DSA_CACHE_MINUTES=20
+INTRADAY_NOTIFY_PRELIMINARY=true
+INTRADAY_NOTIFY_FINAL=true
+```
+
+AlphaSift 仍需按原项目方式启用：
+
+```bash
+ALPHASIFT_ENABLED=true
+```
+
+## 手动验证
+
+只跑选股，不发送通知、不提交 DSA：
+
+```bash
+python scripts/intraday_picker_runner.py --once --at 09:45 --dry-run
+```
+
+真实执行一轮并将 Top10 送入 DSA：
+
+```bash
+python scripts/intraday_picker_runner.py --once --at 09:45
+```
+
+强制重跑同一个 run id：
+
+```bash
+python scripts/intraday_picker_runner.py --once --at 09:45 --force
+```
+
+## 自动运行
+
+常驻早盘 worker：
+
+```bash
+python scripts/intraday_picker_runner.py
+```
+
+Runner 使用 `Asia/Shanghai` 判断 09:35 / 09:45 / 09:55，不依赖 DSA App 是否打开。
+
+Windows 可安装计划任务：
+
+```powershell
+powershell -ExecutionPolicy Bypass -File scripts\install_intraday_picker_task.ps1
+```
+
+卸载：
+
+```powershell
+powershell -ExecutionPolicy Bypass -File scripts\uninstall_intraday_picker_task.ps1
+```
+
+当前安装脚本的启动时钟使用 Windows 本机时间；如果 Windows 时区不是中国标准时间，请通过 `-StartTime` 指定与上海 09:24 对应的本地时间。真正的三次选股仍由 runner 使用 `Asia/Shanghai` 二次校验。
+
+## RVOL_TIME
+
+V1 不为 5200+ 股票建立分钟数据库。AlphaSift 先把全市场压缩到候选池，再仅为候选拉取通达信 5 分钟数据。
+
+```text
+RVOL_TIME =
+今天 09:30 至当前触发时点累计成交额
+÷
+过去交易日同一时点累计成交额中位数
+```
+
+- 历史 >= 10 日：正常置信度。
+- 历史 5–9 日：降置信度。
+- 历史 < 5 日：RVOL 缺失，流程继续，按中性分处理。
+
+缓存位于：
+
+```text
+data/intraday_picker/intraday_history.sqlite3
+```
+
+## 失败降级
+
+- 单个 AlphaSift 策略失败：其他策略继续。
+- 通达信失败：该候选没有 RVOL，但仍可排名。
+- 板块字段缺失：使用中性分。
+- 通知失败：不阻断 DSA。
+- 单个 DSA 分析失败：其他候选继续。
+- DSA 全部未完成：Top5 回退为盘中分排序。
+
+## 注意
+
+盘中 Top10 是量价/策略候选，不等于买入信号。Top5 也只是研究与策略验证输出，不构成投资建议。

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,11 @@ tushare>=1.4.0              # Priority 2: Tushare Pro API
 pytdx>=1.72                 # Priority 2: Tongdaxin quote servers
 baostock>=0.8.0             # Priority 3: Baostock data
 yfinance>=0.2.0             # Priority 4: Yahoo Finance (Fallback)
-longbridge==0.2.75           # Priority 5: Longbridge OpenAPI fallback for US/HK stocks; OAuth capability checked at runtime
+# Longbridge 4.x Linux wheels currently require manylinux_2_39; Docker uses bookworm/glibc 2.36.
+# Priority 5: Docker/Linux fallback SDK.
+longbridge==0.2.74; platform_system == "Linux" and python_version < "3.12"
+# Priority 5: Longbridge OpenAPI SDK with OAuth support.
+longbridge>=4.0.5,<5; platform_system != "Linux" or python_version >= "3.12"
 tickflow>=0.1.24           # TickFlow official SDK; 0.1.24 verified for klines/get batch quotes/universes
 # Built-in optional AlphaSift screening engine
 git+https://github.com/ZhuLinsen/alphasift.git@377049857cc04175dc3cca62121ee41adec6cdb8#egg=alphasift

--- a/scripts/install_intraday_picker_task.ps1
+++ b/scripts/install_intraday_picker_task.ps1
@@ -1,0 +1,23 @@
+param(
+    [string]$TaskName = "DSA-Intraday-Picker",
+    [string]$StartTime = "09:24"
+)
+
+$ErrorActionPreference = "Stop"
+$RepoRoot = Split-Path -Parent $PSScriptRoot
+$VenvPython = Join-Path $RepoRoot ".venv\Scripts\python.exe"
+$Python = if (Test-Path $VenvPython) { $VenvPython } else { "python" }
+$Runner = Join-Path $RepoRoot "scripts\intraday_picker_runner.py"
+
+if (-not (Test-Path $Runner)) {
+    throw "intraday picker runner not found: $Runner"
+}
+
+$Action = New-ScheduledTaskAction -Execute $Python -Argument "`"$Runner`"" -WorkingDirectory $RepoRoot
+$Trigger = New-ScheduledTaskTrigger -Weekly -DaysOfWeek Monday,Tuesday,Wednesday,Thursday,Friday -At $StartTime
+$Settings = New-ScheduledTaskSettingsSet -StartWhenAvailable -MultipleInstances IgnoreNew
+Register-ScheduledTask -TaskName $TaskName -Action $Action -Trigger $Trigger -Settings $Settings -Force | Out-Null
+
+Write-Host "Installed task: $TaskName"
+Write-Host "Worker startup: weekdays $StartTime (host local time)"
+Write-Host "Actual scan times are checked again by the runner in Asia/Shanghai."

--- a/scripts/intraday_picker_runner.py
+++ b/scripts/intraday_picker_runner.py
@@ -11,7 +11,7 @@ import argparse
 import logging
 import sys
 import time
-from datetime import datetime, timedelta
+from datetime import datetime
 from pathlib import Path
 from zoneinfo import ZoneInfo
 
@@ -58,19 +58,21 @@ def run_once(orchestrator, when: datetime, *, dry_run: bool, force: bool):
 
 
 def finalize_with_wait(orchestrator, run_id: str, top, *, wait_seconds: int) -> None:
+    """Poll DSA status without finalizing/sending until the wait is over."""
     if not top:
         return
     deadline = time.monotonic() + max(0, wait_seconds)
-    final = []
     while True:
         now = _now()
-        final = orchestrator.finalize(run_id, top, now)
-        completed = sum(1 for item in final if item.dsa and item.dsa.status == "completed")
+        analyses = orchestrator.dsa_gateway.collect_available(top, now) if orchestrator.config.dsa_enabled else {}
+        completed = sum(1 for item in analyses.values() if item.status == "completed")
         if completed >= min(len(top), orchestrator.config.final_top_n):
             break
         if time.monotonic() >= deadline:
             break
         time.sleep(5)
+
+    final = orchestrator.finalize(run_id, top, _now())
     print("\n=== Final Top ===")
     for idx, item in enumerate(final, 1):
         dsa = "--" if not item.dsa or item.dsa.dsa_score is None else f"{item.dsa.dsa_score:.0f}"

--- a/scripts/intraday_picker_runner.py
+++ b/scripts/intraday_picker_runner.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+"""Headless A-share intraday picker runner.
+
+Runs independently of the Web/Electron UI. All trigger times are interpreted
+in Asia/Shanghai regardless of the host OS timezone.
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import sys
+import time
+from datetime import datetime, timedelta
+from pathlib import Path
+from zoneinfo import ZoneInfo
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from src.services.intraday_picker.config import IntradayPickerConfig
+from src.services.intraday_picker.runtime import build_intraday_picker
+
+TZ = ZoneInfo("Asia/Shanghai")
+logger = logging.getLogger("intraday_picker_runner")
+
+
+def _now() -> datetime:
+    return datetime.now(TZ)
+
+
+def _parse_at(value: str | None, base: datetime | None = None) -> datetime:
+    current = base or _now()
+    if not value:
+        return current
+    hour, minute = [int(part) for part in value.split(":", 1)]
+    return current.replace(hour=hour, minute=minute, second=0, microsecond=0)
+
+
+def _print_top(top) -> None:
+    print("\n=== Intraday Top Candidates ===")
+    for idx, item in enumerate(top, 1):
+        rvol = "--" if item.metrics.rvol_time is None else f"{item.metrics.rvol_time:.2f}x"
+        strategies = ",".join(hit.strategy_id for hit in item.strategy_hits)
+        print(
+            f"{idx:>2}. {item.stock_code} {item.stock_name:<10} "
+            f"score={item.picker_score:5.1f} chg={item.change_pct:+6.2f}% "
+            f"rvol={rvol} [{strategies}]"
+        )
+
+
+def run_once(orchestrator, when: datetime, *, dry_run: bool, force: bool):
+    logger.info("[IntradayPicker] run start: %s", when.isoformat())
+    top = orchestrator.run_preliminary(when, force=force, dry_run=dry_run)
+    _print_top(top)
+    return top
+
+
+def finalize_with_wait(orchestrator, run_id: str, top, *, wait_seconds: int) -> None:
+    if not top:
+        return
+    deadline = time.monotonic() + max(0, wait_seconds)
+    final = []
+    while True:
+        now = _now()
+        final = orchestrator.finalize(run_id, top, now)
+        completed = sum(1 for item in final if item.dsa and item.dsa.status == "completed")
+        if completed >= min(len(top), orchestrator.config.final_top_n):
+            break
+        if time.monotonic() >= deadline:
+            break
+        time.sleep(5)
+    print("\n=== Final Top ===")
+    for idx, item in enumerate(final, 1):
+        dsa = "--" if not item.dsa or item.dsa.dsa_score is None else f"{item.dsa.dsa_score:.0f}"
+        print(f"{idx:>2}. {item.candidate.stock_code} final={item.final_score:.1f} dsa={dsa}")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Headless DSA intraday stock picker")
+    parser.add_argument("--once", action="store_true", help="run one scan and exit")
+    parser.add_argument("--at", help="override logical trigger time, HH:MM")
+    parser.add_argument("--dry-run", action="store_true", help="do not notify or submit DSA tasks")
+    parser.add_argument("--force", action="store_true", help="rerun an already persisted run id")
+    parser.add_argument("--dsa-wait-seconds", type=int, default=120, help="wait for DSA results at the final trigger")
+    args = parser.parse_args()
+
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s | %(levelname)s | %(message)s")
+    config = IntradayPickerConfig.from_env()
+    orchestrator = build_intraday_picker(config)
+
+    if args.once:
+        when = _parse_at(args.at)
+        top = run_once(orchestrator, when, dry_run=args.dry_run, force=args.force)
+        if not args.dry_run:
+            finalize_with_wait(orchestrator, orchestrator.run_id(when), top, wait_seconds=args.dsa_wait_seconds)
+        return 0
+
+    if not config.enabled:
+        logger.info("[IntradayPicker] disabled: set INTRADAY_PICKER_ENABLED=true to enable scheduled mode")
+        return 0
+
+    triggered: set[str] = set()
+    start = _now().replace(hour=9, minute=25, second=0, microsecond=0)
+    end = _now().replace(hour=10, minute=2, second=0, microsecond=0)
+    if _now() > end:
+        return 0
+    while _now() < start:
+        time.sleep(min(30, max(1, int((start - _now()).total_seconds()))))
+
+    final_time = config.schedule_times[-1]
+    while _now() <= end:
+        now = _now()
+        hhmm = now.strftime("%H:%M")
+        for scheduled in config.schedule_times:
+            key = f"{now.date().isoformat()}-{scheduled}"
+            if scheduled == hhmm and key not in triggered:
+                logical_time = _parse_at(scheduled, now)
+                top = run_once(orchestrator, logical_time, dry_run=False, force=False)
+                triggered.add(key)
+                if scheduled == final_time:
+                    finalize_with_wait(
+                        orchestrator,
+                        orchestrator.run_id(logical_time),
+                        top,
+                        wait_seconds=args.dsa_wait_seconds,
+                    )
+        time.sleep(5)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/uninstall_intraday_picker_task.ps1
+++ b/scripts/uninstall_intraday_picker_task.ps1
@@ -1,0 +1,12 @@
+param(
+    [string]$TaskName = "DSA-Intraday-Picker"
+)
+
+$ErrorActionPreference = "Stop"
+$Task = Get-ScheduledTask -TaskName $TaskName -ErrorAction SilentlyContinue
+if ($null -eq $Task) {
+    Write-Host "Task not found: $TaskName"
+    exit 0
+}
+Unregister-ScheduledTask -TaskName $TaskName -Confirm:$false
+Write-Host "Removed task: $TaskName"

--- a/src/services/intraday_picker/__init__.py
+++ b/src/services/intraday_picker/__init__.py
@@ -1,0 +1,23 @@
+"""Isolated intraday stock-picking domain package.
+
+Concrete DSA, AlphaSift and market-data integrations live under ``adapters``.
+Domain modules must stay free of imports from legacy service implementations.
+"""
+
+from .config import IntradayPickerConfig
+from .models import (
+    DsaAnalysisSummary,
+    FinalCandidate,
+    IntradayCandidate,
+    IntradayMetrics,
+    StrategyHit,
+)
+
+__all__ = [
+    "DsaAnalysisSummary",
+    "FinalCandidate",
+    "IntradayCandidate",
+    "IntradayMetrics",
+    "IntradayPickerConfig",
+    "StrategyHit",
+]

--- a/src/services/intraday_picker/adapters/__init__.py
+++ b/src/services/intraday_picker/adapters/__init__.py
@@ -1,0 +1,1 @@
+"""Concrete integrations for the isolated intraday picker domain."""

--- a/src/services/intraday_picker/adapters/alphasift_adapter.py
+++ b/src/services/intraday_picker/adapters/alphasift_adapter.py
@@ -54,6 +54,21 @@ def _candidate_rows(payload: Any) -> Iterable[dict[str, Any]]:
         yield from _candidate_rows(nested)
 
 
+def _flatten_candidate_context(row: dict[str, Any]) -> dict[str, Any]:
+    """Keep the stable DSA shape while surfacing deterministic factor fields."""
+    merged: dict[str, Any] = {}
+    nested_raw = row.get("raw")
+    if isinstance(nested_raw, dict):
+        merged.update(nested_raw)
+    for key in ("factor_scores", "dsa_context"):
+        nested = row.get(key)
+        if isinstance(nested, dict):
+            for nested_key, nested_value in nested.items():
+                merged.setdefault(nested_key, nested_value)
+    merged.update(row)
+    return merged
+
+
 class AlphaSiftStrategyAdapter:
     def __init__(self, picker_config: IntradayPickerConfig):
         self.picker_config = picker_config
@@ -79,8 +94,6 @@ class AlphaSiftStrategyAdapter:
             try:
                 return screen(strategy_id, **kwargs)
             except TypeError:
-                # Backward-compatible fallback for older adapters exposing only
-                # positional strategy/market/max_results.
                 return screen(strategy_id, "cn", max_results)
 
     def _run_strategy(self, strategy_id: str, max_results: int) -> list[StrategyHit]:
@@ -91,6 +104,7 @@ class AlphaSiftStrategyAdapter:
             if not code:
                 continue
             raw_score = row.get("final_score", row.get("score", row.get("strategy_score", 0)))
+            raw = _flatten_candidate_context(row)
             hits.append(
                 StrategyHit(
                     stock_code=code,
@@ -101,7 +115,7 @@ class AlphaSiftStrategyAdapter:
                     strategy_score=_num(raw_score),
                     source="alphasift",
                     quality_score=_num(row.get("quality_score"), 0.0) if row.get("quality_score") is not None else None,
-                    raw=dict(row),
+                    raw=raw,
                 )
             )
         return hits
@@ -124,19 +138,17 @@ class AlphaSiftStrategyAdapter:
             except Exception:
                 continue
 
-        normalized: list[StrategyHit] = []
-        for hit in hits:
-            normalized.append(
-                StrategyHit(
-                    stock_code=hit.stock_code,
-                    strategy_id=hit.strategy_id,
-                    strategy_score=hit.strategy_score,
-                    source=hit.source,
-                    stock_name=hit.stock_name,
-                    price=hit.price,
-                    change_pct=hit.change_pct,
-                    quality_score=quality_by_code.get(hit.stock_code, hit.quality_score),
-                    raw=hit.raw,
-                )
+        return [
+            StrategyHit(
+                stock_code=hit.stock_code,
+                strategy_id=hit.strategy_id,
+                strategy_score=hit.strategy_score,
+                source=hit.source,
+                stock_name=hit.stock_name,
+                price=hit.price,
+                change_pct=hit.change_pct,
+                quality_score=quality_by_code.get(hit.stock_code, hit.quality_score),
+                raw=hit.raw,
             )
-        return normalized
+            for hit in hits
+        ]

--- a/src/services/intraday_picker/adapters/alphasift_adapter.py
+++ b/src/services/intraday_picker/adapters/alphasift_adapter.py
@@ -1,17 +1,26 @@
-"""AlphaSift adapter for intraday candidate discovery.
+"""AlphaSift adapter for fast intraday candidate discovery.
 
 This is the only intraday-picker module allowed to import the existing
-AlphaSift bridge. It normalizes multiple possible AlphaSift result shapes and
-keeps current AlphaSift endpoint/default behaviour untouched.
+AlphaSift bridge. Intraday discovery intentionally calls the AlphaSift adapter
+with ``use_llm=False`` so DSA deep analysis happens only after Top10 is known.
+The existing AlphaSift service/API behaviour remains unchanged.
 """
 
 from __future__ import annotations
 
+import inspect
 from datetime import datetime
 from typing import Any, Iterable
 
 from src.config import get_config
-from src.services.alphasift_service import AlphaSiftService
+from src.services.alphasift_service import (
+    _alphasift_dsa_daily_history_provider,
+    _alphasift_runtime_env,
+    _ensure_alphasift_available_for_use,
+    _ensure_alphasift_enabled,
+    _get_adapter_callable,
+    _get_dsa_adapter,
+)
 
 from ..config import IntradayPickerConfig
 from ..models import StrategyHit
@@ -48,14 +57,34 @@ def _candidate_rows(payload: Any) -> Iterable[dict[str, Any]]:
 class AlphaSiftStrategyAdapter:
     def __init__(self, picker_config: IntradayPickerConfig):
         self.picker_config = picker_config
-        self._service = AlphaSiftService(config=get_config())
+        self._config = get_config()
+
+    def _screen_deterministic(self, strategy_id: str, max_results: int) -> Any:
+        _ensure_alphasift_enabled(self._config)
+        _ensure_alphasift_available_for_use()
+        adapter = _get_dsa_adapter()
+        screen = _get_adapter_callable(adapter, "screen", "screen() unavailable")
+        signature = inspect.signature(screen)
+        params = signature.parameters
+        supports_var_kwargs = any(p.kind == inspect.Parameter.VAR_KEYWORD for p in params.values())
+        kwargs: dict[str, Any] = {"market": "cn"}
+        if "max_results" in params or supports_var_kwargs:
+            kwargs["max_results"] = max_results
+        elif "max_output" in params:
+            kwargs["max_output"] = max_results
+        if "use_llm" in params or supports_var_kwargs:
+            kwargs["use_llm"] = False
+
+        with _alphasift_runtime_env(self._config, max_results=max_results), _alphasift_dsa_daily_history_provider():
+            try:
+                return screen(strategy_id, **kwargs)
+            except TypeError:
+                # Backward-compatible fallback for older adapters exposing only
+                # positional strategy/market/max_results.
+                return screen(strategy_id, "cn", max_results)
 
     def _run_strategy(self, strategy_id: str, max_results: int) -> list[StrategyHit]:
-        payload = self._service.screen(
-            strategy=strategy_id,
-            market="cn",
-            max_results=max_results,
-        )
+        payload = self._screen_deterministic(strategy_id, max_results)
         hits: list[StrategyHit] = []
         for row in _candidate_rows(payload):
             code = str(row.get("code") or row.get("stock_code") or row.get("symbol") or "").strip()
@@ -78,19 +107,15 @@ class AlphaSiftStrategyAdapter:
         return hits
 
     def screen(self, profile: str, now: datetime) -> list[StrategyHit]:
-        del now  # AlphaSift reads the current market snapshot itself.
+        del now
         profile_config = get_profile(profile)
         hits: list[StrategyHit] = []
         for strategy_id in profile_config.get("alphasift", ()):
             try:
                 hits.extend(self._run_strategy(strategy_id, self.picker_config.candidate_limit_per_strategy))
             except Exception:
-                # Strategy isolation: one AlphaSift source/strategy failure must not
-                # terminate the remaining candidate discovery paths.
                 continue
 
-        # Quality-reference strategies do not create extra universe breadth when a
-        # stock is already present; they only attach a quality score when matched.
         quality_by_code: dict[str, float] = {}
         for strategy_id in profile_config.get("quality_reference", ()):
             try:
@@ -101,7 +126,6 @@ class AlphaSiftStrategyAdapter:
 
         normalized: list[StrategyHit] = []
         for hit in hits:
-            quality = quality_by_code.get(hit.stock_code, hit.quality_score)
             normalized.append(
                 StrategyHit(
                     stock_code=hit.stock_code,
@@ -111,7 +135,7 @@ class AlphaSiftStrategyAdapter:
                     stock_name=hit.stock_name,
                     price=hit.price,
                     change_pct=hit.change_pct,
-                    quality_score=quality,
+                    quality_score=quality_by_code.get(hit.stock_code, hit.quality_score),
                     raw=hit.raw,
                 )
             )

--- a/src/services/intraday_picker/adapters/alphasift_adapter.py
+++ b/src/services/intraday_picker/adapters/alphasift_adapter.py
@@ -1,0 +1,118 @@
+"""AlphaSift adapter for intraday candidate discovery.
+
+This is the only intraday-picker module allowed to import the existing
+AlphaSift bridge. It normalizes multiple possible AlphaSift result shapes and
+keeps current AlphaSift endpoint/default behaviour untouched.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, Iterable
+
+from src.config import get_config
+from src.services.alphasift_service import AlphaSiftService
+
+from ..config import IntradayPickerConfig
+from ..models import StrategyHit
+from ..strategy_profiles import get_profile
+
+
+def _num(value: Any, default: float = 0.0) -> float:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _candidate_rows(payload: Any) -> Iterable[dict[str, Any]]:
+    if isinstance(payload, list):
+        for item in payload:
+            if isinstance(item, dict):
+                yield item
+        return
+    if not isinstance(payload, dict):
+        return
+    for key in ("picks", "candidates", "results", "stocks", "items"):
+        value = payload.get(key)
+        if isinstance(value, list):
+            for item in value:
+                if isinstance(item, dict):
+                    yield item
+            return
+    nested = payload.get("result")
+    if nested is not None:
+        yield from _candidate_rows(nested)
+
+
+class AlphaSiftStrategyAdapter:
+    def __init__(self, picker_config: IntradayPickerConfig):
+        self.picker_config = picker_config
+        self._service = AlphaSiftService(config=get_config())
+
+    def _run_strategy(self, strategy_id: str, max_results: int) -> list[StrategyHit]:
+        payload = self._service.screen(
+            strategy=strategy_id,
+            market="cn",
+            max_results=max_results,
+        )
+        hits: list[StrategyHit] = []
+        for row in _candidate_rows(payload):
+            code = str(row.get("code") or row.get("stock_code") or row.get("symbol") or "").strip()
+            if not code:
+                continue
+            raw_score = row.get("final_score", row.get("score", row.get("strategy_score", 0)))
+            hits.append(
+                StrategyHit(
+                    stock_code=code,
+                    stock_name=str(row.get("name") or row.get("stock_name") or ""),
+                    price=_num(row.get("price", row.get("current_price", 0))),
+                    change_pct=_num(row.get("change_pct", row.get("pct_chg", row.get("涨跌幅", 0)))),
+                    strategy_id=strategy_id,
+                    strategy_score=_num(raw_score),
+                    source="alphasift",
+                    quality_score=_num(row.get("quality_score"), 0.0) if row.get("quality_score") is not None else None,
+                    raw=dict(row),
+                )
+            )
+        return hits
+
+    def screen(self, profile: str, now: datetime) -> list[StrategyHit]:
+        del now  # AlphaSift reads the current market snapshot itself.
+        profile_config = get_profile(profile)
+        hits: list[StrategyHit] = []
+        for strategy_id in profile_config.get("alphasift", ()):
+            try:
+                hits.extend(self._run_strategy(strategy_id, self.picker_config.candidate_limit_per_strategy))
+            except Exception:
+                # Strategy isolation: one AlphaSift source/strategy failure must not
+                # terminate the remaining candidate discovery paths.
+                continue
+
+        # Quality-reference strategies do not create extra universe breadth when a
+        # stock is already present; they only attach a quality score when matched.
+        quality_by_code: dict[str, float] = {}
+        for strategy_id in profile_config.get("quality_reference", ()):
+            try:
+                for hit in self._run_strategy(strategy_id, min(20, self.picker_config.candidate_limit_per_strategy)):
+                    quality_by_code[hit.stock_code] = hit.strategy_score
+            except Exception:
+                continue
+
+        normalized: list[StrategyHit] = []
+        for hit in hits:
+            quality = quality_by_code.get(hit.stock_code, hit.quality_score)
+            normalized.append(
+                StrategyHit(
+                    stock_code=hit.stock_code,
+                    strategy_id=hit.strategy_id,
+                    strategy_score=hit.strategy_score,
+                    source=hit.source,
+                    stock_name=hit.stock_name,
+                    price=hit.price,
+                    change_pct=hit.change_pct,
+                    quality_score=quality,
+                    raw=hit.raw,
+                )
+            )
+        return normalized

--- a/src/services/intraday_picker/adapters/dsa_task_queue_adapter.py
+++ b/src/services/intraday_picker/adapters/dsa_task_queue_adapter.py
@@ -1,0 +1,94 @@
+"""Adapter from intraday candidates to the existing DSA task queue."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+from typing import Sequence
+
+from src.services.task_queue import TaskStatus, get_task_queue
+
+from ..config import IntradayPickerConfig
+from ..models import DsaAnalysisSummary, IntradayCandidate
+
+
+class DsaTaskQueueAdapter:
+    def __init__(self, config: IntradayPickerConfig):
+        self.config = config
+        self.queue = get_task_queue()
+        self._task_by_code: dict[str, tuple[str, datetime]] = {}
+
+    def _fresh_ref(self, code: str, now: datetime) -> str | None:
+        cached = self._task_by_code.get(code)
+        if cached is None:
+            return None
+        task_id, submitted_at = cached
+        if now - submitted_at > timedelta(minutes=self.config.dsa_cache_minutes):
+            return None
+        task = self.queue.get_task(task_id)
+        if task is None:
+            return None
+        if task.status in {TaskStatus.PENDING, TaskStatus.PROCESSING, TaskStatus.COMPLETED}:
+            return task_id
+        return None
+
+    def submit_or_reuse(self, candidates: Sequence[IntradayCandidate], now: datetime) -> dict[str, str]:
+        refs: dict[str, str] = {}
+        new_codes: list[str] = []
+        for candidate in candidates:
+            task_id = self._fresh_ref(candidate.stock_code, now)
+            if task_id:
+                refs[candidate.stock_code] = task_id
+            else:
+                new_codes.append(candidate.stock_code)
+
+        if new_codes:
+            accepted, duplicates = self.queue.submit_tasks_batch(
+                stock_codes=new_codes,
+                query_source="intraday_picker",
+                report_type=self.config.dsa_report_type,
+                analysis_phase="intraday",
+                force_refresh=False,
+                notify=False,
+            )
+            for task in accepted:
+                refs[task.stock_code] = task.task_id
+                self._task_by_code[task.stock_code] = (task.task_id, now)
+            for duplicate in duplicates:
+                refs[duplicate.stock_code] = duplicate.existing_task_id
+                self._task_by_code[duplicate.stock_code] = (duplicate.existing_task_id, now)
+        return refs
+
+    @staticmethod
+    def _summary(task) -> DsaAnalysisSummary:
+        result = task.result if isinstance(task.result, dict) else {}
+        report = result.get("report") if isinstance(result.get("report"), dict) else {}
+        summary = report.get("summary") if isinstance(report.get("summary"), dict) else {}
+        details = report.get("details") if isinstance(report.get("details"), dict) else {}
+        raw_score = summary.get("sentiment_score")
+        try:
+            score = float(raw_score) if raw_score is not None else None
+        except (TypeError, ValueError):
+            score = None
+        risk = details.get("risk_warning")
+        risk_level = "有风险提示" if risk else None
+        return DsaAnalysisSummary(
+            stock_code=task.stock_code,
+            status=task.status.value if hasattr(task.status, "value") else str(task.status),
+            dsa_score=score,
+            operation_advice=summary.get("operation_advice"),
+            risk_level=risk_level,
+            summary=summary.get("analysis_summary"),
+            task_id=task.task_id,
+        )
+
+    def collect_available(self, candidates: Sequence[IntradayCandidate], now: datetime) -> dict[str, DsaAnalysisSummary]:
+        output: dict[str, DsaAnalysisSummary] = {}
+        for candidate in candidates:
+            task_id = self._fresh_ref(candidate.stock_code, now)
+            if not task_id:
+                continue
+            task = self.queue.get_task(task_id)
+            if task is None:
+                continue
+            output[candidate.stock_code] = self._summary(task)
+        return output

--- a/src/services/intraday_picker/adapters/notification_adapter.py
+++ b/src/services/intraday_picker/adapters/notification_adapter.py
@@ -1,0 +1,54 @@
+"""Reuse the existing DSA notification facade for intraday summaries."""
+
+from __future__ import annotations
+
+from typing import Sequence
+
+from src.notification import NotificationService
+
+from ..models import FinalCandidate, IntradayCandidate
+
+
+def _strategy_labels(candidate: IntradayCandidate) -> str:
+    ids = [hit.strategy_id for hit in candidate.strategy_hits]
+    ids.extend(result.rule_id for result in candidate.confirmations if result.matched)
+    return " + ".join(dict.fromkeys(ids)) or "-"
+
+
+class DsaNotificationAdapter:
+    def __init__(self):
+        self.service = NotificationService()
+
+    def send_preliminary(self, run_id: str, candidates: Sequence[IntradayCandidate]) -> None:
+        lines = [f"## 早盘实时候选 Top{len(candidates)}", "", f"> run: `{run_id}`", ""]
+        for idx, item in enumerate(candidates, 1):
+            rvol = "--" if item.metrics.rvol_time is None else f"{item.metrics.rvol_time:.2f}x"
+            sector = "--" if item.metrics.sector_score is None else f"{item.metrics.sector_score:.0f}"
+            lines.extend(
+                [
+                    f"**{idx}. {item.stock_name or item.stock_code} ({item.stock_code}) — {item.picker_score:.1f}**",
+                    f"- 涨幅 {item.change_pct:+.2f}% | 同期放量 {rvol} | 板块 {sector}",
+                    f"- 命中：{_strategy_labels(item)}",
+                    "",
+                ]
+            )
+        lines.append("*初选为盘中量价筛选结果，DSA 深度分析在后台继续执行。* ")
+        self.service.send("\n".join(lines), route_type="report", dedup_key=f"intraday-pre-{run_id}")
+
+    def send_final(self, run_id: str, candidates: Sequence[FinalCandidate]) -> None:
+        lines = [f"## DSA 早盘深度精选 Top{len(candidates)}", "", f"> run: `{run_id}`", ""]
+        for idx, item in enumerate(candidates, 1):
+            candidate = item.candidate
+            dsa = item.dsa
+            dsa_score = "--" if dsa is None or dsa.dsa_score is None else f"{dsa.dsa_score:.0f}"
+            advice = dsa.operation_advice if dsa and dsa.operation_advice else "DSA未完成"
+            lines.extend(
+                [
+                    f"**{idx}. {candidate.stock_name or candidate.stock_code} ({candidate.stock_code}) — {item.final_score:.1f}**",
+                    f"- 盘中 {candidate.picker_score:.1f} | DSA {dsa_score} | {advice}",
+                    f"- 命中：{_strategy_labels(candidate)}",
+                    "",
+                ]
+            )
+        lines.append("*仅用于研究与策略验证，不构成投资建议。*")
+        self.service.send("\n".join(lines), route_type="report", dedup_key=f"intraday-final-{run_id}")

--- a/src/services/intraday_picker/adapters/run_state_repository.py
+++ b/src/services/intraday_picker/adapters/run_state_repository.py
@@ -1,0 +1,63 @@
+"""JSON run-state persistence for idempotent intraday scans."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, is_dataclass
+from pathlib import Path
+from typing import Any, Sequence
+
+
+class JsonRunStateRepository:
+    def __init__(self, root: str | Path = "data/intraday_picker/runs"):
+        self.root = Path(root)
+
+    def _path(self, run_id: str) -> Path:
+        date_key = run_id[:8]
+        hhmm = run_id.split("-")[-1]
+        return self.root / date_key / f"{hhmm}.json"
+
+    @staticmethod
+    def _jsonable(value: Any) -> Any:
+        if is_dataclass(value):
+            return asdict(value)
+        if isinstance(value, dict):
+            return {str(k): JsonRunStateRepository._jsonable(v) for k, v in value.items()}
+        if isinstance(value, (list, tuple)):
+            return [JsonRunStateRepository._jsonable(v) for v in value]
+        return value
+
+    def _read(self, run_id: str) -> dict[str, Any]:
+        path = self._path(run_id)
+        try:
+            return json.loads(path.read_text(encoding="utf-8"))
+        except (FileNotFoundError, json.JSONDecodeError):
+            return {}
+
+    def _write(self, run_id: str, payload: dict[str, Any]) -> None:
+        path = self._path(run_id)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(self._jsonable(payload), ensure_ascii=False, indent=2), encoding="utf-8")
+
+    def is_completed(self, run_id: str) -> bool:
+        return self._read(run_id).get("status") == "completed"
+
+    def save_preliminary(self, run_id: str, candidates: Sequence[Any], metadata: dict[str, Any]) -> None:
+        payload = self._read(run_id)
+        payload.update({
+            "run_id": run_id,
+            "status": "preliminary",
+            "metadata": metadata,
+            "top10": list(candidates),
+        })
+        self._write(run_id, payload)
+
+    def save_dsa_tasks(self, run_id: str, task_refs: dict[str, str]) -> None:
+        payload = self._read(run_id)
+        payload["dsa_tasks"] = task_refs
+        self._write(run_id, payload)
+
+    def save_final(self, run_id: str, candidates: Sequence[Any]) -> None:
+        payload = self._read(run_id)
+        payload.update({"status": "completed", "top5": list(candidates)})
+        self._write(run_id, payload)

--- a/src/services/intraday_picker/adapters/run_state_repository.py
+++ b/src/services/intraday_picker/adapters/run_state_repository.py
@@ -40,7 +40,13 @@ class JsonRunStateRepository:
         path.write_text(json.dumps(self._jsonable(payload), ensure_ascii=False, indent=2), encoding="utf-8")
 
     def is_completed(self, run_id: str) -> bool:
-        return self._read(run_id).get("status") == "completed"
+        """Return True once a run has produced preliminary output or final output.
+
+        The historical method name is kept for the domain port, but the semantic
+        is deliberately "already claimed" so a second scheduler tick cannot
+        duplicate Top10 notifications or DSA submissions.
+        """
+        return self._read(run_id).get("status") in {"preliminary", "completed"}
 
     def save_preliminary(self, run_id: str, candidates: Sequence[Any], metadata: dict[str, Any]) -> None:
         payload = self._read(run_id)

--- a/src/services/intraday_picker/adapters/sqlite_history_repository.py
+++ b/src/services/intraday_picker/adapters/sqlite_history_repository.py
@@ -1,0 +1,91 @@
+"""Small SQLite cache for same-time intraday baselines."""
+
+from __future__ import annotations
+
+import sqlite3
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+
+class SqliteHistoryRepository:
+    def __init__(self, path: str | Path = "data/intraday_picker/intraday_history.sqlite3", baseline_days: int = 20):
+        self.path = Path(path)
+        self.baseline_days = max(5, int(baseline_days))
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        self._init_schema()
+
+    def _connect(self) -> sqlite3.Connection:
+        return sqlite3.connect(self.path)
+
+    def _init_schema(self) -> None:
+        with self._connect() as conn:
+            conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS intraday_baseline (
+                    stock_code TEXT NOT NULL,
+                    trade_date TEXT NOT NULL,
+                    minute_key TEXT NOT NULL,
+                    cumulative_amount REAL,
+                    cumulative_volume REAL,
+                    close REAL,
+                    PRIMARY KEY(stock_code, trade_date, minute_key)
+                )
+                """
+            )
+
+    def _load(self, stock_code: str, minute_key: str) -> list[dict[str, Any]]:
+        with self._connect() as conn:
+            rows = conn.execute(
+                """
+                SELECT trade_date, cumulative_amount, cumulative_volume, close
+                FROM intraday_baseline
+                WHERE stock_code=? AND minute_key=?
+                ORDER BY trade_date DESC
+                LIMIT ?
+                """,
+                (stock_code, minute_key, self.baseline_days),
+            ).fetchall()
+        return [
+            {
+                "trade_date": trade_date,
+                "cumulative_amount": amount,
+                "cumulative_volume": volume,
+                "close": close,
+            }
+            for trade_date, amount, volume, close in reversed(rows)
+        ]
+
+    def _save(self, stock_code: str, rows: list[dict[str, Any]]) -> None:
+        if not rows:
+            return
+        with self._connect() as conn:
+            conn.executemany(
+                """
+                INSERT OR REPLACE INTO intraday_baseline
+                (stock_code, trade_date, minute_key, cumulative_amount, cumulative_volume, close)
+                VALUES (?, ?, ?, ?, ?, ?)
+                """,
+                [
+                    (
+                        stock_code,
+                        row.get("trade_date"),
+                        row.get("minute_key"),
+                        row.get("cumulative_amount"),
+                        row.get("cumulative_volume"),
+                        row.get("close"),
+                    )
+                    for row in rows
+                    if row.get("trade_date") and row.get("minute_key")
+                ],
+            )
+
+    def get_or_build_baseline(self, stock_code: str, now: datetime, market_gateway: Any) -> list[dict[str, Any]]:
+        minute_key = now.strftime("%H:%M")
+        cached = self._load(stock_code, minute_key)
+        # Ten observations are enough for a normal-confidence RVOL baseline.
+        if len(cached) >= min(10, self.baseline_days):
+            return cached
+        rows = market_gateway.get_historical_same_time(stock_code, now, self.baseline_days)
+        self._save(stock_code, rows)
+        return self._load(stock_code, minute_key) or rows

--- a/src/services/intraday_picker/adapters/tdx_intraday_adapter.py
+++ b/src/services/intraday_picker/adapters/tdx_intraday_adapter.py
@@ -1,0 +1,99 @@
+"""5-minute TDX market-data adapter for intraday candidate enrichment."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+
+import pandas as pd
+
+from data_provider.pytdx_fetcher import PytdxFetcher
+
+
+class TdxIntradayAdapter:
+    """Read 5-minute bars without changing existing PytdxFetcher behaviour."""
+
+    BAR_COUNT = 800
+
+    def __init__(self, fetcher: PytdxFetcher | None = None):
+        self.fetcher = fetcher or PytdxFetcher()
+
+    def _bars(self, stock_code: str, count: int | None = None) -> pd.DataFrame:
+        market, code = self.fetcher._get_market_code(stock_code)
+        with self.fetcher._pytdx_session() as api:
+            rows = api.get_security_bars(
+                category=0,  # 5-minute bars
+                market=market,
+                code=code,
+                start=0,
+                count=count or self.BAR_COUNT,
+            )
+            if not rows:
+                return pd.DataFrame()
+            df = api.to_df(rows)
+        if "datetime" in df.columns:
+            df["datetime"] = pd.to_datetime(df["datetime"], errors="coerce")
+            df = df.dropna(subset=["datetime"]).sort_values("datetime")
+        return df
+
+    @staticmethod
+    def _cumulative_to(df: pd.DataFrame, trigger_hhmm: str) -> dict[str, Any] | None:
+        if df.empty or "datetime" not in df.columns:
+            return None
+        work = df.copy()
+        work["hhmm"] = work["datetime"].dt.strftime("%H:%M")
+        work = work[(work["hhmm"] >= "09:30") & (work["hhmm"] <= trigger_hhmm)]
+        if work.empty:
+            return None
+        first = work.iloc[0]
+        last = work.iloc[-1]
+        amount = pd.to_numeric(work.get("amount"), errors="coerce").fillna(0).sum() if "amount" in work else 0.0
+        volume_col = "vol" if "vol" in work.columns else "volume" if "volume" in work.columns else None
+        volume = pd.to_numeric(work[volume_col], errors="coerce").fillna(0).sum() if volume_col else 0.0
+        return {
+            "price": float(last.get("close", 0) or 0),
+            "close": float(last.get("close", 0) or 0),
+            "open": float(first.get("open", 0) or 0),
+            "high": float(pd.to_numeric(work.get("high"), errors="coerce").max() or 0),
+            "low": float(pd.to_numeric(work.get("low"), errors="coerce").min() or 0),
+            "cumulative_amount": float(amount),
+            "cumulative_volume": float(volume),
+        }
+
+    def get_intraday_context(self, stock_code: str, now: datetime) -> dict[str, Any]:
+        df = self._bars(stock_code)
+        if df.empty:
+            return {}
+        trade_date = now.date()
+        today = df[df["datetime"].dt.date == trade_date]
+        context = self._cumulative_to(today, now.strftime("%H:%M")) or {}
+        quote = self.fetcher.get_realtime_quote(stock_code) or {}
+        for key in ("price", "open", "high", "low", "amount"):
+            if quote.get(key) not in (None, 0, 0.0, ""):
+                if key == "amount":
+                    context["cumulative_amount"] = float(quote[key])
+                else:
+                    context[key] = float(quote[key])
+        return context
+
+    def get_historical_same_time(
+        self,
+        stock_code: str,
+        now: datetime,
+        days: int,
+    ) -> list[dict[str, Any]]:
+        df = self._bars(stock_code)
+        if df.empty:
+            return []
+        trigger_hhmm = now.strftime("%H:%M")
+        today = now.date()
+        output: list[dict[str, Any]] = []
+        for trade_date, day_df in df.groupby(df["datetime"].dt.date, sort=False):
+            if trade_date >= today:
+                continue
+            row = self._cumulative_to(day_df, trigger_hhmm)
+            if row:
+                row["trade_date"] = trade_date.isoformat()
+                row["minute_key"] = trigger_hhmm
+                output.append(row)
+        return output[-days:]

--- a/src/services/intraday_picker/adapters/tdx_intraday_adapter.py
+++ b/src/services/intraday_picker/adapters/tdx_intraday_adapter.py
@@ -13,24 +13,36 @@ from data_provider.pytdx_fetcher import PytdxFetcher
 class TdxIntradayAdapter:
     """Read 5-minute bars without changing existing PytdxFetcher behaviour."""
 
-    BAR_COUNT = 800
+    PAGE_SIZE = 800
+    DEFAULT_BARS = 1200  # ~25 A-share sessions of 5-minute bars
 
     def __init__(self, fetcher: PytdxFetcher | None = None):
         self.fetcher = fetcher or PytdxFetcher()
 
     def _bars(self, stock_code: str, count: int | None = None) -> pd.DataFrame:
+        requested = max(1, int(count or self.DEFAULT_BARS))
         market, code = self.fetcher._get_market_code(stock_code)
+        frames: list[pd.DataFrame] = []
         with self.fetcher._pytdx_session() as api:
-            rows = api.get_security_bars(
-                category=0,  # 5-minute bars
-                market=market,
-                code=code,
-                start=0,
-                count=count or self.BAR_COUNT,
-            )
-            if not rows:
-                return pd.DataFrame()
-            df = api.to_df(rows)
+            start = 0
+            while start < requested:
+                page_count = min(self.PAGE_SIZE, requested - start)
+                rows = api.get_security_bars(
+                    category=0,  # 5-minute bars
+                    market=market,
+                    code=code,
+                    start=start,
+                    count=page_count,
+                )
+                if not rows:
+                    break
+                frames.append(api.to_df(rows))
+                if len(rows) < page_count:
+                    break
+                start += len(rows)
+        if not frames:
+            return pd.DataFrame()
+        df = pd.concat(frames, ignore_index=True).drop_duplicates()
         if "datetime" in df.columns:
             df["datetime"] = pd.to_datetime(df["datetime"], errors="coerce")
             df = df.dropna(subset=["datetime"]).sort_values("datetime")
@@ -50,12 +62,14 @@ class TdxIntradayAdapter:
         amount = pd.to_numeric(work.get("amount"), errors="coerce").fillna(0).sum() if "amount" in work else 0.0
         volume_col = "vol" if "vol" in work.columns else "volume" if "volume" in work.columns else None
         volume = pd.to_numeric(work[volume_col], errors="coerce").fillna(0).sum() if volume_col else 0.0
+        high_series = pd.to_numeric(work.get("high"), errors="coerce") if "high" in work else pd.Series(dtype=float)
+        low_series = pd.to_numeric(work.get("low"), errors="coerce") if "low" in work else pd.Series(dtype=float)
         return {
             "price": float(last.get("close", 0) or 0),
             "close": float(last.get("close", 0) or 0),
             "open": float(first.get("open", 0) or 0),
-            "high": float(pd.to_numeric(work.get("high"), errors="coerce").max() or 0),
-            "low": float(pd.to_numeric(work.get("low"), errors="coerce").min() or 0),
+            "high": float(high_series.max()) if not high_series.empty else 0.0,
+            "low": float(low_series.min()) if not low_series.empty else 0.0,
             "cumulative_amount": float(amount),
             "cumulative_volume": float(volume),
         }
@@ -82,7 +96,8 @@ class TdxIntradayAdapter:
         now: datetime,
         days: int,
     ) -> list[dict[str, Any]]:
-        df = self._bars(stock_code)
+        requested_bars = max(self.DEFAULT_BARS, int(days) * 50 + 100)
+        df = self._bars(stock_code, requested_bars)
         if df.empty:
             return []
         trigger_hhmm = now.strftime("%H:%M")

--- a/src/services/intraday_picker/config.py
+++ b/src/services/intraday_picker/config.py
@@ -1,0 +1,64 @@
+"""Configuration for the isolated intraday picker.
+
+The public environment surface is intentionally small. Detailed scoring
+thresholds remain code/profile settings so normal operation is simple.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+
+
+def _bool_env(name: str, default: bool) -> bool:
+    raw = os.getenv(name)
+    if raw is None:
+        return default
+    return raw.strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _int_env(name: str, default: int, minimum: int = 1) -> int:
+    try:
+        return max(minimum, int(os.getenv(name, str(default))))
+    except (TypeError, ValueError):
+        return default
+
+
+@dataclass(frozen=True)
+class IntradayPickerConfig:
+    enabled: bool = False
+    profile: str = "strong_start"
+    schedule_times: tuple[str, ...] = ("09:35", "09:45", "09:55")
+    top_n: int = 10
+    final_top_n: int = 5
+    baseline_days: int = 20
+    dsa_enabled: bool = True
+    dsa_report_type: str = "brief"
+    dsa_cache_minutes: int = 20
+    notify_preliminary: bool = True
+    notify_final: bool = True
+    candidate_limit_per_strategy: int = 30
+
+    @classmethod
+    def from_env(cls) -> "IntradayPickerConfig":
+        times = tuple(
+            item.strip()
+            for item in os.getenv("INTRADAY_PICKER_TIMES", "09:35,09:45,09:55").split(",")
+            if item.strip()
+        ) or ("09:35", "09:45", "09:55")
+        report_type = os.getenv("INTRADAY_DSA_REPORT_TYPE", "brief").strip().lower()
+        if report_type not in {"brief", "simple", "detailed", "full"}:
+            report_type = "brief"
+        return cls(
+            enabled=_bool_env("INTRADAY_PICKER_ENABLED", False),
+            profile=os.getenv("INTRADAY_PICKER_PROFILE", "strong_start").strip() or "strong_start",
+            schedule_times=times,
+            top_n=_int_env("INTRADAY_PICKER_TOP_N", 10),
+            final_top_n=_int_env("INTRADAY_FINAL_TOP_N", 5),
+            baseline_days=_int_env("INTRADAY_BASELINE_DAYS", 20, 5),
+            dsa_enabled=_bool_env("INTRADAY_DSA_ENABLED", True),
+            dsa_report_type=report_type,
+            dsa_cache_minutes=_int_env("INTRADAY_DSA_CACHE_MINUTES", 20),
+            notify_preliminary=_bool_env("INTRADAY_NOTIFY_PRELIMINARY", True),
+            notify_final=_bool_env("INTRADAY_NOTIFY_FINAL", True),
+        )

--- a/src/services/intraday_picker/final_ranker.py
+++ b/src/services/intraday_picker/final_ranker.py
@@ -1,0 +1,21 @@
+"""Combine real-time picker score with available DSA analysis."""
+
+from __future__ import annotations
+
+from .models import DsaAnalysisSummary, FinalCandidate, IntradayCandidate
+from .scoring import clamp
+
+
+def rank_final(
+    candidates: list[IntradayCandidate],
+    analyses: dict[str, DsaAnalysisSummary],
+) -> list[FinalCandidate]:
+    ranked: list[FinalCandidate] = []
+    for candidate in candidates:
+        dsa = analyses.get(candidate.stock_code)
+        if dsa is not None and dsa.dsa_score is not None:
+            final_score = candidate.picker_score * 0.65 + clamp(dsa.dsa_score) * 0.35
+        else:
+            final_score = candidate.picker_score
+        ranked.append(FinalCandidate(candidate=candidate, dsa=dsa, final_score=clamp(final_score)))
+    return sorted(ranked, key=lambda item: item.final_score, reverse=True)

--- a/src/services/intraday_picker/metrics.py
+++ b/src/services/intraday_picker/metrics.py
@@ -1,0 +1,71 @@
+"""Pure intraday metric calculations."""
+
+from __future__ import annotations
+
+from statistics import median
+from typing import Any, Iterable, Optional
+
+from .models import IntradayMetrics
+
+
+def _float(value: Any, default: float = 0.0) -> float:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _clamp(value: float, low: float, high: float) -> float:
+    return max(low, min(high, value))
+
+
+def calculate_rvol_time(today_cum_amount: float, historical_cum_amounts: Iterable[float]) -> tuple[Optional[float], float]:
+    history = [float(value) for value in historical_cum_amounts if value is not None and float(value) > 0]
+    if len(history) < 5 or today_cum_amount < 0:
+        return None, 0.0
+    baseline = median(history)
+    if baseline <= 0:
+        return None, 0.0
+    confidence = 1.0 if len(history) >= 10 else 0.6
+    return today_cum_amount / baseline, confidence
+
+
+def calculate_intraday_metrics(
+    current: dict[str, Any],
+    historical_same_time: list[dict[str, Any]],
+    *,
+    sector_score: Optional[float] = None,
+    breakout_score: Optional[float] = None,
+    risk_quality_score: Optional[float] = None,
+) -> IntradayMetrics:
+    price = _float(current.get("price") or current.get("close"))
+    open_price = _float(current.get("open"))
+    day_high = _float(current.get("high"), price)
+    day_low = _float(current.get("low"), price)
+    amount = _float(current.get("cumulative_amount") or current.get("amount"))
+
+    history_amounts = [
+        _float(item.get("cumulative_amount") or item.get("amount"))
+        for item in historical_same_time
+    ]
+    rvol, confidence = calculate_rvol_time(amount, history_amounts)
+
+    price_strength = ((price - open_price) / open_price * 100.0) if open_price > 0 else 0.0
+    if day_high > day_low:
+        high_position = _clamp((price - day_low) / (day_high - day_low), 0.0, 1.0)
+    else:
+        high_position = 0.5
+    pullback = ((day_high - price) / day_high * 100.0) if day_high > 0 else 0.0
+
+    return IntradayMetrics(
+        rvol_time=rvol,
+        rvol_confidence=confidence,
+        price_strength=price_strength,
+        high_position=high_position,
+        pullback_from_high_pct=max(0.0, pullback),
+        sector_score=sector_score,
+        breakout_score=breakout_score,
+        risk_quality_score=risk_quality_score,
+        turnover_rate=_float(current.get("turnover_rate")) if current.get("turnover_rate") is not None else None,
+        limit_state=current.get("limit_state"),
+    )

--- a/src/services/intraday_picker/models.py
+++ b/src/services/intraday_picker/models.py
@@ -1,0 +1,75 @@
+"""Pure domain models for intraday stock picking."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Optional
+
+
+@dataclass(frozen=True)
+class StrategyHit:
+    stock_code: str
+    strategy_id: str
+    strategy_score: float
+    source: str = "alphasift"
+    stock_name: str = ""
+    price: float = 0.0
+    change_pct: float = 0.0
+    quality_score: Optional[float] = None
+    raw: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class RuleResult:
+    rule_id: str
+    matched: bool
+    score: float = 0.0
+    reasons: list[str] = field(default_factory=list)
+
+
+@dataclass
+class IntradayMetrics:
+    rvol_time: Optional[float] = None
+    rvol_confidence: float = 0.0
+    price_strength: float = 0.0
+    high_position: float = 0.5
+    pullback_from_high_pct: float = 0.0
+    sector_score: Optional[float] = None
+    breakout_score: Optional[float] = None
+    risk_quality_score: Optional[float] = None
+    turnover_rate: Optional[float] = None
+    limit_state: Optional[str] = None
+
+
+@dataclass
+class IntradayCandidate:
+    stock_code: str
+    stock_name: str = ""
+    price: float = 0.0
+    change_pct: float = 0.0
+    strategy_hits: list[StrategyHit] = field(default_factory=list)
+    confirmations: list[RuleResult] = field(default_factory=list)
+    metrics: IntradayMetrics = field(default_factory=IntradayMetrics)
+    strategy_score: float = 0.0
+    resonance_score: float = 0.0
+    penalty_score: float = 0.0
+    picker_score: float = 0.0
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class DsaAnalysisSummary:
+    stock_code: str
+    status: str
+    dsa_score: Optional[float] = None
+    operation_advice: Optional[str] = None
+    risk_level: Optional[str] = None
+    summary: Optional[str] = None
+    task_id: Optional[str] = None
+
+
+@dataclass
+class FinalCandidate:
+    candidate: IntradayCandidate
+    dsa: Optional[DsaAnalysisSummary]
+    final_score: float

--- a/src/services/intraday_picker/orchestrator.py
+++ b/src/services/intraday_picker/orchestrator.py
@@ -1,0 +1,164 @@
+"""Application orchestration for the isolated intraday picker.
+
+This module depends only on domain ports. Concrete DSA/AlphaSift/Pytdx
+implementations are injected by ``runtime.py``.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+
+from .config import IntradayPickerConfig
+from .final_ranker import rank_final
+from .metrics import calculate_intraday_metrics
+from .models import IntradayCandidate, StrategyHit
+from .scoring import rank_candidates
+from .stock_analysis_rules import evaluate_rule
+from .strategy_profiles import get_profile
+
+
+def _num(mapping: dict[str, Any], *keys: str) -> float | None:
+    for key in keys:
+        value = mapping.get(key)
+        if value is None:
+            continue
+        try:
+            return float(value)
+        except (TypeError, ValueError):
+            continue
+    return None
+
+
+def merge_strategy_hits(hits: list[StrategyHit]) -> list[IntradayCandidate]:
+    by_code: dict[str, IntradayCandidate] = {}
+    for hit in hits:
+        candidate = by_code.get(hit.stock_code)
+        if candidate is None:
+            candidate = IntradayCandidate(
+                stock_code=hit.stock_code,
+                stock_name=hit.stock_name,
+                price=hit.price,
+                change_pct=hit.change_pct,
+                metadata=dict(hit.raw),
+            )
+            by_code[hit.stock_code] = candidate
+        candidate.strategy_hits.append(hit)
+        candidate.strategy_score = max(candidate.strategy_score, hit.strategy_score)
+        if not candidate.stock_name and hit.stock_name:
+            candidate.stock_name = hit.stock_name
+        if hit.price:
+            candidate.price = hit.price
+        candidate.change_pct = hit.change_pct
+        # Preserve a quality reference without making it an independent universe path.
+        if hit.quality_score is not None:
+            candidate.metadata["quality_score"] = hit.quality_score
+        for key, value in hit.raw.items():
+            candidate.metadata.setdefault(key, value)
+    return list(by_code.values())
+
+
+class IntradayPickerOrchestrator:
+    def __init__(
+        self,
+        *,
+        config: IntradayPickerConfig,
+        strategy_gateway: Any,
+        market_gateway: Any,
+        history_repository: Any,
+        dsa_gateway: Any,
+        notification_gateway: Any,
+        run_state: Any,
+    ):
+        self.config = config
+        self.strategy_gateway = strategy_gateway
+        self.market_gateway = market_gateway
+        self.history_repository = history_repository
+        self.dsa_gateway = dsa_gateway
+        self.notification_gateway = notification_gateway
+        self.run_state = run_state
+
+    @staticmethod
+    def run_id(now: datetime) -> str:
+        return now.strftime("%Y%m%d-%H%M")
+
+    def _enrich_candidate(self, candidate: IntradayCandidate, now: datetime) -> None:
+        profile = get_profile(self.config.profile)
+        for rule_id in profile.get("confirmations", ()):
+            candidate.confirmations.append(evaluate_rule(rule_id, candidate))
+
+        try:
+            current = self.market_gateway.get_intraday_context(candidate.stock_code, now)
+            history = self.history_repository.get_or_build_baseline(
+                candidate.stock_code,
+                now,
+                self.market_gateway,
+            )
+        except Exception as exc:
+            candidate.metadata.setdefault("source_errors", []).append(f"intraday:{exc}")
+            current, history = {}, []
+
+        raw = candidate.metadata
+        sector_score = _num(raw, "board_heat_score", "theme_heat", "sector_score")
+        breakout_score = _num(raw, "breakout_score", "signal_score", "breakout_20d")
+        quality_score = _num(raw, "quality_score", "risk_quality_score")
+        candidate.metrics = calculate_intraday_metrics(
+            current,
+            history,
+            sector_score=sector_score,
+            breakout_score=breakout_score,
+            risk_quality_score=quality_score,
+        )
+        if current.get("price"):
+            candidate.price = float(current["price"])
+
+    def run_preliminary(self, now: datetime, *, force: bool = False, dry_run: bool = False) -> list[IntradayCandidate]:
+        run_id = self.run_id(now)
+        if not force and self.run_state.is_completed(run_id):
+            return []
+
+        hits = self.strategy_gateway.screen(self.config.profile, now)
+        candidates = merge_strategy_hits(hits)
+        for candidate in candidates:
+            self._enrich_candidate(candidate, now)
+        top = rank_candidates(candidates)[: self.config.top_n]
+
+        self.run_state.save_preliminary(
+            run_id,
+            top,
+            {
+                "profile": self.config.profile,
+                "candidate_count": len(candidates),
+                "trigger_time": now.isoformat(),
+                "dry_run": dry_run,
+            },
+        )
+        if dry_run:
+            return top
+
+        if self.config.notify_preliminary:
+            try:
+                self.notification_gateway.send_preliminary(run_id, top)
+            except Exception as exc:
+                for candidate in top:
+                    candidate.metadata.setdefault("source_errors", []).append(f"notify:{exc}")
+
+        if self.config.dsa_enabled and top:
+            try:
+                refs = self.dsa_gateway.submit_or_reuse(top, now)
+                self.run_state.save_dsa_tasks(run_id, refs)
+            except Exception as exc:
+                for candidate in top:
+                    candidate.metadata.setdefault("source_errors", []).append(f"dsa_submit:{exc}")
+        return top
+
+    def finalize(self, run_id: str, candidates: list[IntradayCandidate], now: datetime):
+        analyses = self.dsa_gateway.collect_available(candidates, now) if self.config.dsa_enabled else {}
+        final = rank_final(candidates, analyses)[: self.config.final_top_n]
+        self.run_state.save_final(run_id, final)
+        if self.config.notify_final:
+            try:
+                self.notification_gateway.send_final(run_id, final)
+            except Exception:
+                pass
+        return final

--- a/src/services/intraday_picker/ports.py
+++ b/src/services/intraday_picker/ports.py
@@ -1,0 +1,43 @@
+"""Ports used by the intraday picker domain.
+
+Only adapters may bind these interfaces to concrete AlphaSift, Pytdx, DSA,
+notification or persistence implementations.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, Protocol, Sequence
+
+from .models import DsaAnalysisSummary, IntradayCandidate, StrategyHit
+
+
+class StrategyGateway(Protocol):
+    def screen(self, profile: str, now: datetime) -> list[StrategyHit]: ...
+
+
+class IntradayMarketGateway(Protocol):
+    def get_intraday_context(self, stock_code: str, now: datetime) -> dict[str, Any]: ...
+
+
+class HistoryRepository(Protocol):
+    def get_or_build_baseline(
+        self, stock_code: str, now: datetime, market_gateway: IntradayMarketGateway
+    ) -> list[dict[str, Any]]: ...
+
+
+class DsaAnalysisGateway(Protocol):
+    def submit_or_reuse(self, candidates: Sequence[IntradayCandidate], now: datetime) -> dict[str, str]: ...
+    def collect_available(self, candidates: Sequence[IntradayCandidate], now: datetime) -> dict[str, DsaAnalysisSummary]: ...
+
+
+class NotificationGateway(Protocol):
+    def send_preliminary(self, run_id: str, candidates: Sequence[IntradayCandidate]) -> None: ...
+    def send_final(self, run_id: str, candidates: Sequence[Any]) -> None: ...
+
+
+class RunStateRepository(Protocol):
+    def is_completed(self, run_id: str) -> bool: ...
+    def save_preliminary(self, run_id: str, candidates: Sequence[IntradayCandidate], metadata: dict[str, Any]) -> None: ...
+    def save_dsa_tasks(self, run_id: str, task_refs: dict[str, str]) -> None: ...
+    def save_final(self, run_id: str, candidates: Sequence[Any]) -> None: ...

--- a/src/services/intraday_picker/runtime.py
+++ b/src/services/intraday_picker/runtime.py
@@ -1,0 +1,29 @@
+"""Composition root for the intraday picker.
+
+Only this module wires domain orchestration to concrete legacy adapters.
+"""
+
+from __future__ import annotations
+
+from .adapters.alphasift_adapter import AlphaSiftStrategyAdapter
+from .adapters.dsa_task_queue_adapter import DsaTaskQueueAdapter
+from .adapters.notification_adapter import DsaNotificationAdapter
+from .adapters.run_state_repository import JsonRunStateRepository
+from .adapters.sqlite_history_repository import SqliteHistoryRepository
+from .adapters.tdx_intraday_adapter import TdxIntradayAdapter
+from .config import IntradayPickerConfig
+from .orchestrator import IntradayPickerOrchestrator
+
+
+def build_intraday_picker(config: IntradayPickerConfig | None = None) -> IntradayPickerOrchestrator:
+    config = config or IntradayPickerConfig.from_env()
+    market_gateway = TdxIntradayAdapter()
+    return IntradayPickerOrchestrator(
+        config=config,
+        strategy_gateway=AlphaSiftStrategyAdapter(config),
+        market_gateway=market_gateway,
+        history_repository=SqliteHistoryRepository(baseline_days=config.baseline_days),
+        dsa_gateway=DsaTaskQueueAdapter(config),
+        notification_gateway=DsaNotificationAdapter(),
+        run_state=JsonRunStateRepository(),
+    )

--- a/src/services/intraday_picker/scoring.py
+++ b/src/services/intraday_picker/scoring.py
@@ -1,0 +1,103 @@
+"""Transparent deterministic scoring for intraday candidates."""
+
+from __future__ import annotations
+
+from .models import IntradayCandidate
+
+
+def clamp(value: float, low: float = 0.0, high: float = 100.0) -> float:
+    return max(low, min(high, value))
+
+
+def score_rvol(rvol: float | None) -> float:
+    if rvol is None:
+        return 50.0
+    if rvol < 0.8:
+        return 10.0
+    if rvol < 1.0:
+        return 25.0
+    if rvol < 1.5:
+        return 45.0
+    if rvol < 2.0:
+        return 65.0
+    if rvol < 3.0:
+        return 80.0
+    if rvol < 4.0:
+        return 90.0
+    return 100.0
+
+
+def score_price_strength(candidate: IntradayCandidate) -> float:
+    metrics = candidate.metrics
+    intraday = clamp(50.0 + metrics.price_strength * 8.0)
+    position = clamp(metrics.high_position * 100.0)
+    return intraday * 0.6 + position * 0.4
+
+
+def resonance_bonus(hit_count: int) -> float:
+    if hit_count >= 4:
+        return 7.0
+    if hit_count == 3:
+        return 5.0
+    if hit_count == 2:
+        return 3.0
+    return 0.0
+
+
+def calculate_penalty(candidate: IntradayCandidate) -> float:
+    change = candidate.change_pct
+    pullback = candidate.metrics.pullback_from_high_pct
+    penalty = 0.0
+    if change > 8.8:
+        penalty += 10.0
+    elif change > 7.5:
+        penalty += 5.0
+    elif change > 6.0:
+        penalty += 2.0
+
+    if pullback > 4.0:
+        penalty += 10.0
+    elif pullback > 2.5:
+        penalty += 5.0
+    elif pullback > 1.5:
+        penalty += 2.0
+
+    turnover = candidate.metrics.turnover_rate
+    if turnover is not None and turnover > 25:
+        penalty += 5.0
+    if candidate.metrics.limit_state in {"broken_limit", "weak_limit"}:
+        penalty += 5.0
+    return penalty
+
+
+def score_candidate(candidate: IntradayCandidate) -> float:
+    metrics = candidate.metrics
+    strategy = clamp(candidate.strategy_score)
+    rvol = score_rvol(metrics.rvol_time)
+    if metrics.rvol_time is not None:
+        rvol = rvol * metrics.rvol_confidence + 50.0 * (1.0 - metrics.rvol_confidence)
+    sector = 50.0 if metrics.sector_score is None else clamp(metrics.sector_score)
+    price = score_price_strength(candidate)
+    breakout = 50.0 if metrics.breakout_score is None else clamp(metrics.breakout_score)
+    quality = 50.0 if metrics.risk_quality_score is None else clamp(metrics.risk_quality_score)
+    resonance = resonance_bonus(len(candidate.strategy_hits) + sum(1 for result in candidate.confirmations if result.matched))
+
+    weighted = (
+        strategy * 0.35
+        + rvol * 0.25
+        + sector * 0.15
+        + price * 0.10
+        + breakout * 0.05
+        + quality * 0.05
+        + clamp(resonance / 7.0 * 100.0) * 0.05
+    )
+    candidate.resonance_score = resonance
+    candidate.penalty_score = calculate_penalty(candidate)
+    candidate.picker_score = clamp(weighted - candidate.penalty_score)
+    return candidate.picker_score
+
+
+def rank_candidates(candidates: list[IntradayCandidate]) -> list[IntradayCandidate]:
+    for candidate in candidates:
+        score_candidate(candidate)
+    return sorted(candidates, key=lambda item: item.picker_score, reverse=True)

--- a/src/services/intraday_picker/stock_analysis_rules.py
+++ b/src/services/intraday_picker/stock_analysis_rules.py
@@ -1,0 +1,121 @@
+"""Small confirmation rules inspired by jiasanpang/stock_analysis.
+
+These rules operate only on candidates already produced by AlphaSift. They do
+not fetch data and are intentionally not a second full-market scanner.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Callable
+
+from .models import IntradayCandidate, RuleResult
+
+
+def _num(mapping: dict[str, Any], *keys: str, default: float = 0.0) -> float:
+    for key in keys:
+        value = mapping.get(key)
+        if value is None:
+            continue
+        try:
+            return float(value)
+        except (TypeError, ValueError):
+            continue
+    return default
+
+
+def reversal_breakout(candidate: IntradayCandidate) -> RuleResult:
+    raw = candidate.metadata
+    change = candidate.change_pct
+    change_60d = _num(raw, "change_pct_60d", "60日涨跌幅")
+    volume_ratio = _num(raw, "volume_ratio", "量比")
+    price = candidate.price
+    ma20 = _num(raw, "ma20", "MA20")
+    breakout = _num(raw, "breakout_20d", "breakout_score", "突破强度")
+
+    reasons: list[str] = []
+    score = 0.0
+    if 1.0 <= change <= 7.5:
+        score += 25
+        reasons.append("当日价格出现向上确认")
+    if volume_ratio >= 1.5:
+        score += 25
+        reasons.append("量能温和放大")
+    if price > 0 and ma20 > 0 and price >= ma20:
+        score += 20
+        reasons.append("价格位于MA20之上")
+    if breakout > 0:
+        score += 20
+        reasons.append("存在突破背景")
+    if change_60d <= 40:
+        score += 10
+    matched = score >= 60
+    return RuleResult("reversal_breakout", matched, score, reasons)
+
+
+def buy_pullback(candidate: IntradayCandidate) -> RuleResult:
+    raw = candidate.metadata
+    change_60d = _num(raw, "change_pct_60d", "60日涨跌幅")
+    volume_ratio = _num(raw, "volume_ratio", "量比")
+    ma10 = _num(raw, "ma10", "MA10")
+    ma20 = _num(raw, "ma20", "MA20")
+    price = candidate.price
+    change = candidate.change_pct
+
+    score = 0.0
+    reasons: list[str] = []
+    if 8 <= change_60d <= 65:
+        score += 30
+        reasons.append("中期趋势已建立")
+    if -2 <= change <= 2:
+        score += 25
+        reasons.append("处于温和回踩区间")
+    if 0.5 <= volume_ratio <= 1.5:
+        score += 20
+        reasons.append("回踩量能健康")
+    if price > 0 and ma20 > 0 and price >= ma20:
+        score += 15
+        reasons.append("未跌破MA20")
+    if price > 0 and ma10 > 0 and (price - ma10) / ma10 * 100 <= 5:
+        score += 10
+        reasons.append("靠近MA10支撑")
+    return RuleResult("buy_pullback", score >= 65, score, reasons)
+
+
+def bottom_reversal(candidate: IntradayCandidate) -> RuleResult:
+    raw = candidate.metadata
+    change_60d = _num(raw, "change_pct_60d", "60日涨跌幅")
+    volume_ratio = _num(raw, "volume_ratio", "量比")
+    market_cap = _num(raw, "market_cap", "总市值")
+    change = candidate.change_pct
+
+    score = 0.0
+    reasons: list[str] = []
+    if -25 <= change_60d <= -10:
+        score += 35
+        reasons.append("60日跌幅处于反转观察区")
+    if 1 <= change <= 5:
+        score += 25
+        reasons.append("当日出现反转确认")
+    if volume_ratio >= 1.2:
+        score += 25
+        reasons.append("企稳后量能开始恢复")
+    elif 0.7 <= volume_ratio < 1.2:
+        score += 10
+    if 0 < market_cap <= 300:
+        score += 15
+        reasons.append("市值处于反转策略偏好区间")
+    return RuleResult("bottom_reversal", score >= 65, score, reasons)
+
+
+RULES: dict[str, Callable[[IntradayCandidate], RuleResult]] = {
+    "reversal_breakout": reversal_breakout,
+    "buy_pullback": buy_pullback,
+    "bottom_reversal": bottom_reversal,
+}
+
+
+def evaluate_rule(rule_id: str, candidate: IntradayCandidate) -> RuleResult:
+    rule = RULES.get(rule_id)
+    if rule is None:
+        return RuleResult(rule_id, False, 0.0, ["unknown confirmation rule"])
+    return rule(candidate)

--- a/src/services/intraday_picker/strategy_profiles.py
+++ b/src/services/intraday_picker/strategy_profiles.py
@@ -1,0 +1,29 @@
+"""Strategy-profile definitions.
+
+Profiles describe distinct trade setups. Do not collapse strong-start,
+pullback and reversal semantics into one score.
+"""
+
+from __future__ import annotations
+
+PROFILES: dict[str, dict[str, tuple[str, ...]]] = {
+    "strong_start": {
+        "alphasift": ("capital_heat", "volume_breakout"),
+        "confirmations": ("reversal_breakout",),
+        "quality_reference": ("balanced_alpha",),
+    },
+    "pullback": {
+        "alphasift": ("shrink_pullback",),
+        "confirmations": ("buy_pullback",),
+        "quality_reference": ("balanced_alpha",),
+    },
+    "reversal": {
+        "alphasift": ("oversold_reversal",),
+        "confirmations": ("bottom_reversal",),
+        "quality_reference": ("balanced_alpha",),
+    },
+}
+
+
+def get_profile(profile: str) -> dict[str, tuple[str, ...]]:
+    return PROFILES.get(profile, PROFILES["strong_start"])

--- a/tests/intraday_picker/test_metrics.py
+++ b/tests/intraday_picker/test_metrics.py
@@ -1,0 +1,30 @@
+from src.services.intraday_picker.metrics import calculate_intraday_metrics, calculate_rvol_time
+
+
+def test_rvol_time_uses_same_time_median():
+    rvol, confidence = calculate_rvol_time(300.0, [100, 100, 100, 100, 100, 100, 100, 100, 100, 100])
+    assert rvol == 3.0
+    assert confidence == 1.0
+
+
+def test_rvol_time_fails_open_with_short_history():
+    rvol, confidence = calculate_rvol_time(300.0, [100, 100, 100, 100])
+    assert rvol is None
+    assert confidence == 0.0
+
+
+def test_intraday_price_metrics():
+    metrics = calculate_intraday_metrics(
+        {
+            "price": 10.8,
+            "open": 10.0,
+            "high": 11.0,
+            "low": 9.8,
+            "cumulative_amount": 300.0,
+        },
+        [{"cumulative_amount": 100.0} for _ in range(10)],
+    )
+    assert metrics.rvol_time == 3.0
+    assert round(metrics.price_strength, 2) == 8.0
+    assert 0.0 <= metrics.high_position <= 1.0
+    assert metrics.pullback_from_high_pct > 0

--- a/tests/intraday_picker/test_orchestrator.py
+++ b/tests/intraday_picker/test_orchestrator.py
@@ -1,0 +1,107 @@
+from datetime import datetime
+
+from src.services.intraday_picker.config import IntradayPickerConfig
+from src.services.intraday_picker.models import StrategyHit
+from src.services.intraday_picker.orchestrator import IntradayPickerOrchestrator
+
+
+class FakeStrategy:
+    def screen(self, profile, now):
+        return [
+            StrategyHit(
+                stock_code="600000",
+                stock_name="A",
+                price=10.5,
+                change_pct=3.0,
+                strategy_id="capital_heat",
+                strategy_score=85,
+                raw={"量比": 2.0, "MA20": 10.0, "breakout_score": 80},
+            ),
+            StrategyHit(
+                stock_code="600000",
+                stock_name="A",
+                price=10.5,
+                change_pct=3.0,
+                strategy_id="volume_breakout",
+                strategy_score=82,
+                raw={"量比": 2.0},
+            ),
+        ]
+
+
+class FakeMarket:
+    def get_intraday_context(self, stock_code, now):
+        return {
+            "price": 10.5,
+            "open": 10.0,
+            "high": 10.6,
+            "low": 9.9,
+            "cumulative_amount": 300,
+        }
+
+
+class FakeHistory:
+    def get_or_build_baseline(self, stock_code, now, market_gateway):
+        return [{"cumulative_amount": 100} for _ in range(10)]
+
+
+class FakeDsa:
+    def __init__(self):
+        self.submitted = False
+
+    def submit_or_reuse(self, candidates, now):
+        self.submitted = True
+        return {candidates[0].stock_code: "task-1"}
+
+    def collect_available(self, candidates, now):
+        return {}
+
+
+class FakeNotify:
+    def __init__(self):
+        self.preliminary = False
+
+    def send_preliminary(self, run_id, candidates):
+        self.preliminary = True
+
+    def send_final(self, run_id, candidates):
+        pass
+
+
+class FakeState:
+    def __init__(self):
+        self.saved = False
+
+    def is_completed(self, run_id):
+        return False
+
+    def save_preliminary(self, run_id, candidates, metadata):
+        self.saved = True
+
+    def save_dsa_tasks(self, run_id, refs):
+        pass
+
+    def save_final(self, run_id, candidates):
+        pass
+
+
+def test_orchestrator_keeps_integrations_behind_ports():
+    dsa = FakeDsa()
+    notify = FakeNotify()
+    state = FakeState()
+    orchestrator = IntradayPickerOrchestrator(
+        config=IntradayPickerConfig(enabled=True),
+        strategy_gateway=FakeStrategy(),
+        market_gateway=FakeMarket(),
+        history_repository=FakeHistory(),
+        dsa_gateway=dsa,
+        notification_gateway=notify,
+        run_state=state,
+    )
+    top = orchestrator.run_preliminary(datetime(2026, 8, 17, 9, 45))
+    assert len(top) == 1
+    assert top[0].metrics.rvol_time == 3.0
+    assert top[0].resonance_score > 0
+    assert state.saved
+    assert notify.preliminary
+    assert dsa.submitted

--- a/tests/intraday_picker/test_scoring.py
+++ b/tests/intraday_picker/test_scoring.py
@@ -1,0 +1,44 @@
+from src.services.intraday_picker.models import IntradayCandidate, IntradayMetrics, StrategyHit
+from src.services.intraday_picker.scoring import rank_candidates, score_candidate, score_rvol
+
+
+def _candidate(change=3.0, rvol=3.0, pullback=0.5, hit_count=2):
+    hits = [
+        StrategyHit(stock_code="600000", strategy_id=f"s{i}", strategy_score=80.0)
+        for i in range(hit_count)
+    ]
+    return IntradayCandidate(
+        stock_code="600000",
+        change_pct=change,
+        strategy_hits=hits,
+        strategy_score=80.0,
+        metrics=IntradayMetrics(
+            rvol_time=rvol,
+            rvol_confidence=1.0,
+            price_strength=2.0,
+            high_position=0.8,
+            pullback_from_high_pct=pullback,
+            sector_score=80.0,
+            breakout_score=75.0,
+            risk_quality_score=70.0,
+        ),
+    )
+
+
+def test_rvol_mapping_is_capped():
+    assert score_rvol(0.5) == 10
+    assert score_rvol(2.5) == 80
+    assert score_rvol(10) == 100
+
+
+def test_overheat_and_pullback_reduce_score():
+    healthy = _candidate(change=3.0, pullback=0.5)
+    overheated = _candidate(change=9.0, pullback=4.5)
+    assert score_candidate(healthy) > score_candidate(overheated)
+
+
+def test_multi_strategy_resonance_helps_rank():
+    single = _candidate(hit_count=1)
+    triple = _candidate(hit_count=3)
+    ranked = rank_candidates([single, triple])
+    assert ranked[0] is triple

--- a/tests/intraday_picker/test_stock_analysis_rules.py
+++ b/tests/intraday_picker/test_stock_analysis_rules.py
@@ -1,0 +1,35 @@
+from src.services.intraday_picker.models import IntradayCandidate
+from src.services.intraday_picker.stock_analysis_rules import (
+    bottom_reversal,
+    buy_pullback,
+    reversal_breakout,
+)
+
+
+def test_reversal_breakout_confirmation():
+    candidate = IntradayCandidate(
+        stock_code="600000",
+        price=12.0,
+        change_pct=3.0,
+        metadata={"量比": 2.0, "MA20": 11.0, "breakout_score": 80, "60日涨跌幅": 20},
+    )
+    assert reversal_breakout(candidate).matched
+
+
+def test_buy_pullback_rejects_chasing():
+    candidate = IntradayCandidate(
+        stock_code="600000",
+        price=12.0,
+        change_pct=6.0,
+        metadata={"量比": 0.8, "MA10": 11.8, "MA20": 11.0, "60日涨跌幅": 30},
+    )
+    assert not buy_pullback(candidate).matched
+
+
+def test_bottom_reversal_confirmation():
+    candidate = IntradayCandidate(
+        stock_code="600000",
+        change_pct=3.0,
+        metadata={"量比": 1.6, "60日涨跌幅": -18, "market_cap": 120},
+    )
+    assert bottom_reversal(candidate).matched


### PR DESCRIPTION
<!--
For Chinese contributors: 请直接用中文填写。
For English contributors: please fill in English. All fields marked (EN) accept English.
-->

## PR Type

- [ ] fix
- [ ] feat
- [ ] refactor
- [ ] docs
- [ ] chore
- [ ] test

## Background And Problem

请描述当前问题、影响范围与触发场景。  
*(EN) Describe the problem, its impact, and what triggers it.*

## Scope Of Change

请列出本 PR 修改的模块和文件范围。  
*(EN) List the modules and files changed in this PR.*

> 注意：请按实际 `git diff` 全量列出文件范围（建议注明文件总数），避免遗漏文档/后端/API/前端文件导致描述不一致。

> 若本 PR 修改了 `.github/PULL_REQUEST_TEMPLATE.md`、`.github/copilot-instructions.md`、`AGENTS.md`、`.github/instructions/*` 或 `.claude/skills/**` 等协作与治理文件，请补充“变更原因 + 影响面 + 回滚方式（默认 revert）”到 Summary / Compatibility / Rollback，避免 Scope 与描述不一致。

> 建议先执行并粘贴以下命令输出，避免与实际 diff 不一致：

```bash
BASE_REF=$(git merge-base HEAD origin/main)
git diff --stat "$BASE_REF"..HEAD
git diff --name-only "$BASE_REF"..HEAD
```

- 文件总数 / 变更行数（建议粘贴 `git diff --stat "$BASE_REF"..HEAD`）：
- 文件清单（按实际 diff 全量，逐项列出）：
- 文档更新文件（`docs/*`）：

## Issue Link

必须填写以下之一 / Fill in one of:
- `Fixes #<issue_number>`
- `Refs #<issue_number>`
- 无 Issue 时说明原因与验收标准 / If no issue, explain the motivation and acceptance criteria

## Verification Commands And Results

请填写你实际执行过的命令和关键结果（不要只写"已测试"）。  
*(EN) Paste the commands you actually ran and their key output (don't just write "tested"):*

```bash
# example
./scripts/ci_gate.sh
python -m pytest -m "not network"
```

> `Full-suite note` 必须与当次 PR 的当前 Head CI 结果保持一致；若本地复现存在环境相关失败，请明确标注“本地环境差异”并给出 GitHub CI 的结论与链接。  
> 请避免保留与本 PR 无关的历史失败措辞，按本次实际结果填报。
> 如历史描述中仍保留 `./scripts/ci_gate.sh` 失败记录，请先改为当前 Head CI 状态或说明与 Head CI 的差异来源。
> 若 `Full-suite note` 与当前 Head CI 不一致，PR 文本不完整，请先更新 PR 描述后再提交。

- 请在下面按实际结果填写并与 `Full-suite note` 保持一致（任一未填视为信息缺失）：
  - ai-governance：`pass` / `fail`，附链接
  - backend-gate：`pass` / `fail`，附链接
  - docker-build：`pass` / `fail`，附链接
  - web-gate：`pass` / `fail`，附链接
  - 若本 PR 修改 `.github/PULL_REQUEST_TEMPLATE.md` 等流程模板协作文件，请先说明变更必要性、影响边界，并明确回滚方式（默认 `revert this PR`）；否则请在下一版中拆为单独 chore PR。

关键输出/结论 / Key output & conclusion:

- 【必填】当前 Head CI：`ai-governance:pass / backend-gate:pass / docker-build:pass / web-gate:pass`（按实际结果替换）并附对应链接。  
- 若需保留本地失败现象，请在同段写明“本地环境差异 + 当前 CI 通过/失败结果 + CI 链接”。  
- 若全部通过，需补充一句：`当前状态：全部通过（pass）`，并明确 Head CI 全部为 pass。  

- 建议将本行直接粘贴到 PR 描述正文首段：`当前 Head CI：ai-governance:pass / backend-gate:pass / docker-build:pass / web-gate:pass`（仅示例，按实际结果替换）。

> 若上述核验项与 PR 文本冲突，建议先更新 PR 描述再提交，避免审查因状态不一致被阻塞。

## Visual Evidence (if applicable)

【必填】若本 PR 修改报告格式、报告渲染效果或 Web UI 界面，请在此处附受影响报告 / 页面截图；涉及前后差异时，优先附前后对比。Issue / PR 过程截图、审查截图、一次性验收截图和临时可视证据请放在 PR 描述、PR 评论、GitHub 附件、Actions artifact 或外部可访问链接中，不要作为仓库文件合入。
*(EN) If this PR changes report formatting, report rendering, or Web UI, attach screenshots of the affected report/page here; before/after screenshots are preferred when relevant. Issue/PR process screenshots, review screenshots, one-off acceptance screenshots, and temporary visual evidence should be linked from the PR body/comments, GitHub attachments, Actions artifacts, or external accessible evidence; do not commit them as repository files.)*

> 如截图无法获取，请在“原因”中明确写明替代证据（如 Playwright/e2e 产物路径、审查链接）及其可追溯命令，不得留空。涉及 Web 设置/报告渲染变更时，需确保截图或替代证据明确指向变更项。
>
> 若本 PR 修改 Web UI，建议至少补一条可复现路径，例如（优先 settings page）：
>
> - Playwright 截图产物：`apps/dsa-web/e2e/smoke.spec.ts`（`cd apps/dsa-web && npx playwright test e2e/smoke.spec.ts --grep "settings page renders title and save actions after login"`）
> - 审查证据链接：可直接使用 Actions 产物、GitHub 评论附件或外部可访问链接。

> 替代证据模板（设置页变更建议）：
> - 命令：`cd apps/dsa-web && npx playwright test e2e/smoke.spec.ts --grep "settings page"`
> - 产物路径：`apps/dsa-web/test-results/**/smoke-settings-page-*.png`
> - 说明：截图中应可见本次修改的系统设置项（字段、标签、帮助文案）

- 截图链接 / Screenshot links（Web UI/报告改动项必填，未提供请在下方“不适用原因”给出替代证据）：
- settings 页建议命名：`smoke-settings-page-zh` / `smoke-settings-page-en`
- 前后对比 / Before & After（如有）：
- settings 字段变更说明：截图或产物应明确包含 `MARKET_REVIEW_REGION` 字段与帮助文案区块（中文/英文）。
- 不适用原因 / Reason if not applicable（若未附截图，此项务必填写，且包含可复现证据与命令）：
  - Playwright 命令（无截图时）：`cd apps/dsa-web && npx playwright test e2e/smoke.spec.ts --grep "settings page"`
  - 产物路径（无截图时）：`apps/dsa-web/test-results/**/smoke-settings-page-*.png`
  - 说明：截图（或产物）必须可见本次修改的设置字段文案与帮助信息。

> 若本 PR 修改 Web 设置字段（字段、文案或帮助文案），截图或替代证据必须可定位到对应设置项区域并可追溯至变更项；该项为必填。

> 若本 PR 修改 Web UI 或报告展示且无法获取截图，原因栏必须给出可复现替代证据（例如 Playwright 截图产物路径 + 命令），且不得留空。

## Compatibility And Risk

请说明兼容性影响、潜在风险（如无请写 `None`）。  
*(EN) Describe compatibility impact and potential risks (write `None` if not applicable).*

- 若本 PR 修改第三方模型 / API 的兼容语义、请求参数、路由前缀或 provider fallback，请提供**官方来源链接或公告**，并说明这是长期约束、当前运行时约束还是临时兼容处理。  
  请在下方补充所影响外部 API/服务、回归范围与回退方式。  
  *(EN) If this PR changes third-party model/API compatibility, request parameters, routing prefixes, or provider fallback behavior, include an **official source link or announcement** and clarify whether the rule is permanent, runtime-specific, or a temporary compatibility workaround.)*
- 若本 PR 未触及第三方模型/API、provider/model/base URL 或运行时配置保存/清理/迁移逻辑，请在此段直接按以下文案确认（无须再次展开）：  
  `本 PR 未变更 provider/model/base URL、运行时配置清理迁移语义；历史配置保持不变；回滚方式为 revert 本提交。`
- 若本 PR 修改 `.github/PULL_REQUEST_TEMPLATE.md` / PR 流程模板类文件，请在此明确：仅影响协作流程与模板维护，不改 runtime 行为；回退方式为 revert；并补充是否影响自动化提交流程。  
  *(EN) If this PR changes `.github/PULL_REQUEST_TEMPLATE.md` or other PR workflow files, state that it only affects contribution governance templates (no runtime behavior), provide rollback by revert, and note any CI/checklist impact.)*
- 若本 PR 依赖特定运行时 / 锁定依赖窗口（例如 LiteLLM 版本范围、OpenAI-compatible 路由、YAML alias 行为），请写明当前验证过的兼容范围与覆盖路径。  
  *(EN) If this PR depends on a specific runtime or pinned dependency window (for example a LiteLLM version range, OpenAI-compatible routing, or YAML alias behavior), state the compatibility window you verified and which code paths were covered.)*
- 若本 PR 触及运行时配置保存、清理、迁移或回填逻辑，请明确说明旧配置是否会被自动改写、清空、迁移或保持不变，以及用户如何恢复原行为。  
  *(EN) If this PR touches runtime config save/cleanup/migration/backfill logic, explicitly describe whether existing config is rewritten, cleared, migrated, or left intact, and how users can restore the previous behavior.)*
- 若本 PR **未触及** provider/model/base URL 或运行时配置保存/清理/迁移逻辑（本条仅作为声明），请明确写：`本 PR 未变更 provider/model/base URL、运行时配置清理迁移语义；历史配置保持不变；回滚方式为 revert 本提交。`

## Rollback Plan

请至少写一句可执行的回滚方案（必填）。  
*(EN) Provide at least one actionable rollback step (required).*

- 如果是兼容性修复，默认应写出**最小回滚方式**（例如 `revert this PR`），并说明是否需要额外回滚配置或数据迁移。  
  *(EN) For compatibility fixes, include the **minimal rollback path** (for example `revert this PR`) and whether any additional config or data rollback is required.)*

## EXTRACT_PROMPT Change (if applicable)

若本 PR 修改了 `src/services/image_stock_extractor.py` 中的 `EXTRACT_PROMPT`，请在此处粘贴完整变更后的 prompt。  
*If this PR changes `EXTRACT_PROMPT` in `src/services/image_stock_extractor.py`, paste the full updated prompt here:*

<details>
<summary>展开 / Expand: Full EXTRACT_PROMPT</summary>

```
(paste full prompt here)
```

</details>

## Checklist

- [ ] 本 PR 有明确动机和业务价值 / This PR has a clear motivation and value
- [ ] 已提供可复现的验证命令与结果 / Reproducible verification commands and results are included
- [ ] 已评估兼容性与风险 / Compatibility and risk have been assessed
- [ ] 已提供回滚方案 / A rollback plan is provided
- [ ] 若修改报告格式或 Web UI 界面，已在 PR 描述/评论附受影响报告 / 页面截图，且未把一次性验收截图作为仓库文件合入 / If report formatting or Web UI changed, affected report/page screenshots are linked in the PR body/comments and one-off acceptance screenshots are not committed as repository files
- [ ] 若本 PR 修改 Web 设置字段（字段、文案或帮助文本），请补充设置页截图；无法截图时需提供替代可视证据（命令 + 产物路径），并指向对应变更项 / If Web settings fields changed (labels or help text), screenshots of the settings page are required; if unavailable, provide alternative visual evidence with command + artifact path that points to the changed item.
- [ ] 若涉及用户可见变更，已同步更新相关文档与 `docs/CHANGELOG.md`；`README.md` 仅在首页级信息变化时更新，细节优先写入 `docs/*.md` / If user-visible changes are included, relevant docs and `docs/CHANGELOG.md` are updated; `README.md` is updated only for homepage-level changes, with details kept in `docs/*.md`
