### PR TITLE
feat: add India (NSE/BSE) market support via yfinance suffix codes

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,9 +3,10 @@
 # 复制此文件为 .env 并填入真实配置
 # ===================================
 
-# 自选股列表（逗号分隔，支持沪深两市代码）
+# 自选股列表（逗号分隔，支持沪深两市代码，及美/港/日/韩/台/印海外代码）
 # 沪市：600xxx, 601xxx, 603xxx
 # 深市：000xxx, 002xxx, 300xxx
+# 印度（NSE/BSE, Yahoo Finance suffix）：RELIANCE.NS, TCS.NS, HDFCBANK.BO
 STOCK_LIST=600519,300750,002594
 
 # Futu OpenD（持仓导入）

--- a/data_provider/base.py
+++ b/data_provider/base.py
@@ -200,6 +200,11 @@ def _is_tw_market(code: str) -> bool:
     return is_suffix_market_symbol(code, "tw")
 
 
+def _is_in_market(code: str) -> bool:
+    """判定是否为印度 Yahoo Finance suffix 代码（NSE `.NS` / BSE `.BO`）。"""
+    return is_suffix_market_symbol(code, "in")
+
+
 def _is_etf_code(code: str) -> bool:
     """判定 A 股 ETF 基金代码（保守规则）。"""
     normalized = normalize_stock_code(code)
@@ -240,7 +245,7 @@ def _is_meaningful_chip_distribution(chip: Any) -> bool:
 
 
 def _market_tag(code: str) -> str:
-    """返回市场标签: cn/us/hk/jp/kr/tw."""
+    """返回市场标签: cn/us/hk/jp/kr/tw/in."""
     if _is_us_market(code):
         return "us"
     if _is_hk_market(code):
@@ -251,6 +256,8 @@ def _market_tag(code: str) -> str:
         return "kr"
     if _is_tw_market(code):
         return "tw"
+    if _is_in_market(code):
+        return "in"
     return "cn"
 
 
@@ -623,7 +630,7 @@ class DataFetcherManager:
         "TickFlowFetcher": {"cn"},
         "PytdxFetcher": {"cn"},
         "BaostockFetcher": {"cn"},
-        "YfinanceFetcher": {"cn", "hk", "us", "jp", "kr", "tw"},
+        "YfinanceFetcher": {"cn", "hk", "us", "jp", "kr", "tw", "in"},
         "LongbridgeFetcher": {"hk", "us"},
         "FinnhubFetcher": {"us"},
         "AlphaVantageFetcher": {"us"},
@@ -1291,14 +1298,15 @@ class DataFetcherManager:
         is_jp = (not is_us) and (not is_hk) and _is_jp_market(stock_code)
         is_kr = (not is_us) and (not is_hk) and _is_kr_market(stock_code)
         is_tw = (not is_us) and (not is_hk) and _is_tw_market(stock_code)
-        market = "us" if is_us else "hk" if is_hk else "jp" if is_jp else "kr" if is_kr else "tw" if is_tw else "cn"
+        is_in = (not is_us) and (not is_hk) and _is_in_market(stock_code)
+        market = "us" if is_us else "hk" if is_hk else "jp" if is_jp else "kr" if is_kr else "tw" if is_tw else "in" if is_in else "cn"
         if market != "cn":
             fetchers = self._filter_daily_fetchers_for_market(fetchers, market)
         fetchers = self._filter_fetchers_by_capability(fetchers, capability="daily_data")
         total_fetchers = len(fetchers)
 
         if total_fetchers == 0:
-            market_label = "美股指数" if is_us_index else "美股" if is_us else "港股" if is_hk else "台股" if is_tw else "A股"
+            market_label = "美股指数" if is_us_index else "美股" if is_us else "港股" if is_hk else "台股" if is_tw else "印股" if is_in else "A股"
             error_summary = f"{market_label} {stock_code} 获取失败:\n暂无可用数据源"
             logger.error(f"[数据源终止] {stock_code} 获取失败: {error_summary}")
             raise DataFetchError(error_summary)
@@ -1769,9 +1777,10 @@ class DataFetcherManager:
         is_jp = (not is_us) and (not is_hk) and _is_jp_market(stock_code)
         is_kr = (not is_us) and (not is_hk) and _is_kr_market(stock_code)
         is_tw = (not is_us) and (not is_hk) and _is_tw_market(stock_code)
+        is_in = (not is_us) and (not is_hk) and _is_in_market(stock_code)
 
-        if is_jp or is_kr or is_tw:
-            market_label = "日股" if is_jp else "韩股" if is_kr else "台股"
+        if is_jp or is_kr or is_tw or is_in:
+            market_label = "日股" if is_jp else "韩股" if is_kr else "台股" if is_tw else "印股"
             quote = self._try_fetcher_quote(stock_code, "YfinanceFetcher")
             if quote is not None:
                 logger.info(f"[实时行情] {market_label} {stock_code} 成功获取 (来源: YfinanceFetcher)")
@@ -3132,7 +3141,7 @@ class DataFetcherManager:
         stock_code = normalize_stock_code(stock_code)
         market = _market_tag(stock_code)
         is_etf = _is_etf_code(stock_code)
-        if market in {"us", "hk", "jp", "kr", "tw"}:
+        if market in {"us", "hk", "jp", "kr", "tw", "in"}:
             return self._build_offshore_fundamental_context(
                 stock_code,
                 market=market,

--- a/data_provider/yfinance_fetcher.py
+++ b/data_provider/yfinance_fetcher.py
@@ -94,6 +94,11 @@ class YfinanceFetcher(BaseFetcher):
         """
         return is_suffix_market_symbol(stock_code, "tw")
 
+    @staticmethod
+    def _is_in_suffix_stock(stock_code: str) -> bool:
+        """Return True for supported India suffix-only Yahoo symbols (NSE `.NS` / BSE `.BO`)."""
+        return is_suffix_market_symbol(stock_code, "in")
+
     def _convert_stock_code(self, stock_code: str) -> str:
         """
         转换股票代码为 Yahoo Finance 格式
@@ -132,8 +137,8 @@ class YfinanceFetcher(BaseFetcher):
             return code
 
         # 日股/韩股/台股 MVP：显式 Yahoo Finance suffix-only 代码，原样传给 Yahoo。
-        if self._is_jp_kr_suffix_stock(code) or self._is_tw_suffix_stock(code):
-            logger.debug(f"识别为日韩台 Yahoo suffix 代码: {code}")
+        if self._is_jp_kr_suffix_stock(code) or self._is_tw_suffix_stock(code) or self._is_in_suffix_stock(code):
+            logger.debug(f"识别为日韩台印 Yahoo suffix 代码: {code}")
             return code
 
         # 港股：hk前缀 -> .HK后缀
@@ -815,13 +820,14 @@ class YfinanceFetcher(BaseFetcher):
                 index_name=index_name,
             )
 
-        # 仅处理美股股票或 JP/KR/TW suffix-only 股票
+        # 仅处理美股股票或 JP/KR/TW/IN suffix-only 股票
         if not (
             self._is_us_stock(stock_code)
             or self._is_jp_kr_suffix_stock(stock_code)
             or self._is_tw_suffix_stock(stock_code)
+            or self._is_in_suffix_stock(stock_code)
         ):
-            logger.debug(f"[Yfinance] {stock_code} 不是美股或日韩 suffix 代码，跳过")
+            logger.debug(f"[Yfinance] {stock_code} 不是美股或日韩台印 suffix 代码，跳过")
             return None
 
         try:

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 ## [Unreleased]
 
 - [新功能] `STOCK_LIST` 支持印度股票（NSE `.NS` / BSE `.BO` 后缀，经 yfinance 兜底数据源），market 检测、交易日历（`XNSE`、`Asia/Kolkata`）、LLM 分析语境（中英）、决策信号持久化（`VALID_MARKETS`）与自定义情报源 scope（`_ALLOWED_MARKETS`）同步支持；印度代码为字母数字组合（如 `RELIANCE.NS`），不支持裸代码解析，必须显式带 `.NS`/`.BO` 后缀。
+- [改进] 决策仪表盘日报（`generate_dashboard_report`，含 Telegram 推送）在 `STOCK_LIST` 覆盖多个市场时按市场分组展示（如「美股」「印度股票」独立小节），组内仍按评分排序；仅单一市场时不显示分节标题，行为与既有报告保持一致。分节标题按 `zh`/`en`/`ko` 本地化，市场顺序固定为 `cn,hk,us,jp,kr,tw,in`。
 - [修复] 大盘复盘历史列表与详情统一展示持久化短摘要；旧记录缺少摘要时从完整 Markdown 生成无内部标记的纯文本节选。
 - [修复] 大盘复盘按实际执行的生成后端和模型记录诊断，避免 Codex CLI 或 fallback 被误显示为配置模型。
 <!-- 新条目格式：- [类型] 描述（类型取值：新功能/改进/修复/文档/测试/chore）-->

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+- [新功能] `STOCK_LIST` 支持印度股票（NSE `.NS` / BSE `.BO` 后缀，经 yfinance 兜底数据源），market 检测、交易日历（`XNSE`、`Asia/Kolkata`）、LLM 分析语境（中英）、决策信号持久化（`VALID_MARKETS`）与自定义情报源 scope（`_ALLOWED_MARKETS`）同步支持；印度代码为字母数字组合（如 `RELIANCE.NS`），不支持裸代码解析，必须显式带 `.NS`/`.BO` 后缀。
 - [修复] 大盘复盘历史列表与详情统一展示持久化短摘要；旧记录缺少摘要时从完整 Markdown 生成无内部标记的纯文本节选。
 - [修复] 大盘复盘按实际执行的生成后端和模型记录诊断，避免 Codex CLI 或 fallback 被误显示为配置模型。
 <!-- 新条目格式：- [类型] 描述（类型取值：新功能/改进/修复/文档/测试/chore）-->

--- a/docs/market-support.md
+++ b/docs/market-support.md
@@ -136,3 +136,32 @@ Portfolio 允许 JP/KR 账户、交易和持仓快照进入现有链路，但会
 - Web UI 可视证据口径：Market Light 告警目标范围切到“大盘市场”时，市场区域下拉只显示 A 股、港股、美股，不显示日股/韩股；设置页 `MARKET_REVIEW_REGION` 渲染为可输入逗号分隔值的文本框。当前仓库不保存一次性截图证据，可替代证据为 `apps/dsa-web/src/components/alerts/__tests__/AlertRuleForm.test.tsx`、`apps/dsa-web/src/components/settings/__tests__/SettingsField.test.tsx` 和 `apps/dsa-web/tests/system_config_i18n.test.ts` 的断言。
 
 回滚方式：移除 Portfolio snapshot 的 `data_quality` / `limitations` 扩展，恢复告警前端/后端对市场枚举的旧边界说明；如需整体回滚，移除 `jp/kr` 市场识别、交易日历注册、YFinance 路由扩展、Web/API 类型放行、`scripts/stock_index_seeds/` 日韩种子索引，并删除本文档中的能力声明。
+
+## 印度个股支持（suffix-only MVP）
+
+当前阶段支持手动输入印度股票的 Yahoo Finance 后缀代码，进入既有个股分析、历史保存、报告渲染、DecisionSignal、Portfolio 和 Intelligence 链路。NSE（印度国家证券交易所）使用 `.NS` 后缀，BSE（孟买证券交易所）使用 `.BO` 后缀，二者折叠为同一 `in` 市场标签。
+
+支持格式：
+
+- NSE：`RELIANCE.NS`、`TCS.NS`
+- BSE：`HDFCBANK.BO`
+- 印度代码 base 为字母数字组合（如 `RELIANCE`、`M&M`），与日/韩/台固定位数纯数字代码不同，识别规则单独校验 base 合法字符集（大写字母、数字、`&`、`-`，1-20 位）。
+
+约束与边界：
+
+- **严格 suffix-only**：裸 `RELIANCE` 等不带后缀的代码不会进入印度语义（`detect_market` / `get_market_for_stock` 仅在显式 `.NS`/`.BO` 后缀时返回 `in`），且不支持裸代码索引回填（`suffix_base_lookup_allowed` 对 `in` 恒为 `False`）。当前未内置印度股票索引/种子解析，Web 自动补全不承诺印度股票池；请手动输入完整 suffix 代码。
+- 印度日线和基础实时/近实时行情只走 `YfinanceFetcher`，不尝试 AkShare、Tushare、Efinance、Pytdx、Baostock 等 A 股专属数据源。
+- 基本面复用既有 offshore yfinance 轻量路径；A 股专属资金流、龙虎榜、板块等能力按 `not_supported` 降级。
+- 报告 Prompt 已增加印度市场语义（印度卢比、RBI、SEBI、FII/DII 资金流、circuit filter 涨跌停机制），避免套用 A 股北向资金、龙虎榜等概念。
+- 交易日历注册 `in: XNSE / Asia/Kolkata`。若本地 `exchange-calendars` 版本缺少 `XNSE` 日历，沿用既有 fail-open/fail-closed 语义（`get_open_markets_today()` 在 `exchange-calendars` 不可用时按 fail-open 把 `in` 计入当日开市集合）。
+- `VALID_MARKETS`（Portfolio / DecisionSignal 持久化）与 `_ALLOWED_MARKETS`（Intelligence 自定义情报源 scope）已放行 `in`。
+
+不承诺项：
+
+- 不承诺实时行情；Yahoo Finance 数据可能延迟或字段缺失。
+- 不承诺完整基本面、行业/板块、市场宽度、涨跌家数。
+- 不提供印度主要指数（Nifty 50 / Sensex）大盘复盘；`MARKET_REVIEW_REGION` 仍只接受既有市场子集，未纳入 `in`。
+- 印度股票索引/种子和 Web 自动补全未接入；Market Light 大盘红绿灯告警仍为 `cn/hk/us`，未含 `in`。
+- 不补齐 Portfolio 的 INR 汇率、成本、市值完整口径；印度 Portfolio 仅放开市场类型校验，避免前后端拒绝，不代表估值口径完整。
+
+回滚方式：移除 `in` 市场识别（`src/services/market_symbol_utils.py`）、交易日历注册（`src/core/trading_calendar.py`）、YFinance 路由扩展（`data_provider/base.py`、`data_provider/yfinance_fetcher.py`）、`VALID_MARKETS`/`_ALLOWED_MARKETS` 放行，并删除本文档中的能力声明。

--- a/src/core/trading_calendar.py
+++ b/src/core/trading_calendar.py
@@ -38,7 +38,7 @@ except ImportError:
     )
 
 # Market -> exchange code (exchange-calendars)
-MARKET_EXCHANGE = {"cn": "XSHG", "hk": "XHKG", "us": "XNYS", "jp": "XTKS", "kr": "XKRX", "tw": "XTAI"}
+MARKET_EXCHANGE = {"cn": "XSHG", "hk": "XHKG", "us": "XNYS", "jp": "XTKS", "kr": "XKRX", "tw": "XTAI", "in": "XNSE"}
 
 # Market -> IANA timezone for "today"
 MARKET_TIMEZONE = {
@@ -48,6 +48,7 @@ MARKET_TIMEZONE = {
     "jp": "Asia/Tokyo",
     "kr": "Asia/Seoul",
     "tw": "Asia/Taipei",
+    "in": "Asia/Kolkata",
 }
 
 # P0 market phase baseline (Issue #1386). This is an intentionally small

--- a/src/market_context.py
+++ b/src/market_context.py
@@ -78,6 +78,10 @@ _MARKET_ROLES = {
         "zh": "台股",
         "en": "Taiwan stock",
     },
+    "in": {
+        "zh": "印股",
+        "en": "India stock",
+    },
 }
 
 _MARKET_GUIDELINES = {
@@ -144,6 +148,20 @@ _MARKET_GUIDELINES = {
             "electronics-foundry supply chain, the three institutional investor groups (foreign / "
             "investment-trust / dealer), margin trading and day trading, and the TWSE/TPEx ±10% daily "
             "price limit; do not apply China A-share-specific concepts such as Northbound flows or Dragon Tiger lists."
+        ),
+    },
+    "in": {
+        "zh": (
+            "- 本次分析对象为 **印股**（印度国家证券交易所 `.NS` 或孟买证券交易所 `.BO` 上市股票）。\n"
+            "- 请按印度市场语境分析，关注印度卢比（INR）汇率、印度储备银行（RBI）政策、SEBI 监管动态、"
+            "外国机构投资者（FII）/本地机构投资者（DII）资金流向，以及印度特有的涨跌停（circuit filter）机制；"
+            "不要套用 A 股专属的涨跌停板、北向资金、龙虎榜、融资融券等概念。"
+        ),
+        "en": (
+            "- This analysis covers an **India stock** (NSE-listed `.NS`, or BSE-listed `.BO`).\n"
+            "- Use India-market context: INR FX, RBI monetary policy, SEBI regulatory actions, "
+            "FII/DII flows, and NSE/BSE circuit filter limits; do not apply China A-share-specific "
+            "concepts such as daily price-limit boards, Northbound flows, or Dragon Tiger lists."
         ),
     },
 }

--- a/src/notification.py
+++ b/src/notification.py
@@ -25,6 +25,7 @@ from enum import Enum
 
 from src.config import Config, get_config
 from src.enums import ReportType
+from src.market_context import detect_market
 from src.market_phase_summary import format_public_market_status_line, format_public_phase_pack_excerpt
 from src.notification_routing import (
     get_notification_route_config,
@@ -38,7 +39,9 @@ from src.notification_noise import (
     release_notification_noise,
 )
 from src.report_language import (
+    MARKET_SECTION_ORDER,
     get_localized_stock_name,
+    get_market_section_title,
     get_report_labels,
     get_signal_level,
     get_chip_unavailable_reason,
@@ -1210,6 +1213,25 @@ class NotificationService(
         hold_count = len(buckets) - buy_count - sell_count
         return buy_count, sell_count, hold_count
 
+    @staticmethod
+    def _group_results_by_market(
+        results: List[AnalysisResult],
+    ) -> List[Tuple[str, List[AnalysisResult]]]:
+        """Group results by market, preserving each group's relative order.
+
+        Group order follows MARKET_SECTION_ORDER; any market not in that
+        list (should not happen, detect_market falls back to "cn") is
+        appended after, in first-seen order.
+        """
+        buckets: Dict[str, List[AnalysisResult]] = {}
+        for result in results:
+            market = detect_market(getattr(result, "code", None))
+            buckets.setdefault(market, []).append(result)
+
+        ordered_markets = [m for m in MARKET_SECTION_ORDER if m in buckets]
+        ordered_markets.extend(m for m in buckets if m not in ordered_markets)
+        return [(market, buckets[market]) for market in ordered_markets]
+
     def _get_signal_level(self, result: AnalysisResult) -> tuple:
         """Get display text and signal metadata from the resolved action."""
         report_language = self._get_report_language(result)
@@ -1290,8 +1312,14 @@ class NotificationService(
         if report_date is None:
             report_date = datetime.now().strftime('%Y-%m-%d')
 
-        # 按评分排序（高分在前）
+        # 按评分排序（高分在前），再按市场分组（Issue: multi-market section headers）
         sorted_results = sorted(results, key=lambda x: x.sentiment_score, reverse=True)
+        market_groups = self._group_results_by_market(sorted_results)
+        show_market_sections = len(market_groups) > 1
+        sorted_results = [r for _market, group in market_groups for r in group]
+        market_section_starts = {
+            id(group[0]): market for market, group in market_groups if group
+        }
 
         buy_count, sell_count, hold_count = self._count_display_decisions(results, report_language)
 
@@ -1310,6 +1338,11 @@ class NotificationService(
                 "",
             ])
             for r in sorted_results:
+                if show_market_sections and id(r) in market_section_starts:
+                    report_lines.extend([
+                        f"### {get_market_section_title(market_section_starts[id(r)], report_language)}",
+                        "",
+                    ])
                 signal_text, signal_emoji, _ = self._get_signal_level(r)
                 display_name = self._get_display_name(r, report_language)
                 report_lines.append(
@@ -1331,6 +1364,11 @@ class NotificationService(
         # 逐个股票的决策仪表盘（Issue #262: summary_only 时跳过详情）
         if not self._report_summary_only:
             for result in sorted_results:
+                if show_market_sections and id(result) in market_section_starts:
+                    report_lines.extend([
+                        f"## {get_market_section_title(market_section_starts[id(result)], report_language)}",
+                        "",
+                    ])
                 signal_text, signal_emoji, signal_tag = self._get_signal_level(result)
                 dashboard = result.dashboard if hasattr(result, 'dashboard') and result.dashboard else {}
 

--- a/src/report_language.py
+++ b/src/report_language.py
@@ -832,6 +832,32 @@ def get_report_labels(language: Optional[str]) -> Dict[str, str]:
     return _REPORT_LABELS[normalized]
 
 
+# Canonical rendering order for market-grouped report sections. Markets not
+# in this list (should not happen given detect_market's fallback to "cn")
+# are appended after, in first-seen order.
+MARKET_SECTION_ORDER = ("cn", "hk", "us", "jp", "kr", "tw", "in")
+
+_MARKET_SECTION_TITLES: Dict[str, Dict[str, str]] = {
+    "cn": {"zh": "A 股", "en": "China A-Shares", "ko": "A주"},
+    "hk": {"zh": "港股", "en": "Hong Kong Stocks", "ko": "홍콩 주식"},
+    "us": {"zh": "美股", "en": "US Stocks", "ko": "미국 주식"},
+    "jp": {"zh": "日股", "en": "Japan Stocks", "ko": "일본 주식"},
+    "kr": {"zh": "韩股", "en": "Korea Stocks", "ko": "한국 주식"},
+    "tw": {"zh": "台股", "en": "Taiwan Stocks", "ko": "대만 주식"},
+    "in": {"zh": "印度股票", "en": "India Stocks", "ko": "인도 주식"},
+}
+
+
+def get_market_section_title(market: Optional[str], language: Optional[str]) -> str:
+    """Return a localized market-section heading for grouped reports."""
+    normalized_language = normalize_report_language(language)
+    market_key = (market or "").strip().lower()
+    titles = _MARKET_SECTION_TITLES.get(market_key)
+    if titles is None:
+        return market_key.upper() if market_key else get_unknown_text(normalized_language)
+    return titles[normalized_language]
+
+
 def get_placeholder_text(language: Optional[str]) -> str:
     """Return placeholder text for missing localized content."""
     return _PLACEHOLDER_BY_LANGUAGE[normalize_report_language(language)]

--- a/src/services/intelligence_service.py
+++ b/src/services/intelligence_service.py
@@ -28,7 +28,7 @@ from src.services.run_diagnostics import sanitize_diagnostic_text
 logger = logging.getLogger(__name__)
 _ALLOWED_SOURCE_TYPES = {"rss", "atom", "newsnow"}
 _ALLOWED_SCOPE_TYPES = {"symbol", "market", "sector"}
-_ALLOWED_MARKETS = {"cn", "hk", "us", "jp", "kr", "tw", "global"}
+_ALLOWED_MARKETS = {"cn", "hk", "us", "jp", "kr", "tw", "in", "global"}
 _PRIVATE_HOSTNAMES = {"localhost", "localhost.localdomain"}
 _MAX_FEED_BYTES = 2 * 1024 * 1024
 _MAX_FEED_REDIRECTS = 5

--- a/src/services/market_symbol_utils.py
+++ b/src/services/market_symbol_utils.py
@@ -8,8 +8,14 @@ without introducing import cycles.
 
 from __future__ import annotations
 
+import re
 from dataclasses import dataclass
 from typing import Optional
+
+# NSE/BSE tickers are alphanumeric (e.g. RELIANCE, M&M, L&TFH), unlike the
+# fixed-digit JP/KR/TW codes, so they get a base pattern instead of digit
+# lengths.
+_INDIA_BASE_PATTERN = re.compile(r"^[A-Z0-9&\-]{1,20}$")
 
 
 @dataclass(frozen=True)
@@ -18,15 +24,23 @@ class SuffixMarketSpec:
 
     market: str
     suffixes: tuple[str, ...]
-    digit_lengths: tuple[int, ...]
+    digit_lengths: tuple[int, ...] = ()
+    base_pattern: Optional[re.Pattern[str]] = None
+
+    def base_is_valid(self, base: str) -> bool:
+        if self.base_pattern is not None:
+            return bool(self.base_pattern.match(base))
+        return base.isdigit() and len(base) in self.digit_lengths
 
 
 _SUFFIX_MARKET_SPECS: tuple[SuffixMarketSpec, ...] = (
-    SuffixMarketSpec("jp", ("T",), (4, 5)),
-    SuffixMarketSpec("kr", ("KS", "KQ"), (6,)),
+    SuffixMarketSpec("jp", ("T",), digit_lengths=(4, 5)),
+    SuffixMarketSpec("kr", ("KS", "KQ"), digit_lengths=(6,)),
     # Taiwan support mirrors the same suffix-only pattern; keep it here so the
     # shared helpers stay complete for all yfinance-only offshore markets.
-    SuffixMarketSpec("tw", ("TW", "TWO"), (4, 5, 6)),
+    SuffixMarketSpec("tw", ("TW", "TWO"), digit_lengths=(4, 5, 6)),
+    # India: NSE (.NS) / BSE (.BO) via Yahoo Finance, alphanumeric tickers.
+    SuffixMarketSpec("in", ("NS", "BO"), base_pattern=_INDIA_BASE_PATTERN),
 )
 
 _MARKET_TO_SPEC = {spec.market: spec for spec in _SUFFIX_MARKET_SPECS}
@@ -50,7 +64,7 @@ def split_suffix_symbol(stock_code: str) -> tuple[str, str] | None:
 
 
 def get_suffix_market(stock_code: str) -> Optional[str]:
-    """Return jp/kr/tw for supported suffix-only Yahoo symbols, else None."""
+    """Return jp/kr/tw/in for supported suffix-only Yahoo symbols, else None."""
 
     parts = split_suffix_symbol(stock_code)
     if parts is None:
@@ -59,7 +73,7 @@ def get_suffix_market(stock_code: str) -> Optional[str]:
     spec = _SUFFIX_TO_SPEC.get(suffix)
     if spec is None:
         return None
-    if not (base.isdigit() and len(base) in spec.digit_lengths):
+    if not spec.base_is_valid(base):
         return None
     return spec.market
 
@@ -83,6 +97,10 @@ def is_kr_suffix_symbol(stock_code: str) -> bool:
 
 def is_tw_suffix_symbol(stock_code: str) -> bool:
     return is_suffix_market_symbol(stock_code, "tw")
+
+
+def is_in_suffix_symbol(stock_code: str) -> bool:
+    return is_suffix_market_symbol(stock_code, "in")
 
 
 def normalize_suffix_market_symbol(stock_code: str) -> Optional[str]:

--- a/src/services/portfolio_service.py
+++ b/src/services/portfolio_service.py
@@ -30,7 +30,7 @@ except Exception:  # pragma: no cover - optional dependency path
     yf = None
 
 EPS = 1e-8
-VALID_MARKETS = {"cn", "hk", "us", "jp", "kr", "tw"}
+VALID_MARKETS = {"cn", "hk", "us", "jp", "kr", "tw", "in"}
 PARTIAL_VALUATION_MARKETS = {"jp", "kr", "tw"}
 VALID_COST_METHODS = {"fifo", "avg"}
 VALID_SIDES = {"buy", "sell"}
@@ -1723,7 +1723,7 @@ class PortfolioService:
     def _normalize_market(value: str) -> str:
         market = (value or "").strip().lower()
         if market not in VALID_MARKETS:
-            raise ValueError("market must be one of: cn, hk, us, jp, kr, tw")
+            raise ValueError("market must be one of: cn, hk, us, jp, kr, tw, in")
         return market
 
     @staticmethod

--- a/src/services/stock_code_utils.py
+++ b/src/services/stock_code_utils.py
@@ -445,7 +445,7 @@ def resolve_daily_stock_identity(
         candidates = [raw_code, normalized_code, refill_code]
         if suffix_base_lookup_allowed(normalized_code):
             candidates.append(normalized_code.rsplit(".", 1)[0])
-    if market not in {"jp", "kr", "tw"}:
+    if market not in {"jp", "kr", "tw", "in"}:
         for candidate in list(candidates):
             candidates.extend(
                 _build_market_code_variants(

--- a/tests/test_market_section_report.py
+++ b/tests/test_market_section_report.py
@@ -1,0 +1,83 @@
+# -*- coding: utf-8 -*-
+"""决策仪表盘日报按市场分节展示（多市场 STOCK_LIST 场景）。
+
+背景：STOCK_LIST 可同时混合 A 股 / 美股 / 印度股票等多个市场，日报此前
+按评分单一排序，不同市场的标的会随机穿插，读者难以按市场分区阅读。
+这些用例锁住两个状态：
+1. 多市场混合时，报告按 MARKET_SECTION_ORDER 顺序分节，且组内仍按评分排序；
+2. 单一市场时不出现分节标题，行为与既有报告保持一致（零回归）。
+"""
+
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from src.notification import NotificationService
+from src.report_language import get_market_section_title
+
+
+def _make_result(*, code, sentiment_score, report_language="en"):
+    from src.analyzer import AnalysisResult
+
+    return AnalysisResult(
+        code=code,
+        name=code,
+        sentiment_score=sentiment_score,
+        trend_prediction="hold",
+        operation_advice="watch",
+        analysis_summary="test",
+        report_language=report_language,
+        success=True,
+    )
+
+
+class GroupResultsByMarketTestCase(unittest.TestCase):
+    def test_groups_in_canonical_market_order_with_score_sort_preserved(self):
+        results = sorted(
+            [
+                _make_result(code="AAPL", sentiment_score=80),
+                _make_result(code="RELIANCE.NS", sentiment_score=70),
+                _make_result(code="600519", sentiment_score=90),
+                _make_result(code="TCS.NS", sentiment_score=60),
+            ],
+            key=lambda r: r.sentiment_score,
+            reverse=True,
+        )
+
+        groups = NotificationService._group_results_by_market(results)
+
+        self.assertEqual([market for market, _ in groups], ["cn", "us", "in"])
+        self.assertEqual([r.code for _, group in groups for r in group][2:], ["RELIANCE.NS", "TCS.NS"])
+
+    def test_single_market_returns_one_group(self):
+        results = [_make_result(code="AAPL", sentiment_score=1), _make_result(code="TSLA", sentiment_score=2)]
+        groups = NotificationService._group_results_by_market(results)
+        self.assertEqual(len(groups), 1)
+        self.assertEqual(groups[0][0], "us")
+
+
+class DashboardReportMarketSectionsTestCase(unittest.TestCase):
+    def setUp(self):
+        self.service = NotificationService()
+
+    def test_multi_market_report_shows_localized_section_headings(self):
+        results = [
+            _make_result(code="AAPL", sentiment_score=80),
+            _make_result(code="RELIANCE.NS", sentiment_score=70),
+        ]
+        report = self.service.generate_dashboard_report(results, report_date="2026-08-30")
+
+        self.assertIn(get_market_section_title("us", "en"), report)
+        self.assertIn(get_market_section_title("in", "en"), report)
+
+    def test_single_market_report_has_no_section_heading(self):
+        results = [_make_result(code="AAPL", sentiment_score=80)]
+        report = self.service.generate_dashboard_report(results, report_date="2026-08-30")
+
+        self.assertNotIn(get_market_section_title("us", "en"), report)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_trading_calendar.py
+++ b/tests/test_trading_calendar.py
@@ -885,7 +885,7 @@ class ComputeEffectiveRegionTestCase(unittest.TestCase):
         with patch.object(trading_calendar, "_XCALS_AVAILABLE", False):
             self.assertEqual(
                 trading_calendar.get_open_markets_today(),
-                {"cn", "hk", "us", "jp", "kr", "tw"},
+                {"cn", "hk", "us", "jp", "kr", "tw", "in"},
             )
 
     def test_both_all_open_returns_comma_joined_supported_markets(self):


### PR DESCRIPTION
<!--
For Chinese contributors: 请直接用中文填写。
For English contributors: please fill in English. All fields marked (EN) accept English.
-->

## PR Type

- [ ] fix
- [ ] feat
- [ ] refactor
- [ ] docs
- [ ] chore
- [ ] test

## Background And Problem

请描述当前问题、影响范围与触发场景。  
*(EN) Describe the problem, its impact, and what triggers it.*

## Scope Of Change

请列出本 PR 修改的模块和文件范围。  
*(EN) List the modules and files changed in this PR.*

> 注意：请按实际 `git diff` 全量列出文件范围（建议注明文件总数），避免遗漏文档/后端/API/前端文件导致描述不一致。

> 若本 PR 修改了 `.github/PULL_REQUEST_TEMPLATE.md`、`.github/copilot-instructions.md`、`AGENTS.md`、`.github/instructions/*` 或 `.claude/skills/**` 等协作与治理文件，请补充“变更原因 + 影响面 + 回滚方式（默认 revert）”到 Summary / Compatibility / Rollback，避免 Scope 与描述不一致。

> 建议先执行并粘贴以下命令输出，避免与实际 diff 不一致：

```bash
BASE_REF=$(git merge-base HEAD origin/main)
git diff --stat "$BASE_REF"..HEAD
git diff --name-only "$BASE_REF"..HEAD
```

- 文件总数 / 变更行数（建议粘贴 `git diff --stat "$BASE_REF"..HEAD`）：
- 文件清单（按实际 diff 全量，逐项列出）：
- 文档更新文件（`docs/*`）：

## Issue Link

必须填写以下之一 / Fill in one of:
- `Fixes #<issue_number>`
- `Refs #<issue_number>`
- 无 Issue 时说明原因与验收标准 / If no issue, explain the motivation and acceptance criteria

## Verification Commands And Results

请填写你实际执行过的命令和关键结果（不要只写"已测试"）。  
*(EN) Paste the commands you actually ran and their key output (don't just write "tested"):*

```bash
# example
./scripts/ci_gate.sh
python -m pytest -m "not network"
```

> `Full-suite note` 必须与当次 PR 的当前 Head CI 结果保持一致；若本地复现存在环境相关失败，请明确标注“本地环境差异”并给出 GitHub CI 的结论与链接。  
> 请避免保留与本 PR 无关的历史失败措辞，按本次实际结果填报。
> 如历史描述中仍保留 `./scripts/ci_gate.sh` 失败记录，请先改为当前 Head CI 状态或说明与 Head CI 的差异来源。
> 若 `Full-suite note` 与当前 Head CI 不一致，PR 文本不完整，请先更新 PR 描述后再提交。

- 请在下面按实际结果填写并与 `Full-suite note` 保持一致（任一未填视为信息缺失）：
  - ai-governance：`pass` / `fail`，附链接
  - backend-gate：`pass` / `fail`，附链接
  - docker-build：`pass` / `fail` / `skipped`，运行时附链接
  - web-gate：`pass` / `fail` / `skipped`，运行时附链接
  - 若本 PR 修改 `.github/PULL_REQUEST_TEMPLATE.md` 等流程模板协作文件，请先说明变更必要性、影响边界，并明确回滚方式（默认 `revert this PR`）；否则请在下一版中拆为单独 chore PR。

关键输出/结论 / Key output & conclusion:

- 【必填】当前 Head CI：`ai-governance:pass / backend-gate:pass / docker-build:pass / web-gate:pass`（按实际结果替换）并附对应链接；按路径未运行的 Docker/Web 检查写为 `skipped`。
- 若需保留本地失败现象，请在同段写明“本地环境差异 + 当前 CI 通过/失败结果 + CI 链接”。  
- 若全部通过，需补充一句：`当前状态：全部通过（pass）`，并明确 Head CI 全部为 pass。  

- 建议将本行直接粘贴到 PR 描述正文首段：`当前 Head CI：ai-governance:pass / backend-gate:pass / docker-build:pass / web-gate:pass`（仅示例，按实际结果替换）。

> 若上述核验项与 PR 文本冲突，建议先更新 PR 描述再提交，避免审查因状态不一致被阻塞。

## Visual Evidence (if applicable)

【必填】若本 PR 修改报告格式、报告渲染效果或 Web UI 界面，请在此处附受影响报告 / 页面截图；涉及前后差异时，优先附前后对比。Issue / PR 过程截图、审查截图、一次性验收截图和临时可视证据请放在 PR 描述、PR 评论、GitHub 附件、Actions artifact 或外部可访问链接中，不要作为仓库文件合入。
*(EN) If this PR changes report formatting, report rendering, or Web UI, attach screenshots of the affected report/page here; before/after screenshots are preferred when relevant. Issue/PR process screenshots, review screenshots, one-off acceptance screenshots, and temporary visual evidence should be linked from the PR body/comments, GitHub attachments, Actions artifacts, or external accessible evidence; do not commit them as repository files.)*

> 如截图无法获取，请在“原因”中明确写明替代证据（如 Playwright/e2e 产物路径、审查链接）及其可追溯命令，不得留空。涉及 Web 设置/报告渲染变更时，需确保截图或替代证据明确指向变更项。
>
> 若本 PR 修改 Web UI，建议至少补一条可复现路径，例如（优先 settings page）：
>
> - Playwright 截图产物：`apps/dsa-web/e2e/smoke.spec.ts`（`cd apps/dsa-web && npx playwright test e2e/smoke.spec.ts --grep "settings page renders title and save actions after login"`）
> - 审查证据链接：可直接使用 Actions 产物、GitHub 评论附件或外部可访问链接。

> 替代证据模板（设置页变更建议）：
> - 命令：`cd apps/dsa-web && npx playwright test e2e/smoke.spec.ts --grep "settings page"`
> - 产物路径：`apps/dsa-web/test-results/**/smoke-settings-page-*.png`
> - 说明：截图中应可见本次修改的系统设置项（字段、标签、帮助文案）

- 截图链接 / Screenshot links（Web UI/报告改动项必填，未提供请在下方“不适用原因”给出替代证据）：
- settings 页建议命名：`smoke-settings-page-zh` / `smoke-settings-page-en`
- 前后对比 / Before & After（如有）：
- settings 字段变更说明：截图或产物应明确包含 `MARKET_REVIEW_REGION` 字段与帮助文案区块（中文/英文）。
- 不适用原因 / Reason if not applicable（若未附截图，此项务必填写，且包含可复现证据与命令）：
  - Playwright 命令（无截图时）：`cd apps/dsa-web && npx playwright test e2e/smoke.spec.ts --grep "settings page"`
  - 产物路径（无截图时）：`apps/dsa-web/test-results/**/smoke-settings-page-*.png`
  - 说明：截图（或产物）必须可见本次修改的设置字段文案与帮助信息。

> 若本 PR 修改 Web 设置字段（字段、文案或帮助文案），截图或替代证据必须可定位到对应设置项区域并可追溯至变更项；该项为必填。

> 若本 PR 修改 Web UI 或报告展示且无法获取截图，原因栏必须给出可复现替代证据（例如 Playwright 截图产物路径 + 命令），且不得留空。

## Compatibility And Risk

请说明兼容性影响、潜在风险（如无请写 `None`）。  
*(EN) Describe compatibility impact and potential risks (write `None` if not applicable).*

- 若本 PR 修改第三方模型 / API 的兼容语义、请求参数、路由前缀或 provider fallback，请提供**官方来源链接或公告**，并说明这是长期约束、当前运行时约束还是临时兼容处理。  
  请在下方补充所影响外部 API/服务、回归范围与回退方式。  
  *(EN) If this PR changes third-party model/API compatibility, request parameters, routing prefixes, or provider fallback behavior, include an **official source link or announcement** and clarify whether the rule is permanent, runtime-specific, or a temporary compatibility workaround.)*
- 若本 PR 未触及第三方模型/API、provider/model/base URL 或运行时配置保存/清理/迁移逻辑，请在此段直接按以下文案确认（无须再次展开）：  
  `本 PR 未变更 provider/model/base URL、运行时配置清理迁移语义；历史配置保持不变；回滚方式为 revert 本提交。`
- 若本 PR 修改 `.github/PULL_REQUEST_TEMPLATE.md` / PR 流程模板类文件，请在此明确：仅影响协作流程与模板维护，不改 runtime 行为；回退方式为 revert；并补充是否影响自动化提交流程。  
  *(EN) If this PR changes `.github/PULL_REQUEST_TEMPLATE.md` or other PR workflow files, state that it only affects contribution governance templates (no runtime behavior), provide rollback by revert, and note any CI/checklist impact.)*
- 若本 PR 依赖特定运行时 / 锁定依赖窗口（例如 LiteLLM 版本范围、OpenAI-compatible 路由、YAML alias 行为），请写明当前验证过的兼容范围与覆盖路径。  
  *(EN) If this PR depends on a specific runtime or pinned dependency window (for example a LiteLLM version range, OpenAI-compatible routing, or YAML alias behavior), state the compatibility window you verified and which code paths were covered.)*
- 若本 PR 触及运行时配置保存、清理、迁移或回填逻辑，请明确说明旧配置是否会被自动改写、清空、迁移或保持不变，以及用户如何恢复原行为。  
  *(EN) If this PR touches runtime config save/cleanup/migration/backfill logic, explicitly describe whether existing config is rewritten, cleared, migrated, or left intact, and how users can restore the previous behavior.)*
- 若本 PR **未触及** provider/model/base URL 或运行时配置保存/清理/迁移逻辑（本条仅作为声明），请明确写：`本 PR 未变更 provider/model/base URL、运行时配置清理迁移语义；历史配置保持不变；回滚方式为 revert 本提交。`

## Rollback Plan

请至少写一句可执行的回滚方案（必填）。  
*(EN) Provide at least one actionable rollback step (required).*

- 如果是兼容性修复，默认应写出**最小回滚方式**（例如 `revert this PR`），并说明是否需要额外回滚配置或数据迁移。  
  *(EN) For compatibility fixes, include the **minimal rollback path** (for example `revert this PR`) and whether any additional config or data rollback is required.)*

## EXTRACT_PROMPT Change (if applicable)

若本 PR 修改了 `src/services/image_stock_extractor.py` 中的 `EXTRACT_PROMPT`，请在此处粘贴完整变更后的 prompt。  
*If this PR changes `EXTRACT_PROMPT` in `src/services/image_stock_extractor.py`, paste the full updated prompt here:*

<details>
<summary>展开 / Expand: Full EXTRACT_PROMPT</summary>

```
(paste full prompt here)
```

</details>

## Checklist

- [ ] 本 PR 有明确动机和业务价值 / This PR has a clear motivation and value
- [ ] 已提供可复现的验证命令与结果 / Reproducible verification commands and results are included
- [ ] 已评估兼容性与风险 / Compatibility and risk have been assessed
- [ ] 已提供回滚方案 / A rollback plan is provided
- [ ] 若修改报告格式或 Web UI 界面，已在 PR 描述/评论附受影响报告 / 页面截图，且未把一次性验收截图作为仓库文件合入 / If report formatting or Web UI changed, affected report/page screenshots are linked in the PR body/comments and one-off acceptance screenshots are not committed as repository files
- [ ] 若本 PR 修改 Web 设置字段（字段、文案或帮助文本），请补充设置页截图；无法截图时需提供替代可视证据（命令 + 产物路径），并指向对应变更项 / If Web settings fields changed (labels or help text), screenshots of the settings page are required; if unavailable, provide alternative visual evidence with command + artifact path that points to the changed item.
- [ ] 若涉及用户可见变更，已同步更新相关文档与 `docs/CHANGELOG.md`；`README.md` 仅在首页级信息变化时更新，细节优先写入 `docs/*.md` / If user-visible changes are included, relevant docs and `docs/CHANGELOG.md` are updated; `README.md` is updated only for homepage-level changes, with details kept in `docs/*.md`
