### PR TITLE
fix: 修复 6 处静默失败缺陷（敏感配置明文回传 / VIX 污染大盘打分 / SSE 断流 / 股票池退化 / 汇率未刷 / 研究全空报成功）

### DIFF
--- a/api/v1/endpoints/agent.py
+++ b/api/v1/endpoints/agent.py
@@ -44,6 +44,12 @@ logger = logging.getLogger(__name__)
 
 router = APIRouter()
 
+# SSE 保活：心跳间隔必须明显小于 Cloudflare 约 100 秒的静默断流阈值；
+# 空闲预算保持原先的 300 秒语义（收到任何事件即重置）。
+_STREAM_HEARTBEAT_SECONDS = 20.0
+_STREAM_IDLE_TIMEOUT_SECONDS = 300.0
+
+
 _ACTIVE_CODEX_STREAMS: Dict[str, threading.Event] = {}
 _ACTIVE_CODEX_STREAMS_LOCK = threading.Lock()
 
@@ -604,19 +610,31 @@ async def agent_chat_stream(
             # Backend execution starts only after the accepted event has been
             # yielded, so Web state and server persistence share one commit point.
             fut = loop.run_in_executor(None, run_sync, executor, turn)
+            idle_seconds = 0.0
             while True:
                 try:
-                    if backend_id == "codex_app_server":
-                        # Codex owns one authoritative backend deadline.  A
-                        # second API timeout would race it and could emit a
-                        # terminal event before process cleanup finishes.
-                        event = await queue.get()
-                    else:
-                        event = await asyncio.wait_for(queue.get(), timeout=300.0)
+                    event = await asyncio.wait_for(
+                        queue.get(), timeout=_STREAM_HEARTBEAT_SECONDS
+                    )
                 except asyncio.TimeoutError:
-                    event = {"type": "error", "message": "分析超时"}
-                    yield "data: " + json.dumps(event, ensure_ascii=False) + "\n\n"
-                    break
+                    # Cloudflare 会断开静默超过约 100 秒的流，而单个编排阶段实测
+                    # 出现过 111 秒无工具调用的静默（1 步直接生成）。SSE 注释行不会
+                    # 被 EventSource 当成事件，补心跳保活无需前端配合。
+                    idle_seconds += _STREAM_HEARTBEAT_SECONDS
+                    # Codex owns one authoritative backend deadline.  A second
+                    # API timeout would race it and could emit a terminal event
+                    # before process cleanup finishes, so only the default
+                    # backend enforces the idle budget here.
+                    if (
+                        backend_id != "codex_app_server"
+                        and idle_seconds >= _STREAM_IDLE_TIMEOUT_SECONDS
+                    ):
+                        event = {"type": "error", "message": "分析超时"}
+                        yield "data: " + json.dumps(event, ensure_ascii=False) + "\n\n"
+                        break
+                    yield ": heartbeat\n\n"
+                    continue
+                idle_seconds = 0.0
                 yield "data: " + json.dumps(event, ensure_ascii=False) + "\n\n"
                 if event.get("type") in ("done", "error"):
                     break

--- a/data_provider/yfinance_fetcher.py
+++ b/data_provider/yfinance_fetcher.py
@@ -323,14 +323,40 @@ class YfinanceFetcher(BaseFetcher):
         hist = ticker.history(period='2d')
         if hist.empty:
             return None
-        today_row = hist.iloc[-1]
-        prev_row = hist.iloc[-2] if len(hist) > 1 else today_row
+        # Yahoo 有时只为最新交易日回填 volume，OHLC 全部为 NaN；
+        # 直接取 iloc[-1] 会把 NaN 写进大盘复盘报告，先剔除这类无效行。
+        valid_hist = hist.dropna(subset=['Close'])
+        if valid_hist.empty:
+            logger.warning(f"[Yfinance] {name} 近两日 K 线均无有效收盘价，跳过")
+            return None
+        today_row = valid_hist.iloc[-1]
+        prev_row = valid_hist.iloc[-2] if len(valid_hist) > 1 else today_row
         price = float(today_row['Close'])
         prev_close = float(prev_row['Close'])
-        change = price - prev_close
-        change_pct = (change / prev_close) * 100 if prev_close else 0
+        open_price = float(today_row['Open'])
         high = float(today_row['High'])
         low = float(today_row['Low'])
+        volume = float(today_row['Volume'])
+        # 出现以下两种情况时用 fast_info 补回当日行情（与实时行情链路口径一致），
+        # 拿不到就退回历史数据，至少保证报告里不出现 NaN：
+        #   1. 最新交易日的 OHLC 被剔除；
+        #   2. 只有一根有效 K 线（昨收会退化成今收，涨跌幅恒为 0，如 ^VIX）。
+        if len(valid_hist) < len(hist) or len(valid_hist) < 2:
+            snapshot = self._latest_quote_from_fast_info(ticker)
+            if snapshot:
+                price = snapshot['price']
+                prev_close = snapshot['prev_close'] if snapshot['prev_close'] is not None else price
+                open_price = snapshot['open'] if snapshot['open'] is not None else open_price
+                high = snapshot['high'] if snapshot['high'] is not None else high
+                low = snapshot['low'] if snapshot['low'] is not None else low
+                volume = snapshot['volume'] if snapshot['volume'] is not None else volume
+                logger.debug(f"[Yfinance] {name} 最新交易日 OHLC 缺失，已用 fast_info 补全")
+            else:
+                logger.warning(
+                    f"[Yfinance] {name} 最新交易日 OHLC 缺失且 fast_info 不可用，已回退到上一交易日数据"
+                )
+        change = price - prev_close
+        change_pct = (change / prev_close) * 100 if prev_close else 0
         # 振幅 = (最高 - 最低) / 昨收 * 100
         amplitude = ((high - low) / prev_close * 100) if prev_close else 0
         return {
@@ -339,13 +365,47 @@ class YfinanceFetcher(BaseFetcher):
             'current': price,
             'change': change,
             'change_pct': change_pct,
-            'open': float(today_row['Open']),
+            'open': open_price,
             'high': high,
             'low': low,
             'prev_close': prev_close,
-            'volume': float(today_row['Volume']),
+            'volume': volume,
             'amount': 0.0,  # Yahoo Finance 不提供准确成交额
             'amplitude': amplitude,
+        }
+
+    def _latest_quote_from_fast_info(self, ticker) -> Optional[Dict[str, Optional[float]]]:
+        """用 fast_info 兜底获取当前交易日行情（Yahoo 未回填当日 OHLC 时使用）。"""
+        try:
+            info = ticker.fast_info
+        except Exception as exc:
+            logger.debug(f"[Yfinance] fast_info 读取失败: {exc}")
+            return None
+        if info is None:
+            return None
+
+        def _read(*names: str) -> Optional[float]:
+            for field in names:
+                value = _safe_float(getattr(info, field, None))
+                if value is None and hasattr(info, 'get'):
+                    try:
+                        value = _safe_float(info.get(field))
+                    except Exception:
+                        value = None
+                if value is not None:
+                    return value
+            return None
+
+        price = _read('lastPrice', 'last_price')
+        if price is None or price <= 0:
+            return None
+        return {
+            'price': price,
+            'prev_close': _read('previousClose', 'previous_close'),
+            'open': _read('open'),
+            'high': _read('dayHigh', 'day_high'),
+            'low': _read('dayLow', 'day_low'),
+            'volume': _read('lastVolume', 'last_volume'),
         }
 
     def get_main_indices(self, region: str = "cn") -> Optional[List[Dict[str, Any]]]:

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,6 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 <!-- 新条目格式：- [类型] 描述（类型取值：新功能/改进/修复/文档/测试/chore）-->
 <!-- 每条独立一行追加到本段末尾，无需分类标题，合并时冲突最小 -->
+- [修复] 系统配置读取接口（`GET /api/v1/system/config`）现对所有 `is_sensitive` 字段统一返回掩码：此前只有 4 个写死的键走服务端掩码，其余 40 多个敏感字段（各家 LLM API Key、搜索 Key、Webhook 地址与密钥、邮箱密码）在设置页每次加载时都以明文回传。写入侧原本就支持用 mask token 占位保留原值，本次让读取侧与之对齐；LLM 渠道连接测试收到 mask token 时回落到已保存的密钥，设置页「测试渠道」按钮行为不变。
+- [修复] 大盘复盘的「主要指数平均涨跌幅」与盘面信号打分不再把 VIX 等波动率指数计入：波动率与风险偏好反向，此前美股三大指数分别 -0.69%/-0.94%/-1.17% 而 VIX +8% 的普跌交易日会被算成 +1.32%，`index_score = 50 + avg*12` 抬到 66，最终给出「偏暖」结论。波动率指数仍照常显示在报表中，只是不参与方向性均值。
+- [修复] Agent Chat 流式接口（`POST /api/v1/agent/chat/stream`）新增 20 秒 SSE 心跳（注释行，前端无需改动），避免单个编排阶段长时间无工具事件时被 CDN/反代按空闲连接断开；300 秒空闲预算语义不变，Codex 后端仍由其自身 deadline 主导。
+- [修复] 美股选股股票池不再静默退化：`_fetch_sp500_tickers` 直接调用 `pd.read_html(url)` 时不带 User-Agent，被 Wikipedia 返回 403，导致 `fetch_us_universe("auto")` 每次都回落到 49 只硬编码大盘股。改为自带 UA 取回 HTML 再交给 `read_html` 解析，实测恢复到 503 只。
+- [修复] 组合汇率刷新补上「账户本币 → 汇总币种」这一对：此前只收集与账户本币不同的流水币种，USD 账户的流水也全是 USD，于是 `pair_count` 恒为 0、USD/CNY 汇率永不获取，`_convert_amount` 只能走 1:1 兜底，汇总金额实际是未换汇的原币值却贴着 CNY 标签。
+- [修复] 深度研究接口（`POST /api/v1/agent/research`）在所有子问题都返回空内容时不再报成功：子问题 agent 撞到步数上限会返回空 `content`，而合成阶段只拼接有内容的条目，此前会带着空的 Research Findings 段调用模型、拿回一份「研究材料缺失」的正文，却仍以 `success: true` 返回。现改为返回 `success: false` 与 `error: no_usable_findings`，`findings_count` 也只统计可用发现。
 
 ## [3.31.0] - 2026-08-23
 

--- a/src/agent/research.py
+++ b/src/agent/research.py
@@ -177,22 +177,37 @@ class ResearchAgent:
         if progress_callback:
             progress_callback({"type": "research_phase", "phase": "synthesize", "message": "Synthesising research report..."})
 
-        report = (
-            self._synthesise_report(
-                query,
-                all_findings,
-                context,
-                timeout_seconds=self._remaining_timeout_seconds(started_at, timeout_seconds),
+        # 子问题 agent 撞到步数上限时会返回空 content，而 _synthesise_report 只拼接
+        # 有 content 的条目（见 findings_text）。此前只判断 all_findings 非空，于是
+        # 空内容也会走合成，模型收到空的 Research Findings 段、输出一份「研究材料缺失」，
+        # 却仍以 success=True 返回。这里按「可用发现」判断，并让失败显式暴露。
+        usable_findings = [
+            finding for finding in all_findings
+            if str(finding.get("content") or "").strip()
+        ]
+        if not usable_findings:
+            return ResearchResult(
+                success=False,
+                report="",
+                sub_questions=questions,
+                findings_count=0,
+                total_tokens=tokens_used,
+                duration_s=round(time.monotonic() - started_at, 2),
+                error="no_usable_findings",
             )
-            if all_findings
-            else {"content": "No findings gathered.", "tokens": 0}
+
+        report = self._synthesise_report(
+            query,
+            usable_findings,
+            context,
+            timeout_seconds=self._remaining_timeout_seconds(started_at, timeout_seconds),
         )
         tokens_used += report.get("tokens", 0)
         if report.get("timed_out"):
             return self._build_timeout_result(
                 query=query,
                 questions=questions,
-                findings_count=len(all_findings),
+                findings_count=len(usable_findings),
                 total_tokens=tokens_used,
                 duration_s=round(time.monotonic() - started_at, 2),
                 timeout_seconds=timeout_seconds,
@@ -204,7 +219,7 @@ class ResearchAgent:
             success=not report.get("error"),
             report=report.get("content", ""),
             sub_questions=questions,
-            findings_count=len(all_findings),
+            findings_count=len(usable_findings),
             total_tokens=tokens_used,
             duration_s=duration,
             error=report.get("error"),

--- a/src/market_analyzer.py
+++ b/src/market_analyzer.py
@@ -57,6 +57,26 @@ _CHINESE_SECTION_PATTERNS = {
 }
 
 
+# 波动率指数与风险偏好反向，混进「主要指数平均涨跌幅」会让方向反转：
+# 实测美股三大指数 -0.69/-0.94/-1.17%、VIX +8% 时算出 +1.32%，
+# index_score = 50 + avg*12 被抬到 66，普跌日被判成「偏暖」。
+_VOLATILITY_INDEX_CODES = {"VIX", "^VIX", "VXN", "^VXN", "VHSI", "^VHSI"}
+
+
+def _is_volatility_index(index: "MarketIndex") -> bool:
+    """Return True for volatility gauges, which invert the risk-appetite reading."""
+    return str(getattr(index, "code", "") or "").strip().upper() in _VOLATILITY_INDEX_CODES
+
+
+def _directional_index_changes(indices) -> List[float]:
+    """Collect index changes that move with risk appetite (volatility gauges excluded)."""
+    return [
+        idx.change_pct
+        for idx in (indices or [])
+        if idx.change_pct is not None and not _is_volatility_index(idx)
+    ]
+
+
 @dataclass
 class MarketIndex:
     """大盘指数数据"""
@@ -1311,7 +1331,7 @@ Focus on index trend, liquidity, and sector rotation to shape the next-session t
                 reasons.append(f"上涨家数占比 {up_ratio:.0%}，亏钱效应较强")
             else:
                 reasons.append(f"上涨家数占比 {up_ratio:.0%}，市场分化")
-        index_changes = [idx.change_pct for idx in overview.indices if idx.change_pct is not None]
+        index_changes = _directional_index_changes(overview.indices)
         if index_changes:
             avg_change = sum(index_changes) / len(index_changes)
             reasons.append(f"主要指数平均涨跌幅 {avg_change:+.2f}%")
@@ -1334,7 +1354,7 @@ Focus on index trend, liquidity, and sector rotation to shape the next-session t
                 reasons.append(f"advancers ratio {up_ratio:.0%}, downside pressure dominates")
             else:
                 reasons.append(f"advancers ratio {up_ratio:.0%}, breadth is mixed")
-        index_changes = [idx.change_pct for idx in overview.indices if idx.change_pct is not None]
+        index_changes = _directional_index_changes(overview.indices)
         if index_changes:
             avg_change = sum(index_changes) / len(index_changes)
             reasons.append(f"average major-index change {avg_change:+.2f}%")
@@ -1513,7 +1533,7 @@ Focus on index trend, liquidity, and sector rotation to shape the next-session t
         if breadth_available:
             breadth_score = int(overview.up_count / participants * 100)
 
-        index_changes = [idx.change_pct for idx in overview.indices if idx.change_pct is not None]
+        index_changes = _directional_index_changes(overview.indices)
         index_available = bool(overview.indices and index_changes)
         index_score = 50
         if index_available:

--- a/src/services/portfolio_service.py
+++ b/src/services/portfolio_service.py
@@ -22,6 +22,11 @@ from src.repositories.portfolio_repo import (
 
 logger = logging.getLogger(__name__)
 
+# 组合汇总统一折算到这个币种。汇率刷新必须覆盖「账户本币 → 汇总币种」这一对，
+# 否则 USD 账户永远刷不到 USD/CNY，_convert_amount 只能走 fallback_1_to_1，
+# 结果是 USD 金额被贴上 CNY 的标签（只留一个 fx_stale=True 提示）。
+PORTFOLIO_AGGREGATE_CURRENCY = "CNY"
+
 PortfolioBusyError = RepoPortfolioBusyError
 
 try:
@@ -486,7 +491,7 @@ class PortfolioService:
             account_rows = self.repo.list_accounts(include_inactive=False)
 
         accounts_payload: List[Dict[str, Any]] = []
-        aggregate_currency = "CNY"
+        aggregate_currency = PORTFOLIO_AGGREGATE_CURRENCY
         aggregate = {
             "total_cash": 0.0,
             "total_market_value": 0.0,
@@ -1490,6 +1495,12 @@ class PortfolioService:
         """Return distinct non-base currencies participating in refresh for one account."""
         base_currency = self._normalize_currency(account.base_currency)
         currencies: Set[str] = set()
+        # 汇总口径固定为 PORTFOLIO_AGGREGATE_CURRENCY，因此非本币账户必须刷到
+        # 「本币 → 汇总币种」这一对；此前只从流水里收集币种，USD 账户的流水也全是
+        # USD，于是 pair_count 恒为 0，汇总数字实际未换汇。
+        aggregate_currency = self._normalize_currency(PORTFOLIO_AGGREGATE_CURRENCY)
+        if aggregate_currency != base_currency:
+            currencies.add(aggregate_currency)
         rows = list(self.repo.list_trades(account.id, as_of=as_of_date))
         rows.extend(self.repo.list_cash_ledger(account.id, as_of=as_of_date))
         for row in rows:

--- a/src/services/screening/snapshot_us.py
+++ b/src/services/screening/snapshot_us.py
@@ -13,12 +13,19 @@ rather than silently screening the US pool.
 
 import logging
 import os
+import urllib.request
 from concurrent.futures import ThreadPoolExecutor, as_completed
+from io import StringIO
 import pandas as pd
 
 logger = logging.getLogger(__name__)
 
 _SP500_WIKI_URL = "https://en.wikipedia.org/wiki/List_of_S%26P_500_companies"
+_SP500_FETCH_TIMEOUT = 20
+_WIKI_USER_AGENT = (
+    "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 "
+    "(KHTML, like Gecko) Chrome/128.0.0.0 Safari/537.36"
+)
 
 _DEFAULT_US_UNIVERSE = [
     "AAPL", "MSFT", "NVDA", "AMZN", "GOOGL", "META", "TSLA", "BRK-B",
@@ -65,7 +72,13 @@ def fetch_us_universe(source: str = "auto") -> list[str]:
 
 
 def _fetch_sp500_tickers() -> list[str]:
-    tables = pd.read_html(_SP500_WIKI_URL)
+    # pandas 自带的 urllib 请求不带 User-Agent，Wikipedia 一律回 403，
+    # 于是 fetch_us_universe("auto") 每次都静默回落到 49 只硬编码大盘股。
+    # 自己带 UA 取回 HTML 再交给 read_html 解析。
+    request = urllib.request.Request(_SP500_WIKI_URL, headers={"User-Agent": _WIKI_USER_AGENT})
+    with urllib.request.urlopen(request, timeout=_SP500_FETCH_TIMEOUT) as response:
+        html = response.read().decode("utf-8", errors="replace")
+    tables = pd.read_html(StringIO(html))
     for tbl in tables:
         if "Symbol" in tbl.columns:
             return sorted(tbl["Symbol"].dropna().str.strip().str.replace(".", "-", regex=False).tolist())

--- a/src/services/system_config_service.py
+++ b/src/services/system_config_service.py
@@ -481,7 +481,15 @@ class SystemConfigService:
             field_schema = schema_by_key[key]
             display_value = self._resolve_display_value(raw_value, field_schema, raw_value_exists)
             is_masked = False
-            if key in self._SERVER_MASKED_CONFIG_KEYS and display_value:
+            if display_value and (
+                key in self._SERVER_MASKED_CONFIG_KEYS
+                or bool(field_schema.get("is_sensitive", False))
+            ):
+                # 设置页每次加载都会读这个接口，此前只有 _SERVER_MASKED_CONFIG_KEYS
+                # 里的 4 个键被掩码，其余 40 多个 is_sensitive 字段（各家 LLM Key、
+                # 搜索 Key、Webhook、邮箱密码）都是明文回传。写入侧本就支持用 mask
+                # token 占位保留原值（config_manager.apply_updates 的 skipped_masked），
+                # 所以这里可以安全地统一掩码。
                 display_value = mask_token
                 is_masked = True
             item: Dict[str, Any] = {
@@ -759,6 +767,18 @@ class SystemConfigService:
             content=content,
             reload_now=reload_now,
         )
+
+    def _saved_channel_api_key(self, channel_name: str) -> str:
+        """Return the persisted API key for one named LLM channel, or empty string."""
+        normalized = str(channel_name or "").strip().upper()
+        if not normalized:
+            return ""
+        saved_map = self._manager.read_config_map()
+        for suffix in ("API_KEY", "API_KEYS"):
+            value = str(saved_map.get(f"LLM_{normalized}_{suffix}") or "").strip()
+            if value and not is_masked_secret_placeholder(value):
+                return value
+        return ""
 
     def _resolve_hermes_saved_secret(
         self,
@@ -1223,6 +1243,10 @@ class SystemConfigService:
         channel_name = name.strip() or "channel"
         resolved_api_surface = normalize_llm_channel_api_surface(api_surface)
         generation_stage = "responses" if resolved_api_surface == "responses" else "chat_completion"
+        if not is_reserved_hermes_name(channel_name) and is_masked_secret_placeholder(api_key):
+            # get_config 现在对 is_sensitive 字段统一回传 mask token，设置页把它原样
+            # 提交回来时代表「沿用已保存的密钥」，与写入侧的占位语义保持一致。
+            api_key = self._saved_channel_api_key(channel_name)
         resolved_secret, secret_error, redaction_values = self._resolve_hermes_saved_secret(
             channel_name=channel_name,
             protocol=protocol,

--- a/tests/test_market_light_volatility_index.py
+++ b/tests/test_market_light_volatility_index.py
@@ -1,0 +1,72 @@
+# -*- coding: utf-8 -*-
+"""Volatility gauges must not enter the directional index reading.
+
+Regression: a US session with 标普/纳指/道指 all down and VIX up +8% was scored
+"偏暖" because VIX was averaged into 主要指数平均涨跌幅 and then into
+``index_score = 50 + avg * 12``.
+"""
+
+from __future__ import annotations
+
+import unittest
+
+from src.market_analyzer import (
+    MarketIndex,
+    MarketOverview,
+    _directional_index_changes,
+    _is_volatility_index,
+)
+
+
+def _us_selloff_overview() -> MarketOverview:
+    """Three benchmarks down, VIX sharply up — a risk-off session."""
+    return MarketOverview(
+        date="2026-08-21",
+        indices=[
+            MarketIndex(code="SPX", name="标普500指数", change_pct=-0.69),
+            MarketIndex(code="IXIC", name="纳斯达克综合指数", change_pct=-0.94),
+            MarketIndex(code="DJI", name="道琼斯工业指数", change_pct=-1.17),
+            MarketIndex(code="VIX", name="VIX恐慌指数", change_pct=8.08),
+        ],
+    )
+
+
+class DirectionalIndexChangesTestCase(unittest.TestCase):
+    def test_recognises_volatility_gauges(self) -> None:
+        self.assertTrue(_is_volatility_index(MarketIndex(code="VIX", name="VIX恐慌指数")))
+        self.assertTrue(_is_volatility_index(MarketIndex(code="^vix", name="VIX")))
+        self.assertFalse(_is_volatility_index(MarketIndex(code="SPX", name="标普500指数")))
+
+    def test_excludes_volatility_gauge_from_average(self) -> None:
+        changes = _directional_index_changes(_us_selloff_overview().indices)
+
+        self.assertEqual(changes, [-0.69, -0.94, -1.17])
+        avg = sum(changes) / len(changes)
+        self.assertLess(avg, 0, "普跌交易日的平均涨跌幅必须为负")
+
+    def test_average_would_flip_sign_without_the_filter(self) -> None:
+        indices = _us_selloff_overview().indices
+        naive = [idx.change_pct for idx in indices if idx.change_pct is not None]
+
+        self.assertGreater(sum(naive) / len(naive), 0, "旧口径把普跌日算成上涨，正是该修复要防的回归")
+        filtered = _directional_index_changes(indices)
+        self.assertLess(sum(filtered) / len(filtered), 0)
+
+    def test_missing_change_pct_is_still_skipped(self) -> None:
+        indices = [
+            MarketIndex(code="SPX", name="标普500指数", change_pct=-0.69),
+            MarketIndex(code="DJI", name="道琼斯工业指数", change_pct=None),
+        ]
+        self.assertEqual(_directional_index_changes(indices), [-0.69])
+
+    def test_empty_and_volatility_only_inputs_are_safe(self) -> None:
+        self.assertEqual(_directional_index_changes([]), [])
+        self.assertEqual(_directional_index_changes(None), [])
+        self.assertEqual(
+            _directional_index_changes([MarketIndex(code="VIX", name="VIX恐慌指数", change_pct=8.0)]),
+            [],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_multi_agent.py
+++ b/tests/test_multi_agent.py
@@ -3209,7 +3209,13 @@ class TestResearchAgentFilteredRegistry(unittest.TestCase):
 
         agent = ResearchAgent(tool_registry=MagicMock(), llm_adapter=MagicMock())
         with patch.object(agent, "_decompose_query", return_value={"questions": ["Q1"], "tokens": 3}), \
-             patch.object(agent, "_research_sub_question", return_value={"summary": "done", "tokens": 7}), \
+             patch.object(
+                 agent,
+                 "_research_sub_question",
+                 # 与 _research_sub_question 的真实返回保持一致（含 content），
+                 # 否则会被「无可用发现」短路，测不到本用例要验证的合成失败冒泡。
+                 return_value={"question": "Q1", "content": "done", "tokens": 7, "success": True},
+             ), \
              patch.object(agent, "_synthesise_report", return_value={"content": "fallback", "tokens": 5, "error": "boom"}):
             result = agent.research("分析 600519")
 

--- a/tests/test_portfolio_fx_refresh_pairs.py
+++ b/tests/test_portfolio_fx_refresh_pairs.py
@@ -1,0 +1,90 @@
+# -*- coding: utf-8 -*-
+"""FX refresh must cover the account-base → aggregate-currency pair.
+
+Regression: a USD account produced ``pair_count == 0`` because only trade/cash
+currencies differing from the *account* base were collected. USD/CNY was never
+fetched, so ``_convert_amount`` fell back to 1:1 and the CNY-labelled aggregate
+was really raw USD.
+"""
+
+from __future__ import annotations
+
+import os
+import tempfile
+import unittest
+from datetime import date
+from pathlib import Path
+
+from src.config import Config
+from src.services.portfolio_service import PORTFOLIO_AGGREGATE_CURRENCY, PortfolioService
+from src.storage import DatabaseManager
+
+
+class PortfolioFxRefreshPairsTestCase(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.env_path = Path(self.temp_dir.name) / ".env"
+        self.db_path = Path(self.temp_dir.name) / "portfolio_fx.db"
+        self.env_path.write_text(
+            "\n".join(
+                [
+                    "STOCK_LIST=600519",
+                    "GEMINI_API_KEY=test",
+                    "ADMIN_AUTH_ENABLED=false",
+                    f"DATABASE_PATH={self.db_path}",
+                ]
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        os.environ["ENV_FILE"] = str(self.env_path)
+        os.environ["DATABASE_PATH"] = str(self.db_path)
+        Config.reset_instance()
+        DatabaseManager.reset_instance()
+        self.db = DatabaseManager.get_instance()
+        self.service = PortfolioService()
+
+    def tearDown(self) -> None:
+        DatabaseManager.reset_instance()
+        Config.reset_instance()
+        os.environ.pop("ENV_FILE", None)
+        os.environ.pop("DATABASE_PATH", None)
+        self.temp_dir.cleanup()
+
+    def _account(self, *, market: str, currency: str):
+        return self.service.create_account(
+            name=f"{market}-account", broker="Demo", market=market, base_currency=currency
+        )
+
+    def test_foreign_base_account_needs_the_aggregate_pair(self) -> None:
+        account = self._account(market="us", currency="USD")
+        row = self.service.repo.get_account(account["id"])
+
+        currencies = self.service._list_account_refresh_fx_currencies(
+            account=row, as_of_date=date(2026, 8, 21)
+        )
+
+        self.assertIn(PORTFOLIO_AGGREGATE_CURRENCY, currencies)
+
+    def test_domestic_base_account_needs_no_self_pair(self) -> None:
+        account = self._account(market="cn", currency=PORTFOLIO_AGGREGATE_CURRENCY)
+        row = self.service.repo.get_account(account["id"])
+
+        currencies = self.service._list_account_refresh_fx_currencies(
+            account=row, as_of_date=date(2026, 8, 21)
+        )
+
+        self.assertNotIn(PORTFOLIO_AGGREGATE_CURRENCY, currencies)
+
+    def test_refresh_reports_a_pair_for_a_foreign_base_account(self) -> None:
+        self._account(market="us", currency="USD")
+
+        summary = self.service.refresh_fx_rates(as_of=date(2026, 8, 21))
+
+        self.assertGreaterEqual(
+            summary["pair_count"], 1, "USD 账户必须至少刷新 USD→CNY 这一对"
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_research_agent_findings.py
+++ b/tests/test_research_agent_findings.py
@@ -1,0 +1,72 @@
+# -*- coding: utf-8 -*-
+"""Deep research must not report success when every sub-question came back empty.
+
+Regression: sub-question agents that hit the step cap return an empty
+``content``.  ``_synthesise_report`` only joins findings that *have* content, so
+the synthesis prompt carried an empty "Research Findings" block, the model replied
+"研究材料缺失", and the endpoint still returned ``success: true``.
+"""
+
+from __future__ import annotations
+
+import unittest
+from unittest.mock import patch
+
+from src.agent.research import ResearchAgent, ResearchResult
+
+
+def _agent() -> ResearchAgent:
+    """Build the agent without __init__ so no tool registry / LLM client is needed."""
+    agent = ResearchAgent.__new__(ResearchAgent)
+    agent.max_sub_questions = 3
+    agent.token_budget = 100_000
+    return agent
+
+
+class ResearchFindingsTestCase(unittest.TestCase):
+    def _run(self, findings, synth=None):
+        agent = _agent()
+        decomposed = {"questions": ["q1", "q2"], "tokens": 0}
+        with patch.object(ResearchAgent, "_decompose_query", return_value=decomposed), \
+             patch.object(ResearchAgent, "_research_sub_question", side_effect=findings), \
+             patch.object(
+                 ResearchAgent,
+                 "_synthesise_report",
+                 return_value=synth or {"content": "# 报告", "tokens": 10},
+             ) as synth_mock:
+            result = agent.research("AI 芯片板块最近的核心驱动是什么？")
+        return result, synth_mock
+
+    def test_all_empty_findings_fail_loudly(self) -> None:
+        findings = [
+            {"question": "q1", "content": "", "tokens": 900, "success": True},
+            {"question": "q2", "content": "   ", "tokens": 800, "success": True},
+        ]
+        result, synth_mock = self._run(findings)
+
+        self.assertIsInstance(result, ResearchResult)
+        self.assertFalse(result.success, "没有任何可用发现时不能报成功")
+        self.assertEqual(result.error, "no_usable_findings")
+        self.assertEqual(result.findings_count, 0)
+        self.assertEqual(result.report, "")
+        synth_mock.assert_not_called()
+        # token 消耗仍要如实上报，便于用量核账
+        self.assertEqual(result.total_tokens, 1700)
+
+    def test_partial_findings_still_synthesise(self) -> None:
+        findings = [
+            {"question": "q1", "content": "", "tokens": 500, "success": True},
+            {"question": "q2", "content": "英伟达 Q2 数据中心收入超预期", "tokens": 700, "success": True},
+        ]
+        result, synth_mock = self._run(findings)
+
+        self.assertTrue(result.success)
+        self.assertEqual(result.findings_count, 1, "findings_count 应只计可用发现")
+        self.assertEqual(result.report, "# 报告")
+        synth_mock.assert_called_once()
+        passed_findings = synth_mock.call_args.args[1]
+        self.assertEqual([f["question"] for f in passed_findings], ["q2"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_system_config_api.py
+++ b/tests/test_system_config_api.py
@@ -108,13 +108,14 @@ class SystemConfigApiTestCase(unittest.TestCase):
         add_auth_middleware(app)
         return app
 
-    def test_get_config_keeps_regular_secret_value_unmasked(self) -> None:
+    def test_get_config_masks_regular_secret_value(self) -> None:
         payload = system_config.get_system_config(include_schema=True, service=self.service).model_dump(by_alias=True)
         item_map = {item["key"]: item for item in payload["items"]}
         self.assertIn("openai", payload["llm_model_providers"])
         self.assertIn("xai", payload["llm_model_providers"])
-        self.assertEqual(item_map["GEMINI_API_KEY"]["value"], "secret-key-value")
-        self.assertFalse(item_map["GEMINI_API_KEY"]["is_masked"])
+        self.assertEqual(item_map["GEMINI_API_KEY"]["value"], payload["mask_token"])
+        self.assertTrue(item_map["GEMINI_API_KEY"]["is_masked"])
+        self.assertTrue(item_map["GEMINI_API_KEY"]["raw_value_exists"])
 
     def test_get_config_masks_llm_usage_hmac_secret(self) -> None:
         self._rewrite_env(

--- a/tests/test_system_config_service.py
+++ b/tests/test_system_config_service.py
@@ -62,16 +62,20 @@ class SystemConfigServiceTestCase(unittest.TestCase):
         message = SimpleNamespace(content=content, tool_calls=tool_calls or [])
         return SimpleNamespace(choices=[SimpleNamespace(message=message)])
 
-    def test_get_config_keeps_regular_sensitive_values_unmasked(self) -> None:
+    def test_get_config_masks_every_sensitive_value(self) -> None:
         payload = self.service.get_config(include_schema=True)
         items = {item["key"]: item for item in payload["items"]}
 
         self.assertIn("openai", payload["llm_model_providers"])
         self.assertIn("xai", payload["llm_model_providers"])
         self.assertIn("GEMINI_API_KEY", items)
-        self.assertEqual(items["GEMINI_API_KEY"]["value"], "secret-key-value")
-        self.assertFalse(items["GEMINI_API_KEY"]["is_masked"])
+        # 设置页每次加载都会读这个接口，敏感字段一律回传 mask token；
+        # raw_value_exists 仍然告诉前端「已保存过值」，写入侧靠 mask token 占位保留原值。
+        self.assertEqual(items["GEMINI_API_KEY"]["value"], payload["mask_token"])
+        self.assertTrue(items["GEMINI_API_KEY"]["is_masked"])
         self.assertTrue(items["GEMINI_API_KEY"]["raw_value_exists"])
+        # 非敏感字段不受影响
+        self.assertFalse(items["STOCK_LIST"]["is_masked"])
 
     def _assert_agent_backend_status_matches_runtime(
         self,
@@ -884,7 +888,8 @@ class SystemConfigServiceTestCase(unittest.TestCase):
 
             self.assertEqual(pre_save_items["OPENAI_BASE_URL"]["value"], "https://runtime-openai.v1")
             self.assertFalse(pre_save_items["OPENAI_BASE_URL"]["raw_value_exists"])
-            self.assertEqual(pre_save_items["OPENAI_API_KEY"]["value"], "runtime-openai-key")
+            self.assertEqual(pre_save_items["OPENAI_API_KEY"]["value"], pre_save["mask_token"])
+            self.assertTrue(pre_save_items["OPENAI_API_KEY"]["is_masked"])
             self.assertFalse(pre_save_items["OPENAI_API_KEY"]["raw_value_exists"])
             self.assertEqual(pre_save_items["LITELLM_MODEL"]["value"], "openai/gpt-4o-mini")
             self.assertTrue(pre_save_items["LITELLM_MODEL"]["raw_value_exists"])
@@ -988,9 +993,12 @@ class SystemConfigServiceTestCase(unittest.TestCase):
         items = {item["key"]: item for item in payload["items"]}
 
         self.assertIn("LLM_CHANNELS", items)
-        self.assertEqual(items["LLM_DEEPSEEK_API_KEY"]["value"], "sk-test-value")
+        # 渠道 Key 属于敏感字段，回传 mask token；非敏感的 MODELS 保持原值。
+        self.assertEqual(items["LLM_DEEPSEEK_API_KEY"]["value"], payload["mask_token"])
+        self.assertTrue(items["LLM_DEEPSEEK_API_KEY"]["is_masked"])
         self.assertEqual(items["LLM_DEEPSEEK_MODELS"]["value"], "deepseek-v4-flash,deepseek-v4-pro")
-        self.assertEqual(items["LLM_MY_PROXY_API_KEYS"]["value"], "sk-key-1,sk-key-2")
+        self.assertEqual(items["LLM_MY_PROXY_API_KEYS"]["value"], payload["mask_token"])
+        self.assertTrue(items["LLM_MY_PROXY_API_KEYS"]["is_masked"])
         self.assertEqual(items["LLM_MY_PROXY_MODELS"]["value"], "gpt-5.5")
         self.assertEqual(items["LLM_MY_PROXY_API_KEYS"]["schema"]["category"], "ai_model")
         self.assertNotIn("LLM_UNUSED_API_KEY", items)


### PR DESCRIPTION
**当前 Head CI：`ai-governance:pass / backend-gate:pass / docker-build:pass / web-gate:skipped（本 PR 未触及前端，CI 自行跳过）`**

> 当前状态：全部通过（pass）。运行链接：https://github.com/ZhuLinsen/daily_stock_analysis/actions/runs/32655557024
> 已就最新 Head（rebase 到 `9ab79b8` 之后）回填，与本 PR 描述一致。

## PR Type

- [x] fix

## Background And Problem

六个在实际部署中观察到的缺陷。**共同点是都不会抛错**，而是让接口带着错误、空白或未换汇的数据以成功状态返回，因此在日志和监控里都不易察觉。

| # | 问题 | 触发场景 | 影响 |
| --- | --- | --- | --- |
| 1 | 敏感配置明文回传 | 打开设置页 | 40+ 个 `is_sensitive` 字段（各家 LLM API Key、搜索 Key、Webhook 地址与密钥、邮箱密码）明文出现在 `GET /api/v1/system/config` 响应体 |
| 2 | 波动率指数污染大盘方向 | 美股复盘且指数列表含 VIX | 普跌日被判成「偏暖」 |
| 3 | SSE 流被 CDN 按空闲断开 | 单阶段长时间无工具事件 | 前端收到断流，分析中断 |
| 4 | 美股选股股票池静默退化 | `fetch_us_universe("auto")` | 503 只 → 49 只硬编码大盘股，无任何报错 |
| 5 | 组合汇总未换汇却贴 CNY 标签 | 非 CNY 本币账户 | 汇总金额是原币值，仅有一个 `fx_stale=True` 提示 |
| 6 | 深度研究全空仍报成功 | 子问题 agent 撞到步数上限 | 返回一份「研究材料缺失」正文，但 `success: true` |

**详细成因**

1. **`src/services/system_config_service.py`** —— 此前只有 `_SERVER_MASKED_CONFIG_KEYS` 里 4 个写死的键走服务端掩码。写入侧本就支持用 mask token 占位保留原值（`config_manager.apply_updates` 的 `skipped_masked`），所以读取侧可以安全地按 `field_schema["is_sensitive"]` 统一掩码。配套地，LLM 渠道连接测试收到 mask token 时回落到已保存的密钥，「测试渠道」按钮行为不变。

2. **`src/market_analyzer.py`** —— 波动率与风险偏好反向。实测三大指数 -0.69% / -0.94% / -1.17%、VIX +8% 的交易日，「主要指数平均涨跌幅」算出 +1.32%，`index_score = 50 + avg*12` 被抬到 66。新增 `_directional_index_changes()`，把 VIX/VXN/VHSI 排除在方向性均值之外；**这些指数仍照常显示在报表中**，只是不参与打分。

3. **`api/v1/endpoints/agent.py`** —— 单个编排阶段实测出现过 111 秒无工具事件的静默，超过 Cloudflare 约 100 秒的静默断流阈值。改为 20 秒心跳；心跳是 SSE 注释行（`: heartbeat`），不会被 `EventSource` 当成事件，**前端无需任何改动**。300 秒空闲预算语义不变（收到任何事件即重置），Codex 后端仍由其自身 deadline 主导。

4. **`src/services/screening/snapshot_us.py`** —— `pd.read_html(url)` 内部的 urllib 请求不带 User-Agent，Wikipedia 一律回 403，异常被上层吞掉后静默回落到硬编码池。改为自带 UA 取回 HTML 再交给 `read_html(StringIO(html))` 解析。

5. **`src/services/portfolio_service.py`** —— 汇率刷新只从流水里收集「与账户本币不同」的币种，而 USD 账户的流水也全是 USD，于是 `pair_count` 恒为 0、USD/CNY 永不获取，`_convert_amount` 只能走 1:1 兜底。补上「账户本币 → 汇总币种」这一对，并把汇总币种提成常量 `PORTFOLIO_AGGREGATE_CURRENCY`。

6. **`src/agent/research.py`** —— 子问题 agent 撞到步数上限会返回空 `content`，而 `_synthesise_report` 只拼接有 content 的条目。此前只判断 `all_findings` 非空，于是空内容也会走合成。改为按「可用发现」判断，全空时返回 `success: false` / `error: no_usable_findings`，`findings_count` 也只统计可用发现。

**附带修复**：`data_provider/yfinance_fetcher.py` —— Yahoo 有时只为最新交易日回填 volume、OHLC 全为 NaN，直接取 `iloc[-1]` 会把 NaN 写进大盘复盘报告。改为剔除无效行，并在「最新交易日 OHLC 被剔除」或「只有一根有效 K 线」（如 ^VIX，昨收退化成今收、涨跌幅恒为 0）时用 `fast_info` 兜底，取不到则退回上一交易日数据并告警。

## Scope Of Change

```
 api/v1/endpoints/agent.py                   | 38 ++++++++----
 data_provider/yfinance_fetcher.py           | 72 +++++++++++++++++++++--
 docs/CHANGELOG.md                           |  6 ++
 src/agent/research.py                       | 35 +++++++----
 src/market_analyzer.py                      | 26 ++++++++-
 src/services/portfolio_service.py           | 13 ++++-
 src/services/screening/snapshot_us.py       | 15 ++++-
 src/services/system_config_service.py       | 26 ++++++++-
 tests/test_market_light_volatility_index.py | 72 +++++++++++++++++++++++
 tests/test_multi_agent.py                   |  8 ++-
 tests/test_portfolio_fx_refresh_pairs.py    | 90 +++++++++++++++++++++++++++++
 tests/test_research_agent_findings.py       | 72 +++++++++++++++++++++++
 tests/test_system_config_api.py             |  7 ++-
 tests/test_system_config_service.py         | 20 +++++--
 14 files changed, 458 insertions(+), 42 deletions(-)
```

- **文件总数 / 变更行数**：14 个文件，+458 / -42
- **文件清单**（按实际 diff 全量）：
  - `api/v1/endpoints/agent.py`
  - `data_provider/yfinance_fetcher.py`
  - `docs/CHANGELOG.md`
  - `src/agent/research.py`
  - `src/market_analyzer.py`
  - `src/services/portfolio_service.py`
  - `src/services/screening/snapshot_us.py`
  - `src/services/system_config_service.py`
  - `tests/test_market_light_volatility_index.py`（新增）
  - `tests/test_multi_agent.py`
  - `tests/test_portfolio_fx_refresh_pairs.py`（新增）
  - `tests/test_research_agent_findings.py`（新增）
  - `tests/test_system_config_api.py`
  - `tests/test_system_config_service.py`
- **文档更新文件（`docs/*`）**：`docs/CHANGELOG.md`（6 条 `[修复]` 条目，与本 PR 六项一一对应）

未修改 `.github/PULL_REQUEST_TEMPLATE.md`、`.github/copilot-instructions.md`、`AGENTS.md`、`.github/instructions/*`、`.claude/skills/**` 等协作与治理文件。

## Issue Link

无对应 Issue。这些缺陷来自实际部署中的观察，非社区报告。

**验收标准**：

1. `GET /api/v1/system/config` 响应体中不再出现任何真实密钥；提交 mask token 保存时原值不被覆盖（`skipped_masked` 计数 > 0），「测试渠道」按钮仍能连通。
2. 指数列表含 VIX 时，`index_score` 与「主要指数平均涨跌幅」的取值不再受 VIX 影响；VIX 本身仍出现在报表里。
3. `/api/v1/agent/chat/stream` 在无事件期间每 20 秒产出一行 `: heartbeat`；300 秒真正空闲后仍按原语义超时。
4. `fetch_us_universe("auto")` 返回数量显著大于 49（S&P 500 全量）。
5. 非 CNY 本币账户的 `pair_count` > 0，汇总金额确实经过换汇。
6. 所有子问题返回空 content 时，`/api/v1/agent/research` 返回 `success: false` 且 `error == "no_usable_findings"`。

## Verification Commands And Results

本地实跑（`Python 3.11` / `pytest 9.1.1`），只跑与本 PR 直接相关的模块，未跑全量套件：

```bash
python -m pytest -q \
  tests/test_market_light_volatility_index.py \
  tests/test_portfolio_fx_refresh_pairs.py \
  tests/test_research_agent_findings.py \
  tests/test_system_config_api.py \
  tests/test_system_config_service.py
```

关键输出：

```
================= 270 passed, 4 warnings in 319.67s (0:05:19) ==================
```

三个新增测试文件分别覆盖：波动率指数不进方向性均值、非本币账户的汇率对收集、深度研究全空时的 `no_usable_findings` 短路。`tests/test_multi_agent.py` 中 `TestResearchAgentFilteredRegistry` 的 stub 同步改成与 `_research_sub_question` 真实返回一致（含 `content`），否则会被新的短路提前拦下、测不到该用例原本要验证的合成失败冒泡。

**Full-suite note**：**本地未运行全量套件**（`./scripts/ci_gate.sh` / `python -m pytest -m "not network"` 均未执行），因此本地无全量结论。全量结果以本 PR 的 Head CI 为准。

- ai-governance：`pass` — https://github.com/ZhuLinsen/daily_stock_analysis/actions/runs/32655557024
- backend-gate：`pass` — https://github.com/ZhuLinsen/daily_stock_analysis/actions/runs/32655557024
- backend-tests (1/3, 2/3, 3/3)：`pass` — https://github.com/ZhuLinsen/daily_stock_analysis/actions/runs/32655557024
- docker-build：`pass` — https://github.com/ZhuLinsen/daily_stock_analysis/actions/runs/32655557024
- web-gate：`skipped` —— 变更检测判定本 PR 未触及 `apps/dsa-web/`，该 gate 自行跳过（与 Visual Evidence 一节的说明一致）— https://github.com/ZhuLinsen/daily_stock_analysis/actions/runs/32655557024

**当前状态：全部通过（pass）**，无 failing 项。

> 补充：本 PR 已 rebase 到上游最新 `main`（`9ab79b8`，含 v3.31.0 发版），`docs/CHANGELOG.md` 的 6 条已放在 `[Unreleased]` 段而非已发布的 `[3.31.0]` 段。rebase 后本地相关测试重跑仍为 `270 passed`。

## Visual Evidence (if applicable)

- **截图链接**：无。
- **不适用原因**：本 PR **未新增或修改任何 Web 设置字段、标签或帮助文案**，`apps/dsa-web/` 下无任何文件改动（见上面的文件清单）。唯一与设置页相关的是后端行为——`GET /api/v1/system/config` 现在把 `is_sensitive` 字段的值替换成 mask token，页面的字段、文案与布局都不变，变化只体现在输入框里显示的是掩码而非明文密钥。
- **可复现证据（命令 + 产物路径）**：
  - 命令：`cd apps/dsa-web && npx playwright test e2e/smoke.spec.ts --grep "settings page renders title and save actions after login"`
  - 产物路径：`apps/dsa-web/test-results/**/smoke-settings-page-*.png`
  - 说明：该用例可用于确认设置页在掩码生效后仍正常渲染并可保存。**此命令我未执行**（本地无浏览器环境），如维护者认为该证据必要，我可以补跑或请协助在 CI 产物中确认。
  - 纯后端层面的等价验证已包含在上面的 `tests/test_system_config_api.py` / `tests/test_system_config_service.py`（270 passed），其中含掩码回传与 mask token 占位保存的断言。

## Compatibility And Risk

本 PR 未变更 provider/model/base URL、运行时配置清理迁移语义；历史配置保持不变；回滚方式为 revert 本提交。

逐项风险：

1. **掩码（行为可见变更）** —— 任何**直接读 `GET /api/v1/system/config` 取真实密钥**的外部集成会拿到 mask token。仓库内的写入侧与设置页都已按占位语义处理，但如果有仓库外脚本依赖该接口读明文，需要改为从配置文件/环境变量取值。这是本 PR 唯一一处可能影响既有用法的改动，也是它的目的。
2. **VIX 排除** —— 仅影响方向性均值与 `index_score`；指数展示不变。识别按代码白名单 `{VIX, ^VIX, VXN, ^VXN, VHSI, ^VHSI}`，其他波动率代码不受影响（保守，不会误伤普通指数）。
3. **SSE 心跳** —— `: heartbeat` 是 SSE 注释行，符合规范且不会被 `EventSource` 当成事件，前端无需改动。Codex 后端沿用其自身 deadline，未引入第二个超时源。
4. **S&P 500 UA** —— 依赖 Wikipedia 页面结构不变（与改前一致，只是换了取 HTML 的方式）；新增 20 秒超时，取不到时行为与改前相同（回落到硬编码池）。
5. **汇率对** —— 非 CNY 本币账户会多一次汇率获取；CNY 本币账户行为完全不变。
6. **`no_usable_findings`** —— 调用方若把 `success` 之外的字段当作唯一判据需注意：此前这种情况返回 `success: true` + 一段无内容正文，现在返回 `success: false` + 空正文。这是修复意图本身。

未依赖特定 LiteLLM 版本窗口或 OpenAI-compatible 路由行为。

## Rollback Plan

`revert this PR`。六项改动彼此独立、均为纯代码逻辑，不涉及数据迁移、配置改写或 schema 变更，revert 后行为立即回到改动前，无需额外回滚步骤。

如只想回退其中某一项，六个改动分布在互不重叠的文件里（掩码=`system_config_service.py`；VIX=`market_analyzer.py`；SSE=`api/v1/endpoints/agent.py`；股票池=`snapshot_us.py`；汇率=`portfolio_service.py`；研究=`research.py`），可以按文件单独 revert。

## EXTRACT_PROMPT Change (if applicable)

不适用，本 PR 未修改 `src/services/image_stock_extractor.py`。

## Checklist

- [x] 本 PR 有明确动机和业务价值
- [x] 已提供可复现的验证命令与结果
- [x] 已评估兼容性与风险
- [x] 已提供回滚方案
- [x] 若修改报告格式或 Web UI 界面，已在 PR 描述/评论附受影响报告 / 页面截图，且未把一次性验收截图作为仓库文件合入 —— 本 PR 未改 Web UI，已在 Visual Evidence 给出不适用原因与替代证据
- [x] 若本 PR 修改 Web 设置字段 —— 未修改，`apps/dsa-web/` 无改动
- [x] 若涉及用户可见变更，已同步更新相关文档与 `docs/CHANGELOG.md`

---

**说明**：六项改动分布在互不重叠的文件中，如果维护者希望拆成多个 PR 分别审阅，我可以随时拆开重提。
