### PR TITLE
feat: add alert invalidation radar

### DIFF
--- a/apps/dsa-web/src/components/alerts/AlertInvalidationRadar.tsx
+++ b/apps/dsa-web/src/components/alerts/AlertInvalidationRadar.tsx
@@ -1,0 +1,255 @@
+import type React from 'react';
+import { Activity, CircleAlert, Radar, ShieldCheck, TriangleAlert } from 'lucide-react';
+import { Badge, Card, Loading, StatusDot } from '../common';
+import type { AlertRuleItem, AlertTriggerItem, AlertType } from '../../types/alerts';
+import { cn } from '../../utils/cn';
+import { formatDateTime } from '../../utils/format';
+
+type GuardFamilyKey = 'price' | 'technical' | 'portfolio' | 'market';
+
+interface GuardFamily {
+  key: GuardFamilyKey;
+  title: string;
+  description: string;
+  alertTypes: AlertType[];
+}
+
+interface FamilySummary extends GuardFamily {
+  enabledCount: number;
+  totalCount: number;
+  latestTriggeredAt?: string | null;
+}
+
+const GUARD_FAMILIES: GuardFamily[] = [
+  {
+    key: 'price',
+    title: '价格失效',
+    description: '关键价位、涨跌幅',
+    alertTypes: ['price_cross', 'price_change_percent', 'volume_spike'],
+  },
+  {
+    key: 'technical',
+    title: '技术失效',
+    description: '均线、RSI、MACD、KDJ、CCI',
+    alertTypes: ['ma_price_cross', 'rsi_threshold', 'macd_cross', 'kdj_cross', 'cci_threshold'],
+  },
+  {
+    key: 'portfolio',
+    title: '组合失效',
+    description: '止损、集中度、回撤、价格新鲜度',
+    alertTypes: ['portfolio_stop_loss', 'portfolio_concentration', 'portfolio_drawdown', 'portfolio_price_stale'],
+  },
+  {
+    key: 'market',
+    title: '大盘失效',
+    description: '红绿灯状态、市场评分下行',
+    alertTypes: ['market_light_status', 'market_light_score_drop'],
+  },
+];
+
+const FAMILY_BY_TYPE = GUARD_FAMILIES.reduce((mapping, family) => {
+  family.alertTypes.forEach((alertType) => {
+    mapping[alertType] = family.key;
+  });
+  return mapping;
+}, {} as Record<AlertType, GuardFamilyKey>);
+
+function familyForRule(rule: AlertRuleItem): GuardFamilyKey {
+  return FAMILY_BY_TYPE[rule.alertType] ?? 'price';
+}
+
+function isTriggerProblem(status: string): boolean {
+  return status === 'triggered' || status === 'degraded' || status === 'failed';
+}
+
+function formatNumber(value: number | null | undefined): string {
+  if (value === null || value === undefined) return '--';
+  return Number.isFinite(value) ? String(value) : '--';
+}
+
+function buildFamilySummaries(rules: AlertRuleItem[], triggers: AlertTriggerItem[]): FamilySummary[] {
+  return GUARD_FAMILIES.map((family) => {
+    const familyRules = rules.filter((rule) => familyForRule(rule) === family.key);
+    const familyTargets = new Set(familyRules.map((rule) => rule.target));
+    const latestTriggeredAt = triggers
+      .filter((trigger) => familyTargets.has(trigger.target) && isTriggerProblem(trigger.status))
+      .map((trigger) => trigger.triggeredAt ?? trigger.dataTimestamp ?? null)
+      .filter((value): value is string => Boolean(value))
+      .sort()
+      .at(-1);
+
+    return {
+      ...family,
+      totalCount: familyRules.length,
+      enabledCount: familyRules.filter((rule) => rule.enabled).length,
+      latestTriggeredAt,
+    };
+  });
+}
+
+const StatTile: React.FC<{
+  label: string;
+  value: string;
+  note: string;
+  tone?: 'success' | 'warning' | 'danger' | 'info' | 'neutral';
+}> = ({ label, value, note, tone = 'neutral' }) => (
+  <div className="min-w-0 rounded-lg border border-subtle bg-base/35 px-3 py-2.5">
+    <div className="flex items-center gap-2 text-xs text-muted-text">
+      <StatusDot tone={tone} className="h-2 w-2" />
+      <span className="truncate">{label}</span>
+    </div>
+    <div className="mt-2 truncate text-xl font-semibold text-foreground">{value}</div>
+    <div className="mt-1 truncate text-xs text-secondary-text">{note}</div>
+  </div>
+);
+
+const FamilyRow: React.FC<{ family: FamilySummary }> = ({ family }) => {
+  const covered = family.enabledCount > 0;
+  return (
+    <div className="grid gap-2 rounded-lg border border-subtle bg-base/25 px-3 py-2.5 sm:grid-cols-[minmax(0,1fr)_auto]">
+      <div className="min-w-0">
+        <div className="flex min-w-0 items-center gap-2">
+          <StatusDot tone={covered ? 'success' : 'warning'} className="h-2 w-2" />
+          <span className="truncate text-sm font-medium text-foreground">{family.title}</span>
+        </div>
+        <div className="mt-1 truncate text-xs text-muted-text">{family.description}</div>
+      </div>
+      <div className="flex flex-wrap items-center gap-2 sm:justify-end">
+        <Badge variant={covered ? 'success' : 'warning'}>{covered ? '已覆盖' : '待补规则'}</Badge>
+        <span className="text-xs text-secondary-text">{family.enabledCount}/{family.totalCount}</span>
+        <span className="text-xs text-muted-text">{formatDateTime(family.latestTriggeredAt)}</span>
+      </div>
+    </div>
+  );
+};
+
+const TriggerRow: React.FC<{ trigger: AlertTriggerItem }> = ({ trigger }) => (
+  <div className="grid gap-2 rounded-lg border border-subtle bg-base/25 px-3 py-2.5 sm:grid-cols-[minmax(0,1fr)_auto]">
+    <div className="min-w-0">
+      <div className="flex min-w-0 items-center gap-2">
+        <StatusDot
+          tone={trigger.status === 'triggered' ? 'danger' : 'warning'}
+          className="h-2 w-2"
+        />
+        <span className="truncate font-mono text-sm font-medium text-foreground">{trigger.target}</span>
+        <Badge variant={trigger.status === 'triggered' ? 'danger' : 'warning'}>{trigger.status}</Badge>
+      </div>
+      <div className="mt-1 line-clamp-2 text-xs text-secondary-text">
+        {trigger.reason || trigger.diagnostics || '暂无原因'}
+      </div>
+    </div>
+    <div className="text-xs text-muted-text sm:text-right">
+      <div>{formatNumber(trigger.observedValue)} / {formatNumber(trigger.threshold)}</div>
+      <div className="mt-1">{formatDateTime(trigger.triggeredAt ?? trigger.dataTimestamp)}</div>
+    </div>
+  </div>
+);
+
+interface AlertInvalidationRadarProps {
+  rules: AlertRuleItem[];
+  triggers: AlertTriggerItem[];
+  rulesLoading?: boolean;
+  triggersLoading?: boolean;
+  className?: string;
+}
+
+export const AlertInvalidationRadar: React.FC<AlertInvalidationRadarProps> = ({
+  rules,
+  triggers,
+  rulesLoading = false,
+  triggersLoading = false,
+  className,
+}) => {
+  const enabledRules = rules.filter((rule) => rule.enabled);
+  const criticalRules = enabledRules.filter((rule) => rule.severity === 'critical');
+  const problemTriggers = triggers.filter((trigger) => isTriggerProblem(trigger.status));
+  const triggeredGuards = problemTriggers.filter((trigger) => trigger.status === 'triggered');
+  const dataGapTriggers = problemTriggers.filter((trigger) => trigger.status === 'degraded' || trigger.status === 'failed');
+  const familySummaries = buildFamilySummaries(rules, triggers);
+  const coveredFamilies = familySummaries.filter((family) => family.enabledCount > 0);
+  const recentProblemTriggers = problemTriggers.slice(0, 4);
+
+  return (
+    <Card
+      title="假设失效雷达"
+      subtitle="规则守卫"
+      variant="bordered"
+      padding="md"
+      className={cn('space-y-4', className)}
+    >
+      {rulesLoading || triggersLoading ? <Loading label="正在加载失效雷达" /> : null}
+
+      <div className="grid gap-3 md:grid-cols-4">
+        <StatTile
+          label="守卫覆盖"
+          value={`${coveredFamilies.length}/${GUARD_FAMILIES.length}`}
+          note={`${enabledRules.length} 条启用规则`}
+          tone={coveredFamilies.length === GUARD_FAMILIES.length ? 'success' : 'warning'}
+        />
+        <StatTile
+          label="近期触发"
+          value={String(triggeredGuards.length)}
+          note={`${problemTriggers.length} 条失效线索`}
+          tone={triggeredGuards.length > 0 ? 'danger' : 'success'}
+        />
+        <StatTile
+          label="数据缺口"
+          value={String(dataGapTriggers.length)}
+          note="degraded / failed"
+          tone={dataGapTriggers.length > 0 ? 'warning' : 'success'}
+        />
+        <StatTile
+          label="高优先级"
+          value={String(criticalRules.length)}
+          note="critical rules"
+          tone={criticalRules.length > 0 ? 'danger' : 'neutral'}
+        />
+      </div>
+
+      <div className="grid gap-4 xl:grid-cols-[minmax(0,1.05fr)_minmax(0,0.95fr)]">
+        <section className="min-w-0">
+          <div className="mb-2 flex items-center gap-2 text-sm font-medium text-foreground">
+            <ShieldCheck className="h-4 w-4 text-success" aria-hidden="true" />
+            守卫矩阵
+          </div>
+          <div className="grid gap-2">
+            {familySummaries.map((family) => (
+              <FamilyRow key={family.key} family={family} />
+            ))}
+          </div>
+        </section>
+
+        <section className="min-w-0">
+          <div className="mb-2 flex items-center gap-2 text-sm font-medium text-foreground">
+            {recentProblemTriggers.length > 0 ? (
+              <TriangleAlert className="h-4 w-4 text-warning" aria-hidden="true" />
+            ) : (
+              <Radar className="h-4 w-4 text-primary" aria-hidden="true" />
+            )}
+            近期失效线索
+          </div>
+          {recentProblemTriggers.length === 0 ? (
+            <div className="flex min-h-[160px] items-center justify-center rounded-lg border border-dashed border-subtle bg-base/20 px-4 py-6 text-center">
+              <div>
+                <CircleAlert className="mx-auto h-5 w-5 text-muted-text" aria-hidden="true" />
+                <div className="mt-2 text-sm font-medium text-foreground">暂无失效线索</div>
+                <div className="mt-1 text-xs text-muted-text">最近触发记录没有 triggered、degraded 或 failed。</div>
+              </div>
+            </div>
+          ) : (
+            <div className="grid gap-2">
+              {recentProblemTriggers.map((trigger) => (
+                <TriggerRow key={trigger.id} trigger={trigger} />
+              ))}
+            </div>
+          )}
+        </section>
+      </div>
+
+      <div className="flex flex-wrap items-center gap-2 text-xs text-muted-text">
+        <Activity className="h-3.5 w-3.5" aria-hidden="true" />
+        <span>规则覆盖负责事前约束，触发历史负责事后复盘，通知记录负责送达诊断。</span>
+      </div>
+    </Card>
+  );
+};

--- a/apps/dsa-web/src/components/alerts/__tests__/AlertInvalidationRadar.test.tsx
+++ b/apps/dsa-web/src/components/alerts/__tests__/AlertInvalidationRadar.test.tsx
@@ -1,0 +1,84 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { AlertInvalidationRadar } from '../AlertInvalidationRadar';
+import type { AlertRuleItem, AlertTriggerItem } from '../../../types/alerts';
+
+const rules: AlertRuleItem[] = [
+  {
+    id: 1,
+    name: '茅台跌破买入假设',
+    targetScope: 'single_symbol',
+    target: '600519',
+    alertType: 'price_cross',
+    parameters: { direction: 'below', price: 1650 },
+    severity: 'warning',
+    enabled: true,
+    source: 'api',
+  },
+  {
+    id: 2,
+    name: '组合止损',
+    targetScope: 'portfolio_account',
+    target: 'all',
+    alertType: 'portfolio_stop_loss',
+    parameters: { mode: 'breach' },
+    severity: 'critical',
+    enabled: true,
+    source: 'api',
+  },
+  {
+    id: 3,
+    name: 'MACD 观察',
+    targetScope: 'single_symbol',
+    target: '300750',
+    alertType: 'macd_cross',
+    parameters: { direction: 'bearish_cross', fastPeriod: 12, slowPeriod: 26, signalPeriod: 9 },
+    severity: 'info',
+    enabled: false,
+    source: 'api',
+  },
+];
+
+const triggers: AlertTriggerItem[] = [
+  {
+    id: 10,
+    ruleId: 1,
+    target: '600519',
+    observedValue: 1648,
+    threshold: 1650,
+    reason: '价格跌破关键支撑',
+    dataSource: 'realtime_quote',
+    dataTimestamp: '2026-05-18T09:30:00',
+    triggeredAt: '2026-05-18T09:30:01',
+    status: 'triggered',
+  },
+  {
+    id: 11,
+    ruleId: 2,
+    target: 'all',
+    observedValue: null,
+    threshold: null,
+    reason: '组合价格降级',
+    triggeredAt: '2026-05-18T09:31:01',
+    status: 'degraded',
+  },
+];
+
+describe('AlertInvalidationRadar', () => {
+  it('summarizes guard coverage, problem triggers, and missing guard families', () => {
+    render(<AlertInvalidationRadar rules={rules} triggers={triggers} />);
+
+    expect(screen.getByText('假设失效雷达')).toBeInTheDocument();
+    expect(screen.getByText('2/4')).toBeInTheDocument();
+    expect(screen.getByText('2 条启用规则')).toBeInTheDocument();
+    expect(screen.getByText('2 条失效线索')).toBeInTheDocument();
+    expect(screen.getByText('价格失效')).toBeInTheDocument();
+    expect(screen.getByText('组合失效')).toBeInTheDocument();
+    expect(screen.getByText('技术失效')).toBeInTheDocument();
+    expect(screen.getByText('大盘失效')).toBeInTheDocument();
+    expect(screen.getAllByText('已覆盖')).toHaveLength(2);
+    expect(screen.getAllByText('待补规则')).toHaveLength(2);
+    expect(screen.getByText('价格跌破关键支撑')).toBeInTheDocument();
+    expect(screen.getByText('组合价格降级')).toBeInTheDocument();
+  });
+});

--- a/apps/dsa-web/src/pages/AlertsPage.tsx
+++ b/apps/dsa-web/src/pages/AlertsPage.tsx
@@ -4,6 +4,7 @@ import { BellRing } from 'lucide-react';
 import { alertsApi } from '../api/alerts';
 import type { ParsedApiError } from '../api/error';
 import { getParsedApiError } from '../api/error';
+import { AlertInvalidationRadar } from '../components/alerts/AlertInvalidationRadar';
 import { AlertRuleForm } from '../components/alerts/AlertRuleForm';
 import {
   AlertRuleList,
@@ -280,6 +281,13 @@ const AlertsPage: React.FC = () => {
         />
       ) : null}
       {rulesError ? <ApiErrorAlert error={rulesError} onDismiss={() => setRulesError(null)} /> : null}
+
+      <AlertInvalidationRadar
+        rules={rules}
+        triggers={triggers}
+        rulesLoading={rulesLoading}
+        triggersLoading={triggersLoading}
+      />
 
       <div className="grid items-stretch gap-5 xl:grid-cols-[380px_minmax(0,1fr)]">
         <AlertRuleForm onSubmit={handleCreateRule} isSubmitting={createLoading} />

--- a/apps/dsa-web/src/pages/__tests__/AlertsPage.test.tsx
+++ b/apps/dsa-web/src/pages/__tests__/AlertsPage.test.tsx
@@ -112,8 +112,9 @@ describe('AlertsPage', () => {
     render(<AlertsPage />);
 
     expect(screen.getByText('管理事件告警、日线技术指标、自选股、持仓/账户联动和大盘红绿灯规则，执行一次性测试，并查看后台评估任务记录的触发历史。')).toBeInTheDocument();
+    expect(screen.getByText('假设失效雷达')).toBeInTheDocument();
     expect(await screen.findByText('茅台价格突破')).toBeInTheDocument();
-    expect(await screen.findByText('600519 price above 1800')).toBeInTheDocument();
+    expect((await screen.findAllByText('600519 price above 1800')).length).toBeGreaterThanOrEqual(2);
     expect(await screen.findByText('暂无通知尝试记录')).toBeInTheDocument();
     expect(listRules).toHaveBeenCalledWith({
       enabled: undefined,

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - [改进] PR CI 增加文档路径检测：仅修改普通文档、非治理 Markdown 或 LICENSE 时跳过后端测试分片、Docker、Web 与桌面打包，保留轻量治理和门禁汇总；契约文档、静态 API 规格与测试 fixture 仍执行后端回归。
 - [修复] Linux/Docker 分享图补齐 Noto CJK 字体与中韩文字体栈，避免 PNG 只显示数字和英文、中文或韩文内容消失。
 - [新功能] Web Chat 意图识别层新增分词模块：`web_intent_tokenizer` 六步管道（多股票全名实体扫描 → 标点/空白切分 → 代码形提取 → 市场关键词 → 无歧义关键词 → 残存 gap 多策略 DFS 匹配）把用户消息切分为携带语义标签的 Token 序列；配套 `web_intent_types` 数据字典（Token 结构、Market 枚举、21 个语义 tag、clean/extend 双词池与正则机器）。核心原则"宁可不做，不可做错"：Step 1~5 只做精确匹配，Step 6 要求整段 TAG 全覆盖（交叉验证）才产出，未覆盖片段保持空 tag 交下游 LLM 兜底；代码形 token 辨认为 `stock_code`（附 code/name/market 三元组）/ `wrong_{market}_code` / `unknown_{market}_code` 三态，token 层代码拼写统一 canonical 归一（a=6 位裸数字、hk=HK+5 位、us=大写 ticker）。意图枚举与意图识别结果随后续 `web_intent_resolver` PR 引入。新增 183 个分词单元测试。
+- [改进] Web 告警中心新增“假设失效雷达”，按价格、技术、组合、大盘四类聚合规则覆盖、近期触发、数据缺口和高优先级守卫。
 <!-- 新条目格式：- [类型] 描述（类型取值：新功能/改进/修复/文档/测试/chore）-->
 <!-- 每条独立一行追加到本段末尾，无需分类标题，合并时冲突最小 -->
 - [新功能] 完善 Futu OpenD 港股数据源接入：系统设置支持 OpenD 地址、端口和港股实时数据源优先级，保留 Longbridge、AkShare、YFinance fallback。

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -45,6 +45,7 @@
 | [Bot 命令与接入](bot-command.md) | Bot 命令、Webhook、平台接入和回调说明 |
 | [Bot 平台配置](bot/) | 飞书、钉钉、Discord 等 Bot 配置截图和补充说明 |
 | [实时告警中心](alerts.md) | EventMonitor 基线、Web 规则管理、通知结果、冷却状态和 Phase 边界 |
+| [监控中心假设失效雷达](monitor-thesis-invalidation.md) | 告警中心按价格、技术、组合、大盘四类组织投资假设失效守卫和近期触发线索 |
 | [DecisionSignal 决策信号专题](decision-signals.md) | AI 建议池字段语义、API、Web 展示、告警/通知/组合风险联动、后验评估、脱敏、迁移与回滚 |
 | [资讯 / 情报源](intelligence-sources.md) | RSS/Atom 合规资讯源配置、测试、拉取、去重、存储、查询与安全边界 |
 | [分析上下文包契约、运行态消费与可见性](analysis-context-pack.md) | AnalysisContextPack 首版范围、字段质量状态、P1/P2 内部契约、P3 Prompt 摘要消费、P4 历史/API/Web 低敏可见性、P5 数据质量评分、P6 迁移回滚与源码锚点；完整指南补充 #1386 阶段感知分析、迁移与回滚入口 |

--- a/docs/monitor-thesis-invalidation.md
+++ b/docs/monitor-thesis-invalidation.md
@@ -1,0 +1,35 @@
+# 监控中心假设失效雷达
+
+Web 告警中心新增“假设失效雷达”，用于把已有告警规则和触发历史组织成投资假设守卫视角。
+
+## 展示结构
+
+| 区域 | 内容 | 数据来源 |
+| --- | --- | --- |
+| 守卫覆盖 | 已覆盖的守卫类别数量、启用规则数 | 告警规则列表 |
+| 近期触发 | `triggered` 状态的触发数量 | 告警触发历史 |
+| 数据缺口 | `degraded` / `failed` 状态数量 | 告警触发历史 |
+| 高优先级 | `critical` 且启用的规则数量 | 告警规则列表 |
+| 守卫矩阵 | 价格、技术、组合、大盘四类规则覆盖情况 | 告警规则类型 |
+| 近期失效线索 | 最近触发、降级或失败的目标、观察值、阈值、原因 | 告警触发历史 |
+
+## 守卫分类
+
+| 分类 | 告警类型 |
+| --- | --- |
+| 价格失效 | `price_cross`、`price_change_percent`、`volume_spike` |
+| 技术失效 | `ma_price_cross`、`rsi_threshold`、`macd_cross`、`kdj_cross`、`cci_threshold` |
+| 组合失效 | `portfolio_stop_loss`、`portfolio_concentration`、`portfolio_drawdown`、`portfolio_price_stale` |
+| 大盘失效 | `market_light_status`、`market_light_score_drop` |
+
+## 边界
+
+- 本次只做前端聚合展示，不新增后端规则类型。
+- 规则创建、启停、测试、删除和触发历史表格保持原有交互。
+- `degraded` 和 `failed` 归为数据缺口，提醒用户先复核数据与规则可用性。
+
+## 后续扩展
+
+- ResearchArtifact 接入后，可把 `invalidation_conditions` 直接生成或关联为告警规则。
+- 单股研究页接入后，可从“假设失效雷达”跳到对应股票工作台。
+- 组合页接入后，可把失效线索按账户、行业、货币暴露拆分。


### PR DESCRIPTION
Closes #2281

## Summary
- Add an Alert Invalidation Radar to the monitor/alerts center.
- Group rules and triggers into price, technical, portfolio, and market invalidation coverage.
- Surface recent triggers, data gaps, and high-priority rules without changing alert APIs.

## Validation
- `npm run test -- src/components/alerts/__tests__/AlertInvalidationRadar.test.tsx src/pages/__tests__/AlertsPage.test.tsx`
- `npm run lint`
- `npm run build`
- `git diff --check`

## Data Completeness
- This PR does not add a TickFlow-bound complete production data source.
- The radar aggregates existing alert rules/triggers and surfaces data-gap coverage; completeness depends on configured alert rules and available trigger history.
- Screenshot data is local Playwright mock sample data used to verify real UI rendering, not production alert data.

## Visual Evidence
![Alert invalidation radar](https://raw.githubusercontent.com/ZhuLinsen/daily_stock_analysis/evidence/pr-screenshots-2026-08-27/.github/pr-screenshots/2026-08-27/pr-2294-alert-invalidation-radar.png)

## Risk
- Web-only aggregation over existing alert rules/triggers; no runtime alert evaluation changes.

## Rollback
- Revert this PR to remove the radar component, page integration, tests, and docs.