### PR TITLE
fix: sync research artifact OpenAPI contract

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,7 +9,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
-- [修复] 同步 ResearchArtifact 与 `AnalysisReport.structured_report` 到静态 OpenAPI，避免公开 API 规格与运行时契约漂移。
 - [新功能] 支持通过 `main.py --stocks` 一次性分析已登记板块指数，自动使用指数适用的数据与分析能力，并保持报告、历史和决策信号兼容。
 - [修复] `main.py --stocks` 在解析股票列表前先 best-effort 刷新股票索引注册表，保证首次运行能吃到刷新后的指数 alias/身份；刷新失败、超时或禁用不阻断分析。
 - [修复] 交易日过滤对市场未知的指数 code（如 `sh000016`/`csi930955`/`930955.CSI`）按 `market=cn` 参与 A 股休市过滤，避免休市日指数被 fail-open 保留；市场仍未知的非指数 code 继续保留。
@@ -18,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - [新功能] 新增数据源能力与数据集质量只读契约，提供 `/api/v1/data/overview` 和 `/api/v1/data/capabilities`，为大盘看板、数据中心、个股详情和自选 2.0 统一暴露 provider capability、dataset quality 和 source priority。
 - [改进] PR CI 增加文档路径检测：仅修改普通文档、非治理 Markdown 或 LICENSE 时跳过后端测试分片、Docker、Web 与桌面打包，保留轻量治理和门禁汇总；契约文档、静态 API 规格与测试 fixture 仍执行后端回归。
 - [新功能] 新增 ResearchArtifact 结构化研究产物契约，在 `AnalysisReport.structured_report` 中承载 Thesis、Evidence、Invalidation Conditions、Next Actions 和 Data Quality，并提供从现有报告生成结构化产物的后端 helper 与 Web 类型。
+- [修复] 同步 ResearchArtifact 与 `AnalysisReport.structured_report` 到静态 OpenAPI，避免公开 API 规格与运行时契约漂移。
 - [修复] Linux/Docker 分享图补齐 Noto CJK 字体与中韩文字体栈，避免 PNG 只显示数字和英文、中文或韩文内容消失。
 - [新功能] Web Chat 意图识别层新增分词模块：`web_intent_tokenizer` 六步管道（多股票全名实体扫描 → 标点/空白切分 → 代码形提取 → 市场关键词 → 无歧义关键词 → 残存 gap 多策略 DFS 匹配）把用户消息切分为携带语义标签的 Token 序列；配套 `web_intent_types` 数据字典（Token 结构、Market 枚举、21 个语义 tag、clean/extend 双词池与正则机器）。核心原则"宁可不做，不可做错"：Step 1~5 只做精确匹配，Step 6 要求整段 TAG 全覆盖（交叉验证）才产出，未覆盖片段保持空 tag 交下游 LLM 兜底；代码形 token 辨认为 `stock_code`（附 code/name/market 三元组）/ `wrong_{market}_code` / `unknown_{market}_code` 三态，token 层代码拼写统一 canonical 归一（a=6 位裸数字、hk=HK+5 位、us=大写 ticker）。意图枚举与意图识别结果随后续 `web_intent_resolver` PR 引入。新增 183 个分词单元测试。
 <!-- 新条目格式：- [类型] 描述（类型取值：新功能/改进/修复/文档/测试/chore）-->

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+- [修复] 同步 ResearchArtifact 与 `AnalysisReport.structured_report` 到静态 OpenAPI，避免公开 API 规格与运行时契约漂移。
 - [新功能] 支持通过 `main.py --stocks` 一次性分析已登记板块指数，自动使用指数适用的数据与分析能力，并保持报告、历史和决策信号兼容。
 - [修复] `main.py --stocks` 在解析股票列表前先 best-effort 刷新股票索引注册表，保证首次运行能吃到刷新后的指数 alias/身份；刷新失败、超时或禁用不阻断分析。
 - [修复] 交易日过滤对市场未知的指数 code（如 `sh000016`/`csi930955`/`930955.CSI`）按 `market=cn` 参与 A 股休市过滤，避免休市日指数被 fail-open 保留；市场仍未知的非指数 code 继续保留。

--- a/docs/architecture/api_spec.json
+++ b/docs/architecture/api_spec.json
@@ -3419,6 +3419,17 @@
                 "description": "市场结构上下文（题材主线与个股市场位置信息，JSON）"
               }
             }
+          },
+          "structured_report": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ResearchArtifact"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "结构化研究产物，供看板、个股研究页、监控和 Copilot 复用"
           }
         },
         "required": [
@@ -7805,6 +7816,552 @@
         ],
         "title": "DataProviderCapability",
         "description": "Visible capability metadata for one data provider."
+      },
+      "ResearchArtifact": {
+        "properties": {
+          "schema_version": {
+            "type": "string",
+            "const": "research-artifact-v1",
+            "title": "Schema Version",
+            "default": "research-artifact-v1"
+          },
+          "artifact_id": {
+            "type": "string",
+            "minLength": 1,
+            "title": "Artifact Id"
+          },
+          "source_report_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Source Report Id"
+          },
+          "source_query_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Source Query Id"
+          },
+          "created_at": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Created At"
+          },
+          "subject": {
+            "$ref": "#/components/schemas/ResearchSubject"
+          },
+          "thesis": {
+            "$ref": "#/components/schemas/ResearchThesis"
+          },
+          "evidence": {
+            "items": {
+              "$ref": "#/components/schemas/ResearchEvidenceItem"
+            },
+            "type": "array",
+            "title": "Evidence"
+          },
+          "invalidation_conditions": {
+            "items": {
+              "$ref": "#/components/schemas/ResearchInvalidationCondition"
+            },
+            "type": "array",
+            "minItems": 1,
+            "title": "Invalidation Conditions"
+          },
+          "next_actions": {
+            "items": {
+              "$ref": "#/components/schemas/ResearchNextAction"
+            },
+            "type": "array",
+            "title": "Next Actions"
+          },
+          "data_quality": {
+            "$ref": "#/components/schemas/ResearchDataQuality"
+          },
+          "metadata": {
+            "additionalProperties": true,
+            "type": "object",
+            "title": "Metadata"
+          }
+        },
+        "type": "object",
+        "required": [
+          "artifact_id",
+          "subject",
+          "thesis",
+          "invalidation_conditions"
+        ],
+        "title": "ResearchArtifact",
+        "description": "Structured report artifact for dashboard, stock detail, monitor and copilot reuse."
+      },
+      "ResearchDataQuality": {
+        "properties": {
+          "level": {
+            "type": "string",
+            "enum": [
+              "good",
+              "usable",
+              "limited",
+              "poor",
+              "unknown"
+            ],
+            "title": "Level",
+            "default": "unknown"
+          },
+          "overall_score": {
+            "anyOf": [
+              {
+                "type": "integer",
+                "maximum": 100.0,
+                "minimum": 0.0
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Overall Score"
+          },
+          "source_count": {
+            "type": "integer",
+            "minimum": 0.0,
+            "title": "Source Count",
+            "default": 0
+          },
+          "stale_count": {
+            "type": "integer",
+            "minimum": 0.0,
+            "title": "Stale Count",
+            "default": 0
+          },
+          "missing_blocks": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Missing Blocks"
+          },
+          "limitations": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Limitations"
+          }
+        },
+        "type": "object",
+        "title": "ResearchDataQuality",
+        "description": "Low-sensitive quality summary for the artifact inputs."
+      },
+      "ResearchEvidenceItem": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "minLength": 1,
+            "title": "Id"
+          },
+          "source_type": {
+            "type": "string",
+            "minLength": 1,
+            "title": "Source Type"
+          },
+          "title": {
+            "type": "string",
+            "minLength": 1,
+            "title": "Title"
+          },
+          "summary": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Summary"
+          },
+          "source": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Source"
+          },
+          "freshness": {
+            "type": "string",
+            "enum": [
+              "fresh",
+              "stale",
+              "unknown"
+            ],
+            "title": "Freshness",
+            "default": "unknown"
+          },
+          "quality_level": {
+            "type": "string",
+            "enum": [
+              "good",
+              "usable",
+              "limited",
+              "poor",
+              "unknown"
+            ],
+            "title": "Quality Level",
+            "default": "unknown"
+          },
+          "as_of": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "As Of"
+          },
+          "url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Url"
+          },
+          "metadata": {
+            "additionalProperties": true,
+            "type": "object",
+            "title": "Metadata"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "source_type",
+          "title"
+        ],
+        "title": "ResearchEvidenceItem",
+        "description": "One evidence item with freshness and quality status."
+      },
+      "ResearchInvalidationCondition": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "minLength": 1,
+            "title": "Id"
+          },
+          "category": {
+            "type": "string",
+            "enum": [
+              "price",
+              "volume",
+              "evidence",
+              "market",
+              "time",
+              "data_quality",
+              "manual"
+            ],
+            "title": "Category"
+          },
+          "description": {
+            "type": "string",
+            "minLength": 1,
+            "title": "Description"
+          },
+          "trigger": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Trigger"
+          },
+          "severity": {
+            "type": "string",
+            "enum": [
+              "watch",
+              "warning",
+              "critical"
+            ],
+            "title": "Severity",
+            "default": "warning"
+          },
+          "metric": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Metric"
+          },
+          "threshold": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Threshold"
+          },
+          "due_at": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Due At"
+          },
+          "metadata": {
+            "additionalProperties": true,
+            "type": "object",
+            "title": "Metadata"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "category",
+          "description"
+        ],
+        "title": "ResearchInvalidationCondition",
+        "description": "Condition that should invalidate or force reassessment of the thesis."
+      },
+      "ResearchNextAction": {
+        "properties": {
+          "action": {
+            "type": "string",
+            "minLength": 1,
+            "title": "Action"
+          },
+          "label": {
+            "type": "string",
+            "minLength": 1,
+            "title": "Label"
+          },
+          "reason": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Reason"
+          },
+          "due_at": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Due At"
+          },
+          "metadata": {
+            "additionalProperties": true,
+            "type": "object",
+            "title": "Metadata"
+          }
+        },
+        "type": "object",
+        "required": [
+          "action",
+          "label"
+        ],
+        "title": "ResearchNextAction",
+        "description": "Suggested next action for a human or workflow."
+      },
+      "ResearchSubject": {
+        "properties": {
+          "stock_code": {
+            "type": "string",
+            "minLength": 1,
+            "title": "Stock Code"
+          },
+          "stock_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Stock Name"
+          },
+          "market": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Market"
+          },
+          "entity_ref": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Entity Ref",
+            "description": "Optional EntityLink ref when available"
+          }
+        },
+        "type": "object",
+        "required": [
+          "stock_code"
+        ],
+        "title": "ResearchSubject",
+        "description": "The entity being researched."
+      },
+      "ResearchThesis": {
+        "properties": {
+          "direction": {
+            "type": "string",
+            "enum": [
+              "bullish",
+              "bearish",
+              "neutral",
+              "unknown"
+            ],
+            "title": "Direction",
+            "default": "unknown"
+          },
+          "summary": {
+            "type": "string",
+            "title": "Summary",
+            "description": "Concise thesis statement",
+            "default": ""
+          },
+          "confidence": {
+            "anyOf": [
+              {
+                "type": "number",
+                "maximum": 1.0,
+                "minimum": 0.0
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Confidence"
+          },
+          "score": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Score",
+            "description": "Original sentiment score when available"
+          },
+          "horizon": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Horizon"
+          },
+          "action": {
+            "anyOf": [
+              {
+                "type": "string",
+                "enum": [
+                  "buy",
+                  "add",
+                  "hold",
+                  "reduce",
+                  "sell",
+                  "watch",
+                  "avoid",
+                  "alert"
+                ]
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Action"
+          },
+          "action_label": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Action Label"
+          },
+          "reasons": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Reasons"
+          },
+          "risks": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Risks"
+          }
+        },
+        "type": "object",
+        "title": "ResearchThesis",
+        "description": "Structured investment thesis extracted from a report."
       }
     },
     "securitySchemes": {

--- a/docs/architecture/api_spec.json
+++ b/docs/architecture/api_spec.json
@@ -3437,6 +3437,552 @@
           "summary"
         ]
       },
+      "ResearchArtifact": {
+        "properties": {
+          "schema_version": {
+            "type": "string",
+            "const": "research-artifact-v1",
+            "title": "Schema Version",
+            "default": "research-artifact-v1"
+          },
+          "artifact_id": {
+            "type": "string",
+            "minLength": 1,
+            "title": "Artifact Id"
+          },
+          "source_report_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Source Report Id"
+          },
+          "source_query_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Source Query Id"
+          },
+          "created_at": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Created At"
+          },
+          "subject": {
+            "$ref": "#/components/schemas/ResearchSubject"
+          },
+          "thesis": {
+            "$ref": "#/components/schemas/ResearchThesis"
+          },
+          "evidence": {
+            "items": {
+              "$ref": "#/components/schemas/ResearchEvidenceItem"
+            },
+            "type": "array",
+            "title": "Evidence"
+          },
+          "invalidation_conditions": {
+            "items": {
+              "$ref": "#/components/schemas/ResearchInvalidationCondition"
+            },
+            "type": "array",
+            "minItems": 1,
+            "title": "Invalidation Conditions"
+          },
+          "next_actions": {
+            "items": {
+              "$ref": "#/components/schemas/ResearchNextAction"
+            },
+            "type": "array",
+            "title": "Next Actions"
+          },
+          "data_quality": {
+            "$ref": "#/components/schemas/ResearchDataQuality"
+          },
+          "metadata": {
+            "additionalProperties": true,
+            "type": "object",
+            "title": "Metadata"
+          }
+        },
+        "type": "object",
+        "required": [
+          "artifact_id",
+          "subject",
+          "thesis",
+          "invalidation_conditions"
+        ],
+        "title": "ResearchArtifact",
+        "description": "Structured report artifact for dashboard, stock detail, monitor and copilot reuse."
+      },
+      "ResearchDataQuality": {
+        "properties": {
+          "level": {
+            "type": "string",
+            "enum": [
+              "good",
+              "usable",
+              "limited",
+              "poor",
+              "unknown"
+            ],
+            "title": "Level",
+            "default": "unknown"
+          },
+          "overall_score": {
+            "anyOf": [
+              {
+                "type": "integer",
+                "maximum": 100.0,
+                "minimum": 0.0
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Overall Score"
+          },
+          "source_count": {
+            "type": "integer",
+            "minimum": 0.0,
+            "title": "Source Count",
+            "default": 0
+          },
+          "stale_count": {
+            "type": "integer",
+            "minimum": 0.0,
+            "title": "Stale Count",
+            "default": 0
+          },
+          "missing_blocks": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Missing Blocks"
+          },
+          "limitations": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Limitations"
+          }
+        },
+        "type": "object",
+        "title": "ResearchDataQuality",
+        "description": "Low-sensitive quality summary for the artifact inputs."
+      },
+      "ResearchEvidenceItem": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "minLength": 1,
+            "title": "Id"
+          },
+          "source_type": {
+            "type": "string",
+            "minLength": 1,
+            "title": "Source Type"
+          },
+          "title": {
+            "type": "string",
+            "minLength": 1,
+            "title": "Title"
+          },
+          "summary": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Summary"
+          },
+          "source": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Source"
+          },
+          "freshness": {
+            "type": "string",
+            "enum": [
+              "fresh",
+              "stale",
+              "unknown"
+            ],
+            "title": "Freshness",
+            "default": "unknown"
+          },
+          "quality_level": {
+            "type": "string",
+            "enum": [
+              "good",
+              "usable",
+              "limited",
+              "poor",
+              "unknown"
+            ],
+            "title": "Quality Level",
+            "default": "unknown"
+          },
+          "as_of": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "As Of"
+          },
+          "url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Url"
+          },
+          "metadata": {
+            "additionalProperties": true,
+            "type": "object",
+            "title": "Metadata"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "source_type",
+          "title"
+        ],
+        "title": "ResearchEvidenceItem",
+        "description": "One evidence item with freshness and quality status."
+      },
+      "ResearchInvalidationCondition": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "minLength": 1,
+            "title": "Id"
+          },
+          "category": {
+            "type": "string",
+            "enum": [
+              "price",
+              "volume",
+              "evidence",
+              "market",
+              "time",
+              "data_quality",
+              "manual"
+            ],
+            "title": "Category"
+          },
+          "description": {
+            "type": "string",
+            "minLength": 1,
+            "title": "Description"
+          },
+          "trigger": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Trigger"
+          },
+          "severity": {
+            "type": "string",
+            "enum": [
+              "watch",
+              "warning",
+              "critical"
+            ],
+            "title": "Severity",
+            "default": "warning"
+          },
+          "metric": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Metric"
+          },
+          "threshold": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Threshold"
+          },
+          "due_at": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Due At"
+          },
+          "metadata": {
+            "additionalProperties": true,
+            "type": "object",
+            "title": "Metadata"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "category",
+          "description"
+        ],
+        "title": "ResearchInvalidationCondition",
+        "description": "Condition that should invalidate or force reassessment of the thesis."
+      },
+      "ResearchNextAction": {
+        "properties": {
+          "action": {
+            "type": "string",
+            "minLength": 1,
+            "title": "Action"
+          },
+          "label": {
+            "type": "string",
+            "minLength": 1,
+            "title": "Label"
+          },
+          "reason": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Reason"
+          },
+          "due_at": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Due At"
+          },
+          "metadata": {
+            "additionalProperties": true,
+            "type": "object",
+            "title": "Metadata"
+          }
+        },
+        "type": "object",
+        "required": [
+          "action",
+          "label"
+        ],
+        "title": "ResearchNextAction",
+        "description": "Suggested next action for a human or workflow."
+      },
+      "ResearchSubject": {
+        "properties": {
+          "stock_code": {
+            "type": "string",
+            "minLength": 1,
+            "title": "Stock Code"
+          },
+          "stock_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Stock Name"
+          },
+          "market": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Market"
+          },
+          "entity_ref": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Entity Ref",
+            "description": "Optional EntityLink ref when available"
+          }
+        },
+        "type": "object",
+        "required": [
+          "stock_code"
+        ],
+        "title": "ResearchSubject",
+        "description": "The entity being researched."
+      },
+      "ResearchThesis": {
+        "properties": {
+          "direction": {
+            "type": "string",
+            "enum": [
+              "bullish",
+              "bearish",
+              "neutral",
+              "unknown"
+            ],
+            "title": "Direction",
+            "default": "unknown"
+          },
+          "summary": {
+            "type": "string",
+            "title": "Summary",
+            "description": "Concise thesis statement",
+            "default": ""
+          },
+          "confidence": {
+            "anyOf": [
+              {
+                "type": "number",
+                "maximum": 1.0,
+                "minimum": 0.0
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Confidence"
+          },
+          "score": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Score",
+            "description": "Original sentiment score when available"
+          },
+          "horizon": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Horizon"
+          },
+          "action": {
+            "anyOf": [
+              {
+                "type": "string",
+                "enum": [
+                  "buy",
+                  "add",
+                  "hold",
+                  "reduce",
+                  "sell",
+                  "watch",
+                  "avoid",
+                  "alert"
+                ]
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Action"
+          },
+          "action_label": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Action Label"
+          },
+          "reasons": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Reasons"
+          },
+          "risks": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Risks"
+          }
+        },
+        "type": "object",
+        "title": "ResearchThesis",
+        "description": "Structured investment thesis extracted from a report."
+      },
       "StockQuote": {
         "type": "object",
         "description": "股票实时行情",
@@ -7816,552 +8362,6 @@
         ],
         "title": "DataProviderCapability",
         "description": "Visible capability metadata for one data provider."
-      },
-      "ResearchArtifact": {
-        "properties": {
-          "schema_version": {
-            "type": "string",
-            "const": "research-artifact-v1",
-            "title": "Schema Version",
-            "default": "research-artifact-v1"
-          },
-          "artifact_id": {
-            "type": "string",
-            "minLength": 1,
-            "title": "Artifact Id"
-          },
-          "source_report_id": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Source Report Id"
-          },
-          "source_query_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Source Query Id"
-          },
-          "created_at": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Created At"
-          },
-          "subject": {
-            "$ref": "#/components/schemas/ResearchSubject"
-          },
-          "thesis": {
-            "$ref": "#/components/schemas/ResearchThesis"
-          },
-          "evidence": {
-            "items": {
-              "$ref": "#/components/schemas/ResearchEvidenceItem"
-            },
-            "type": "array",
-            "title": "Evidence"
-          },
-          "invalidation_conditions": {
-            "items": {
-              "$ref": "#/components/schemas/ResearchInvalidationCondition"
-            },
-            "type": "array",
-            "minItems": 1,
-            "title": "Invalidation Conditions"
-          },
-          "next_actions": {
-            "items": {
-              "$ref": "#/components/schemas/ResearchNextAction"
-            },
-            "type": "array",
-            "title": "Next Actions"
-          },
-          "data_quality": {
-            "$ref": "#/components/schemas/ResearchDataQuality"
-          },
-          "metadata": {
-            "additionalProperties": true,
-            "type": "object",
-            "title": "Metadata"
-          }
-        },
-        "type": "object",
-        "required": [
-          "artifact_id",
-          "subject",
-          "thesis",
-          "invalidation_conditions"
-        ],
-        "title": "ResearchArtifact",
-        "description": "Structured report artifact for dashboard, stock detail, monitor and copilot reuse."
-      },
-      "ResearchDataQuality": {
-        "properties": {
-          "level": {
-            "type": "string",
-            "enum": [
-              "good",
-              "usable",
-              "limited",
-              "poor",
-              "unknown"
-            ],
-            "title": "Level",
-            "default": "unknown"
-          },
-          "overall_score": {
-            "anyOf": [
-              {
-                "type": "integer",
-                "maximum": 100.0,
-                "minimum": 0.0
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Overall Score"
-          },
-          "source_count": {
-            "type": "integer",
-            "minimum": 0.0,
-            "title": "Source Count",
-            "default": 0
-          },
-          "stale_count": {
-            "type": "integer",
-            "minimum": 0.0,
-            "title": "Stale Count",
-            "default": 0
-          },
-          "missing_blocks": {
-            "items": {
-              "type": "string"
-            },
-            "type": "array",
-            "title": "Missing Blocks"
-          },
-          "limitations": {
-            "items": {
-              "type": "string"
-            },
-            "type": "array",
-            "title": "Limitations"
-          }
-        },
-        "type": "object",
-        "title": "ResearchDataQuality",
-        "description": "Low-sensitive quality summary for the artifact inputs."
-      },
-      "ResearchEvidenceItem": {
-        "properties": {
-          "id": {
-            "type": "string",
-            "minLength": 1,
-            "title": "Id"
-          },
-          "source_type": {
-            "type": "string",
-            "minLength": 1,
-            "title": "Source Type"
-          },
-          "title": {
-            "type": "string",
-            "minLength": 1,
-            "title": "Title"
-          },
-          "summary": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Summary"
-          },
-          "source": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Source"
-          },
-          "freshness": {
-            "type": "string",
-            "enum": [
-              "fresh",
-              "stale",
-              "unknown"
-            ],
-            "title": "Freshness",
-            "default": "unknown"
-          },
-          "quality_level": {
-            "type": "string",
-            "enum": [
-              "good",
-              "usable",
-              "limited",
-              "poor",
-              "unknown"
-            ],
-            "title": "Quality Level",
-            "default": "unknown"
-          },
-          "as_of": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "As Of"
-          },
-          "url": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Url"
-          },
-          "metadata": {
-            "additionalProperties": true,
-            "type": "object",
-            "title": "Metadata"
-          }
-        },
-        "type": "object",
-        "required": [
-          "id",
-          "source_type",
-          "title"
-        ],
-        "title": "ResearchEvidenceItem",
-        "description": "One evidence item with freshness and quality status."
-      },
-      "ResearchInvalidationCondition": {
-        "properties": {
-          "id": {
-            "type": "string",
-            "minLength": 1,
-            "title": "Id"
-          },
-          "category": {
-            "type": "string",
-            "enum": [
-              "price",
-              "volume",
-              "evidence",
-              "market",
-              "time",
-              "data_quality",
-              "manual"
-            ],
-            "title": "Category"
-          },
-          "description": {
-            "type": "string",
-            "minLength": 1,
-            "title": "Description"
-          },
-          "trigger": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Trigger"
-          },
-          "severity": {
-            "type": "string",
-            "enum": [
-              "watch",
-              "warning",
-              "critical"
-            ],
-            "title": "Severity",
-            "default": "warning"
-          },
-          "metric": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Metric"
-          },
-          "threshold": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Threshold"
-          },
-          "due_at": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Due At"
-          },
-          "metadata": {
-            "additionalProperties": true,
-            "type": "object",
-            "title": "Metadata"
-          }
-        },
-        "type": "object",
-        "required": [
-          "id",
-          "category",
-          "description"
-        ],
-        "title": "ResearchInvalidationCondition",
-        "description": "Condition that should invalidate or force reassessment of the thesis."
-      },
-      "ResearchNextAction": {
-        "properties": {
-          "action": {
-            "type": "string",
-            "minLength": 1,
-            "title": "Action"
-          },
-          "label": {
-            "type": "string",
-            "minLength": 1,
-            "title": "Label"
-          },
-          "reason": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Reason"
-          },
-          "due_at": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Due At"
-          },
-          "metadata": {
-            "additionalProperties": true,
-            "type": "object",
-            "title": "Metadata"
-          }
-        },
-        "type": "object",
-        "required": [
-          "action",
-          "label"
-        ],
-        "title": "ResearchNextAction",
-        "description": "Suggested next action for a human or workflow."
-      },
-      "ResearchSubject": {
-        "properties": {
-          "stock_code": {
-            "type": "string",
-            "minLength": 1,
-            "title": "Stock Code"
-          },
-          "stock_name": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Stock Name"
-          },
-          "market": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Market"
-          },
-          "entity_ref": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Entity Ref",
-            "description": "Optional EntityLink ref when available"
-          }
-        },
-        "type": "object",
-        "required": [
-          "stock_code"
-        ],
-        "title": "ResearchSubject",
-        "description": "The entity being researched."
-      },
-      "ResearchThesis": {
-        "properties": {
-          "direction": {
-            "type": "string",
-            "enum": [
-              "bullish",
-              "bearish",
-              "neutral",
-              "unknown"
-            ],
-            "title": "Direction",
-            "default": "unknown"
-          },
-          "summary": {
-            "type": "string",
-            "title": "Summary",
-            "description": "Concise thesis statement",
-            "default": ""
-          },
-          "confidence": {
-            "anyOf": [
-              {
-                "type": "number",
-                "maximum": 1.0,
-                "minimum": 0.0
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Confidence"
-          },
-          "score": {
-            "anyOf": [
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Score",
-            "description": "Original sentiment score when available"
-          },
-          "horizon": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Horizon"
-          },
-          "action": {
-            "anyOf": [
-              {
-                "type": "string",
-                "enum": [
-                  "buy",
-                  "add",
-                  "hold",
-                  "reduce",
-                  "sell",
-                  "watch",
-                  "avoid",
-                  "alert"
-                ]
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Action"
-          },
-          "action_label": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Action Label"
-          },
-          "reasons": {
-            "items": {
-              "type": "string"
-            },
-            "type": "array",
-            "title": "Reasons"
-          },
-          "risks": {
-            "items": {
-              "type": "string"
-            },
-            "type": "array",
-            "title": "Risks"
-          }
-        },
-        "type": "object",
-        "title": "ResearchThesis",
-        "description": "Structured investment thesis extracted from a report."
       }
     },
     "securitySchemes": {

--- a/tests/test_api_schema_pydantic.py
+++ b/tests/test_api_schema_pydantic.py
@@ -71,6 +71,15 @@ DATA_CAPABILITY_SCHEMAS = (
     "DataPriorityView",
     "DataProviderCapability",
 )
+RESEARCH_ARTIFACT_SCHEMAS = (
+    "ResearchArtifact",
+    "ResearchDataQuality",
+    "ResearchEvidenceItem",
+    "ResearchInvalidationCondition",
+    "ResearchNextAction",
+    "ResearchSubject",
+    "ResearchThesis",
+)
 
 
 def _collect_component_schema_refs(node: Any) -> set[str]:
@@ -245,6 +254,15 @@ def test_decision_signal_static_api_spec_matches_runtime_paths() -> None:
         assert static_spec["paths"][path] == runtime_spec["paths"][path]
     for schema_name in DATA_CAPABILITY_SCHEMAS:
         assert static_spec["components"]["schemas"][schema_name] == runtime_spec["components"]["schemas"][schema_name]
+    for schema_name in RESEARCH_ARTIFACT_SCHEMAS:
+        assert (
+            static_spec["components"]["schemas"][schema_name]
+            == runtime_spec["components"]["schemas"][schema_name]
+        )
+    assert (
+        static_spec["components"]["schemas"]["AnalysisReport"]["properties"]["structured_report"]
+        == runtime_spec["components"]["schemas"]["AnalysisReport"]["properties"]["structured_report"]
+    )
     schema_refs = _collect_component_schema_refs(static_spec)
     missing_schema_refs = sorted(schema_refs - set(static_spec["components"]["schemas"]))
     assert missing_schema_refs == []


### PR DESCRIPTION
## PR Type

- [x] fix

## Background And Problem

Follow-up to merged PR #2291. Runtime OpenAPI already exposes `AnalysisReport.structured_report`, but the committed static specification did not contain that property or any of the referenced `ResearchArtifact` schemas.

Concrete example: a client generated from `docs/architecture/api_spec.json` would believe `structured_report` does not exist, even though `/api/v1/history` may return it. If the property were added without its referenced schemas, OpenAPI tooling would instead fail on unresolved `$ref` entries.

## Scope Of Change

3 files, 576 insertions:

- `docs/architecture/api_spec.json`: add `structured_report` and its seven reachable ResearchArtifact schemas from runtime OpenAPI.
- `tests/test_api_schema_pydantic.py`: compare those static schemas and the property against runtime OpenAPI.
- `docs/CHANGELOG.md`: record the contract synchronization.

## Issue Link

Refs #2278. Follow-up to #2291.

## Verification Commands And Results

- `python -m pytest tests/test_api_schema_pydantic.py -q` — 23 passed.
- `python -m py_compile tests/test_api_schema_pydantic.py` — passed.
- `python -m flake8 tests/test_api_schema_pydantic.py` — passed.
- Direct static-versus-runtime ResearchArtifact schema comparison — passed.
- `git diff --check` — passed.
- Current-head GitHub CI on `259073e7`: ai-governance, all three backend test shards, and backend-gate passed; Docker/Web/Desktop checks were skipped by path detection. Current-head Codex review completed with no new findings.

## Visual Evidence

Not applicable. This PR does not change Web UI or report rendering.

## Compatibility And Risk

- Environment variables/configuration: unchanged.
- Public API runtime behavior: unchanged; the static API contract now describes behavior already present at runtime.
- Web UI/Desktop: unchanged.
- Report generation/rendering: unchanged.
- Database/migrations: unchanged.
- Workflows/deployment: unchanged.

The main risk is future runtime schema drift. The new equality checks cover the ResearchArtifact graph and `AnalysisReport.structured_report` to detect it.

## Rollback Plan

Revert this PR. No configuration or data rollback is required.

## Checklist

- [x] This PR has a clear motivation and value.
- [x] Reproducible verification commands and results are included.
- [x] Compatibility and risk have been assessed.
- [x] A rollback plan is provided.
- [x] Static API documentation and `docs/CHANGELOG.md` are updated.