### PR TITLE
fix: 美股日线路由消费既有数据源优先级(*_PRIORITY)

### DIFF
--- a/data_provider/base.py
+++ b/data_provider/base.py
@@ -1726,6 +1726,10 @@ class DataFetcherManager:
                 source_order = ["LongbridgeFetcher", "FinnhubFetcher", "AlphaVantageFetcher", "YfinanceFetcher"]
             else:
                 source_order = ["FinnhubFetcher", "AlphaVantageFetcher", "YfinanceFetcher", "LongbridgeFetcher"]
+            # 消费各数据源当前优先级(含 *_PRIORITY 环境变量):默认优先级与内置链路一致,
+            # 单项调整(如 YFINANCE_PRIORITY=0)即时生效;指数/Longbridge preferred 的锚定首选不被普通优先级覆盖
+            pin_first = bool(is_us_index or prefer_lb)
+            source_order = self._order_us_sources_by_priority(source_order, pin_first=pin_first)
             market_label = "美股指数" if is_us_index else "美股"
 
             for order_index, src_name in enumerate(source_order):
@@ -2498,6 +2502,23 @@ class DataFetcherManager:
                     setattr(primary, f, val)
                     filled.append(f)
         return filled
+
+    def _order_us_sources_by_priority(self, source_order: List[str], *, pin_first: bool) -> List[str]:
+        """按各数据源当前优先级重排美股日线路由(消费既有 *_PRIORITY 配置)。
+
+        稳定排序:各源默认优先级(Finnhub=2/AlphaVantage=3/Yfinance=4/Longbridge=5)
+        与内置链路一致,默认行为不变;单项 *_PRIORITY 调整即时生效。
+        pin_first=True 时保持链路首位(指数固定 Yfinance、Longbridge preferred),
+        其余成员按优先级排序。
+        """
+        self._ensure_concurrency_guards()
+        if not source_order:
+            return source_order
+        priority_by_name = {f.name: f.priority for f in self._get_fetchers_snapshot()}
+        if pin_first:
+            pinned, rest = source_order[0], source_order[1:]
+            return [pinned] + sorted(rest, key=lambda name: priority_by_name.get(name, 10 ** 9))
+        return sorted(source_order, key=lambda name: priority_by_name.get(name, 10 ** 9))
 
     def _longbridge_preferred(self, capability: str = "realtime_quote") -> bool:
         """Return True when Longbridge keys are configured and available.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 > For user-friendly release highlights, see the [GitHub Releases](https://github.com/ZhuLinsen/daily_stock_analysis/releases) page.
 
 ## [Unreleased]
+- [修复] 美股日线路由现按各数据源当前优先级排序，单项 `*_PRIORITY` 配置（如 `YFINANCE_PRIORITY=0`）对美股即时生效；指数固定首选与 Longbridge preferred 语义保持不变
 
 - [改进] PR CI 增加文档路径检测：仅修改普通文档、非治理 Markdown 或 LICENSE 时跳过后端测试分片、Docker、Web 与桌面打包，保留轻量治理和门禁汇总；契约文档、静态 API 规格与测试 fixture 仍执行后端回归。
 - [修复] Linux/Docker 分享图补齐 Noto CJK 字体与中韩文字体栈，避免 PNG 只显示数字和英文、中文或韩文内容消失。

--- a/tests/test_us_routing_priority.py
+++ b/tests/test_us_routing_priority.py
@@ -1,0 +1,76 @@
+# -*- coding: utf-8 -*-
+"""Tests: US daily routing consumes per-source fetcher priorities."""
+
+from __future__ import annotations
+
+import threading
+from pathlib import Path
+
+from data_provider.base import DataFetcherManager
+
+DEFAULT_US_ORDER = ["FinnhubFetcher", "AlphaVantageFetcher", "YfinanceFetcher", "LongbridgeFetcher"]
+
+
+class _F:
+    def __init__(self, name, priority):
+        self.name, self.priority = name, priority
+
+
+def _manager(fetchers):
+    manager = DataFetcherManager.__new__(DataFetcherManager)
+    manager._fetchers = list(fetchers)
+    manager._fetchers_lock = threading.RLock()
+    manager._fetchers_by_name = {f.name: f for f in fetchers}
+    manager._fetcher_call_locks = {}
+    manager._fetcher_call_locks_lock = manager._fetchers_lock
+    manager._stock_name_cache = {}
+    manager._stock_name_cache_lock = manager._fetchers_lock
+    return manager
+
+
+def _defaults():
+    return [
+        _F("FinnhubFetcher", 2),
+        _F("AlphaVantageFetcher", 3),
+        _F("YfinanceFetcher", 4),
+        _F("LongbridgeFetcher", 5),
+    ]
+
+
+class TestUSRoutingByPriority:
+    def test_default_priorities_keep_builtin_order(self):
+        manager = _manager(_defaults())
+        order = manager._order_us_sources_by_priority(list(DEFAULT_US_ORDER), pin_first=False)
+        assert order == DEFAULT_US_ORDER
+
+    def test_yfinance_priority_zero_promotes_it_first(self):
+        fetchers = _defaults()
+        fetchers[2] = _F("YfinanceFetcher", 0)  # YFINANCE_PRIORITY=0
+        manager = _manager(fetchers)
+        order = manager._order_us_sources_by_priority(list(DEFAULT_US_ORDER), pin_first=False)
+        assert order[0] == "YfinanceFetcher"
+        assert order[1:] == ["FinnhubFetcher", "AlphaVantageFetcher", "LongbridgeFetcher"]
+
+    def test_longbridge_preferred_stays_pinned_first(self):
+        manager = _manager(_defaults())
+        order = manager._order_us_sources_by_priority(
+            ["LongbridgeFetcher", "FinnhubFetcher", "AlphaVantageFetcher", "YfinanceFetcher"],
+            pin_first=True,
+        )
+        assert order[0] == "LongbridgeFetcher"
+        assert order[1:] == ["FinnhubFetcher", "AlphaVantageFetcher", "YfinanceFetcher"]
+
+    def test_us_index_keeps_yfinance_pinned(self):
+        manager = _manager(_defaults())
+        order = manager._order_us_sources_by_priority(["YfinanceFetcher", "FinnhubFetcher"], pin_first=True)
+        assert order == ["YfinanceFetcher", "FinnhubFetcher"]
+
+
+def test_env_example_has_no_conflict_markers() -> None:
+    """配置模板不得包含未解决的 git 冲突标记。"""
+    content = Path(".env.example").read_text(encoding="utf-8")
+    for line in content.splitlines():
+        stripped = line.strip()
+        assert not stripped.startswith("<<<<<<<"), f"conflict marker: {line!r}"
+        assert not stripped.startswith(">>>>>>>"), f"conflict marker: {line!r}"
+        assert stripped != "=======", f"conflict marker: {line!r}"


### PR DESCRIPTION
## 概述

修复美股日线路由对数据源优先级的"消费断层":`get_daily_data()` 的美股分支此前使用固定的 `Finnhub → AlphaVantage → Yfinance → Longbridge` 顺序,不消费各 fetcher 的优先级,导致 `YFINANCE_PRIORITY=0` 这类既有单项配置对美股完全不生效。

## 设计说明(回应维护者疑问,已按"单一配置真源"重构)

维护者指出的问题成立:原先的 `DATA_SOURCE_PRIORITIES` 与既有 `*_PRIORITY` 形成两套并行入口、类名作配置键、A 股通用链重复覆盖。**本 PR 已重构为不新增任何配置**:

- 美股日线路由按各数据源**当前优先级**稳定排序,直接消费既有 `*_PRIORITY` 环境变量;
- 各源默认优先级(Finnhub=2 / AlphaVantage=3 / Yfinance=4 / Longbridge=5)与内置链路完全一致,**未调整配置时行为零变化**;
- 两个刻意设计的第一位语义保持锚定,不被普通优先级覆盖:美股指数固定 Yfinance 首选、Longbridge preferred;
- 用户故事:`YFINANCE_PRIORITY=0` 现在对美股日线即时生效(Yfinance 提到链首),不再需要额外配置。

## Changes

- `data_provider/base.py`:`_order_us_sources_by_priority()`(稳定排序 + pin_first 语义)接入美股日线分支
- `docs/CHANGELOG.md` 扁平条目
- `tests/test_us_routing_priority.py`:默认顺序不变 / 单项调整生效 / Longbridge 锚定 / 指数锚定 / 配置模板冲突标记守卫

## Testing

- [x] `pytest tests/test_us_routing_priority.py tests/test_finnhub_fetcher.py tests/test_fetcher_source_optimization.py` — 35 通过
- [x] flake8 CI 口径(E9,F63,F7,F82)0 错误

## Issue Link

N/A(修复型改动;如需先建 issue 对齐可补)

## Rollback Plan

单提交 revert 即可。纯路由排序行为改动,无配置、无数据迁移、无 schema 变更;各源默认优先级与原内置链一致,回滚后无残留状态。
