### PR TITLE
feat: Web Chat 分词器 (#2239 Web Intent 模块 PR-2)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 ## [Unreleased]
 
 - [修复] Linux/Docker 分享图补齐 Noto CJK 字体与中韩文字体栈，避免 PNG 只显示数字和英文、中文或韩文内容消失。
+- [新功能] Web Chat 意图识别层新增分词模块：`web_intent_tokenizer` 六步管道（多股票全名实体扫描 → 标点/空白切分 → 代码形提取 → 市场关键词 → 无歧义关键词 → 残存 gap 多策略 DFS 匹配）把用户消息切分为携带语义标签的 Token 序列；配套 `web_intent_types` 数据字典（Token 结构、Market 枚举、21 个语义 tag、clean/extend 双词池与正则机器）。核心原则"宁可不做，不可做错"：Step 1~5 只做精确匹配，Step 6 要求整段 TAG 全覆盖（交叉验证）才产出，未覆盖片段保持空 tag 交下游 LLM 兜底；代码形 token 辨认为 `stock_code`（附 code/name/market 三元组）/ `wrong_{market}_code` / `unknown_{market}_code` 三态，token 层代码拼写统一 canonical 归一（a=6 位裸数字、hk=HK+5 位、us=大写 ticker）。意图枚举与意图识别结果随后续 `web_intent_resolver` PR 引入。新增 183 个分词单元测试。
 <!-- 新条目格式：- [类型] 描述（类型取值：新功能/改进/修复/文档/测试/chore）-->
 <!-- 每条独立一行追加到本段末尾，无需分类标题，合并时冲突最小 -->
 

--- a/src/agent/web_intent_tokenizer.py
+++ b/src/agent/web_intent_tokenizer.py
@@ -1,0 +1,802 @@
+# -*- coding: utf-8 -*-
+"""
+Web Chat 意图识别层 — 六步分词管道（Intent Tokenizer）。
+
+把一条用户消息切分为携带语义标签的 ``Token`` 序列，供
+``web_intent_resolver.WebIntentResolver`` 做规则分类；本模块不做任何
+意图判定，只负责"识别出消息里有什么"。
+
+== 六步管道（_preprocess_text，按执行顺序）==
+  Step 1   多股票实体扫描（仅全名精确匹配，8~2 字窗口，含改名旧称；入口
+           extend_AkShare 把 AkShare 全量并入 stockDB——扩展点钉死在全
+           管道最前）
+  Step 2   特殊标点与空白切分（排除 * - .，可能出现在股票名/代码中；仅
+           作用于 Step 1 的 gap）
+  Step 3   代码形字符串提取（unknown_code；任意位裸数字 → unknown_number）
+  Step 4   市场关键词提取（含"股"+"份"消歧）
+  Step 5   无歧义关键词分词（clean 词池）
+  Step 6   残存 gap 多策略匹配（关键词/精确/子串/拼音/模糊 DFS）
+
+== 核心原则 ==
+宁可不做，不可做错，放弃一切低置信度的匹配。Step 1-5 只做精确匹配；
+Step 6 混合匹配但要求整段 TAG 全覆盖（交叉验证）才产出，任一片段无 tag
+则整体原样返回，交下游 LLM 兜底。
+
+== 关键不变量 ==
+  - 实体扫描（Step 1）先于一切切分类步骤：全名一旦被撕裂即无法复原，
+    含代码形/关键词子串的全名（"TCL科技"/"恒生电子"）必须先被整名消费。
+    AkShare 扩展因此钉死在管道最前，Steps 1~6 自始面对同一合并后库视图。
+  - 输入侧 NFKC 宽度归一 + 窗口匹配时删去输入端空格："贵 州 茅 台" 与
+    常规书写同样整名命中（库侧源数据归一属 resolver 层，后续 PR 引入）。
+  - token 层代码身份的规范拼写单一定义点 ``_canonical_stock_code``（a=6
+    位裸数字、hk=HK+5 位、us=大写 ticker）：名称路径与代码路径共享同一
+    拼写，下游从其它来源（LLM 输出/session 继承）构造 stocks 时必须复用，
+    否则同一股票出现多重代码身份。
+  - sector 系三标签词池见 web_intent_types（泛称/行业名/行业兼股票名），
+    全管道不做个股名匹配；行业名+泛称相邻为高置信度板块组合。
+
+unknown_code 由 ``_identify_stock_codes`` 辨认：库命中 → stock_code（附
+三元组）；形态非法或该市场库全量未命中 → wrong_{market}_code；库非全量
+未命中 → unknown_{market}_code（存疑交下游 LLM）。
+"""
+
+from __future__ import annotations
+
+import re
+import unicodedata
+from typing import Dict, List, Optional, Tuple
+
+from src.agent.stock_scope import extract_stock_codes  # 代码格式校验（不查库）
+from src.agent.web_intent_types import (
+    Market,
+    TAG_FILLER,
+    TAG_SECTOR,
+    TAG_SECTOR_NAME,
+    TAG_SECTOR_N_STOCK,
+    TAG_STOCK_CODE,
+    TAG_STOCK_NAME,
+    TAG_SUBJECT_INDEX,
+    TAG_SUBJECT_MARKET,
+    TAG_SUBJECT_MARKET_BROAD,
+    TAG_UNKNOWN_CODE,
+    TAG_UNKNOWN_NUMBER,
+    Token,
+    _ASCII_KEYWORD_UPPER,
+    _CLEAN_KEYWORDS_PATTERN,
+    _DIGIT_KEYWORDS_RE,
+    _HAS_CONTENT_PATTERN,
+    _KW_TO_MARKET,
+    _SPECIAL_PUNCT_RE,
+    _TAG_KEYWORD_LISTS_EXTEND,
+    _classify_keyword,
+    _compile_kw_pattern,
+    unknown_code_tag,
+    wrong_code_tag,
+)
+from src.services.name_to_code_resolver import (
+    Stock,  # (code/name/market)
+    US_stock_code_match,  # 美股代码匹配
+    _db_lock,  # stockDB 读锁：与下游 extend_AkShare 的并发合并串行
+    extend_AkShare,  # Step 1 入口调用：合并 AkShare 全量进 stockDB（幂等）
+    is_known_stock_name,  # 本地名称表成员判定（不联网）
+    is_market_db_complete,  # 市场库全量判定（wrong/unknown 细分依据）
+    lookup_stock_by_code,  # 代码查库（stock_code 三元组来源）
+    resolver_name_to_code_list,
+    stockAliases,  # 改名旧称（code→{旧名}）：实体索引与 resolver 口径对齐
+    stockDB,  # 全局名称库（code→name，可被 AkShare 原地扩充）
+)
+from src.services.stock_code_utils import (  # 交易所推断权威实现（无 agent 反向依赖）
+    _infer_cn_exchange,
+)
+
+
+def _extract_markets_from_tokens(tokens: List[Token]) -> List[Market]:
+    """从 token 提取市场枚举（唯一提取点）：TAG_SUBJECT_MARKET → _KW_TO_MARKET，
+    另识别 ASCII 简写 "us"/"hk"。消歧已在 _split_market_tokens 完成，此处仅映射。
+
+    小写简写仅在消息含 CJK 时生效：纯英文消息里独立的小写 "us" 几乎总是
+    代词；大写 US/HK 是刻意形态，不受语境限制。"""
+    has_cjk = any("\u3400" <= ch <= "\u9fff" for t in tokens for ch in t.text)
+    markets: List[Market] = []
+    seen: set = set()
+    for t in tokens:
+        if t.tag == TAG_SUBJECT_MARKET:
+            mkt = _KW_TO_MARKET.get(t.text.lower())
+            if mkt and mkt not in seen:
+                markets.append(mkt)
+                seen.add(mkt)
+        else:
+            stripped = t.text.strip()
+            shorthand = stripped.lower()
+            if shorthand in ("us", "hk") and (has_cjk or shorthand != stripped):
+                mkt = Market(shorthand)
+                if mkt not in seen:
+                    markets.append(mkt)
+                    seen.add(mkt)
+    return markets
+
+
+def _recognition_rate(tokens: List[Token]) -> float:
+    """已打标签 token 占全部 token 的比例，低则升级 LLM 兜底。"""
+    if not tokens:
+        return 0.0
+    return sum(1 for t in tokens if t.tag) / len(tokens)
+
+
+def _market_of_code(code: str) -> str:
+    """从代码形态推断市场：6 位→a、5 位→hk、字母 ticker→us（与
+    name_to_code_resolver._infer_code_market 语义一致）。"""
+    c = (code or "").strip().upper()
+    if not c:
+        return ""
+    if c.isdigit():
+        if len(c) == 5:
+            return "hk"
+        if len(c) == 6:
+            return "a"
+        return ""
+    if re.match(r"^[A-Z]{1,5}(\.[A-Z])?$", c):
+        return "us"
+    return ""
+
+
+def _canonical_stock_code(code: str, market: str) -> str:
+    """token 层股票代码的规范拼写：hk → HK+5 位，a/us 保持 stockDB 键原样
+    （6 位裸数字 / 大写 ticker）。名称路径产出的唯一归一点——不归一会与
+    代码路径形成同一股票的双重身份。"""
+    if market == "hk" and code.isdigit():
+        return f"HK{code}"
+    return code
+
+
+def _canonical_stocks(stocks: List[Stock]) -> List[Stock]:
+    """批量套用 _canonical_stock_code（Stock 为 frozen，需重建）。"""
+    return [
+        Stock(code=_canonical_stock_code(s.code, s.market), name=s.name, market=s.market)
+        for s in stocks
+    ]
+
+
+# =========================================================================
+# Step 1 — 多股票实体扫描（仅全名精确匹配，管道首步）
+# =========================================================================
+
+def _build_entity_index() -> Tuple[List[str], Dict[str, List[Tuple[str, str, str]]]]:
+    """构建实体扫描索引：全名列表 + 名称 → [(code, market, 规范名)]。
+
+    含 stockAliases 改名旧称（与 resolver 口径对齐），别名命中同样展示当前
+    规范名。每消息重建一次（stockDB 可能被 AkShare 扩充改变，不能跨消息
+    缓存）；只读当时的 stockDB，绝不主动发起扩展。
+    """
+    names: List[str] = []
+    name_codes: Dict[str, List[Tuple[str, str, str]]] = {}
+    # 持锁迭代：与并发请求的 extend_AkShare 原地合并串行，防 dict 迭代崩溃
+    with _db_lock:
+        for code, name in stockDB.items():
+            if not name or not code:
+                continue
+            if name not in name_codes:
+                names.append(name)
+                name_codes[name] = []
+            market = _market_of_code(code)
+            if market:
+                name_codes[name].append((code, market, name))
+        for code, aliases in stockAliases.items():
+            market = _market_of_code(code)
+            canonical = stockDB.get(code) or ""
+            for alias in aliases:
+                if not alias:
+                    continue
+                if alias not in name_codes:
+                    names.append(alias)
+                    name_codes[alias] = []
+                entry = (code, market, canonical or alias)
+                if market and entry not in name_codes[alias]:
+                    name_codes[alias].append(entry)
+    return names, name_codes
+
+
+# 实体扫描压缩长度上限：按删空格后计，与库内最长全名取小、封顶 8（9 字
+# 以上 CJK 股名不存在，超长指称交 Step 6/下游 LLM）；下探到 2 字（美团/
+# 快手 等港股短名）——窗口必须整体等于全名，误切风险有界
+_MAX_ENTITY_LEN = 8
+
+# sector 系词池并集：与股票名冲突时行业语义优先，全管道不做个股名匹配。
+# 含恰为库中全名的词（"机器人"=300024）——Step 1 放行，交 Step 6 打 tag
+_SECTOR_KEYWORD_SET = frozenset(
+    kw
+    for tag in (TAG_SECTOR, TAG_SECTOR_NAME, TAG_SECTOR_N_STOCK)
+    for kw in _TAG_KEYWORD_LISTS_EXTEND.get(tag, [])
+)
+
+# ST 风险警示前缀（"ST德豪"/"*ST美丽"/"ST*美丽"）：前缀三型互认，AB 汉字
+# 部分必须等于库中全名；Step 3 放行其 ASCII 前缀不作代码候选（见 _split_by_codes）
+_ST_PREFIX_RE = re.compile(r"^(\*ST|ST\*|ST)([\u3400-\u9fff]+)$")
+
+
+def _st_prefix_variants(name: str) -> set:
+    """ST 前缀三型等价拼写集合：STAB / *STAB / ST*AB 互认（前缀后须为
+    CJK，排除 "STO" 等普通英文词）；非该形态返回 {name} 自身。"""
+    m = _ST_PREFIX_RE.match(name)
+    if not m:
+        return {name}
+    tail = m.group(2)
+    return {f"ST{tail}", f"*ST{tail}", f"ST*{tail}"}
+
+
+def _split_by_stock_entities(text: str) -> List[Token]:
+    """Step 1 子函数（管道首步）：多股票实体扫描（仅全名精确匹配，最长优先、
+    非重叠）。
+
+    入口先把空白（含 tab/换行）收敛为单空格，随后逐位置尝试"最宽跨度 ~ 2
+    字"窗口（收敛后 max_len 字全名最宽占 2*max_len-1 个 raw 字符，跨度上界
+    静态完备）；窗口删空格后必须整体等于库中全名（含改名旧称），禁止
+    子串/拼音/模糊（"贵 州 茅 台"/"中 国 海 洋 石 油"→整名命中）。
+    全名恰为枚举行业词（"机器人"）时放行交 Step 6
+    打 sector；缩写（"茅台"）非全名，交 Step 6 多策略匹配承接。唯一命中
+    → TAG_STOCK_NAME 确定实体；跨市场同名多只（"阿里巴巴"）→ 携带多候选
+    交下游歧义确认。未命中片段保留为空 tag token 交后续步骤。
+    """
+    if not text:
+        return []
+    # 空白（含 tab/换行）收敛为单空格：收敛后 max_len 字全名最宽占
+    # 2*max_len-1 个 raw 字符，窗口跨度上界得以静态封顶；亦统一本步
+    # 删 ' ' 与 Step 2 按空白切分的两套口径（tab 分隔指称同样可命中）。
+    # gap 文本随之规整——空白本就被后续步骤切分与过滤，无信息损失
+    text = re.sub(r"\s+", " ", text)
+    if not any("\u3400" <= ch <= "\u9fff" for ch in text):
+        return [Token(text)]  # 纯英文段由 Step 6 DFS（拼音/美股代码）兜底
+    names, name_codes = _build_entity_index()
+    max_len = min(_MAX_ENTITY_LEN, max((len(n) for n in names), default=0))
+    max_span = 2 * max_len - 1  # 收敛后最长全名的最宽 raw 跨度（静态完备）
+    tokens: List[Token] = []
+    i, gap_start, n = 0, 0, len(text)
+    while i < n:
+        matched = False
+        for length in range(max_span, 1, -1):  # 最宽跨度~2 字窗口（带空格全名也整名命中）
+            if i + length > n:
+                continue
+            window = text[i:i + length]
+            if not any("\u3400" <= ch <= "\u9fff" for ch in window):
+                continue  # 不含 CJK 的窗口不扫描（代码/ASCII 由其他步骤处理）
+            window = window.replace(' ', '')  # 输入端删去空格再与全名比较
+            if len(window) > max_len:
+                continue  # 压缩后超库内最长全名（无空格文本的长跨度窗口），必不命中
+            pairs = name_codes.get(window)
+            if not pairs:
+                for variant in _st_prefix_variants(window):
+                    if variant == window:
+                        continue
+                    pairs = name_codes.get(variant)
+                    if pairs:
+                        break
+            if pairs and window not in _SECTOR_KEYWORD_SET:
+                stocks = [
+                    Stock(code=_canonical_stock_code(code, market),
+                          name=canonical, market=market)
+                    for code, market, canonical in pairs
+                ]
+                if gap_start < i:
+                    tokens.append(Token(text[gap_start:i]))
+                tokens.append(Token(window, TAG_STOCK_NAME, stocks=stocks))
+                i += length
+                gap_start = i
+                matched = True
+                break
+        if not matched:
+            i += 1
+    if gap_start < n:
+        tokens.append(Token(text[gap_start:]))
+    return tokens
+
+
+def _is_identified_token(token: Token) -> bool:
+    """Token 是否已被前序步骤识别（有 tag 或是已知股票名/代码）。"""
+    if token.tag:
+        return True
+    if is_known_stock_name(token.text):
+        return True
+    return False
+
+
+def _extract_full_names_first(normalized: str) -> List[Token]:
+    """Step 1: 对整条归一后消息做多股票全名精确匹配扫描（管道首步）。
+
+    实体扫描先于一切切分类步骤（全名撕裂后无法复原，见模块 docstring）。
+    入口先 ``extend_AkShare``（幂等）把 AkShare 全量并入 stockDB——首条
+    冷消息即与暖态产出一致。直接以整条消息为扫描对象（不经逐 token 包装），
+    实体索引每消息只构建一次。
+    """
+    if any("\u3400" <= ch <= "\u9fff" for ch in normalized):
+        extend_AkShare()
+    return _split_by_stock_entities(normalized)
+
+
+# =========================================================================
+# Step 4 — 市场关键词提取（"股"+"份"消歧）
+# =========================================================================
+
+# 市场相关 tag 关键词 union；"股"+"份"消歧见 _split_market_tokens
+# （防 "大港股份" 中的 "港股" 子串被误提取）
+_MARKET_TOKEN_PATTERN = _compile_kw_pattern(
+    TAG_SUBJECT_MARKET, TAG_SUBJECT_MARKET_BROAD, TAG_SUBJECT_INDEX,
+)
+
+
+def _split_market_tokens(text: str) -> List[Token]:
+    """Step 4 子函数：提取市场关键词打 tag。"股"后接"份"（股票名后缀）跳过不上报。"""
+    if not text:
+        return []
+    tokens: List[Token] = []
+    pos = 0
+    for m in _MARKET_TOKEN_PATTERN.finditer(text):
+        s, e = m.start(), m.end()
+        matched = m.group()
+        if matched.endswith("股") and e < len(text) and text[e] == "份":
+            continue
+        if pos < s:
+            gap = text[pos:s].strip()
+            if gap:
+                tokens.append(Token(gap))
+        tag = _classify_keyword(matched)
+        tokens.append(Token(matched, tag))
+        pos = e
+    tail = text[pos:].strip()
+    if tail:
+        tokens.append(Token(tail))
+    return tokens
+
+
+def _apply_market_extraction(tokens: List[Token]) -> List[Token]:
+    """Step 4: 对非代码/非全名 token 做市场关键词提取 + 股份消歧。"""
+    result: List[Token] = []
+    for t in tokens:
+        if _is_identified_token(t):
+            result.append(t)
+        else:
+            result.extend(_split_market_tokens(t.text))
+    return result
+
+
+# =========================================================================
+# Step 5 — 无歧义关键词分词（clean 词池）
+# =========================================================================
+
+def _tokenize_by_clean_keywords(text: str) -> List[Token]:
+    """Step 5 子函数：无歧义关键词分词，间隙保留为空 tag token 交 Step 6。"""
+    tokens: List[Token] = []
+    pos = 0
+    for m in _CLEAN_KEYWORDS_PATTERN.finditer(text):
+        gap = text[pos:m.start()].strip()
+        if gap:
+            tokens.append(Token(gap))
+        tokens.append(Token(m.group(), _classify_keyword(m.group())))
+        pos = m.end()
+    tail = text[pos:].strip()
+    if tail:
+        tokens.append(Token(tail))
+    return tokens
+
+
+def _apply_clean_keyword_extraction(tokens: List[Token]) -> List[Token]:
+    """Step 5: 对未识别 token 用无歧义关键词（如"分析""走势""怎样"）分词。"""
+    result: List[Token] = []
+    for t in tokens:
+        if _is_identified_token(t):
+            result.append(t)
+        else:
+            result.extend(_tokenize_by_clean_keywords(t.text))
+    return result
+
+
+# =========================================================================
+# Step 6 — 多策略智能匹配（DFS 全匹配：板块词/关键词/股票名）
+# =========================================================================
+
+def _isAlpha(s: str) -> bool:
+    """检测字符串是否为纯英文字母（a-z, A-Z）。"""
+    return bool(s) and all(c.isascii() and c.isalpha() for c in s)
+
+
+# 单字 filler 集合：全由这些字符组成的片段绝不做股票名全库扫描——否则
+# "和"*200 一类刷屏文本在 DFS 逐位置触发全库扫描（5500 名库实测秒级耗时）
+_SINGLE_CHAR_FILLERS = frozenset(
+    kw for kw in _TAG_KEYWORD_LISTS_EXTEND[TAG_FILLER] if len(kw) == 1
+)
+
+
+def _is_filler_only(segment: str) -> bool:
+    """片段是否完全由单字 filler 关键词字符组成（如"和和""的的"）。"""
+    return bool(segment) and all(ch in _SINGLE_CHAR_FILLERS for ch in segment)
+
+
+def _dfs_match(text: str) -> Optional[List[Token]]:
+    """深度优先全匹配：0 位置起匹配关键词/股票名并递归剩余文本；无法全匹配
+    返回 None（宁可不做也不做错）。全匹配即交叉验证。
+
+    "XX板块"类复合词无专用正则：行业名与泛称分别在各自词池命中，DFS 自然
+    产出相邻 [sector_name/sector_n_stock]+[sector] 高置信度组合；未枚举
+    行业词（"预制菜板块"）无法全匹配则原样返回，交下游 LLM 兜底。
+    """
+    if len(text) == 0:
+        return []
+
+    # 以字母开头：提取连续英文字母组成的单词
+    if _isAlpha(text[0]):
+        # 直接组成连续的最大单词 例如 "Alibaba的基本面" → "Alibaba", "的基本面"
+        i = 1
+        while i < len(text) and _isAlpha(text[i]):
+            i += 1
+        segment = text[:i]
+        # 纯英文做股票名拼音检测 + 美股代码检测；双源按 (code, market) 去重
+        # （名称恰等于 ticker 的 AMD/Meta 两源各出一份同实体），先归一到
+        # canonical 拼写使去重键与产出一致
+        stock_list = _canonical_stocks(resolver_name_to_code_list(segment))
+        seen = {(s.code, s.market) for s in stock_list}
+        stock_list += [
+            s for s in US_stock_code_match(segment)
+            if (s.code, s.market) not in seen
+        ]
+        if stock_list:
+            rest = _dfs_match(text[i:])
+            if rest is not None:
+                return [Token(segment, TAG_STOCK_NAME, stocks=stock_list)] + rest
+
+    # 尝试连续 2~4 汉字片段（优先长匹配）
+    for length in (4, 3, 2, 1):
+        if length > len(text):
+            continue
+        segment = text[:length]
+
+        # 不分割连续的字母
+        if _isAlpha(segment[-1]) and length < len(text) and _isAlpha(text[length]):
+            continue
+
+        # 递归搜索匹配，策略不变
+        tag = _classify_keyword(segment)  # 全部关键词（clean + extend）
+        stock_list = []
+        # filler 连续片段不构成股票名：跳过全库扫描，杜绝逐位置扫描失控；
+        # 通用公司后缀（公司/集团…）在 extend 词池打 corp_suffix tag，tag
+        # 路径同样跳过扫描（词池为单一事实源，见 web_intent_types）
+        if not tag and not _is_filler_only(segment):
+            stock_list = _canonical_stocks(resolver_name_to_code_list(segment))
+        if tag or len(stock_list) > 0:
+            rest = _dfs_match(text[length:])
+            if rest is not None:
+                return [Token(segment, tag or TAG_STOCK_NAME, stocks=stock_list or None)] + rest
+            # 库内全名"精确"命中（别名规范名 != 输入，不计）即实体自证：
+            # 直接确认返回，余文留空 tag 交 LLM；关键词/子串/拼音/模糊命中
+            # 不享此待遇，维持全覆盖交叉验证
+            if not tag and stock_list and all(s.name == segment for s in stock_list):
+                tail = text[length:]
+                return [Token(segment, TAG_STOCK_NAME, stocks=stock_list or None)] + (
+                    [Token(tail)] if tail else []
+                )
+
+    return None
+
+
+# Step 6 单 token 长度上限：50 字连续无标点且无前序步骤信号，即非正常
+# 对话（刷屏/粘贴大段文字），整体放弃交 LLM。技术上封顶逐字符递归深入
+# （实测 ~1500 字 RecursionError）与最坏线性×全库扫描，保证有界；正常
+# 聊天分片经 Step 2 标点切分后远短于该上限
+_MAX_MULTI_MATCH_TEXT_LEN = 50
+
+
+# 动态混合匹配文本
+def _multi_match(text: str) -> List[Token]:
+    """Step 6 子函数：多策略智能匹配（关键词/名称库精确/子串/拼音/模糊）；
+    无法完全匹配则原样返回（宁可不做也不做错）。
+
+    前置条件：AkShare 扩展与全名精确消费由管道 Step 1 独占承担——直接
+    调用本函数喂冷库长文本会重新暴露无记忆化 DFS 的指数回溯面，调用方应
+    走 ``_preprocess_text``。"""
+    if not text:
+        return []
+    if len(text) > _MAX_MULTI_MATCH_TEXT_LEN: # DFS 复杂度控制, 过长 token 交由 LLM 判断
+        return [Token(text)]
+    result = _dfs_match(text)
+    return result if result is not None else [Token(text)]
+
+
+def _apply_multi_extraction(tokens: List[Token]) -> List[Token]:
+    """Step 6: 对每个空 tag token 做多策略智能匹配，已打 tag 的 token 受保护。"""
+    result: List[Token] = []
+    for t in tokens:
+        if t.tag:
+            result.append(t)
+        else:
+            result.extend(_multi_match(t.text))
+    return result
+
+
+# =========================================================================
+# Step 2 — 特殊标点切分
+# =========================================================================
+
+def _split_by_special_punct(text: str) -> List[Token]:
+    """Step 2: 按特殊标点与空白边界切分（排除 * - .；空白同为词界，
+    "tsla aapl" 与 "tsla,aapl" 同构处理）。仅作用于 Step 1 的 gap；切分符
+    留作空 tag token，由末端 _HAS_CONTENT_PATTERN 过滤。"""
+    if not text:
+        return []
+    tokens: List[Token] = []
+    pos = 0
+    for m in _SPECIAL_PUNCT_RE.finditer(text):
+        if pos < m.start():
+            gap = text[pos:m.start()].strip()
+            if gap:
+                tokens.append(Token(gap))
+        tokens.append(Token(m.group()))
+        pos = m.end()
+    tail = text[pos:].strip()
+    if tail:
+        tokens.append(Token(tail))
+    return tokens
+
+
+# =========================================================================
+# Step 3 — 代码形字符串提取
+# =========================================================================
+
+# ---- _CODE_CANDIDATE_PATTERNS — 代码形字符串候选正则（_split_by_codes 专用） ----
+# 宽松匹配（宁多勿漏）：命中"像代码"的片段打 TAG_UNKNOWN_CODE，合法性交
+# _identify_stock_codes。纯文本匹配不查库、同位置多正则取最长、不推断市场。
+_CODE_CANDIDATE_PATTERNS: List[Tuple[str, int]] = [
+    # 1. 交易所前缀 + 任意位数字: SH600519, HK88888, SZ123
+    (r'(?<![a-zA-Z])(?:SH|SZ|BJ|HK)\d{1,}(?!\d)', re.IGNORECASE),
+    # 2. 数字.交易所后缀: 123456.HK, 235454354.sh
+    (r'(?<!\d)\d{1,}\.(?:SH|SZ|BJ|HK)(?!\d)', re.IGNORECASE),
+    # 3. 裸任意位数字: 600519, 12（形态歧义 → unknown_number，不按位数猜测）
+    (r'(?<!\d)\d{1,}(?!\d)', 0),
+    # 4. 美股大写 ticker（左右不紧邻字母数字），可选交易所后缀 BRK.B——
+    #    后缀与主体整体成 span，防止 "BRK" 与 ".B" 撕成两段
+    (r'(?<![A-Za-z0-9.])([A-Z]{2,5}(?:\.[A-Z]{1,2})?)(?![A-Za-z0-9])', 0),
+    # 5. 连续字母 + .us 后缀（大小写不敏感）: aapl.us, BABA.US
+    (r'(?<![A-Za-z0-9.])([A-Za-z]{1,5}\.us)(?![A-Za-z0-9])', re.IGNORECASE),
+]
+
+
+def _split_by_codes(text: str) -> List[Token]:
+    """Step 3 子函数：宽口径代码形字符串提取。
+
+    5 类正则命中"像代码"的片段 → TAG_UNKNOWN_CODE，任意位裸数字 →
+    TAG_UNKNOWN_NUMBER（形态歧义，交下游 LLM 辨析）；间隙保留为空 tag
+    token。只做形态匹配与最大连续合并，不校验合法性、不推断市场。
+    不复用 extract_stock_codes：其首码白名单会丢弃 777777 这类非法代码，
+    本函数保留供下游二次确认。
+    """
+    if not text:
+        return []
+
+    # 阶段 1：正则独立扫描收集 span，重叠/嵌套交阶段 2 合并。两类放行保
+    # 证不影响关键词语义：关键词池内纯 ASCII 词（"AI"/"PK" 大写也不作代码
+    # 候选，交关键词分类）；含数字枚举指数词（"沪深300"）内的数字段（完全
+    # 包含于关键词 span 才放行，部分重叠如 "沪深3000" 不适用）
+    digit_keyword_spans: List[Tuple[int, int]] = (
+        [(m.start(), m.end()) for m in _DIGIT_KEYWORDS_RE.finditer(text)]
+        if _DIGIT_KEYWORDS_RE is not None
+        else []
+    )
+    spans: List[Tuple[int, int]] = []
+    for pattern, flags in _CODE_CANDIDATE_PATTERNS:
+        for m in re.finditer(pattern, text, flags):
+            if m.group().upper() in _ASCII_KEYWORD_UPPER:
+                continue
+            # ST 前缀放行：后继 CJK / 前邻 * / 后继 *+CJK 时 "ST" 不作代码
+            # 候选，整名交 Step 1（兜底库外 ST 名不被撕走前缀）
+            if m.group() == "ST" and (
+                (m.end() < len(text) and "\u3400" <= text[m.end()] <= "\u9fff")
+                or (m.start() > 0 and text[m.start() - 1] == "*")
+                or (m.end() + 1 < len(text) and text[m.end()] == "*"
+                    and "\u3400" <= text[m.end() + 1] <= "\u9fff")
+            ):
+                continue
+            if any(ps <= m.start() and m.end() <= pe for ps, pe in digit_keyword_spans):
+                continue
+            spans.append((m.start(), m.end()))
+
+    # 无命中 → 整段文本作为一个空 tag token 返回
+    if not spans:
+        return [Token(text)]
+
+    # 阶段 2：最大连续合并（重叠 span 取最长，不被子串截断）
+    spans.sort()
+    merged: List[Tuple[int, int]] = []
+    for s, e in spans:
+        if merged and s < merged[-1][1]:
+            if e > merged[-1][1]:
+                merged[-1] = (merged[-1][0], e)
+        else:
+            merged.append((s, e))
+
+    # 阶段 3：按合并后 span 切分：候选 → unknown_code；间隙 → 空 tag token
+    tokens: List[Token] = []
+    pos = 0
+    for s, e in merged:
+        if pos < s:
+            gap = text[pos:s].strip()
+            if gap:
+                tokens.append(Token(gap))
+        span_text = text[s:e]
+        if span_text.isdigit():
+            # 裸数字形态歧义（代码/指数/价格/年份/日期…）→ unknown_number，
+            # 不进代码校验，交下游 LLM 辨析
+            tokens.append(Token(span_text, TAG_UNKNOWN_NUMBER))
+        else:
+            tokens.append(Token(span_text, TAG_UNKNOWN_CODE))
+        pos = e
+    tail = text[pos:].strip()
+    if tail:
+        tokens.append(Token(tail))
+    return tokens
+
+
+def _apply_code_extraction(tokens: List[Token]) -> List[Token]:
+    """Step 3: 对空 tag token 做代码形提取（已识别 token 受保护）。"""
+    result: List[Token] = []
+    for t in tokens:
+        if _is_identified_token(t):
+            result.append(t)
+        else:
+            result.extend(_split_by_codes(t.text))
+    return result
+
+
+# =========================================================================
+# _preprocess_text — 六步管道入口
+# =========================================================================
+
+def _preprocess_text(text: str) -> Tuple[str, List[Token]]:
+    """六步管道分词，返回 (原文本, token列表)。步骤与不变量见模块 docstring。
+
+    入口对工作副本做 NFKC 宽度归一（返回的原文本不变）：全角数字/字母
+    （"６００５１９"/"Ａ股"）与半角同形参与全部步骤。unknown_code 随后由
+    _identify_stock_codes 辨认为 stock_code / wrong_{market}_code /
+    unknown_{market}_code。
+    """
+    # ---- 六步管道 ----
+    normalized = unicodedata.normalize("NFKC", text)  # 宽度归一（工作副本，原文原样返回）
+    tokens: List[Token] = []
+    for t in _extract_full_names_first(normalized):   # Step 1: 全名实体扫描
+        if t.tag:
+            tokens.append(t)                # 已识别 token 不再切分
+        else:
+            tokens.extend(_split_by_special_punct(t.text))  # Step 2: 标点/空白只切 gap
+    tokens = _apply_code_extraction(tokens)           # Step 3: 代码形提取
+    tokens = _apply_market_extraction(tokens)         # Step 4: 市场关键词
+    tokens = _apply_clean_keyword_extraction(tokens)  # Step 5: 无歧义关键词
+    tokens = _apply_multi_extraction(tokens)          # Step 6: 多策略匹配
+
+    # 过滤纯标点/空白 token
+    tokens = [t for t in tokens if t.text.strip() and _HAS_CONTENT_PATTERN.search(t.text)]
+
+    return text, tokens
+
+
+# =========================================================================
+# 代码辨认 — unknown_code → stock_code / wrong_{market}_code / unknown_{market}_code
+# =========================================================================
+
+def _is_valid_canonical_numeric_code(code: str) -> bool:
+    """extract_stock_codes 规范化后的数字代码是否满足裸格式约束（6 位 A 股
+    首码白名单 0/3/6/4/8 或 92 段、HK+5 位）。extract 只去前缀不校验白名单，
+    规范化结果必须再过本闸门，否则带前缀的非法代码会绕过确认直接执行。
+    """
+    c = (code or "").strip().upper()
+    if c.startswith("HK"):
+        digits = c[2:]
+        return digits.isdigit() and len(digits) == 5
+    if c.isdigit():
+        return len(c) == 6 and (c[0] in "03648" or c.startswith("92"))
+    return False
+
+
+def _shape_market(text: str, canonical: str) -> str:
+    """代码市场推断：优先规范化形态（HK 前缀 → hk、6 位 → a、字母 → us），
+    形态非法（canonical 为空）时回退原始文本的前缀/后缀形状；兜底 a。"""
+    if canonical:
+        if canonical.startswith("HK"):
+            return "hk"
+        m = _market_of_code(canonical)
+        if m:
+            return m
+    t = (text or "").upper()
+    if t.startswith("HK") or t.endswith(".HK"):
+        return "hk"
+    if _isAlpha(t.split(".", 1)[0]) and not any(ch.isdigit() for ch in t):
+        return "us"
+    return "a"
+
+
+# 显式交易所标注解析：前缀 SH/SZ/BJ/HK 或后缀 .SH/.SZ/.BJ/.HK（大小写
+# 不敏感），后缀优先。判决层权威解析，不复用 extract_stock_codes（那是
+# 候选收集器，位数不符时静默放行，不适用于判决）；标注市场与数字形态
+# 矛盾 → wrong_{标注市场}，绝不静默换市场解析
+_EXPLICIT_MARKER_RE = re.compile(
+    r"^(?P<pfx>SH|SZ|BJ|HK)?(?P<digits>[0-9]+)(?:[.](?P<sfx>SH|SZ|BJ|HK))?$",
+    re.IGNORECASE,
+)
+_MARKER_MARKET = {"SH": "a", "SZ": "a", "BJ": "a", "HK": "hk"}
+
+
+def _identify_one_code(t: Token) -> Token:
+    """单个 TAG_UNKNOWN_CODE token 的辨认（_identify_stock_codes 子函数）：
+    显式标注优先的确定性判决。
+
+    标注市场/交易所与数字形态矛盾 → wrong_{标注市场}（HK600519 / SH00700 /
+    SH000001 不静默改按其它市场或交易所解析）；形态合法则查库 → stock_code，
+    未命中按该市场库全量与否细分 wrong/unknown。纯字母 → 美股 ticker 路径；
+    无标注的防御形态走 extract 兜底（管道契约下 Step 3 不会产出该形态）。"""
+    text = t.text
+
+    # 纯字母 → 美股 ticker：仅本地库命中才认可，未命中一律存疑交 LLM
+    if not any(ch.isdigit() for ch in text):
+        ticker = text.split(".", 1)[0].upper()
+        matched = US_stock_code_match(ticker)
+        if matched:
+            # 统一规范大写拼写（aapl.us → AAPL），同一股票共享同一代码身份
+            return Token(ticker, TAG_STOCK_CODE, stocks=tuple(matched))
+        return Token(text, unknown_code_tag("us"))
+
+    m = _EXPLICIT_MARKER_RE.match(text)
+    pfx, sfx = (m.group("pfx"), m.group("sfx")) if m else (None, None)
+    if pfx and sfx and pfx.upper() != sfx.upper():
+        # 前后缀双标注市场互斥（HK600519.SH）：静态规则断非法，按后缀市场
+        return Token(text, wrong_code_tag(_MARKER_MARKET[sfx.upper()]))
+    marker = (sfx or pfx) if m else None
+    if marker is not None:
+        market = _MARKER_MARKET[marker.upper()]
+        digits = m.group("digits")
+        # HK 短码先补零再校验（1810.HK/HK700 → HK01810/HK00700，对齐
+        # stock_code_utils zfill(5) 归一口径；≥5 位 zfill 无操作，位数
+        # 超标判决不受影响）
+        canonical = f"HK{digits.zfill(5)}" if marker.upper() == "HK" else digits
+        # 标注市场的形态闸门（HK=5 位、A 股=6 位+首码白名单）：不符即
+        # wrong_{标注市场}，即使数字段恰为其它市场合法代码也不改判
+        if not _is_valid_canonical_numeric_code(canonical):
+            return Token(text, wrong_code_tag(market))
+        if marker.upper() != "HK" and _infer_cn_exchange(digits) != marker.upper():
+            # 数字形态所属交易所与标注点名矛盾（SH000001/BJ600519）：
+            # wrong_{标注市场}，不得静默解析成其它交易所的同号代码
+            return Token(text, wrong_code_tag(market))
+        stock = lookup_stock_by_code(canonical)
+        if stock is not None:
+            # 规范化拼写（hk00700 → HK00700、600519.SH → 600519）
+            return Token(canonical, TAG_STOCK_CODE, stocks=(stock,))
+        if is_market_db_complete(market):
+            # 该市场库已全量仍未命中（如 A 股 AkShare 已并入）：确定不存在
+            return Token(text, wrong_code_tag(market))
+        # 库非全量（A 股未扩展 / hk/us 本地精选库）：存疑交下游 LLM 判断
+        return Token(text, unknown_code_tag(market))
+
+    # 无标注防御路径（管道契约下不出现：Step 3 裸数字 → unknown_number）
+    extracted = [c.upper() for c in extract_stock_codes(text)]
+    canonical = extracted[0] if extracted else ""
+    if not canonical or not all(_is_valid_canonical_numeric_code(c) for c in extracted):
+        return Token(text, wrong_code_tag(_shape_market(text, canonical)))
+    stock = lookup_stock_by_code(canonical)
+    if stock is not None:
+        return Token(canonical, TAG_STOCK_CODE, stocks=(stock,))
+    market = _shape_market(text, canonical)
+    if is_market_db_complete(market):
+        return Token(text, wrong_code_tag(market))
+    return Token(text, unknown_code_tag(market))
+
+
+def _identify_stock_codes(tokens: List[Token]) -> List[Token]:
+    """对 TAG_UNKNOWN_CODE 逐个辨认，三种产出：
+
+    - 库命中 → ``stock_code``：``stocks`` 附完整三元组，文本用规范化拼写
+      （hk00700 → HK00700、600519.SH → 600519，与名称路径
+      ``_canonical_stock_code`` 同源归一，同一股票共享同一代码身份）；
+    - 形态非法或该市场库已全量未命中 → ``wrong_{market}_code``：确定不存在；
+    - 该市场库非全量未命中 → ``unknown_{market}_code``：存疑交下游 LLM。
+    """
+    result: List[Token] = []
+    for t in tokens:
+        if t.tag != TAG_UNKNOWN_CODE:
+            result.append(t)
+            continue
+        result.append(_identify_one_code(t))
+    return result

--- a/src/agent/web_intent_types.py
+++ b/src/agent/web_intent_types.py
@@ -1,0 +1,390 @@
+# -*- coding: utf-8 -*-
+"""
+Web Chat 意图识别层 — 分词模块的类型与常量（Intent Tokenizer Types）。
+
+== 模块定位 ==
+本模块是 ``web_intent_tokenizer.py`` 六步分词管道的"数据字典"：Token
+结构、tag/关键词/正则常量。意图层定义（意图枚举、意图识别结果、置信度/
+会话常量）随 ``web_intent_resolver.py`` 在后续 PR 引入。
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from enum import Enum
+from typing import Dict, List, Optional, Tuple
+
+from src.services.name_to_code_resolver import Stock
+
+__all__ = [
+    "Market",
+    "Token",
+    "TAG_UNKNOWN_CODE",
+    "TAG_UNKNOWN_NUMBER",
+    "TAG_STOCK_CODE",
+    "unknown_code_tag",
+    "wrong_code_tag",
+    "TAG_STOCK_NAME",
+    "TAG_SUBJECT_RESEARCH",
+    "TAG_SUBJECT_PORTFOLIO",
+    "TAG_SUBJECT_MARKET",
+    "TAG_SUBJECT_MARKET_BROAD",
+    "TAG_SUBJECT_INDEX",
+    "TAG_REQUEST",
+    "TAG_ACTION_RESEARCH",
+    "TAG_ACTION_PORTFOLIO",
+    "TAG_FOLLOWUP",
+    "TAG_QUESTION",
+    "TAG_COMPARISON",
+    "TAG_SECTOR",
+    "TAG_SECTOR_NAME",
+    "TAG_SECTOR_N_STOCK",
+    "TAG_TIME",
+    "TAG_FILLER",
+    "TAG_CORP_SUFFIX",
+]
+
+
+# =========================================================================
+# Token 语义标签常量 — 5 大类 21 个标签，近义词归入同一标签，供正则匹配使用
+# =========================================================================
+
+# --- 股票识别 ---
+TAG_UNKNOWN_CODE = "unknown_code"      # 待验证的代码形字符串，Step 3 提取的中间态，由 _identify_stock_codes 辨认
+TAG_UNKNOWN_NUMBER = "unknown_number"  # 任意位裸数字（代码/指数/价格/年份/数量/日期…形态歧义），Step 3 直接标记，不进入代码校验
+TAG_STOCK_CODE = "stock_code"          # 库命中的股票代码（stocks 附完整 code/name/market 三元组）
+
+# 代码辨认失败态按市场细分（_identify_stock_codes 产出）：
+#   wrong_{market}_code   — 确定不存在：形态非法（交易所静态规则），或该市场库已
+#                           全量（A 股 AkShare 已并入）仍未命中
+#   unknown_{market}_code — 存疑：该市场库非全量（hk/us 本地精选库）未命中，
+#                           交下游 LLM 判断，绝不硬猜
+
+
+def wrong_code_tag(market: str) -> str:
+    """确定非法代码的 tag（market ∈ a/hk/us → wrong_a_code / wrong_hk_code / wrong_us_code）。"""
+    return f"wrong_{market}_code"
+
+
+def unknown_code_tag(market: str) -> str:
+    """存疑代码的 tag（market ∈ a/hk/us → unknown_a_code / unknown_hk_code / unknown_us_code）。"""
+    return f"unknown_{market}_code"
+
+TAG_STOCK_NAME = "stock_name"          # 股票实体（全名或一对一缩写），Step 1 仅全名精确匹配、Step 6 多策略匹配提取
+
+# --- 意图主题 ---
+TAG_SUBJECT_RESEARCH = "subject_research"       # 研究主题（走势/趋势/技术面/基本面/筹码）
+TAG_SUBJECT_PORTFOLIO = "subject_portfolio"     # 持仓主题（持仓/仓位/自选股/盈亏）
+TAG_SUBJECT_MARKET = "subject_market"           # 市场标识（A股/港股/美股/沪市…）
+TAG_SUBJECT_MARKET_BROAD = "subject_market_broad"  # 泛市场概念（大盘/行情/指数/两市）
+TAG_SUBJECT_INDEX = "subject_index"             # 具体指数（上证/恒生/纳斯达克/沪深300…）
+
+# --- 动作 ---
+TAG_REQUEST = "request"                       # 分析动作词（分析/看看/研究/诊断/查一下/评估）
+TAG_ACTION_RESEARCH = "action_research"       # 研究决策（能买/可以买/止损/目标价/buy/sell）
+TAG_ACTION_PORTFOLIO = "action_portfolio"     # 持仓操作（加仓/减仓/调仓/满仓/空仓）
+
+# --- 辅助 ---
+TAG_FOLLOWUP = "followup"     # 追问延续（继续/刚才/这只/它/上面/上次/该股）
+TAG_QUESTION = "question"     # 疑问（怎么看/怎么样/涨还是跌/怎么/为何/吗/呢）
+TAG_COMPARISON = "comparison"  # 对比（对比/比较/哪个好/vs/pk/二选一）
+TAG_SECTOR = "sector"          # 板块泛称词（板块/行业/赛道/概念/题材/龙头）+ XX+后缀 复合形态
+TAG_SECTOR_NAME = "sector_name"        # 行业名（金融/建筑/证券/农业…），裸用即行业意图
+TAG_SECTOR_N_STOCK = "sector_n_stock"  # 行业名兼股票全名（机器人=300024），裸用歧义交下游 LLM 消歧
+TAG_TIME = "time"             # 时间指示（今天/本周/交易日/实时）
+TAG_FILLER = "filler"         # 回复填充词（单字独立匹配：的/买/卖/选/那/这…）
+TAG_CORP_SUFFIX = "corp_suffix"  # 通用公司后缀（公司/集团/控股/股份/国际）：零区分度，精确命中即跳过股票名匹配
+
+class Market(str, Enum):
+    """市场标识枚举（str 子类，成员可直接与字符串比较）。"""
+
+    A = "a"    # A 股
+    HK = "hk"  # 港股
+    US = "us"  # 美股
+
+
+# =========================================================================
+# Tag → 关键词列表 — 所有中文关键词的唯一定义处
+# =========================================================================
+# 后续正则全部从这里编译，不手写中文关键词；TAG_SUBJECT_MARKET 由 _MARKET_KEYWORD_MAP 派生。
+# 排除项：多 token 跨词模式（和.*比…）→ extra 参数；"值得" → 与股票名"值得买"冲突，已删除
+
+_MARKET_KEYWORD_MAP: Dict[Market, tuple] = {
+    Market.A: ("a股", "大a", "沪市", "深市", "沪深"),
+    Market.HK: ("港股", "h股", "香港"),
+    Market.US: ("美股", "美国"),
+}
+
+# 按照是否影响股票实体混合匹配，关键词分两池：clean 无歧义可直接分词，置信度较高；
+#       extend 可能与股票名混淆，增加分词多样性，但置信度较低，需要做交叉验证，否则宁可放弃。
+# _TAG_KEYWORD_LISTS 由两者合并，下游逻辑不变
+
+_TAG_KEYWORD_LISTS_CLEAN: Dict[str, List[str]] = {
+    TAG_REQUEST: [
+        "分析", "看看", "研究", "诊断", "评估", "查一下", "查下",
+        "analyze", "analyse", "research",
+    ],
+    TAG_SUBJECT_RESEARCH: [
+        "走势", "走向", "涨势", "趋势", "技术面", "基本面", "筹码", "后市", "trend",
+    ],
+    TAG_ACTION_RESEARCH: [
+        "能买", "可以买", "目标价", "止损", "买点", "卖点", "抄底", "buy", "sell",
+    ],
+    TAG_QUESTION: [
+        "涨还是跌", "怎么看", "怎么样", "怎么", "是否",
+        "为何", "为什么", "还会", "要不要",
+        "能否", "能不能", "如何", "吗", "？", "?",
+    ],
+    TAG_SUBJECT_PORTFOLIO: [
+        "持仓", "仓位", "我的股票", "自选股", "盈亏", "成本价",
+        "portfolio", "position",
+    ],
+    TAG_ACTION_PORTFOLIO: [
+        "加仓", "减仓", "调仓", "满仓", "空仓",
+    ],
+    TAG_SUBJECT_MARKET_BROAD: [
+        "大盘", "行情", "两市", "北向", "股市", "market", "sector", "指数",
+    ],
+    TAG_SUBJECT_INDEX: [
+        "上证", "深证", "创业板", 
+        "恒指", "纳斯达克", "纳指",
+        "标普", "道琼斯", "道指", 
+        "沪指", "深成指", "深证成指",
+        "科创", "科创板", "index", "indices",
+        # 含数字指数词（CJK+数字复合词）：数字段与裸数字共形，Step 3 由
+        # _DIGIT_KEYWORDS_RE 保护区放行，否则整词永远无法在 Step 4/5 命中
+        "中证A500", "中证1000", "中证2000", "中证500", "中证800", "中证100",
+        "上证50", "北证50", "深证100", "创业板50", "沪深300", "科创50",
+    ],
+    TAG_FOLLOWUP: [
+        "继续", "接着", "刚才", "上面", "上次", "这只", "该股", "它", "他",
+        "然后",
+    ],
+    TAG_COMPARISON: [
+        "哪个好", "哪个", "哪只", "谁更", "二选一",
+        "差别", "区别", "优劣", "pk", "vs",
+    ],
+    TAG_TIME: [
+        "今天", "本周", "交易日", "实时", "最近",
+    ],
+    TAG_FILLER: [
+        "那个", "这个", "一只", "一下", "帮我", "我要", "我想", "以及",
+        "其他", "其它",
+    ],
+}
+
+_TAG_KEYWORD_LISTS_EXTEND: Dict[str, List[str]] = {
+    TAG_SUBJECT_INDEX: [
+        "恒生",  # 与股票名"恒生电子"混淆
+    ],
+    TAG_COMPARISON: [
+        "对比", "比较", "多选", "选哪",
+    ],
+    TAG_SECTOR: [
+        # 泛称词：XX行业名的后缀落款（板块/行业/赛道/概念/题材）+ 龙头。
+        # Step 6 DFS 把"建筑板块"分解为相邻 [sector_name]+[sector] 组合，
+        # 该相邻组合即高置信度板块信号（由下游消费）；龙头非后缀，指
+        # 龙头个股（"白酒龙头"），不参与相邻组合语义
+        "板块", "行业", "赛道", "概念", "题材", "龙头",
+    ],
+    TAG_SECTOR_NAME: [
+        # 行业名：裸用即行业意图。含与股票名冲突的词（全量库实证："证券"⊂
+        # 中信证券、"农业"⊂农业银行…）——名称库子串命中置信度极低，
+        # 行业语义优先，全管道不做个股名匹配
+        "新能源", "半导体", "消费", "医药", "白酒",
+        "军工", "银行", "地产", "保险", "券商",
+        "煤炭", "有色", "钢铁", "汽车", "光伏", "锂电",
+        "芯片", "人工智能", "互联网", "金融", "科技", "AI",
+        "证券", "农业", "电力", "建筑", "传媒", "教育",
+        "航空", "软件", "通信", "旅游",
+    ],
+    TAG_SECTOR_N_STOCK: [
+        # 行业名兼库中股票全名（"机器人"=300024）：精确全名命中，行业/个股
+        # 双解皆合理——裸用打歧义 tag 交下游 LLM/确认消歧，不直接打
+        # stock_name，也不武断打 sector_name
+        "机器人",
+    ],
+    TAG_FILLER: [
+        "和", "下", "是", "再",
+        "的", "买", "卖", "选", "了", "吧", "呢",
+        "那", "这", "只", "支", "啊", "呀", "咯",
+        "哦", "嘛", "么", "就", "请", "第", "个",
+    ],
+    TAG_CORP_SUFFIX: [
+        # 通用公司后缀（零区分度）：精确命中即打 corp_suffix tag 并跳过
+        # 股票名扫描——子串匹配在名库必然命中带词头的全名（"公司"⊂中微
+        # 公司、"集团"⊂上汽集团），命中是噪声非信号；并作为可覆盖片段
+        # 参与 DFS 全覆盖（"腾讯公司"→腾讯+公司）。带区分度词头的
+        # "苹果公司"/"中芯国际"不受影响。区别于 filler：语义是公司名
+        # 后缀而非填充词，下游可单独识别处理。仅 extend 不入 clean
+        # （clean 正则会在 Step 5 从 token 中途撕出后缀）
+        "公司", "集团", "控股", "股份", "国际",
+    ],
+}
+
+_TAG_KEYWORD_LISTS: Dict[str, List[str]] = {}
+for _tag in set(_TAG_KEYWORD_LISTS_CLEAN) | set(_TAG_KEYWORD_LISTS_EXTEND):
+    _TAG_KEYWORD_LISTS[_tag] = (
+        _TAG_KEYWORD_LISTS_CLEAN.get(_tag, []) +
+        _TAG_KEYWORD_LISTS_EXTEND.get(_tag, [])
+    )
+
+# 市场标识关键词 → tag（从 _MARKET_KEYWORD_MAP 派生）
+_MARKET_KW_TAG_MAP: Dict[str, str] = {
+    kw: TAG_SUBJECT_MARKET
+    for keywords in _MARKET_KEYWORD_MAP.values()
+    for kw in keywords
+}
+
+# market keyword → Market 枚举（反转，O(1) 查询）
+_KW_TO_MARKET: Dict[str, Market] = {
+    kw: mkt for mkt, keywords in _MARKET_KEYWORD_MAP.items() for kw in keywords
+}
+
+# keyword → tag（反转 + 市场词合并，供 _classify_keyword O(1) 查询）
+_KEYWORD_TAG_MAP: Dict[str, str] = {
+    kw: tag for tag, kws in _TAG_KEYWORD_LISTS.items() for kw in kws
+}
+_KEYWORD_TAG_MAP.update(_MARKET_KW_TAG_MAP)
+
+# 小写归一映射：关键词大小写不敏感分类的回退查询点。词池存储形态混合
+# （多数 ASCII 词小写、"AI"/"中证A500" 大写），只做输入 lower 回退会让
+# 大写存储词的小写形态（"ai赛道"/"中证a500"）整体失效，故关键词侧也
+# 统一归一到小写。当前词池无小写同形词；若将来出现会在本表静默合并，
+# 需保持词池互斥。
+_KEYWORD_TAG_MAP_LOWER: Dict[str, str] = {
+    kw.lower(): tag for kw, tag in _KEYWORD_TAG_MAP.items()
+}
+
+# 含数字的枚举关键词（CJK+数字复合词，如 "沪深300"/"中证1000"）：其数字段
+# 与裸数字在文本中共形，若 Step 3 按裸数字提取，整词将被拆成"前缀+数字"
+# 永远无法在 Step 4/5 命中。_split_by_codes 用本正则把关键词 span 标记为
+# 保护区，完全落在保护区内的数字候选 span 放行（部分重叠如 "沪深3000"
+# 不适用，维持裸数字行为），整词交 Step 4/5 关键词分词。
+_DIGIT_KEYWORDS: Tuple[str, ...] = tuple(sorted(
+    (
+        kw
+        for kws in _TAG_KEYWORD_LISTS.values()
+        for kw in kws
+        if any(ch.isdigit() for ch in kw) and any("\u3400" <= ch <= "\u9fff" for ch in kw)
+    ),
+    key=len,
+    reverse=True,
+))
+# 大小写不敏感编译："中证a500" 与 "中证A500" 同受数字段保护（tag 分类侧
+# 的大小写归一见 _KEYWORD_TAG_MAP_LOWER）。
+_DIGIT_KEYWORDS_RE = (
+    re.compile("|".join(re.escape(kw) for kw in _DIGIT_KEYWORDS), re.IGNORECASE)
+    if _DIGIT_KEYWORDS
+    else None
+)
+
+# 全部纯 ASCII 关键词的大写集合：Step 3 代码候选的放行谓词（大小写不敏
+# 感）——"PK"/"Buy"/"AI" 等关键词形态不得被美股 ticker 正则抠走，否则
+# 关键词语义丢失、误入代码辨认（含原 sector 词池精确匹配放行的 "AI"，
+# 取代其职责；"HK"/"US" 非关键词，仍照常作为代码候选）
+_ASCII_KEYWORD_UPPER: frozenset = frozenset(
+    kw.upper() for kw in _KEYWORD_TAG_MAP if kw.isascii() and kw.isalpha()
+)
+
+
+# =========================================================================
+# 正则编译工具 — 全部从 _TAG_KEYWORD_LISTS 编译
+# =========================================================================
+
+def _compile_kw_fragment(kw: str) -> str:
+    """单个关键词 → regex 片段：ASCII 包裹 (?i:)，CJK 直接 escape。"""
+    if re.search(r"[A-Za-z]", kw):
+        return f"(?i:{re.escape(kw)})"
+    return re.escape(kw)
+
+
+def _compile_kw_pattern(*tags: str, extra: str = "") -> re.Pattern:
+    """从指定 tag 列表提取所有关键词，编译为单个正则。
+
+    按长度降序排列确保长关键词优先（"沪深300" 不被 "沪深" 截断）。
+    extra 参数可追加原生 regex 片段（如 vs 词边界、多 token 跨词模式）。
+    """
+    kws: List[str] = []
+    for tag in tags:
+        if tag == TAG_SUBJECT_MARKET:
+            kws.extend(_MARKET_KW_TAG_MAP.keys())
+        else:
+            kws.extend(_TAG_KEYWORD_LISTS.get(tag, []))
+    fragments = sorted(
+        ({_compile_kw_fragment(k) for k in kws} |
+         ({extra} if extra else set())),
+        key=len, reverse=True,
+    )
+    return re.compile("|".join(fragments))
+
+
+# Step 5 关键词分词正则（排除市场类 tag，Step 4 独立处理，避免 "大港股份" 消歧失效）
+_NON_MARKET_TAGS = frozenset({
+    TAG_REQUEST, TAG_SUBJECT_RESEARCH, TAG_ACTION_RESEARCH, TAG_QUESTION,
+    TAG_SUBJECT_PORTFOLIO, TAG_ACTION_PORTFOLIO,
+    TAG_FOLLOWUP, TAG_COMPARISON, TAG_SECTOR, TAG_SECTOR_NAME,
+    TAG_SECTOR_N_STOCK, TAG_TIME, TAG_FILLER,
+})
+
+
+def _compile_clean_kw_pattern(*tags: str) -> re.Pattern:
+    """仅用 _TAG_KEYWORD_LISTS_CLEAN 编译正则，排除可能混淆股票名的扩展关键词。"""
+    kws: List[str] = []
+    for tag in tags:
+        kws.extend(_TAG_KEYWORD_LISTS_CLEAN.get(tag, []))
+    fragments = sorted({_compile_kw_fragment(k) for k in kws}, key=len, reverse=True)
+    return re.compile("|".join(fragments))
+
+
+# Step 5 无歧义关键词分词正则（如"分析""走势""持仓"等不可能混淆股票名的词）
+_CLEAN_KEYWORDS_PATTERN = _compile_clean_kw_pattern(*_NON_MARKET_TAGS)
+
+
+# 纯标点/空白过滤：至少含一个 CJK/字母/数字
+_HAS_CONTENT_PATTERN = re.compile(r"[\u3400-\u9fffA-Za-z0-9]")
+
+# 特殊标点集合（Step 1 分词边界）。排除 * - .：可能出现在股票名/代码中（ST*、600519.SH）
+_SPECIAL_PUNCT_CHARS = (
+    "\uff0c\u3002\uff01\uff1f\uff1b\uff1a\u3001\u201c\u201d\u2018\u2019"
+    "\uff08\uff09\u3010\u3011\u300a\u300b\u2026\uff5e\u2014\uff0f\uff20"
+    "\uff03\uff04\uff05\uff3e\uff06\uff0b\uff1d"
+    ",!?;:\"'()[]{}<>/@#$%^&+=~`|\\\\"
+)
+# 空白（普通/全角空格、制表、换行）同为词界一并切分：ASCII 词与代码间
+# 的分隔（"tsla aapl"）此前仅靠 Step 3 大写或标点兜底，小写多词整段漏给
+# LLM；空白 token 无内容，由管道末端 _HAS_CONTENT_PATTERN 过滤丢弃
+_SPECIAL_PUNCT_RE = re.compile("[" + re.escape(_SPECIAL_PUNCT_CHARS) + r"|\s]")
+
+
+def _classify_keyword(token_text: str) -> str:
+    """查 _KEYWORD_TAG_MAP 取语义标签；未精确命中按小写归一表回退
+    （大小写不敏感与 (?i:) 编译声明同构，见 _KEYWORD_TAG_MAP_LOWER 注释）；
+    未命中返回空串。"""
+    tag = _KEYWORD_TAG_MAP.get(token_text)
+    if tag:
+        return tag
+    return _KEYWORD_TAG_MAP_LOWER.get(token_text.lower(), "")
+
+
+# =========================================================================
+# Token — 分词结构体，text + tag
+# =========================================================================
+
+
+@dataclass(frozen=True)
+class Token:
+    """分词结构体：文本 + 语义标签 + 可选的已解析股票实体。
+
+    frozen=True 使 Token 可哈希；tag 为空表示未识别；stocks 透传已解析实体
+    避免下游重复解析。stocks 构造时传 list 会被 __post_init__ 归一为 tuple
+    （frozen 字段值必须可哈希），下游按序列消费不受影响。
+    """
+    text: str
+    tag: str = ""
+    stocks: Optional[Tuple["Stock", ...]] = None
+
+    def __post_init__(self) -> None:
+        if isinstance(self.stocks, list):
+            object.__setattr__(self, "stocks", tuple(self.stocks))

--- a/tests/test_web_intent_tokenizer.py
+++ b/tests/test_web_intent_tokenizer.py
@@ -1,0 +1,1458 @@
+# -*- coding: utf-8 -*-
+"""web_intent_tokenizer 六步分词管道单测。
+
+只测分词与实体提取（不涉及 WebIntentResolver 的意图判定）：
+  Step 1   股票全名精确扫描（_split_by_stock_entities，管道首步，入口扩展）
+  Step 2   特殊标点切分（仅作用于 Step 1 的 gap）
+  Step 3   代码形提取（_split_by_codes：裸数字 → unknown_number）
+  Step 4   市场词提取（_split_market_tokens，"股"+"份"消歧）
+  Step 5   无歧义关键词（_tokenize_by_clean_keywords）
+  Step 6   多策略 DFS 匹配（_multi_match；板块词先于 DFS 整体 sector）
+  代码辨认 _identify_stock_codes（unknown_code → stock_code 附三元组 /
+  wrong_{market}_code / unknown_{market}_code）
+
+AkShare 扩展在管道 Step 1 入口触发（幂等），测试 mock 为最小全量 A 股
+数据（_MOCK_AKSHARE_A_SHARES）保证离线确定性；mock 之外的库外名称仍不可
+解析。
+"""
+
+from unittest.mock import patch
+
+import pytest
+
+from src.agent.web_intent_tokenizer import (
+    Token,
+    _extract_markets_from_tokens,
+    _identify_stock_codes,
+    _is_identified_token,
+    _market_of_code,
+    _multi_match,
+    _preprocess_text,
+    _split_by_codes,
+    _split_by_stock_entities,
+    _split_market_tokens,
+    _tokenize_by_clean_keywords,
+)
+from src.services.name_to_code_resolver import (
+    Stock,
+    is_known_stock_name,
+    resolver_name_to_code_list,
+)
+from src.agent.web_intent_types import (
+    Market,
+    TAG_ACTION_RESEARCH,
+    TAG_COMPARISON,
+    TAG_CORP_SUFFIX,
+    TAG_FILLER,
+    TAG_QUESTION,
+    TAG_REQUEST,
+    TAG_SECTOR,
+    TAG_SECTOR_NAME,
+    TAG_SECTOR_N_STOCK,
+    TAG_STOCK_CODE,
+    TAG_STOCK_NAME,
+    TAG_SUBJECT_MARKET,
+    TAG_SUBJECT_MARKET_BROAD,
+    TAG_SUBJECT_INDEX,
+    TAG_SUBJECT_RESEARCH,
+    TAG_UNKNOWN_CODE,
+    TAG_UNKNOWN_NUMBER,
+    unknown_code_tag,
+    wrong_code_tag,
+)
+
+# AkShare 扩展由下游 resolver_name_to_code_list 的 CJK 路径触发（分词层不扩展）。
+# 本测试模块 mock 一份最小全量 A 股数据：确定、离线、不依赖真实网络。
+_MOCK_AKSHARE_A_SHARES = {
+    "酒鬼酒": "000799",
+    "三花智控": "002050",
+    "中大力德": "002896",
+}
+
+
+@pytest.fixture(autouse=True)
+def _mock_akshare_extension():
+    with patch(
+        "src.services.name_to_code_resolver._get_akshare_name_to_code",
+        return_value=_MOCK_AKSHARE_A_SHARES,
+    ):
+        yield
+
+
+@pytest.fixture(autouse=True)
+def _restore_resolver_state():
+    """快照/还原 name_to_code_resolver 模块级可变状态，用例间互不泄漏。"""
+    from src.services import name_to_code_resolver as resolver_mod
+
+    db = dict(resolver_mod.stockDB)
+    aliases = {code: set(names) for code, names in resolver_mod.stockAliases.items()}
+    merged = resolver_mod._akshare_merged
+    yield
+    resolver_mod.stockDB.clear()
+    resolver_mod.stockDB.update(db)
+    resolver_mod.stockAliases.clear()
+    resolver_mod.stockAliases.update(aliases)
+    resolver_mod._akshare_merged = merged
+    # stockDB 原地增删，按对象身份缓存的名称/拼音列表可能已陈旧，强制重建
+    resolver_mod._names_cache[:] = [None, None, None]
+    resolver_mod._pinyin_cache[:] = [None, None]
+
+
+# =========================================================================
+# Step 3 — 代码形提取
+# =========================================================================
+
+class TestSplitByCodes:
+    """任意位裸数字在 _split_by_codes 阶段直接打 unknown_number；
+    带交易所前缀/后缀与美股 ticker 形态打 unknown_code。"""
+
+    def test_year_tag(self):
+        assert _split_by_codes("2024") == [Token("2024", TAG_UNKNOWN_NUMBER)]
+
+    def test_month_tag(self):
+        assert _split_by_codes("12") == [Token("12", TAG_UNKNOWN_NUMBER)]
+
+    def test_bare_4digit_tag(self):
+        assert _split_by_codes("0070") == [Token("0070", TAG_UNKNOWN_NUMBER)]
+
+    def test_bare_5digit_tag(self):
+        assert _split_by_codes("00700") == [Token("00700", TAG_UNKNOWN_NUMBER)]
+
+    def test_bare_6digit_tag(self):
+        assert _split_by_codes("600519") == [Token("600519", TAG_UNKNOWN_NUMBER)]
+
+    def test_bare_7digit_tag(self):
+        assert _split_by_codes("6005199") == [Token("6005199", TAG_UNKNOWN_NUMBER)]
+
+    def test_hk_suffix_still_unknown_code(self):
+        assert _split_by_codes("1234.HK") == [Token("1234.HK", TAG_UNKNOWN_CODE)]
+
+    def test_sz_suffix_still_unknown_code(self):
+        assert _split_by_codes("0070.SZ") == [Token("0070.SZ", TAG_UNKNOWN_CODE)]
+
+    def test_hk_prefix_still_unknown_code(self):
+        assert _split_by_codes("HK12") == [Token("HK12", TAG_UNKNOWN_CODE)]
+
+    def test_sh_prefix_form(self):
+        assert _split_by_codes("SH600519") == [Token("SH600519", TAG_UNKNOWN_CODE)]
+
+    def test_us_ticker_form(self):
+        assert _split_by_codes("BABA") == [Token("BABA", TAG_UNKNOWN_CODE)]
+
+    def test_us_suffix_case_insensitive(self):
+        assert _split_by_codes("aapl.us") == [Token("aapl.us", TAG_UNKNOWN_CODE)]
+
+    def test_date_splits_into_three_number_tokens(self):
+        tokens = _split_by_codes("2024-08-12")
+        assert [t.tag for t in tokens if t.tag] == [TAG_UNKNOWN_NUMBER] * 3
+        # "-" 不在标点切分集合（可能出现在代码/名称中），作为间隙 token 保留
+        assert [t.text for t in tokens if not t.tag] == ["-", "-"]
+
+    def test_overlapping_spans_merge_to_longest(self):
+        # "HK3294384923"：前缀正则 (0,12) 与裸数字正则 (2,12) 合并为最长 span
+        assert _split_by_codes("HK3294384923") == [
+            Token("HK3294384923", TAG_UNKNOWN_CODE),
+        ]
+
+    def test_gap_text_preserved_as_untagged_token(self):
+        tokens = _split_by_codes("分析一下600519.SH")
+        assert tokens == [
+            Token("分析一下"),
+            Token("600519.SH", TAG_UNKNOWN_CODE),
+        ]
+
+    def test_lowercase_words_not_code_candidates(self):
+        # 普通小写英文单词不是代码形候选（美股 ticker 要求大写/带 .us）
+        assert _split_by_codes("tell us about") == [Token("tell us about")]
+
+    def test_empty_text_returns_no_tokens(self):
+        assert _split_by_codes("") == []
+
+
+# =========================================================================
+# Step 2 — 含数字指数词放行（CJK+数字复合词不被裸数字提取破坏）
+# =========================================================================
+
+class TestDigitKeywordRelease:
+    """"沪深300"/"中证1000" 等含数字枚举指数词：数字段受 _DIGIT_KEYWORDS_RE
+    保护区放行，整词交 Step 4/5 命中 subject_index；裸数字本身行为不变。"""
+
+    @pytest.mark.parametrize("keyword", [
+        "沪深300", "科创50",                       # 既有词池
+        "中证A500", "中证1000", "中证2000",        # 本次补充（含用户指定）
+        "中证500", "中证800", "中证100",
+        "上证50", "北证50", "深证100", "创业板50",
+    ])
+    def test_digit_index_keyword_kept_whole(self, keyword):
+        _, tokens = _preprocess_text(f"{keyword}怎么样")
+        pairs = [(t.text, t.tag) for t in tokens]
+        assert (keyword, TAG_SUBJECT_INDEX) in pairs
+        # 关键词的数字段不得泄漏为独立裸数字 token
+        assert all(
+            t.tag != TAG_UNKNOWN_NUMBER or keyword.find(t.text) < 0
+            for t in tokens
+        )
+
+    def test_hushen_300_pipeline_exact(self):
+        _, tokens = _preprocess_text("沪深300怎么样")
+        assert [(t.text, t.tag) for t in tokens] == [
+            ("沪深300", TAG_SUBJECT_INDEX),
+            ("怎么样", TAG_QUESTION),
+        ]
+
+    def test_zhengzheng_1000_pipeline_exact(self):
+        _, tokens = _preprocess_text("中证1000走势")
+        assert [(t.text, t.tag) for t in tokens] == [
+            ("中证1000", TAG_SUBJECT_INDEX),
+            ("走势", TAG_SUBJECT_RESEARCH),
+        ]
+
+    def test_bare_numbers_untouched(self):
+        # 放行只作用于"完全包含于关键词 span"的数字段，裸数字行为不变
+        assert _split_by_codes("300") == [Token("300", TAG_UNKNOWN_NUMBER)]
+        assert _split_by_codes("1000") == [Token("1000", TAG_UNKNOWN_NUMBER)]
+        assert _split_by_codes("50") == [Token("50", TAG_UNKNOWN_NUMBER)]
+
+    def test_number_adjacent_to_digit_keyword(self):
+        # "2024年沪深300"：年份照常裸数字，指数整词命中，互不干扰
+        _, tokens = _preprocess_text("2024年沪深300")
+        pairs = [(t.text, t.tag) for t in tokens]
+        assert ("2024", TAG_UNKNOWN_NUMBER) in pairs
+        assert ("沪深300", TAG_SUBJECT_INDEX) in pairs
+
+    def test_code_after_digit_keyword(self):
+        _, tokens = _preprocess_text("中证1000和600519")
+        pairs = [(t.text, t.tag) for t in tokens]
+        assert ("中证1000", TAG_SUBJECT_INDEX) in pairs
+        assert ("600519", TAG_UNKNOWN_NUMBER) in pairs
+
+    def test_partial_overlap_not_released(self):
+        # 数字段仅部分重叠关键词（"沪深3000" ≠ "沪深300"+0）不适用保护：
+        # 维持裸数字提取，前缀交下游
+        tokens = _split_by_codes("沪深3000")
+        pairs = [(t.text, t.tag) for t in tokens]
+        assert ("3000", TAG_UNKNOWN_NUMBER) in pairs
+
+
+# =========================================================================
+# 代码辨认 — unknown_code → stock_code / wrong_{market}_code / unknown_{market}_code
+# =========================================================================
+
+class TestIdentifyStockCodes:
+    """库命中附完整三元组 + 规范化拼写；未命中按市场库全量与否细分 wrong/unknown。"""
+
+    @staticmethod
+    def _identify(token_text, tag=TAG_UNKNOWN_CODE):
+        return _identify_stock_codes([Token(token_text, tag)])
+
+    def test_ashare_suffix_canonicalized(self):
+        assert self._identify("600519.SH") == [
+            Token("600519", TAG_STOCK_CODE, stocks=(Stock("600519", "贵州茅台", "a"),))
+        ]
+
+    def test_ashare_prefix_canonicalized(self):
+        assert self._identify("SH600519") == [
+            Token("600519", TAG_STOCK_CODE, stocks=(Stock("600519", "贵州茅台", "a"),))
+        ]
+
+    def test_hk_suffix_canonicalized(self):
+        assert self._identify("00700.HK") == [
+            Token("HK00700", TAG_STOCK_CODE, stocks=(Stock("HK00700", "腾讯控股", "hk"),))
+        ]
+
+    def test_hk_prefixed_bare_key_canonicalized(self):
+        assert self._identify("HK00700") == [
+            Token("HK00700", TAG_STOCK_CODE, stocks=(Stock("HK00700", "腾讯控股", "hk"),))
+        ]
+
+    def test_hk_short_suffix_padded_before_validation(self):
+        # 4 位短码后缀（1810.HK=小米）：构造 canonical 时先补零再过 5 位
+        # 闸门，token 文本用规范拼写 HK01810（对齐 stock_code_utils zfill(5)）
+        assert self._identify("1810.HK") == [
+            Token("HK01810", TAG_STOCK_CODE, stocks=(Stock("HK01810", "小米集团", "hk"),))
+        ]
+
+    def test_hk_short_suffix_with_leading_zero_padded(self):
+        assert self._identify("0700.HK") == [
+            Token("HK00700", TAG_STOCK_CODE, stocks=(Stock("HK00700", "腾讯控股", "hk"),))
+        ]
+
+    def test_hk_short_prefix_padded(self):
+        # 前缀短码同样补零：HK700 → HK00700 腾讯
+        assert self._identify("HK700") == [
+            Token("HK00700", TAG_STOCK_CODE, stocks=(Stock("HK00700", "腾讯控股", "hk"),))
+        ]
+
+    def test_hk_one_digit_suffix_padded(self):
+        # 单位极端例：700.HK → HK00700（与 stock_scope 正则 \d{1,5}\.HK 同口径）
+        assert self._identify("700.HK") == [
+            Token("HK00700", TAG_STOCK_CODE, stocks=(Stock("HK00700", "腾讯控股", "hk"),))
+        ]
+
+    def test_us_ticker_in_db(self):
+        assert self._identify("TSLA") == [
+            Token("TSLA", TAG_STOCK_CODE, stocks=(Stock("TSLA", "特斯拉", "us"),))
+        ]
+
+    def test_us_ticker_lowercase_suffix_canonicalized(self):
+        # aapl.us → 规范大写 AAPL（extract 的美股正则只认大写，回退大写拼写）
+        assert self._identify("aapl.us") == [
+            Token("AAPL", TAG_STOCK_CODE, stocks=(Stock("AAPL", "苹果", "us"),))
+        ]
+
+    def test_prefixed_illegal_code_is_wrong_a(self):
+        # 带前缀的非法代码（SH777777）与裸 777777 一样按 A 股形态进 wrong_a_code，
+        # 不得因前缀形态被放行（形态非法由交易所静态规则断定，与库状态无关）
+        assert self._identify("SH777777") == [Token("SH777777", wrong_code_tag("a"))]
+
+    def test_hk_bad_digit_count_is_wrong_hk(self):
+        # HK + 11 位：位数不符形态非法 → wrong_hk_code
+        assert self._identify("HK3294384923") == [
+            Token("HK3294384923", wrong_code_tag("hk"))
+        ]
+
+    def test_hk_prefix_with_ashare_digits_is_wrong_hk(self):
+        # HK 前缀 + 6 位（A 股位数）→ 与标注矛盾判 wrong_hk，
+        # 不得静默解析成 A 股 600519 贵州茅台
+        assert self._identify("HK600519") == [
+            Token("HK600519", wrong_code_tag("hk"))
+        ]
+
+    def test_sh_prefix_with_hk_digits_is_wrong_a(self):
+        # SH 前缀 + 5 位（港股位数）→ wrong_a，不得静默变 HK00700 腾讯
+        assert self._identify("SH00700") == [
+            Token("SH00700", wrong_code_tag("a"))
+        ]
+
+    def test_sz_suffix_with_hk_digits_is_wrong_a(self):
+        assert self._identify("00700.SZ") == [
+            Token("00700.SZ", wrong_code_tag("a"))
+        ]
+
+    def test_hk_suffix_with_ashare_digits_is_wrong_hk(self):
+        # .HK 后缀 + 6 位 → wrong_hk：不得从数字中段截取片段与后缀拼接
+        # 解析（多候选只取首个的顺序依赖同样不允许）
+        assert self._identify("600519.HK") == [
+            Token("600519.HK", wrong_code_tag("hk"))
+        ]
+
+    def test_sh_marker_with_sz_digits_is_wrong_a(self):
+        # SH 前缀 + 深市代码（000001=平安银行）：交易所标注与数字形态矛盾
+        # → wrong_a，不得静默解析成平安银行（SH000001 本意是上证指数）
+        assert self._identify("SH000001") == [
+            Token("SH000001", wrong_code_tag("a"))
+        ]
+
+    def test_bj_marker_with_sh_digits_is_wrong_a(self):
+        # BJ 前缀 + 沪市代码（600519=贵州茅台）→ wrong_a，不得静默解析成茅台
+        assert self._identify("BJ600519") == [
+            Token("BJ600519", wrong_code_tag("a"))
+        ]
+
+    def test_sz_marker_with_sh_digits_is_wrong_a(self):
+        # SZ 后缀 + 沪市代码 → wrong_a（后缀标注与形态同样受一致性闸门约束）
+        assert self._identify("600519.SZ") == [
+            Token("600519.SZ", wrong_code_tag("a"))
+        ]
+
+    def test_consistent_sz_marker_resolves(self):
+        # 标注一致（SZ+000001 深市代码）照常命中：一致性闸门不误伤正确标注
+        assert self._identify("SZ000001") == [
+            Token("000001", TAG_STOCK_CODE, stocks=(Stock("000001", "平安银行", "a"),))
+        ]
+
+    def test_marker_case_insensitive(self):
+        assert self._identify("hk00700") == [
+            Token("HK00700", TAG_STOCK_CODE,
+                  stocks=(Stock("HK00700", "腾讯控股", "hk"),))
+        ]
+        assert self._identify("sh600519") == [
+            Token("600519", TAG_STOCK_CODE,
+                  stocks=(Stock("600519", "贵州茅台", "a"),))
+        ]
+
+    def test_contradictory_double_marker_is_wrong(self):
+        # 前后缀标注市场互斥：按后缀市场判 wrong，不取数字段静默解析
+        assert self._identify("HK600519.SH") == [
+            Token("HK600519.SH", wrong_code_tag("a"))
+        ]
+
+    def test_consistent_double_marker_resolves(self):
+        assert self._identify("SH600519.SH") == [
+            Token("600519", TAG_STOCK_CODE,
+                  stocks=(Stock("600519", "贵州茅台", "a"),))
+        ]
+
+    def test_out_of_db_ticker_kept_unknown_us(self):
+        # SOFI 不在本地库：美股库永不视为全量，存疑 unknown_us_code 交下游 LLM
+        assert self._identify("SOFI") == [Token("SOFI", unknown_code_tag("us"))]
+
+    def test_plain_english_word_kept_unknown_us(self):
+        assert self._identify("OK") == [Token("OK", unknown_code_tag("us"))]
+
+    def test_absent_ashare_code_before_extension_unknown(self, monkeypatch):
+        # A 股库未扩展（_akshare_merged 为 None）：格式合法但库未命中 → 存疑
+        from src.services import name_to_code_resolver as resolver_mod
+
+        monkeypatch.setattr(resolver_mod, "_akshare_merged", None)
+        assert self._identify("SH603999") == [Token("SH603999", unknown_code_tag("a"))]
+
+    def test_absent_ashare_code_after_extension_wrong(self, monkeypatch):
+        # AkShare 已并入仍命中失败 → 确定不存在 wrong_a_code
+        from src.services import name_to_code_resolver as resolver_mod
+
+        monkeypatch.setattr(resolver_mod, "_akshare_merged", {"贵州茅台": "600519"})
+        assert self._identify("SH603999") == [Token("SH603999", wrong_code_tag("a"))]
+
+    def test_hk_absent_code_always_unknown(self):
+        # 港股本地库永不视为全量：格式合法但库未命中（HK39999）→ 存疑
+        assert self._identify("HK39999") == [Token("HK39999", unknown_code_tag("hk"))]
+
+    def test_mock_akshare_merge_makes_code_matched(self):
+        # mock 的 AkShare 全量并入后：SZ000799（酒鬼酒，深市代码配深市标注）
+        # 辨认命中并附三元组
+        resolver_name_to_code_list("酒鬼酒")  # CJK 触发下游扩展（mock 并入）
+        assert self._identify("SZ000799") == [
+            Token("000799", TAG_STOCK_CODE, stocks=(Stock("000799", "酒鬼酒", "a"),))
+        ]
+
+    def test_untagged_tokens_pass_through(self):
+        tokens = [Token("分析", TAG_REQUEST), Token("600519", TAG_UNKNOWN_NUMBER)]
+        assert _identify_stock_codes(tokens) == tokens
+
+
+# =========================================================================
+# Step 1 — 股票全名精确扫描（管道首步）
+# =========================================================================
+
+class TestFullNameScan:
+    """窗口必须整体等于库中股票全名（4~3 字）；缩写与非全名留给 Step 6。"""
+
+    def test_full_name_inside_sentence(self):
+        tokens = _split_by_stock_entities("分析贵州茅台走势")
+        assert [t.text for t in tokens] == ["分析", "贵州茅台", "走势"]
+        name_token = tokens[1]
+        assert name_token.tag == TAG_STOCK_NAME
+        assert [s.code for s in name_token.stocks] == ["600519"]
+
+    def test_cross_market_same_name_carries_candidates(self):
+        # 阿里巴巴 → hk 09988 / us BABA 同名多只，token 携带多候选
+        tokens = _split_by_stock_entities("阿里巴巴")
+        assert len(tokens) == 1
+        assert tokens[0].tag == TAG_STOCK_NAME
+        assert {s.code for s in tokens[0].stocks} == {"HK09988", "BABA"}
+
+    def test_abbreviation_not_matched_here(self):
+        # 一对一缩写（茅台）非全名，Step 1 不做匹配，交由 Step 6 承接
+        assert _split_by_stock_entities("茅台") == [Token("茅台")]
+
+    def test_non_name_text_untouched(self):
+        assert _split_by_stock_entities("大港股份怎么样") == [Token("大港股份怎么样")]
+
+    def test_intra_name_space_matched_after_compact(self):
+        # 契约：窗口匹配前输入端统一删去空格（与库内压平拼写对齐），
+        # 带空格指称与常规书写同样整名命中，token 文本为压平拼写
+        tokens = _split_by_stock_entities("贵 州 茅 台怎么样")
+        assert [(t.text, t.tag) for t in tokens] == [
+            ("贵州茅台", TAG_STOCK_NAME), ("怎么样", "")
+        ]
+        assert [s.code for s in tokens[0].stocks] == ["600519"]
+        assert _split_by_stock_entities("五 粮 液") == [
+            Token("五粮液", TAG_STOCK_NAME, stocks=(Stock("000858", "五粮液", "a"),))
+        ]
+
+    def test_spaced_name_pipeline_resolves(self):
+        # 全管道：带空格指称整名命中，余文关键词照常提取
+        _, tokens = _preprocess_text("五 粮 液怎么样")
+        assert [(t.text, t.tag) for t in tokens] == [
+            ("五粮液", TAG_STOCK_NAME),
+            ("怎么样", TAG_QUESTION),
+        ]
+        assert [s.code for s in tokens[0].stocks] == ["000858"]
+
+    def test_pure_ascii_short_circuit(self):
+        # 纯英文段直接原样返回（交 Step 6 拼音/美股代码兜底）
+        assert _split_by_stock_entities("TSLA") == [Token("TSLA")]
+
+    def test_two_char_full_name_matched(self):
+        # 8~2 窗口契约（原"2 字名不扫描"已反转）：2 字全名（美团=03690）
+        # 整名精确命中，不再依赖 Step 6 模糊路径
+        tokens = _split_by_stock_entities("美团")
+        assert [(t.text, t.tag) for t in tokens] == [("美团", TAG_STOCK_NAME)]
+        assert [s.code for s in tokens[0].stocks] == ["HK03690"]
+
+    def test_six_char_full_name_matched_whole(self):
+        # 6 字全名（中国海洋石油=00883）整名命中：不再落给 DFS 拆成
+        # "中国海洋"+"石油" 错误边界（"石油"子串曾带入未提及的中国石油）
+        tokens = _split_by_stock_entities("中国海洋石油怎么样")
+        assert [(t.text, t.tag) for t in tokens] == [
+            ("中国海洋石油", TAG_STOCK_NAME),
+            ("怎么样", ""),
+        ]
+        assert [s.code for s in tokens[0].stocks] == ["HK00883"]
+
+    def test_spaced_six_char_name_matched_whole(self):
+        # 单空格书写的 6 字全名（raw 11 字符，超压缩长度上限 8）：空白收敛
+        # + 跨度上界（2*max_len-1）下整名命中，token 文本为压平拼写
+        tokens = _split_by_stock_entities("中 国 海 洋 石 油怎么样")
+        assert [(t.text, t.tag) for t in tokens] == [
+            ("中国海洋石油", TAG_STOCK_NAME),
+            ("怎么样", ""),
+        ]
+        assert [s.code for s in tokens[0].stocks] == ["HK00883"]
+
+    def test_spaced_long_name_pipeline_resolves(self):
+        # 全管道：带空格 6 字全名整名命中——Step 2 按空白切分会把名撕裂成
+        # 单字且 Step 6 无从复原，Step 1 必须在此消费
+        _, tokens = _preprocess_text("中 国 海 洋 石 油怎么样")
+        assert [(t.text, t.tag) for t in tokens] == [
+            ("中国海洋石油", TAG_STOCK_NAME),
+            ("怎么样", TAG_QUESTION),
+        ]
+        assert [s.code for s in tokens[0].stocks] == ["HK00883"]
+
+    def test_multi_space_and_tab_separated_name_matched(self):
+        # 多空格/tab/连续空白分隔的全名同样整名命中：入口把空白收敛为单空格，
+        # 统一 Step 1 删 ' ' 与 Step 2 按 \s 切分的两套口径（旧实现 tab 分
+        # 隔两头落空）
+        tokens = _split_by_stock_entities("贵  州\t茅   台怎么样")
+        assert [(t.text, t.tag) for t in tokens] == [
+            ("贵州茅台", TAG_STOCK_NAME),
+            ("怎么样", ""),
+        ]
+        assert [s.code for s in tokens[0].stocks] == ["600519"]
+
+
+# =========================================================================
+# 港股代码身份不变量 — 名称路径与代码路径共享同一拼写
+# =========================================================================
+
+class TestHkCodeIdentityInvariant:
+    """token 层代码身份契约：a=6 位裸数字、hk=HK+5 位、us=大写 ticker
+    （单一定义点 _canonical_stock_code）。名称路径（Step 1 实体/别名扫描、
+    Step 6 子串/拼音匹配）与代码路径（_identify_stock_codes）产出必须一致，
+    否则同一股票跨轮次出现多重身份（recent_stocks 去重/事件比较失效）。
+    stockDB 港股键为裸 5 位，归一化只在 token 层发生，resolver 契约不变。"""
+
+    @pytest.mark.parametrize("name, code", [
+        ("腾讯控股", "HK00700"),
+        ("美团", "HK03690"),
+    ])
+    def test_name_path_matches_code_path(self, name, code):
+        # P1-1 回归：同一条消息里名称指称与代码指称必须解析到同一代码拼写
+        _, tokens = _preprocess_text(f"{name}怎么样")
+        name_codes = {s.code for t in tokens if t.tag == TAG_STOCK_NAME
+                      for s in (t.stocks or ())}
+        out = _identify_stock_codes([Token(code.lower(), TAG_UNKNOWN_CODE)])
+        code_codes = {s.code for t in out for s in (t.stocks or ())}
+        assert name_codes == code_codes == {code}
+
+    def test_step1_alias_hit_canonical(self):
+        # Step 1 别名分支：命中展示当前规范名 + canonical 拼写
+        from src.services import name_to_code_resolver as resolver_mod
+
+        resolver_mod.stockAliases.setdefault("00700", set()).add("老腾讯名")
+        resolver_mod._names_cache[:] = [None, None, None]
+        try:
+            tokens = _split_by_stock_entities("老腾讯名怎么样")
+            assert [(t.text, t.tag) for t in tokens] == [
+                ("老腾讯名", TAG_STOCK_NAME), ("怎么样", "")
+            ]
+            assert [s.code for s in tokens[0].stocks] == ["HK00700"]
+            assert tokens[0].stocks[0].name == "腾讯控股"
+        finally:
+            resolver_mod.stockAliases["00700"].discard("老腾讯名")
+            if not resolver_mod.stockAliases["00700"]:
+                del resolver_mod.stockAliases["00700"]
+            resolver_mod._names_cache[:] = [None, None, None]
+
+    def test_dfs_cjk_substring_path_canonical(self):
+        # Step 6 CJK 循环经 resolver 子串命中港股（腾讯 ⊂ 腾讯控股）
+        _, tokens = _preprocess_text("腾讯怎么样")
+        assert [s.code for t in tokens if t.tag == TAG_STOCK_NAME
+                for s in (t.stocks or ())] == ["HK00700"]
+
+    def test_dfs_alpha_pinyin_path_canonical(self):
+        # Step 6 alpha 路径经拼音命中港股（tengxun ⊂ tengxunkonggu）
+        _, tokens = _preprocess_text("tengxun怎么样")
+        assert [s.code for t in tokens if t.tag == TAG_STOCK_NAME
+                for s in (t.stocks or ())] == ["HK00700"]
+
+    def test_no_bare_hk_code_in_any_token(self):
+        # 不变量扫描：任何 token 的 stocks 不得出现 market=="hk" 且纯数字 code
+        # （跨市场名"理想汽车"= LI + 02015 同 token 内按市场逐候选归一）
+        for msg in ["腾讯控股和美团对比", "阿里巴巴vs贵州茅台", "港股腾讯控股",
+                    "分析hk00700和腾讯控股", "理想汽车怎么样"]:
+            _, tokens = _preprocess_text(msg)
+            for t in tokens:
+                for s in (t.stocks or ()):
+                    assert not (s.market == "hk" and s.code.isdigit()), (msg, s)
+
+
+# =========================================================================
+# Step 1 实体扫描前置 — 含 ASCII 大写子串的库内全名不被代码形提取撕裂
+# =========================================================================
+
+class TestAsciiContainedFullName:
+    """P1-1 回归：库内全名含形同美股 ticker 的大写 ASCII 子串（"TCL科技"
+    的 "TCL"）时，Step 1 实体扫描（管道首步，入口先扩展）必须整名消费。
+    旧序（代码形提取先于实体扫描）会把 "TCL" 撕成 unknown_code、把
+    "科技" 误打成 sector_name——实体丢失且产出错误的行业/市场信号，
+    冷热库行为一致地坏。"""
+
+    _TCL_MOCK = {"TCL科技": "000100"}
+
+    def _run(self, msg):
+        """冷启动前提：重置扩展态，首条消息即在 Step 1 入口面对扩展。"""
+        from src.services import name_to_code_resolver as resolver_mod
+
+        with patch(
+            "src.services.name_to_code_resolver._get_akshare_name_to_code",
+            return_value=self._TCL_MOCK,
+        ):
+            resolver_mod._akshare_merged = None
+            resolver_mod._names_cache[:] = [None, None, None]
+            _, tokens = _preprocess_text(msg)
+        return _identify_stock_codes(tokens)
+
+    def test_in_sentence_cold_start(self):
+        tokens = self._run("分析TCL科技走势")
+        assert [(t.text, t.tag) for t in tokens] == [
+            ("分析", TAG_REQUEST),
+            ("TCL科技", TAG_STOCK_NAME),
+            ("走势", TAG_SUBJECT_RESEARCH),
+        ]
+        assert [s.code for s in tokens[1].stocks] == ["000100"]
+
+    def test_bare_name_message(self):
+        # 整条消息即全名（无标点词界）：同样必须整名消费——Step 6 DFS 的
+        # 长度循环无法处理 ASCII+CJK 混段（alpha 路径只取纯字母前缀）
+        tokens = self._run("TCL科技")
+        assert [(t.text, t.tag) for t in tokens] == [("TCL科技", TAG_STOCK_NAME)]
+        assert [(s.code, s.name, s.market) for s in tokens[0].stocks] == [
+            ("000100", "TCL科技", "a")
+        ]
+
+    def test_repeated_entity(self):
+        tokens = self._run("TCL科技TCL科技怎么样")
+        assert [(t.text, t.tag) for t in tokens] == [
+            ("TCL科技", TAG_STOCK_NAME),
+            ("TCL科技", TAG_STOCK_NAME),
+            ("怎么样", TAG_QUESTION),
+        ]
+
+    def test_market_keyword_coexists(self):
+        tokens = self._run("美股TCL科技怎么样")
+        assert [(t.text, t.tag) for t in tokens] == [
+            ("美股", TAG_SUBJECT_MARKET),
+            ("TCL科技", TAG_STOCK_NAME),
+            ("怎么样", TAG_QUESTION),
+        ]
+
+    def test_out_of_db_ascii_name_degrades_gracefully(self):
+        # 已知限制：库外含 ASCII 名（如港股 "TCL电子"）不在库中，Step 1
+        # 无法整名消费，"TCL" 照旧降级为 unknown_us_code 交下游 LLM 兜底
+        # （形态层面本质歧义：大写字母后接 CJK 一律放行会误伤 "TSLA怎么样"）
+        tokens = self._run("TCL电子怎么样")
+        pairs = [(t.text, t.tag) for t in tokens]
+        assert ("TCL", unknown_code_tag("us")) in pairs
+
+
+# =========================================================================
+# 关键词大小写不敏感 — 大写存储词的小写形态同构命中
+# =========================================================================
+
+class TestCaseInsensitiveKeywordClassification:
+    """P1-2 回归：关键词大小写不敏感与 (?i:) 编译声明同构——存储为大写的
+    关键词（"AI"/"中证A500"）的小写形态（"ai赛道"/"中证a500"）必须与
+    大写原形产出完全一致，不得整体失效或被裸数字提取撕裂。"""
+
+    def test_lowercase_ai_sector_pair(self):
+        _, tokens = _preprocess_text("ai赛道")
+        assert [(t.text, t.tag) for t in tokens] == [
+            ("ai", TAG_SECTOR_NAME),
+            ("赛道", TAG_SECTOR),
+        ]
+
+    def test_lowercase_digit_index_keyword_kept_whole(self):
+        # "中证a500" 的数字段受保护区放行（大小写不敏感），整词命中
+        # subject_index，不被撕成 "中证a" + "500"
+        _, tokens = _preprocess_text("中证a500走势")
+        assert [(t.text, t.tag) for t in tokens] == [
+            ("中证a500", TAG_SUBJECT_INDEX),
+            ("走势", TAG_SUBJECT_RESEARCH),
+        ]
+
+    def test_digit_keyword_release_case_insensitive(self):
+        assert _split_by_codes("中证a500") == [Token("中证a500")]
+
+    def test_uppercase_pool_keyword_original_form_unchanged(self):
+        # 大写存储词的原形匹配不受归一表影响
+        assert _preprocess_text("AI赛道")[1][0].tag == TAG_SECTOR_NAME
+
+
+# =========================================================================
+# 字母.交易所后缀代码 — 后缀与主体整体成 span
+# =========================================================================
+
+class TestSuffixedUsTicker:
+    """BRK.B / AAPL.N / TSLA.N 形态（与 extract_stock_codes 的美股正则
+    同构）：后缀与主体必须整体成 span，不得撕成 "BRK" + ".B" 两段——
+    旧正则会把库外代码文本撕残（unknown_us_code 只剩 "BRK"）。"""
+
+    def test_step3_keeps_suffix_whole(self):
+        assert _split_by_codes("BRK.B") == [Token("BRK.B", TAG_UNKNOWN_CODE)]
+        assert _split_by_codes("AAPL.N") == [Token("AAPL.N", TAG_UNKNOWN_CODE)]
+        assert _split_by_codes("TSLA.N怎么样") == [
+            Token("TSLA.N", TAG_UNKNOWN_CODE),
+            Token("怎么样"),
+        ]
+
+    def test_identify_in_db_ticker_with_suffix(self):
+        # 库内 ticker：取主体规范化大写拼写（AAPL.N → AAPL）
+        assert _identify_stock_codes([Token("AAPL.N", TAG_UNKNOWN_CODE)]) == [
+            Token("AAPL", TAG_STOCK_CODE, stocks=(Stock("AAPL", "苹果", "us"),))
+        ]
+
+    def test_identify_out_of_db_keeps_text_intact(self):
+        # 库外带后缀代码：文本保持完整交下游确认（不再残缺成 "BRK"+".B"）
+        assert _identify_stock_codes([Token("BRK.B", TAG_UNKNOWN_CODE)]) == [
+            Token("BRK.B", unknown_code_tag("us"))
+        ]
+
+    def test_us_suffix_pattern_unaffected(self):
+        # .us 后缀（大小写不敏感）行为不变
+        assert _split_by_codes("aapl.us") == [Token("aapl.us", TAG_UNKNOWN_CODE)]
+        assert _split_by_codes("BABA.US") == [Token("BABA.US", TAG_UNKNOWN_CODE)]
+
+
+# =========================================================================
+# Step 4 — 市场词提取
+# =========================================================================
+
+class TestMarketTokenSplit:
+    """"股"后接"份"（股票名后缀）时跳过，避免"大港股份"中的"港股"被误提取。"""
+
+    def test_market_word_tagged(self):
+        tokens = _split_market_tokens("港股")
+        assert [(t.text, t.tag) for t in tokens] == [("港股", TAG_SUBJECT_MARKET)]
+
+    def test_ascii_market_case_insensitive(self):
+        tokens = _split_market_tokens("A股")
+        assert [(t.text, t.tag) for t in tokens] == [("A股", TAG_SUBJECT_MARKET)]
+
+    def test_market_suffix_company_name_not_split(self):
+        # "大港股份"中的"港股"子串后接"份"→ 跳过，整段保留
+        assert _split_market_tokens("大港股份") == [Token("大港股份")]
+
+    def test_broad_market_keyword(self):
+        tokens = _split_market_tokens("行情怎么样")
+        assert ("行情", TAG_SUBJECT_MARKET_BROAD) in [(t.text, t.tag) for t in tokens]
+
+    def test_gap_untagged(self):
+        tokens = _split_market_tokens("看看港股走势")
+        assert [t.text for t in tokens] == ["看看", "港股", "走势"]
+        assert tokens[1].tag == TAG_SUBJECT_MARKET
+
+
+# =========================================================================
+# Step 5 — 无歧义关键词
+# =========================================================================
+
+class TestCleanKeywordTokenize:
+    def test_request_and_filler(self):
+        tokens = _tokenize_by_clean_keywords("帮我分析一下")
+        assert [(t.text, t.tag) for t in tokens] == [
+            ("帮我", TAG_FILLER),
+            ("分析", TAG_REQUEST),
+            ("一下", TAG_FILLER),
+        ]
+
+    def test_research_subject(self):
+        tokens = _tokenize_by_clean_keywords("走势")
+        assert tokens == [Token("走势", TAG_SUBJECT_RESEARCH)]
+
+    def test_ambiguous_keyword_not_in_clean_pool(self):
+        # "对比"在 extend 池（可能与股票名混淆），clean 分词不提取
+        assert _tokenize_by_clean_keywords("对比") == [Token("对比")]
+
+
+# =========================================================================
+# Step 6 板块词契约 — 板块词不做个股名匹配（Step 6 之前禁止模糊匹配）
+# =========================================================================
+
+class TestSectorWordNotStockMatched:
+    """sector 系词不做个股名匹配。"XX板块/行业/赛道/概念/题材"无专用正则：
+    Step 6 DFS 把词池内的行业名与泛称切为相邻 [sector_name/sector_n_stock]
+    +[sector] token 对——该相邻组合即高置信度板块信号，由下游消费。
+    Step 1~5 保持纯精确匹配。"""
+
+    def test_suffix_decomposes_to_adjacent_pair(self):
+        # Step 5 clean 关键词先于 Step 6；"建筑板块"→[sector_name]+[sector] 相邻
+        _, tokens = _preprocess_text("看看建筑板块")
+        assert [(t.text, t.tag) for t in tokens] == [
+            ("看看", TAG_REQUEST),
+            ("建筑", TAG_SECTOR_NAME),
+            ("板块", TAG_SECTOR),
+        ]
+
+    def test_industry_prefix_never_stock_matched(self):
+        # "建筑"不得经名称库子串解析成"中国建筑"个股
+        _, tokens = _preprocess_text("看看建筑板块")
+        assert all(t.tag != TAG_STOCK_NAME for t in tokens)
+
+    def test_multi_match_adjacent_pair_direct(self):
+        assert _multi_match("建筑板块") == [
+            Token("建筑", TAG_SECTOR_NAME),
+            Token("板块", TAG_SECTOR),
+        ]
+
+    def test_adjacent_pair_then_dfs_recursion(self):
+        # 相邻组合命中后，余文在同一递归链内继续匹配
+        tokens = _multi_match("建筑板块怎么样")
+        assert [(t.text, t.tag) for t in tokens] == [
+            ("建筑", TAG_SECTOR_NAME),
+            ("板块", TAG_SECTOR),
+            ("怎么样", TAG_QUESTION),
+        ]
+
+    def test_ascii_industry_word_pair(self):
+        # ASCII 行业名（AI 在 TAG_SECTOR_NAME 池）同样走相邻组合
+        assert _multi_match("AI赛道") == [
+            Token("AI", TAG_SECTOR_NAME),
+            Token("赛道", TAG_SECTOR),
+        ]
+
+    def test_bare_suffix_still_keyword_matched(self):
+        # 无前缀的裸后缀"板块"由 DFS extend 精确关键词命中
+        assert _multi_match("板块") == [Token("板块", TAG_SECTOR)]
+
+    def test_unenumerated_industry_word_left_for_llm(self):
+        # 未枚举行业词（预制菜）不在词池：整段无法全匹配 → 原样空 tag 交 LLM 兜底
+        assert _multi_match("预制菜板块") == [Token("预制菜板块")]
+
+    def test_enumerated_industry_word_sector_first(self):
+        # "建筑"已枚举进 TAG_SECTOR_NAME 池（全量库实证 ⊂ 中国建筑）：裸词
+        # 行业语义优先，打 sector_name，不解析成"中国建筑"个股
+        assert _multi_match("建筑") == [Token("建筑", TAG_SECTOR_NAME)]
+
+    def test_enumerated_word_beats_name_library_substring(self):
+        # 基础库真实碰撞："农业"⊂农业银行、"证券"⊂中信证券——Step 6 关键词
+        # 分类优先于名称库子串命中，裸词打 sector_name
+        assert _multi_match("农业") == [Token("农业", TAG_SECTOR_NAME)]
+        assert _multi_match("证券") == [Token("证券", TAG_SECTOR_NAME)]
+
+    def test_sector_n_stock_word_ambiguous_tag(self):
+        # 行业名兼股票全名（机器人=300024）：裸用打歧义 tag sector_n_stock，
+        # 既不打 stock_name 也不武断打 sector_name，交下游 LLM/确认消歧
+        assert _multi_match("机器人") == [Token("机器人", TAG_SECTOR_N_STOCK)]
+
+    def test_full_name_scan_releases_enumerated_word(self):
+        # "机器人"在生产全量库是 300024 的全名：注入后 Step 1 必须放行，
+        # 不得在 Step 6 之前打成 stock_name，交 Step 6 关键词打歧义 tag
+        from src.services import name_to_code_resolver as resolver_mod
+
+        resolver_mod.stockDB["300024"] = "机器人"
+        assert _split_by_stock_entities("机器人板块") == [Token("机器人板块")]
+        # DFS 回归：4 字窗口"机器人板"会先被 difflib 模糊命中"机器人"
+        # （ratio≈0.86），但余文"块"无法全匹配 → 回溯到 3 字关键词路径，
+        # 产出 [sector_n_stock]+[sector] 高置信度相邻组合
+        _, tokens = _preprocess_text("机器人板块")
+        assert [(t.text, t.tag) for t in tokens] == [
+            ("机器人", TAG_SECTOR_N_STOCK),
+            ("板块", TAG_SECTOR),
+        ]
+        _, tokens = _preprocess_text("机器人怎么样")
+        assert [(t.text, t.tag) for t in tokens] == [
+            ("机器人", TAG_SECTOR_N_STOCK),
+            ("怎么样", TAG_QUESTION),
+        ]
+
+
+# =========================================================================
+# Step 6 — 多策略 DFS 匹配
+# =========================================================================
+
+class TestMultiMatch:
+    def test_filler_run_split_to_single_chars(self):
+        tokens = _multi_match("的的")
+        assert [t.text for t in tokens] == ["的", "的"]
+        assert all(t.tag == TAG_FILLER for t in tokens)
+
+    def test_overlong_token_returned_unchanged(self):
+        text = "的" * 250
+        assert _multi_match(text) == [Token(text)]
+
+    def test_length_cap_boundary_50_processed(self):
+        # 恰好 50 字（≤ 上限）仍进 DFS：filler 逐字全覆盖（filler-only
+        # 路径跳过全库扫描，无性能风险）
+        tokens = _multi_match("的" * 50)
+        assert [t.text for t in tokens] == ["的"] * 50
+        assert all(t.tag == TAG_FILLER for t in tokens)
+
+    def test_length_cap_boundary_51_abandoned(self):
+        # 51 字（> 上限）：50+ 字连续无标点且不含 Steps 2~5 已提取信号，
+        # 默认非正常对话，整体放弃交下游 LLM
+        text = "的" * 51
+        assert _multi_match(text) == [Token(text)]
+
+    def test_length_cap_leaves_earlier_steps_intact(self):
+        # 超限只作用于 Step 6：Steps 2~5 已提取的代码/全名/关键词不受影响
+        _, tokens = _preprocess_text("分析600519.SH，" + "的" * 60)
+        pairs = [(t.text, t.tag) for t in tokens]
+        assert ("分析", TAG_REQUEST) in pairs
+        assert ("600519.SH", TAG_UNKNOWN_CODE) in pairs
+        assert ("的" * 60, "") in pairs
+
+    def test_one_to_one_abbreviation_resolves(self):
+        tokens = _multi_match("茅台")
+        assert len(tokens) == 1
+        assert tokens[0].tag == TAG_STOCK_NAME
+        assert [s.code for s in tokens[0].stocks] == ["600519"]
+
+    def test_generic_corp_suffix_not_fabricated(self):
+        # "苹果公司"不得拆成 苹果+公司 双 stock_name："公司"是零区分度通用
+        # 后缀（extend 词池 corp_suffix），子串命中中微公司是噪声非信号——
+        # 苹果精确命中、"公司"打 corp_suffix tag 参与 DFS 全覆盖
+        tokens = _multi_match("苹果公司")
+        assert [(t.text, t.tag) for t in tokens] == [
+            ("苹果", TAG_STOCK_NAME), ("公司", TAG_CORP_SUFFIX)
+        ]
+        assert [s.code for s in tokens[0].stocks] == ["AAPL"]
+
+    def test_suffix_tag_enables_full_coverage(self):
+        # 后缀 corp_suffix 使 DFS 全覆盖成立："腾讯公司"→腾讯(腾讯控股)+
+        # 公司(corp_suffix)，不再整段放弃交下游（空 tag 方案下无法覆盖）
+        tokens = _multi_match("腾讯公司")
+        assert [(t.text, t.tag) for t in tokens] == [
+            ("腾讯", TAG_STOCK_NAME), ("公司", TAG_CORP_SUFFIX)
+        ]
+        assert [s.code for s in tokens[0].stocks] == ["HK00700"]
+
+    def test_bare_generic_suffix_tagged_corp_suffix(self):
+        # 纯通用后缀单独成词：不做全库扫描，打 corp_suffix tag（原实现解析
+        # 成上汽/豪威/小米/京东/百度 5 候选 stock_name）
+        assert _multi_match("集团") == [Token("集团", TAG_CORP_SUFFIX)]
+
+    def test_generic_suffix_pipeline_not_injected(self):
+        # 全管道回归：分析 苹果公司 走势 → 只产出苹果(AAPL)，不注入 688012
+        _, tokens = _preprocess_text("分析 苹果公司 走势")
+        assert [(t.text, t.tag) for t in tokens] == [
+            ("分析", TAG_REQUEST),
+            ("苹果", TAG_STOCK_NAME),
+            ("公司", TAG_CORP_SUFFIX),
+            ("走势", TAG_SUBJECT_RESEARCH),
+        ]
+        assert [s.code for t in tokens if t.tag == TAG_STOCK_NAME
+                for s in (t.stocks or ())] == ["AAPL"]
+
+    def test_suffix_containing_full_name_still_matched(self):
+        # 防过度拦截：含后缀词头但非纯后缀的全名（中芯国际）照常整名命中，
+        # 跨市场同名双候选各按 canonical 拼写（a=688981、hk=HK00981）
+        tokens = _multi_match("中芯国际")
+        assert [(t.text, t.tag) for t in tokens] == [("中芯国际", TAG_STOCK_NAME)]
+        assert {s.code for s in tokens[0].stocks} == {"688981", "HK00981"}
+
+    def test_space_separated_ascii_words_resolved(self):
+        # 空白是词界、Step 1 切分——空格分隔的小写多词与逗号分隔同构
+        # （原整段失败交 LLM；≤4 字余词靠"带空格模糊命中"侥幸通过且 token
+        # 文本残留前导空格的偶然边界一并消除）
+        _, tokens = _preprocess_text("tsla aapl")
+        assert [(t.text, t.tag) for t in tokens] == [
+            ("tsla", TAG_STOCK_NAME), ("aapl", TAG_STOCK_NAME)
+        ]
+        assert [s.code for t in tokens for s in (t.stocks or ())] == ["TSLA", "AAPL"]
+
+    def test_space_equivalent_to_comma(self):
+        # 空格与逗号产出同构：独立 token、无前导空格残留
+        _, spaced = _preprocess_text("tsla amd")
+        _, commaed = _preprocess_text("tsla,amd")
+        assert [(t.text, t.tag) for t in spaced] == [(t.text, t.tag) for t in commaed]
+
+    def test_space_separated_word_failure_not_contagious(self):
+        # 词间独立：垃圾词空 tag 交 LLM，不连坐拖垮相邻已解析词
+        _, tokens = _preprocess_text("tsla jkl")
+        assert [(t.text, t.tag) for t in tokens] == [
+            ("tsla", TAG_STOCK_NAME), ("jkl", "")
+        ]
+
+    def test_cjk_with_spaces_deterministic(self):
+        # CJK 带空格（含全角）：Step 1 词界切分，不再依赖"带空格模糊命中"
+        _, tokens = _preprocess_text("茅台　和　五粮液")
+        assert [(t.text, t.tag) for t in tokens] == [
+            ("茅台", TAG_STOCK_NAME), ("和", TAG_FILLER), ("五粮液", TAG_STOCK_NAME)
+        ]
+
+    def test_alpha_path_ascii_name_dedup(self):
+        # 名称恰等于 ticker 的 ASCII 名美股（AMD）：resolver 精确名匹配与
+        # US ticker 匹配双源各出一份，拼接须按 (code, market) 去重，
+        # 否则 stocks 重复会被下游误判名称歧义
+        tokens = _multi_match("amd")
+        assert len(tokens) == 1
+        assert tokens[0].tag == TAG_STOCK_NAME
+        assert [(s.code, s.market) for s in tokens[0].stocks] == [("AMD", "us")]
+
+    def test_full_pinyin_resolves(self):
+        tokens = _multi_match("guizhoumaotai")
+        assert len(tokens) == 1
+        assert tokens[0].tag == TAG_STOCK_NAME
+        assert [s.code for s in tokens[0].stocks] == ["600519"]
+
+    @pytest.mark.parametrize("message", ["O", "K", "hi", "ai", "ma", "no", "you", "long", "open"])
+    def test_common_latin_noise_not_stock(self, message):
+        # 过短拼音片段不得命中股票名拼音子串（hi/long/open…）
+        tokens = _multi_match(message)
+        assert all(t.tag != TAG_STOCK_NAME for t in tokens)
+
+    def test_unresolvable_text_returned_unchanged(self):
+        assert _multi_match("你好股份") == [Token("你好股份")]
+
+    def test_cjk_with_particle_not_pinyin_matched(self):
+        # 回归：扩展库并入中大力德（拼音 zhongdalide）后，"阿里的"（拼音
+        # alide ⊂ zhongdalide）不得经拼音子串层误命中；DFS 最长优先的
+        # 3 字路径落空后必须回退到 2 字"阿里"子串 + "的"filler 的正确组合
+        resolver_name_to_code_list("酒鬼酒")  # CJK 触发 mock AkShare 并入
+        tokens = _multi_match("阿里的")
+        assert [(t.text, t.tag) for t in tokens] == [
+            ("阿里", "stock_name"),
+            ("的", "filler"),
+        ]
+        assert [s.code for s in tokens[0].stocks] == ["HK09988", "BABA"]
+
+
+# =========================================================================
+# Step 6 — 冷启动 DFS 回溯预算哨兵
+# =========================================================================
+
+# 触发构造三要素：
+#   1. 4 字库名（长城汽车）：同一对齐位置 len4 精确 / len3 模糊("长城汽"
+#      vs "长城汽车" ratio=0.75 失败、但"长城汽"对截断名可命中)/len2 子串
+#      多分支并存，回溯树分支因子 >1；
+#   2. 不可被模糊吸收的尾字（"咣"："汽车咣" vs "长城汽车" ratio≈0.67
+#      < 0.8）阻断首路径快速成功，迫使全树回溯；
+#   3. 冷启动：该名不在本地库中，Step 1 入口扩展后中途并入——若整名消费
+#      链路退化（扩展点后移/窗口收窄/别名索引移除），该名只能落给 Step 6
+#      DFS 首次 CJK resolver 调用路径，指数回溯面重新暴露。
+_BACKTRACK_NAME = "长城汽车"
+_BACKTRACK_TAIL = "咣"
+
+
+class TestDfsBacktrackingColdStart:
+    """DFS 回溯预算哨兵：Step 6 长度循环多分支并存（len4 精确 / len3
+    模糊 / len2 子串）时，"重复全名 + 不可吸收尾字"构造会指数回溯。
+    精确全名经 Step 1（管道首步入口扩展、8~2 窗口、实体/别名索引）整名
+    消费后，到达 DFS 的只剩无名 gap，调用数为常数级；无精确锚点的低置信
+    路径最坏为线性×全库扫描，由 50 字上限封顶。本预算断言防止整名消费
+    链路任一环节（扩展点前移、窗口宽度、别名索引、精确确认边界）退化后
+    指数回溯回归。"""
+
+    @staticmethod
+    def _cold_start_run(text):
+        """mock 扩展仅含触发名：调用前库中无该名（冷启动前提），
+        Step 3 入口扩展后并入。返回 (tokens, resolver 调用数)。"""
+        import src.agent.web_intent_tokenizer as tokenizer_mod
+
+        calls = {"n": 0}
+        orig = tokenizer_mod.resolver_name_to_code_list
+
+        def _counting(fragment):
+            calls["n"] += 1
+            return orig(fragment)
+
+        with patch(
+            "src.agent.web_intent_tokenizer.resolver_name_to_code_list",
+            _counting,
+        ), patch(
+            "src.services.name_to_code_resolver._get_akshare_name_to_code",
+            return_value={_BACKTRACK_NAME: "601633"},
+        ):
+            _, tokens = _preprocess_text(text)
+        return tokens, calls["n"]
+
+    def test_cold_start_output_contract(self):
+        # 契约：精确全名命中即实体自证——每个实体确认返回、尾部原样空
+        # tag 交下游 LLM；整段放弃仅适用于非精确命中（缩写/子串/拼音/模糊）。
+        # 小 n 控制用例耗时
+        assert not is_known_stock_name(_BACKTRACK_NAME)  # 冷启动前提
+        text = _BACKTRACK_NAME * 4 + _BACKTRACK_TAIL
+        tokens, _ = self._cold_start_run(text)
+        assert [(t.text, t.tag) for t in tokens] == [
+            (_BACKTRACK_NAME, TAG_STOCK_NAME)
+            for _ in range(4)
+        ] + [(_BACKTRACK_TAIL, "")]
+
+    def test_alias_repeat_backtracking_budget(self):
+        # 别名重复预算哨兵：4 字改名旧称重复 + 不可吸收尾字是指数回溯
+        # 构造；别名参与 Step 3 实体索引精确匹配后全名被整名消费，调用
+        # 数应为常数级。超预算即说明别名索引被移除或失效
+        from src.services import name_to_code_resolver as resolver_mod
+        import src.agent.web_intent_tokenizer as tokenizer_mod
+
+        resolver_mod.stockAliases.setdefault("601919", set()).add("中国远洋")
+        resolver_mod._names_cache[:] = [None, None, None]
+        try:
+            calls = {"n": 0}
+            orig = tokenizer_mod.resolver_name_to_code_list
+
+            def _counting(fragment):
+                calls["n"] += 1
+                return orig(fragment)
+
+            with patch(
+                "src.agent.web_intent_tokenizer.resolver_name_to_code_list",
+                _counting,
+            ):
+                text = "中国远洋" * 12 + "咣"
+                _, tokens = _preprocess_text(text)
+            assert calls["n"] <= 50, (
+                f"别名索引失效：resolver 调用数 {calls['n']}"
+            )
+            pairs = [(t.text, t.tag) for t in tokens]
+            assert pairs.count(("中国远洋", TAG_STOCK_NAME)) == 12
+            assert pairs[-1] == ("咣", "")
+            # 命中展示当前规范名（与 resolver 别名展示约定一致）
+            stock_tokens = [t for t in tokens if t.tag == TAG_STOCK_NAME]
+            assert all(s.name == "中远海控" and s.code == "601919"
+                       for t in stock_tokens for s in (t.stocks or ()))
+        finally:
+            resolver_mod.stockAliases.pop("601919", None)
+            resolver_mod._names_cache[:] = [None, None, None]
+
+    def test_cold_start_resolver_call_budget(self):
+        # 预算断言用确定性的 resolver 调用数（避开 wall-clock 抖动）：
+        # n=12、len=49，恰在 _MAX_MULTI_MATCH_TEXT_LEN=50 限内的最坏情形
+        # （>50 的输入已在上限处整体放弃）。整名消费生效时调用数为常数
+        # 级，2000 已留足余量
+        _, calls = self._cold_start_run(_BACKTRACK_NAME * 12 + _BACKTRACK_TAIL)
+        assert calls <= 2000, (
+            f"回溯预算: resolver 调用数 {calls} 超预算 2000（疑似指数回溯回归）"
+        )
+
+# =========================================================================
+# DFS 耗时比哨兵 — 防指数回溯回归
+# =========================================================================
+
+class TestDfsRescanBudgetSentinel:
+    """关键词链消息（无精确锚点）对同长零命中文本的耗时比上限：线性×
+    全库扫描属正常代价；超限疑似指数回溯回归（Step 3 整名消费被破坏时
+    比值爆到千倍级）或线性系数显著劣化（库规模叠加代码退化）。比值与
+    机器速度、库规模双重无关（分子分母同库同机）。"""
+
+    def test_keyword_chain_bounded_time(self):
+        import itertools
+        import time
+        from src.services import name_to_code_resolver as resolver_mod
+
+        db = dict(resolver_mod.stockDB)
+        try:
+            # 受控 ~4913 名合成库（≈ AkShare A 股全量规模），字符池与两个
+            # 测量文本零交集，保证"零命中"基线干净
+            pool = "金木水火土天地人和风云雷电山海川湖林石田"
+            i = 600000
+            for combo in itertools.product(pool[:17], repeat=3):
+                resolver_mod.stockDB[str(i)] = "".join(combo)
+                i += 1
+            resolver_mod._names_cache[:] = [None, None, None]
+
+            chain_text = "白酒板块" * 11 + "好"       # 45 字，<50 上限
+            gib_text = "狐猬獾貂蚨鹉鹦鹋鹌" * 2        # 18 字、零命中、同上限内
+
+            t0 = time.perf_counter()
+            _multi_match(chain_text)
+            chain = time.perf_counter() - t0
+            t0 = time.perf_counter()
+            _multi_match(gib_text)
+            gib = time.perf_counter() - t0
+
+            ratio = chain / max(gib, 1e-9)
+            assert ratio < 60, (
+                f"哨兵: 关键词链消息耗时 {chain*1000:.0f}ms，"
+                f"为同长零命中文本({gib*1000:.0f}ms)的 {ratio:.0f} 倍（阈值 60）——"
+                f"疑似指数回溯回归或线性系数显著劣化"
+            )
+        finally:
+            resolver_mod.stockDB.clear()
+            resolver_mod.stockDB.update(db)
+            resolver_mod._names_cache[:] = [None, None, None]
+
+
+# =========================================================================
+# Step 3 放行 + Step 1 星号等价精确匹配 + Step 6 禁模糊
+# =========================================================================
+
+class TestStPrefixNames:
+    """ST 全名 = 前缀(ST/*ST/ST* 三型互认) + AB 汉字：Step 3 不把 "ST" 当
+    代码候选（三型排布均放行），Step 1 做三型互认的整名精确匹配——容差仅
+    在前缀形式（省略 */星号位置各异），AB 汉字部分必须整体等于库中全名。"""
+
+    def test_step3_releases_st_prefix(self):
+        # 三型排布的 "ST" 均不作代码候选，整名保留（库外名交 Step 6 兜底，
+        # 库内名已在 Step 1 整名消费）
+        assert _split_by_codes("*ST美丽怎么样") == [Token("*ST美丽怎么样")]
+        assert _split_by_codes("ST德豪怎么样") == [Token("ST德豪怎么样")]
+        assert _split_by_codes("ST*美丽怎么样") == [Token("ST*美丽怎么样")]
+
+    def test_step1_exact_match_with_star(self):
+        from src.services import name_to_code_resolver as resolver_mod
+
+        resolver_mod.stockDB["000010"] = "*ST美丽"
+        try:
+            tokens = _split_by_stock_entities("*ST美丽怎么样")
+            assert [(t.text, t.tag) for t in tokens] == [
+                ("*ST美丽", TAG_STOCK_NAME), ("怎么样", "")
+            ]
+            assert tokens[0].stocks == (Stock("000010", "*ST美丽", "a"),)
+        finally:
+            del resolver_mod.stockDB["000010"]
+
+    def test_step1_star_equivalent_omitted_star(self):
+        # 用户省略 *：窗口 "ST美丽" 命中库内 "*ST美丽"，token 保留输入拼写
+        from src.services import name_to_code_resolver as resolver_mod
+
+        resolver_mod.stockDB["000010"] = "*ST美丽"
+        try:
+            tokens = _split_by_stock_entities("ST美丽怎么样")
+            assert [(t.text, t.tag) for t in tokens] == [
+                ("ST美丽", TAG_STOCK_NAME), ("怎么样", "")
+            ]
+            assert tokens[0].stocks == (Stock("000010", "*ST美丽", "a"),)
+        finally:
+            del resolver_mod.stockDB["000010"]
+
+    def test_step1_three_prefix_forms_interchangeable(self):
+        # 三型互认：库内 "*ST美丽"，输入 "ST*美丽" 同样整名命中，
+        # token 保留输入拼写、stocks 展示库内规范名
+        from src.services import name_to_code_resolver as resolver_mod
+
+        resolver_mod.stockDB["000010"] = "*ST美丽"
+        try:
+            tokens = _split_by_stock_entities("ST*美丽怎么样")
+            assert [(t.text, t.tag) for t in tokens] == [
+                ("ST*美丽", TAG_STOCK_NAME), ("怎么样", "")
+            ]
+            assert tokens[0].stocks == (Stock("000010", "*ST美丽", "a"),)
+        finally:
+            del resolver_mod.stockDB["000010"]
+
+    def test_step1_star_equivalent_reverse(self):
+        # 库名无星、用户带星：反向等价
+        from src.services import name_to_code_resolver as resolver_mod
+
+        resolver_mod.stockDB["002174"] = "ST德豪"
+        try:
+            tokens = _split_by_stock_entities("*ST德豪走势")
+            assert [(t.text, t.tag) for t in tokens] == [
+                ("*ST德豪", TAG_STOCK_NAME), ("走势", "")
+            ]
+            assert tokens[0].stocks == (Stock("002174", "ST德豪", "a"),)
+        finally:
+            del resolver_mod.stockDB["002174"]
+
+    def test_library_external_st_name_left_for_llm(self):
+        # 库外 ST 名：Step 3 三型互认未命中，本环境 Step 6 全策略亦无
+        # 命中 → 整段空 tag 交 LLM 兜底（Step 6 无 ST 特殊分支）
+        _, tokens = _preprocess_text("ST德豪怎么样")
+        assert [(t.text, t.tag) for t in tokens] == [
+            ("ST德豪", ""), ("怎么样", TAG_QUESTION)
+        ]
+
+    def test_cold_start_st_name_matched(self):
+        # Step 3 入口扩展后走同一精确匹配：冷启动首条消息即整名命中
+        # （验证扩展点前移覆盖 ST 形态；Step 6 已无扩展/重扫）
+        from src.services import name_to_code_resolver as resolver_mod
+
+        assert "*ST美丽" not in set(resolver_mod.stockDB.values())
+        with patch(
+            "src.services.name_to_code_resolver._get_akshare_name_to_code",
+            return_value={"*ST美丽": "000010"},
+        ):
+            resolver_mod._akshare_merged = None
+            _, tokens = _preprocess_text("*ST美丽怎么样")
+        assert [(t.text, t.tag) for t in tokens] == [
+            ("*ST美丽", TAG_STOCK_NAME), ("怎么样", TAG_QUESTION)
+        ]
+
+
+# =========================================================================
+# Step 6 交叉验证 — 宁可不做，不可做错
+# =========================================================================
+
+class TestCrossValidation:
+    """Step 6 交叉验证契约：多个低置信度命中组合成整段 TAG 全覆盖才产出，
+    任一片段无 tag 则整体放弃（宁可不做，不可做错）。"""
+
+    def test_full_coverage_mixed_entities(self):
+        # "茅台和白酒板块"：个股缩写+filler+行业名+泛称交叉验证，TAG 全覆盖
+        _, tokens = _preprocess_text("茅台和白酒板块")
+        assert [(t.text, t.tag) for t in tokens] == [
+            ("茅台", TAG_STOCK_NAME),
+            ("和", TAG_FILLER),
+            ("白酒", TAG_SECTOR_NAME),
+            ("板块", TAG_SECTOR),
+        ]
+        assert [s.code for s in tokens[0].stocks] == ["600519"]
+
+    def test_partial_coverage_abandoned(self):
+        # "茅台你好"："茅台"子串命中属低置信度，余文"你好"无法覆盖 →
+        # 整体放弃，不打任何 tag（宁可不做）
+        _, tokens = _preprocess_text("茅台你好")
+        assert [(t.text, t.tag) for t in tokens] == [("茅台你好", "")]
+
+    def test_step3_releases_ascii_keywords_case_insensitive(self):
+        # 关键词形态的 ASCII 片段不作代码候选（大小写不敏感）——
+        # 大写形态被 ticker 正则抠走会让 keyword 语义丢失、误入美股辨认
+        assert _split_by_codes("茅台PK五粮液") == [Token("茅台PK五粮液")]
+        assert _split_by_codes("BUY") == [Token("BUY")]
+        # 非关键词的大写词仍照常作为代码候选（宽口径不变）
+        assert _split_by_codes("ROE") == [Token("ROE", TAG_UNKNOWN_CODE)]
+
+    def test_uppercase_ascii_keyword_pipeline(self):
+        # 全管道：大写关键词与实体共存，语义与实体两全
+        _, tokens = _preprocess_text("茅台PK五粮液")
+        assert [(t.text, t.tag) for t in tokens] == [
+            ("茅台", TAG_STOCK_NAME),
+            ("PK", TAG_COMPARISON),
+            ("五粮液", TAG_STOCK_NAME),
+        ]
+        _, tokens = _preprocess_text("比亚迪BUY怎么样")
+        pairs = [(t.text, t.tag) for t in tokens]
+        assert ("BUY", TAG_ACTION_RESEARCH) in pairs
+        assert ("比亚迪", TAG_STOCK_NAME) in pairs
+
+    def test_step3_releases_sector_pool_ascii_word(self):
+        # Step 3 不影响板块实体识别："AI"在板块词池内，不作代码候选拦截，
+        # 管道层即可产出相邻高置信度组合
+        _, tokens = _preprocess_text("AI赛道")
+        assert [(t.text, t.tag) for t in tokens] == [
+            ("AI", TAG_SECTOR_NAME),
+            ("赛道", TAG_SECTOR),
+        ]
+
+
+# =========================================================================
+# 市场枚举提取 / 已识别判定 / 代码市场推断
+# =========================================================================
+
+class TestExtractMarketsFromTokens:
+    def test_market_tag_mapped(self):
+        assert _extract_markets_from_tokens(
+            [Token("港股", TAG_SUBJECT_MARKET)]
+        ) == [Market.HK]
+        assert _extract_markets_from_tokens(
+            [Token("A股", TAG_SUBJECT_MARKET)]
+        ) == [Market.A]
+
+    def test_ascii_market_shorthand(self):
+        # "HK" Step 3 会被标成 unknown_code，但文本形态仍是市场提示
+        assert _extract_markets_from_tokens([Token("HK", TAG_UNKNOWN_CODE)]) == [Market.HK]
+        # 小写简写需 CJK 语境：中文消息里的独立 "us" 是市场提示
+        assert _extract_markets_from_tokens([Token("看看"), Token("us")]) == [Market.US]
+
+    def test_english_pronoun_us_not_market(self):
+        # 纯英文消息里的小写 "us" 是代词（"tell us about…"），不是市场提示
+        assert _extract_markets_from_tokens([
+            Token("tell"), Token("us"), Token("about"),
+        ]) == []
+        # 大写简写是刻意形态，不受语境限制
+        assert _extract_markets_from_tokens([Token("US")]) == [Market.US]
+
+    def test_dedup(self):
+        markets = _extract_markets_from_tokens([
+            Token("港股", TAG_SUBJECT_MARKET),
+            Token("香港", TAG_SUBJECT_MARKET),
+        ])
+        assert markets == [Market.HK]
+
+
+class TestIsIdentifiedToken:
+    def test_tagged_token_identified(self):
+        assert _is_identified_token(Token("分析", TAG_REQUEST)) is True
+
+    def test_known_full_name_identified(self):
+        assert _is_identified_token(Token("贵州茅台")) is True
+
+    def test_code_like_text_not_identified_as_name(self):
+        # 代码键不算名称命中：裸数字必须继续进入代码提取步骤
+        assert _is_identified_token(Token("600519")) is False
+
+    def test_abbreviation_not_identified_as_name(self):
+        # "茅台"是缩写不是全名：不在名称表，交 Step 6 多策略匹配
+        assert _is_identified_token(Token("茅台")) is False
+
+
+class TestMarketOfCode:
+    @pytest.mark.parametrize("code,expected", [
+        ("600519", "a"),
+        ("000799", "a"),
+        ("00700", "hk"),
+        ("09988", "hk"),
+        ("AAPL", "us"),
+        ("AAPL.N", "us"),   # 单字母交易所后缀（NYSE/NASDAQ 简写）
+        ("AAPL.US", ""),    # 双字母后缀不在单字母推断契约内
+        ("77", ""),
+        ("", ""),
+    ])
+    def test_inference(self, code, expected):
+        assert _market_of_code(code) == expected
+
+
+# =========================================================================
+# _preprocess_text — 端到端管道
+# =========================================================================
+
+class TestPreprocessPipeline:
+    def test_explicit_code_with_request(self):
+        _, tokens = _preprocess_text("分析一下600519.SH")
+        tokens = _identify_stock_codes(tokens)
+        pairs = [(t.text, t.tag) for t in tokens]
+        assert ("分析", TAG_REQUEST) in pairs
+        assert ("600519", TAG_STOCK_CODE) in pairs
+
+    def test_extended_full_name_resolved_by_pipeline(self):
+        # 首次解析中 Step 6 的 CJK 片段解析触发下游扩展（mock 并入 stockDB）：
+        # 库外全名"酒鬼酒"以确定实体标签出现在管道产出里
+        _, tokens = _preprocess_text("对比茅台和酒鬼酒的基本面")
+        name_tokens = [t for t in tokens if t.tag == TAG_STOCK_NAME]
+        codes = {s.code for t in name_tokens for s in (t.stocks or ())}
+        assert {"600519", "000799"} <= codes
+
+    def test_pipeline_deterministic_after_warmup(self):
+        # 预先完成扩展（模拟进程 lifespan warmup）：stockDB 到达扩展终态后
+        # 管道跨调用产出确定一致。未预热的首条 CJK 消息由 Step 6 在扩展库上
+        # 兜底解析，resolve 级结果一致，但 token 边界可能与后续消息不同
+        from src.services import name_to_code_resolver as resolver_mod
+
+        resolver_mod.extend_AkShare()
+        _, tokens1 = _preprocess_text("对比茅台和酒鬼酒的基本面")
+        _, tokens2 = _preprocess_text("对比茅台和酒鬼酒的基本面")
+        assert [(t.text, t.tag) for t in tokens1] == [(t.text, t.tag) for t in tokens2]
+        pairs = [(t.text, t.tag) for t in tokens1]
+        assert ("酒鬼酒", TAG_STOCK_NAME) in pairs
+
+    def test_punctuation_tokens_filtered(self):
+        # 纯标点/空白 token 在管道末端被过滤
+        _, tokens = _preprocess_text("你好，在吗？？")
+        assert all(t.text.strip() for t in tokens)
+        assert all(t.text not in ("，", "？") for t in tokens)
+
+    def test_nfkc_width_normalization(self):
+        # 入口 NFKC 宽度归一（工作副本）：全角数字/字母与半角同形参与全部
+        # 步骤——全角数字曾被末端过滤器静默丢弃、全角 Ａ 错过市场关键词；
+        # 返回的原文本保持用户输入原样
+        _, tokens = _preprocess_text("Ａ股分析６００５１９")
+        pairs = [(t.text, t.tag) for t in tokens]
+        assert ("A股", TAG_SUBJECT_MARKET) in pairs
+        assert ("分析", TAG_REQUEST) in pairs
+        assert ("600519", TAG_UNKNOWN_NUMBER) in pairs
+        text, _ = _preprocess_text("Ａ股分析６００５１９")
+        assert text == "Ａ股分析６００５１９"
+
+    def test_nfkc_fullwidth_suffixed_code_resolves(self):
+        # 全角代码 + 交易所后缀：NFKC 归一后走标注判决，命中库即 stock_code
+        _, tokens = _preprocess_text("６００５１９.SH")
+        tokens = _identify_stock_codes(tokens)
+        assert ("600519", TAG_STOCK_CODE) in [(t.text, t.tag) for t in tokens]
+
+    def test_returns_original_text(self):
+        text, _ = _preprocess_text("分析一下600519.SH")
+        assert text == "分析一下600519.SH"


### PR DESCRIPTION
## PR Type

- [x] feat

## Background And Problem

本 PR 是 [Web Intent 最小 PR 拆分计划（#2239）]中的 **PR-2：Web Intent 分词层**（web_intent_types + web_intent_tokenizer + 分词单测）。

- **用途**：Web Chat 意图识别第一阶段——把用户输入切分为带语义标签的 Token 序列
（`stock_code` / `stock_name` / `subject_*` / `sector` / `time` …），
完成代码形提取、股票全名精确匹配、市场词消歧与多策略匹配，供 PR-3 的 web_intent_resolver 消费。
- **边界**：不接 SSE/API；生产代码尚无调用方，合入后无任何外部行为变化。

核心设计（详见模块 docstring）：

- **六步管道**（`web_intent_tokenizer._preprocess_text`）：
  Step 1 多股票全名实体扫描（仅全名精确匹配，8~2 字窗口，入口 `extend_AkShare` 扩库）→ Step 2 标点/空白切分 → 
  Step 3 代码形提取（裸数字 → `unknown_number`）→ Step 4 市场关键词（含"股"+"份"消歧）→ Step 5 无歧义关键词 → 
  Step 6 残存 gap 多策略 DFS 匹配（关键词/精确/子串/拼音/模糊）。
- **核心原则"宁可不做，不可做错"**：
  Step 1~5 只做精确匹配；Step 6 要求整段 TAG 全覆盖（交叉验证）才产出，未覆盖片段保持空 tag 交下游 LLM 兜底。
- **代码辨认三态**：库命中 → `stock_code`（附 code/name/market 三元组）；
  形态非法或该市场库全量未命中 → `wrong_{market}_code`；市场库非全量未命中 → `unknown_{market}_code`（存疑交 LLM）。
  token 层代码拼写统一 canonical 归一（a=6 位裸数字、hk=HK+5 位、us=大写 ticker），避免同一股票多重代码身份。
- **配套数据字典**（`web_intent_types.py`）：`Token` 结构、`Market` 枚举、20 个语义 tag、clean/extend 双关键词池与正则编译机器。

### 与计划的偏差声明：types 采用方案B而非方案A

本 PR 实际采用计划中的**备选方案B**（types 严格二分，仅含分词侧定义，378 行）：

- 理由：意图层定义与其首个消费者（PR-3 resolver）同 PR 落位，本 PR 审查面更纯粹、职责单一；
- 代价（同计划所述）：PR-3 需二次修改共享文件 `web_intent_types.py`（回补约 100 行意图定义），stacked 分支增加一次小 rebase。

## Scope Of Change

```bash
BASE_REF=$(git merge-base HEAD origin/main)
# BASE_REF=e45d5ce2025dc00f34e1f2a511c29e710586b864

git diff --stat "$BASE_REF"..HEAD
 docs/CHANGELOG.md                  |    1 +
 src/agent/web_intent_tokenizer.py  |  780 ++++++++++++++++++
 src/agent/web_intent_types.py      |  378 ++++++++++
 tests/test_web_intent_tokenizer.py | 1333 +++++++++++++++++++++++++++++++++
 4 files changed, 2651 insertions(+)
```

- 文件总数 / 变更行数：4 个文件，+2651 行（单提交）。
- 文件清单（与计划 PR-2 影响文件一致，均为新增）：
  - `src/agent/web_intent_types.py` — 分词侧数据字典（计划估算 ~470 行，实际 390 行：因采用方案B不含提前量）
  - `src/agent/web_intent_tokenizer.py` — 六步分词管道与代码辨认（计划估算 ~687 行，实际 802 行）
  - `tests/test_web_intent_tokenizer.py` — 离线单测（计划估算 ~521 行，实际 1458 行）
- 文档更新文件（`docs/*`）：`docs/CHANGELOG.md`（[Unreleased] 段追加一条 [新功能]）。
- 无 Web/前端/配置/流程模板文件改动；`name_to_code_resolver.py` 及其测试与基线 e45d5ce2 完全一致（PR-1 已在 main）。

## Issue Link

- `Refs #2239` : Web Intent 最小 PR 拆分计划；
本 PR 为其中的 PR-2。PR-1 已随 v3.31.0 合入 main，PR-3 / PR-4 将按计划顺序后续提交

## Verification Commands And Results

计划验收命令及加测（真实执行输出）：

```bash
# 计划 PR-2 验收命令
python -m pytest tests/test_web_intent_tokenizer.py -q
# 183 passed

# 加测：确认 resolver 基线（PR-1 已合入部分）不受影响
python -m pytest tests/test_web_intent_tokenizer.py tests/test_name_to_code_resolver.py -q
# 224 passed in 5.73s（分词模块 167 + resolver 基线 57）

python -m py_compile src/agent/web_intent_types.py src/agent/web_intent_tokenizer.py
# py_compile: OK
```

测试覆盖：全名实体扫描（唯一/跨市场同名/改名旧称/ST 前缀三型/带空格指称）、六步管道顺序、代码形提取与辨认三态（显式交易所标注矛盾、非法形态、库全量/非全量细分）、"股"+"份"消歧、sector 系词池与相邻组合、关键词大小写不敏感、filler 刷屏与超长 token 的复杂度防线。全部离线运行，AkShare 扩展路径以最小 mock 数据覆盖，不依赖真实网络（同计划要求）。

## Visual Evidence (if applicable)

不适用原因：纯后端新增模块（分词 + 类型 + 单测），不修改报告格式、报告渲染或 Web UI，无用户可见界面变化。

## Compatibility And Risk

- 纯新增：4 个文件均为新增或 CHANGELOG 追加，未修改任何既有代码路径；生产代码尚无调用方（同计划定位），合入后无任何外部行为变化。
- 未触及第三方模型/API、provider/model/base URL、请求参数或路由前缀。
- 通过 `name_to_code_resolver` 既有公开接口（`resolver_name_to_code_list` / `extend_AkShare` / `US_stock_code_match` / `lookup_stock_by_code` / `is_market_db_complete` 等，PR-1 已在 main）取数，接口语义未改。
- 本 PR 未变更 provider/model/base URL、运行时配置清理迁移语义；历史配置保持不变；回滚方式为 revert 本提交。

## Rollback Plan

`revert this PR`（当前为单提交 29c1742b，revert 即完全移除分词模块与 CHANGELOG 条目）；无配置、数据迁移或缓存需要额外回滚。

## EXTRACT_PROMPT Change (if applicable)

不适用：未修改 `src/services/image_stock_extractor.py`。

## Checklist

- [x] 本 PR 有明确动机和业务价值 / This PR has a clear motivation and value
- [x] 已提供可复现的验证命令与结果 / Reproducible verification commands and results are included
- [x] 已评估兼容性与风险 / Compatibility and risk have been assessed
- [x] 已提供回滚方案 / A rollback plan is provided
- [x] 报告格式 / Web UI 截图项：不适用（无报告渲染或 UI 变更）
- [x] Web 设置字段截图项：不适用（无设置字段变更）
- [x] 用户可见变更已同步 `docs/CHANGELOG.md`（内部模块新增，已按 [新功能] 记录于 [Unreleased] 段）
