### PR TITLE
fix: 避免外部 unable 降低 Skill 预测权重

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 ## [Unreleased]
 - [新功能] 新增 `SEARXNG_TIMEOUT_SECONDS` 配置自建 SearXNG 单次搜索超时（默认 10 秒），已接线全部 SearchService 构造入口（含题材搜索子进程重建）与默认 GitHub Actions 工作流
 
+- [修复] Skill Outcome 自动权重仅惩罚明确归因于 Skill 的 unable，股票身份、市场上下文、交易日历及未知原因继续计入可评估性统计但保持权重中性。
 - [修复] 美股日线路由现按各数据源当前优先级排序，单项 `*_PRIORITY` 配置（如 `YFINANCE_PRIORITY=0`）对美股即时生效；指数固定首选与 Longbridge preferred 语义保持不变
 
 - [新功能] 新增个股研究聚合 API，以统一 canonical code 返回行情、历史、研究产物、资讯、缓存持仓关系和监控规则，并对每个块独立标记 fresh/partial/unavailable。

--- a/docs/multi-strategy-contract.md
+++ b/docs/multi-strategy-contract.md
@@ -24,9 +24,9 @@ Outcome 核心阶段（#2116）基于已合并的 #2073，只提供 Outcome eval
 
 ### Skill Opinion Outcome 表现统计
 
-Outcome 统计是只读数据面，按 `skill_id + horizon + engine_version` 独立分 bucket。任何 bucket 都不能借用同 skill 的其他 horizon、其他 skill、其他 engine version 或全局样本解锁指标。当前固定门槛为 `evaluated >= 30`；只有 individual skill opinion 自身 signal 产生的 `hit` / `miss` 计入 evaluated，`pending`、`observational` 和 `unable` 只保留计数，不计入样本充足度。
+Outcome 统计是只读数据面，按 `skill_id + horizon + engine_version` 独立分 bucket。任何 bucket 都不能借用同 skill 的其他 horizon、其他 skill、其他 engine version 或全局样本解锁指标。当前固定门槛为 `evaluated >= 30`；只有 individual skill opinion 自身 signal 产生的 `hit` / `miss` 计入 evaluated，`pending`、`observational` 和 `unable` 只保留计数，不计入样本充足度。终态 `unable` 继续保留总数，并按稳定 reason 映射派生 `skill_attributable_unable`、`external_unable` 和 `unclassified_unable`；未知 reason 必须进入 `unclassified`，不得默认归因于 Skill。
 
-样本不足时，bucket 的 `sample_status` 为 `observational`，计数继续返回，但 `hit_rate_pct`、`miss_rate_pct`、`avg_directional_return_pct` 和 `unable_rate_pct` 全部为 `null`，不得输出排名或推导权重。样本充足时，hit/miss rate 以 `hit + miss` 为分母，平均方向收益只使用 evaluated rows；unable rate 以终态记录 `evaluated + observational + unable` 为分母，临时 `pending` 不得稀释永久失败比例。
+样本不足时，bucket 的 `sample_status` 为 `observational`，计数继续返回，但 `hit_rate_pct`、`miss_rate_pct`、`avg_directional_return_pct`、`unable_rate_pct` 和 `skill_attributable_unable_rate_pct` 全部为 `null`，不得输出排名或推导权重。样本充足时，hit/miss rate 以 `hit + miss` 为分母，平均方向收益只使用 evaluated rows；原有 unable rate 仍以终态记录 `evaluated + observational + unable` 为分母，作为数据质量/可评估性指标，临时 `pending` 不得稀释永久失败比例。预测权重只消费明确归因于 Skill 的 unable；外部上下文、契约异常和未知 reason 均不参与惩罚。
 
 只读统计阶段（PR #2119）本身不修改 `BacktestService.get_skill_summary()`、`AgentMemory` 或 `SkillAggregator`，也不新增 API、Pipeline 自动触发和 Web 展示；本页后文的 Phase 4 在该统计契约之上独立接入保守运行时权重。当前组合实现仍只读消费已经持久化的 Outcome，不负责自动触发 evaluator。
 
@@ -391,14 +391,16 @@ individual Skill Outcome 调整运行时相对权重。权重统计继续严格�
 n = hit + miss
 posterior_hit_rate = (hit + 15) / (n + 30)
 direction_score = 2 * posterior_hit_rate - 1
-unable_rate = unable / (evaluated + observational + unable)
-bucket_score = clamp(direction_score - 0.25 * unable_rate, -1, 1)
+attributable_unable_rate =
+    skill_attributable_unable
+    / (evaluated + observational + skill_attributable_unable)
+bucket_score = clamp(direction_score - 0.25 * attributable_unable_rate, -1, 1)
 evidence_strength = n / (n + 30)
 ```
 
-`pending` 不进入 unable rate 分母，`observational` / `unable` 不能补足
-evaluated 门槛。当前 opinion 没有可信 horizon，因此只对已经各自满足门槛的
-bucket 做证据强度加权模型平均：
+当前 `skill-opinion-outcome-v1` 的正常生产链没有可归因于预测能力的终态 unable reason：股票身份、分析日期、市场快照、effective date 与交易日历失败都归为 `external_unable`；`invalid_signal`、`unsupported_horizon` 以及未知 reason 归为 `unclassified_unable`。当前 sample 链已在持久化前排除非法 signal，因此这类契约异常不能反向惩罚 Skill。只有未来明确加入归因白名单的 reason 才能进入 `skill_attributable_unable`；新增 reason 默认 fail-neutral。
+
+`pending` 不进入任一 unable rate 分母，`observational` / `unable` 不能补足 evaluated 门槛。当前 opinion 没有可信 horizon，因此只对已经各自满足门槛的 bucket 做证据强度加权模型平均：
 
 ```text
 combined_score =

--- a/src/core/skill_opinion_outcome_evaluator.py
+++ b/src/core/skill_opinion_outcome_evaluator.py
@@ -20,6 +20,38 @@ SUPPORTED_SKILL_OUTCOME_HORIZONS = {
 
 _BULLISH_SIGNALS = frozenset({"strong_buy", "buy"})
 
+SKILL_UNABLE_ATTRIBUTION_SKILL = "skill_attributable"
+SKILL_UNABLE_ATTRIBUTION_EXTERNAL = "external"
+SKILL_UNABLE_ATTRIBUTION_UNCLASSIFIED = "unclassified"
+
+# The current sample contract persists only valid, canonical Skill opinions, so
+# v1 has no normally reachable terminal reason that represents prediction
+# quality.  Keep this explicit allowlist empty until the evaluator gains such a
+# reason; newly introduced reasons must never become weight penalties by
+# default.
+SKILL_ATTRIBUTABLE_UNABLE_REASONS = frozenset()
+EXTERNAL_SKILL_UNABLE_REASONS = frozenset(
+    {
+        "invalid_stock_code",
+        "missing_analysis_date",
+        "invalid_market_phase_context",
+        "invalid_effective_daily_bar_date",
+        "future_effective_daily_bar_date",
+        "unresolvable_expected_start_date",
+    }
+)
+
+
+def classify_skill_opinion_unable_reason(reason: Any) -> str:
+    """Classify a terminal unable reason without defaulting to Skill blame."""
+
+    normalized = str(reason or "").strip()
+    if normalized in SKILL_ATTRIBUTABLE_UNABLE_REASONS:
+        return SKILL_UNABLE_ATTRIBUTION_SKILL
+    if normalized in EXTERNAL_SKILL_UNABLE_REASONS:
+        return SKILL_UNABLE_ATTRIBUTION_EXTERNAL
+    return SKILL_UNABLE_ATTRIBUTION_UNCLASSIFIED
+
 
 @dataclass(frozen=True)
 class SkillOpinionOutcomeEvaluation:

--- a/src/repositories/skill_opinion_outcome_repo.py
+++ b/src/repositories/skill_opinion_outcome_repo.py
@@ -44,6 +44,7 @@ class SkillOpinionPerformanceBucket:
     hit: int
     miss: int
     avg_directional_return_pct: Optional[float]
+    unable_reason_counts: Dict[str, int]
 
 
 class SkillOpinionOutcomeRepository:
@@ -262,6 +263,41 @@ class SkillOpinionOutcomeRepository:
                 )
             ).all()
 
+            unable_reason_rows = session.execute(
+                select(
+                    SkillOpinionSampleRecord.skill_id,
+                    SkillOpinionOutcomeRecord.horizon,
+                    SkillOpinionOutcomeRecord.engine_version,
+                    SkillOpinionOutcomeRecord.unable_reason,
+                    func.count(SkillOpinionOutcomeRecord.id),
+                )
+                .join(
+                    SkillOpinionSampleRecord,
+                    SkillOpinionSampleRecord.id
+                    == SkillOpinionOutcomeRecord.skill_opinion_sample_id,
+                )
+                .where(
+                    and_(
+                        *conditions,
+                        SkillOpinionOutcomeRecord.eval_status == "unable",
+                    )
+                )
+                .group_by(
+                    SkillOpinionSampleRecord.skill_id,
+                    SkillOpinionOutcomeRecord.horizon,
+                    SkillOpinionOutcomeRecord.engine_version,
+                    SkillOpinionOutcomeRecord.unable_reason,
+                )
+            ).all()
+
+        unable_reason_counts: Dict[Tuple[str, str, str], Dict[str, int]] = {}
+        for row in unable_reason_rows:
+            bucket_key = (str(row[0]), str(row[1]), str(row[2]))
+            reason = str(row[3] or "").strip()
+            unable_reason_counts.setdefault(bucket_key, {})[reason] = int(
+                row[4] or 0
+            )
+
         return [
             SkillOpinionPerformanceBucket(
                 skill_id=str(row[0]),
@@ -276,6 +312,12 @@ class SkillOpinionOutcomeRepository:
                 miss=int(row[9] or 0),
                 avg_directional_return_pct=(
                     float(row[10]) if row[10] is not None else None
+                ),
+                unable_reason_counts=dict(
+                    unable_reason_counts.get(
+                        (str(row[0]), str(row[1]), str(row[2])),
+                        {},
+                    )
                 ),
             )
             for row in rows

--- a/src/services/skill_opinion_performance_service.py
+++ b/src/services/skill_opinion_performance_service.py
@@ -7,6 +7,9 @@ from typing import Any, Dict, List, Optional, Sequence
 
 from src.core.skill_opinion_outcome_evaluator import (
     SUPPORTED_SKILL_OUTCOME_HORIZONS,
+    SKILL_UNABLE_ATTRIBUTION_EXTERNAL,
+    SKILL_UNABLE_ATTRIBUTION_SKILL,
+    classify_skill_opinion_unable_reason,
 )
 from src.repositories.skill_opinion_outcome_repo import (
     SkillOpinionOutcomeRepository,
@@ -95,6 +98,16 @@ class SkillOpinionPerformanceService:
         terminal_denominator = (
             bucket.evaluated + bucket.observational + bucket.unable
         )
+        (
+            skill_attributable_unable,
+            external_unable,
+            unclassified_unable,
+        ) = SkillOpinionPerformanceService._classify_unable_counts(bucket)
+        attributable_terminal_denominator = (
+            bucket.evaluated
+            + bucket.observational
+            + skill_attributable_unable
+        )
         return {
             "skill_id": bucket.skill_id,
             "horizon": bucket.horizon,
@@ -104,6 +117,9 @@ class SkillOpinionPerformanceService:
             "evaluated": bucket.evaluated,
             "observational": bucket.observational,
             "unable": bucket.unable,
+            "skill_attributable_unable": skill_attributable_unable,
+            "external_unable": external_unable,
+            "unclassified_unable": unclassified_unable,
             "hit": bucket.hit,
             "miss": bucket.miss,
             "sample_sufficient": sample_sufficient,
@@ -131,7 +147,34 @@ class SkillOpinionPerformanceService:
                 if sample_sufficient and terminal_denominator
                 else None
             ),
+            "skill_attributable_unable_rate_pct": (
+                round(
+                    skill_attributable_unable
+                    / attributable_terminal_denominator
+                    * 100,
+                    2,
+                )
+                if sample_sufficient and attributable_terminal_denominator
+                else None
+            ),
         }
+
+    @staticmethod
+    def _classify_unable_counts(
+        bucket: SkillOpinionPerformanceBucket,
+    ) -> tuple[int, int, int]:
+        skill_attributable = 0
+        external = 0
+        unclassified = 0
+        for reason, count in bucket.unable_reason_counts.items():
+            attribution = classify_skill_opinion_unable_reason(reason)
+            if attribution == SKILL_UNABLE_ATTRIBUTION_SKILL:
+                skill_attributable += count
+            elif attribution == SKILL_UNABLE_ATTRIBUTION_EXTERNAL:
+                external += count
+            else:
+                unclassified += count
+        return skill_attributable, external, unclassified
 
     @staticmethod
     def _required_text(value: Any, field_name: str) -> str:

--- a/src/services/skill_opinion_weight_service.py
+++ b/src/services/skill_opinion_weight_service.py
@@ -163,21 +163,48 @@ class SkillOpinionWeightService:
             bucket.get("observational")
         )
         unable = SkillOpinionWeightService._count(bucket.get("unable"))
-        if None in (evaluated, hit, miss, observational, unable):
+        skill_attributable_unable = SkillOpinionWeightService._count(
+            bucket.get("skill_attributable_unable")
+        )
+        external_unable = SkillOpinionWeightService._count(
+            bucket.get("external_unable")
+        )
+        unclassified_unable = SkillOpinionWeightService._count(
+            bucket.get("unclassified_unable")
+        )
+        if None in (
+            evaluated,
+            hit,
+            miss,
+            observational,
+            unable,
+            skill_attributable_unable,
+            external_unable,
+            unclassified_unable,
+        ):
             return None
         if evaluated < MIN_SKILL_OUTCOME_SAMPLE_SIZE:
             return None
         if hit + miss != evaluated:
+            return None
+        if (
+            skill_attributable_unable
+            + external_unable
+            + unclassified_unable
+            != unable
+        ):
             return None
 
         posterior_hit_rate = (
             hit + _BETA_PRIOR_HITS
         ) / (evaluated + _BETA_PRIOR_SIZE)
         direction_score = 2.0 * posterior_hit_rate - 1.0
-        terminal_count = evaluated + observational + unable
+        terminal_count = (
+            evaluated + observational + skill_attributable_unable
+        )
         if terminal_count <= 0:
             return None
-        unable_rate = unable / terminal_count
+        unable_rate = skill_attributable_unable / terminal_count
         bucket_score = min(
             1.0,
             max(

--- a/tests/test_skill_opinion_outcome_stats.py
+++ b/tests/test_skill_opinion_outcome_stats.py
@@ -55,6 +55,7 @@ def _add_outcome(
     eval_status: str,
     outcome: str | None = None,
     directional_return_pct: float | None = None,
+    unable_reason: str = "invalid_metadata",
 ) -> None:
     with db.session_scope() as session:
         history = AnalysisHistory(
@@ -89,7 +90,7 @@ def _add_outcome(
                 ),
                 directional_return_pct=directional_return_pct,
                 unable_reason=(
-                    "invalid_metadata" if eval_status == "unable" else None
+                    unable_reason if eval_status == "unable" else None
                 ),
             )
         )
@@ -130,6 +131,7 @@ def test_repository_aggregates_raw_bucket_counts(isolated_db) -> None:
     assert bucket.hit == 1
     assert bucket.miss == 1
     assert bucket.avg_directional_return_pct == pytest.approx(1.5)
+    assert bucket.unable_reason_counts == {"invalid_metadata": 1}
 
 
 def test_service_keeps_insufficient_bucket_observational(isolated_db) -> None:
@@ -161,6 +163,9 @@ def test_service_keeps_insufficient_bucket_observational(isolated_db) -> None:
     assert bucket["evaluated"] == 2
     assert bucket["observational"] == 1
     assert bucket["unable"] == 1
+    assert bucket["skill_attributable_unable"] == 0
+    assert bucket["external_unable"] == 0
+    assert bucket["unclassified_unable"] == 1
     assert bucket["pending"] == 1
     assert bucket["hit"] == 1
     assert bucket["miss"] == 1
@@ -170,6 +175,7 @@ def test_service_keeps_insufficient_bucket_observational(isolated_db) -> None:
     assert bucket["miss_rate_pct"] is None
     assert bucket["avg_directional_return_pct"] is None
     assert bucket["unable_rate_pct"] is None
+    assert bucket["skill_attributable_unable_rate_pct"] is None
 
 
 def test_service_unlocks_metrics_at_exact_sample_threshold(isolated_db) -> None:
@@ -204,6 +210,43 @@ def test_service_unlocks_metrics_at_exact_sample_threshold(isolated_db) -> None:
     assert bucket["miss_rate_pct"] == 40.0
     assert bucket["avg_directional_return_pct"] == 0.8
     assert bucket["unable_rate_pct"] == 6.06
+    assert bucket["skill_attributable_unable"] == 0
+    assert bucket["external_unable"] == 0
+    assert bucket["unclassified_unable"] == 2
+    assert bucket["skill_attributable_unable_rate_pct"] == 0.0
+
+
+def test_service_separates_external_and_unclassified_unable(
+    isolated_db,
+) -> None:
+    for _ in range(30):
+        _add_outcome(
+            isolated_db,
+            eval_status="evaluated",
+            outcome="hit",
+            directional_return_pct=1.0,
+        )
+    _add_outcome(
+        isolated_db,
+        eval_status="unable",
+        unable_reason="invalid_market_phase_context",
+    )
+    _add_outcome(
+        isolated_db,
+        eval_status="unable",
+        unable_reason="future_reason",
+    )
+
+    bucket = SkillOpinionPerformanceService(
+        db_manager=isolated_db
+    ).get_stats()["buckets"][0]
+
+    assert bucket["unable"] == 2
+    assert bucket["skill_attributable_unable"] == 0
+    assert bucket["external_unable"] == 1
+    assert bucket["unclassified_unable"] == 1
+    assert bucket["unable_rate_pct"] == 6.25
+    assert bucket["skill_attributable_unable_rate_pct"] == 0.0
 
 
 def test_non_evaluated_rows_do_not_unlock_metrics(isolated_db) -> None:

--- a/tests/test_skill_opinion_outcomes.py
+++ b/tests/test_skill_opinion_outcomes.py
@@ -13,7 +13,13 @@ from sqlalchemy import inspect
 from sqlalchemy.exc import IntegrityError
 
 from src.config import Config
-from src.core.skill_opinion_outcome_evaluator import SkillOpinionOutcomeEvaluator
+from src.core.skill_opinion_outcome_evaluator import (
+    SKILL_ATTRIBUTABLE_UNABLE_REASONS,
+    SKILL_UNABLE_ATTRIBUTION_EXTERNAL,
+    SKILL_UNABLE_ATTRIBUTION_UNCLASSIFIED,
+    SkillOpinionOutcomeEvaluator,
+    classify_skill_opinion_unable_reason,
+)
 from src.repositories.skill_opinion_outcome_repo import SkillOpinionOutcomeRepository
 from src.services.skill_opinion_outcome_service import (
     SKILL_OPINION_OUTCOME_ENGINE_VERSION,
@@ -49,6 +55,39 @@ def isolated_db(tmp_path):
 
 def _bar(day: date, close: float):
     return SimpleNamespace(date=day, close=close)
+
+
+@pytest.mark.parametrize(
+    "reason",
+    [
+        "invalid_stock_code",
+        "missing_analysis_date",
+        "invalid_market_phase_context",
+        "invalid_effective_daily_bar_date",
+        "future_effective_daily_bar_date",
+        "unresolvable_expected_start_date",
+    ],
+)
+def test_current_context_unable_reasons_are_external(reason) -> None:
+    assert (
+        classify_skill_opinion_unable_reason(reason)
+        == SKILL_UNABLE_ATTRIBUTION_EXTERNAL
+    )
+
+
+@pytest.mark.parametrize(
+    "reason",
+    ["invalid_signal", "unsupported_horizon", "future_reason", None, ""],
+)
+def test_contract_and_unknown_unable_reasons_are_unclassified(reason) -> None:
+    assert (
+        classify_skill_opinion_unable_reason(reason)
+        == SKILL_UNABLE_ATTRIBUTION_UNCLASSIFIED
+    )
+
+
+def test_current_engine_has_no_skill_attributable_unable_reason() -> None:
+    assert SKILL_ATTRIBUTABLE_UNABLE_REASONS == frozenset()
 
 
 def _add_sample(

--- a/tests/test_skill_opinion_weights.py
+++ b/tests/test_skill_opinion_weights.py
@@ -55,8 +55,17 @@ def _bucket(
     miss=12,
     observational=0,
     unable=0,
+    skill_attributable_unable=0,
+    external_unable=None,
+    unclassified_unable=0,
     sample_sufficient=True,
 ):
+    if external_unable is None:
+        external_unable = (
+            unable
+            - skill_attributable_unable
+            - unclassified_unable
+        )
     return {
         "skill_id": skill_id,
         "horizon": horizon,
@@ -66,6 +75,9 @@ def _bucket(
         "evaluated": evaluated,
         "observational": observational,
         "unable": unable,
+        "skill_attributable_unable": skill_attributable_unable,
+        "external_unable": external_unable,
+        "unclassified_unable": unclassified_unable,
         "hit": hit,
         "miss": miss,
         "sample_sufficient": sample_sufficient,
@@ -145,6 +157,45 @@ def _add_real_hits(
                     outcome="hit",
                     direction_correct=True,
                     directional_return_pct=1.0,
+                )
+            )
+
+
+def _add_real_external_unable(
+    db: DatabaseManager,
+    *,
+    skill_id: str,
+    count: int,
+) -> None:
+    with db.session_scope() as session:
+        for index in range(count):
+            history = AnalysisHistory(
+                query_id=f"weight-unable-{skill_id}-{index}",
+                code="600519",
+                report_type="simple",
+                operation_advice="buy",
+            )
+            session.add(history)
+            session.flush()
+            sample = SkillOpinionSampleRecord(
+                analysis_history_id=history.id,
+                stock_code="600519",
+                skill_id=skill_id,
+                signal="buy",
+                confidence=1.0,
+                sample_schema_version="skill-opinion-sample-v1",
+            )
+            session.add(sample)
+            session.flush()
+            session.add(
+                SkillOpinionOutcomeRecord(
+                    skill_opinion_sample_id=sample.id,
+                    horizon="1d",
+                    engine_version=(
+                        SKILL_OPINION_OUTCOME_ENGINE_VERSION
+                    ),
+                    eval_status="unable",
+                    unable_reason="invalid_market_phase_context",
                 )
             )
 
@@ -242,7 +293,7 @@ def test_sufficient_horizons_use_evidence_weighted_model_average():
     assert weights["alpha"] == pytest.approx(1.2 ** combined_score)
 
 
-def test_terminal_unable_rate_conservatively_reduces_factor():
+def test_external_unable_does_not_reduce_prediction_factor():
     service = _service(
         _bucket(
             evaluated=30,
@@ -254,7 +305,24 @@ def test_terminal_unable_rate_conservatively_reduces_factor():
 
     weights = service.compute_weights(["alpha"])
 
-    # direction=0.5, terminal unable rate=30/(30+30)=0.5,
+    assert weights["alpha"] == pytest.approx(1.2 ** 0.5)
+
+
+def test_skill_attributable_unable_conservatively_reduces_factor():
+    service = _service(
+        _bucket(
+            evaluated=30,
+            hit=30,
+            miss=0,
+            unable=30,
+            skill_attributable_unable=30,
+            external_unable=0,
+        ),
+    )
+
+    weights = service.compute_weights(["alpha"])
+
+    # direction=0.5, attributable unable rate=30/(30+30)=0.5,
     # bucket score=0.5-0.25*0.5=0.375.
     assert weights["alpha"] == pytest.approx(1.2 ** 0.375)
     assert 1.0 < weights["alpha"] < 1.2 ** 0.5
@@ -267,6 +335,8 @@ def test_extreme_negative_evidence_stays_at_multiplicative_lower_bound():
             hit=0,
             miss=300,
             unable=300,
+            skill_attributable_unable=300,
+            external_unable=0,
         ),
     )
 
@@ -282,6 +352,20 @@ def test_extreme_negative_evidence_stays_at_multiplicative_lower_bound():
         _bucket(evaluated=30, hit=31, miss=-1),
         _bucket(evaluated=30, hit=20, miss=10, unable=-1),
         _bucket(evaluated=30, hit=20, miss=9),
+        _bucket(
+            evaluated=30,
+            hit=20,
+            miss=10,
+            unable=1,
+            external_unable=0,
+        ),
+        _bucket(
+            evaluated=30,
+            hit=20,
+            miss=10,
+            unable=1,
+            unclassified_unable=-1,
+        ),
     ],
 )
 def test_malformed_bucket_fails_neutral(bucket):
@@ -316,6 +400,11 @@ def test_real_outcomes_flow_through_statistics_into_aggregator(
     isolated_db,
 ):
     _add_real_hits(isolated_db, skill_id="alpha", count=30)
+    _add_real_external_unable(
+        isolated_db,
+        skill_id="alpha",
+        count=30,
+    )
     weight_service = SkillOpinionWeightService(
         performance_service=SkillOpinionPerformanceService(
             db_manager=isolated_db


### PR DESCRIPTION
## PR 类型

- [x] fix
- [ ] feat
- [ ] refactor
- [ ] docs
- [ ] chore
- [x] test

## 背景与问题

Skill Opinion 历史权重此前会把所有 `unable` 结果计入预测惩罚。股票代码解析、市场上下文、交易日历、历史数据兼容或行情数据条件等外部原因并不代表 SkillAgent 的预测质量，却会降低经常覆盖港股、遗留代码或数据质量较差场景的 Skill 权重。

## 修改范围

- 在 outcome evaluator 中集中定义稳定的 unable 归因映射：`skill_attributable`、`external`、`unclassified`
- repository 按现有 skill / horizon / engine bucket 聚合 `unable_reason_counts`
- performance service 保留旧 `unable` / `unable_rate`，并追加三类归因计数及 attributable rate
- weight service 仅使用 `skill_attributable_unable` 计算预测惩罚；分类缺失、计数不守恒或未来未知原因均 fail-neutral
- 补充 evaluator、统计链路和权重回归测试
- 更新多策略契约文档与 CHANGELOG

共 9 个文件，新增 332 行、删除 14 行。

## Issue / 验收标准

暂无关联 Issue。本修复源于 Skill Outcome 自动权重链路的公平性检查。

验收标准：

- 外部数据/上下文导致的 unable 不降低预测权重
- 只有明确归因于 Skill 的 unable 才参与预测惩罚
- 未知或旧数据无法稳定归因时保持中性
- 旧统计字段和 engine_version 分桶语义保持兼容
- 分类计数异常时不产生错误权重

## 验证

- `python -m pytest -q tests/test_skill_opinion_outcomes.py tests/test_skill_opinion_outcome_stats.py tests/test_skill_opinion_weights.py`
  - 76 passed，1 个依赖弃用 warning
- `python -m py_compile <changed Python files>`
  - passed
- `python -m flake8 <changed Python files>`
  - passed
- `git diff --check upstream/main...HEAD`
  - passed

本地未完整执行 `scripts/ci_gate.sh`：当前 Windows sandbox 的 WSL 启动被 `E_ACCESSDENIED` 阻止。非 network 全量 pytest 曾运行到约 12%，目标模块通过，但被与本改动无关的 Windows Codex app-server platform status 测试阻断；以本 PR 的 GitHub CI 为最终全量证据。

## 当前 Head CI

- `ai-governance`: passed
- `backend-gate`: running（3 个 backend test shards）
- `docker-build`: running
- `web-gate`: skipped（无 Web 改动）

## 可视证据

不适用。本 PR 不修改报告格式、报告渲染或 Web UI；可复现证据为上述定向 pytest。

## 兼容性与回滚

本 PR 未变更 provider/model/base URL、运行时配置清理迁移语义；历史配置保持不变；回滚方式为 revert 本提交。

- 不新增 schema、API 或配置项，也不需要数据迁移
- 旧 `unable` / `unable_rate` 字段继续输出
- 旧数据、未知 reason、缺失分类和异常聚合均采用 fail-neutral
- 紧急运行时缓解可设置 `AGENT_SKILL_AUTOWEIGHT=false`
- 完整回滚可 revert 本提交，无需数据库或配置回滚

## EXTRACT_PROMPT

不适用；未修改 `src/services/image_stock_extractor.py`。

## 自查

- [x] 已基于最新 `upstream/main`（`ac8bd29b`）变基
- [x] 改动范围聚焦于 unable 归因与权重契约
- [x] 已补充真实生产调用链回归测试
- [x] 已更新专题文档与 `docs/CHANGELOG.md`
- [x] 未修改配置、API、Schema、Web 或 Desktop
- [x] 已提供兼容性、风险与回滚说明
