### PR TITLE
fix: 净化大盘复盘历史摘要

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+- [修复] 大盘复盘历史列表与详情统一展示持久化短摘要；旧记录缺少摘要时从完整 Markdown 生成无内部标记的纯文本节选。
 <!-- 新条目格式：- [类型] 描述（类型取值：新功能/改进/修复/文档/测试/chore）-->
 <!-- 每条独立一行追加到本段末尾，无需分类标题，合并时冲突最小 -->
 - [修复] 已配置钉钉 Webhook 时不再误报“未配置通知渠道”；钉钉 Stream 仍仅用于交互，不作为定时静态推送渠道。

--- a/src/services/history_service.py
+++ b/src/services/history_service.py
@@ -12,10 +12,12 @@ Responsibilities:
 from __future__ import annotations
 import json
 import logging
+import re
 from datetime import date, datetime, timedelta
 from typing import Optional, Dict, Any, List, Tuple, TYPE_CHECKING
 
 from src.config import get_config, resolve_news_window_days
+from src.formatters import markdown_to_plain_text
 from src.data.stock_index_loader import resolve_index_stock_code
 from src.report_language import (
     get_bias_status_emoji,
@@ -334,6 +336,13 @@ class HistoryService:
             getattr(record, "context_snapshot", None),
         )
         action_fields = self._decision_action_fields_for_record(record, raw_result)
+        analysis_summary = record.analysis_summary
+        if getattr(record, "report_type", None) == "market_review":
+            market_review_content = self._extract_market_review_content(record, raw_result)
+            analysis_summary = self._market_review_summary(
+                record.analysis_summary,
+                market_review_content,
+            )
 
         return {
             "id": record.id,
@@ -345,7 +354,7 @@ class HistoryService:
                 getattr(record, "context_snapshot", None)
             ),
             "trend_prediction": record.trend_prediction,
-            "analysis_summary": record.analysis_summary,
+            "analysis_summary": analysis_summary,
             "sentiment_score": record.sentiment_score,
             "operation_advice": record.operation_advice,
             "action": action_fields["action"],
@@ -570,6 +579,39 @@ class HistoryService:
             return news_content
         return None
 
+    @staticmethod
+    def _market_review_summary(
+        persisted_summary: Any,
+        markdown: Any,
+        *,
+        limit: int = 120,
+    ) -> Optional[str]:
+        """Return a stable short summary without leaking report Markdown or metadata."""
+        persisted = str(persisted_summary or "").strip()
+        if persisted:
+            return persisted
+
+        source = str(markdown or "").strip()
+        if not source:
+            return None
+
+        # Full reports can contain internal reference metadata, tables, links and
+        # fenced diagnostic payloads. Keep readable prose only for summary fields.
+        source = re.sub(r"```[^\n]*\n.*?```", " ", source, flags=re.DOTALL)
+        source = re.sub(r"!\[([^\]]*)\]\([^)]*\)", r"\1", source)
+        source = re.sub(r"\[([^\]]+)\]\([^)]*\)", r"\1", source)
+        source = re.sub(r"<[^>]+>", " ", source)
+        text = markdown_to_plain_text(source)
+        text = re.sub(r"[`~|]", " ", text)
+        text = re.sub(r"^\s*:?-{3,}:?(?:\s+:?-{3,}:?)+\s*$", " ", text, flags=re.MULTILINE)
+        text = re.sub(r"^[+\d]+[.)]\s+", "", text, flags=re.MULTILINE)
+        text = re.sub(r"\s+", " ", text).strip(" •-—")
+        if not text:
+            return None
+        if len(text) > limit:
+            return text[:limit].rstrip() + "…"
+        return text
+
     def _record_to_detail_dict(self, record) -> Dict[str, Any]:
         """
         Convert an AnalysisHistory ORM record to a detail response dict.
@@ -588,8 +630,13 @@ class HistoryService:
                 context_snapshot = record.context_snapshot
 
         market_review_content = None
+        analysis_summary = record.analysis_summary
         if getattr(record, "report_type", None) == "market_review":
             market_review_content = self._extract_market_review_content(record, raw_result)
+            analysis_summary = self._market_review_summary(
+                record.analysis_summary,
+                market_review_content,
+            )
 
         action_fields = self._decision_action_fields_for_record(record, raw_result)
         display_code = self._display_stock_code(record.code)
@@ -603,7 +650,7 @@ class HistoryService:
             "report_type": record.report_type,
             "created_at": self._serialize_created_at(record.created_at),
             "model_used": model_used,
-            "analysis_summary": market_review_content or record.analysis_summary,
+            "analysis_summary": analysis_summary,
             "operation_advice": record.operation_advice,
             "action": action_fields["action"],
             "action_label": action_fields["action_label"],

--- a/tests/test_analysis_history.py
+++ b/tests/test_analysis_history.py
@@ -1947,10 +1947,40 @@ class AnalysisHistoryTestCase(unittest.TestCase):
         report = get_history_detail(str(record_id), db_manager=self.db)
 
         self.assertEqual(report.meta.report_type, "market_review")
-        self.assertEqual(report.summary.analysis_summary, report_content)
+        self.assertEqual(report.summary.analysis_summary, "今日大盘复盘")
         self.assertIsNone(report.summary.action)
         self.assertIsNone(report.summary.action_label)
         self.assertEqual(report.details.news_content, report_content)
+
+    def test_market_review_summary_falls_back_to_sanitized_excerpt(self) -> None:
+        service = HistoryService(self.db)
+        markdown = (
+            "[dsa-market-region]: # (cn)\n\n"
+            "# 🎯 大盘复盘\n\n"
+            "## 今日观点\n\n"
+            "**成交活跃**，关注 [科技板块](https://example.com)。\n\n"
+            "| 指标 | 数值 |\n| --- | --- |\n| 涨跌 | +1% |\n\n"
+            "```json\n{\"internal\": true}\n```"
+        )
+
+        summary = service._market_review_summary("  ", markdown)
+
+        self.assertEqual(summary, "🎯 大盘复盘 今日观点 成交活跃，关注 科技板块。 指标 数值 涨跌 +1%")
+        self.assertNotIn("dsa-market-region", summary)
+        self.assertNotIn("internal", summary)
+
+    def test_market_review_summary_prefers_persisted_summary_and_truncates_fallback(self) -> None:
+        service = HistoryService(self.db)
+
+        self.assertEqual(
+            service._market_review_summary(" 已保存的短摘要 ", "# 不应使用"),
+            "已保存的短摘要",
+        )
+        self.assertEqual(
+            service._market_review_summary(None, "# " + "复" * 130),
+            "复" * 120 + "…",
+        )
+        self.assertIsNone(service._market_review_summary(None, "[dsa-market-region]: # (cn)"))
 
     def test_history_detail_localizes_english_summary_fields(self) -> None:
         """History detail should localize summary enums for English reports."""


### PR DESCRIPTION
## 问题

大盘复盘历史详情把完整 Markdown 报告写入 `analysis_summary`。Web 摘要区域因此显示标题符号、表格、链接和内部 `[dsa-market-region]` 元数据；旧记录没有短摘要时问题尤其明显。历史列表与详情的摘要来源也不一致。

## 根因

详情转换逻辑用 `market_review_content or record.analysis_summary`，把“完整正文”和“短摘要”两个不同字段契约混在一起。

## 修复

- 列表和详情统一优先使用数据库中持久化的短摘要。
- 旧记录缺少摘要时，复用项目已有 Markdown→纯文本转换，再处理隐藏元数据、链接、表格、HTML、代码块及长度上限。
- `news_content` 与 Markdown 下载仍保留完整复盘正文，不破坏完整报告能力。
- 增加持久化摘要优先、旧数据净化、内部标记过滤及 120 字截断回归测试。

这是已关闭 PR #2198 中“历史摘要”问题的独立重做。没有带入端口探测改动：`SO_REUSEADDR` 不能证明或修复另一个进程仍占用监听端口的根因，避免把无关且结论不成立的改动混入。

## 真实前后对比

以下使用**同一条大盘复盘历史记录**，完整正文均为：

````markdown
[dsa-market-region]: # (cn)

# 🎯 大盘复盘

## 今日观点

**成交活跃**，关注 [科技板块](https://example.com)。

| 指标 | 数值 |
| --- | --- |
| 涨跌 | +1% |

```json
{"internal": true}
```
````

API / 字段契约对比：

| 项目 | 改动前 | 改动后 |
| --- | --- | --- |
| `summary.analysisSummary` | 被完整 Markdown 覆盖，包含内部标记、标题、链接、表格、代码块 | 优先返回持久化短摘要：`今日大盘复盘` |
| `details.newsContent` | 完整 Markdown | 完整 Markdown，保持不变 |
| 旧记录无短摘要 | 完整 Markdown 直接进入摘要 | 生成最多 120 字的纯文本节选，去除内部元数据和 fenced code |
| 历史列表 / 详情 | 摘要来源不一致 | 使用同一摘要规则 |

对应公开详情返回的关键断言：

```text
改动前:
summary.analysisSummary == 完整 Markdown 正文
details.newsContent      == 完整 Markdown 正文

改动后:
summary.analysisSummary == "今日大盘复盘"
details.newsContent      == 完整 Markdown 正文
```

Web 证据使用项目真实的 `MarketReviewReportView` 渲染同一份报告数据；不是静态设计稿。可以看到完整正文完全一致，只有“复盘摘要”卡片从原始 Markdown 变成短摘要。截图 fixture 与图片未合入仓库。

### 改动前

![PR 2242 改动前：摘要卡片泄漏完整 Markdown](https://n.uguu.se/EGbbNfNn.png)

### 改动后

![PR 2242 改动后：摘要卡片显示持久化短摘要](https://n.uguu.se/AgppuprV.png)

## 验证

- `python -m pytest tests/test_analysis_history.py -q`：60 passed；2 个与本 PR 无关的既有市场日历断言失败（CN 有效交易日、JP/KR legacy warning）。
- `python -m py_compile src/services/history_service.py`：通过
- flake8 `E9,F63,F7,F82`：通过
- `git diff --check origin/main...HEAD`：通过
- `cd apps/dsa-web && npm run build`：通过（用于上述真实组件渲染证据）

## 风险与回滚

仅改变市场复盘历史的摘要展示；完整正文和持久化结构不变。旧记录的兜底摘要会变成最多 120 字纯文本。可整体回滚本 PR 恢复旧展示。

Refs #2198