### PR TITLE
docs: prepare v3.31.0 release

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,10 +9,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
-- [修复] 大盘复盘历史列表与详情统一展示持久化短摘要；旧记录缺少摘要时从完整 Markdown 生成无内部标记的纯文本节选。
-- [修复] 大盘复盘按实际执行的生成后端和模型记录诊断，避免 Codex CLI 或 fallback 被误显示为配置模型。
 <!-- 新条目格式：- [类型] 描述（类型取值：新功能/改进/修复/文档/测试/chore）-->
 <!-- 每条独立一行追加到本段末尾，无需分类标题，合并时冲突最小 -->
+
+## [3.31.0] - 2026-08-23
+
+### 发布亮点
+
+- feat: Agent 工具调用新增按类别和单工具配置的超时契约，并补齐防重试、协作取消、并发预算与热重载一致性。
+- feat: 股票名称解析、`canonical_id` 双写和 A 股指数多数据源路由共同完善股票身份与行情降级链路。
+- improve: 新闻检索为空时在报告中如实披露证据边界，Anspire 默认覆盖全球区域，公共 SearXNG 实例改为显式启用。
+- fix: 定时任务恢复、无报告失败反馈、通知发送和大盘复盘历史/诊断信息进一步收敛，减少静默失败与误导展示。
+- security: 桌面端升级 `builder-util-runtime`，修复 CVE-2026-54673 涉及的重定向凭据头信息泄露风险。
+- docs: 增加 xAI Grok 的 LiteLLM 配置示例、Grok Bot 集成说明与可复用 Skill。
+
+### 变更明细
+
+- [修复] 大盘复盘历史列表与详情统一展示持久化短摘要；旧记录缺少摘要时从完整 Markdown 生成无内部标记的纯文本节选。
+- [修复] 大盘复盘按实际执行的生成后端和模型记录诊断，避免 Codex CLI 或 fallback 被误显示为配置模型。
 - [修复] 已配置钉钉 Webhook 时不再误报“未配置通知渠道”；钉钉 Stream 仍仅用于交互，不作为定时静态推送渠道。
 - [修复] WebUI/API/Desktop 以 `--serve-only` 重启后会恢复已启用的定时任务，同时保持启动时不立即执行分析；通知路由示例补充钉钉 Webhook 渠道。
 - [改进] AIHubMix 注册与引流链接统一使用 inferera.com，改善中国大陆网络直连体验。
@@ -28,6 +42,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - [新功能] 股票名称解析引擎重构增强：新增 `resolver_name_to_code_list()` 公开 API，返回按市场排序（A 股→港股→美股）的 `Stock` 候选列表（最多 5 个），新增 `US_stock_code_match()` 匹配美股 ticker（1~5 位字母且仅限本地库已存在代码，避免 hello/open 等英文词误判为股票）；AkShare 全量 A 股数据经幂等 `extend_AkShare()` 合并进全局 `stockDB`（30 分钟缓存 + 失败 5 分钟退避 + Future 单飞：TTL 过期 stale-while-revalidate 零等待、冷启动等待上界由拉取超时推导（拉取经子进程封顶 25s）、worker 先清账唤醒等待者再做日志/落盘（finally 兜底 BaseException）、成功拉取落盘 `data/cache` 跨重启复用，非中文输入跳过网络扩展），匹配策略升级为「精确→子串（≥2 汉字）→拼音子串（≥5 字母）→difflib 模糊（0.8，单字误写 0.7 兜底）」；`resolve_name_to_code()` 保持既有本地优先语义（本地精确命中零网络，调用方离线低延迟契约不变），跨市场候选能力由 `resolver_name_to_code_list()` 独立提供；解析全链路线程安全（`stockDB` 读写加锁、名称/拼音索引随库变更自动失效），新增 40 个单元测试覆盖精确/跨市场排序/子串/拼音/模糊/幂等扩展/失败退避/多候选场景。
 - [改进] `StockDaily` 表新增可空 `canonical_id` 列并支持双写（Expand-Contract PR2，issue #2207）：自愈式迁移幂等加列 + 普通索引 `ix_stock_daily_canonical_id`，存量行与 `save_daily_data` 未显式传参时均经 index-aware 推导（裸指数码命中注册表时统一到指数 `canonical_id`，避免同一指数按输入形态分裂到不同桶——例如裸 `000300` 与显式 `sh000300` 现在都收敛到 `sh000300`，而非裸码被推导为 `sz000300`），推导失败写 NULL 降级；读路径仍用 `code` 列，`(code, date)` 唯一约束保留不变。显式登记契约漂移：PRD Glossary/FR-1/DD-3 与架构 AD-1/AD-7 中 canonical_id 的点分格式描述（`000016.SH`）已被 Phase 1 已合入代码的前缀格式（`sh000016`）取代，本变更遵循代码，PRD/架构文档的同步修正留待后续 PR 统一收敛。
 - [新功能] 当前注册表已识别的 5 个沪深 A 股指数以显式市场输入按 canonical 身份路由：名称优先使用注册表并以 Tencent、AkShare、TickFlow 兜底，日线固定使用 Tencent、AkShare、TickFlow、yfinance 多源降级链，不读取普通 A 股日 K 的 `*_PRIORITY` 配置；裸代码仍按股票处理，并隔离同码股票名称缓存。
+- [修复] Anspire 搜索默认切换为全球区域模式（`region_mode=2`），使海外股票新闻检索能够覆盖境外信息。
+- [修复] 桌面端将 `builder-util-runtime` 升级至 9.7.0，修复 CVE-2026-54673 涉及的 HTTP 重定向凭据头信息泄露风险。
+- [文档] 增加 xAI Grok 的 LiteLLM 配置示例、Grok Bot 集成指南和异步分析 Skill，明确分析模型与 AI teammate 两类接入边界。
+- [测试] 固定 yfinance 股息 TTM 与单股报告文件名的时间夹具，消除跨日期和合并后时间基准冲突造成的 CI 波动。
 
 ## [3.30.0] - 2026-08-09
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2215,7 +2215,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ---
 
-[Unreleased]: https://github.com/ZhuLinsen/daily_stock_analysis/compare/v3.30.0...HEAD
+[Unreleased]: https://github.com/ZhuLinsen/daily_stock_analysis/compare/v3.31.0...HEAD
+[3.31.0]: https://github.com/ZhuLinsen/daily_stock_analysis/compare/v3.30.0...v3.31.0
 [3.30.0]: https://github.com/ZhuLinsen/daily_stock_analysis/compare/v3.29.0...v3.30.0
 [3.29.0]: https://github.com/ZhuLinsen/daily_stock_analysis/compare/v3.28.0...v3.29.0
 [3.28.0]: https://github.com/ZhuLinsen/daily_stock_analysis/compare/v3.27.0...v3.28.0


### PR DESCRIPTION
## PR Type

- [ ] fix
- [ ] feat
- [ ] refactor
- [x] docs
- [x] chore
- [ ] test

## Background And Problem

`v3.30.0..origin/main` 已合入 Agent 超时契约、股票身份与指数数据源增强、新闻证据披露、运行与通知稳定性修复、桌面端安全依赖升级，以及 xAI/Grok 集成文档。当前 `[Unreleased]` 仍是并发维护用的扁平条目，且遗漏了 CVE-2026-54673、Anspire 全球搜索、Grok 文档和测试稳定性修复，不能直接作为正式发行说明。

本 PR 将这些已合入变更整理为 `v3.31.0`。选择 minor 版本是因为包含 Agent 超时配置、股票名称解析和 A 股指数路由等新增能力；现有 API 与配置保持兼容。

## Scope Of Change

- 文件总数：1
- `docs/CHANGELOG.md`
  - 清空 `[Unreleased]` 并保留扁平条目模板
  - 新增 `3.31.0 - 2026-08-23`
  - 按“发布亮点 + 变更明细”汇总 `v3.30.0..main`
  - 补齐安全、搜索、文档和测试类遗漏项

## Issue Link

无对应 Issue。本 PR 是 v3.31.0 发布准备；验收标准为版本范围完整、release notes 可解析、Changelog 契约测试通过。

## Verification Commands And Results

```bash
python -m pytest tests/test_build_release_notes.py tests/test_alerts_docs.py tests/test_analysis_context_pack_docs.py tests/test_searxng_env_docs.py -q
# 54 passed

git diff --check
# pass
```

版本范围已按 `git log --first-parent v3.30.0..origin/main` 逐项核对，共 18 个合入提交。

## Visual Evidence

不适用。仅整理 Changelog，不修改报告格式、Web UI 或桌面界面。

## Compatibility And Risk

- Docs only，不改变 runtime、API、配置、数据库、Web 或 Desktop 行为。
- 风险仅在发行说明遗漏或分类错误；已对照版本范围并通过 release notes 解析与 Changelog 消费测试。
- 本 PR 为 docs-only，`auto-tag.yml` 的 `paths-ignore` 不会自动创建 tag。
- 合入后应在该 PR 的 merge commit 上创建 annotated tag `v3.31.0`；tag 将触发 GitHub Release、Docker 发布和桌面包发布工作流。

## Rollback Plan

Tag 前可直接 revert 本 PR。Tag 后如发行中止，应先停止/取消发布工作流，再按仓库发布策略处理 Release 与 tag；无需配置或数据回滚。

## Checklist

- [x] 有明确动机和验收标准
- [x] 已提供可复现验证结果
- [x] 已核对 `v3.30.0..main` 版本范围
- [x] 已评估兼容性与风险
- [x] 已提供回滚方案
- [x] 不涉及 UI 或报告截图
## Current Head CI

Head `8426a695`：

- Change Detection — pass
- ai-governance — pass
- backend-tests 1/3、2/3、3/3 — pass
- backend-gate — pass
- Docker / Web / Windows Desktop / macOS Desktop — skipped（docs-only，符合路径过滤预期）

当前状态：全部适用检查通过，可以合入。

<!-- autocode:repair-summary:start -->
## AutoCode Repair Update
- Scope: 1 file(s), `+2 / -1`.
- Changed files: `docs/CHANGELOG.md`
- Validation: diff-check:PASS
- Commands: `git diff --check`
- Execution/self-review summary: 第 1 轮：已按 review 修复 `docs/CHANGELOG.md` 底部引用定义，将 `[Unreleased]` 从 `v3.30.0...HEAD` 前移到 `v3.31.0...HEAD`。 已新增 `[3.31.0]` 对比链接，指向 `v3.30.0...v3.31.0`，与既有 release section 约定保持一致。 验证已完成：`python -m pytest tests/test_build_release_notes.py tests/test_alerts_docs.py tests/test_analysis_context_pack_docs.py tests/test_searxng_env_docs.py` 结果：`54 passed in 0.47s` 第 1 轮提交前自审：检查了 `git diff`、`docs/CHANGELOG.md` 的 `3.31.0` 发布段与底部引用定义、以及相关 release-notes / docs 测试链路。当前未提交 diff 已正确补上 `[3.31.0]` 对比链接，并把 `[Unreleased]` 从 `v3.30.0...HEAD` 前移到 `v3.31.0...HEAD`；`git diff --check` 通过，`python -m pytest tests/test_build_release_notes.py tests/test_alerts_docs.py tests/test_analysis_context_pack_docs.py tests/test_searxng_env_docs.py -q` 为 `54 passed`。 本轮未发现需要继续修的正确性或契约问题，因此没有追加无关改动。建议同步 PR description：把“Scope Of Change”或 review follow-up 补充为“更新 changelog 底部版本引用定义”，其余验证、兼容性和风险说明可保持不变。
- Compatibility, risk, documentation, and PR scope were re-evaluated before this push.
<!-- autocode:repair-summary:end -->