### PR TITLE
fix: 记录大盘复盘实际生成后端

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 ## [Unreleased]
 
 - [修复] 大盘复盘历史列表与详情统一展示持久化短摘要；旧记录缺少摘要时从完整 Markdown 生成无内部标记的纯文本节选。
+- [修复] 大盘复盘按实际执行的生成后端和模型记录诊断，避免 Codex CLI 或 fallback 被误显示为配置模型。
 <!-- 新条目格式：- [类型] 描述（类型取值：新功能/改进/修复/文档/测试/chore）-->
 <!-- 每条独立一行追加到本段末尾，无需分类标题，合并时冲突最小 -->
 - [修复] 已配置钉钉 Webhook 时不再误报“未配置通知渠道”；钉钉 Stream 仍仅用于交互，不作为定时静态推送渠道。

--- a/src/analyzer.py
+++ b/src/analyzer.py
@@ -16,7 +16,7 @@ import math
 import re
 import time
 from dataclasses import dataclass
-from typing import Optional, Dict, Any, List, Tuple, Callable
+from typing import Optional, Dict, Any, List, Tuple, Callable, Union
 
 import litellm
 from json_repair import repair_json
@@ -62,6 +62,7 @@ from src.llm.generation_backend import (
     GenerationBackend,
     GenerationError,
     GenerationErrorCode,
+    GenerationResult,
 )
 from src.llm.usage import (
     attach_legacy_message_stability_audit,
@@ -2980,7 +2981,8 @@ class GeminiAnalyzer:
         stream_progress_callback: Optional[Callable[[int], None]] = None,
         response_validator: Optional[Callable[[str], None]] = None,
         audit_context: Optional[Dict[str, Any]] = None,
-    ) -> Tuple[str, str, Dict[str, Any]]:
+        return_generation_result: bool = False,
+    ) -> Union[Tuple[str, str, Dict[str, Any]], GenerationResult]:
         """Compatibility wrapper around the configured generation backend."""
         preflight_error = self.get_generation_backend_config_error()
         if preflight_error is not None and not self._can_use_generation_fallback(preflight_error):
@@ -3078,6 +3080,8 @@ class GeminiAnalyzer:
                         "fallback_error": str(fallback_exc),
                     },
                 ) from fallback_exc
+        if return_generation_result:
+            return result
         return result.text, result.model, result.usage
 
     def _call_litellm_impl(
@@ -3352,6 +3356,38 @@ class GeminiAnalyzer:
             raise
         except Exception as exc:
             logger.error("[generate_text] LLM call failed: %s", exc)
+            return None
+
+    def get_generation_backend_identity(self) -> Tuple[str, str]:
+        """Return the configured primary backend identity for live diagnostics."""
+        backend_id, _fallback_backend_id = self._resolve_generation_backend_config()
+        if backend_id in LOCAL_CLI_GENERATION_BACKEND_IDS:
+            return backend_id, backend_id
+        config = self._get_runtime_config()
+        return backend_id, str(getattr(config, "litellm_model", "") or "")
+
+    def generate_text_with_metadata(
+        self,
+        prompt: str,
+        max_tokens: int = 2048,
+        temperature: float = 0.7,
+    ) -> Optional[GenerationResult]:
+        """Generate text and return the actual backend/model used for diagnostics."""
+        try:
+            result = self._call_litellm(
+                prompt,
+                generation_config={"max_tokens": max_tokens, "temperature": temperature},
+                return_generation_result=True,
+            )
+            if not isinstance(result, GenerationResult):
+                raise TypeError("generation backend returned an invalid result")
+            if should_persist_usage_telemetry(result.usage):
+                persist_llm_usage(result.usage, result.model, call_type="market_review")
+            return result
+        except GenerationError:
+            raise
+        except Exception as exc:
+            logger.error("[generate_text_with_metadata] LLM call failed: %s", exc)
             return None
 
     def analyze(

--- a/src/analyzer.py
+++ b/src/analyzer.py
@@ -2920,6 +2920,9 @@ class GeminiAnalyzer:
                 candidate_model,
                 recovery_model_list,
             )
+            explicit_provider = get_explicit_llm_channel_model_provider(candidate_model)
+            if candidate_provider and not explicit_provider:
+                return resolved_model or candidate_model, candidate_provider
             if resolved_provider:
                 return resolved_model or candidate_model, resolved_provider
         return "", candidate_provider

--- a/src/analyzer.py
+++ b/src/analyzer.py
@@ -276,8 +276,9 @@ class _AllModelsFailedError(Exception):
     that *did* return a response (but whose JSON could not be validated), so
     callers can still attempt a best-effort text fallback.
 
-    ``last_model`` and ``last_usage`` record the model name and token usage
-    from the last attempt so callers can persist usage even on fallback.
+    ``last_model``, ``last_provider`` and ``last_usage`` record the resolved
+    route identity and token usage from the last attempt so callers can persist
+    diagnostics even on fallback.
     """
 
     def __init__(
@@ -286,11 +287,13 @@ class _AllModelsFailedError(Exception):
         *,
         last_response_text: Optional[str] = None,
         last_model: Optional[str] = None,
+        last_provider: Optional[str] = None,
         last_usage: Optional[Dict[str, Any]] = None,
     ):
         super().__init__(message)
         self.last_response_text = last_response_text
         self.last_model = last_model
+        self.last_provider = last_provider
         self.last_usage = last_usage or {}
 
 
@@ -3132,6 +3135,7 @@ class GeminiAnalyzer:
         last_error = None
         last_response_text: Optional[str] = None
         last_model: Optional[str] = None
+        last_provider: Optional[str] = None
         last_usage: Dict[str, Any] = {}
         effective_system_prompt = system_prompt or self.TEXT_SYSTEM_PROMPT
         router_model_names = set(get_configured_llm_models(config.llm_model_list))
@@ -3144,6 +3148,8 @@ class GeminiAnalyzer:
             if legacy_router_model_list and model == config.litellm_model and not use_channel_router:
                 recovery_model_list = legacy_router_model_list
             usage_model, usage_provider = resolved_model_provider_identity(model, recovery_model_list)
+            if usage_provider:
+                last_provider = usage_provider
 
             try:
                 def _attach_usage_audit(
@@ -3323,6 +3329,7 @@ class GeminiAnalyzer:
             f"All LLM models failed (tried {len(models_to_try)} model(s)). Last error: {last_error}",
             last_response_text=last_response_text,
             last_model=last_model,
+            last_provider=last_provider,
             last_usage=last_usage,
         )
 
@@ -3400,7 +3407,7 @@ class GeminiAnalyzer:
                 retryable=False,
                 fallbackable=False,
                 backend=failed_backend,
-                provider=failed_backend,
+                provider=exc.last_provider or failed_backend,
                 details={
                     "reason": "all_models_failed",
                     "configured_primary_backend": backend_id,

--- a/src/analyzer.py
+++ b/src/analyzer.py
@@ -2823,6 +2823,8 @@ class GeminiAnalyzer:
         """Return the actual response model/provider when LiteLLM exposes them."""
         response_model = str(self._get_response_field(response, "model") or "").strip()
         if response_model:
+            if "/" not in response_model:
+                return response_model, str(fallback_provider or "").strip()
             return response_model, resolved_model_provider_identity(response_model)[1]
         return "", str(fallback_provider or "").strip()
 

--- a/src/analyzer.py
+++ b/src/analyzer.py
@@ -3136,6 +3136,7 @@ class GeminiAnalyzer:
         effective_system_prompt = system_prompt or self.TEXT_SYSTEM_PROMPT
         router_model_names = set(get_configured_llm_models(config.llm_model_list))
         for model in models_to_try:
+            last_model = model
             origins = route_deployment_origins(config.llm_model_list, model)
             model_stream = bool(stream and not origins.has_hermes)
             recovery_model_list = config.llm_model_list

--- a/src/analyzer.py
+++ b/src/analyzer.py
@@ -35,6 +35,7 @@ from src.config import (
     get_api_keys_for_model,
     get_config,
     get_configured_llm_models,
+    get_explicit_llm_channel_model_provider,
     resolve_news_window_days,
 )
 from src.llm.hermes import (
@@ -2825,7 +2826,10 @@ class GeminiAnalyzer:
         if response_model:
             if "/" not in response_model:
                 return response_model, str(fallback_provider or "").strip()
-            return response_model, resolved_model_provider_identity(response_model)[1]
+            response_provider = get_explicit_llm_channel_model_provider(response_model)
+            if response_provider:
+                return response_model, response_provider
+            return response_model, str(fallback_provider or "").strip()
         return "", str(fallback_provider or "").strip()
 
     def _resolve_router_failure_identity(

--- a/src/analyzer.py
+++ b/src/analyzer.py
@@ -2820,17 +2820,43 @@ class GeminiAnalyzer:
         response: Any,
         *,
         fallback_provider: Optional[str] = None,
+        configured_model: str = "",
+        model_list: Optional[List[Dict[str, Any]]] = None,
     ) -> Tuple[str, str]:
         """Return the actual response model/provider when LiteLLM exposes them."""
+        configured_provider = str(fallback_provider or "").strip()
+        normalized_configured_model = str(configured_model or "").strip()
+        if normalized_configured_model:
+            resolved_configured_model, _ = resolved_model_provider_identity(
+                normalized_configured_model,
+                model_list,
+            )
+            configured_route = str(resolved_configured_model or normalized_configured_model).strip().lower()
+            if configured_route.startswith("openai/~") or "openrouter" in configured_route:
+                configured_provider = "openrouter"
         response_model = str(self._get_response_field(response, "model") or "").strip()
         if response_model:
             if "/" not in response_model:
-                return response_model, str(fallback_provider or "").strip()
+                return response_model, configured_provider
             response_provider = get_explicit_llm_channel_model_provider(response_model)
+            if configured_provider == "openrouter":
+                return response_model, configured_provider
             if response_provider:
                 return response_model, response_provider
-            return response_model, str(fallback_provider or "").strip()
-        return "", str(fallback_provider or "").strip()
+            return response_model, configured_provider
+        return "", configured_provider
+
+    @staticmethod
+    def _promote_error_identity(details: Any) -> Dict[str, str]:
+        """Lift route/model diagnostics from nested GenerationError details."""
+        if not isinstance(details, dict):
+            return {}
+        promoted: Dict[str, str] = {}
+        for key in ("last_model", "route_name", "last_provider"):
+            candidate = str(details.get(key) or "").strip()
+            if candidate:
+                promoted[key] = candidate
+        return promoted
 
     def _resolve_router_failure_identity(
         self,
@@ -3151,6 +3177,7 @@ class GeminiAnalyzer:
             except _AllModelsFailedError:
                 raise
             except GenerationError as fallback_exc:
+                fallback_identity = self._promote_error_identity(fallback_exc.details)
                 raise GenerationError(
                     error_code=fallback_exc.error_code,
                     stage="fallback",
@@ -3160,6 +3187,7 @@ class GeminiAnalyzer:
                     provider=fallback_exc.provider,
                     details={
                         "reason": "fallback_backend_failed",
+                        **fallback_identity,
                         "primary_error": {
                             "error_code": exc.error_code.value,
                             "backend": exc.backend,
@@ -3416,6 +3444,8 @@ class GeminiAnalyzer:
                     response_model, response_provider = self._resolve_response_model_provider(
                         response,
                         fallback_provider=usage_provider,
+                        configured_model=model,
+                        model_list=recovery_model_list,
                     )
                     actual_model = response_model or model
                     usage_messages = None if audit_context is not None else call_kwargs["messages"]

--- a/src/analyzer.py
+++ b/src/analyzer.py
@@ -3271,6 +3271,8 @@ class GeminiAnalyzer:
                     last_response_text = _stream_text
                     last_model = model
                     _stream_usage = _attach_usage_audit(_stream_usage, call_kwargs["messages"])
+                    if usage_provider:
+                        _stream_usage.setdefault("provider", usage_provider)
                     last_usage = _stream_usage
                     if response_validator is not None:
                         response_validator(_stream_text)
@@ -3301,6 +3303,8 @@ class GeminiAnalyzer:
                     )
                     if audit_context is not None:
                         usage = _attach_usage_audit(usage, call_kwargs["messages"])
+                    if usage_provider:
+                        usage.setdefault("provider", usage_provider)
                     last_response_text = content
                     last_model = model
                     last_usage = usage

--- a/src/analyzer.py
+++ b/src/analyzer.py
@@ -2814,6 +2814,18 @@ class GeminiAnalyzer:
             return obj.get(key)
         return getattr(obj, key, None)
 
+    def _resolve_response_model_provider(
+        self,
+        response: Any,
+        *,
+        fallback_provider: Optional[str] = None,
+    ) -> Tuple[str, str]:
+        """Return the actual response model/provider when LiteLLM exposes them."""
+        response_model = str(self._get_response_field(response, "model") or "").strip()
+        if response_model:
+            return response_model, resolved_model_provider_identity(response_model)[1]
+        return "", str(fallback_provider or "").strip()
+
     def _extract_text_blocks(self, blocks: Any, *, strip: bool = True) -> str:
         """Extract final-answer text from OpenAI-compatible content blocks.
 
@@ -3300,23 +3312,32 @@ class GeminiAnalyzer:
 
                 content = self._extract_completion_text(response)
                 if content:
+                    response_model, response_provider = self._resolve_response_model_provider(
+                        response,
+                        fallback_provider=usage_provider,
+                    )
+                    actual_model = response_model or model
                     usage_messages = None if audit_context is not None else call_kwargs["messages"]
                     usage = self._normalize_usage(
                         extract_usage_payload(response),
-                        model=usage_model or model,
-                        provider=usage_provider,
+                        model=response_model or usage_model or model,
+                        provider=response_provider or usage_provider,
                         messages=usage_messages,
                     )
                     if audit_context is not None:
                         usage = _attach_usage_audit(usage, call_kwargs["messages"])
-                    if usage_provider:
-                        usage.setdefault("provider", usage_provider)
+                    if response_model:
+                        usage.setdefault("response_model", response_model)
+                    if response_provider or usage_provider:
+                        usage.setdefault("provider", response_provider or usage_provider)
                     last_response_text = content
-                    last_model = model
+                    last_model = actual_model
+                    if response_provider:
+                        last_provider = response_provider
                     last_usage = usage
                     if response_validator is not None:
                         response_validator(content)
-                    return (content, model, usage)
+                    return (content, actual_model, usage)
                 raise ValueError("LLM returned empty response")
 
             except Exception as e:
@@ -3400,6 +3421,28 @@ class GeminiAnalyzer:
             raise
         except _AllModelsFailedError as exc:
             backend_id, fallback_backend_id = self._resolve_generation_backend_config()
+            if not fallback_backend_id and backend_id == LITELLM_BACKEND_ID:
+                logger.warning(
+                    "[generate_text_with_metadata] Primary LiteLLM exhausted all configured models; "
+                    "returning empty GenerationResult so caller fallback can continue"
+                )
+                usage = dict(exc.last_usage or {})
+                if exc.last_provider:
+                    usage.setdefault("provider", exc.last_provider)
+                return GenerationResult(
+                    text="",
+                    model=exc.last_model or str(getattr(self._get_runtime_config(), "litellm_model", "") or ""),
+                    provider=exc.last_provider or backend_id,
+                    backend=backend_id,
+                    usage=usage,
+                    diagnostics={
+                        "reason": "all_models_failed",
+                        "configured_primary_backend": backend_id,
+                        "configured_fallback_backend": fallback_backend_id,
+                        "last_model": exc.last_model,
+                        "template_fallback": True,
+                    },
+                )
             failed_backend = fallback_backend_id or backend_id
             raise GenerationError(
                 error_code=GenerationErrorCode.UNKNOWN_BACKEND_ERROR,

--- a/src/analyzer.py
+++ b/src/analyzer.py
@@ -3386,9 +3386,26 @@ class GeminiAnalyzer:
             return result
         except GenerationError:
             raise
+        except _AllModelsFailedError as exc:
+            backend_id, fallback_backend_id = self._resolve_generation_backend_config()
+            failed_backend = fallback_backend_id or backend_id
+            raise GenerationError(
+                error_code=GenerationErrorCode.UNKNOWN_BACKEND_ERROR,
+                stage="fallback" if fallback_backend_id else "generation",
+                retryable=False,
+                fallbackable=False,
+                backend=failed_backend,
+                provider=failed_backend,
+                details={
+                    "reason": "all_models_failed",
+                    "configured_primary_backend": backend_id,
+                    "configured_fallback_backend": fallback_backend_id,
+                    "last_model": exc.last_model,
+                },
+            ) from exc
         except Exception as exc:
             logger.error("[generate_text_with_metadata] LLM call failed: %s", exc)
-            return None
+            raise
 
     def analyze(
         self, 

--- a/src/analyzer.py
+++ b/src/analyzer.py
@@ -2828,6 +2828,98 @@ class GeminiAnalyzer:
             return response_model, resolved_model_provider_identity(response_model)[1]
         return "", str(fallback_provider or "").strip()
 
+    def _resolve_router_failure_identity(
+        self,
+        exc: Any,
+        *,
+        route_name: str,
+        recovery_model_list: List[Dict[str, Any]],
+    ) -> Tuple[str, str]:
+        """Resolve the final Router deployment identity from a transport exception."""
+        normalized_route_name = str(route_name or "").strip()
+        origins = route_deployment_origins(recovery_model_list, normalized_route_name)
+        deployment_count = len(origins.hermes_deployments) + len(origins.non_hermes_deployments)
+        candidate_models: List[str] = []
+        candidate_provider = ""
+        seen_payloads: set[int] = set()
+
+        def _remember_model(value: Any) -> None:
+            normalized = str(value or "").strip()
+            if not normalized:
+                return
+            if deployment_count > 1 and normalized == normalized_route_name:
+                return
+            if normalized not in candidate_models:
+                candidate_models.append(normalized)
+
+        def _remember_provider(value: Any) -> None:
+            nonlocal candidate_provider
+            normalized = str(value or "").strip()
+            if normalized and not candidate_provider:
+                candidate_provider = normalized
+
+        def _walk(payload: Any) -> None:
+            if payload is None:
+                return
+            payload_id = id(payload)
+            if payload_id in seen_payloads:
+                return
+            seen_payloads.add(payload_id)
+
+            if isinstance(payload, dict):
+                params = payload.get("litellm_params")
+                if isinstance(params, dict):
+                    _remember_model(params.get("model"))
+                    _remember_provider(
+                        params.get("custom_llm_provider") or params.get("provider")
+                    )
+                for key in (
+                    "litellm_model",
+                    "response_model",
+                    "deployment_model",
+                    "model",
+                    "model_name",
+                ):
+                    _remember_model(payload.get(key))
+                _remember_provider(
+                    payload.get("llm_provider")
+                    or payload.get("litellm_provider")
+                    or payload.get("custom_llm_provider")
+                    or payload.get("provider")
+                )
+                for key in ("response", "error", "details", "metadata", "body"):
+                    _walk(payload.get(key))
+                return
+
+            for key in ("response", "error", "details", "metadata", "body"):
+                nested = getattr(payload, key, None)
+                if nested is not payload:
+                    _walk(nested)
+            _remember_provider(
+                getattr(payload, "llm_provider", None)
+                or getattr(payload, "litellm_provider", None)
+                or getattr(payload, "custom_llm_provider", None)
+                or getattr(payload, "provider", None)
+            )
+            for key in (
+                "litellm_model",
+                "response_model",
+                "deployment_model",
+                "model",
+                "model_name",
+            ):
+                _remember_model(getattr(payload, key, None))
+
+        _walk(exc)
+        for candidate_model in candidate_models:
+            resolved_model, resolved_provider = resolved_model_provider_identity(
+                candidate_model,
+                recovery_model_list,
+            )
+            if resolved_provider:
+                return resolved_model or candidate_model, resolved_provider
+        return "", candidate_provider
+
     def _extract_text_blocks(self, blocks: Any, *, strip: bool = True) -> str:
         """Extract final-answer text from OpenAI-compatible content blocks.
 
@@ -3343,6 +3435,16 @@ class GeminiAnalyzer:
                 raise ValueError("LLM returned empty response")
 
             except Exception as e:
+                if uses_router:
+                    router_model, router_provider = self._resolve_router_failure_identity(
+                        e,
+                        route_name=model,
+                        recovery_model_list=recovery_model_list,
+                    )
+                    if router_model:
+                        last_model = router_model
+                    if router_provider:
+                        last_provider = router_provider
                 safe_error = self._sanitize_litellm_exception_text(e, config=config, model=model)
                 logger.warning("[LiteLLM] %s failed: %s", model, safe_error)
                 last_error = RuntimeError(f"{type(e).__name__}: {safe_error}")

--- a/src/analyzer.py
+++ b/src/analyzer.py
@@ -2815,6 +2815,37 @@ class GeminiAnalyzer:
             return obj.get(key)
         return getattr(obj, key, None)
 
+    @staticmethod
+    def _resolve_configured_response_provider(
+        configured_model: str,
+        response_model: str,
+        model_list: Optional[List[Dict[str, Any]]] = None,
+    ) -> str:
+        """Match the actual response model against all deployments of one alias."""
+        normalized_configured_model = str(configured_model or "").strip()
+        normalized_response_model = str(response_model or "").strip().lower()
+        if not normalized_configured_model or not normalized_response_model or not model_list:
+            return ""
+
+        for entry in model_list:
+            params = entry.get("litellm_params", {}) or {}
+            model_name = str(entry.get("model_name") or "").strip()
+            if not model_name:
+                model_name = str(params.get("model") or "").strip()
+            if model_name != normalized_configured_model:
+                continue
+
+            deployment_model = str(params.get("model") or "").strip()
+            if deployment_model.lower() != normalized_response_model:
+                continue
+
+            _resolved_model, resolved_provider = resolved_model_provider_identity(
+                deployment_model,
+            )
+            if resolved_provider:
+                return resolved_provider
+        return ""
+
     def _resolve_response_model_provider(
         self,
         response: Any,
@@ -2838,9 +2869,16 @@ class GeminiAnalyzer:
         if response_model:
             if "/" not in response_model:
                 return response_model, configured_provider
-            response_provider = get_explicit_llm_channel_model_provider(response_model)
+            matched_provider = self._resolve_configured_response_provider(
+                normalized_configured_model,
+                response_model,
+                model_list,
+            )
+            if matched_provider:
+                return response_model, matched_provider
             if configured_provider == "openrouter":
                 return response_model, configured_provider
+            response_provider = get_explicit_llm_channel_model_provider(response_model)
             if response_provider:
                 return response_model, response_provider
             return response_model, configured_provider

--- a/src/analyzer.py
+++ b/src/analyzer.py
@@ -3349,7 +3349,9 @@ class GeminiAnalyzer:
                             config,
                         )
                     effective_audit_context = dict(audit_context)
-                    effective_audit_context["provider"] = usage_provider
+                    effective_audit_context["provider"] = (
+                        usage.get("provider") or usage_provider
+                    )
                     effective_audit_context["transport"] = (
                         effective_audit_context.get("transport") or "litellm"
                     )
@@ -3463,6 +3465,8 @@ class GeminiAnalyzer:
                 if _stream_text is not None:
                     last_response_text = _stream_text
                     last_model = model
+                    if usage_provider:
+                        _stream_usage["provider"] = usage_provider
                     _stream_usage = _attach_usage_audit(_stream_usage, call_kwargs["messages"])
                     if usage_provider:
                         _stream_usage.setdefault("provider", usage_provider)
@@ -3505,6 +3509,8 @@ class GeminiAnalyzer:
                         provider=response_provider or usage_provider,
                         messages=usage_messages,
                     )
+                    if response_provider or usage_provider:
+                        usage["provider"] = response_provider or usage_provider
                     if audit_context is not None:
                         usage = _attach_usage_audit(usage, call_kwargs["messages"])
                     if response_model:

--- a/src/analyzer.py
+++ b/src/analyzer.py
@@ -3485,15 +3485,19 @@ class GeminiAnalyzer:
                     logger=logger,
                 )
 
+                response_model, response_provider = self._resolve_response_model_provider(
+                    response,
+                    fallback_provider=usage_provider,
+                    configured_model=model,
+                    model_list=recovery_model_list,
+                )
+                actual_model = response_model or model
+                if response_model:
+                    last_model = actual_model
+                if response_provider:
+                    last_provider = response_provider
                 content = self._extract_completion_text(response)
                 if content:
-                    response_model, response_provider = self._resolve_response_model_provider(
-                        response,
-                        fallback_provider=usage_provider,
-                        configured_model=model,
-                        model_list=recovery_model_list,
-                    )
-                    actual_model = response_model or model
                     usage_messages = None if audit_context is not None else call_kwargs["messages"]
                     usage = self._normalize_usage(
                         extract_usage_payload(response),

--- a/src/analyzer.py
+++ b/src/analyzer.py
@@ -2946,7 +2946,11 @@ class GeminiAnalyzer:
                 candidate_model,
                 recovery_model_list,
             )
+            normalized_route = str(resolved_model or candidate_model).strip().lower()
             explicit_provider = get_explicit_llm_channel_model_provider(candidate_model)
+            route_text = f"{candidate_provider} {normalized_route}".strip().lower()
+            if normalized_route.startswith("openai/~") or "openrouter" in route_text:
+                return resolved_model or candidate_model, "openrouter"
             if candidate_provider and not explicit_provider:
                 return resolved_model or candidate_model, candidate_provider
             if resolved_provider:

--- a/src/analyzer.py
+++ b/src/analyzer.py
@@ -2839,6 +2839,10 @@ class GeminiAnalyzer:
             if deployment_model.lower() != normalized_response_model:
                 continue
 
+            normalized_deployment_model = deployment_model.lower()
+            if normalized_deployment_model.startswith("openai/~") or "openrouter" in normalized_deployment_model:
+                return "openrouter"
+
             _resolved_model, resolved_provider = resolved_model_provider_identity(
                 deployment_model,
             )

--- a/src/market_analyzer.py
+++ b/src/market_analyzer.py
@@ -669,8 +669,8 @@ Focus on index trend, liquidity, and sector rotation to shape the next-session t
             )
             record_llm_run(
                 success=False,
-                provider="litellm",
-                model=getattr(self.config, "litellm_model", None),
+                provider=backend_error.provider or backend_error.backend,
+                model=backend_error.backend,
                 call_type="market_review",
                 error_type=type(backend_error).__name__,
                 error_message=backend_error,
@@ -688,20 +688,29 @@ Focus on index trend, liquidity, and sector rotation to shape the next-session t
         prompt = self._build_review_prompt(overview, news)
 
         logger.info("[大盘] %s action=generate_review status=start", self._log_context())
-        # Use the public generate_text() entry point - never access private analyzer attributes.
+        # Use public analyzer APIs so diagnostics reflect the actual execution backend.
         llm_started_at = time.perf_counter()
+        provider, model = self.analyzer.get_generation_backend_identity()
         try:
             record_llm_run_started(
-                provider="litellm",
-                model=getattr(self.config, "litellm_model", None),
+                provider=provider,
+                model=model,
                 call_type="market_review",
             )
-            review = self.analyzer.generate_text(prompt, max_tokens=8192, temperature=0.7)
+            generation_result = self.analyzer.generate_text_with_metadata(
+                prompt,
+                max_tokens=8192,
+                temperature=0.7,
+            )
+            review = generation_result.text if generation_result else None
+            if generation_result is not None:
+                provider = generation_result.provider or generation_result.backend or provider
+                model = generation_result.model or model
         except Exception as exc:
             record_llm_run(
                 success=False,
-                provider="litellm",
-                model=getattr(self.config, "litellm_model", None),
+                provider=getattr(exc, "provider", None) or getattr(exc, "backend", None) or provider,
+                model=getattr(exc, "backend", None) or model,
                 call_type="market_review",
                 duration_ms=int((time.perf_counter() - llm_started_at) * 1000),
                 error_type=type(exc).__name__,
@@ -711,8 +720,8 @@ Focus on index trend, liquidity, and sector rotation to shape the next-session t
 
         record_llm_run(
             success=bool(review),
-            provider="litellm",
-            model=getattr(self.config, "litellm_model", None),
+            provider=provider,
+            model=model,
             call_type="market_review",
             duration_ms=int((time.perf_counter() - llm_started_at) * 1000),
             error_type=None if review else "EmptyResponse",

--- a/src/market_analyzer.py
+++ b/src/market_analyzer.py
@@ -162,14 +162,22 @@ class MarketAnalyzer:
         model: str,
         backend: str,
         usage_provider: str = "",
+        response_model: str = "",
     ) -> str:
         """Resolve LiteLLM router aliases before persisting diagnostics."""
         normalized_backend = str(backend or "").strip().lower()
         normalized_model = str(model or "").strip()
         normalized_usage_provider = str(usage_provider or "").strip()
+        normalized_response_model = str(response_model or "").strip()
         normalized_provider = str(provider or "").strip()
         if normalized_usage_provider:
             return normalized_usage_provider
+        if normalized_response_model:
+            _wire_model, resolved_provider = resolved_model_provider_identity(
+                normalized_response_model,
+            )
+            if resolved_provider:
+                return resolved_provider
         if normalized_backend != "litellm" or not normalized_model:
             return normalized_provider
 
@@ -728,6 +736,9 @@ Focus on index trend, liquidity, and sector rotation to shape the next-session t
                 temperature=0.7,
             )
             review = generation_result.text if generation_result else None
+            generation_diagnostics = (
+                getattr(generation_result, "diagnostics", None) if generation_result is not None else None
+            )
             if generation_result is not None:
                 model = generation_result.model or model
                 usage_payload = getattr(generation_result, "usage", None)
@@ -737,6 +748,9 @@ Focus on index trend, liquidity, and sector rotation to shape the next-session t
                     backend=generation_result.backend or "",
                     usage_provider=(
                         usage_payload.get("provider") if isinstance(usage_payload, dict) else ""
+                    ),
+                    response_model=(
+                        usage_payload.get("response_model") if isinstance(usage_payload, dict) else ""
                     ),
                 )
         except Exception as exc:
@@ -756,14 +770,26 @@ Focus on index trend, liquidity, and sector rotation to shape the next-session t
             )
             raise
 
+        failed_all_models = (
+            isinstance(generation_diagnostics, dict)
+            and generation_diagnostics.get("reason") == "all_models_failed"
+        )
         record_llm_run(
             success=bool(review),
             provider=provider,
             model=model,
             call_type="market_review",
             duration_ms=int((time.perf_counter() - llm_started_at) * 1000),
-            error_type=None if review else "EmptyResponse",
-            error_message=None if review else "empty market review response",
+            error_type=None if review else ("AllModelsFailed" if failed_all_models else "EmptyResponse"),
+            error_message=(
+                None
+                if review
+                else (
+                    generation_diagnostics
+                    if failed_all_models
+                    else "empty market review response"
+                )
+            ),
         )
 
         if review:

--- a/src/market_analyzer.py
+++ b/src/market_analyzer.py
@@ -187,6 +187,26 @@ class MarketAnalyzer:
         )
         return resolved_provider or normalized_provider or "openai"
 
+    def _resolve_recorded_error_model(
+        self,
+        *,
+        error: Any,
+        fallback_model: str = "",
+    ) -> str:
+        """Preserve route/model diagnostics for LiteLLM configuration failures."""
+        details = getattr(error, "details", None)
+        if isinstance(details, dict):
+            for key in ("last_model", "route_name"):
+                candidate = str(details.get(key) or "").strip()
+                if candidate:
+                    return candidate
+        backend = str(getattr(error, "backend", "") or "").strip()
+        configured_model = str(getattr(self.config, "litellm_model", "") or "").strip()
+        normalized_fallback_model = str(fallback_model or "").strip()
+        if backend == "litellm":
+            return normalized_fallback_model or configured_model or backend
+        return normalized_fallback_model or backend
+
     def _get_output_language(self) -> str:
         """Return the truthful report language (zh/en/ko) for payload and directives."""
         return normalize_report_language(
@@ -703,7 +723,7 @@ Focus on index trend, liquidity, and sector rotation to shape the next-session t
             record_llm_run(
                 success=False,
                 provider=backend_error.provider or backend_error.backend,
-                model=backend_error.backend,
+                model=self._resolve_recorded_error_model(error=backend_error),
                 call_type="market_review",
                 error_type=type(backend_error).__name__,
                 error_message=backend_error,
@@ -754,11 +774,11 @@ Focus on index trend, liquidity, and sector rotation to shape the next-session t
                     ),
                 )
         except Exception as exc:
-            error_details = getattr(exc, "details", None)
             error_provider = getattr(exc, "provider", None) or getattr(exc, "backend", None) or provider
-            error_model = (
-                error_details.get("last_model") if isinstance(error_details, dict) else None
-            ) or getattr(exc, "backend", None) or model
+            error_model = self._resolve_recorded_error_model(
+                error=exc,
+                fallback_model=model,
+            )
             record_llm_run(
                 success=False,
                 provider=error_provider,

--- a/src/market_analyzer.py
+++ b/src/market_analyzer.py
@@ -20,6 +20,7 @@ from typing import Optional, Dict, Any, List
 
 import pandas as pd
 
+from src.agent.provider_trace import resolved_model_provider_identity
 from src.config import get_config
 from src.report_language import normalize_report_language
 from src.search_service import SearchService
@@ -153,6 +154,30 @@ class MarketAnalyzer:
 
     def _log_context(self) -> str:
         return f"component=market_review region={self.region}"
+
+    def _resolve_recorded_provider(
+        self,
+        *,
+        provider: str,
+        model: str,
+        backend: str,
+        usage_provider: str = "",
+    ) -> str:
+        """Resolve LiteLLM router aliases before persisting diagnostics."""
+        normalized_backend = str(backend or "").strip().lower()
+        normalized_model = str(model or "").strip()
+        normalized_usage_provider = str(usage_provider or "").strip()
+        normalized_provider = str(provider or "").strip()
+        if normalized_usage_provider:
+            return normalized_usage_provider
+        if normalized_backend != "litellm" or not normalized_model:
+            return normalized_provider
+
+        _wire_model, resolved_provider = resolved_model_provider_identity(
+            normalized_model,
+            getattr(self.config, "llm_model_list", None) or [],
+        )
+        return resolved_provider or normalized_provider or "openai"
 
     def _get_output_language(self) -> str:
         """Return the truthful report language (zh/en/ko) for payload and directives."""
@@ -704,8 +729,16 @@ Focus on index trend, liquidity, and sector rotation to shape the next-session t
             )
             review = generation_result.text if generation_result else None
             if generation_result is not None:
-                provider = generation_result.provider or generation_result.backend or provider
                 model = generation_result.model or model
+                usage_payload = getattr(generation_result, "usage", None)
+                provider = self._resolve_recorded_provider(
+                    provider=generation_result.provider or generation_result.backend or provider,
+                    model=model,
+                    backend=generation_result.backend or "",
+                    usage_provider=(
+                        usage_payload.get("provider") if isinstance(usage_payload, dict) else ""
+                    ),
+                )
         except Exception as exc:
             error_details = getattr(exc, "details", None)
             error_provider = getattr(exc, "provider", None) or getattr(exc, "backend", None) or provider

--- a/src/market_analyzer.py
+++ b/src/market_analyzer.py
@@ -707,10 +707,15 @@ Focus on index trend, liquidity, and sector rotation to shape the next-session t
                 provider = generation_result.provider or generation_result.backend or provider
                 model = generation_result.model or model
         except Exception as exc:
+            error_details = getattr(exc, "details", None)
+            error_provider = getattr(exc, "provider", None) or getattr(exc, "backend", None) or provider
+            error_model = (
+                error_details.get("last_model") if isinstance(error_details, dict) else None
+            ) or getattr(exc, "backend", None) or model
             record_llm_run(
                 success=False,
-                provider=getattr(exc, "provider", None) or getattr(exc, "backend", None) or provider,
-                model=getattr(exc, "backend", None) or model,
+                provider=error_provider,
+                model=error_model,
                 call_type="market_review",
                 duration_ms=int((time.perf_counter() - llm_started_at) * 1000),
                 error_type=type(exc).__name__,

--- a/src/market_analyzer.py
+++ b/src/market_analyzer.py
@@ -170,6 +170,16 @@ class MarketAnalyzer:
         normalized_usage_provider = str(usage_provider or "").strip()
         normalized_response_model = str(response_model or "").strip()
         normalized_provider = str(provider or "").strip()
+        resolved_route_model = ""
+        resolved_route_provider = ""
+        if normalized_backend == "litellm" and normalized_model:
+            resolved_route_model, resolved_route_provider = resolved_model_provider_identity(
+                normalized_model,
+                getattr(self.config, "llm_model_list", None) or [],
+            )
+            normalized_route = str(resolved_route_model or normalized_model).strip().lower()
+            if normalized_route.startswith("openai/~") or "openrouter" in normalized_route:
+                return "openrouter"
         if normalized_usage_provider:
             return normalized_usage_provider
         if normalized_response_model:
@@ -180,12 +190,7 @@ class MarketAnalyzer:
                 return resolved_provider
         if normalized_backend != "litellm" or not normalized_model:
             return normalized_provider
-
-        _wire_model, resolved_provider = resolved_model_provider_identity(
-            normalized_model,
-            getattr(self.config, "llm_model_list", None) or [],
-        )
-        return resolved_provider or normalized_provider or "openai"
+        return resolved_route_provider or normalized_provider or "openai"
 
     def _resolve_recorded_error_model(
         self,
@@ -196,10 +201,30 @@ class MarketAnalyzer:
         """Preserve route/model diagnostics for LiteLLM configuration failures."""
         details = getattr(error, "details", None)
         if isinstance(details, dict):
-            for key in ("last_model", "route_name"):
-                candidate = str(details.get(key) or "").strip()
-                if candidate:
-                    return candidate
+            visited: set[int] = set()
+
+            def _find_error_model(payload: Dict[str, Any]) -> str:
+                payload_id = id(payload)
+                if payload_id in visited:
+                    return ""
+                visited.add(payload_id)
+                for key in ("last_model", "route_name"):
+                    candidate = str(payload.get(key) or "").strip()
+                    if candidate:
+                        return candidate
+                fallback_error = payload.get("fallback_error")
+                if isinstance(fallback_error, dict):
+                    nested_details = fallback_error.get("details")
+                    if isinstance(nested_details, dict):
+                        candidate = _find_error_model(nested_details)
+                        if candidate:
+                            return candidate
+                    return _find_error_model(fallback_error)
+                return ""
+
+            candidate = _find_error_model(details)
+            if candidate:
+                return candidate
         backend = str(getattr(error, "backend", "") or "").strip()
         configured_model = str(getattr(self.config, "litellm_model", "") or "").strip()
         normalized_fallback_model = str(fallback_model or "").strip()

--- a/src/market_analyzer.py
+++ b/src/market_analyzer.py
@@ -40,6 +40,7 @@ from data_provider.base import DataFetcherManager
 
 logger = logging.getLogger(__name__)
 
+_LEGACY_ANALYZER_BACKEND_ID = "legacy_analyzer"
 
 _ENGLISH_SECTION_PATTERNS = {
     "market_summary": r"###\s*(?:1\.\s*)?Market Summary",
@@ -920,6 +921,10 @@ Focus on index trend, liquidity, and sector rotation to shape the next-session t
             return backend_id, backend_id
         return backend_id, str(getattr(self.config, "litellm_model", "") or "")
 
+    def _get_legacy_analyzer_generation_backend_identity(self) -> tuple[str, str]:
+        """Return a neutral identity for injected analyzers that expose no metadata APIs."""
+        return _LEGACY_ANALYZER_BACKEND_ID, _LEGACY_ANALYZER_BACKEND_ID
+
     def _get_analyzer_generation_backend_identity(self) -> tuple[str, str]:
         """Use analyzer metadata API when available, otherwise fall back to configured identity."""
         if self.analyzer is None:
@@ -929,7 +934,7 @@ Focus on index trend, liquidity, and sector rotation to shape the next-session t
             method = getattr(self.analyzer, "get_generation_backend_identity", None)
             if callable(method):
                 return method()
-        return self._get_configured_generation_backend_identity()
+        return self._get_legacy_analyzer_generation_backend_identity()
 
     def _generate_market_review_with_metadata(
         self,

--- a/src/market_analyzer.py
+++ b/src/market_analyzer.py
@@ -155,6 +155,37 @@ class MarketAnalyzer:
     def _log_context(self) -> str:
         return f"component=market_review region={self.region}"
 
+    @staticmethod
+    def _resolve_configured_response_provider(
+        configured_model: str,
+        response_model: str,
+        model_list: Optional[List[Dict[str, Any]]] = None,
+    ) -> str:
+        """Match the actual response model against all deployments of one alias."""
+        normalized_configured_model = str(configured_model or "").strip()
+        normalized_response_model = str(response_model or "").strip().lower()
+        if not normalized_configured_model or not normalized_response_model or not model_list:
+            return ""
+
+        for entry in model_list:
+            params = entry.get("litellm_params", {}) or {}
+            model_name = str(entry.get("model_name") or "").strip()
+            if not model_name:
+                model_name = str(params.get("model") or "").strip()
+            if model_name != normalized_configured_model:
+                continue
+
+            deployment_model = str(params.get("model") or "").strip()
+            if deployment_model.lower() != normalized_response_model:
+                continue
+
+            _resolved_model, resolved_provider = resolved_model_provider_identity(
+                deployment_model,
+            )
+            if resolved_provider:
+                return resolved_provider
+        return ""
+
     def _resolve_recorded_provider(
         self,
         *,
@@ -170,7 +201,6 @@ class MarketAnalyzer:
         normalized_usage_provider = str(usage_provider or "").strip()
         normalized_response_model = str(response_model or "").strip()
         normalized_provider = str(provider or "").strip()
-        resolved_route_model = ""
         resolved_route_provider = ""
         if normalized_backend == "litellm" and normalized_model:
             resolved_route_model, resolved_route_provider = resolved_model_provider_identity(
@@ -179,10 +209,19 @@ class MarketAnalyzer:
             )
             normalized_route = str(resolved_route_model or normalized_model).strip().lower()
             if normalized_route.startswith("openai/~") or "openrouter" in normalized_route:
-                return "openrouter"
+                resolved_route_provider = "openrouter"
         if normalized_usage_provider:
             return normalized_usage_provider
         if normalized_response_model:
+            resolved_response_provider = self._resolve_configured_response_provider(
+                normalized_model,
+                normalized_response_model,
+                getattr(self.config, "llm_model_list", None) or [],
+            )
+            if resolved_response_provider:
+                return resolved_response_provider
+            if resolved_route_provider == "openrouter":
+                return resolved_route_provider
             _wire_model, resolved_provider = resolved_model_provider_identity(
                 normalized_response_model,
             )

--- a/src/market_analyzer.py
+++ b/src/market_analyzer.py
@@ -27,10 +27,12 @@ from src.search_service import SearchService
 from src.core.market_profile import get_profile, MarketProfile
 from src.core.market_strategy import get_market_strategy_blueprint
 from src.llm.backend_registry import (
+    LOCAL_CLI_GENERATION_BACKEND_IDS,
+    LITELLM_BACKEND_ID,
     resolve_generation_backend_id,
     resolve_generation_fallback_backend_id,
 )
-from src.llm.generation_backend import GenerationError
+from src.llm.generation_backend import GenerationError, GenerationResult
 from src.schemas.market_light import MARKET_LIGHT_REGIONS, MarketLightSnapshot
 from src.services.run_diagnostics import record_llm_run, record_llm_run_started
 from src.services.intelligence_service import IntelligenceService
@@ -807,17 +809,17 @@ Focus on index trend, liquidity, and sector rotation to shape the next-session t
         logger.info("[大盘] %s action=generate_review status=start", self._log_context())
         # Use public analyzer APIs so diagnostics reflect the actual execution backend.
         llm_started_at = time.perf_counter()
-        provider, model = self.analyzer.get_generation_backend_identity()
+        provider, model = self._get_analyzer_generation_backend_identity()
         try:
             record_llm_run_started(
                 provider=provider,
                 model=model,
                 call_type="market_review",
             )
-            generation_result = self.analyzer.generate_text_with_metadata(
+            generation_result = self._generate_market_review_with_metadata(
                 prompt,
-                max_tokens=8192,
-                temperature=0.7,
+                provider=provider,
+                model=model,
             )
             review = generation_result.text if generation_result else None
             generation_diagnostics = (
@@ -908,6 +910,70 @@ Focus on index trend, liquidity, and sector rotation to shape the next-session t
             return None
         error = method()
         return error if isinstance(error, GenerationError) else None
+
+    def _get_configured_generation_backend_identity(self) -> tuple[str, str]:
+        """Best-effort backend identity for legacy analyzers without metadata APIs."""
+        backend_id = str(getattr(self.config, "generation_backend", "") or "").strip().lower()
+        if not backend_id:
+            backend_id = LITELLM_BACKEND_ID
+        if backend_id in LOCAL_CLI_GENERATION_BACKEND_IDS:
+            return backend_id, backend_id
+        return backend_id, str(getattr(self.config, "litellm_model", "") or "")
+
+    def _get_analyzer_generation_backend_identity(self) -> tuple[str, str]:
+        """Use analyzer metadata API when available, otherwise fall back to configured identity."""
+        if self.analyzer is None:
+            return self._get_configured_generation_backend_identity()
+        missing = object()
+        if getattr_static(self.analyzer, "get_generation_backend_identity", missing) is not missing:
+            method = getattr(self.analyzer, "get_generation_backend_identity", None)
+            if callable(method):
+                return method()
+        return self._get_configured_generation_backend_identity()
+
+    def _generate_market_review_with_metadata(
+        self,
+        prompt: str,
+        *,
+        provider: str,
+        model: str,
+    ) -> Optional[GenerationResult]:
+        """Support legacy analyzers that only implement the public generate_text() contract."""
+        if self.analyzer is None:
+            return None
+        missing = object()
+        if getattr_static(self.analyzer, "generate_text_with_metadata", missing) is not missing:
+            method = getattr(self.analyzer, "generate_text_with_metadata", None)
+            if callable(method):
+                return method(
+                    prompt,
+                    max_tokens=8192,
+                    temperature=0.7,
+                )
+
+        if getattr_static(self.analyzer, "generate_text", missing) is missing:
+            raise AttributeError(
+                "analyzer must implement generate_text_with_metadata() or generate_text()"
+            )
+        legacy_method = getattr(self.analyzer, "generate_text", None)
+        if not callable(legacy_method):
+            raise AttributeError(
+                "analyzer must implement generate_text_with_metadata() or generate_text()"
+            )
+        review = legacy_method(
+            prompt,
+            max_tokens=8192,
+            temperature=0.7,
+        )
+        if review is None:
+            return None
+        return GenerationResult(
+            text=review,
+            provider=provider,
+            model=model,
+            backend=provider,
+            usage={},
+        )
 
     def build_market_review_payload(
         self,

--- a/src/market_analyzer.py
+++ b/src/market_analyzer.py
@@ -182,6 +182,10 @@ class MarketAnalyzer:
             if deployment_model.lower() != normalized_response_model:
                 continue
 
+            normalized_deployment_model = deployment_model.lower()
+            if normalized_deployment_model.startswith("openai/~") or "openrouter" in normalized_deployment_model:
+                return "openrouter"
+
             _resolved_model, resolved_provider = resolved_model_provider_identity(
                 deployment_model,
             )
@@ -213,14 +217,18 @@ class MarketAnalyzer:
             normalized_route = str(resolved_route_model or normalized_model).strip().lower()
             if normalized_route.startswith("openai/~") or "openrouter" in normalized_route:
                 resolved_route_provider = "openrouter"
-        if normalized_usage_provider:
-            return normalized_usage_provider
+        resolved_response_provider = ""
         if normalized_response_model:
             resolved_response_provider = self._resolve_configured_response_provider(
                 normalized_model,
                 normalized_response_model,
                 getattr(self.config, "llm_model_list", None) or [],
             )
+            if resolved_response_provider == "openrouter":
+                return resolved_response_provider
+        if normalized_usage_provider:
+            return normalized_usage_provider
+        if normalized_response_model:
             if resolved_response_provider:
                 return resolved_response_provider
             if resolved_route_provider == "openrouter":

--- a/tests/test_market_analyzer_generate_text.py
+++ b/tests/test_market_analyzer_generate_text.py
@@ -254,6 +254,31 @@ class TestAnalyzerGenerateText:
             "last_model": "openai/qwen3.7-max",
         }
 
+    def test_call_litellm_impl_tracks_last_model_when_all_attempts_fail(self):
+        from src.analyzer import _AllModelsFailedError
+
+        analyzer = self._make_analyzer()
+        analyzer._config_override.litellm_model = "openai/primary-model"
+        analyzer._config_override.litellm_fallback_models = ["openai/fallback-model"]
+        analyzer._config_override.llm_model_list = []
+
+        def fake_dispatch(model, call_kwargs, **kwargs):
+            if model == "openai/primary-model":
+                return SimpleNamespace(
+                    choices=[SimpleNamespace(message=SimpleNamespace(content=None))],
+                    usage=None,
+                )
+            raise RuntimeError("fallback transport error")
+
+        with patch.object(analyzer, "_dispatch_litellm_completion", side_effect=fake_dispatch):
+            with pytest.raises(_AllModelsFailedError) as exc_info:
+                analyzer._call_litellm_impl(
+                    "写一份复盘",
+                    {"max_tokens": 128, "temperature": 0.7},
+                )
+
+        assert exc_info.value.last_model == "openai/fallback-model"
+
     @pytest.mark.parametrize(
         ("generation_backend", "executable_name"),
         [
@@ -2899,6 +2924,39 @@ class TestMarketAnalyzerBypassFix:
         assert started.call_args.kwargs["model"] == "codex_cli"
         assert recorded.call_args.kwargs["provider"] == "openai"
         assert recorded.call_args.kwargs["model"] == "openai/qwen3.7-max"
+
+    def test_market_review_records_failed_fallback_last_model(self):
+        from src.analyzer import _AllModelsFailedError
+        from src.llm.generation_backend import GenerationError
+        from src.market_analyzer import MarketOverview
+
+        ma = self._make_market_analyzer_with_mock_generate_text(return_value=None)
+        ma.analyzer._config_override.generation_backend = "codex_cli"
+        ma.analyzer._config_override.generation_fallback_backend = "litellm"
+        ma.analyzer.get_generation_backend_identity.return_value = ("codex_cli", "codex_cli")
+        ma.analyzer.generate_text_with_metadata = ma.analyzer.__class__.generate_text_with_metadata.__get__(
+            ma.analyzer,
+            ma.analyzer.__class__,
+        )
+        exhausted = _AllModelsFailedError(
+            "all fallback models failed",
+            last_model="openai/qwen3.7-max",
+        )
+
+        with patch.object(ma.analyzer, "_call_litellm", side_effect=exhausted), \
+             patch("src.market_analyzer.record_llm_run_started") as started, \
+             patch("src.market_analyzer.record_llm_run") as recorded:
+            with pytest.raises(GenerationError) as exc_info:
+                ma.generate_market_review(MarketOverview(date="2026-03-05"), [])
+
+        assert exc_info.value.stage == "fallback"
+        assert exc_info.value.backend == "litellm"
+        assert exc_info.value.details["last_model"] == "openai/qwen3.7-max"
+        assert started.call_args.kwargs["provider"] == "codex_cli"
+        assert started.call_args.kwargs["model"] == "codex_cli"
+        assert recorded.call_args.kwargs["provider"] == "litellm"
+        assert recorded.call_args.kwargs["model"] == "openai/qwen3.7-max"
+        assert recorded.call_args.kwargs["success"] is False
 
     def test_generate_template_review_uses_english_shell_for_cn_when_report_language_is_en(self):
         from src.market_analyzer import MarketOverview, MarketIndex

--- a/tests/test_market_analyzer_generate_text.py
+++ b/tests/test_market_analyzer_generate_text.py
@@ -253,6 +253,38 @@ class TestAnalyzerGenerateText:
         assert result.provider == "anthropic"
         assert result.usage["provider"] == "anthropic"
 
+    def test_generate_text_with_metadata_prefers_actual_response_model(self):
+        analyzer = self._make_analyzer()
+        analyzer._config_override.generation_backend = "litellm"
+        analyzer._config_override.generation_fallback_backend = ""
+        analyzer._config_override.litellm_model = "analysis-route"
+        analyzer._config_override.litellm_fallback_models = []
+        analyzer._config_override.llm_model_list = [
+            {
+                "model_name": "analysis-route",
+                "litellm_params": {"model": "openai/gpt-4o-mini"},
+            },
+            {
+                "model_name": "analysis-route",
+                "litellm_params": {"model": "anthropic/claude-sonnet-test"},
+            },
+        ]
+        response = SimpleNamespace(
+            model="anthropic/claude-sonnet-test",
+            choices=[SimpleNamespace(message=SimpleNamespace(content="复盘"))],
+            usage=None,
+        )
+
+        with patch.object(analyzer, "_dispatch_litellm_completion", return_value=response):
+            result = analyzer.generate_text_with_metadata("写一份复盘")
+
+        assert result is not None
+        assert result.backend == "litellm"
+        assert result.model == "anthropic/claude-sonnet-test"
+        assert result.provider == "anthropic"
+        assert result.usage["provider"] == "anthropic"
+        assert result.usage["response_model"] == "anthropic/claude-sonnet-test"
+
     def test_generate_text_with_metadata_preserves_exhausted_fallback_failure(self):
         from src.analyzer import _AllModelsFailedError
         from src.llm.generation_backend import GenerationError
@@ -280,6 +312,37 @@ class TestAnalyzerGenerateText:
             "configured_primary_backend": "codex_cli",
             "configured_fallback_backend": "litellm",
             "last_model": "analysis-route",
+        }
+
+    def test_generate_text_with_metadata_preserves_primary_litellm_exhaustion_metadata(self):
+        from src.analyzer import _AllModelsFailedError
+        from src.llm.generation_backend import GenerationResult
+
+        analyzer = self._make_analyzer()
+        analyzer._config_override.generation_backend = "litellm"
+        analyzer._config_override.generation_fallback_backend = ""
+        exhausted = _AllModelsFailedError(
+            "all primary models failed",
+            last_model="analysis-route",
+            last_provider="anthropic",
+            last_usage={},
+        )
+
+        with patch.object(analyzer, "_call_litellm", side_effect=exhausted):
+            result = analyzer.generate_text_with_metadata("写一份复盘")
+
+        assert isinstance(result, GenerationResult)
+        assert result.text == ""
+        assert result.backend == "litellm"
+        assert result.provider == "anthropic"
+        assert result.model == "analysis-route"
+        assert result.usage["provider"] == "anthropic"
+        assert result.diagnostics == {
+            "reason": "all_models_failed",
+            "configured_primary_backend": "litellm",
+            "configured_fallback_backend": None,
+            "last_model": "analysis-route",
+            "template_fallback": True,
         }
 
     def test_call_litellm_impl_tracks_last_model_when_all_attempts_fail(self):
@@ -3030,6 +3093,38 @@ class TestMarketAnalyzerBypassFix:
         assert recorded.call_args.kwargs["provider"] == "anthropic"
         assert recorded.call_args.kwargs["model"] == "analysis-route"
 
+    def test_market_review_prefers_actual_response_model_provider_for_duplicate_aliases(self):
+        from src.market_analyzer import MarketOverview
+
+        ma = self._make_market_analyzer_with_mock_generate_text("复盘结果")
+        ma.analyzer.get_generation_backend_identity.return_value = ("codex_cli", "codex_cli")
+        ma.config.llm_model_list = [
+            {
+                "model_name": "analysis-route",
+                "litellm_params": {"model": "openai/gpt-4o-mini"},
+            },
+            {
+                "model_name": "analysis-route",
+                "litellm_params": {"model": "anthropic/claude-sonnet-test"},
+            },
+        ]
+        ma.analyzer.generate_text_with_metadata.return_value = SimpleNamespace(
+            text="复盘结果",
+            provider="openai",
+            model="analysis-route",
+            backend="litellm",
+            usage={"response_model": "anthropic/claude-sonnet-test"},
+        )
+
+        with patch("src.market_analyzer.record_llm_run_started") as started, \
+             patch("src.market_analyzer.record_llm_run") as recorded:
+            ma.generate_market_review(MarketOverview(date="2026-03-05"), [])
+
+        assert started.call_args.kwargs["provider"] == "codex_cli"
+        assert started.call_args.kwargs["model"] == "codex_cli"
+        assert recorded.call_args.kwargs["provider"] == "anthropic"
+        assert recorded.call_args.kwargs["model"] == "analysis-route"
+
     def test_market_review_records_failed_fallback_last_model(self):
         from src.analyzer import _AllModelsFailedError
         from src.llm.generation_backend import GenerationError
@@ -3065,6 +3160,51 @@ class TestMarketAnalyzerBypassFix:
         assert recorded.call_args.kwargs["provider"] == "anthropic"
         assert recorded.call_args.kwargs["model"] == "analysis-route"
         assert recorded.call_args.kwargs["success"] is False
+
+    def test_market_review_preserves_template_fallback_for_primary_litellm_exhaustion(self):
+        from src.market_analyzer import MarketOverview, MarketIndex
+
+        ma = self._make_market_analyzer_with_mock_generate_text(return_value=None)
+        ma.analyzer.get_generation_backend_identity.return_value = ("litellm", "analysis-route")
+        overview = MarketOverview(
+            date="2026-03-05",
+            indices=[
+                MarketIndex(
+                    code="000001",
+                    name="上证指数",
+                    current=3300.0,
+                    change=5.0,
+                    change_pct=0.15,
+                )
+            ],
+        )
+        ma.analyzer.generate_text_with_metadata.return_value = SimpleNamespace(
+            text="",
+            provider="anthropic",
+            model="analysis-route",
+            backend="litellm",
+            usage={"provider": "anthropic"},
+            diagnostics={
+                "reason": "all_models_failed",
+                "configured_primary_backend": "litellm",
+                "configured_fallback_backend": None,
+                "last_model": "analysis-route",
+                "template_fallback": True,
+            },
+        )
+
+        with patch.object(ma, "_generate_template_review", wraps=ma._generate_template_review) as template_review, \
+             patch("src.market_analyzer.record_llm_run_started") as started, \
+             patch("src.market_analyzer.record_llm_run") as recorded:
+            result = ma.generate_market_review(overview, [])
+
+        assert isinstance(result, str) and len(result) > 0
+        template_review.assert_called_once()
+        assert started.call_args.kwargs["provider"] == "litellm"
+        assert recorded.call_args.kwargs["provider"] == "anthropic"
+        assert recorded.call_args.kwargs["model"] == "analysis-route"
+        assert recorded.call_args.kwargs["success"] is False
+        assert recorded.call_args.kwargs["error_type"] == "AllModelsFailed"
 
     def test_generate_template_review_uses_english_shell_for_cn_when_report_language_is_en(self):
         from src.market_analyzer import MarketOverview, MarketIndex

--- a/tests/test_market_analyzer_generate_text.py
+++ b/tests/test_market_analyzer_generate_text.py
@@ -313,6 +313,34 @@ class TestAnalyzerGenerateText:
         assert result.usage["provider"] == "anthropic"
         assert result.usage["response_model"] == "claude-sonnet-test"
 
+    def test_generate_text_with_metadata_preserves_openrouter_provider_for_latest_alias(self):
+        analyzer = self._make_analyzer()
+        analyzer._config_override.generation_backend = "litellm"
+        analyzer._config_override.generation_fallback_backend = ""
+        analyzer._config_override.litellm_model = "analysis-route"
+        analyzer._config_override.litellm_fallback_models = []
+        analyzer._config_override.llm_model_list = [
+            {
+                "model_name": "analysis-route",
+                "litellm_params": {"model": "openai/~anthropic/claude-sonnet-latest"},
+            },
+        ]
+        response = SimpleNamespace(
+            model="anthropic/claude-sonnet-4.6",
+            choices=[SimpleNamespace(message=SimpleNamespace(content="复盘"))],
+            usage=None,
+        )
+
+        with patch.object(analyzer, "_dispatch_litellm_completion", return_value=response):
+            result = analyzer.generate_text_with_metadata("写一份复盘")
+
+        assert result is not None
+        assert result.backend == "litellm"
+        assert result.model == "anthropic/claude-sonnet-4.6"
+        assert result.provider == "openrouter"
+        assert result.usage["provider"] == "openrouter"
+        assert result.usage["response_model"] == "anthropic/claude-sonnet-4.6"
+
     @pytest.mark.parametrize(
         "configured_model,response_model",
         [
@@ -833,7 +861,10 @@ class TestAnalyzerGenerateText:
             fallbackable=True,
             backend="litellm",
             provider="gemini",
-            details={"reason": "invalid_json"},
+            details={
+                "reason": "invalid_json",
+                "route_name": "invalid-shared-route",
+            },
         )
         primary_backend = MagicMock(spec=GenerationBackend)
         primary_backend.generate.side_effect = primary_error
@@ -851,6 +882,7 @@ class TestAnalyzerGenerateText:
         assert error.stage == "fallback"
         assert error.error_code is GenerationErrorCode.INVALID_JSON
         assert error.details["reason"] == "fallback_backend_failed"
+        assert error.details["route_name"] == "invalid-shared-route"
         assert error.details["primary_error"]["error_code"] == "command_not_found"
         assert error.details["primary_error"]["details"]["reason"] == "executable_not_found"
         assert error.details["fallback_error"]["error_code"] == "invalid_json"
@@ -3321,6 +3353,34 @@ class TestMarketAnalyzerBypassFix:
         assert recorded.call_args.kwargs["provider"] == "anthropic"
         assert recorded.call_args.kwargs["model"] == "analysis-route"
 
+    def test_market_review_preserves_openrouter_provider_for_latest_alias(self):
+        from src.market_analyzer import MarketOverview
+
+        ma = self._make_market_analyzer_with_mock_generate_text("复盘结果")
+        ma.analyzer.get_generation_backend_identity.return_value = ("codex_cli", "codex_cli")
+        ma.config.llm_model_list = [
+            {
+                "model_name": "analysis-route",
+                "litellm_params": {"model": "openai/~anthropic/claude-sonnet-latest"},
+            },
+        ]
+        ma.analyzer.generate_text_with_metadata.return_value = SimpleNamespace(
+            text="复盘结果",
+            provider="anthropic",
+            model="analysis-route",
+            backend="litellm",
+            usage={"response_model": "anthropic/claude-sonnet-4.6"},
+        )
+
+        with patch("src.market_analyzer.record_llm_run_started") as started, \
+             patch("src.market_analyzer.record_llm_run") as recorded:
+            ma.generate_market_review(MarketOverview(date="2026-03-05"), [])
+
+        assert started.call_args.kwargs["provider"] == "codex_cli"
+        assert started.call_args.kwargs["model"] == "codex_cli"
+        assert recorded.call_args.kwargs["provider"] == "openrouter"
+        assert recorded.call_args.kwargs["model"] == "analysis-route"
+
     def test_market_review_records_failed_fallback_last_model(self):
         from src.analyzer import _AllModelsFailedError
         from src.llm.generation_backend import GenerationError
@@ -3355,6 +3415,61 @@ class TestMarketAnalyzerBypassFix:
         assert started.call_args.kwargs["model"] == "codex_cli"
         assert recorded.call_args.kwargs["provider"] == "anthropic"
         assert recorded.call_args.kwargs["model"] == "analysis-route"
+        assert recorded.call_args.kwargs["success"] is False
+
+    def test_market_review_records_nested_fallback_route_on_failure(self):
+        from src.llm.generation_backend import GenerationBackend, GenerationError, GenerationErrorCode
+        from src.market_analyzer import MarketOverview
+
+        ma = self._make_market_analyzer_with_mock_generate_text(return_value=None)
+        ma.analyzer._config_override.generation_backend = "codex_cli"
+        ma.analyzer._config_override.generation_fallback_backend = "litellm"
+        ma.analyzer.get_generation_backend_identity.return_value = ("codex_cli", "codex_cli")
+        ma.analyzer.get_generation_backend_config_error = MagicMock(return_value=None)
+        ma.analyzer.generate_text_with_metadata = ma.analyzer.__class__.generate_text_with_metadata.__get__(
+            ma.analyzer,
+            ma.analyzer.__class__,
+        )
+        primary_error = GenerationError(
+            error_code=GenerationErrorCode.COMMAND_NOT_FOUND,
+            stage="configuration",
+            retryable=False,
+            fallbackable=True,
+            backend="codex_cli",
+            provider="codex_cli",
+            details={"reason": "executable_not_found"},
+        )
+        fallback_error = GenerationError(
+            error_code=GenerationErrorCode.INVALID_JSON,
+            stage="validation",
+            retryable=True,
+            fallbackable=True,
+            backend="litellm",
+            provider="hermes",
+            details={
+                "reason": "mixed_hermes_route_unsupported",
+                "route_name": "invalid-shared-route",
+            },
+        )
+        primary_backend = MagicMock(spec=GenerationBackend)
+        primary_backend.generate.side_effect = primary_error
+        fallback_backend = MagicMock(spec=GenerationBackend)
+        fallback_backend.generate.side_effect = fallback_error
+
+        def _backend_for(backend_id):
+            return primary_backend if backend_id == "codex_cli" else fallback_backend
+
+        with patch.object(ma.analyzer, "_get_generation_backend", side_effect=_backend_for), \
+             patch("src.market_analyzer.record_llm_run_started") as started, \
+             patch("src.market_analyzer.record_llm_run") as recorded:
+            with pytest.raises(GenerationError) as exc_info:
+                ma.generate_market_review(MarketOverview(date="2026-03-05"), [])
+
+        assert exc_info.value.details["route_name"] == "invalid-shared-route"
+        assert started.call_args.kwargs["provider"] == "codex_cli"
+        assert started.call_args.kwargs["model"] == "codex_cli"
+        assert recorded.call_args.kwargs["provider"] == "hermes"
+        assert recorded.call_args.kwargs["model"] == "invalid-shared-route"
         assert recorded.call_args.kwargs["success"] is False
 
     def test_market_review_preserves_template_fallback_for_primary_litellm_exhaustion(self):

--- a/tests/test_market_analyzer_generate_text.py
+++ b/tests/test_market_analyzer_generate_text.py
@@ -426,6 +426,44 @@ class TestAnalyzerGenerateText:
         assert exc_info.value.last_model == "analysis-route"
         assert exc_info.value.last_provider == "anthropic"
 
+    def test_call_litellm_impl_uses_last_router_deployment_provider_for_alias_failure(self):
+        from src.analyzer import _AllModelsFailedError
+
+        class RouterTransportError(RuntimeError):
+            def __init__(self):
+                super().__init__("router transport error")
+                self.model = "anthropic/claude-sonnet-test"
+                self.llm_provider = "anthropic"
+
+        analyzer = self._make_analyzer()
+        analyzer._router = MagicMock()
+        analyzer._config_override.litellm_model = "analysis-route"
+        analyzer._config_override.litellm_fallback_models = []
+        analyzer._config_override.llm_model_list = [
+            {
+                "model_name": "analysis-route",
+                "litellm_params": {"model": "openai/gpt-4o-mini"},
+            },
+            {
+                "model_name": "analysis-route",
+                "litellm_params": {"model": "anthropic/claude-sonnet-test"},
+            },
+        ]
+
+        with patch.object(
+            analyzer,
+            "_dispatch_litellm_completion",
+            side_effect=RouterTransportError(),
+        ):
+            with pytest.raises(_AllModelsFailedError) as exc_info:
+                analyzer._call_litellm_impl(
+                    "写一份复盘",
+                    {"max_tokens": 128, "temperature": 0.7},
+                )
+
+        assert exc_info.value.last_model == "anthropic/claude-sonnet-test"
+        assert exc_info.value.last_provider == "anthropic"
+
     @pytest.mark.parametrize(
         ("generation_backend", "executable_name"),
         [
@@ -3003,6 +3041,63 @@ class TestMarketAnalyzerBypassFix:
             assert exc_info.value.details["requested_backend"] == "codex"
             template_review.assert_not_called()
             mock_record_llm_run.assert_called_once()
+
+    def test_generation_backend_config_error_records_failing_route_model(self):
+        from src.llm.generation_backend import GenerationError, GenerationErrorCode
+        from src.market_analyzer import MarketOverview
+
+        ma = self._make_market_analyzer_with_mock_generate_text(return_value=None)
+        ma.analyzer.get_generation_backend_config_error = MagicMock(return_value=GenerationError(
+            error_code=GenerationErrorCode.UNSAFE_CONFIG,
+            stage="configuration",
+            retryable=False,
+            fallbackable=False,
+            backend="litellm",
+            provider="hermes",
+            details={
+                "reason": "invalid_model",
+                "field": "LLM_HERMES_MODELS",
+            },
+        ))
+        ma.config.litellm_model = "bad hermes route"
+
+        with patch("src.market_analyzer.record_llm_run") as mock_record_llm_run:
+            with pytest.raises(GenerationError):
+                ma.generate_market_review(MarketOverview(date="2026-03-05"), [])
+
+        diagnostic = mock_record_llm_run.call_args.kwargs
+        assert diagnostic["provider"] == "hermes"
+        assert diagnostic["model"] == "bad hermes route"
+        assert diagnostic["success"] is False
+
+    def test_generation_backend_config_error_prefers_route_name_diagnostics(self):
+        from src.llm.generation_backend import GenerationError, GenerationErrorCode
+        from src.market_analyzer import MarketOverview
+
+        ma = self._make_market_analyzer_with_mock_generate_text(return_value=None)
+        ma.analyzer.get_generation_backend_config_error = MagicMock(return_value=GenerationError(
+            error_code=GenerationErrorCode.UNSAFE_CONFIG,
+            stage="configuration",
+            retryable=False,
+            fallbackable=False,
+            backend="litellm",
+            provider="hermes",
+            details={
+                "reason": "mixed_hermes_route_unsupported",
+                "field": "LLM_CHANNELS",
+                "route_name": "invalid-shared-route",
+            },
+        ))
+        ma.config.litellm_model = "configured-primary-route"
+
+        with patch("src.market_analyzer.record_llm_run") as mock_record_llm_run:
+            with pytest.raises(GenerationError):
+                ma.generate_market_review(MarketOverview(date="2026-03-05"), [])
+
+        diagnostic = mock_record_llm_run.call_args.kwargs
+        assert diagnostic["provider"] == "hermes"
+        assert diagnostic["model"] == "invalid-shared-route"
+        assert diagnostic["success"] is False
 
     def test_market_review_uses_8192_max_tokens(self):
         """generate_market_review() should request a larger output budget to avoid truncation."""

--- a/tests/test_market_analyzer_generate_text.py
+++ b/tests/test_market_analyzer_generate_text.py
@@ -206,6 +206,27 @@ class TestAnalyzerGenerateText:
         assert result == "复盘"
         mock_persist.assert_not_called()
 
+    def test_generate_text_with_metadata_returns_actual_backend_result(self):
+        from src.llm.generation_backend import GenerationResult
+
+        analyzer = self._make_analyzer()
+        generation_result = GenerationResult(
+            text="复盘",
+            provider="codex_cli",
+            model="codex_cli",
+            backend="codex_cli",
+            usage={"usage_available": False, "usage_source": "unavailable"},
+        )
+        with patch.object(analyzer, "_call_litellm", return_value=generation_result) as mock_call:
+            result = analyzer.generate_text_with_metadata("写一份复盘")
+
+        assert result is generation_result
+        mock_call.assert_called_once_with(
+            "写一份复盘",
+            generation_config={"max_tokens": 2048, "temperature": 0.7},
+            return_generation_result=True,
+        )
+
     @pytest.mark.parametrize(
         ("generation_backend", "executable_name"),
         [
@@ -2621,7 +2642,21 @@ class TestMarketAnalyzerBypassFix:
             analyzer._router = None
             analyzer._litellm_available = True
             analyzer._config_override = cfg
-            analyzer.generate_text = MagicMock(return_value=return_value)
+            analyzer.get_generation_backend_identity = MagicMock(
+                return_value=("litellm", cfg.litellm_model)
+            )
+            analyzer.generate_text_with_metadata = MagicMock(
+                return_value=(
+                    None
+                    if return_value is None
+                    else SimpleNamespace(
+                        text=return_value,
+                        provider="litellm",
+                        model=cfg.litellm_model,
+                        backend="litellm",
+                    )
+                )
+            )
 
             ma = MarketAnalyzer.__new__(MarketAnalyzer)
             ma.analyzer = analyzer
@@ -2632,16 +2667,15 @@ class TestMarketAnalyzerBypassFix:
             return ma
 
     def test_no_access_to_private_model_attribute(self):
-        """generate_text() must be called; _model must never be accessed."""
+        """The public metadata API must be called; _model must never be accessed."""
         ma = self._make_market_analyzer_with_mock_generate_text("复盘结果")
         # Ensure _model attribute does not exist (simulates PR #494 state)
         assert not hasattr(ma.analyzer, "_model") or ma.analyzer._model is None, (
             "_model should not be set on the LiteLLM-based analyzer"
         )
-        # generate_text is a MagicMock, so calling it won't crash
-        result = ma.analyzer.generate_text("prompt")
-        assert isinstance(result, str) and len(result) > 0
-        ma.analyzer.generate_text.assert_called_once()
+        result = ma.analyzer.generate_text_with_metadata("prompt")
+        assert result.text == "复盘结果"
+        ma.analyzer.generate_text_with_metadata.assert_called_once()
 
     def test_generate_text_none_falls_back_to_template(self):
         """generate_market_review() falls back to template when generate_text returns None."""
@@ -2662,7 +2696,7 @@ class TestMarketAnalyzerBypassFix:
         )
         result = ma.generate_market_review(overview, [])
         assert isinstance(result, str) and len(result) > 0
-        ma.analyzer.generate_text.assert_called_once()
+        ma.analyzer.generate_text_with_metadata.assert_called_once()
 
     def test_generation_backend_config_error_does_not_template_fallback(self):
         from src.llm.generation_backend import GenerationError
@@ -2691,7 +2725,7 @@ class TestMarketAnalyzerBypassFix:
         assert exc_info.value.details["field"] == "GENERATION_BACKEND"
         assert exc_info.value.details["requested_backend"] == "codex"
         template_review.assert_not_called()
-        ma.analyzer.generate_text.assert_not_called()
+        ma.analyzer.generate_text_with_metadata.assert_not_called()
         mock_record_llm_run.assert_called_once()
         diagnostic = mock_record_llm_run.call_args.kwargs
         assert diagnostic["success"] is False
@@ -2704,7 +2738,7 @@ class TestMarketAnalyzerBypassFix:
         from src.market_analyzer import MarketOverview, MarketIndex
 
         ma = self._make_market_analyzer_with_mock_generate_text(return_value=None)
-        ma.analyzer.generate_text.side_effect = GenerationError(
+        ma.analyzer.generate_text_with_metadata.side_effect = GenerationError(
             error_code=GenerationErrorCode.COMMAND_NOT_FOUND,
             stage="configuration",
             retryable=False,
@@ -2792,10 +2826,52 @@ class TestMarketAnalyzerBypassFix:
         result = ma.generate_market_review(overview, [])
 
         assert isinstance(result, str) and len(result) > 0
-        ma.analyzer.generate_text.assert_called_once()
-        _, kwargs = ma.analyzer.generate_text.call_args
+        ma.analyzer.generate_text_with_metadata.assert_called_once()
+        _, kwargs = ma.analyzer.generate_text_with_metadata.call_args
         assert kwargs["max_tokens"] == 8192
         assert kwargs["temperature"] == 0.7
+
+    def test_market_review_records_actual_codex_backend(self):
+        from src.market_analyzer import MarketOverview
+
+        ma = self._make_market_analyzer_with_mock_generate_text("复盘结果")
+        ma.analyzer.get_generation_backend_identity.return_value = ("codex_cli", "codex_cli")
+        ma.analyzer.generate_text_with_metadata.return_value = SimpleNamespace(
+            text="复盘结果",
+            provider="codex_cli",
+            model="codex_cli",
+            backend="codex_cli",
+        )
+
+        with patch("src.market_analyzer.record_llm_run_started") as started, \
+             patch("src.market_analyzer.record_llm_run") as recorded:
+            ma.generate_market_review(MarketOverview(date="2026-03-05"), [])
+
+        assert started.call_args.kwargs["provider"] == "codex_cli"
+        assert started.call_args.kwargs["model"] == "codex_cli"
+        assert recorded.call_args.kwargs["provider"] == "codex_cli"
+        assert recorded.call_args.kwargs["model"] == "codex_cli"
+
+    def test_market_review_records_actual_litellm_fallback(self):
+        from src.market_analyzer import MarketOverview
+
+        ma = self._make_market_analyzer_with_mock_generate_text("复盘结果")
+        ma.analyzer.get_generation_backend_identity.return_value = ("codex_cli", "codex_cli")
+        ma.analyzer.generate_text_with_metadata.return_value = SimpleNamespace(
+            text="复盘结果",
+            provider="openai",
+            model="openai/qwen3.7-max",
+            backend="litellm",
+        )
+
+        with patch("src.market_analyzer.record_llm_run_started") as started, \
+             patch("src.market_analyzer.record_llm_run") as recorded:
+            ma.generate_market_review(MarketOverview(date="2026-03-05"), [])
+
+        assert started.call_args.kwargs["provider"] == "codex_cli"
+        assert started.call_args.kwargs["model"] == "codex_cli"
+        assert recorded.call_args.kwargs["provider"] == "openai"
+        assert recorded.call_args.kwargs["model"] == "openai/qwen3.7-max"
 
     def test_generate_template_review_uses_english_shell_for_cn_when_report_language_is_en(self):
         from src.market_analyzer import MarketOverview, MarketIndex

--- a/tests/test_market_analyzer_generate_text.py
+++ b/tests/test_market_analyzer_generate_text.py
@@ -2951,6 +2951,55 @@ class TestMarketAnalyzerBypassFix:
         assert recorded.call_args.kwargs["provider"] == "openai"
         assert recorded.call_args.kwargs["model"] == "openai/qwen3.7-max"
 
+    def test_market_review_prefers_generation_usage_provider_when_recording(self):
+        from src.market_analyzer import MarketOverview
+
+        ma = self._make_market_analyzer_with_mock_generate_text("复盘结果")
+        ma.analyzer.get_generation_backend_identity.return_value = ("codex_cli", "codex_cli")
+        ma.analyzer.generate_text_with_metadata.return_value = SimpleNamespace(
+            text="复盘结果",
+            provider="openai",
+            model="analysis-route",
+            backend="litellm",
+            usage={"provider": "anthropic"},
+        )
+
+        with patch("src.market_analyzer.record_llm_run_started") as started, \
+             patch("src.market_analyzer.record_llm_run") as recorded:
+            ma.generate_market_review(MarketOverview(date="2026-03-05"), [])
+
+        assert started.call_args.kwargs["provider"] == "codex_cli"
+        assert started.call_args.kwargs["model"] == "codex_cli"
+        assert recorded.call_args.kwargs["provider"] == "anthropic"
+        assert recorded.call_args.kwargs["model"] == "analysis-route"
+
+    def test_market_review_resolves_litellm_alias_provider_before_recording(self):
+        from src.market_analyzer import MarketOverview
+
+        ma = self._make_market_analyzer_with_mock_generate_text("复盘结果")
+        ma.analyzer.get_generation_backend_identity.return_value = ("codex_cli", "codex_cli")
+        ma.config.llm_model_list = [
+            {
+                "model_name": "analysis-route",
+                "litellm_params": {"model": "anthropic/claude-sonnet-test"},
+            }
+        ]
+        ma.analyzer.generate_text_with_metadata.return_value = SimpleNamespace(
+            text="复盘结果",
+            provider="openai",
+            model="analysis-route",
+            backend="litellm",
+        )
+
+        with patch("src.market_analyzer.record_llm_run_started") as started, \
+             patch("src.market_analyzer.record_llm_run") as recorded:
+            ma.generate_market_review(MarketOverview(date="2026-03-05"), [])
+
+        assert started.call_args.kwargs["provider"] == "codex_cli"
+        assert started.call_args.kwargs["model"] == "codex_cli"
+        assert recorded.call_args.kwargs["provider"] == "anthropic"
+        assert recorded.call_args.kwargs["model"] == "analysis-route"
+
     def test_market_review_records_failed_fallback_last_model(self):
         from src.analyzer import _AllModelsFailedError
         from src.llm.generation_backend import GenerationError

--- a/tests/test_market_analyzer_generate_text.py
+++ b/tests/test_market_analyzer_generate_text.py
@@ -285,6 +285,34 @@ class TestAnalyzerGenerateText:
         assert result.usage["provider"] == "anthropic"
         assert result.usage["response_model"] == "anthropic/claude-sonnet-test"
 
+    def test_generate_text_with_metadata_preserves_fallback_provider_for_unqualified_response_model(self):
+        analyzer = self._make_analyzer()
+        analyzer._config_override.generation_backend = "litellm"
+        analyzer._config_override.generation_fallback_backend = ""
+        analyzer._config_override.litellm_model = "analysis-route"
+        analyzer._config_override.litellm_fallback_models = []
+        analyzer._config_override.llm_model_list = [
+            {
+                "model_name": "analysis-route",
+                "litellm_params": {"model": "anthropic/claude-sonnet-test"},
+            },
+        ]
+        response = SimpleNamespace(
+            model="claude-sonnet-test",
+            choices=[SimpleNamespace(message=SimpleNamespace(content="复盘"))],
+            usage=None,
+        )
+
+        with patch.object(analyzer, "_dispatch_litellm_completion", return_value=response):
+            result = analyzer.generate_text_with_metadata("写一份复盘")
+
+        assert result is not None
+        assert result.backend == "litellm"
+        assert result.model == "claude-sonnet-test"
+        assert result.provider == "anthropic"
+        assert result.usage["provider"] == "anthropic"
+        assert result.usage["response_model"] == "claude-sonnet-test"
+
     def test_generate_text_with_metadata_preserves_exhausted_fallback_failure(self):
         from src.analyzer import _AllModelsFailedError
         from src.llm.generation_backend import GenerationError

--- a/tests/test_market_analyzer_generate_text.py
+++ b/tests/test_market_analyzer_generate_text.py
@@ -503,6 +503,40 @@ class TestAnalyzerGenerateText:
         assert exc_info.value.last_model == "anthropic/claude-sonnet-test"
         assert exc_info.value.last_provider == "anthropic"
 
+    def test_call_litellm_impl_prefers_transport_provider_for_unqualified_failure_model(self):
+        from src.analyzer import _AllModelsFailedError
+
+        class RouterTransportError(RuntimeError):
+            def __init__(self):
+                super().__init__("router transport error")
+                self.deployment_model = "claude-sonnet-test"
+                self.llm_provider = "anthropic"
+
+        analyzer = self._make_analyzer()
+        analyzer._router = MagicMock()
+        analyzer._config_override.litellm_model = "analysis-route"
+        analyzer._config_override.litellm_fallback_models = []
+        analyzer._config_override.llm_model_list = [
+            {
+                "model_name": "analysis-route",
+                "litellm_params": {"model": "anthropic/claude-sonnet-test"},
+            },
+        ]
+
+        with patch.object(
+            analyzer,
+            "_dispatch_litellm_completion",
+            side_effect=RouterTransportError(),
+        ):
+            with pytest.raises(_AllModelsFailedError) as exc_info:
+                analyzer._call_litellm_impl(
+                    "写一份复盘",
+                    {"max_tokens": 128, "temperature": 0.7},
+                )
+
+        assert exc_info.value.last_model == "claude-sonnet-test"
+        assert exc_info.value.last_provider == "anthropic"
+
     @pytest.mark.parametrize(
         ("generation_backend", "executable_name"),
         [

--- a/tests/test_market_analyzer_generate_text.py
+++ b/tests/test_market_analyzer_generate_text.py
@@ -313,6 +313,45 @@ class TestAnalyzerGenerateText:
         assert result.usage["provider"] == "anthropic"
         assert result.usage["response_model"] == "claude-sonnet-test"
 
+    @pytest.mark.parametrize(
+        "configured_model,response_model",
+        [
+            ("openai/Qwen/Qwen3-235B-A22B-Thinking-2507", "Qwen/Qwen3-235B-A22B-Thinking-2507"),
+            ("openai/deepseek-ai/DeepSeek-V3", "deepseek-ai/DeepSeek-V3"),
+        ],
+    )
+    def test_generate_text_with_metadata_preserves_fallback_provider_for_gateway_slash_model_ids(
+        self,
+        configured_model,
+        response_model,
+    ):
+        analyzer = self._make_analyzer()
+        analyzer._config_override.generation_backend = "litellm"
+        analyzer._config_override.generation_fallback_backend = ""
+        analyzer._config_override.litellm_model = "analysis-route"
+        analyzer._config_override.litellm_fallback_models = []
+        analyzer._config_override.llm_model_list = [
+            {
+                "model_name": "analysis-route",
+                "litellm_params": {"model": configured_model},
+            },
+        ]
+        response = SimpleNamespace(
+            model=response_model,
+            choices=[SimpleNamespace(message=SimpleNamespace(content="复盘"))],
+            usage=None,
+        )
+
+        with patch.object(analyzer, "_dispatch_litellm_completion", return_value=response):
+            result = analyzer.generate_text_with_metadata("写一份复盘")
+
+        assert result is not None
+        assert result.backend == "litellm"
+        assert result.model == response_model
+        assert result.provider == "openai"
+        assert result.usage["provider"] == "openai"
+        assert result.usage["response_model"] == response_model
+
     def test_generate_text_with_metadata_preserves_exhausted_fallback_failure(self):
         from src.analyzer import _AllModelsFailedError
         from src.llm.generation_backend import GenerationError

--- a/tests/test_market_analyzer_generate_text.py
+++ b/tests/test_market_analyzer_generate_text.py
@@ -227,6 +227,33 @@ class TestAnalyzerGenerateText:
             return_generation_result=True,
         )
 
+    def test_generate_text_with_metadata_preserves_exhausted_fallback_failure(self):
+        from src.analyzer import _AllModelsFailedError
+        from src.llm.generation_backend import GenerationError
+
+        analyzer = self._make_analyzer()
+        analyzer._config_override.generation_backend = "codex_cli"
+        analyzer._config_override.generation_fallback_backend = "litellm"
+        exhausted = _AllModelsFailedError(
+            "all fallback models failed",
+            last_model="openai/qwen3.7-max",
+            last_usage={},
+        )
+
+        with patch.object(analyzer, "_call_litellm", side_effect=exhausted):
+            with pytest.raises(GenerationError) as exc_info:
+                analyzer.generate_text_with_metadata("写一份复盘")
+
+        error = exc_info.value
+        assert error.stage == "fallback"
+        assert error.backend == "litellm"
+        assert error.details == {
+            "reason": "all_models_failed",
+            "configured_primary_backend": "codex_cli",
+            "configured_fallback_backend": "litellm",
+            "last_model": "openai/qwen3.7-max",
+        }
+
     @pytest.mark.parametrize(
         ("generation_backend", "executable_name"),
         [

--- a/tests/test_market_analyzer_generate_text.py
+++ b/tests/test_market_analyzer_generate_text.py
@@ -227,6 +227,32 @@ class TestAnalyzerGenerateText:
             return_generation_result=True,
         )
 
+    def test_generate_text_with_metadata_resolves_router_alias_provider(self):
+        analyzer = self._make_analyzer()
+        analyzer._config_override.generation_backend = "litellm"
+        analyzer._config_override.generation_fallback_backend = ""
+        analyzer._config_override.litellm_model = "analysis-route"
+        analyzer._config_override.litellm_fallback_models = []
+        analyzer._config_override.llm_model_list = [
+            {
+                "model_name": "analysis-route",
+                "litellm_params": {"model": "anthropic/claude-sonnet-test"},
+            }
+        ]
+        response = SimpleNamespace(
+            choices=[SimpleNamespace(message=SimpleNamespace(content="复盘"))],
+            usage=None,
+        )
+
+        with patch.object(analyzer, "_dispatch_litellm_completion", return_value=response):
+            result = analyzer.generate_text_with_metadata("写一份复盘")
+
+        assert result is not None
+        assert result.backend == "litellm"
+        assert result.model == "analysis-route"
+        assert result.provider == "anthropic"
+        assert result.usage["provider"] == "anthropic"
+
     def test_generate_text_with_metadata_preserves_exhausted_fallback_failure(self):
         from src.analyzer import _AllModelsFailedError
         from src.llm.generation_backend import GenerationError
@@ -2934,6 +2960,7 @@ class TestMarketAnalyzerBypassFix:
         ma.analyzer._config_override.generation_backend = "codex_cli"
         ma.analyzer._config_override.generation_fallback_backend = "litellm"
         ma.analyzer.get_generation_backend_identity.return_value = ("codex_cli", "codex_cli")
+        ma.analyzer.get_generation_backend_config_error = MagicMock(return_value=None)
         ma.analyzer.generate_text_with_metadata = ma.analyzer.__class__.generate_text_with_metadata.__get__(
             ma.analyzer,
             ma.analyzer.__class__,

--- a/tests/test_market_analyzer_generate_text.py
+++ b/tests/test_market_analyzer_generate_text.py
@@ -262,7 +262,8 @@ class TestAnalyzerGenerateText:
         analyzer._config_override.generation_fallback_backend = "litellm"
         exhausted = _AllModelsFailedError(
             "all fallback models failed",
-            last_model="openai/qwen3.7-max",
+            last_model="analysis-route",
+            last_provider="anthropic",
             last_usage={},
         )
 
@@ -273,11 +274,12 @@ class TestAnalyzerGenerateText:
         error = exc_info.value
         assert error.stage == "fallback"
         assert error.backend == "litellm"
+        assert error.provider == "anthropic"
         assert error.details == {
             "reason": "all_models_failed",
             "configured_primary_backend": "codex_cli",
             "configured_fallback_backend": "litellm",
-            "last_model": "openai/qwen3.7-max",
+            "last_model": "analysis-route",
         }
 
     def test_call_litellm_impl_tracks_last_model_when_all_attempts_fail(self):
@@ -304,6 +306,34 @@ class TestAnalyzerGenerateText:
                 )
 
         assert exc_info.value.last_model == "openai/fallback-model"
+        assert exc_info.value.last_provider == "openai"
+
+    def test_call_litellm_impl_preserves_resolved_provider_for_router_alias_failure(self):
+        from src.analyzer import _AllModelsFailedError
+
+        analyzer = self._make_analyzer()
+        analyzer._config_override.litellm_model = "analysis-route"
+        analyzer._config_override.litellm_fallback_models = []
+        analyzer._config_override.llm_model_list = [
+            {
+                "model_name": "analysis-route",
+                "litellm_params": {"model": "anthropic/claude-sonnet-test"},
+            }
+        ]
+
+        with patch.object(
+            analyzer,
+            "_dispatch_litellm_completion",
+            side_effect=RuntimeError("router transport error"),
+        ):
+            with pytest.raises(_AllModelsFailedError) as exc_info:
+                analyzer._call_litellm_impl(
+                    "写一份复盘",
+                    {"max_tokens": 128, "temperature": 0.7},
+                )
+
+        assert exc_info.value.last_model == "analysis-route"
+        assert exc_info.value.last_provider == "anthropic"
 
     @pytest.mark.parametrize(
         ("generation_backend", "executable_name"),
@@ -3016,7 +3046,8 @@ class TestMarketAnalyzerBypassFix:
         )
         exhausted = _AllModelsFailedError(
             "all fallback models failed",
-            last_model="openai/qwen3.7-max",
+            last_model="analysis-route",
+            last_provider="anthropic",
         )
 
         with patch.object(ma.analyzer, "_call_litellm", side_effect=exhausted), \
@@ -3027,11 +3058,12 @@ class TestMarketAnalyzerBypassFix:
 
         assert exc_info.value.stage == "fallback"
         assert exc_info.value.backend == "litellm"
-        assert exc_info.value.details["last_model"] == "openai/qwen3.7-max"
+        assert exc_info.value.provider == "anthropic"
+        assert exc_info.value.details["last_model"] == "analysis-route"
         assert started.call_args.kwargs["provider"] == "codex_cli"
         assert started.call_args.kwargs["model"] == "codex_cli"
-        assert recorded.call_args.kwargs["provider"] == "litellm"
-        assert recorded.call_args.kwargs["model"] == "openai/qwen3.7-max"
+        assert recorded.call_args.kwargs["provider"] == "anthropic"
+        assert recorded.call_args.kwargs["model"] == "analysis-route"
         assert recorded.call_args.kwargs["success"] is False
 
     def test_generate_template_review_uses_english_shell_for_cn_when_report_language_is_en(self):

--- a/tests/test_market_analyzer_generate_text.py
+++ b/tests/test_market_analyzer_generate_text.py
@@ -341,6 +341,34 @@ class TestAnalyzerGenerateText:
         assert result.usage["provider"] == "openrouter"
         assert result.usage["response_model"] == "anthropic/claude-sonnet-4.6"
 
+    def test_generate_text_with_metadata_preserves_openrouter_provider_for_latest_alias_deployment_echo(self):
+        analyzer = self._make_analyzer()
+        analyzer._config_override.generation_backend = "litellm"
+        analyzer._config_override.generation_fallback_backend = ""
+        analyzer._config_override.litellm_model = "analysis-route"
+        analyzer._config_override.litellm_fallback_models = []
+        analyzer._config_override.llm_model_list = [
+            {
+                "model_name": "analysis-route",
+                "litellm_params": {"model": "openai/~anthropic/claude-sonnet-latest"},
+            },
+        ]
+        response = SimpleNamespace(
+            model="openai/~anthropic/claude-sonnet-latest",
+            choices=[SimpleNamespace(message=SimpleNamespace(content="复盘"))],
+            usage=None,
+        )
+
+        with patch.object(analyzer, "_dispatch_litellm_completion", return_value=response):
+            result = analyzer.generate_text_with_metadata("写一份复盘")
+
+        assert result is not None
+        assert result.backend == "litellm"
+        assert result.model == "openai/~anthropic/claude-sonnet-latest"
+        assert result.provider == "openrouter"
+        assert result.usage["provider"] == "openrouter"
+        assert result.usage["response_model"] == "openai/~anthropic/claude-sonnet-latest"
+
     def test_generate_text_with_metadata_prefers_actual_response_model_provider_for_openrouter_first_duplicate_aliases(self):
         analyzer = self._make_analyzer()
         analyzer._config_override.generation_backend = "litellm"
@@ -3521,6 +3549,37 @@ class TestMarketAnalyzerBypassFix:
             model="analysis-route",
             backend="litellm",
             usage={"response_model": "anthropic/claude-sonnet-4.6"},
+        )
+
+        with patch("src.market_analyzer.record_llm_run_started") as started, \
+             patch("src.market_analyzer.record_llm_run") as recorded:
+            ma.generate_market_review(MarketOverview(date="2026-03-05"), [])
+
+        assert started.call_args.kwargs["provider"] == "codex_cli"
+        assert started.call_args.kwargs["model"] == "codex_cli"
+        assert recorded.call_args.kwargs["provider"] == "openrouter"
+        assert recorded.call_args.kwargs["model"] == "analysis-route"
+
+    def test_market_review_preserves_openrouter_provider_for_latest_alias_deployment_echo(self):
+        from src.market_analyzer import MarketOverview
+
+        ma = self._make_market_analyzer_with_mock_generate_text("复盘结果")
+        ma.analyzer.get_generation_backend_identity.return_value = ("codex_cli", "codex_cli")
+        ma.config.llm_model_list = [
+            {
+                "model_name": "analysis-route",
+                "litellm_params": {"model": "openai/~anthropic/claude-sonnet-latest"},
+            },
+        ]
+        ma.analyzer.generate_text_with_metadata.return_value = SimpleNamespace(
+            text="复盘结果",
+            provider="openai",
+            model="analysis-route",
+            backend="litellm",
+            usage={
+                "provider": "openai",
+                "response_model": "openai/~anthropic/claude-sonnet-latest",
+            },
         )
 
         with patch("src.market_analyzer.record_llm_run_started") as started, \

--- a/tests/test_market_analyzer_generate_text.py
+++ b/tests/test_market_analyzer_generate_text.py
@@ -2212,6 +2212,48 @@ class TestAnalyzerGenerateText:
         assert "贵州茅台" not in usage["known_dynamic_marker_positions"]
         assert "2026-06-19" not in usage["known_dynamic_marker_positions"]
 
+    def test_call_litellm_non_stream_preserves_resolved_provider_with_audit_context(self):
+        analyzer = self._make_analyzer()
+        analyzer._config_override = SimpleNamespace(
+            litellm_model="analysis-route",
+            litellm_fallback_models=[],
+            llm_model_list=[
+                {
+                    "model_name": "analysis-route",
+                    "litellm_params": {"model": "openai/gpt-4o-mini"},
+                },
+                {
+                    "model_name": "analysis-route",
+                    "litellm_params": {"model": "anthropic/claude-sonnet-test"},
+                },
+            ],
+        )
+        response = SimpleNamespace(
+            model="anthropic/claude-sonnet-test",
+            choices=[SimpleNamespace(message=SimpleNamespace(content="ok"))],
+            usage=SimpleNamespace(prompt_tokens=10, completion_tokens=1, total_tokens=11),
+        )
+
+        with patch.object(analyzer, "_dispatch_litellm_completion", return_value=response):
+            text, model_used, usage = analyzer._call_litellm(
+                "same user prompt 600519",
+                {"max_tokens": 128, "temperature": 0.2},
+                system_prompt="system prompt zh cn",
+                audit_context={
+                    "language": "zh",
+                    "market_group": "cn",
+                    "analysis_mode": "stock_analysis",
+                },
+            )
+
+        assert text == "ok"
+        assert model_used == "anthropic/claude-sonnet-test"
+        _assert_usage_contains(usage, {"prompt_tokens": 10, "completion_tokens": 1, "total_tokens": 11})
+        assert usage["provider"] == "anthropic"
+        assert usage["response_model"] == "anthropic/claude-sonnet-test"
+        assert usage["transport"] == "litellm"
+        assert usage["analysis_mode"] == "stock_analysis"
+
     def test_call_litellm_system_hmac_distinguishes_language_and_market_prompt(self):
         analyzer = self._make_analyzer()
         analyzer._config_override = SimpleNamespace(

--- a/tests/test_market_analyzer_generate_text.py
+++ b/tests/test_market_analyzer_generate_text.py
@@ -531,6 +531,40 @@ class TestAnalyzerGenerateText:
         assert exc_info.value.last_model == "anthropic/claude-sonnet-test"
         assert exc_info.value.last_provider == "anthropic"
 
+    def test_call_litellm_impl_preserves_openrouter_provider_for_exhausted_latest_alias_failure(self):
+        from src.analyzer import _AllModelsFailedError
+
+        class RouterTransportError(RuntimeError):
+            def __init__(self):
+                super().__init__("router transport error")
+                self.model = "openai/~anthropic/claude-sonnet-latest"
+                self.llm_provider = "openai"
+
+        analyzer = self._make_analyzer()
+        analyzer._router = MagicMock()
+        analyzer._config_override.litellm_model = "analysis-route"
+        analyzer._config_override.litellm_fallback_models = []
+        analyzer._config_override.llm_model_list = [
+            {
+                "model_name": "analysis-route",
+                "litellm_params": {"model": "openai/~anthropic/claude-sonnet-latest"},
+            },
+        ]
+
+        with patch.object(
+            analyzer,
+            "_dispatch_litellm_completion",
+            side_effect=RouterTransportError(),
+        ):
+            with pytest.raises(_AllModelsFailedError) as exc_info:
+                analyzer._call_litellm_impl(
+                    "写一份复盘",
+                    {"max_tokens": 128, "temperature": 0.7},
+                )
+
+        assert exc_info.value.last_model == "openai/~anthropic/claude-sonnet-latest"
+        assert exc_info.value.last_provider == "openrouter"
+
     def test_call_litellm_impl_prefers_transport_provider_for_unqualified_failure_model(self):
         from src.analyzer import _AllModelsFailedError
 
@@ -3415,6 +3449,48 @@ class TestMarketAnalyzerBypassFix:
         assert started.call_args.kwargs["model"] == "codex_cli"
         assert recorded.call_args.kwargs["provider"] == "anthropic"
         assert recorded.call_args.kwargs["model"] == "analysis-route"
+        assert recorded.call_args.kwargs["success"] is False
+
+    def test_market_review_records_openrouter_provider_for_exhausted_latest_alias_failure(self):
+        from src.analyzer import _AllModelsFailedError
+        from src.llm.generation_backend import GenerationError
+        from src.market_analyzer import MarketOverview
+
+        ma = self._make_market_analyzer_with_mock_generate_text(return_value=None)
+        ma.analyzer._config_override.generation_backend = "codex_cli"
+        ma.analyzer._config_override.generation_fallback_backend = "litellm"
+        ma.analyzer._config_override.llm_model_list = [
+            {
+                "model_name": "analysis-route",
+                "litellm_params": {"model": "openai/~anthropic/claude-sonnet-latest"},
+            },
+        ]
+        ma.analyzer.get_generation_backend_identity.return_value = ("codex_cli", "codex_cli")
+        ma.analyzer.get_generation_backend_config_error = MagicMock(return_value=None)
+        ma.analyzer.generate_text_with_metadata = ma.analyzer.__class__.generate_text_with_metadata.__get__(
+            ma.analyzer,
+            ma.analyzer.__class__,
+        )
+        exhausted = _AllModelsFailedError(
+            "all fallback models failed",
+            last_model="openai/~anthropic/claude-sonnet-latest",
+            last_provider="openrouter",
+        )
+
+        with patch.object(ma.analyzer, "_call_litellm", side_effect=exhausted), \
+             patch("src.market_analyzer.record_llm_run_started") as started, \
+             patch("src.market_analyzer.record_llm_run") as recorded:
+            with pytest.raises(GenerationError) as exc_info:
+                ma.generate_market_review(MarketOverview(date="2026-03-05"), [])
+
+        assert exc_info.value.stage == "fallback"
+        assert exc_info.value.backend == "litellm"
+        assert exc_info.value.provider == "openrouter"
+        assert exc_info.value.details["last_model"] == "openai/~anthropic/claude-sonnet-latest"
+        assert started.call_args.kwargs["provider"] == "codex_cli"
+        assert started.call_args.kwargs["model"] == "codex_cli"
+        assert recorded.call_args.kwargs["provider"] == "openrouter"
+        assert recorded.call_args.kwargs["model"] == "openai/~anthropic/claude-sonnet-latest"
         assert recorded.call_args.kwargs["success"] is False
 
     def test_market_review_records_nested_fallback_route_on_failure(self):

--- a/tests/test_market_analyzer_generate_text.py
+++ b/tests/test_market_analyzer_generate_text.py
@@ -341,6 +341,38 @@ class TestAnalyzerGenerateText:
         assert result.usage["provider"] == "openrouter"
         assert result.usage["response_model"] == "anthropic/claude-sonnet-4.6"
 
+    def test_generate_text_with_metadata_prefers_actual_response_model_provider_for_openrouter_first_duplicate_aliases(self):
+        analyzer = self._make_analyzer()
+        analyzer._config_override.generation_backend = "litellm"
+        analyzer._config_override.generation_fallback_backend = ""
+        analyzer._config_override.litellm_model = "analysis-route"
+        analyzer._config_override.litellm_fallback_models = []
+        analyzer._config_override.llm_model_list = [
+            {
+                "model_name": "analysis-route",
+                "litellm_params": {"model": "openai/~anthropic/claude-sonnet-latest"},
+            },
+            {
+                "model_name": "analysis-route",
+                "litellm_params": {"model": "anthropic/claude-sonnet-4.6"},
+            },
+        ]
+        response = SimpleNamespace(
+            model="anthropic/claude-sonnet-4.6",
+            choices=[SimpleNamespace(message=SimpleNamespace(content="复盘"))],
+            usage=None,
+        )
+
+        with patch.object(analyzer, "_dispatch_litellm_completion", return_value=response):
+            result = analyzer.generate_text_with_metadata("写一份复盘")
+
+        assert result is not None
+        assert result.backend == "litellm"
+        assert result.model == "anthropic/claude-sonnet-4.6"
+        assert result.provider == "anthropic"
+        assert result.usage["provider"] == "anthropic"
+        assert result.usage["response_model"] == "anthropic/claude-sonnet-4.6"
+
     @pytest.mark.parametrize(
         "configured_model,response_model",
         [
@@ -3413,6 +3445,38 @@ class TestMarketAnalyzerBypassFix:
         assert started.call_args.kwargs["provider"] == "codex_cli"
         assert started.call_args.kwargs["model"] == "codex_cli"
         assert recorded.call_args.kwargs["provider"] == "openrouter"
+        assert recorded.call_args.kwargs["model"] == "analysis-route"
+
+    def test_market_review_prefers_actual_response_model_provider_for_openrouter_first_duplicate_aliases(self):
+        from src.market_analyzer import MarketOverview
+
+        ma = self._make_market_analyzer_with_mock_generate_text("复盘结果")
+        ma.analyzer.get_generation_backend_identity.return_value = ("codex_cli", "codex_cli")
+        ma.config.llm_model_list = [
+            {
+                "model_name": "analysis-route",
+                "litellm_params": {"model": "openai/~anthropic/claude-sonnet-latest"},
+            },
+            {
+                "model_name": "analysis-route",
+                "litellm_params": {"model": "anthropic/claude-sonnet-4.6"},
+            },
+        ]
+        ma.analyzer.generate_text_with_metadata.return_value = SimpleNamespace(
+            text="复盘结果",
+            provider="openrouter",
+            model="analysis-route",
+            backend="litellm",
+            usage={"response_model": "anthropic/claude-sonnet-4.6"},
+        )
+
+        with patch("src.market_analyzer.record_llm_run_started") as started, \
+             patch("src.market_analyzer.record_llm_run") as recorded:
+            ma.generate_market_review(MarketOverview(date="2026-03-05"), [])
+
+        assert started.call_args.kwargs["provider"] == "codex_cli"
+        assert started.call_args.kwargs["model"] == "codex_cli"
+        assert recorded.call_args.kwargs["provider"] == "anthropic"
         assert recorded.call_args.kwargs["model"] == "analysis-route"
 
     def test_market_review_records_failed_fallback_last_model(self):

--- a/tests/test_market_analyzer_generate_text.py
+++ b/tests/test_market_analyzer_generate_text.py
@@ -625,6 +625,36 @@ class TestAnalyzerGenerateText:
         assert exc_info.value.last_model == "openai/~anthropic/claude-sonnet-latest"
         assert exc_info.value.last_provider == "openrouter"
 
+    def test_call_litellm_impl_preserves_response_model_for_empty_router_response(self):
+        from src.analyzer import _AllModelsFailedError
+
+        analyzer = self._make_analyzer()
+        analyzer._router = MagicMock()
+        analyzer._config_override.litellm_model = "analysis-route"
+        analyzer._config_override.litellm_fallback_models = []
+        analyzer._config_override.llm_model_list = [
+            {
+                "model_name": "analysis-route",
+                "litellm_params": {"model": "openai/~anthropic/claude-sonnet-latest"},
+            },
+        ]
+
+        response = SimpleNamespace(
+            model="anthropic/claude-sonnet-4.6",
+            choices=[SimpleNamespace(message=SimpleNamespace(content=None))],
+            usage=None,
+        )
+
+        with patch.object(analyzer, "_dispatch_litellm_completion", return_value=response):
+            with pytest.raises(_AllModelsFailedError) as exc_info:
+                analyzer._call_litellm_impl(
+                    "写一份复盘",
+                    {"max_tokens": 128, "temperature": 0.7},
+                )
+
+        assert exc_info.value.last_model == "anthropic/claude-sonnet-4.6"
+        assert exc_info.value.last_provider == "openrouter"
+
     def test_call_litellm_impl_prefers_transport_provider_for_unqualified_failure_model(self):
         from src.analyzer import _AllModelsFailedError
 
@@ -3700,6 +3730,49 @@ class TestMarketAnalyzerBypassFix:
         assert recorded.call_args.kwargs["provider"] == "openrouter"
         assert recorded.call_args.kwargs["model"] == "openai/~anthropic/claude-sonnet-latest"
         assert recorded.call_args.kwargs["success"] is False
+
+    def test_market_review_records_response_model_for_empty_router_response_failure(self):
+        from src.market_analyzer import MarketOverview
+
+        ma = self._make_market_analyzer_with_mock_generate_text(return_value=None)
+        ma.analyzer._router = MagicMock()
+        ma.analyzer._config_override.generation_backend = "litellm"
+        ma.analyzer._config_override.generation_fallback_backend = ""
+        ma.analyzer._config_override.litellm_model = "analysis-route"
+        ma.analyzer._config_override.litellm_fallback_models = []
+        ma.analyzer._config_override.llm_model_list = [
+            {
+                "model_name": "analysis-route",
+                "litellm_params": {"model": "openai/~anthropic/claude-sonnet-latest"},
+            },
+        ]
+        ma.config.llm_model_list = ma.analyzer._config_override.llm_model_list
+        ma.analyzer.get_generation_backend_identity.return_value = ("litellm", "analysis-route")
+        ma.analyzer.get_generation_backend_config_error = MagicMock(return_value=None)
+        ma.analyzer.generate_text_with_metadata = ma.analyzer.__class__.generate_text_with_metadata.__get__(
+            ma.analyzer,
+            ma.analyzer.__class__,
+        )
+        response = SimpleNamespace(
+            model="anthropic/claude-sonnet-4.6",
+            choices=[SimpleNamespace(message=SimpleNamespace(content=None))],
+            usage=None,
+        )
+
+        with patch.object(ma.analyzer, "_dispatch_litellm_completion", return_value=response), \
+             patch.object(ma, "_generate_template_review", wraps=ma._generate_template_review) as template_review, \
+             patch("src.market_analyzer.record_llm_run_started") as started, \
+             patch("src.market_analyzer.record_llm_run") as recorded:
+            result = ma.generate_market_review(MarketOverview(date="2026-03-05"), [])
+
+        assert isinstance(result, str) and len(result) > 0
+        template_review.assert_called_once()
+        assert started.call_args.kwargs["provider"] == "litellm"
+        assert started.call_args.kwargs["model"] == "analysis-route"
+        assert recorded.call_args.kwargs["provider"] == "openrouter"
+        assert recorded.call_args.kwargs["model"] == "anthropic/claude-sonnet-4.6"
+        assert recorded.call_args.kwargs["success"] is False
+        assert recorded.call_args.kwargs["error_type"] == "AllModelsFailed"
 
     def test_market_review_records_nested_fallback_route_on_failure(self):
         from src.llm.generation_backend import GenerationBackend, GenerationError, GenerationErrorCode

--- a/tests/test_market_analyzer_generate_text.py
+++ b/tests/test_market_analyzer_generate_text.py
@@ -3333,10 +3333,10 @@ class TestMarketAnalyzerBypassFix:
                 "temperature": 0.7,
             }
         ]
-        assert started.call_args.kwargs["provider"] == "litellm"
-        assert started.call_args.kwargs["model"] == ma.config.litellm_model
-        assert recorded.call_args.kwargs["provider"] == "gemini"
-        assert recorded.call_args.kwargs["model"] == ma.config.litellm_model
+        assert started.call_args.kwargs["provider"] == "legacy_analyzer"
+        assert started.call_args.kwargs["model"] == "legacy_analyzer"
+        assert recorded.call_args.kwargs["provider"] == "legacy_analyzer"
+        assert recorded.call_args.kwargs["model"] == "legacy_analyzer"
 
     def test_market_review_legacy_injected_analyzer_ignores_invalid_backend_config(self):
         from src.market_analyzer import MarketOverview
@@ -3364,8 +3364,8 @@ class TestMarketAnalyzerBypassFix:
 
         with patch.object(ma, "_build_review_prompt", return_value="legacy prompt"), \
              patch.object(ma, "_inject_data_into_review", return_value="渲染后复盘"), \
-             patch("src.market_analyzer.record_llm_run_started"), \
-             patch("src.market_analyzer.record_llm_run"):
+             patch("src.market_analyzer.record_llm_run_started") as started, \
+             patch("src.market_analyzer.record_llm_run") as recorded:
             result = ma.generate_market_review(MarketOverview(date="2026-03-05"), [])
 
         assert result == "渲染后复盘"
@@ -3376,6 +3376,10 @@ class TestMarketAnalyzerBypassFix:
                 "temperature": 0.7,
             }
         ]
+        assert started.call_args.kwargs["provider"] == "legacy_analyzer"
+        assert started.call_args.kwargs["model"] == "legacy_analyzer"
+        assert recorded.call_args.kwargs["provider"] == "legacy_analyzer"
+        assert recorded.call_args.kwargs["model"] == "legacy_analyzer"
 
     def test_market_review_records_actual_codex_backend(self):
         from src.market_analyzer import MarketOverview

--- a/tests/test_market_analyzer_generate_text.py
+++ b/tests/test_market_analyzer_generate_text.py
@@ -3296,6 +3296,87 @@ class TestMarketAnalyzerBypassFix:
         assert kwargs["max_tokens"] == 8192
         assert kwargs["temperature"] == 0.7
 
+    def test_market_review_supports_legacy_injected_analyzer_contract(self):
+        from src.market_analyzer import MarketOverview
+
+        class LegacyAnalyzer:
+            def __init__(self):
+                self.calls = []
+
+            def is_available(self):
+                return True
+
+            def generate_text(self, prompt, max_tokens=2048, temperature=0.7):
+                self.calls.append(
+                    {
+                        "prompt": prompt,
+                        "max_tokens": max_tokens,
+                        "temperature": temperature,
+                    }
+                )
+                return "复盘结果"
+
+        ma = self._make_market_analyzer_with_mock_generate_text(return_value="unused")
+        ma.analyzer = LegacyAnalyzer()
+
+        with patch.object(ma, "_build_review_prompt", return_value="legacy prompt"), \
+             patch.object(ma, "_inject_data_into_review", return_value="渲染后复盘"), \
+             patch("src.market_analyzer.record_llm_run_started") as started, \
+             patch("src.market_analyzer.record_llm_run") as recorded:
+            result = ma.generate_market_review(MarketOverview(date="2026-03-05"), [])
+
+        assert result == "渲染后复盘"
+        assert ma.analyzer.calls == [
+            {
+                "prompt": "legacy prompt",
+                "max_tokens": 8192,
+                "temperature": 0.7,
+            }
+        ]
+        assert started.call_args.kwargs["provider"] == "litellm"
+        assert started.call_args.kwargs["model"] == ma.config.litellm_model
+        assert recorded.call_args.kwargs["provider"] == "gemini"
+        assert recorded.call_args.kwargs["model"] == ma.config.litellm_model
+
+    def test_market_review_legacy_injected_analyzer_ignores_invalid_backend_config(self):
+        from src.market_analyzer import MarketOverview
+
+        class LegacyAnalyzer:
+            def __init__(self):
+                self.calls = []
+
+            def is_available(self):
+                return True
+
+            def generate_text(self, prompt, max_tokens=2048, temperature=0.7):
+                self.calls.append(
+                    {
+                        "prompt": prompt,
+                        "max_tokens": max_tokens,
+                        "temperature": temperature,
+                    }
+                )
+                return "复盘结果"
+
+        ma = self._make_market_analyzer_with_mock_generate_text(return_value="unused")
+        ma.analyzer = LegacyAnalyzer()
+        ma.config.generation_backend = "broken-backend"
+
+        with patch.object(ma, "_build_review_prompt", return_value="legacy prompt"), \
+             patch.object(ma, "_inject_data_into_review", return_value="渲染后复盘"), \
+             patch("src.market_analyzer.record_llm_run_started"), \
+             patch("src.market_analyzer.record_llm_run"):
+            result = ma.generate_market_review(MarketOverview(date="2026-03-05"), [])
+
+        assert result == "渲染后复盘"
+        assert ma.analyzer.calls == [
+            {
+                "prompt": "legacy prompt",
+                "max_tokens": 8192,
+                "temperature": 0.7,
+            }
+        ]
+
     def test_market_review_records_actual_codex_backend(self):
         from src.market_analyzer import MarketOverview
 


### PR DESCRIPTION
## 问题

大盘复盘诊断此前固定记录 `provider=litellm` 和配置模型。启用 Codex CLI，或主后端失败后实际走 fallback 时，任务虽然成功，诊断、历史和排障信息却仍显示配置后端，形成错误审计事实。

## 根因

市场复盘只使用返回文本的 `generate_text()`，实际执行后端、provider 和模型元数据在兼容层被丢弃；调用侧随后用静态配置补写诊断。

## 修复

- 在既有生成后端兼容层增加保留 `GenerationResult` 的公开入口，不新增平行调用链。
- 开始事件记录配置的主后端；完成事件改为记录实际成功的 backend/provider/model。
- Codex CLI、LiteLLM 和 fallback 共用同一生成、用量持久化及错误传播路径；LiteLLM 路由别名使用现有 wire-model 解析结果记录真实 provider。
- 配置错误与执行异常也使用异常携带的后端信息；CLI 与 LiteLLM fallback 同时耗尽时，尝试循环保留最后实际尝试模型，并将该模型写入最终 run diagnostics，不误记为 backend 名或 EmptyResponse。
- 补充 Codex 成功、LiteLLM fallback、空响应、配置错误及既有兼容路径回归测试。

这是对已关闭 PR #2177 的重新实现，移除了旧分支冲突和无关 changelog，仅保留单一问题范围。

## 验证

- `python -m pytest tests/test_market_analyzer_generate_text.py tests/test_run_flow.py -q`：143 passed
- `python -m py_compile src/analyzer.py src/market_analyzer.py`：通过
- flake8 `E9,F63,F7,F82`：通过
- `git diff --check origin/main...HEAD`：通过

## 风险与回滚

风险集中在市场复盘诊断元数据，不改变报告正文、后端选择优先级或 fallback 行为。可整体回滚本 PR；旧行为会恢复为静态配置诊断。

Refs #2177

<!-- autocode:repair-summary:start -->
## AutoCode Repair Update
- Scope: 2 file(s), `+49 / -1`.
- Changed files: `src/analyzer.py`, `tests/test_market_analyzer_generate_text.py`
- Validation: lint:PASS, test:PASS
- Commands: `./scripts/ci_gate.sh flake8`; `python -m pytest tests/test_market_analyzer_generate_text.py`
- Execution/self-review summary: 第 1 轮：已修复 `src/analyzer.py` 中 LiteLLM `audit_context` 路径的 provider 回写顺序，确保 routed 响应先写入实际 `response_provider`，不会再被配置路由 provider 覆盖。 同时补充了 `tests/test_market_analyzer_generate_text.py` 回归用例，覆盖 `_call_litellm(..., audit_context=...)` 在 alias 路由返回不同 `response.model` 时仍记录真实 provider 的场景。 已执行 `python -m py_compile src/analyzer.py tests/test_market_analyzer_generate_text.py` 通过。 已执行 `python -m pytest tests/test_market_analyzer_generate_text.py -k "test_call_litellm_non_stream_records_legacy_message_audit_for_actual_messages or test_call_litellm_non_stream_preserves_resolved_provider_with_audit_context or test_call_litellm_stream_records_legacy_message_audit_for_actual_messages"`，结果 `3 passed`。 第 1 轮提交前自审：检查了 `git diff`、`src/analyzer.py -> _call_litellm() -> audit_context/usage audit -> persist_llm_usage` 共享调用链，以及相关回归测试。确认 review 指出的 blocker 原因成立：`audit_context` 会把已解析出的真实 `response_provider` 覆盖回路由配置 provider。 已修复/确认： - `src/analyzer.py` 现在在附加 legacy audit 前优先沿用 `usage["provider"]`，避免成功路由调用被写回错误 provider。 - 补充并收紧了 `tests/test_market_analyzer_generate_text.py` 的回归测试，明确覆盖 `_call_litellm(..., audit_context=...)` 命中路由别名但实际返回其他 provider 的场景。 验证情况： - `python -m pytest tests/test_market_analyz...
- Compatibility, risk, documentation, and PR scope were re-evaluated before this push.
<!-- autocode:repair-summary:end -->