### PR TITLE
docs: link arXiv paper and add citation metadata

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,21 @@
+cff-version: 1.2.0
+message: "If you use DSA in research, please cite the paper below."
+title: "Daily Stock Analysis (DSA)"
+type: software
+authors:
+  - family-names: "Zhu"
+    given-names: "Linsen"
+repository-code: "https://github.com/ZhuLinsen/daily_stock_analysis"
+url: "https://github.com/ZhuLinsen/daily_stock_analysis"
+license: MIT
+preferred-citation:
+  type: article
+  authors:
+    - family-names: "Zhu"
+      given-names: "Linsen"
+    - family-names: "Shi"
+      given-names: "Yi"
+  title: "DSA: Evidence-Aware LLM-Agent Orchestration for Multi-Market Stock Research"
+  journal: "arXiv"
+  year: 2026
+  url: "https://arxiv.org/abs/2608.26990"

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 # 📈 股票智能分析系统
 
 [![GitHub stars](https://img.shields.io/github/stars/ZhuLinsen/daily_stock_analysis?style=social)](https://github.com/ZhuLinsen/daily_stock_analysis/stargazers)
+[![arXiv](https://img.shields.io/badge/arXiv-2608.26990-b31b1b.svg)](https://arxiv.org/abs/2608.26990)
 [![CI](https://github.com/ZhuLinsen/daily_stock_analysis/actions/workflows/ci.yml/badge.svg)](https://github.com/ZhuLinsen/daily_stock_analysis/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Python 3.10+](https://img.shields.io/badge/python-3.10+-blue.svg)](https://www.python.org/downloads/)

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+- [文档] 在中英繁 README 顶部关联 DSA arXiv 论文，并新增 `CITATION.cff` 统一项目引用信息。
 - [改进] PR CI 增加文档路径检测：仅修改普通文档、非治理 Markdown 或 LICENSE 时跳过后端测试分片、Docker、Web 与桌面打包，保留轻量治理和门禁汇总；契约文档、静态 API 规格与测试 fixture 仍执行后端回归。
 - [修复] Linux/Docker 分享图补齐 Noto CJK 字体与中韩文字体栈，避免 PNG 只显示数字和英文、中文或韩文内容消失。
 - [新功能] Web Chat 意图识别层新增分词模块：`web_intent_tokenizer` 六步管道（多股票全名实体扫描 → 标点/空白切分 → 代码形提取 → 市场关键词 → 无歧义关键词 → 残存 gap 多策略 DFS 匹配）把用户消息切分为携带语义标签的 Token 序列；配套 `web_intent_types` 数据字典（Token 结构、Market 枚举、21 个语义 tag、clean/extend 双词池与正则机器）。核心原则"宁可不做，不可做错"：Step 1~5 只做精确匹配，Step 6 要求整段 TAG 全覆盖（交叉验证）才产出，未覆盖片段保持空 tag 交下游 LLM 兜底；代码形 token 辨认为 `stock_code`（附 code/name/market 三元组）/ `wrong_{market}_code` / `unknown_{market}_code` 三态，token 层代码拼写统一 canonical 归一（a=6 位裸数字、hk=HK+5 位、us=大写 ticker）。意图枚举与意图识别结果随后续 `web_intent_resolver` PR 引入。新增 183 个分词单元测试。

--- a/docs/README_CHT.md
+++ b/docs/README_CHT.md
@@ -3,6 +3,7 @@
 # 股票智能分析系統
 
 [![GitHub stars](https://img.shields.io/github/stars/ZhuLinsen/daily_stock_analysis?style=social)](https://github.com/ZhuLinsen/daily_stock_analysis/stargazers)
+[![arXiv](https://img.shields.io/badge/arXiv-2608.26990-b31b1b.svg)](https://arxiv.org/abs/2608.26990)
 [![CI](https://github.com/ZhuLinsen/daily_stock_analysis/actions/workflows/ci.yml/badge.svg)](https://github.com/ZhuLinsen/daily_stock_analysis/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Python 3.10+](https://img.shields.io/badge/python-3.10+-blue.svg)](https://www.python.org/downloads/)

--- a/docs/README_EN.md
+++ b/docs/README_EN.md
@@ -3,6 +3,7 @@
 # AI Stock Analysis System
 
 [![GitHub stars](https://img.shields.io/github/stars/ZhuLinsen/daily_stock_analysis?style=social)](https://github.com/ZhuLinsen/daily_stock_analysis/stargazers)
+[![arXiv](https://img.shields.io/badge/arXiv-2608.26990-b31b1b.svg)](https://arxiv.org/abs/2608.26990)
 [![CI](https://github.com/ZhuLinsen/daily_stock_analysis/actions/workflows/ci.yml/badge.svg)](https://github.com/ZhuLinsen/daily_stock_analysis/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Python 3.10+](https://img.shields.io/badge/python-3.10+-blue.svg)](https://www.python.org/downloads/)


### PR DESCRIPTION
## PR Type

- [ ] fix
- [ ] feat
- [ ] refactor
- [x] docs
- [ ] chore
- [ ] test

## Background And Problem

The DSA paper is now publicly available as [arXiv:2608.26990](https://arxiv.org/abs/2608.26990), but the repository landing pages did not provide a direct paper link or machine-readable citation metadata.

Acceptance criteria:

- Add a visible arXiv badge to the Simplified Chinese, English, and Traditional Chinese README files.
- Add valid CFF 1.2.0 citation metadata with the paper as the preferred citation.
- Record the documentation change in the changelog.

## Scope Of Change

- Change size: 5 files changed, 25 insertions.
- Files:
  - `CITATION.cff`
  - `README.md`
  - `docs/README_EN.md`
  - `docs/README_CHT.md`
  - `docs/CHANGELOG.md`
- User-visible documentation: all three README variants and the changelog.

Implementation notes:

- Each README links the badge to `https://arxiv.org/abs/2608.26990`.
- `CITATION.cff` identifies the software and sets the arXiv paper as `preferred-citation`.
- The DOI was intentionally omitted because DataCite registration was not yet available when this change was prepared; the canonical arXiv URL remains usable.

## Issue Link

No linked issue. This PR connects the repository to the newly published DSA paper.

## Verification Commands And Results

```text
cffconvert --validate -i CITATION.cff
# Citation metadata are valid according to schema version 1.2.0.

python -c "import pathlib, yaml; ..."
# CITATION.cff YAML and required-field checks passed

git diff --cached --check
# pass, no output

HTTP HEAD https://arxiv.org/abs/2608.26990
# 200

HTTP HEAD https://img.shields.io/badge/arXiv-2608.26990-b31b1b.svg
# 200
```

Docs only; application tests were not run locally.

Head CI results:

- `ai-governance`: success
- `backend-gate`: success
- `backend-tests (1/3)`: success
- `backend-tests (2/3)`: success
- `backend-tests (3/3)`: success
- `docker-build`: skipped by change detection
- `web-gate`: skipped by change detection
- desktop package jobs: skipped by change detection

## Visual Evidence (if applicable)

Not applicable. This PR changes repository landing-page Markdown and citation metadata rather than the application UI. The rendered arXiv badge can be reviewed directly in the changed README files.

## Compatibility And Risk

This is a documentation-only change. It does not change runtime behavior, APIs, configuration, model routing, data providers, reports, or deployment workflows. The external badge depends on shields.io and the link depends on arXiv availability; neither dependency affects application execution.

## Rollback Plan

Revert commit `95c8cdfe` or revert this PR. No data migration or runtime rollback is required.

## EXTRACT_PROMPT Change (if applicable)

Not applicable; `EXTRACT_PROMPT` is unchanged.

## Checklist

- [x] The PR description matches the actual diff.
- [x] Relevant commands, paths, and external links were checked.
- [x] Compatibility and risk are documented.
- [x] A rollback plan is included.
- [x] No application UI or report rendering changed.
- [x] Bilingual/Traditional Chinese README synchronization was evaluated and completed.
- [x] User-visible documentation and `docs/CHANGELOG.md` were updated.