### PR TITLE
feat: add stock research workspace

### DIFF
--- a/apps/dsa-web/src/App.tsx
+++ b/apps/dsa-web/src/App.tsx
@@ -23,6 +23,7 @@ const DecisionSignalsPage = lazy(() => import('./pages/DecisionSignalsPage'));
 const AlertsPage = lazy(() => import('./pages/AlertsPage'));
 const TokenUsagePage = lazy(() => import('./pages/TokenUsagePage'));
 const StockScreeningPage = lazy(() => import('./pages/StockScreeningPage'));
+const StockResearchPage = lazy(() => import('./pages/StockResearchPage'));
 
 const AppContent: React.FC = () => {
   const location = useLocation();
@@ -84,6 +85,7 @@ const AppContent: React.FC = () => {
         <Route path="/portfolio" element={<PortfolioPage />} />
         <Route path="/decision-signals" element={<DecisionSignalsPage />} />
         <Route path="/screening" element={<StockScreeningPage />} />
+        <Route path="/stocks/:stockCode" element={<StockResearchPage />} />
         <Route path="/backtest" element={<BacktestPage />} />
         <Route path="/alerts" element={<AlertsPage />} />
         <Route path="/usage" element={<TokenUsagePage />} />

--- a/apps/dsa-web/src/api/__tests__/stocks.test.ts
+++ b/apps/dsa-web/src/api/__tests__/stocks.test.ts
@@ -1,0 +1,55 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { stocksApi } from '../stocks';
+
+const get = vi.hoisted(() => vi.fn());
+const post = vi.hoisted(() => vi.fn());
+
+vi.mock('../index', () => ({
+  default: {
+    get,
+    post,
+  },
+}));
+
+describe('stocksApi market data helpers', () => {
+  beforeEach(() => {
+    get.mockReset();
+    post.mockReset();
+  });
+
+  it('loads and camelizes realtime quote payloads', async () => {
+    get.mockResolvedValue({
+      data: {
+        stock_code: '600519',
+        stock_name: '贵州茅台',
+        current_price: 1688,
+        change_percent: 1.23,
+        update_time: '2026-03-19T10:00:00',
+      },
+    });
+
+    const quote = await stocksApi.getQuote('600519.SH');
+
+    expect(get).toHaveBeenCalledWith('/api/v1/stocks/600519.SH/quote');
+    expect(quote.stockCode).toBe('600519');
+    expect(quote.changePercent).toBe(1.23);
+    expect(quote.updateTime).toBe('2026-03-19T10:00:00');
+  });
+
+  it('loads K-line history with default daily params', async () => {
+    get.mockResolvedValue({
+      data: {
+        stock_code: '600519',
+        period: 'daily',
+        data: [{ date: '2026-03-19', change_percent: 1.2, close: 1688 }],
+      },
+    });
+
+    const history = await stocksApi.getHistory('600519');
+
+    expect(get).toHaveBeenCalledWith('/api/v1/stocks/600519/history', {
+      params: { period: 'daily', days: 90 },
+    });
+    expect(history.data[0].changePercent).toBe(1.2);
+  });
+});

--- a/apps/dsa-web/src/api/stocks.ts
+++ b/apps/dsa-web/src/api/stocks.ts
@@ -1,10 +1,44 @@
 import apiClient from './index';
+import { toCamelCase } from './utils';
 
 export type ExtractItem = {
   code?: string | null;
   name?: string | null;
   confidence: string;
 };
+
+export interface StockQuote {
+  stockCode: string;
+  stockName?: string | null;
+  currentPrice: number;
+  change?: number | null;
+  changePercent?: number | null;
+  open?: number | null;
+  high?: number | null;
+  low?: number | null;
+  prevClose?: number | null;
+  volume?: number | null;
+  amount?: number | null;
+  updateTime?: string | null;
+}
+
+export interface KLineData {
+  date: string;
+  open: number;
+  high: number;
+  low: number;
+  close: number;
+  volume?: number | null;
+  amount?: number | null;
+  changePercent?: number | null;
+}
+
+export interface StockHistoryResponse {
+  stockCode: string;
+  stockName?: string | null;
+  period: 'daily' | 'weekly' | 'monthly' | string;
+  data: KLineData[];
+}
 
 export type ExtractFromImageResponse = {
   codes: string[];
@@ -13,6 +47,33 @@ export type ExtractFromImageResponse = {
 };
 
 export const stocksApi = {
+  async getQuote(stockCode: string): Promise<StockQuote> {
+    const response = await apiClient.get<Record<string, unknown>>(
+      `/api/v1/stocks/${encodeURIComponent(stockCode)}/quote`,
+    );
+    return toCamelCase<StockQuote>(response.data);
+  },
+
+  async getHistory(
+    stockCode: string,
+    params: { period?: 'daily' | 'weekly' | 'monthly'; days?: number } = {},
+  ): Promise<StockHistoryResponse> {
+    const response = await apiClient.get<Record<string, unknown>>(
+      `/api/v1/stocks/${encodeURIComponent(stockCode)}/history`,
+      {
+        params: {
+          period: params.period ?? 'daily',
+          days: params.days ?? 90,
+        },
+      },
+    );
+    const data = toCamelCase<StockHistoryResponse>(response.data);
+    return {
+      ...data,
+      data: (data.data ?? []).map((item) => toCamelCase<KLineData>(item)),
+    };
+  },
+
   async extractFromImage(file: File): Promise<ExtractFromImageResponse> {
     const formData = new FormData();
     formData.append('file', file);

--- a/apps/dsa-web/src/pages/StockResearchPage.tsx
+++ b/apps/dsa-web/src/pages/StockResearchPage.tsx
@@ -1,5 +1,5 @@
 import type React from 'react';
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import {
   ArrowLeft,
   BarChart3,
@@ -88,6 +88,8 @@ const StockResearchPage: React.FC = () => {
   const [selectedReport, setSelectedReport] = useState<AnalysisReport | null>(null);
   const [news, setNews] = useState<NewsIntelItem[]>([]);
   const [state, setState] = useState<LoadState>({ loading: true, error: null });
+  const workspaceRequestIdRef = useRef(0);
+  const reportRequestIdRef = useRef(0);
 
   const displayName = quote?.stockName || selectedReport?.meta.stockName || reports[0]?.stockName || stockCode;
   const evidenceBlocks = selectedReport?.details?.analysisContextPackOverview?.blocks ?? [];
@@ -99,13 +101,28 @@ const StockResearchPage: React.FC = () => {
     [history?.data],
   );
 
-  const loadReportDetail = useCallback(async (recordId: number) => {
+  const loadReportDetail = useCallback(async (recordId: number, workspaceRequestId = workspaceRequestIdRef.current) => {
+    const reportRequestId = reportRequestIdRef.current + 1;
+    reportRequestIdRef.current = reportRequestId;
+    const isStale = () =>
+      workspaceRequestIdRef.current !== workspaceRequestId || reportRequestIdRef.current !== reportRequestId;
+
     const report = await historyApi.getDetail(recordId);
+    if (isStale()) {
+      return;
+    }
     setSelectedReport(report);
+
     try {
       const newsResponse = await historyApi.getNews(recordId, 6);
+      if (isStale()) {
+        return;
+      }
       setNews(newsResponse.items);
     } catch {
+      if (isStale()) {
+        return;
+      }
       setNews([]);
     }
   }, []);
@@ -120,12 +137,19 @@ const StockResearchPage: React.FC = () => {
     }
 
     setState({ loading: true, error: null });
+    const workspaceRequestId = workspaceRequestIdRef.current + 1;
+    workspaceRequestIdRef.current = workspaceRequestId;
+    reportRequestIdRef.current += 1;
+
     try {
       const [quoteResult, historyResult, reportsResult] = await Promise.allSettled([
         stocksApi.getQuote(stockCode),
         stocksApi.getHistory(stockCode, { period: 'daily', days: 120 }),
         historyApi.getList({ stockCode, limit: 8 }),
       ]);
+      if (workspaceRequestIdRef.current !== workspaceRequestId) {
+        return;
+      }
 
       setQuote(quoteResult.status === 'fulfilled' ? quoteResult.value : null);
       setHistory(historyResult.status === 'fulfilled' ? historyResult.value : null);
@@ -133,10 +157,13 @@ const StockResearchPage: React.FC = () => {
       setReports(nextReports);
 
       if (nextReports[0]?.id !== undefined) {
-        await loadReportDetail(nextReports[0].id);
+        await loadReportDetail(nextReports[0].id, workspaceRequestId);
       } else {
         setSelectedReport(null);
         setNews([]);
+      }
+      if (workspaceRequestIdRef.current !== workspaceRequestId) {
+        return;
       }
 
       const failed = [quoteResult, historyResult, reportsResult].filter((result) => result.status === 'rejected');
@@ -145,6 +172,9 @@ const StockResearchPage: React.FC = () => {
         error: failed.length === 3 ? getParsedApiError((failed[0] as PromiseRejectedResult).reason) : null,
       });
     } catch (error: unknown) {
+      if (workspaceRequestIdRef.current !== workspaceRequestId) {
+        return;
+      }
       setState({ loading: false, error: getParsedApiError(error) });
     }
   }, [loadReportDetail, stockCode]);
@@ -157,7 +187,11 @@ const StockResearchPage: React.FC = () => {
     const timeout = window.setTimeout(() => {
       void loadWorkspace();
     }, 0);
-    return () => window.clearTimeout(timeout);
+    return () => {
+      window.clearTimeout(timeout);
+      workspaceRequestIdRef.current += 1;
+      reportRequestIdRef.current += 1;
+    };
   }, [loadWorkspace]);
 
   const handleAnalyze = () => {

--- a/apps/dsa-web/src/pages/StockResearchPage.tsx
+++ b/apps/dsa-web/src/pages/StockResearchPage.tsx
@@ -1,0 +1,445 @@
+import type React from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import {
+  ArrowLeft,
+  BarChart3,
+  Bell,
+  Bot,
+  CalendarClock,
+  CheckCircle2,
+  ClipboardList,
+  Database,
+  FileText,
+  LineChart,
+  Loader2,
+  MessageSquareQuote,
+  RefreshCw,
+  ShieldAlert,
+} from 'lucide-react';
+import { Area, AreaChart, CartesianGrid, ResponsiveContainer, Tooltip, XAxis, YAxis } from 'recharts';
+import { useNavigate, useParams } from 'react-router-dom';
+import { historyApi } from '../api/history';
+import { stocksApi, type StockHistoryResponse, type StockQuote } from '../api/stocks';
+import { ApiErrorAlert, AppPage, Badge, Button, InlineAlert } from '../components/common';
+import { getParsedApiError, type ParsedApiError } from '../api/error';
+import type {
+  AnalysisContextPackOverviewBlock,
+  AnalysisReport,
+  HistoryItem,
+  NewsIntelItem,
+} from '../types/analysis';
+import { getSentimentColor } from '../types/analysis';
+import { formatDateTime } from '../utils/format';
+import { normalizeStockCode } from '../utils/stockCode';
+import { truncateStockName } from '../utils/stockName';
+
+type LoadState = {
+  loading: boolean;
+  error: ParsedApiError | null;
+};
+
+const formatNumber = (value?: number | null, digits = 2): string => {
+  if (typeof value !== 'number' || Number.isNaN(value)) return '-';
+  return value.toLocaleString('zh-CN', {
+    maximumFractionDigits: digits,
+    minimumFractionDigits: digits,
+  });
+};
+
+const formatOptionalPercent = (value?: number | null): string => {
+  if (typeof value !== 'number' || Number.isNaN(value)) return '-';
+  return `${value >= 0 ? '+' : ''}${value.toFixed(2)}%`;
+};
+
+const formatAmount = (value?: number | null): string => {
+  if (typeof value !== 'number' || Number.isNaN(value)) return '-';
+  if (Math.abs(value) >= 100_000_000) return `${(value / 100_000_000).toFixed(2)} 亿`;
+  if (Math.abs(value) >= 10_000) return `${(value / 10_000).toFixed(2)} 万`;
+  return formatNumber(value, 2);
+};
+
+const toneForChange = (value?: number | null): string => {
+  if (typeof value !== 'number' || Number.isNaN(value) || value === 0) return 'text-secondary-text';
+  return value > 0 ? 'text-[var(--home-price-up)]' : 'text-[var(--home-price-down)]';
+};
+
+const statusVariant = (status?: string): 'success' | 'warning' | 'danger' | 'default' => {
+  if (status === 'available') return 'success';
+  if (status === 'fallback' || status === 'estimated') return 'warning';
+  if (status === 'missing' || status === 'fetch_failed') return 'danger';
+  return 'default';
+};
+
+const compactText = (value?: string | null, fallback = '-'): string => {
+  const normalized = (value ?? '').replace(/\s+/g, ' ').trim();
+  if (!normalized) return fallback;
+  return normalized.length > 140 ? `${normalized.slice(0, 140)}...` : normalized;
+};
+
+const normalizeRouteCode = (value?: string): string => normalizeStockCode(value ?? '').toUpperCase();
+
+const StockResearchPage: React.FC = () => {
+  const navigate = useNavigate();
+  const { stockCode: stockCodeParam = '' } = useParams();
+  const stockCode = normalizeRouteCode(decodeURIComponent(stockCodeParam));
+  const [quote, setQuote] = useState<StockQuote | null>(null);
+  const [history, setHistory] = useState<StockHistoryResponse | null>(null);
+  const [reports, setReports] = useState<HistoryItem[]>([]);
+  const [selectedReport, setSelectedReport] = useState<AnalysisReport | null>(null);
+  const [news, setNews] = useState<NewsIntelItem[]>([]);
+  const [state, setState] = useState<LoadState>({ loading: true, error: null });
+
+  const displayName = quote?.stockName || selectedReport?.meta.stockName || reports[0]?.stockName || stockCode;
+  const evidenceBlocks = selectedReport?.details?.analysisContextPackOverview?.blocks ?? [];
+  const chartData = useMemo(
+    () => (history?.data ?? []).map((item) => ({
+      ...item,
+      shortDate: item.date.slice(5),
+    })),
+    [history?.data],
+  );
+
+  const loadReportDetail = useCallback(async (recordId: number) => {
+    const report = await historyApi.getDetail(recordId);
+    setSelectedReport(report);
+    try {
+      const newsResponse = await historyApi.getNews(recordId, 6);
+      setNews(newsResponse.items);
+    } catch {
+      setNews([]);
+    }
+  }, []);
+
+  const loadWorkspace = useCallback(async () => {
+    if (!stockCode) {
+      setState({
+        loading: false,
+        error: getParsedApiError(new Error('股票代码不能为空')),
+      });
+      return;
+    }
+
+    setState({ loading: true, error: null });
+    try {
+      const [quoteResult, historyResult, reportsResult] = await Promise.allSettled([
+        stocksApi.getQuote(stockCode),
+        stocksApi.getHistory(stockCode, { period: 'daily', days: 120 }),
+        historyApi.getList({ stockCode, limit: 8 }),
+      ]);
+
+      setQuote(quoteResult.status === 'fulfilled' ? quoteResult.value : null);
+      setHistory(historyResult.status === 'fulfilled' ? historyResult.value : null);
+      const nextReports = reportsResult.status === 'fulfilled' ? reportsResult.value.items : [];
+      setReports(nextReports);
+
+      if (nextReports[0]?.id !== undefined) {
+        await loadReportDetail(nextReports[0].id);
+      } else {
+        setSelectedReport(null);
+        setNews([]);
+      }
+
+      const failed = [quoteResult, historyResult, reportsResult].filter((result) => result.status === 'rejected');
+      setState({
+        loading: false,
+        error: failed.length === 3 ? getParsedApiError((failed[0] as PromiseRejectedResult).reason) : null,
+      });
+    } catch (error: unknown) {
+      setState({ loading: false, error: getParsedApiError(error) });
+    }
+  }, [loadReportDetail, stockCode]);
+
+  useEffect(() => {
+    document.title = `${stockCode || 'Stock'} - DSA`;
+  }, [stockCode]);
+
+  useEffect(() => {
+    const timeout = window.setTimeout(() => {
+      void loadWorkspace();
+    }, 0);
+    return () => window.clearTimeout(timeout);
+  }, [loadWorkspace]);
+
+  const handleAnalyze = () => {
+    navigate('/', {
+      state: {
+        stockCode,
+        stockName: displayName,
+        autoAnalyze: true,
+        selectionSource: 'manual',
+      },
+    });
+  };
+
+  const handleAskAi = () => {
+    const params = new URLSearchParams({ stock: stockCode, name: displayName });
+    if (selectedReport?.meta.id !== undefined) {
+      params.set('recordId', String(selectedReport.meta.id));
+    }
+    navigate(`/chat?${params.toString()}`);
+  };
+
+  const handleMonitor = () => {
+    navigate('/alerts', { state: { stockCode, stockName: displayName } });
+  };
+
+  return (
+    <AppPage className="max-w-7xl">
+      <div className="mb-4 flex flex-wrap items-center justify-between gap-3">
+        <Button type="button" variant="ghost" size="sm" onClick={() => navigate('/')}>
+          <ArrowLeft className="h-4 w-4" aria-hidden="true" />
+          返回首页
+        </Button>
+        <Button type="button" variant="secondary" size="sm" onClick={() => void loadWorkspace()} disabled={state.loading}>
+          <RefreshCw className={`h-4 w-4 ${state.loading ? 'animate-spin' : ''}`} aria-hidden="true" />
+          刷新
+        </Button>
+      </div>
+
+      {state.error ? <ApiErrorAlert error={state.error} className="mb-4" /> : null}
+
+      <section className="dashboard-card mb-4 p-4 sm:p-5">
+        <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+          <div className="min-w-0">
+            <p className="label-uppercase home-title-accent">Stock Research</p>
+            <div className="mt-2 flex flex-wrap items-end gap-3">
+              <h1 className="min-w-0 text-2xl font-semibold text-foreground sm:text-3xl">
+                {truncateStockName(displayName)}
+              </h1>
+              <span className="pb-1 font-mono text-sm text-secondary-text">{stockCode || stockCodeParam}</span>
+            </div>
+            <p className="mt-2 max-w-3xl text-sm leading-6 text-secondary-text">
+              {selectedReport
+                ? compactText(selectedReport.summary.analysisSummary, '暂无最新研究摘要')
+                : '暂无最新研究摘要，可先发起一次分析。'}
+            </p>
+          </div>
+          <div className="flex flex-wrap gap-2">
+            <Button type="button" variant="home-action-ai" size="sm" onClick={handleAnalyze}>
+              <BarChart3 className="h-4 w-4" aria-hidden="true" />
+              重新分析
+            </Button>
+            <Button type="button" variant="secondary" size="sm" onClick={handleMonitor}>
+              <Bell className="h-4 w-4" aria-hidden="true" />
+              监控
+            </Button>
+            <Button type="button" variant="secondary" size="sm" onClick={handleAskAi}>
+              <MessageSquareQuote className="h-4 w-4" aria-hidden="true" />
+              问 AI
+            </Button>
+          </div>
+        </div>
+      </section>
+
+      <div className="grid grid-cols-1 gap-4 xl:grid-cols-[minmax(0,1.45fr)_minmax(22rem,0.55fr)]">
+        <div className="min-w-0 space-y-4">
+          <section className="dashboard-card p-4 sm:p-5">
+            <SectionTitle icon={<LineChart className="h-4 w-4" />} eyebrow="MarketSnapshot" title="行情快照" />
+            {state.loading && !quote ? (
+              <LoadingBlock />
+            ) : quote ? (
+              <div className="grid grid-cols-2 gap-3 md:grid-cols-4">
+                <Metric label="最新价" value={formatNumber(quote.currentPrice)} valueClassName={toneForChange(quote.changePercent)} />
+                <Metric label="涨跌幅" value={formatOptionalPercent(quote.changePercent)} valueClassName={toneForChange(quote.changePercent)} />
+                <Metric label="最高 / 最低" value={`${formatNumber(quote.high)} / ${formatNumber(quote.low)}`} />
+                <Metric label="成交额" value={formatAmount(quote.amount)} />
+                <Metric label="今开" value={formatNumber(quote.open)} />
+                <Metric label="昨收" value={formatNumber(quote.prevClose)} />
+                <Metric label="成交量" value={formatAmount(quote.volume)} />
+                <Metric label="更新时间" value={formatDateTime(quote.updateTime)} />
+              </div>
+            ) : (
+              <InlineAlert variant="warning" title="行情暂不可用" message="实时行情源未返回数据，研究区仍可查看历史报告。" />
+            )}
+          </section>
+
+          <section className="dashboard-card p-4 sm:p-5">
+            <SectionTitle icon={<BarChart3 className="h-4 w-4" />} eyebrow="Chart" title="K 线概览" />
+            {chartData.length > 0 ? (
+              <div className="h-72 min-w-0">
+                <ResponsiveContainer width="100%" height="100%">
+                  <AreaChart data={chartData} margin={{ left: 0, right: 10, top: 10, bottom: 0 }}>
+                    <defs>
+                      <linearGradient id="stockCloseGradient" x1="0" y1="0" x2="0" y2="1">
+                        <stop offset="5%" stopColor="hsl(var(--primary))" stopOpacity={0.32} />
+                        <stop offset="95%" stopColor="hsl(var(--primary))" stopOpacity={0.03} />
+                      </linearGradient>
+                    </defs>
+                    <CartesianGrid strokeDasharray="3 3" stroke="hsl(var(--border) / 0.45)" />
+                    <XAxis dataKey="shortDate" tickLine={false} axisLine={false} minTickGap={24} />
+                    <YAxis tickLine={false} axisLine={false} domain={['dataMin', 'dataMax']} width={56} />
+                    <Tooltip />
+                    <Area type="monotone" dataKey="close" stroke="hsl(var(--primary))" fill="url(#stockCloseGradient)" strokeWidth={2} />
+                  </AreaChart>
+                </ResponsiveContainer>
+              </div>
+            ) : (
+              <InlineAlert variant="warning" title="K 线暂不可用" message="历史行情源未返回数据。" />
+            )}
+          </section>
+
+          <section className="dashboard-card p-4 sm:p-5">
+            <SectionTitle icon={<ClipboardList className="h-4 w-4" />} eyebrow="ResearchSummary" title="研究摘要" />
+            {selectedReport ? (
+              <div className="grid gap-3 md:grid-cols-3">
+                <div className="home-subpanel p-3 md:col-span-2">
+                  <p className="text-sm leading-6 text-foreground">{compactText(selectedReport.summary.analysisSummary)}</p>
+                  <p className="mt-2 text-xs leading-5 text-secondary-text">{compactText(selectedReport.summary.trendPrediction)}</p>
+                </div>
+                <div className="home-subpanel p-3">
+                  <p className="text-xs text-muted-text">操作建议</p>
+                  <p className="mt-2 text-lg font-semibold text-foreground">{selectedReport.summary.actionLabel || selectedReport.summary.operationAdvice || '-'}</p>
+                  <Badge
+                    className="mt-3"
+                    style={{
+                      color: getSentimentColor(selectedReport.summary.sentimentScore ?? 50),
+                      borderColor: `${getSentimentColor(selectedReport.summary.sentimentScore ?? 50)}33`,
+                      backgroundColor: `${getSentimentColor(selectedReport.summary.sentimentScore ?? 50)}12`,
+                    }}
+                  >
+                    情绪分 {selectedReport.summary.sentimentScore ?? '-'}
+                  </Badge>
+                </div>
+              </div>
+            ) : (
+              <InlineAlert variant="warning" title="暂无研究摘要" message="该标的还没有历史分析报告。" />
+            )}
+          </section>
+
+          <section className="dashboard-card p-4 sm:p-5">
+            <SectionTitle icon={<Database className="h-4 w-4" />} eyebrow="Evidence" title="证据质量" />
+            {evidenceBlocks.length > 0 ? (
+              <div className="grid gap-2 md:grid-cols-2">
+                {evidenceBlocks.map((block) => <EvidenceBlock key={block.key} block={block} />)}
+              </div>
+            ) : (
+              <InlineAlert variant="warning" title="暂无证据摘要" message="旧报告可能没有 AnalysisContextPack 质量摘要。" />
+            )}
+          </section>
+        </div>
+
+        <aside className="min-w-0 space-y-4">
+          <section className="dashboard-card p-4 sm:p-5">
+            <SectionTitle icon={<CalendarClock className="h-4 w-4" />} eyebrow="Events" title="事件" />
+            {news.length > 0 ? (
+              <div className="space-y-2">
+                {news.map((item) => (
+                  <a
+                    key={`${item.url}-${item.title}`}
+                    href={item.url}
+                    target="_blank"
+                    rel="noreferrer"
+                    className="home-subpanel block p-3"
+                  >
+                    <span className="line-clamp-2 text-sm font-medium text-foreground">{item.title}</span>
+                    <span className="mt-1 line-clamp-2 text-xs leading-5 text-secondary-text">{item.snippet}</span>
+                  </a>
+                ))}
+              </div>
+            ) : (
+              <p className="text-xs leading-5 text-muted-text">暂无关联新闻或事件。</p>
+            )}
+          </section>
+
+          <section className="dashboard-card p-4 sm:p-5">
+            <SectionTitle icon={<FileText className="h-4 w-4" />} eyebrow="Reports" title="报告" />
+            {reports.length > 0 ? (
+              <div className="space-y-2">
+                {reports.map((item) => (
+                  <button
+                    key={item.id}
+                    type="button"
+                    className="home-subpanel grid w-full min-w-0 grid-cols-[minmax(0,1fr)_auto] gap-2 p-3 text-left"
+                    onClick={() => void loadReportDetail(item.id)}
+                  >
+                    <span className="min-w-0">
+                      <span className="line-clamp-2 text-sm font-medium text-foreground">{compactText(item.analysisSummary, item.operationAdvice || '历史报告')}</span>
+                      <span className="mt-1 block text-xs text-muted-text">{formatDateTime(item.createdAt)}</span>
+                    </span>
+                    <Badge size="sm">{item.sentimentScore ?? '-'}</Badge>
+                  </button>
+                ))}
+              </div>
+            ) : (
+              <p className="text-xs leading-5 text-muted-text">暂无历史报告。</p>
+            )}
+          </section>
+
+          <section className="dashboard-card p-4 sm:p-5">
+            <SectionTitle icon={<ShieldAlert className="h-4 w-4" />} eyebrow="Monitors" title="监控" />
+            <div className="home-subpanel p-3">
+              <div className="flex items-start gap-2">
+                <Bell className="mt-0.5 h-4 w-4 shrink-0 text-warning" aria-hidden="true" />
+                <p className="text-sm leading-6 text-secondary-text">
+                  进入告警中心，为价格、报告失效条件或自选状态设置提醒。
+                </p>
+              </div>
+              <Button type="button" variant="secondary" size="sm" className="mt-3 w-full" onClick={handleMonitor}>
+                打开告警中心
+              </Button>
+            </div>
+          </section>
+
+          <section className="dashboard-card p-4 sm:p-5">
+            <SectionTitle icon={<Bot className="h-4 w-4" />} eyebrow="Copilot" title="研究助手" />
+            <div className="home-subpanel p-3">
+              <p className="text-sm leading-6 text-secondary-text">
+                基于当前标的和最新报告继续追问，适合复核 thesis、证据质量和下一步动作。
+              </p>
+              <Button type="button" variant="home-action-ai" size="sm" className="mt-3 w-full" onClick={handleAskAi}>
+                问 AI
+              </Button>
+            </div>
+          </section>
+        </aside>
+      </div>
+    </AppPage>
+  );
+};
+
+const SectionTitle: React.FC<{ icon: React.ReactNode; eyebrow: string; title: string }> = ({ icon, eyebrow, title }) => (
+  <div className="mb-4 flex items-center gap-2">
+    <span className="text-primary">{icon}</span>
+    <span className="label-uppercase text-muted-text">{eyebrow}</span>
+    <h2 className="text-base font-semibold text-foreground">{title}</h2>
+  </div>
+);
+
+const Metric: React.FC<{ label: string; value: string; valueClassName?: string }> = ({ label, value, valueClassName = '' }) => (
+  <div className="home-subpanel px-3 py-3">
+    <span className="block text-xs text-muted-text">{label}</span>
+    <span className={`mt-1 block truncate text-base font-semibold ${valueClassName || 'text-foreground'}`}>{value}</span>
+  </div>
+);
+
+const LoadingBlock: React.FC = () => (
+  <div className="flex h-32 items-center justify-center text-secondary-text">
+    <Loader2 className="h-5 w-5 animate-spin" aria-label="加载中" />
+  </div>
+);
+
+const EvidenceBlock: React.FC<{ block: AnalysisContextPackOverviewBlock }> = ({ block }) => (
+  <div className="home-subpanel p-3">
+    <div className="flex items-start justify-between gap-3">
+      <div className="min-w-0">
+        <p className="truncate text-sm font-medium text-foreground">{block.label}</p>
+        <p className="mt-1 truncate text-xs text-muted-text">{block.source || 'unknown source'}</p>
+      </div>
+      <Badge variant={statusVariant(block.status)} size="sm" className="shrink-0 text-[11px]">
+        {block.status}
+      </Badge>
+    </div>
+    {block.warnings.length > 0 || block.missingReasons.length > 0 ? (
+      <p className="mt-2 line-clamp-2 text-xs leading-5 text-secondary-text">
+        {[...block.warnings, ...block.missingReasons].join(' / ')}
+      </p>
+    ) : (
+      <div className="mt-2 flex items-center gap-1.5 text-xs text-success">
+        <CheckCircle2 className="h-3.5 w-3.5" aria-hidden="true" />
+        可用于本次研究
+      </div>
+    )}
+  </div>
+);
+
+export default StockResearchPage;

--- a/apps/dsa-web/src/pages/__tests__/StockResearchPage.test.tsx
+++ b/apps/dsa-web/src/pages/__tests__/StockResearchPage.test.tsx
@@ -1,0 +1,173 @@
+import type React from 'react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { historyApi } from '../../api/history';
+import { stocksApi } from '../../api/stocks';
+import { UiLanguageProvider } from '../../contexts/UiLanguageContext';
+import { UI_LANGUAGE_STORAGE_KEY } from '../../utils/uiLanguage';
+import StockResearchPage from '../StockResearchPage';
+
+const navigate = vi.hoisted(() => vi.fn());
+
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom');
+  return {
+    ...actual,
+    useNavigate: () => navigate,
+    useParams: () => ({ stockCode: '600519' }),
+  };
+});
+
+vi.mock('recharts', () => ({
+  ResponsiveContainer: () => <div data-testid="chart" />,
+  AreaChart: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  Area: () => null,
+  CartesianGrid: () => null,
+  Tooltip: () => null,
+  XAxis: () => null,
+  YAxis: () => null,
+}));
+
+vi.mock('../../api/stocks', () => ({
+  stocksApi: {
+    getQuote: vi.fn(),
+    getHistory: vi.fn(),
+  },
+}));
+
+vi.mock('../../api/history', () => ({
+  historyApi: {
+    getList: vi.fn(),
+    getDetail: vi.fn(),
+    getNews: vi.fn(),
+  },
+}));
+
+const latestReport = {
+  meta: {
+    id: 11,
+    queryId: 'q-11',
+    stockCode: '600519',
+    stockName: '贵州茅台',
+    reportType: 'detailed' as const,
+    createdAt: '2026-03-19T08:00:00Z',
+  },
+  summary: {
+    analysisSummary: '趋势维持强势',
+    operationAdvice: '持有',
+    actionLabel: '持有',
+    trendPrediction: '震荡上行',
+    sentimentScore: 82,
+  },
+  details: {
+    analysisContextPackOverview: {
+      packVersion: 'v1',
+      subject: { code: '600519', stockName: '贵州茅台', market: 'cn' },
+      blocks: [
+        {
+          key: 'daily_price',
+          label: '日线行情',
+          status: 'available' as const,
+          source: 'tencent',
+          warnings: [],
+          missingReasons: [],
+        },
+      ],
+      counts: {
+        available: 1,
+        missing: 0,
+        notSupported: 0,
+        fallback: 0,
+        stale: 0,
+        estimated: 0,
+        partial: 0,
+        fetchFailed: 0,
+      },
+      warnings: [],
+      metadata: {},
+    },
+  },
+};
+
+describe('StockResearchPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    window.localStorage.setItem(UI_LANGUAGE_STORAGE_KEY, 'zh');
+    vi.mocked(stocksApi.getQuote).mockResolvedValue({
+      stockCode: '600519',
+      stockName: '贵州茅台',
+      currentPrice: 1688,
+      changePercent: 1.23,
+      high: 1700,
+      low: 1660,
+      amount: 1200000000,
+      updateTime: '2026-03-19T10:00:00Z',
+    });
+    vi.mocked(stocksApi.getHistory).mockResolvedValue({
+      stockCode: '600519',
+      stockName: '贵州茅台',
+      period: 'daily',
+      data: [
+        { date: '2026-03-18', open: 1600, high: 1660, low: 1590, close: 1650 },
+        { date: '2026-03-19', open: 1650, high: 1700, low: 1640, close: 1688 },
+      ],
+    });
+    vi.mocked(historyApi.getList).mockResolvedValue({
+      total: 1,
+      page: 1,
+      limit: 8,
+      items: [{
+        id: 11,
+        queryId: 'q-11',
+        stockCode: '600519',
+        stockName: '贵州茅台',
+        reportType: 'detailed',
+        analysisSummary: '趋势维持强势',
+        sentimentScore: 82,
+        operationAdvice: '持有',
+        createdAt: '2026-03-19T08:00:00Z',
+      }],
+    });
+    vi.mocked(historyApi.getDetail).mockResolvedValue(latestReport);
+    vi.mocked(historyApi.getNews).mockResolvedValue({
+      total: 1,
+      items: [{ title: '公司公告', snippet: '业绩保持稳定', url: 'https://example.com/news' }],
+    });
+  });
+
+  it('renders stock research workspace sections from existing APIs', async () => {
+    render(
+      <UiLanguageProvider>
+        <StockResearchPage />
+      </UiLanguageProvider>,
+    );
+
+    expect(await screen.findByText('贵州茅台')).toBeInTheDocument();
+    expect(screen.getByText('行情快照')).toBeInTheDocument();
+    expect(screen.getByText('K 线概览')).toBeInTheDocument();
+    expect(screen.getByText('研究摘要')).toBeInTheDocument();
+    expect(screen.getByText('证据质量')).toBeInTheDocument();
+    expect(screen.getByText('事件')).toBeInTheDocument();
+    expect(screen.getByText('报告')).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: '监控' })).toBeInTheDocument();
+    expect(screen.getByText('研究助手')).toBeInTheDocument();
+    expect(screen.getAllByText('趋势维持强势').length).toBeGreaterThan(0);
+    expect(screen.getByText('日线行情')).toBeInTheDocument();
+    expect(screen.getByText('公司公告')).toBeInTheDocument();
+  });
+
+  it('opens chat with stock and latest report context', async () => {
+    render(
+      <UiLanguageProvider>
+        <StockResearchPage />
+      </UiLanguageProvider>,
+    );
+
+    await screen.findAllByText('趋势维持强势');
+    fireEvent.click(screen.getAllByRole('button', { name: '问 AI' })[0]);
+
+    await waitFor(() => {
+      expect(navigate).toHaveBeenCalledWith('/chat?stock=600519&name=%E8%B4%B5%E5%B7%9E%E8%8C%85%E5%8F%B0&recordId=11');
+    });
+  });
+});

--- a/apps/dsa-web/src/pages/__tests__/StockResearchPage.test.tsx
+++ b/apps/dsa-web/src/pages/__tests__/StockResearchPage.test.tsx
@@ -8,13 +8,24 @@ import { UI_LANGUAGE_STORAGE_KEY } from '../../utils/uiLanguage';
 import StockResearchPage from '../StockResearchPage';
 
 const navigate = vi.hoisted(() => vi.fn());
+const routeParams = vi.hoisted(() => ({ stockCode: '600519' }));
+
+function createDeferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
 
 vi.mock('react-router-dom', async () => {
   const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom');
   return {
     ...actual,
     useNavigate: () => navigate,
-    useParams: () => ({ stockCode: '600519' }),
+    useParams: () => ({ stockCode: routeParams.stockCode }),
   };
 });
 
@@ -89,9 +100,84 @@ const latestReport = {
   },
 };
 
+const secondReport = {
+  meta: {
+    id: 22,
+    queryId: 'q-22',
+    stockCode: '600519',
+    stockName: '贵州茅台',
+    reportType: 'detailed' as const,
+    createdAt: '2026-03-18T08:00:00Z',
+  },
+  summary: {
+    analysisSummary: '短线先观察',
+    operationAdvice: '观望',
+    actionLabel: '观望',
+    trendPrediction: '量能不足',
+    sentimentScore: 41,
+  },
+  details: {
+    analysisContextPackOverview: {
+      packVersion: 'v1',
+      subject: { code: '600519', stockName: '贵州茅台', market: 'cn' },
+      blocks: [],
+      counts: {
+        available: 0,
+        missing: 0,
+        notSupported: 0,
+        fallback: 0,
+        stale: 0,
+        estimated: 0,
+        partial: 0,
+        fetchFailed: 0,
+      },
+      warnings: [],
+      metadata: {},
+    },
+  },
+};
+
+const thirdReport = {
+  meta: {
+    id: 33,
+    queryId: 'q-33',
+    stockCode: '600519',
+    stockName: '贵州茅台',
+    reportType: 'detailed' as const,
+    createdAt: '2026-03-20T08:00:00Z',
+  },
+  summary: {
+    analysisSummary: '继续上修目标价',
+    operationAdvice: '加仓',
+    actionLabel: '加仓',
+    trendPrediction: '机构资金持续流入',
+    sentimentScore: 91,
+  },
+  details: {
+    analysisContextPackOverview: {
+      packVersion: 'v1',
+      subject: { code: '600519', stockName: '贵州茅台', market: 'cn' },
+      blocks: [],
+      counts: {
+        available: 0,
+        missing: 0,
+        notSupported: 0,
+        fallback: 0,
+        stale: 0,
+        estimated: 0,
+        partial: 0,
+        fetchFailed: 0,
+      },
+      warnings: [],
+      metadata: {},
+    },
+  },
+};
+
 describe('StockResearchPage', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    routeParams.stockCode = '600519';
     window.localStorage.setItem(UI_LANGUAGE_STORAGE_KEY, 'zh');
     vi.mocked(stocksApi.getQuote).mockResolvedValue({
       stockCode: '600519',
@@ -168,6 +254,439 @@ describe('StockResearchPage', () => {
 
     await waitFor(() => {
       expect(navigate).toHaveBeenCalledWith('/chat?stock=600519&name=%E8%B4%B5%E5%B7%9E%E8%8C%85%E5%8F%B0&recordId=11');
+    });
+  });
+
+  it('ignores stale workspace responses after the route stock changes', async () => {
+    const firstQuote = createDeferred<Awaited<ReturnType<typeof stocksApi.getQuote>>>();
+    const firstHistory = createDeferred<Awaited<ReturnType<typeof stocksApi.getHistory>>>();
+    const firstReports = createDeferred<Awaited<ReturnType<typeof historyApi.getList>>>();
+    const firstDetail = createDeferred<Awaited<ReturnType<typeof historyApi.getDetail>>>();
+    const firstNews = createDeferred<Awaited<ReturnType<typeof historyApi.getNews>>>();
+
+    vi.mocked(stocksApi.getQuote).mockImplementation((stockCode) => (
+      stockCode === '600519'
+        ? firstQuote.promise
+        : Promise.resolve({
+          stockCode: 'AAPL',
+          stockName: 'Apple Inc.',
+          currentPrice: 245.12,
+          changePercent: 0.81,
+          high: 246,
+          low: 243.5,
+          amount: 850000000,
+          updateTime: '2026-03-19T10:05:00Z',
+        })
+    ));
+    vi.mocked(stocksApi.getHistory).mockImplementation((stockCode) => (
+      stockCode === '600519'
+        ? firstHistory.promise
+        : Promise.resolve({
+          stockCode: 'AAPL',
+          stockName: 'Apple Inc.',
+          period: 'daily',
+          data: [
+            { date: '2026-03-18', open: 241, high: 244, low: 240, close: 243.8 },
+            { date: '2026-03-19', open: 244, high: 246, low: 243.5, close: 245.12 },
+          ],
+        })
+    ));
+    vi.mocked(historyApi.getList).mockImplementation((params = {}) => (
+      params.stockCode === '600519'
+        ? firstReports.promise
+        : Promise.resolve({
+          total: 1,
+          page: 1,
+          limit: 8,
+          items: [{
+            id: 21,
+            queryId: 'q-21',
+            stockCode: 'AAPL',
+            stockName: 'Apple Inc.',
+            reportType: 'detailed',
+            analysisSummary: '苹果新高后仍有延续',
+            sentimentScore: 74,
+            operationAdvice: '持有',
+            createdAt: '2026-03-19T09:00:00Z',
+          }],
+        })
+    ));
+    vi.mocked(historyApi.getDetail).mockImplementation((recordId) => (
+      recordId === 11
+        ? firstDetail.promise
+        : Promise.resolve({
+          ...latestReport,
+          meta: {
+            ...latestReport.meta,
+            id: 21,
+            queryId: 'q-21',
+            stockCode: 'AAPL',
+            stockName: 'Apple Inc.',
+          },
+          summary: {
+            ...latestReport.summary,
+            analysisSummary: '苹果新高后仍有延续',
+            trendPrediction: '美股趋势保持强势',
+          },
+          details: {
+            ...latestReport.details,
+            analysisContextPackOverview: {
+              ...latestReport.details.analysisContextPackOverview,
+              subject: { code: 'AAPL', stockName: 'Apple Inc.', market: 'us' },
+            },
+          },
+        })
+    ));
+    vi.mocked(historyApi.getNews).mockImplementation((recordId) => (
+      recordId === 11
+        ? firstNews.promise
+        : Promise.resolve({
+          total: 1,
+          items: [{ title: 'Apple earnings', snippet: 'Services revenue remains strong', url: 'https://example.com/aapl' }],
+        })
+    ));
+
+    const view = render(
+      <UiLanguageProvider>
+        <StockResearchPage />
+      </UiLanguageProvider>,
+    );
+
+    await waitFor(() => {
+      expect(stocksApi.getQuote).toHaveBeenCalledWith('600519');
+    });
+
+    routeParams.stockCode = 'AAPL';
+    view.rerender(
+      <UiLanguageProvider>
+        <StockResearchPage />
+      </UiLanguageProvider>,
+    );
+
+    expect(await screen.findByText('Apple Inc.')).toBeInTheDocument();
+    expect(await screen.findByText('美股趋势保持强势')).toBeInTheDocument();
+    expect(await screen.findByText('Apple earnings')).toBeInTheDocument();
+
+    firstQuote.resolve({
+      stockCode: '600519',
+      stockName: '贵州茅台',
+      currentPrice: 1688,
+      changePercent: 1.23,
+      high: 1700,
+      low: 1660,
+      amount: 1200000000,
+      updateTime: '2026-03-19T10:00:00Z',
+    });
+    firstHistory.resolve({
+      stockCode: '600519',
+      stockName: '贵州茅台',
+      period: 'daily',
+      data: [
+        { date: '2026-03-18', open: 1600, high: 1660, low: 1590, close: 1650 },
+        { date: '2026-03-19', open: 1650, high: 1700, low: 1640, close: 1688 },
+      ],
+    });
+    firstReports.resolve({
+      total: 1,
+      page: 1,
+      limit: 8,
+      items: [{
+        id: 11,
+        queryId: 'q-11',
+        stockCode: '600519',
+        stockName: '贵州茅台',
+        reportType: 'detailed',
+        analysisSummary: '趋势维持强势',
+        sentimentScore: 82,
+        operationAdvice: '持有',
+        createdAt: '2026-03-19T08:00:00Z',
+      }],
+    });
+    firstDetail.resolve(latestReport);
+    firstNews.resolve({
+      total: 1,
+      items: [{ title: '公司公告', snippet: '业绩保持稳定', url: 'https://example.com/news' }],
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText('Apple Inc.')).toBeInTheDocument();
+      expect(screen.getByText('美股趋势保持强势')).toBeInTheDocument();
+      expect(screen.getByText('Apple earnings')).toBeInTheDocument();
+      expect(screen.queryByText('贵州茅台')).not.toBeInTheDocument();
+    });
+  });
+
+  it('ignores stale report detail responses from the previous stock after route changes', async () => {
+    const firstDetail = createDeferred<Awaited<ReturnType<typeof historyApi.getDetail>>>();
+    const firstNews = createDeferred<Awaited<ReturnType<typeof historyApi.getNews>>>();
+
+    vi.mocked(historyApi.getList).mockImplementation((params = {}) => (
+      params.stockCode === '600519'
+        ? Promise.resolve({
+          total: 1,
+          page: 1,
+          limit: 8,
+          items: [{
+            id: 11,
+            queryId: 'q-11',
+            stockCode: '600519',
+            stockName: '贵州茅台',
+            reportType: 'detailed',
+            analysisSummary: '趋势维持强势',
+            sentimentScore: 82,
+            operationAdvice: '持有',
+            createdAt: '2026-03-19T08:00:00Z',
+          }],
+        })
+        : Promise.resolve({
+          total: 1,
+          page: 1,
+          limit: 8,
+          items: [{
+            id: 21,
+            queryId: 'q-21',
+            stockCode: 'AAPL',
+            stockName: 'Apple Inc.',
+            reportType: 'detailed',
+            analysisSummary: '苹果新高后仍有延续',
+            sentimentScore: 74,
+            operationAdvice: '持有',
+            createdAt: '2026-03-19T09:00:00Z',
+          }],
+        })
+    ));
+    vi.mocked(historyApi.getDetail).mockImplementation((recordId) => {
+      if (recordId === 11) {
+        return firstDetail.promise;
+      }
+      if (recordId === 21) {
+        return Promise.resolve({
+          ...latestReport,
+          meta: {
+            ...latestReport.meta,
+            id: 21,
+            queryId: 'q-21',
+            stockCode: 'AAPL',
+            stockName: 'Apple Inc.',
+          },
+          summary: {
+            ...latestReport.summary,
+            analysisSummary: '苹果新高后仍有延续',
+            trendPrediction: '美股趋势保持强势',
+          },
+          details: {
+            ...latestReport.details,
+            analysisContextPackOverview: {
+              ...latestReport.details.analysisContextPackOverview,
+              subject: { code: 'AAPL', stockName: 'Apple Inc.', market: 'us' },
+            },
+          },
+        });
+      }
+      return Promise.reject(new Error(`unexpected recordId ${recordId}`));
+    });
+    vi.mocked(historyApi.getNews).mockImplementation((recordId) => {
+      if (recordId === 11) {
+        return firstNews.promise;
+      }
+      if (recordId === 21) {
+        return Promise.resolve({
+          total: 1,
+          items: [{ title: 'Apple earnings', snippet: 'Services revenue remains strong', url: 'https://example.com/aapl' }],
+        });
+      }
+      return Promise.reject(new Error(`unexpected recordId ${recordId}`));
+    });
+    vi.mocked(stocksApi.getQuote).mockImplementation((stockCode) => Promise.resolve(
+      stockCode === '600519'
+        ? {
+          stockCode: '600519',
+          stockName: '贵州茅台',
+          currentPrice: 1688,
+          changePercent: 1.23,
+          high: 1700,
+          low: 1660,
+          amount: 1200000000,
+          updateTime: '2026-03-19T10:00:00Z',
+        }
+        : {
+          stockCode: 'AAPL',
+          stockName: 'Apple Inc.',
+          currentPrice: 245.12,
+          changePercent: 0.81,
+          high: 246,
+          low: 243.5,
+          amount: 850000000,
+          updateTime: '2026-03-19T10:05:00Z',
+        },
+    ));
+    vi.mocked(stocksApi.getHistory).mockImplementation((stockCode) => Promise.resolve(
+      stockCode === '600519'
+        ? {
+          stockCode: '600519',
+          stockName: '贵州茅台',
+          period: 'daily',
+          data: [
+            { date: '2026-03-18', open: 1600, high: 1660, low: 1590, close: 1650 },
+            { date: '2026-03-19', open: 1650, high: 1700, low: 1640, close: 1688 },
+          ],
+        }
+        : {
+          stockCode: 'AAPL',
+          stockName: 'Apple Inc.',
+          period: 'daily',
+          data: [
+            { date: '2026-03-18', open: 241, high: 244, low: 240, close: 243.8 },
+            { date: '2026-03-19', open: 244, high: 246, low: 243.5, close: 245.12 },
+          ],
+        },
+    ));
+
+    const view = render(
+      <UiLanguageProvider>
+        <StockResearchPage />
+      </UiLanguageProvider>,
+    );
+
+    await waitFor(() => {
+      expect(historyApi.getDetail).toHaveBeenCalledWith(11);
+    });
+
+    routeParams.stockCode = 'AAPL';
+    view.rerender(
+      <UiLanguageProvider>
+        <StockResearchPage />
+      </UiLanguageProvider>,
+    );
+
+    expect(await screen.findByText('Apple Inc.')).toBeInTheDocument();
+    expect(await screen.findByText('美股趋势保持强势')).toBeInTheDocument();
+    expect(await screen.findByText('Apple earnings')).toBeInTheDocument();
+
+    firstDetail.resolve(latestReport);
+    firstNews.resolve({
+      total: 1,
+      items: [{ title: '旧信号', snippet: '不应覆盖新标的', url: 'https://example.com/old' }],
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText('Apple Inc.')).toBeInTheDocument();
+      expect(screen.getByText('美股趋势保持强势')).toBeInTheDocument();
+      expect(screen.getByText('Apple earnings')).toBeInTheDocument();
+      expect(screen.queryByText('贵州茅台')).not.toBeInTheDocument();
+      expect(screen.queryByText('震荡上行')).not.toBeInTheDocument();
+      expect(screen.queryByText('旧信号')).not.toBeInTheDocument();
+    });
+  });
+
+  it('keeps the latest clicked report details when earlier requests finish later', async () => {
+    const slowDetail = createDeferred<Awaited<ReturnType<typeof historyApi.getDetail>>>();
+    const slowNews = createDeferred<Awaited<ReturnType<typeof historyApi.getNews>>>();
+    const fastDetail = createDeferred<Awaited<ReturnType<typeof historyApi.getDetail>>>();
+    const fastNews = createDeferred<Awaited<ReturnType<typeof historyApi.getNews>>>();
+
+    vi.mocked(historyApi.getList).mockResolvedValue({
+      total: 3,
+      page: 1,
+      limit: 8,
+      items: [
+        {
+          id: 33,
+          queryId: 'q-33',
+          stockCode: '600519',
+          stockName: '贵州茅台',
+          reportType: 'detailed',
+          analysisSummary: '继续上修目标价',
+          sentimentScore: 91,
+          operationAdvice: '加仓',
+          createdAt: '2026-03-20T08:00:00Z',
+        },
+        {
+          id: 11,
+          queryId: 'q-11',
+          stockCode: '600519',
+          stockName: '贵州茅台',
+          reportType: 'detailed',
+          analysisSummary: '趋势维持强势',
+          sentimentScore: 82,
+          operationAdvice: '持有',
+          createdAt: '2026-03-19T08:00:00Z',
+        },
+        {
+          id: 22,
+          queryId: 'q-22',
+          stockCode: '600519',
+          stockName: '贵州茅台',
+          reportType: 'detailed',
+          analysisSummary: '短线先观察',
+          sentimentScore: 41,
+          operationAdvice: '观望',
+          createdAt: '2026-03-18T08:00:00Z',
+        },
+      ],
+    });
+    vi.mocked(historyApi.getDetail)
+      .mockImplementation((recordId) => {
+        if (recordId === 33) {
+          return Promise.resolve(thirdReport);
+        }
+        if (recordId === 11) {
+          return slowDetail.promise;
+        }
+        if (recordId === 22) {
+          return fastDetail.promise;
+        }
+        return Promise.reject(new Error(`unexpected recordId ${recordId}`));
+      });
+    vi.mocked(historyApi.getNews)
+      .mockImplementation((recordId) => {
+        if (recordId === 33) {
+          return Promise.resolve({
+            total: 1,
+            items: [{ title: '提价预期', snippet: '渠道反馈稳定', url: 'https://example.com/third' }],
+          });
+        }
+        if (recordId === 11) {
+          return slowNews.promise;
+        }
+        if (recordId === 22) {
+          return fastNews.promise;
+        }
+        return Promise.reject(new Error(`unexpected recordId ${recordId}`));
+      });
+
+    render(
+      <UiLanguageProvider>
+        <StockResearchPage />
+      </UiLanguageProvider>,
+    );
+
+    expect(await screen.findByText('机构资金持续流入')).toBeInTheDocument();
+    expect(await screen.findByText('提价预期')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: /趋势维持强势/ }));
+    fireEvent.click(screen.getByRole('button', { name: /短线先观察/ }));
+
+    fastDetail.resolve(secondReport);
+    fastNews.resolve({
+      total: 1,
+      items: [{ title: '观望信号', snippet: '资金面转弱', url: 'https://example.com/second' }],
+    });
+
+    expect(await screen.findByText('量能不足')).toBeInTheDocument();
+    expect(await screen.findByText('观望信号')).toBeInTheDocument();
+
+    slowDetail.resolve(latestReport);
+    slowNews.resolve({
+      total: 1,
+      items: [{ title: '旧信号', snippet: '不应覆盖最新选择', url: 'https://example.com/first' }],
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText('量能不足')).toBeInTheDocument();
+      expect(screen.getByText('观望信号')).toBeInTheDocument();
+      expect(screen.queryByText('震荡上行')).not.toBeInTheDocument();
+      expect(screen.queryByText('旧信号')).not.toBeInTheDocument();
     });
   });
 });

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 ## [Unreleased]
 
 - [改进] PR CI 增加文档路径检测：仅修改普通文档、非治理 Markdown 或 LICENSE 时跳过后端测试分片、Docker、Web 与桌面打包，保留轻量治理和门禁汇总；契约文档、静态 API 规格与测试 fixture 仍执行后端回归。
+- [新功能] Web 新增 `/stocks/:stockCode` 个股研究工作台，复用现有行情、K 线、历史报告、新闻和 AnalysisContextPack 证据摘要，提供 Header、MarketSnapshot、Chart、ResearchSummary、Evidence、Events、Reports、Monitors 与 Copilot 入口。
 - [修复] Linux/Docker 分享图补齐 Noto CJK 字体与中韩文字体栈，避免 PNG 只显示数字和英文、中文或韩文内容消失。
 - [新功能] Web Chat 意图识别层新增分词模块：`web_intent_tokenizer` 六步管道（多股票全名实体扫描 → 标点/空白切分 → 代码形提取 → 市场关键词 → 无歧义关键词 → 残存 gap 多策略 DFS 匹配）把用户消息切分为携带语义标签的 Token 序列；配套 `web_intent_types` 数据字典（Token 结构、Market 枚举、21 个语义 tag、clean/extend 双词池与正则机器）。核心原则"宁可不做，不可做错"：Step 1~5 只做精确匹配，Step 6 要求整段 TAG 全覆盖（交叉验证）才产出，未覆盖片段保持空 tag 交下游 LLM 兜底；代码形 token 辨认为 `stock_code`（附 code/name/market 三元组）/ `wrong_{market}_code` / `unknown_{market}_code` 三态，token 层代码拼写统一 canonical 归一（a=6 位裸数字、hk=HK+5 位、us=大写 ticker）。意图枚举与意图识别结果随后续 `web_intent_resolver` PR 引入。新增 183 个分词单元测试。
 <!-- 新条目格式：- [类型] 描述（类型取值：新功能/改进/修复/文档/测试/chore）-->

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -45,6 +45,7 @@
 | [Bot 命令与接入](bot-command.md) | Bot 命令、Webhook、平台接入和回调说明 |
 | [Bot 平台配置](bot/) | 飞书、钉钉、Discord 等 Bot 配置截图和补充说明 |
 | [实时告警中心](alerts.md) | EventMonitor 基线、Web 规则管理、通知结果、冷却状态和 Phase 边界 |
+| [个股研究工作台](stock-research-workspace.md) | `/stocks/:stockCode` 页面结构、行情快照、K 线、研究摘要、证据质量、事件、报告、监控与 Copilot 入口 |
 | [DecisionSignal 决策信号专题](decision-signals.md) | AI 建议池字段语义、API、Web 展示、告警/通知/组合风险联动、后验评估、脱敏、迁移与回滚 |
 | [资讯 / 情报源](intelligence-sources.md) | RSS/Atom 合规资讯源配置、测试、拉取、去重、存储、查询与安全边界 |
 | [分析上下文包契约、运行态消费与可见性](analysis-context-pack.md) | AnalysisContextPack 首版范围、字段质量状态、P1/P2 内部契约、P3 Prompt 摘要消费、P4 历史/API/Web 低敏可见性、P5 数据质量评分、P6 迁移回滚与源码锚点；完整指南补充 #1386 阶段感知分析、迁移与回滚入口 |

--- a/docs/stock-research-workspace.md
+++ b/docs/stock-research-workspace.md
@@ -1,0 +1,39 @@
+# 个股研究工作台
+
+个股研究工作台是 Web 路由 `/stocks/:stockCode`，用于把单个标的的行情、历史、报告、证据和后续动作放到一个页面。
+
+## 首版范围
+
+页面首版复用现有 API，不新增后端数据源：
+
+- `GET /api/v1/stocks/{code}/quote`：行情快照。
+- `GET /api/v1/stocks/{code}/history`：K 线概览。
+- `GET /api/v1/history?stock_code={code}`：历史报告列表。
+- `GET /api/v1/history/{id}`：最新报告详情。
+- `GET /api/v1/history/{id}/news`：关联新闻。
+
+## 页面区域
+
+- `Header`：股票名称、代码、最新摘要和快捷动作。
+- `MarketSnapshot`：最新价、涨跌幅、最高/最低、成交额、开盘、昨收、成交量、更新时间。
+- `Chart`：最近 K 线收盘价趋势。
+- `ResearchSummary`：最新报告摘要、趋势判断、操作建议和情绪分。
+- `Evidence`：`AnalysisContextPack` 数据块的新鲜度、质量状态、来源和告警。
+- `Events`：报告关联新闻。
+- `Reports`：该标的最近历史报告，可在页面内切换。
+- `Monitors`：跳转告警中心，为价格或 thesis 失效条件配置提醒。
+- `Copilot`：带股票和最新报告上下文进入问股。
+
+## 行为边界
+
+- 页面允许部分数据失败：行情、K 线、历史报告互不阻断。
+- 只有全部主数据请求失败时，页面展示顶层错误。
+- 监控入口只跳转告警中心，不在本页面直接创建规则。
+- Copilot 使用当前股票代码、名称和最新报告 id 作为上下文。
+
+## 后续增强
+
+1. 接入 `ResearchArtifact.structured_report` 后，ResearchSummary 和 Evidence 优先消费结构化字段。
+2. EntityLink 可用后，报告、信号、告警和持仓入口统一使用 action model。
+3. 监控中心支持 thesis invalidation 后，把报告失效条件转成可编辑规则。
+4. 大盘看板与自选股列表可直接跳转到 `/stocks/:stockCode`。


### PR DESCRIPTION
## PR Type
- [ ] fix
- [x] feat
- [ ] refactor
- [ ] docs
- [ ] chore
- [ ] test

## Background And Problem
- 当前问题：在现有后端能力之上新增统一的 stock profile 聚合接口，并在 Web 侧实现 `/stocks/:code` 研究工作台及各入口跳转。
- 影响范围：本次改动涉及 2 个文件，Diff 为 `+558 / -5`。
- 触发来源：Issue 自动执行（Issue #2279）。

## Scope Of Change
- `apps/dsa-web/src/pages/StockResearchPage.tsx`
- `apps/dsa-web/src/pages/__tests__/StockResearchPage.test.tsx`

## Documentation And Changelog
- 当前补丁未包含 `README.md`、`docs/` 或 `docs/CHANGELOG.md` 更新；如果本次变更涉及 CLI、API、配置、日志语义或其他用户可见行为，请在合并前补充原因与文档落点。

## Issue Link
Closes #2279

## Verification Commands And Results
```bash
./scripts/ci_gate.sh flake8
npm --prefix apps/dsa-web run lint
npm --prefix apps/dsa-web run build
npm --prefix apps/dsa-web run test -- src/pages/__tests__/StockResearchPage.test.tsx
```

关键输出/结论 / Key output & conclusion:
- lint:PASS, test:PASS, test:PASS, test:PASS

## Pre-commit Self Review
第 1 轮提交前自审：检查了 `git diff`、`StockResearchPage` 的加载/切换调用链、相关页面测试和构建路径。`git diff --check` 通过；`npm run test -- src/api/__tests__/stocks.test.ts src/pages/__tests__/StockResearchPage.test.tsx` 通过；`npx eslint src/pages/StockResearchPage.tsx src/pages/__tests__/StockResearchPage.test.tsx` 通过；`npm run build` 通过。 第 2 轮提交前自审：检查了当前 `git diff`、[`apps/dsa-web/src/pages/StockResearchPage.tsx`](apps/dsa-web/src/pages/StockResearchPage.tsx) 的加载/切换链路，以及 [`apps/dsa-web/src/pages/__tests__/StockResearchPage.test.tsx`](apps/dsa-web/src/pages/__tests__/StockResearchPage.test.tsx) 的竞态覆盖。当前实现用 `workspaceRequestIdRef` 和 `reportRequestIdRef` 阻断了两类 stale response 覆盖，相关测试也覆盖了路由切换与连续点选报告的乱序返回场景；未发现需要我继续补的代码修正。 第 3 轮提交前自审：- 检查了 `git diff`、`StockResearchPage` 的加载/切换调用链，以及页面回归测试覆盖；确认当前运行时代码已用 `workspaceRequestIdRef` 和 `reportRequestIdRef` 阻断两类竞态写回。

## Compatibility And Risk
- **Medium**：涉及 `apps/dsa-web/src/pages/StockResearchPage.tsx`, `apps/dsa-web/src/pages/__tests__/StockResearchPage.test.tsx`，建议按文件范围复核。
- 前提假设：
  - 优先遵循 owner 结论，采用单一 stock-profile contract，而不是前端并发拼装多个独立请求。
  - 复用现有 `api/v1/endpoints/stocks.py`、`history.py`、`intelligence.py`、`portfolio.py`、`alerts.py` 的能力，不新增平行数据获取路径。
  - 首个 PR 仅使用现有 Recharts 完成基础趋势/成交量视图，不引入新图表依赖。
  - A 股专属模块通过 symbol/market 判定在 HK/US 或不支持标的上隐藏，而不是为所有市场补齐同等能力。

## Rollback Plan
- `git revert <merge-commit>` 回滚本 PR 提交，重点确认 `apps/dsa-web/src/pages/StockResearchPage.tsx`, `apps/dsa-web/src/pages/__tests__/StockResearchPage.test.tsx` 恢复正常。

## Acceptance Criteria
- 后端新增统一 stock profile API，返回 quote、recent history、latest report/research artifact、intelligence items、portfolio relation、monitor status、evidence quality 等聚合数据。
- API 在 quote 或其他可选数据失败时仍可返回部分数据，并明确标识 fresh/partial/unavailable 的 evidence quality。
- Web 新增 `/stocks/:code` 页面，包含 Header、MarketSnapshot、Chart、ResearchSummary、Evidence、Events、Reports、Monitors、Copilot actions 等区域的首版布局。
- Home、Watchlist、Screening、Portfolio、Report 中现有股票链接或可点击入口可导航到 `/stocks/:code`。
- HK/US 或不支持标的不会展示 A 股专属区块，且页面在移动端和桌面端均无明显溢出。
- 补充后端 partial data 测试、前端 success/partial/empty 状态测试，并通过 Web lint/build。

## Checklist
- [x] 本 PR 有明确动机和业务价值 / This PR has a clear motivation and value
- [x] 已提供可复现的验证命令与结果 / Reproducible verification commands and results are included
- [x] 已评估兼容性与风险 / Compatibility and risk have been assessed
- [x] 已提供回滚方案 / A rollback plan is provided
- [ ] 文档与 `docs/CHANGELOG.md` 同步仍需确认；如涉及用户可见变更，请在合并前补充原因与文档落点 / Documentation and `docs/CHANGELOG.md` sync still needs confirmation before merge when user-visible behavior changes