### PR TITLE
feat(evals): 新增 agent trajectory 评估管线（纯函数指标层 + golden 样例）

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -45,7 +45,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - [修复] 阻止任意更新的非 bundled 指数候选（含 legacy `static` 子集）在 remote 缺失/损坏时以 active-index 子集覆盖 bundled baseline：所有非 bundled 候选必须为 bundled active-index canonical 集合的合法超集，否则回退 bundled 并记录 WARNING。
 - [新功能] 桌面端全局右上角增加更新入口，与设置页共用更新状态；普通浏览器 WebUI 不展示，且不会在挂载时重复触发后台检查。
 - [修复] 桌面端右上角更新入口与设置页共用检查中状态，避免一侧检查时另一侧仍可重复触发 GitHub Releases 检查；主进程手动检查路径同步增加 in-flight 防重。
-- [新功能] 新增 agent trajectory 评估管线（`evals/agent_trajectory`）：纯函数指标模块消费 `tool_calls_log` 计算工具命中率、冗余与缓存调用、失败重试与步数效率（含 `golden_samples.json` 3 个样例与单元测试）；不修改 `src/` 执行语义、不接入 CI 阻断门、不新增运行时配置。
+- [新功能] 新增 agent trajectory 评估管线（`evals/agent_trajectory`）：纯函数指标模块消费 `tool_calls_log` 计算工具命中率、冗余与缓存调用、失败重试与步数效率（含 `golden_samples.json` 3 个样例、`expected_outcomes` 轨迹特征断言与单元测试）；不修改 `src/` 执行语义、不接入 CI 阻断门、不新增运行时配置。
 
 ## [3.31.0] - 2026-08-23
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -45,7 +45,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - [修复] 阻止任意更新的非 bundled 指数候选（含 legacy `static` 子集）在 remote 缺失/损坏时以 active-index 子集覆盖 bundled baseline：所有非 bundled 候选必须为 bundled active-index canonical 集合的合法超集，否则回退 bundled 并记录 WARNING。
 - [新功能] 桌面端全局右上角增加更新入口，与设置页共用更新状态；普通浏览器 WebUI 不展示，且不会在挂载时重复触发后台检查。
 - [修复] 桌面端右上角更新入口与设置页共用检查中状态，避免一侧检查时另一侧仍可重复触发 GitHub Releases 检查；主进程手动检查路径同步增加 in-flight 防重。
-- [新功能] 新增 agent trajectory 评估管线（`evals/agent_trajectory`）：纯函数指标模块消费 `tool_calls_log` 计算工具命中率、冗余与缓存调用、失败重试与步数效率（含 `golden_samples.json` 3 个样例、`expected_outcomes` 轨迹特征断言与单元测试）；不修改 `src/` 执行语义、不接入 CI 阻断门、不新增运行时配置。
+- [新功能] 新增 agent trajectory 评估管线（`evals/agent_trajectory`）：纯函数指标模块消费 `tool_calls_log` 计算工具命中率（stock-scoped，精确匹配 `stock_code` 参数并按调用逐条报告错误股票）、冗余与缓存调用、失败重试与步数效率（含 `golden_samples.json` 3 个样例、`expected_outcomes` 轨迹特征断言与单元测试）；不修改 `src/` 执行语义、不接入 CI 阻断门、不新增运行时配置。
 
 ## [3.31.0] - 2026-08-23
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -45,6 +45,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - [修复] 阻止任意更新的非 bundled 指数候选（含 legacy `static` 子集）在 remote 缺失/损坏时以 active-index 子集覆盖 bundled baseline：所有非 bundled 候选必须为 bundled active-index canonical 集合的合法超集，否则回退 bundled 并记录 WARNING。
 - [新功能] 桌面端全局右上角增加更新入口，与设置页共用更新状态；普通浏览器 WebUI 不展示，且不会在挂载时重复触发后台检查。
 - [修复] 桌面端右上角更新入口与设置页共用检查中状态，避免一侧检查时另一侧仍可重复触发 GitHub Releases 检查；主进程手动检查路径同步增加 in-flight 防重。
+- [新功能] 新增 agent trajectory 评估管线（`evals/agent_trajectory`）：纯函数指标模块消费 `tool_calls_log` 计算工具命中率、冗余与缓存调用、失败重试与步数效率（含 `golden_samples.json` 3 个样例与单元测试）；不修改 `src/` 执行语义、不接入 CI 阻断门、不新增运行时配置。
 
 ## [3.31.0] - 2026-08-23
 

--- a/evals/agent_trajectory/__init__.py
+++ b/evals/agent_trajectory/__init__.py
@@ -1,0 +1,6 @@
+# -*- coding: utf-8 -*-
+"""Agent trajectory evaluation pipeline (Issue #1956).
+
+评估管线与生产链路解耦：本包只消费 ``tool_calls_log`` 轨迹数据（纯函数指标层），
+不修改 ``src/`` 下任何执行语义。PR-1 提供指标与 golden 样例，PR-2 提供 live-run 驱动。
+"""

--- a/evals/agent_trajectory/golden_samples.json
+++ b/evals/agent_trajectory/golden_samples.json
@@ -25,6 +25,7 @@
     "expected_tools": ["get_stock_info", "get_daily_history"],
     "allowed_max_steps": 10,
     "allow_optional_tools": true,
-    "expected_outcomes": ["guarded_retry"]
+    "expected_outcomes": ["guarded_retry"],
+    "expected_guarded_stock": "600519"
   }
 ]

--- a/evals/agent_trajectory/golden_samples.json
+++ b/evals/agent_trajectory/golden_samples.json
@@ -1,0 +1,29 @@
+[
+  {
+    "id": "600519_technical",
+    "task_description": "分析贵州茅台（600519）近期技术面走势：先取实时行情与日线历史，再做趋势分析并给出结论。允许使用期望集合之外的工具（如新闻检索）作为补充。",
+    "stock_code": "600519",
+    "skills": [],
+    "expected_tools": ["get_realtime_quote", "get_daily_history", "analyze_trend"],
+    "allowed_max_steps": 8,
+    "allow_optional_tools": true
+  },
+  {
+    "id": "000001_core_data_strict",
+    "task_description": "获取平安银行（000001）的基础行情与日线历史数据。严格模式：只允许核心数据工具，任何期望集合之外的工具调用都记为违规。",
+    "stock_code": "000001",
+    "skills": [],
+    "expected_tools": ["get_realtime_quote", "get_daily_history"],
+    "allowed_max_steps": 6,
+    "allow_optional_tools": false
+  },
+  {
+    "id": "600036_guarded_retry",
+    "task_description": "在单一股票 scope（expected=600036）下分析招商银行，并故意要求顺带分析 600519：越界的工具调用应被 stock_scope guard 拦截（guarded=true 且计为失败），后续同参数重试应命中非可重试缓存（cached=true）或再次失败。",
+    "stock_code": "600036",
+    "skills": [],
+    "expected_tools": ["get_stock_info", "get_daily_history"],
+    "allowed_max_steps": 10,
+    "allow_optional_tools": true
+  }
+]

--- a/evals/agent_trajectory/golden_samples.json
+++ b/evals/agent_trajectory/golden_samples.json
@@ -25,6 +25,6 @@
     "expected_tools": ["get_stock_info", "get_daily_history"],
     "allowed_max_steps": 10,
     "allow_optional_tools": true,
-    "expected_outcomes": ["guarded", "retry"]
+    "expected_outcomes": ["guarded_retry"]
   }
 ]

--- a/evals/agent_trajectory/golden_samples.json
+++ b/evals/agent_trajectory/golden_samples.json
@@ -19,7 +19,7 @@
   },
   {
     "id": "600036_guarded_retry",
-    "task_description": "在单一股票 scope（expected=600036）下分析招商银行，并故意要求顺带分析 600519：越界的工具调用应被 stock_scope guard 拦截（guarded=true 且计为失败），后续同参数重试应命中非可重试缓存（cached=true）或再次失败。",
+    "task_description": "在单一股票 scope（expected=600036）下分析招商银行，并故意要求顺带分析 600519：越界的工具调用应被 stock_scope guard 拦截（guarded=true 且计为失败），后续同参数重试应命中非可重试缓存（cached=true）或再次失败；任何后续同参数调用都不得越过 guard 直接成功。",
     "stock_code": "600036",
     "skills": [],
     "expected_tools": ["get_stock_info", "get_daily_history"],

--- a/evals/agent_trajectory/golden_samples.json
+++ b/evals/agent_trajectory/golden_samples.json
@@ -24,6 +24,7 @@
     "skills": [],
     "expected_tools": ["get_stock_info", "get_daily_history"],
     "allowed_max_steps": 10,
-    "allow_optional_tools": true
+    "allow_optional_tools": true,
+    "expected_outcomes": ["guarded", "retry"]
   }
 ]

--- a/evals/agent_trajectory/golden_samples.json
+++ b/evals/agent_trajectory/golden_samples.json
@@ -19,7 +19,7 @@
   },
   {
     "id": "600036_guarded_retry",
-    "task_description": "在单一股票 scope（expected=600036）下分析招商银行，并故意要求顺带分析 600519：越界的工具调用应被 stock_scope guard 拦截（guarded=true 且计为失败），后续同参数重试应命中非可重试缓存（cached=true）或再次失败；任何后续同参数调用都不得越过 guard 直接成功。",
+    "task_description": "在单一股票 scope（expected=600036）下分析招商银行，并故意要求顺带分析 600519：越界的工具调用应被 stock_scope guard 拦截（guarded=true 且计为失败），后续同参数重试应命中非可重试缓存（cached=true）或再次失败；同一越界同参数调用在整个轨迹中任何时候都不得越过 guard 直接成功（无论发生在首次 guard 之前还是之后）。",
     "stock_code": "600036",
     "skills": [],
     "expected_tools": ["get_stock_info", "get_daily_history"],

--- a/evals/agent_trajectory/metrics.py
+++ b/evals/agent_trajectory/metrics.py
@@ -102,9 +102,12 @@ Metric semantics
   ``SH600519`` / ``600519.SH`` / ``SZ.000001`` / ``hk700`` resolve to the
   same identity as their clean code instead of being mis-scored as
   wrong-stock.  Entries with no stock evidence at all keep the name-only
-  tolerance, and *every* call of an expected tool whose stock resolves to a
-  different code is reported in a violation — one matching call does not
-  legitimize cross-stock calls of the same tool.  The one exception is the
+  tolerance — reserved for entries with no stock evidence at all; an
+  explicitly present but invalid value (null / boolean / non-scalar, empty
+  guard metadata) is a non-match and earns no hit credit.  *Every* call of
+  an expected tool whose stock resolves to a different code is reported in a
+  violation — one matching call does not legitimize cross-stock calls of the
+  same tool.  The one exception is the
   sample's own pinned out-of-scope stock (``expected_guarded_stock``): a call
   that targets it and stays blocked (``guarded`` / ``cached`` / failed) is
   the deliberate probe the task itself requires, so it is exempt from
@@ -349,28 +352,41 @@ def _entry_matches_stock(
     object with a ``stock_code`` field, the recovered value is canonicalized
     and compared exactly like a runner argument (so ``hk700`` matches an
     ``HK00700`` golden); otherwise the preview is scanned by substring as a
-    best-effort fallback.  Entries with no stock evidence at all (or
-    unresolvable values) keep the name-only tolerance so malformed or minimal
-    entries still count as before.
+    best-effort fallback.  Entries with no stock evidence at all keep the
+    name-only tolerance so minimal entries still count as before; an
+    explicitly present but invalid value (null / boolean / non-scalar) is a
+    non-match — it provably does not target the golden stock and must not
+    earn hit credit (see the module docstring).
     """
-    requested = entry.get("requested_stock_code")
-    if requested:
+    if "requested_stock_code" in entry:
+        requested = entry["requested_stock_code"]
+        # An explicitly present but invalid guard record is a non-match:
+        # it carries no usable target and must not fall through to the
+        # name-only tolerance (an empty string compares non-equal below).
         if not isinstance(requested, (str, int)) or isinstance(requested, bool):
-            return True
+            return False
         return _apply_stock_normalizer(normalizer, requested) == stock_code
     args = entry.get("arguments")
     if isinstance(args, dict):
-        value = args.get("stock_code")
-        if not isinstance(value, (str, int)) or isinstance(value, bool):
+        if "stock_code" not in args:
+            # No stock evidence in the payload: documented name-only
+            # tolerance (the entry still counts, like a minimal entry).
             return True
+        value = args["stock_code"]
+        # Explicitly present but invalid (null / boolean / non-scalar):
+        # not evidence for the golden stock, so not a hit either.
+        if not isinstance(value, (str, int)) or isinstance(value, bool):
+            return False
         return _apply_stock_normalizer(normalizer, value) == stock_code
     summary = entry.get("arguments_summary")
     if isinstance(summary, str) and summary:
         value = _summary_stock_code(summary)
         if value is _SUMMARY_NO_EVIDENCE:
             return stock_code in summary
+        # Recovered but invalid (JSON null / false / array): a non-match,
+        # never name-only tolerance.
         if not isinstance(value, (str, int)) or isinstance(value, bool):
-            return True
+            return False
         return _apply_stock_normalizer(normalizer, value) == stock_code
     return True
 

--- a/evals/agent_trajectory/metrics.py
+++ b/evals/agent_trajectory/metrics.py
@@ -63,16 +63,23 @@ Metric semantics
   per the contract above, and ``guarded_retry`` when a (tool, args-key) pair
   with a guarded occurrence is *followed by* a later occurrence of the same
   pair — the guarded call itself was retried, so a guard from one call plus a
-  retry of an unrelated call does not satisfy it.  A required outcome that is
-  not observed is reported as a violation, so a golden sample that declares
-  guard / cache / retry expectations cannot be passed by a trajectory that
-  skips the behaviour it describes.
+  retry of an unrelated call does not satisfy it.  When the sample sets
+  ``expected_guarded_stock``, the guarded occurrence of ``guarded_retry``
+  must additionally target that stock (the task's required out-of-scope
+  call), so two guarded retries of any other stock do not satisfy it.  A
+  required outcome that is not observed is reported as a violation, so a
+  golden sample that declares guard / cache / retry expectations cannot be
+  passed by a trajectory that skips the behaviour it describes.
 * ``expected_hit_rate`` is stock-scoped: an expected tool counts as hit only
-  when at least one of its calls references ``golden.stock_code`` (in the
-  serialized arguments, in the guard metadata ``requested_stock_code``, or in
-  the Codex ``arguments_summary`` preview — best-effort).  Entries with no
-  stock evidence at all keep the name-only tolerance, and calls of expected
-  tools for other stocks are reported as a violation.
+  when at least one of its calls references ``golden.stock_code`` — matched
+  exactly against the dedicated ``stock_code`` argument field of runner
+  entries (normalized string comparison, never a substring scan, so e.g.
+  ``"1600519"`` cannot satisfy ``600519``), the guard metadata
+  ``requested_stock_code``, or the Codex ``arguments_summary`` preview
+  (substring match, best-effort).  Entries with no stock evidence at all keep
+  the name-only tolerance, and *every* call of an expected tool whose stock
+  resolves to a different code is reported in a violation — one matching call
+  does not legitimize cross-stock calls of the same tool.
 * ``max_steps_touched``: the log does not carry ``max_steps`` itself, so this
   is the conservative heuristic ``max(step) >= golden.allowed_max_steps`` —
   a proxy for "the run reached the step budget", not proof of the loop
@@ -106,6 +113,9 @@ class GoldenSample:
     ``expected_outcomes`` are required trajectory features from the vocabulary
     ``guarded`` / ``cached`` / ``retry`` / ``guarded_retry`` (see the module
     docstring); every declared outcome must be observable in the log.
+    ``expected_guarded_stock`` optionally pins the stock the guard must
+    intercept (the task's out-of-scope call): when set, ``guarded_retry`` is
+    only observed for guarded calls targeting that stock.
     """
 
     id: str
@@ -116,6 +126,7 @@ class GoldenSample:
     allowed_max_steps: int = 10
     allow_optional_tools: bool = True
     expected_outcomes: List[str] = field(default_factory=list)
+    expected_guarded_stock: Optional[str] = None
 
 
 @dataclass
@@ -168,26 +179,62 @@ def _coerce_step(value: Any) -> int:
     return step if step > 0 else 0
 
 
+def _normalized_stock(value: Any) -> str:
+    """Normalize a resolvable stock value (str / int) for exact comparison."""
+    return str(value).strip()
+
+
 def _entry_matches_stock(entry: Dict[str, Any], stock_code: str) -> bool:
     """Best-effort check that a log entry's call targeted ``stock_code``.
 
     Guard metadata (``requested_stock_code``) is authoritative; runner
-    entries are matched by scanning the stable argument serialization for the
-    code (param names are tool-specific); Codex App Server entries carry only
-    the redacted ``arguments_summary`` preview (substring match).  Entries
-    with no stock evidence at all keep the name-only tolerance so malformed
-    or minimal entries still count as before.
+    entries are matched exactly against their dedicated ``stock_code``
+    argument field (every stock tool in the repository takes it) — the value
+    is normalized and compared for equality, never scanned as a substring, so
+    ``"1600519"`` cannot satisfy a ``600519`` golden.  Codex App Server
+    entries carry only the redacted ``arguments_summary`` preview, which has
+    no structured field and is matched by substring.  Entries with no stock
+    evidence at all (or unresolvable values) keep the name-only tolerance so
+    malformed or minimal entries still count as before.
     """
     requested = entry.get("requested_stock_code")
     if requested:
-        return requested == stock_code
+        if not isinstance(requested, (str, int)) or isinstance(requested, bool):
+            return True
+        return _normalized_stock(requested) == stock_code
     args = entry.get("arguments")
     if isinstance(args, dict):
-        return stock_code in _args_key(args)
+        value = args.get("stock_code")
+        if not isinstance(value, (str, int)) or isinstance(value, bool):
+            return True
+        return _normalized_stock(value) == stock_code
     summary = entry.get("arguments_summary")
     if isinstance(summary, str) and summary:
         return stock_code in summary
     return True
+
+
+def _entry_mismatches_stock(entry: Dict[str, Any], stock_code: str) -> bool:
+    """True when the entry's stock resolves to a *different* code.
+
+    Only evidence that resolves to a concrete code can mismatch: guard
+    metadata, or the ``stock_code`` argument field of runner entries.
+    Unresolvable evidence (Codex summary previews, malformed values) is
+    treated as "no evidence" — it can neither match nor mismatch, so it never
+    produces a wrong-stock violation on its own.
+    """
+    requested = entry.get("requested_stock_code")
+    if requested:
+        if not isinstance(requested, (str, int)) or isinstance(requested, bool):
+            return False
+        return _normalized_stock(requested) != stock_code
+    args = entry.get("arguments")
+    if isinstance(args, dict):
+        value = args.get("stock_code")
+        if not isinstance(value, (str, int)) or isinstance(value, bool):
+            return False
+        return _normalized_stock(value) != stock_code
+    return False
 
 
 def compute_trajectory_metrics(
@@ -210,8 +257,27 @@ def compute_trajectory_metrics(
     key_retries: Dict[tuple, int] = {}
     key_guarded_at: Dict[tuple, int] = {}
     stock_hit: Dict[str, bool] = {}
+    wrong_stock_calls: List[str] = []
     codex_shaped = False
     stock_code = golden.stock_code if isinstance(golden.stock_code, str) and golden.stock_code.strip() else ""
+    guarded_stock = golden.expected_guarded_stock
+    guarded_stock_valid = isinstance(guarded_stock, str) and bool(guarded_stock.strip())
+    # Extract the expected tool list before scanning entries so per-entry
+    # wrong-stock reporting can consult it during the loop.
+    if isinstance(golden.expected_tools, list):
+        expected = [t for t in golden.expected_tools if isinstance(t, str) and t]
+    else:
+        # Defend against hand-edited samples passing a bare string:
+        # validation rejects it at load time, but scoring must not misparse
+        # it into per-character tool names either.
+        expected = []
+    # A hand-edited sample may repeat a tool name; normalize to first
+    # occurrences before scoring so the hit rate cannot be inflated
+    # (["quote", "quote"] with one quote call must read 1/2, not 2/3).
+    expected_dupes = len(set(expected)) != len(expected)
+    if expected_dupes:
+        expected = list(dict.fromkeys(expected))
+    expected_set = set(expected)
     failed_calls = 0
     cached_calls = 0
     guarded_calls = 0
@@ -228,6 +294,12 @@ def compute_trajectory_metrics(
             used_tools.append(tool)
         if stock_code and tool and tool not in stock_hit and _entry_matches_stock(entry, stock_code):
             stock_hit[tool] = True
+        # Every call of an expected tool whose stock resolves to a different
+        # code is reported — a matching call elsewhere must not legitimize
+        # cross-stock usage of the same tool (stock_hit only tracks whether
+        # the tool ever matched, not whether every call did).
+        if stock_code and tool in expected_set and _entry_mismatches_stock(entry, stock_code):
+            wrong_stock_calls.append(tool)
         step = _coerce_step(entry.get("step"))
         if step and step not in seen_steps:
             seen_steps.add(step)
@@ -250,8 +322,11 @@ def compute_trajectory_metrics(
         # Record the occurrence index of the (first) guarded call so the
         # "guarded_retry" outcome can require a *later* occurrence of the
         # same key instead of matching any guard and any retry anywhere.
+        # When the sample pins the guarded stock, only guarded calls
+        # targeting that stock can seed the outcome.
         if entry.get("guarded") and key not in key_guarded_at:
-            key_guarded_at[key] = key_counts[key]
+            if not guarded_stock_valid or _entry_matches_stock(entry, guarded_stock):
+                key_guarded_at[key] = key_counts[key]
         # An occurrence is a retry only when the same call already failed
         # before it (see module docstring for the precise contract).
         if key_failed_seen.get(key):
@@ -288,19 +363,8 @@ def compute_trajectory_metrics(
         distinct_steps = max(distinct_steps, total)
         max_step = max(max_step, total)
 
-    if isinstance(golden.expected_tools, list):
-        expected = [t for t in golden.expected_tools if isinstance(t, str) and t]
-    else:
-        # Defend against hand-edited samples passing a bare string:
-        # validation rejects it at load time, but scoring must not misparse
-        # it into per-character tool names either.
-        expected = []
-    # A hand-edited sample may repeat a tool name; normalize to first
-    # occurrences before scoring so the hit rate cannot be inflated
-    # (["quote", "quote"] with one quote call must read 1/2, not 2/3).
-    if len(set(expected)) != len(expected):
+    if expected_dupes:
         violations.append("expected_tools contains duplicate names")
-        expected = list(dict.fromkeys(expected))
     if not stock_code:
         violations.append("golden.stock_code is not a non-empty string")
     # Stock-scoped hit semantics: an expected tool only counts when one of
@@ -309,12 +373,10 @@ def compute_trajectory_metrics(
     missing_expected = (
         [t for t in expected if t not in stock_hit] if stock_code else [t for t in expected if t not in used_tools]
     )
-    if stock_code:
-        wrong_stock = [t for t in expected if t in used_tools and t not in stock_hit]
-        if wrong_stock:
-            violations.append(
-                f"expected tools called for a different stock than " f"{golden.stock_code}: {', '.join(wrong_stock)}"
-            )
+    if stock_code and wrong_stock_calls:
+        violations.append(
+            f"expected tools called for a different stock than " f"{golden.stock_code}: {', '.join(wrong_stock_calls)}"
+        )
     expected_hit_rate = (len(expected) - len(missing_expected)) / len(expected) if expected else 0.0
     optional_tools_used = [t for t in used_tools if t not in expected]
 
@@ -345,6 +407,10 @@ def compute_trajectory_metrics(
         unknown = [t for t in outcomes if t not in EXPECTED_OUTCOME_TAGS]
         if unknown:
             violations.append(f"unknown expected outcome tags: {', '.join(unknown)}")
+    # A pinned but malformed guarded stock must not silently disable the
+    # stock binding for guarded_retry.
+    if golden.expected_guarded_stock is not None and not guarded_stock_valid:
+        violations.append("expected_guarded_stock must be a non-empty string")
     observed = []
     if guarded_calls:
         observed.append("guarded")
@@ -465,7 +531,9 @@ def validate_golden_sample(
     ``allow_optional_tools`` a boolean.  ``expected_tools`` and
     ``expected_outcomes`` must be duplicate-free, and outcome tags must come
     from the fixed vocabulary ``guarded`` / ``cached`` / ``retry`` /
-    ``guarded_retry``.
+    ``guarded_retry``.  ``expected_guarded_stock``, when set, must be a
+    non-empty string that differs from ``stock_code`` (it names the
+    out-of-scope call) and pairs with a declared ``guarded_retry`` outcome.
     """
     issues: List[str] = []
     known = set(known_tool_names) if known_tool_names is not None else None
@@ -509,4 +577,11 @@ def validate_golden_sample(
         unknown = [t for t in sample.expected_outcomes if t not in EXPECTED_OUTCOME_TAGS]
         if unknown:
             issues.append(f"unknown expected_outcomes: {', '.join(unknown)}")
+    if sample.expected_guarded_stock is not None:
+        if not isinstance(sample.expected_guarded_stock, str) or not sample.expected_guarded_stock.strip():
+            issues.append("expected_guarded_stock must be a non-empty string")
+        elif sample.expected_guarded_stock.strip() == sample.stock_code:
+            issues.append("expected_guarded_stock must differ from stock_code (it names the out-of-scope call)")
+        elif not isinstance(sample.expected_outcomes, list) or "guarded_retry" not in sample.expected_outcomes:
+            issues.append("expected_guarded_stock requires guarded_retry in expected_outcomes")
     return issues

--- a/evals/agent_trajectory/metrics.py
+++ b/evals/agent_trajectory/metrics.py
@@ -21,9 +21,12 @@ from any source.
 Both entry paths enforce the same golden-sample structure contract:
 ``validate_golden_sample`` (the loader path) rejects malformed samples
 outright, while ``compute_trajectory_metrics`` (the direct-construction path)
-reports malformed fields as violations and excludes the invalid parts from
-scoring — a caller who builds a ``GoldenSample`` by hand must never get a
-silently relaxed result (see the compute docstring for the exact mapping).
+excludes the invalid parts from scoring, reports its own scoring-level
+violations with the validator's wording, and finally appends *every* issue
+``validate_golden_sample`` reports, verbatim and deduplicated — a caller who
+builds a ``GoldenSample`` by hand can never get a silently relaxed result,
+and a new validator check applies to direct scoring automatically (see the
+compute docstring for the exact mapping).
 
 Idempotency key contract
 ------------------------
@@ -518,8 +521,11 @@ def compute_trajectory_metrics(
 
     Direct construction of a hand-edited ``GoldenSample`` is held to the same
     structure contract as :func:`validate_golden_sample` on the loader path:
-    malformed parts are reported as violations and excluded from scoring
-    instead of silently reshaping the result.  Malformed ``expected_tools`` /
+    malformed parts are excluded from scoring instead of silently reshaping
+    the result, scoring-level violations are reported with the validator's
+    wording, and every issue the validator reports — ``id`` /
+    ``task_description`` / ``skills`` included — is appended verbatim
+    (deduplicated) before returning.  Malformed ``expected_tools`` /
     ``expected_outcomes`` elements — non-strings, empty strings and
     whitespace-only strings, the validator's exact predicate — are dropped
     with an explicit violation, a non-positive ``allowed_max_steps`` is
@@ -695,13 +701,13 @@ def compute_trajectory_metrics(
         max_step = max(max_step, total)
 
     if expected_dupes:
-        violations.append("expected_tools contains duplicate names")
+        violations.append("expected_tools must not contain duplicate names")
     if expected_tools_malformed:
         violations.append("expected_tools must contain only non-empty strings")
     if normalizer_invalid:
         violations.append("stock_code_normalizer is not callable")
     if not stock_code:
-        violations.append("golden.stock_code is not a non-empty string")
+        violations.append("stock_code must be a non-empty string")
     # Stock-scoped hit semantics: an expected tool only counts when one of
     # its calls actually referenced the golden stock (see module docstring);
     # without a valid golden stock the scoring falls back to name-only.
@@ -715,8 +721,10 @@ def compute_trajectory_metrics(
     expected_hit_rate = (len(expected) - len(missing_expected)) / len(expected) if expected else 0.0
     optional_tools_used = [t for t in used_tools if t not in expected]
 
-    if not expected:
-        violations.append("golden sample has no expected_tools")
+    if not isinstance(golden.expected_tools, list):
+        violations.append("expected_tools must be a list of tool names")
+    elif not golden.expected_tools:
+        violations.append("expected_tools must be a non-empty list")
 
     # Malformed golden samples must not crash scoring nor flip semantics:
     # a truthy string like "false" must not silently turn a strict sample
@@ -746,11 +754,11 @@ def compute_trajectory_metrics(
             violations.append("expected_outcomes must contain only non-empty strings")
         outcomes = [t for t in golden.expected_outcomes if isinstance(t, str) and t.strip()]
         if len(set(outcomes)) != len(outcomes):
-            violations.append("expected_outcomes contains duplicate tags")
+            violations.append("expected_outcomes must not contain duplicate tags")
             outcomes = list(dict.fromkeys(outcomes))
         unknown = [t for t in outcomes if t not in EXPECTED_OUTCOME_TAGS]
         if unknown:
-            violations.append(f"unknown expected outcome tags: {', '.join(unknown)}")
+            violations.append(f"unknown expected_outcomes: {', '.join(unknown)}")
     # A pinned but malformed guarded stock must not silently disable the
     # stock binding for guarded_retry — nor silently keep it: mirror the
     # structure contract validate_golden_sample() enforces at load time, so
@@ -795,7 +803,7 @@ def compute_trajectory_metrics(
 
     limit = golden.allowed_max_steps
     if isinstance(limit, bool) or not isinstance(limit, int):
-        violations.append("allowed_max_steps is not an integer")
+        violations.append("allowed_max_steps must be an integer")
         limit = 0
     elif limit < 1:
         # Validator wording for the same field: a non-positive limit must
@@ -805,6 +813,17 @@ def compute_trajectory_metrics(
     max_steps_touched = bool(max_step and limit > 0 and max_step >= limit)
     if max_steps_touched:
         violations.append(f"trajectory reached allowed_max_steps ({golden.allowed_max_steps})")
+
+    # The direct-score path surfaces the validator's complete structure
+    # contract, not only the checks scoring itself depends on: every issue
+    # validate_golden_sample() reports is appended verbatim (deduplicated
+    # against the inline violations above), so a hand-built malformed golden
+    # can never score as valid — and a new validator check applies to direct
+    # scoring automatically.  The two entry paths stay aligned by
+    # construction instead of by convention.
+    for issue in validate_golden_sample(golden):
+        if issue not in violations:
+            violations.append(issue)
 
     return TrajectoryMetrics(
         expected_hit_rate=expected_hit_rate,

--- a/evals/agent_trajectory/metrics.py
+++ b/evals/agent_trajectory/metrics.py
@@ -31,13 +31,18 @@ Metric semantics
   first — regardless of success.
 * ``retries``: occurrences that follow a *failed* occurrence of the same pair
   (i.e. "tried again after a failure").  ``retries`` is a subset of
-  ``redundant_calls``; repeats after success count as redundant but not retry.
+  ``redundant_calls``; repeats after success count as redundant but not retry,
+  and a success clears the pair's failure state — so ``fail -> success ->
+  success`` counts exactly one retry, not two.
 * ``cached_calls``: entries with ``cached=True`` (runner semantics: reuse of a
   non-retriable failure result).
 * ``max_steps_touched``: the log does not carry ``max_steps`` itself, so this
   is the conservative heuristic ``max(step) >= golden.allowed_max_steps`` —
   a proxy for "the run reached the step budget", not proof of the loop
-  exhausting it.
+  exhausting it.  When ``total_steps`` is supplied (see
+  :func:`compute_trajectory_metrics`), the larger of ``total_steps`` and the
+  log-derived step is compared instead — the final answer round consumes a
+  step but produces no tool call, so the log alone understates consumption.
 """
 
 from __future__ import annotations
@@ -115,8 +120,20 @@ def _coerce_step(value: Any) -> int:
     return step if step > 0 else 0
 
 
-def compute_trajectory_metrics(log: List[Dict[str, Any]], golden: GoldenSample) -> TrajectoryMetrics:
-    """Compute all trajectory metrics from a ``tool_calls_log`` and a golden sample."""
+def compute_trajectory_metrics(
+    log: List[Dict[str, Any]],
+    golden: GoldenSample,
+    total_steps: Optional[int] = None,
+) -> TrajectoryMetrics:
+    """Compute all trajectory metrics from a ``tool_calls_log`` and a golden sample.
+
+    ``total_steps`` optionally carries the number of loop rounds the run
+    actually consumed (``RunLoopResult.total_steps``), which includes the
+    final plain-answer round that produces no tool call.  When it is larger
+    than the log-derived step count it is used for ``distinct_steps`` and the
+    ``max_steps_touched`` heuristic; otherwise the log alone decides, and the
+    default ``None`` keeps the log-only behaviour.
+    """
     used_tools: List[str] = []
     key_counts: Dict[tuple, int] = {}
     key_failed_seen: Dict[tuple, bool] = {}
@@ -153,10 +170,29 @@ def compute_trajectory_metrics(log: List[Dict[str, Any]], golden: GoldenSample) 
         # before it (see module docstring for the precise contract).
         if key_failed_seen.get(key):
             key_retries[key] = key_retries.get(key, 0) + 1
-        if not success:
-            key_failed_seen[key] = True
+        # A success clears the failure state: repeats after a recovery count
+        # as redundant only, not as further retries.
+        key_failed_seen[key] = not success
 
-    expected = [t for t in (golden.expected_tools or []) if isinstance(t, str) and t]
+    # The final answer round consumes a step but produces no tool call, so
+    # when the caller supplies the run's real total it may exceed the log.
+    total = 0
+    if total_steps is not None:
+        try:
+            total = int(total_steps)
+        except (TypeError, ValueError):
+            total = 0
+        total = total if total > 0 else 0
+    distinct_steps = max(distinct_steps, total)
+    max_step = max(max_step, total)
+
+    if isinstance(golden.expected_tools, list):
+        expected = [t for t in golden.expected_tools if isinstance(t, str) and t]
+    else:
+        # Defend against hand-edited samples passing a bare string:
+        # validation rejects it at load time, but scoring must not misparse
+        # it into per-character tool names either.
+        expected = []
     missing_expected = [t for t in expected if t not in used_tools]
     expected_hit_rate = (len(expected) - len(missing_expected)) / len(expected) if expected else 0.0
     optional_tools_used = [t for t in used_tools if t not in expected]
@@ -262,7 +298,9 @@ def validate_golden_sample(
         issues.append("task_description must be a non-empty string")
     if not sample.stock_code or not sample.stock_code.strip():
         issues.append("stock_code must be a non-empty string")
-    if not sample.expected_tools:
+    if not isinstance(sample.expected_tools, list):
+        issues.append("expected_tools must be a list of tool names")
+    elif not sample.expected_tools:
         issues.append("expected_tools must be a non-empty list")
     elif any(not isinstance(t, str) or not t.strip() for t in sample.expected_tools):
         issues.append("expected_tools must contain only non-empty strings")

--- a/evals/agent_trajectory/metrics.py
+++ b/evals/agent_trajectory/metrics.py
@@ -27,9 +27,10 @@ unhashable values (dict / list), so the key is built with
 not a hash.  Do not replace this with ``tuple(arguments)`` or ``repr()``:
 insertion order or collection type would then change call identity and corrupt
 redundancy / retry counts.  Mirroring the production
-``_build_tool_cache_key``, the ``stock_code`` field is canonicalized before
-serialization so runtime-equivalent alias forms share one identity; all other
-arguments stay raw.
+``_build_tool_cache_key``, a *string* ``stock_code`` field is canonicalized
+before serialization so runtime-equivalent alias forms share one identity,
+while non-string values (JSON numbers) stay raw; all other arguments stay
+raw.
 
 Codex App Server entries carry only ``arguments_summary`` — the redacted and
 truncated preview produced by ``redact_diagnostic_value`` — so their identity
@@ -171,22 +172,30 @@ def _args_key(arguments: Any, normalizer: Optional[Callable[[Any], str]] = None)
     """Return a stable idempotency key for tool-call arguments (see module docstring).
 
     Mirrors ``src/agent/tools/execution._build_tool_cache_key``: when the
-    payload is a dict, its ``stock_code`` field is canonicalized before
-    serialization so runtime-equivalent alias forms (``SH600519`` /
+    payload is a dict, a *string* ``stock_code`` field is canonicalized
+    before serialization so runtime-equivalent alias forms (``SH600519`` /
     ``600519.SH`` / ``600519``) share one call identity; every other
-    argument stays raw, exactly like the production cache key.  Non-dict
+    argument stays raw, exactly like the production cache key.  Non-string
+    ``stock_code`` values (JSON numbers from ``json.loads``) are preserved
+    as-is because the production normalizer returns them unchanged, so
+    ``600519`` and ``"600519"`` remain distinct identities.  Non-dict
     payloads (Codex ``arguments_summary`` wrappers, bare fallbacks) are
     serialized as-is.
     """
     if arguments is None:
         arguments = {}
-    if normalizer is None:
-        normalizer = _canonicalize_stock_code
     if isinstance(arguments, dict) and "stock_code" in arguments:
-        normalized = dict(arguments)
-        normalized["stock_code"] = _apply_stock_normalizer(normalizer, arguments["stock_code"])
-        arguments = normalized
-    return json.dumps(arguments, sort_keys=True, default=str)
+        value = arguments["stock_code"]
+        # Only strings pass through the canonicalizer, mirroring the
+        # type-preserving production ``_normalize_tool_stock_code``; the
+        # runtime cache key keeps ``600519`` and ``"600519"`` apart.
+        if isinstance(value, str):
+            if normalizer is None:
+                normalizer = _canonicalize_stock_code
+            normalized = dict(arguments)
+            normalized["stock_code"] = _apply_stock_normalizer(normalizer, value)
+            arguments = normalized
+    return json.dumps(arguments, ensure_ascii=False, sort_keys=True, default=str)
 
 
 def _entry_arguments(entry: Dict[str, Any]) -> Any:

--- a/evals/agent_trajectory/metrics.py
+++ b/evals/agent_trajectory/metrics.py
@@ -35,6 +35,15 @@ truncation may be over-counted as redundant.  A stable argument fingerprint
 requires a producer-side change in ``src/agent/codex_agent_backend.py``, which
 is out of scope for this metrics layer.
 
+Codex App Server entries also record ``step=1`` for every tool call in a turn
+and ``total_steps=1`` on success — the real budget there is the tool-call
+count (``max_tool_calls=request.max_steps``).  Step-derived metrics
+(``distinct_steps`` / ``max_steps_touched``) are therefore suppressed with an
+explicit violation for Codex-shaped logs instead of reporting a misleading
+one-step result.  A comparable step budget requires a producer-side field in
+``src/agent/codex_agent_backend.py``, which is out of scope for this metrics
+layer.
+
 Metric semantics
 ----------------
 * ``redundant_calls``: every occurrence of a (tool, args-key) pair beyond its
@@ -47,13 +56,23 @@ Metric semantics
 * ``cached_calls``: entries with ``cached=True`` (runner semantics: reuse of a
   non-retriable failure result).
 * ``expected_outcomes``: machine-readable trajectory features a golden sample
-  may require, from the fixed vocabulary ``guarded`` / ``cached`` / ``retry``.
-  ``guarded`` is observed when any entry carries ``guarded=True`` (the stock-
-  scope guard interception), ``cached`` when any entry carries ``cached=True``
-  and ``retry`` when at least one retry is counted per the contract above.  A
-  required outcome that is not observed is reported as a violation, so a
-  golden sample that declares guard / cache / retry expectations cannot be
-  passed by a trajectory that skips the behaviour it describes.
+  may require, from the fixed vocabulary ``guarded`` / ``cached`` / ``retry`` /
+  ``guarded_retry``.  ``guarded`` is observed when any entry carries
+  ``guarded=True`` (the stock-scope guard interception), ``cached`` when any
+  entry carries ``cached=True``, ``retry`` when at least one retry is counted
+  per the contract above, and ``guarded_retry`` when a (tool, args-key) pair
+  with a guarded occurrence is *followed by* a later occurrence of the same
+  pair — the guarded call itself was retried, so a guard from one call plus a
+  retry of an unrelated call does not satisfy it.  A required outcome that is
+  not observed is reported as a violation, so a golden sample that declares
+  guard / cache / retry expectations cannot be passed by a trajectory that
+  skips the behaviour it describes.
+* ``expected_hit_rate`` is stock-scoped: an expected tool counts as hit only
+  when at least one of its calls references ``golden.stock_code`` (in the
+  serialized arguments, in the guard metadata ``requested_stock_code``, or in
+  the Codex ``arguments_summary`` preview — best-effort).  Entries with no
+  stock evidence at all keep the name-only tolerance, and calls of expected
+  tools for other stocks are reported as a violation.
 * ``max_steps_touched``: the log does not carry ``max_steps`` itself, so this
   is the conservative heuristic ``max(step) >= golden.allowed_max_steps`` —
   a proxy for "the run reached the step budget", not proof of the loop
@@ -72,8 +91,10 @@ from typing import Any, Dict, Iterable, List, Optional
 
 #: Machine-readable trajectory features a golden sample may require of a log
 #: (``guarded`` = a guarded call, ``cached`` = a cached call, ``retry`` = at
-#: least one retry).  See the "Metric semantics" section of the module docstring.
-EXPECTED_OUTCOME_TAGS = ("guarded", "cached", "retry")
+#: least one retry, ``guarded_retry`` = a guarded call followed by a later
+#: occurrence of the same (tool, args-key) pair).  See the "Metric semantics"
+#: section of the module docstring.
+EXPECTED_OUTCOME_TAGS = ("guarded", "cached", "retry", "guarded_retry")
 
 
 @dataclass
@@ -83,8 +104,8 @@ class GoldenSample:
     ``expected_tools`` are the tool names the agent should call; tools outside
     this set are tolerated only when ``allow_optional_tools`` is true.
     ``expected_outcomes`` are required trajectory features from the vocabulary
-    ``guarded`` / ``cached`` / ``retry`` (see the module docstring); every
-    declared outcome must be observable in the log.
+    ``guarded`` / ``cached`` / ``retry`` / ``guarded_retry`` (see the module
+    docstring); every declared outcome must be observable in the log.
     """
 
     id: str
@@ -147,6 +168,28 @@ def _coerce_step(value: Any) -> int:
     return step if step > 0 else 0
 
 
+def _entry_matches_stock(entry: Dict[str, Any], stock_code: str) -> bool:
+    """Best-effort check that a log entry's call targeted ``stock_code``.
+
+    Guard metadata (``requested_stock_code``) is authoritative; runner
+    entries are matched by scanning the stable argument serialization for the
+    code (param names are tool-specific); Codex App Server entries carry only
+    the redacted ``arguments_summary`` preview (substring match).  Entries
+    with no stock evidence at all keep the name-only tolerance so malformed
+    or minimal entries still count as before.
+    """
+    requested = entry.get("requested_stock_code")
+    if requested:
+        return requested == stock_code
+    args = entry.get("arguments")
+    if isinstance(args, dict):
+        return stock_code in _args_key(args)
+    summary = entry.get("arguments_summary")
+    if isinstance(summary, str) and summary:
+        return stock_code in summary
+    return True
+
+
 def compute_trajectory_metrics(
     log: List[Dict[str, Any]],
     golden: GoldenSample,
@@ -165,6 +208,10 @@ def compute_trajectory_metrics(
     key_counts: Dict[tuple, int] = {}
     key_failed_seen: Dict[tuple, bool] = {}
     key_retries: Dict[tuple, int] = {}
+    key_guarded_at: Dict[tuple, int] = {}
+    stock_hit: Dict[str, bool] = {}
+    codex_shaped = False
+    stock_code = golden.stock_code if isinstance(golden.stock_code, str) and golden.stock_code.strip() else ""
     failed_calls = 0
     cached_calls = 0
     guarded_calls = 0
@@ -179,6 +226,8 @@ def compute_trajectory_metrics(
         tool = entry.get("tool") or ""
         if tool and tool not in used_tools:
             used_tools.append(tool)
+        if stock_code and tool and tool not in stock_hit and _entry_matches_stock(entry, stock_code):
+            stock_hit[tool] = True
         step = _coerce_step(entry.get("step"))
         if step and step not in seen_steps:
             seen_steps.add(step)
@@ -191,11 +240,18 @@ def compute_trajectory_metrics(
             cached_calls += 1
         if entry.get("guarded"):
             guarded_calls += 1
+        if not isinstance(entry.get("arguments"), dict) and entry.get("arguments_summary"):
+            codex_shaped = True
 
         key = (tool, _args_key(_entry_arguments(entry)))
         if key_counts.get(key, 0):
             redundant_calls += 1
         key_counts[key] = key_counts.get(key, 0) + 1
+        # Record the occurrence index of the (first) guarded call so the
+        # "guarded_retry" outcome can require a *later* occurrence of the
+        # same key instead of matching any guard and any retry anywhere.
+        if entry.get("guarded") and key not in key_guarded_at:
+            key_guarded_at[key] = key_counts[key]
         # An occurrence is a retry only when the same call already failed
         # before it (see module docstring for the precise contract).
         if key_failed_seen.get(key):
@@ -204,20 +260,33 @@ def compute_trajectory_metrics(
         # as redundant only, not as further retries.
         key_failed_seen[key] = not success
 
-    # The final answer round consumes a step but produces no tool call, so
-    # when the caller supplies the run's real total it may exceed the log.
-    total = 0
-    if total_steps is not None:
-        try:
-            total = int(total_steps)
-        except (TypeError, ValueError):
-            total = 0
-        total = total if total > 0 else 0
-    distinct_steps = max(distinct_steps, total)
-    max_step = max(max_step, total)
-
     retries = sum(key_retries.values())
     violations: List[str] = []
+
+    if codex_shaped:
+        # Codex App Server backend records step=1 for every tool call in a
+        # turn and total_steps=1 on success, so step-derived metrics would
+        # silently read as a normal one-step run; suppress them instead.
+        violations.append(
+            "step metrics are unsupported for Codex App Server logs (backend "
+            "records step=1 per turn and total_steps=1 on success): "
+            "distinct_steps / max_steps_touched suppressed"
+        )
+        distinct_steps = 0
+        max_step = 0
+    else:
+        # The final answer round consumes a step but produces no tool call,
+        # so when the caller supplies the run's real total it may exceed the
+        # log.
+        total = 0
+        if total_steps is not None:
+            try:
+                total = int(total_steps)
+            except (TypeError, ValueError):
+                total = 0
+            total = total if total > 0 else 0
+        distinct_steps = max(distinct_steps, total)
+        max_step = max(max_step, total)
 
     if isinstance(golden.expected_tools, list):
         expected = [t for t in golden.expected_tools if isinstance(t, str) and t]
@@ -232,7 +301,20 @@ def compute_trajectory_metrics(
     if len(set(expected)) != len(expected):
         violations.append("expected_tools contains duplicate names")
         expected = list(dict.fromkeys(expected))
-    missing_expected = [t for t in expected if t not in used_tools]
+    if not stock_code:
+        violations.append("golden.stock_code is not a non-empty string")
+    # Stock-scoped hit semantics: an expected tool only counts when one of
+    # its calls actually referenced the golden stock (see module docstring);
+    # without a valid golden stock the scoring falls back to name-only.
+    missing_expected = (
+        [t for t in expected if t not in stock_hit] if stock_code else [t for t in expected if t not in used_tools]
+    )
+    if stock_code:
+        wrong_stock = [t for t in expected if t in used_tools and t not in stock_hit]
+        if wrong_stock:
+            violations.append(
+                f"expected tools called for a different stock than " f"{golden.stock_code}: {', '.join(wrong_stock)}"
+            )
     expected_hit_rate = (len(expected) - len(missing_expected)) / len(expected) if expected else 0.0
     optional_tools_used = [t for t in used_tools if t not in expected]
 
@@ -270,6 +352,8 @@ def compute_trajectory_metrics(
         observed.append("cached")
     if retries:
         observed.append("retry")
+    if any(idx < key_counts.get(k, 0) for k, idx in key_guarded_at.items()):
+        observed.append("guarded_retry")
     missing_outcomes = [t for t in outcomes if t in EXPECTED_OUTCOME_TAGS and t not in observed]
     if missing_outcomes:
         violations.append(f"expected outcomes not observed: {', '.join(missing_outcomes)}")
@@ -380,7 +464,8 @@ def validate_golden_sample(
     ``expected_outcomes`` must be lists, ``allowed_max_steps`` an integer and
     ``allow_optional_tools`` a boolean.  ``expected_tools`` and
     ``expected_outcomes`` must be duplicate-free, and outcome tags must come
-    from the fixed vocabulary ``guarded`` / ``cached`` / ``retry``.
+    from the fixed vocabulary ``guarded`` / ``cached`` / ``retry`` /
+    ``guarded_retry``.
     """
     issues: List[str] = []
     known = set(known_tool_names) if known_tool_names is not None else None

--- a/evals/agent_trajectory/metrics.py
+++ b/evals/agent_trajectory/metrics.py
@@ -76,7 +76,10 @@ Metric semantics
   retry of an unrelated call does not satisfy it.  When the sample sets
   ``expected_guarded_stock``, the guarded occurrence of ``guarded_retry``
   must additionally target that stock (the task's required out-of-scope
-  call), and every occurrence of the pair must remain blocked
+  call) with *actual stock evidence* — the name-only tolerance does not
+  apply to the pinned check, so a blocked call that never identifies a
+  stock (empty or missing arguments payload) cannot prove the pinned probe.
+  Every occurrence of the pair must remain blocked
   (``cached`` / ``guarded`` / failed): a clean success at *any* point — before
   or after the first guarded occurrence — is an escape (the scope guard was
   bypassed, or the call provably gets through it) and does not satisfy it.  A
@@ -109,7 +112,8 @@ Metric semantics
   violation — one matching call does not legitimize cross-stock calls of the
   same tool.  The one exception is the
   sample's own pinned out-of-scope stock (``expected_guarded_stock``): a call
-  that targets it and stays blocked (``guarded`` / ``cached`` / failed) is
+  that targets it (with actual stock evidence, the same strict match as the
+  outcome seeding) and stays blocked (``guarded`` / ``cached`` / failed) is
   the deliberate probe the task itself requires, so it is exempt from
   wrong-stock reporting; a clean success on the pinned stock is still
   reported (and escapes ``guarded_retry``).
@@ -339,6 +343,7 @@ def _entry_matches_stock(
     entry: Dict[str, Any],
     stock_code: str,
     normalizer: Callable[[Any], str],
+    require_evidence: bool = False,
 ) -> bool:
     """Best-effort check that a log entry's call targeted ``stock_code``.
 
@@ -357,6 +362,11 @@ def _entry_matches_stock(
     explicitly present but invalid value (null / boolean / non-scalar) is a
     non-match — it provably does not target the golden stock and must not
     earn hit credit (see the module docstring).
+
+    ``require_evidence`` tightens the check for stock-pinned assertions
+    (``expected_guarded_stock``): entries with no stock evidence at all are
+    non-matches instead of name-only hits — a blocked call that never
+    identifies a stock cannot prove the pinned out-of-scope probe.
     """
     if "requested_stock_code" in entry:
         requested = entry["requested_stock_code"]
@@ -370,8 +380,9 @@ def _entry_matches_stock(
     if isinstance(args, dict):
         if "stock_code" not in args:
             # No stock evidence in the payload: documented name-only
-            # tolerance (the entry still counts, like a minimal entry).
-            return True
+            # tolerance for ordinary hit scoring (the entry still counts,
+            # like a minimal entry) — but never for stock-pinned assertions.
+            return not require_evidence
         value = args["stock_code"]
         # Explicitly present but invalid (null / boolean / non-scalar):
         # not evidence for the golden stock, so not a hit either.
@@ -388,7 +399,7 @@ def _entry_matches_stock(
         if not isinstance(value, (str, int)) or isinstance(value, bool):
             return False
         return _apply_stock_normalizer(normalizer, value) == stock_code
-    return True
+    return not require_evidence
 
 
 # Sentinel distinguishing "the summary holds no structured stock_code" from a
@@ -565,7 +576,7 @@ def compute_trajectory_metrics(
         # guarded_retry).
         pinned_probe_blocked = (
             guarded_stock_valid
-            and _entry_matches_stock(entry, guarded_stock, normalizer)
+            and _entry_matches_stock(entry, guarded_stock, normalizer, require_evidence=True)
             and _entry_stayed_blocked(entry, success)
         )
         if (
@@ -605,9 +616,11 @@ def compute_trajectory_metrics(
         # "guarded_retry" outcome can require a *later* occurrence of the
         # same key instead of matching any guard and any retry anywhere.
         # When the sample pins the guarded stock, only guarded calls
-        # targeting that stock can seed the outcome.
+        # carrying actual stock evidence for that stock can seed the
+        # outcome — a blocked call that never identifies a stock cannot
+        # prove the pinned out-of-scope probe (no name-only tolerance here).
         if entry.get("guarded") and key not in key_guarded_at:
-            if not guarded_stock_valid or _entry_matches_stock(entry, guarded_stock, normalizer):
+            if not guarded_stock_valid or _entry_matches_stock(entry, guarded_stock, normalizer, require_evidence=True):
                 key_guarded_at[key] = key_counts[key]
         # An occurrence is a retry only when the same call already failed
         # before it (see module docstring for the precise contract).

--- a/evals/agent_trajectory/metrics.py
+++ b/evals/agent_trajectory/metrics.py
@@ -122,7 +122,13 @@ Metric semantics
   wrong-stock.  Entries with no stock evidence at all keep the name-only
   tolerance — reserved for entries with no stock evidence at all; an
   explicitly present but invalid value (null / boolean / non-scalar, empty
-  guard metadata) is a non-match and earns no hit credit.  *Every* call of
+  guard metadata) is a non-match and earns no hit credit.  Float-shaped
+  evidence follows the guard chain's coercion instead: an integral float
+  (``600519.0``) is converted to ``int`` before comparison exactly like
+  ``execution._normalize_guard_stock_code`` — the runner records arguments
+  verbatim, so a JSON-parsed code can legitimately arrive in float shape —
+  and any other float is compared as its ``str`` form (``600519.5``), which
+  never canonicalizes to an integer-formed code.  *Every* call of
   an expected tool whose stock resolves to a different code is reported in a
   violation — one matching call does not legitimize cross-stock calls of the
   same tool.  The one exception is the
@@ -356,6 +362,20 @@ def _apply_stock_normalizer(normalizer: Callable[[Any], str], value: Any) -> str
     return result if isinstance(result, str) else _canonicalize_stock_code(value)
 
 
+def _coerce_guard_float(value: Any) -> Any:
+    """Coerce float stock evidence exactly like the runtime guard chain.
+
+    ``execution._normalize_guard_stock_code`` converts an integral float
+    (``600519.0``) to ``int`` before normalization, so the guard compares it
+    as ``600519``; any other float falls back to its ``str`` form
+    (``600519.5``), which never canonicalizes to an integer-formed code.
+    Non-float values pass through untouched.
+    """
+    if isinstance(value, float):
+        return int(value) if value.is_integer() else str(value)
+    return value
+
+
 def _entry_matches_stock(
     entry: Dict[str, Any],
     stock_code: str,
@@ -378,7 +398,13 @@ def _entry_matches_stock(
     name-only tolerance so minimal entries still count as before; an
     explicitly present but invalid value (null / boolean / non-scalar) is a
     non-match — it provably does not target the golden stock and must not
-    earn hit credit (see the module docstring).
+    earn hit credit (see the module docstring).  Float evidence is coerced
+    exactly like the runtime guard chain
+    (``execution._normalize_guard_stock_code``): an integral float
+    (``600519.0``) becomes ``int`` — the runner records arguments verbatim,
+    so JSON-parsed codes arrive in float shape — while any other float is
+    compared as its ``str`` form (``600519.5``), which never canonicalizes
+    to an integer-formed code.
 
     ``require_evidence`` tightens the check for stock-pinned assertions
     (``expected_guarded_stock``): entries with no stock evidence at all are
@@ -386,7 +412,7 @@ def _entry_matches_stock(
     identifies a stock cannot prove the pinned out-of-scope probe.
     """
     if "requested_stock_code" in entry:
-        requested = entry["requested_stock_code"]
+        requested = _coerce_guard_float(entry["requested_stock_code"])
         # An explicitly present but invalid guard record is a non-match:
         # it carries no usable target and must not fall through to the
         # name-only tolerance (an empty string compares non-equal below).
@@ -400,7 +426,7 @@ def _entry_matches_stock(
             # tolerance for ordinary hit scoring (the entry still counts,
             # like a minimal entry) — but never for stock-pinned assertions.
             return not require_evidence
-        value = args["stock_code"]
+        value = _coerce_guard_float(args["stock_code"])
         # Explicitly present but invalid (null / boolean / non-scalar):
         # not evidence for the golden stock, so not a hit either.
         if not isinstance(value, (str, int)) or isinstance(value, bool):
@@ -408,7 +434,7 @@ def _entry_matches_stock(
         return _apply_stock_normalizer(normalizer, value) == stock_code
     summary = entry.get("arguments_summary")
     if isinstance(summary, str) and summary:
-        value = _summary_stock_code(summary)
+        value = _coerce_guard_float(_summary_stock_code(summary))
         if value is _SUMMARY_NO_EVIDENCE:
             return stock_code in summary
         # Recovered but invalid (JSON null / false / array): a non-match,
@@ -470,22 +496,25 @@ def _entry_mismatches_stock(
     ``arguments_summary``.  Unresolvable evidence (truncated / redacted
     previews, malformed values) is treated as "no evidence" — it can neither
     match nor mismatch, so it never produces a wrong-stock violation on its
-    own.
+    own.  Float evidence follows the guard chain's coercion (integral ->
+    ``int``, otherwise ``str``), so ``600519.0`` reads as ``600519`` and
+    ``600519.5`` as the distinct literal code.
     """
     requested = entry.get("requested_stock_code")
     if requested:
+        requested = _coerce_guard_float(requested)
         if not isinstance(requested, (str, int)) or isinstance(requested, bool):
             return False
         return _apply_stock_normalizer(normalizer, requested) != stock_code
     args = entry.get("arguments")
     if isinstance(args, dict):
-        value = args.get("stock_code")
+        value = _coerce_guard_float(args.get("stock_code"))
         if not isinstance(value, (str, int)) or isinstance(value, bool):
             return False
         return _apply_stock_normalizer(normalizer, value) != stock_code
     summary = entry.get("arguments_summary")
     if isinstance(summary, str) and summary:
-        value = _summary_stock_code(summary)
+        value = _coerce_guard_float(_summary_stock_code(summary))
         if value is _SUMMARY_NO_EVIDENCE:
             return False
         if not isinstance(value, (str, int)) or isinstance(value, bool):

--- a/evals/agent_trajectory/metrics.py
+++ b/evals/agent_trajectory/metrics.py
@@ -130,8 +130,10 @@ Metric semantics
   that targets it (with actual stock evidence, the same strict match as the
   outcome seeding) and stays blocked (``guarded`` / ``cached`` / failed) is
   the deliberate probe the task itself requires, so it is exempt from
-  wrong-stock reporting; a clean success on the pinned stock is still
-  reported (and escapes ``guarded_retry``).
+  wrong-stock reporting; a clean success on the pinned stock — by *any*
+  tool, expected or optional (the runtime guard intercepts every
+  stock-scoped tool alike) — is still reported (and escapes
+  ``guarded_retry``).
 * Stock-code canonicalization: :func:`_canonicalize_stock_code` mirrors the
   runtime normalization chain
   (``src/agent/tools/execution._normalize_tool_stock_code`` delegating to
@@ -552,6 +554,8 @@ def compute_trajectory_metrics(
     key_guarded_escaped: set = set()
     stock_hit: Dict[str, bool] = {}
     wrong_stock_calls: List[str] = []
+    optional_stock_escapes: List[str] = []
+    pinned_stock_escaped = False
     codex_shaped = False
     if stock_code_normalizer is None:
         normalizer = _canonicalize_stock_code
@@ -636,6 +640,20 @@ def compute_trajectory_metrics(
             and _entry_mismatches_stock(entry, stock_code, normalizer)
         ):
             wrong_stock_calls.append(tool)
+        # A clean success on the pinned out-of-scope stock is an escape no
+        # matter which tool made the call: the runtime guard intercepts
+        # every stock-scoped tool alike, so an optional tool reaching the
+        # guarded stock cleanly proves the scope guard was bypassed just as
+        # much as an expected one does.
+        if (
+            guarded_stock_valid
+            and tool
+            and _entry_matches_stock(entry, guarded_stock, normalizer, require_evidence=True)
+            and not _entry_stayed_blocked(success)
+        ):
+            pinned_stock_escaped = True
+            if tool not in expected_set:
+                optional_stock_escapes.append(tool)
         step = _coerce_step(entry.get("step"))
         if step and step not in seen_steps:
             seen_steps.add(step)
@@ -729,6 +747,11 @@ def compute_trajectory_metrics(
         violations.append(
             f"expected tools called for a different stock than " f"{golden.stock_code}: {', '.join(wrong_stock_calls)}"
         )
+    if optional_stock_escapes:
+        violations.append(
+            f"optional tools escaped the guarded stock {golden.expected_guarded_stock}: "
+            f"{', '.join(optional_stock_escapes)}"
+        )
     expected_hit_rate = (len(expected) - len(missing_expected)) / len(expected) if expected else 0.0
     optional_tools_used = [t for t in used_tools if t not in expected]
 
@@ -804,7 +827,12 @@ def compute_trajectory_metrics(
         observed.append("cached")
     if retries:
         observed.append("retry")
-    if any(idx < key_counts.get(k, 0) and k not in key_guarded_escaped for k, idx in key_guarded_at.items()):
+    # A clean success on the pinned out-of-scope stock — by any tool,
+    # expected or optional — proves the scope guard was bypassed, so it
+    # escapes guarded_retry even when the guarded pair itself stayed blocked.
+    if not pinned_stock_escaped and any(
+        idx < key_counts.get(k, 0) and k not in key_guarded_escaped for k, idx in key_guarded_at.items()
+    ):
         observed.append("guarded_retry")
     missing_outcomes = [
         t for t in outcomes if t in EXPECTED_OUTCOME_TAGS and t not in observed and t not in unsupported_outcomes

--- a/evals/agent_trajectory/metrics.py
+++ b/evals/agent_trajectory/metrics.py
@@ -520,12 +520,15 @@ def compute_trajectory_metrics(
     structure contract as :func:`validate_golden_sample` on the loader path:
     malformed parts are reported as violations and excluded from scoring
     instead of silently reshaping the result.  Malformed ``expected_tools`` /
-    ``expected_outcomes`` elements are dropped with an explicit violation,
-    and a pinned ``expected_guarded_stock`` is only honoured for the coherent
-    pairing the validator requires (``guarded_retry`` declared, and a stock
-    different from ``golden.stock_code`` after canonicalization) — an
-    unpaired pin is reported and disabled rather than silently erasing
-    wrong-stock reporting.
+    ``expected_outcomes`` elements — non-strings, empty strings and
+    whitespace-only strings, the validator's exact predicate — are dropped
+    with an explicit violation, a non-positive ``allowed_max_steps`` is
+    reported with the validator's wording (and the budget assertion stays
+    disabled), and a pinned ``expected_guarded_stock`` is only honoured for
+    the coherent pairing the validator requires (``guarded_retry`` declared,
+    and a stock different from ``golden.stock_code`` after
+    canonicalization) — an unpaired pin is reported and disabled rather than
+    silently erasing wrong-stock reporting.
     """
     used_tools: List[str] = []
     key_counts: Dict[tuple, int] = {}
@@ -564,8 +567,10 @@ def compute_trajectory_metrics(
     # below (mirroring validate_golden_sample, which rejects them at load
     # time) and only the valid names take part in scoring.
     if isinstance(golden.expected_tools, list):
-        expected_tools_malformed = [t for t in golden.expected_tools if not isinstance(t, str) or not t]
-        expected = [t for t in golden.expected_tools if isinstance(t, str) and t]
+        # Same element predicate as validate_golden_sample(): whitespace-only
+        # strings count as malformed too, not just falsy ones.
+        expected_tools_malformed = [t for t in golden.expected_tools if not isinstance(t, str) or not t.strip()]
+        expected = [t for t in golden.expected_tools if isinstance(t, str) and t.strip()]
     else:
         # Defend against hand-edited samples passing a bare string:
         # validation rejects it at load time, but scoring must not misparse
@@ -718,7 +723,7 @@ def compute_trajectory_metrics(
     # permissive, and a non-integer step limit must not crash the comparison.
     optional_allowed = golden.allow_optional_tools
     if not isinstance(optional_allowed, bool):
-        violations.append("allow_optional_tools is not a boolean")
+        violations.append("allow_optional_tools must be a boolean")
         optional_allowed = False
     if optional_tools_used and not optional_allowed:
         violations.append(f"optional tools used but not allowed: {', '.join(optional_tools_used)}")
@@ -730,13 +735,16 @@ def compute_trajectory_metrics(
         violations.append("expected_outcomes must be a list of outcome tags")
         outcomes: List[str] = []
     else:
-        malformed_outcomes = [t for t in golden.expected_outcomes if not isinstance(t, str) or not t]
+        # Same element predicate as validate_golden_sample(): whitespace-only
+        # strings are malformed too, so they never fall through to the
+        # unknown-tag check or the required-outcome set.
+        malformed_outcomes = [t for t in golden.expected_outcomes if not isinstance(t, str) or not t.strip()]
         # Malformed outcome elements are reported (same wording as
         # validate_golden_sample) instead of silently dropping the
         # requirement they tried to declare.
         if malformed_outcomes:
             violations.append("expected_outcomes must contain only non-empty strings")
-        outcomes = [t for t in golden.expected_outcomes if isinstance(t, str) and t]
+        outcomes = [t for t in golden.expected_outcomes if isinstance(t, str) and t.strip()]
         if len(set(outcomes)) != len(outcomes):
             violations.append("expected_outcomes contains duplicate tags")
             outcomes = list(dict.fromkeys(outcomes))
@@ -788,6 +796,11 @@ def compute_trajectory_metrics(
     limit = golden.allowed_max_steps
     if isinstance(limit, bool) or not isinstance(limit, int):
         violations.append("allowed_max_steps is not an integer")
+        limit = 0
+    elif limit < 1:
+        # Validator wording for the same field: a non-positive limit must
+        # not silently disable the budget assertion on the direct-score path.
+        violations.append("allowed_max_steps must be >= 1")
         limit = 0
     max_steps_touched = bool(max_step and limit > 0 and max_step >= limit)
     if max_steps_touched:

--- a/evals/agent_trajectory/metrics.py
+++ b/evals/agent_trajectory/metrics.py
@@ -26,7 +26,10 @@ unhashable values (dict / list), so the key is built with
 ``json.dumps(arguments, sort_keys=True, default=str)`` — a *stable string*,
 not a hash.  Do not replace this with ``tuple(arguments)`` or ``repr()``:
 insertion order or collection type would then change call identity and corrupt
-redundancy / retry counts.
+redundancy / retry counts.  Mirroring the production
+``_build_tool_cache_key``, the ``stock_code`` field is canonicalized before
+serialization so runtime-equivalent alias forms share one identity; all other
+arguments stay raw.
 
 Codex App Server entries carry only ``arguments_summary`` — the redacted and
 truncated preview produced by ``redact_diagnostic_value`` — so their identity
@@ -164,10 +167,25 @@ class TrajectoryMetrics:
     violations: List[str]
 
 
-def _args_key(arguments: Any) -> str:
-    """Return a stable idempotency key for tool-call arguments (see module docstring)."""
+def _args_key(arguments: Any, normalizer: Optional[Callable[[Any], str]] = None) -> str:
+    """Return a stable idempotency key for tool-call arguments (see module docstring).
+
+    Mirrors ``src/agent/tools/execution._build_tool_cache_key``: when the
+    payload is a dict, its ``stock_code`` field is canonicalized before
+    serialization so runtime-equivalent alias forms (``SH600519`` /
+    ``600519.SH`` / ``600519``) share one call identity; every other
+    argument stays raw, exactly like the production cache key.  Non-dict
+    payloads (Codex ``arguments_summary`` wrappers, bare fallbacks) are
+    serialized as-is.
+    """
     if arguments is None:
         arguments = {}
+    if normalizer is None:
+        normalizer = _canonicalize_stock_code
+    if isinstance(arguments, dict) and "stock_code" in arguments:
+        normalized = dict(arguments)
+        normalized["stock_code"] = _apply_stock_normalizer(normalizer, arguments["stock_code"])
+        arguments = normalized
     return json.dumps(arguments, sort_keys=True, default=str)
 
 
@@ -426,7 +444,7 @@ def compute_trajectory_metrics(
         if not isinstance(entry.get("arguments"), dict) and entry.get("arguments_summary"):
             codex_shaped = True
 
-        key = (tool, _args_key(_entry_arguments(entry)))
+        key = (tool, _args_key(_entry_arguments(entry), normalizer))
         if key_counts.get(key, 0):
             redundant_calls += 1
         key_counts[key] = key_counts.get(key, 0) + 1
@@ -698,8 +716,11 @@ def validate_golden_sample(
     if sample.expected_guarded_stock is not None:
         if not isinstance(sample.expected_guarded_stock, str) or not sample.expected_guarded_stock.strip():
             issues.append("expected_guarded_stock must be a non-empty string")
-        elif sample.expected_guarded_stock.strip() == sample.stock_code:
-            issues.append("expected_guarded_stock must differ from stock_code (it names the out-of-scope call)")
+        elif _canonicalize_stock_code(sample.expected_guarded_stock) == _canonicalize_stock_code(sample.stock_code):
+            issues.append(
+                "expected_guarded_stock must name a different stock than stock_code "
+                "after canonicalization (it names the out-of-scope call)"
+            )
         elif not isinstance(sample.expected_outcomes, list) or "guarded_retry" not in sample.expected_outcomes:
             issues.append("expected_guarded_stock requires guarded_retry in expected_outcomes")
     return issues

--- a/evals/agent_trajectory/metrics.py
+++ b/evals/agent_trajectory/metrics.py
@@ -112,9 +112,10 @@ Metric semantics
   exactly against the dedicated ``stock_code`` argument field of runner
   entries (never a substring scan, so e.g. ``"1600519"`` cannot satisfy
   ``600519``), the guard metadata ``requested_stock_code``, or the Codex
-  ``arguments_summary`` preview (structured ``stock_code`` recovered from a
-  well-formed preview is compared exactly; otherwise a substring scan,
-  best-effort).  Both sides
+  ``arguments_summary`` preview (only the structured ``stock_code``
+  recovered from a well-formed preview is compared exactly; a truncated /
+  unparseable preview carries unreadable evidence and is a non-match — no
+  substring scan, no name-only tolerance).  Both sides
   of each comparison are canonicalized first with the runtime-equivalent
   stock-code normalization (see below), so production-accepted forms such as
   ``SH600519`` / ``600519.SH`` / ``SZ.000001`` / ``hk700`` resolve to the
@@ -393,8 +394,11 @@ def _entry_matches_stock(
     ``arguments_summary`` preview: when that preview parses back to a JSON
     object with a ``stock_code`` field, the recovered value is canonicalized
     and compared exactly like a runner argument (so ``hk700`` matches an
-    ``HK00700`` golden); otherwise the preview is scanned by substring as a
-    best-effort fallback.  Entries with no stock evidence at all keep the
+    ``HK00700`` golden); a truncated / unparseable preview carries
+    unreadable evidence and is a non-match — never a substring scan (a
+    truncated ``1600519`` would contain ``600519``), never name-only
+    tolerance, because the call's stock cannot be verified.  Entries with
+    no stock evidence at all keep the
     name-only tolerance so minimal entries still count as before; an
     explicitly present but invalid value (null / boolean / non-scalar) is a
     non-match — it provably does not target the golden stock and must not
@@ -436,7 +440,12 @@ def _entry_matches_stock(
     if isinstance(summary, str) and summary:
         value = _coerce_guard_float(_summary_stock_code(summary))
         if value is _SUMMARY_NO_EVIDENCE:
-            return stock_code in summary
+            # A truncated / redacted preview carries unreadable evidence:
+            # never grant stock credit by raw substring (a truncated
+            # 1600519 would contain 600519), and never fall back to
+            # name-only tolerance — the call's stock cannot be verified,
+            # so it cannot score the stock-scoped hit.
+            return False
         # Recovered but invalid (JSON null / false / array): a non-match,
         # never name-only tolerance.
         if not isinstance(value, (str, int)) or isinstance(value, bool):
@@ -474,8 +483,9 @@ def _summary_stock_code(summary: str) -> Any:
 
     Returns ``_SUMMARY_NO_EVIDENCE`` when the preview does not parse back to
     a JSON object with a ``stock_code`` key (truncated / redacted /
-    non-object previews), leaving callers to their documented no-evidence
-    tolerance or substring fallback.
+    non-object previews) — callers treat such an entry as carrying
+    unreadable evidence: a non-match for stock scoring, never a substring
+    scan.
     """
     parsed = _summary_dict(summary)
     if parsed is not None and "stock_code" in parsed:

--- a/evals/agent_trajectory/metrics.py
+++ b/evals/agent_trajectory/metrics.py
@@ -32,8 +32,14 @@ before serialization so runtime-equivalent alias forms share one identity,
 while non-string values (JSON numbers) stay raw; all other arguments stay
 raw.
 
-Codex App Server entries carry only ``arguments_summary`` — the redacted and
-truncated preview produced by ``redact_diagnostic_value`` — so their identity
+Codex App Server entries carry only ``arguments_summary`` — the preview
+produced by ``redact_diagnostic_value`` (the JSON serialization of the
+arguments dict, possibly redacted / truncated).  A well-formed preview is
+parsed back to the original arguments dict *before* keying, so the recovered
+payload goes through the same ``_args_key`` canonicalization as a runner
+payload: alias spellings of ``stock_code`` and argument insertion order do
+not split call identity.  Previews that no longer parse to an object
+(truncated / redacted) fall back to keying by the raw preview string, which
 is best-effort: distinct calls whose summaries collide after redaction or
 truncation may be over-counted as redundant.  A stable argument fingerprint
 requires a producer-side change in ``src/agent/codex_agent_backend.py``, which
@@ -76,7 +82,13 @@ Metric semantics
   bypassed, or the call provably gets through it) and does not satisfy it.  A
   required outcome that is not observed is reported as a violation, so a
   golden sample that declares guard / cache / retry expectations cannot be
-  passed by a trajectory that skips the behaviour it describes.
+  passed by a trajectory that skips the behaviour it describes.  Codex-shaped
+  logs cannot observe guard-dependent tags (``guarded`` / ``cached`` /
+  ``guarded_retry``) because the producer drops that metadata; declaring them
+  for such a log is reported as an explicit unsupported violation instead of
+  a false "not observed" regression.  ``retry`` stays scoreable for Codex
+  logs — it derives from (tool, args-key) repeats, which their entries do
+  carry.
 * ``expected_hit_rate`` is stock-scoped: an expected tool counts as hit only
   when at least one of its calls references ``golden.stock_code`` — matched
   exactly against the dedicated ``stock_code`` argument field of runner
@@ -92,7 +104,12 @@ Metric semantics
   wrong-stock.  Entries with no stock evidence at all keep the name-only
   tolerance, and *every* call of an expected tool whose stock resolves to a
   different code is reported in a violation — one matching call does not
-  legitimize cross-stock calls of the same tool.
+  legitimize cross-stock calls of the same tool.  The one exception is the
+  sample's own pinned out-of-scope stock (``expected_guarded_stock``): a call
+  that targets it and stays blocked (``guarded`` / ``cached`` / failed) is
+  the deliberate probe the task itself requires, so it is exempt from
+  wrong-stock reporting; a clean success on the pinned stock is still
+  reported (and escapes ``guarded_retry``).
 * Stock-code canonicalization: :func:`_canonicalize_stock_code` mirrors the
   runtime normalization chain
   (``src/agent/tools/execution._normalize_tool_stock_code`` delegating to
@@ -128,6 +145,13 @@ from typing import Any, Callable, Dict, Iterable, List, Optional
 #: module docstring.
 EXPECTED_OUTCOME_TAGS = ("guarded", "cached", "retry", "guarded_retry")
 
+#: Outcome tags that depend on per-entry guard / cache metadata.  The Codex
+#: App Server backend drops that metadata (it records only step / tool /
+#: arguments_summary / success / duration), so Codex-shaped logs can never
+#: observe these tags and such declarations are marked unsupported instead of
+#: failing as "not observed" (see the module docstring).
+GUARD_DEPENDENT_OUTCOME_TAGS = ("guarded", "cached", "guarded_retry")
+
 
 @dataclass
 class GoldenSample:
@@ -140,7 +164,9 @@ class GoldenSample:
     docstring); every declared outcome must be observable in the log.
     ``expected_guarded_stock`` optionally pins the stock the guard must
     intercept (the task's out-of-scope call): when set, ``guarded_retry`` is
-    only observed for guarded calls targeting that stock.
+    only observed for guarded calls targeting that stock, and blocked calls
+    (guarded / cached / failed) targeting it are exempt from wrong-stock
+    reporting — the sample itself requires the probe.
     """
 
     id: str
@@ -204,16 +230,25 @@ def _args_key(arguments: Any, normalizer: Optional[Callable[[Any], str]] = None)
 def _entry_arguments(entry: Dict[str, Any]) -> Any:
     """Extract the idempotent argument payload from a log entry.
 
-    Runner entries carry ``arguments`` (a dict); Codex App Server entries carry
-    ``arguments_summary`` (a string) instead.  Falling back to ``{}`` for
-    non-dict ``arguments`` would merge every summary-only entry into one key,
-    so the summary is wrapped to keep call identity distinct.
+    Runner entries carry ``arguments`` (a dict).  Codex App Server entries
+    carry ``arguments_summary`` — the JSON serialization of the arguments
+    dict (possibly redacted / truncated) — so a well-formed preview is parsed
+    back to the original dict and keyed through ``_args_key`` exactly like a
+    runner payload (``stock_code`` canonicalization, sorted keys, argument
+    insertion order must not split call identity).  Previews that do not
+    parse back to a dict fall back to a raw-preview wrapper so distinct
+    calls whose summaries collide after truncation keep distinct identities
+    (documented best-effort; falling back to ``{}`` would merge every
+    summary-only entry into one key).
     """
     arguments = entry.get("arguments")
     if isinstance(arguments, dict):
         return arguments
     summary = entry.get("arguments_summary")
-    if summary:
+    if isinstance(summary, str) and summary:
+        recovered = _summary_dict(summary)
+        if recovered is not None:
+            return recovered
         return {"arguments_summary": summary}
     return arguments
 
@@ -345,22 +380,35 @@ def _entry_matches_stock(
 _SUMMARY_NO_EVIDENCE = object()
 
 
-def _summary_stock_code(summary: str) -> Any:
-    """Recover the structured ``stock_code`` value from a Codex ``arguments_summary``.
+def _summary_dict(summary: str) -> Optional[Dict[str, Any]]:
+    """Parse a Codex ``arguments_summary`` back to the arguments dict.
 
     ``src/agent/codex_agent_backend`` stores
-    ``redact_diagnostic_value(record.arguments)`` — the JSON-serialized
-    arguments dict — so a well-formed (untruncated, unredacted) preview
-    parses back to the original payload.  Returns ``_SUMMARY_NO_EVIDENCE``
-    when the preview is not a JSON object with a ``stock_code`` key
-    (truncated / redacted / non-object previews), leaving callers to their
-    documented no-evidence tolerance or substring fallback.
+    ``redact_diagnostic_value(record.arguments)`` — the JSON serialization of
+    the arguments dict — so a well-formed (untruncated, unredacted) preview
+    recovers the original payload.  Returns ``None`` when the preview is not
+    intact JSON of an object (truncated / redacted / non-object previews);
+    callers then fall back to their documented best-effort handling.
     """
     try:
         parsed = json.loads(summary)
     except (TypeError, ValueError):
-        return _SUMMARY_NO_EVIDENCE
-    if isinstance(parsed, dict) and "stock_code" in parsed:
+        return None
+    if isinstance(parsed, dict):
+        return parsed
+    return None
+
+
+def _summary_stock_code(summary: str) -> Any:
+    """Recover the structured ``stock_code`` value from a Codex ``arguments_summary``.
+
+    Returns ``_SUMMARY_NO_EVIDENCE`` when the preview does not parse back to
+    a JSON object with a ``stock_code`` key (truncated / redacted /
+    non-object previews), leaving callers to their documented no-evidence
+    tolerance or substring fallback.
+    """
+    parsed = _summary_dict(summary)
+    if parsed is not None and "stock_code" in parsed:
         return parsed["stock_code"]
     return _SUMMARY_NO_EVIDENCE
 
@@ -400,6 +448,17 @@ def _entry_mismatches_stock(
             return False
         return _apply_stock_normalizer(normalizer, value) != stock_code
     return False
+
+
+def _entry_stayed_blocked(entry: Dict[str, Any], success: bool) -> bool:
+    """True when the call did not execute cleanly (guarded / cached / failed).
+
+    A blocked call proves nothing about whether the scope guard can be
+    bypassed, while a clean success of an out-of-scope call does — the same
+    predicate drives the ``guarded_retry`` escape tracking and the
+    wrong-stock exemption for pinned out-of-scope probes.
+    """
+    return bool(entry.get("cached") or entry.get("guarded") or not success)
 
 
 def compute_trajectory_metrics(
@@ -474,6 +533,7 @@ def compute_trajectory_metrics(
         if not isinstance(entry, dict):
             continue
         tool = entry.get("tool") or ""
+        success = bool(entry.get("success", True))
         if tool and tool not in used_tools:
             used_tools.append(tool)
         if stock_code and tool and tool not in stock_hit and _entry_matches_stock(entry, stock_code, normalizer):
@@ -481,15 +541,29 @@ def compute_trajectory_metrics(
         # Every call of an expected tool whose stock resolves to a different
         # code is reported — a matching call elsewhere must not legitimize
         # cross-stock usage of the same tool (stock_hit only tracks whether
-        # the tool ever matched, not whether every call did).
-        if stock_code and tool in expected_set and _entry_mismatches_stock(entry, stock_code, normalizer):
+        # the tool ever matched, not whether every call did).  The one
+        # exception is the sample's pinned out-of-scope stock: a blocked
+        # probe of it (guarded / cached / failed) is exactly what the golden
+        # requires, so it is not a wrong-stock violation — but a clean
+        # success on the pinned stock is still reported (and escapes
+        # guarded_retry).
+        pinned_probe_blocked = (
+            guarded_stock_valid
+            and _entry_matches_stock(entry, guarded_stock, normalizer)
+            and _entry_stayed_blocked(entry, success)
+        )
+        if (
+            stock_code
+            and tool in expected_set
+            and not pinned_probe_blocked
+            and _entry_mismatches_stock(entry, stock_code, normalizer)
+        ):
             wrong_stock_calls.append(tool)
         step = _coerce_step(entry.get("step"))
         if step and step not in seen_steps:
             seen_steps.add(step)
             distinct_steps += 1
             max_step = max(max_step, step)
-        success = bool(entry.get("success", True))
         if not success:
             failed_calls += 1
         if entry.get("cached"):
@@ -509,7 +583,7 @@ def compute_trajectory_metrics(
         # the golden contract requires every out-of-scope call to stay
         # blocked at all times, and a pre-guard success proves the call can
         # get through the guard.
-        if not (entry.get("cached") or entry.get("guarded") or not success):
+        if not _entry_stayed_blocked(entry, success):
             key_guarded_escaped.add(key)
         # Record the occurrence index of the (first) guarded call so the
         # "guarded_retry" outcome can require a *later* occurrence of the
@@ -605,6 +679,19 @@ def compute_trajectory_metrics(
     # stock binding for guarded_retry.
     if golden.expected_guarded_stock is not None and not guarded_stock_valid:
         violations.append("expected_guarded_stock must be a non-empty string")
+    # Codex App Server entries carry no guarded / cached metadata (the
+    # backend records only step / tool / arguments_summary / success /
+    # duration), so guard-dependent outcome tags can never be observed from a
+    # Codex-shaped log; mark them unsupported instead of emitting a false
+    # "expected outcomes not observed" regression.  ``retry`` stays
+    # scoreable: it derives from (tool, args-key) repeats, which Codex
+    # entries do carry.
+    unsupported_outcomes = [t for t in outcomes if t in GUARD_DEPENDENT_OUTCOME_TAGS] if codex_shaped else []
+    if unsupported_outcomes:
+        violations.append(
+            "expected outcomes unsupported for Codex App Server logs "
+            "(backend drops guarded/cached metadata): " + ", ".join(unsupported_outcomes)
+        )
     observed = []
     if guarded_calls:
         observed.append("guarded")
@@ -614,7 +701,9 @@ def compute_trajectory_metrics(
         observed.append("retry")
     if any(idx < key_counts.get(k, 0) and k not in key_guarded_escaped for k, idx in key_guarded_at.items()):
         observed.append("guarded_retry")
-    missing_outcomes = [t for t in outcomes if t in EXPECTED_OUTCOME_TAGS and t not in observed]
+    missing_outcomes = [
+        t for t in outcomes if t in EXPECTED_OUTCOME_TAGS and t not in observed and t not in unsupported_outcomes
+    ]
     if missing_outcomes:
         violations.append(f"expected outcomes not observed: {', '.join(missing_outcomes)}")
 

--- a/evals/agent_trajectory/metrics.py
+++ b/evals/agent_trajectory/metrics.py
@@ -46,6 +46,14 @@ Metric semantics
   success`` counts exactly one retry, not two.
 * ``cached_calls``: entries with ``cached=True`` (runner semantics: reuse of a
   non-retriable failure result).
+* ``expected_outcomes``: machine-readable trajectory features a golden sample
+  may require, from the fixed vocabulary ``guarded`` / ``cached`` / ``retry``.
+  ``guarded`` is observed when any entry carries ``guarded=True`` (the stock-
+  scope guard interception), ``cached`` when any entry carries ``cached=True``
+  and ``retry`` when at least one retry is counted per the contract above.  A
+  required outcome that is not observed is reported as a violation, so a
+  golden sample that declares guard / cache / retry expectations cannot be
+  passed by a trajectory that skips the behaviour it describes.
 * ``max_steps_touched``: the log does not carry ``max_steps`` itself, so this
   is the conservative heuristic ``max(step) >= golden.allowed_max_steps`` —
   a proxy for "the run reached the step budget", not proof of the loop
@@ -62,6 +70,11 @@ from dataclasses import dataclass, field, fields
 from pathlib import Path
 from typing import Any, Dict, Iterable, List, Optional
 
+#: Machine-readable trajectory features a golden sample may require of a log
+#: (``guarded`` = a guarded call, ``cached`` = a cached call, ``retry`` = at
+#: least one retry).  See the "Metric semantics" section of the module docstring.
+EXPECTED_OUTCOME_TAGS = ("guarded", "cached", "retry")
+
 
 @dataclass
 class GoldenSample:
@@ -69,6 +82,9 @@ class GoldenSample:
 
     ``expected_tools`` are the tool names the agent should call; tools outside
     this set are tolerated only when ``allow_optional_tools`` is true.
+    ``expected_outcomes`` are required trajectory features from the vocabulary
+    ``guarded`` / ``cached`` / ``retry`` (see the module docstring); every
+    declared outcome must be observable in the log.
     """
 
     id: str
@@ -78,6 +94,7 @@ class GoldenSample:
     skills: List[str] = field(default_factory=list)
     allowed_max_steps: int = 10
     allow_optional_tools: bool = True
+    expected_outcomes: List[str] = field(default_factory=list)
 
 
 @dataclass
@@ -150,6 +167,7 @@ def compute_trajectory_metrics(
     key_retries: Dict[tuple, int] = {}
     failed_calls = 0
     cached_calls = 0
+    guarded_calls = 0
     redundant_calls = 0
     distinct_steps = 0
     max_step = 0
@@ -171,6 +189,8 @@ def compute_trajectory_metrics(
             failed_calls += 1
         if entry.get("cached"):
             cached_calls += 1
+        if entry.get("guarded"):
+            guarded_calls += 1
 
         key = (tool, _args_key(_entry_arguments(entry)))
         if key_counts.get(key, 0):
@@ -196,6 +216,9 @@ def compute_trajectory_metrics(
     distinct_steps = max(distinct_steps, total)
     max_step = max(max_step, total)
 
+    retries = sum(key_retries.values())
+    violations: List[str] = []
+
     if isinstance(golden.expected_tools, list):
         expected = [t for t in golden.expected_tools if isinstance(t, str) and t]
     else:
@@ -203,11 +226,16 @@ def compute_trajectory_metrics(
         # validation rejects it at load time, but scoring must not misparse
         # it into per-character tool names either.
         expected = []
+    # A hand-edited sample may repeat a tool name; normalize to first
+    # occurrences before scoring so the hit rate cannot be inflated
+    # (["quote", "quote"] with one quote call must read 1/2, not 2/3).
+    if len(set(expected)) != len(expected):
+        violations.append("expected_tools contains duplicate names")
+        expected = list(dict.fromkeys(expected))
     missing_expected = [t for t in expected if t not in used_tools]
     expected_hit_rate = (len(expected) - len(missing_expected)) / len(expected) if expected else 0.0
     optional_tools_used = [t for t in used_tools if t not in expected]
 
-    violations: List[str] = []
     if not expected:
         violations.append("golden sample has no expected_tools")
 
@@ -220,6 +248,31 @@ def compute_trajectory_metrics(
         optional_allowed = False
     if optional_tools_used and not optional_allowed:
         violations.append(f"optional tools used but not allowed: {', '.join(optional_tools_used)}")
+
+    # Machine-readable outcome expectations: each declared tag must be
+    # observable in the log, otherwise the sample's guard / cache / retry
+    # contract is violated (see the module docstring).
+    if not isinstance(golden.expected_outcomes, list):
+        violations.append("expected_outcomes must be a list of outcome tags")
+        outcomes: List[str] = []
+    else:
+        outcomes = [t for t in golden.expected_outcomes if isinstance(t, str) and t]
+        if len(set(outcomes)) != len(outcomes):
+            violations.append("expected_outcomes contains duplicate tags")
+            outcomes = list(dict.fromkeys(outcomes))
+        unknown = [t for t in outcomes if t not in EXPECTED_OUTCOME_TAGS]
+        if unknown:
+            violations.append(f"unknown expected outcome tags: {', '.join(unknown)}")
+    observed = []
+    if guarded_calls:
+        observed.append("guarded")
+    if cached_calls:
+        observed.append("cached")
+    if retries:
+        observed.append("retry")
+    missing_outcomes = [t for t in outcomes if t in EXPECTED_OUTCOME_TAGS and t not in observed]
+    if missing_outcomes:
+        violations.append(f"expected outcomes not observed: {', '.join(missing_outcomes)}")
 
     limit = golden.allowed_max_steps
     if isinstance(limit, bool) or not isinstance(limit, int):
@@ -237,7 +290,7 @@ def compute_trajectory_metrics(
         redundant_calls=redundant_calls,
         cached_calls=cached_calls,
         failed_calls=failed_calls,
-        retries=sum(key_retries.values()),
+        retries=retries,
         distinct_steps=distinct_steps,
         max_steps_touched=max_steps_touched,
         violations=violations,
@@ -323,9 +376,11 @@ def validate_golden_sample(
 
     Field *types* are part of the structural contract — hand-edited golden
     JSON must fail with a clear message instead of crashing or silently
-    passing: text fields must be strings, ``expected_tools``/``skills`` must
-    be lists, ``allowed_max_steps`` an integer and ``allow_optional_tools`` a
-    boolean.
+    passing: text fields must be strings, ``expected_tools``/``skills`` and
+    ``expected_outcomes`` must be lists, ``allowed_max_steps`` an integer and
+    ``allow_optional_tools`` a boolean.  ``expected_tools`` and
+    ``expected_outcomes`` must be duplicate-free, and outcome tags must come
+    from the fixed vocabulary ``guarded`` / ``cached`` / ``retry``.
     """
     issues: List[str] = []
     known = set(known_tool_names) if known_tool_names is not None else None
@@ -341,6 +396,8 @@ def validate_golden_sample(
         issues.append("expected_tools must be a non-empty list")
     elif any(not isinstance(t, str) or not t.strip() for t in sample.expected_tools):
         issues.append("expected_tools must contain only non-empty strings")
+    elif len(set(sample.expected_tools)) != len(sample.expected_tools):
+        issues.append("expected_tools must not contain duplicate names")
     elif known is not None:
         # Only reachable when expected_tools is a non-empty list of non-empty
         # strings, so malformed values can never crash the membership check.
@@ -357,4 +414,14 @@ def validate_golden_sample(
         issues.append("allowed_max_steps must be >= 1")
     if not isinstance(sample.allow_optional_tools, bool):
         issues.append("allow_optional_tools must be a boolean")
+    if not isinstance(sample.expected_outcomes, list):
+        issues.append("expected_outcomes must be a list of outcome tags")
+    elif any(not isinstance(t, str) or not t.strip() for t in sample.expected_outcomes):
+        issues.append("expected_outcomes must contain only non-empty strings")
+    elif len(set(sample.expected_outcomes)) != len(sample.expected_outcomes):
+        issues.append("expected_outcomes must not contain duplicate tags")
+    else:
+        unknown = [t for t in sample.expected_outcomes if t not in EXPECTED_OUTCOME_TAGS]
+        if unknown:
+            issues.append(f"unknown expected_outcomes: {', '.join(unknown)}")
     return issues

--- a/evals/agent_trajectory/metrics.py
+++ b/evals/agent_trajectory/metrics.py
@@ -66,20 +66,37 @@ Metric semantics
   retry of an unrelated call does not satisfy it.  When the sample sets
   ``expected_guarded_stock``, the guarded occurrence of ``guarded_retry``
   must additionally target that stock (the task's required out-of-scope
-  call), so two guarded retries of any other stock do not satisfy it.  A
+  call), and every *later* occurrence of the pair must remain blocked
+  (``cached`` / ``guarded`` / failed): a clean success after the guard is an
+  escape — the scope guard was bypassed — and does not satisfy it.  A
   required outcome that is not observed is reported as a violation, so a
   golden sample that declares guard / cache / retry expectations cannot be
   passed by a trajectory that skips the behaviour it describes.
 * ``expected_hit_rate`` is stock-scoped: an expected tool counts as hit only
   when at least one of its calls references ``golden.stock_code`` — matched
   exactly against the dedicated ``stock_code`` argument field of runner
-  entries (normalized string comparison, never a substring scan, so e.g.
-  ``"1600519"`` cannot satisfy ``600519``), the guard metadata
-  ``requested_stock_code``, or the Codex ``arguments_summary`` preview
-  (substring match, best-effort).  Entries with no stock evidence at all keep
-  the name-only tolerance, and *every* call of an expected tool whose stock
-  resolves to a different code is reported in a violation — one matching call
-  does not legitimize cross-stock calls of the same tool.
+  entries (never a substring scan, so e.g. ``"1600519"`` cannot satisfy
+  ``600519``), the guard metadata ``requested_stock_code``, or the Codex
+  ``arguments_summary`` preview (substring match, best-effort).  Both sides
+  of each comparison are canonicalized first with the runtime-equivalent
+  stock-code normalization (see below), so production-accepted forms such as
+  ``SH600519`` / ``600519.SH`` / ``SZ.000001`` / ``hk700`` resolve to the
+  same identity as their clean code instead of being mis-scored as
+  wrong-stock.  Entries with no stock evidence at all keep the name-only
+  tolerance, and *every* call of an expected tool whose stock resolves to a
+  different code is reported in a violation — one matching call does not
+  legitimize cross-stock calls of the same tool.
+* Stock-code canonicalization: :func:`_canonicalize_stock_code` mirrors the
+  runtime normalization chain
+  (``src/agent/tools/execution._normalize_tool_stock_code`` delegating to
+  ``data_provider.base.normalize_stock_code`` /
+  ``canonical_stock_code``): whitespace / case folding, exchange
+  prefix/suffix stripping (SH / SZ / SS / BJ), HK variants folded to
+  ``HK00xxx``, Yahoo JP / KR / TW suffix forms preserved.  The metrics layer
+  stays free of runtime imports; the test suite keeps a parity test against
+  the production function so the mirror cannot silently drift, and live-run
+  callers can inject the production normalizer via
+  ``stock_code_normalizer``.
 * ``max_steps_touched``: the log does not carry ``max_steps`` itself, so this
   is the conservative heuristic ``max(step) >= golden.allowed_max_steps`` —
   a proxy for "the run reached the step budget", not proof of the loop
@@ -94,13 +111,14 @@ from __future__ import annotations
 import json
 from dataclasses import dataclass, field, fields
 from pathlib import Path
-from typing import Any, Dict, Iterable, List, Optional
+from typing import Any, Callable, Dict, Iterable, List, Optional
 
 #: Machine-readable trajectory features a golden sample may require of a log
 #: (``guarded`` = a guarded call, ``cached`` = a cached call, ``retry`` = at
-#: least one retry, ``guarded_retry`` = a guarded call followed by a later
-#: occurrence of the same (tool, args-key) pair).  See the "Metric semantics"
-#: section of the module docstring.
+#: least one retry, ``guarded_retry`` = a guarded call followed by later
+#: occurrences of the same (tool, args-key) pair that all remain blocked —
+#: cached / guarded / failed).  See the "Metric semantics" section of the
+#: module docstring.
 EXPECTED_OUTCOME_TAGS = ("guarded", "cached", "retry", "guarded_retry")
 
 
@@ -179,42 +197,116 @@ def _coerce_step(value: Any) -> int:
     return step if step > 0 else 0
 
 
-def _normalized_stock(value: Any) -> str:
-    """Normalize a resolvable stock value (str / int) for exact comparison."""
-    return str(value).strip()
+def _canonicalize_stock_code(value: Any) -> str:
+    """Canonicalize a stock code the way the runtime does before comparing.
+
+    Mirrors ``src/agent/tools/execution._normalize_tool_stock_code`` (the
+    guard path) and its delegate
+    ``data_provider.base.normalize_stock_code``: trims whitespace, folds
+    case, strips exchange prefixes/suffixes (``SH600519`` / ``600519.SH`` /
+    ``SZ.000001`` / ``BJ920748`` ...), folds HK variants to ``HK00xxx``, and
+    preserves Yahoo JP/KR/TW suffix forms (``7203.T`` / ``005930.KS`` /
+    ``2330.TW``).  The mirror keeps this module free of runtime imports;
+    ``tests/test_agent_trajectory_metrics.py`` asserts parity with the
+    production function, and live-run callers can inject the production
+    normalizer instead (see :func:`compute_trajectory_metrics`).
+    """
+    if not isinstance(value, str):
+        return str(value)
+    text = value.strip().upper()
+    if not text:
+        return text
+    if text.endswith(".HK"):
+        base = text[:-3]
+        if base.isdigit() and 1 <= len(base) <= 5:
+            return "HK" + base.zfill(5)
+    if text.startswith("HK"):
+        base = text[2:]
+        if base.isdigit() and 1 <= len(base) <= 5:
+            return "HK" + base.zfill(5)
+    if text.isdigit() and len(text) == 5:
+        return "HK" + text
+    code = value.strip()
+    upper = code.upper()
+    if upper.startswith(("SH", "SZ", "SS")) and not upper.startswith(("SH.", "SZ.", "SS.")):
+        candidate = code[2:]
+        if candidate.isdigit() and len(candidate) in (5, 6):
+            return candidate
+    if upper.startswith(("SH.", "SZ.", "SS.")):
+        candidate = code[3:]
+        if candidate.isdigit() and len(candidate) in (5, 6):
+            return candidate
+    if upper.startswith("BJ") and not upper.startswith("BJ."):
+        candidate = code[2:]
+        if candidate.isdigit() and len(candidate) == 6:
+            return candidate
+    if upper.startswith("BJ."):
+        candidate = code[3:]
+        if candidate.isdigit() and len(candidate) == 6:
+            return candidate
+    if "." in code:
+        base, suffix = code.rsplit(".", 1)
+        if suffix.upper() == "T" and base.isdigit() and len(base) in (4, 5):
+            return base + ".T"
+        if suffix.upper() in ("KS", "KQ") and base.isdigit() and len(base) == 6:
+            return base + "." + suffix.upper()
+        if suffix.upper() in ("TW", "TWO") and base.isdigit() and 4 <= len(base) <= 6:
+            return base + "." + suffix.upper()
+        if suffix.upper() == "HK" and base.isdigit() and 1 <= len(base) <= 5:
+            return "HK" + base.zfill(5)
+        if base.upper() in ("SH", "SS", "SZ", "BJ") and suffix.isdigit():
+            return suffix
+        if suffix.upper() in ("SH", "SZ", "SS", "BJ") and base.isdigit():
+            return base
+    return text
 
 
-def _entry_matches_stock(entry: Dict[str, Any], stock_code: str) -> bool:
+def _apply_stock_normalizer(normalizer: Callable[[Any], str], value: Any) -> str:
+    """Apply a stock normalizer defensively (non-str results fall back to the mirror)."""
+    result = normalizer(value)
+    return result if isinstance(result, str) else _canonicalize_stock_code(value)
+
+
+def _entry_matches_stock(
+    entry: Dict[str, Any],
+    stock_code: str,
+    normalizer: Callable[[Any], str],
+) -> bool:
     """Best-effort check that a log entry's call targeted ``stock_code``.
 
     Guard metadata (``requested_stock_code``) is authoritative; runner
     entries are matched exactly against their dedicated ``stock_code``
     argument field (every stock tool in the repository takes it) — the value
-    is normalized and compared for equality, never scanned as a substring, so
-    ``"1600519"`` cannot satisfy a ``600519`` golden.  Codex App Server
-    entries carry only the redacted ``arguments_summary`` preview, which has
-    no structured field and is matched by substring.  Entries with no stock
-    evidence at all (or unresolvable values) keep the name-only tolerance so
-    malformed or minimal entries still count as before.
+    is canonicalized and compared for equality, never scanned as a substring,
+    so ``"1600519"`` cannot satisfy a ``600519`` golden while
+    ``"SH600519"`` can.  Codex App Server entries carry only the redacted
+    ``arguments_summary`` preview, which has no structured field and is
+    matched by substring.  Entries with no stock evidence at all (or
+    unresolvable values) keep the name-only tolerance so malformed or minimal
+    entries still count as before.
     """
     requested = entry.get("requested_stock_code")
     if requested:
         if not isinstance(requested, (str, int)) or isinstance(requested, bool):
             return True
-        return _normalized_stock(requested) == stock_code
+        return _apply_stock_normalizer(normalizer, requested) == stock_code
     args = entry.get("arguments")
     if isinstance(args, dict):
         value = args.get("stock_code")
         if not isinstance(value, (str, int)) or isinstance(value, bool):
             return True
-        return _normalized_stock(value) == stock_code
+        return _apply_stock_normalizer(normalizer, value) == stock_code
     summary = entry.get("arguments_summary")
     if isinstance(summary, str) and summary:
         return stock_code in summary
     return True
 
 
-def _entry_mismatches_stock(entry: Dict[str, Any], stock_code: str) -> bool:
+def _entry_mismatches_stock(
+    entry: Dict[str, Any],
+    stock_code: str,
+    normalizer: Callable[[Any], str],
+) -> bool:
     """True when the entry's stock resolves to a *different* code.
 
     Only evidence that resolves to a concrete code can mismatch: guard
@@ -227,13 +319,13 @@ def _entry_mismatches_stock(entry: Dict[str, Any], stock_code: str) -> bool:
     if requested:
         if not isinstance(requested, (str, int)) or isinstance(requested, bool):
             return False
-        return _normalized_stock(requested) != stock_code
+        return _apply_stock_normalizer(normalizer, requested) != stock_code
     args = entry.get("arguments")
     if isinstance(args, dict):
         value = args.get("stock_code")
         if not isinstance(value, (str, int)) or isinstance(value, bool):
             return False
-        return _normalized_stock(value) != stock_code
+        return _apply_stock_normalizer(normalizer, value) != stock_code
     return False
 
 
@@ -241,6 +333,7 @@ def compute_trajectory_metrics(
     log: List[Dict[str, Any]],
     golden: GoldenSample,
     total_steps: Optional[int] = None,
+    stock_code_normalizer: Optional[Callable[[Any], str]] = None,
 ) -> TrajectoryMetrics:
     """Compute all trajectory metrics from a ``tool_calls_log`` and a golden sample.
 
@@ -250,18 +343,36 @@ def compute_trajectory_metrics(
     than the log-derived step count it is used for ``distinct_steps`` and the
     ``max_steps_touched`` heuristic; otherwise the log alone decides, and the
     default ``None`` keeps the log-only behaviour.
+
+    ``stock_code_normalizer`` optionally injects the runtime stock-code
+    canonicalization for live runs (e.g.
+    ``src.agent.tools.execution._normalize_tool_stock_code``); the default is
+    the module's runtime-equivalent mirror :func:`_canonicalize_stock_code`,
+    which keeps the metrics layer free of runtime imports.
     """
     used_tools: List[str] = []
     key_counts: Dict[tuple, int] = {}
     key_failed_seen: Dict[tuple, bool] = {}
     key_retries: Dict[tuple, int] = {}
     key_guarded_at: Dict[tuple, int] = {}
+    key_guarded_escaped: set = set()
     stock_hit: Dict[str, bool] = {}
     wrong_stock_calls: List[str] = []
     codex_shaped = False
-    stock_code = golden.stock_code if isinstance(golden.stock_code, str) and golden.stock_code.strip() else ""
+    if stock_code_normalizer is None:
+        normalizer = _canonicalize_stock_code
+        normalizer_invalid = False
+    elif callable(stock_code_normalizer):
+        normalizer = stock_code_normalizer
+        normalizer_invalid = False
+    else:
+        normalizer = _canonicalize_stock_code
+        normalizer_invalid = True
+    golden_stock_valid = isinstance(golden.stock_code, str) and bool(golden.stock_code.strip())
+    stock_code = _apply_stock_normalizer(normalizer, golden.stock_code) if golden_stock_valid else ""
     guarded_stock = golden.expected_guarded_stock
     guarded_stock_valid = isinstance(guarded_stock, str) and bool(guarded_stock.strip())
+    guarded_stock = _apply_stock_normalizer(normalizer, guarded_stock) if guarded_stock_valid else guarded_stock
     # Extract the expected tool list before scanning entries so per-entry
     # wrong-stock reporting can consult it during the loop.
     if isinstance(golden.expected_tools, list):
@@ -292,13 +403,13 @@ def compute_trajectory_metrics(
         tool = entry.get("tool") or ""
         if tool and tool not in used_tools:
             used_tools.append(tool)
-        if stock_code and tool and tool not in stock_hit and _entry_matches_stock(entry, stock_code):
+        if stock_code and tool and tool not in stock_hit and _entry_matches_stock(entry, stock_code, normalizer):
             stock_hit[tool] = True
         # Every call of an expected tool whose stock resolves to a different
         # code is reported — a matching call elsewhere must not legitimize
         # cross-stock usage of the same tool (stock_hit only tracks whether
         # the tool ever matched, not whether every call did).
-        if stock_code and tool in expected_set and _entry_mismatches_stock(entry, stock_code):
+        if stock_code and tool in expected_set and _entry_mismatches_stock(entry, stock_code, normalizer):
             wrong_stock_calls.append(tool)
         step = _coerce_step(entry.get("step"))
         if step and step not in seen_steps:
@@ -319,13 +430,18 @@ def compute_trajectory_metrics(
         if key_counts.get(key, 0):
             redundant_calls += 1
         key_counts[key] = key_counts.get(key, 0) + 1
+        # Every occurrence after a guarded call must remain blocked (cached
+        # / guarded / failed): a clean success escapes the scope guard and
+        # disqualifies the key from the "guarded_retry" outcome.
+        if key in key_guarded_at and not (entry.get("cached") or entry.get("guarded") or not success):
+            key_guarded_escaped.add(key)
         # Record the occurrence index of the (first) guarded call so the
         # "guarded_retry" outcome can require a *later* occurrence of the
         # same key instead of matching any guard and any retry anywhere.
         # When the sample pins the guarded stock, only guarded calls
         # targeting that stock can seed the outcome.
         if entry.get("guarded") and key not in key_guarded_at:
-            if not guarded_stock_valid or _entry_matches_stock(entry, guarded_stock):
+            if not guarded_stock_valid or _entry_matches_stock(entry, guarded_stock, normalizer):
                 key_guarded_at[key] = key_counts[key]
         # An occurrence is a retry only when the same call already failed
         # before it (see module docstring for the precise contract).
@@ -365,6 +481,8 @@ def compute_trajectory_metrics(
 
     if expected_dupes:
         violations.append("expected_tools contains duplicate names")
+    if normalizer_invalid:
+        violations.append("stock_code_normalizer is not callable")
     if not stock_code:
         violations.append("golden.stock_code is not a non-empty string")
     # Stock-scoped hit semantics: an expected tool only counts when one of
@@ -418,7 +536,7 @@ def compute_trajectory_metrics(
         observed.append("cached")
     if retries:
         observed.append("retry")
-    if any(idx < key_counts.get(k, 0) for k, idx in key_guarded_at.items()):
+    if any(idx < key_counts.get(k, 0) and k not in key_guarded_escaped for k, idx in key_guarded_at.items()):
         observed.append("guarded_retry")
     missing_outcomes = [t for t in outcomes if t in EXPECTED_OUTCOME_TAGS and t not in observed]
     if missing_outcomes:

--- a/evals/agent_trajectory/metrics.py
+++ b/evals/agent_trajectory/metrics.py
@@ -18,6 +18,13 @@ JSON file from disk.  This keeps the metrics layer deterministic, unit-testable
 without an API key, and free of ``src/`` imports — it can score trajectories
 from any source.
 
+Both entry paths enforce the same golden-sample structure contract:
+``validate_golden_sample`` (the loader path) rejects malformed samples
+outright, while ``compute_trajectory_metrics`` (the direct-construction path)
+reports malformed fields as violations and excludes the invalid parts from
+scoring — a caller who builds a ``GoldenSample`` by hand must never get a
+silently relaxed result (see the compute docstring for the exact mapping).
+
 Idempotency key contract
 ------------------------
 Two log entries are considered "the same call" when their ``tool`` names are
@@ -508,6 +515,17 @@ def compute_trajectory_metrics(
     ``src.agent.tools.execution._normalize_tool_stock_code``); the default is
     the module's runtime-equivalent mirror :func:`_canonicalize_stock_code`,
     which keeps the metrics layer free of runtime imports.
+
+    Direct construction of a hand-edited ``GoldenSample`` is held to the same
+    structure contract as :func:`validate_golden_sample` on the loader path:
+    malformed parts are reported as violations and excluded from scoring
+    instead of silently reshaping the result.  Malformed ``expected_tools`` /
+    ``expected_outcomes`` elements are dropped with an explicit violation,
+    and a pinned ``expected_guarded_stock`` is only honoured for the coherent
+    pairing the validator requires (``guarded_retry`` declared, and a stock
+    different from ``golden.stock_code`` after canonicalization) — an
+    unpaired pin is reported and disabled rather than silently erasing
+    wrong-stock reporting.
     """
     used_tools: List[str] = []
     key_counts: Dict[tuple, int] = {}
@@ -530,16 +548,29 @@ def compute_trajectory_metrics(
     golden_stock_valid = isinstance(golden.stock_code, str) and bool(golden.stock_code.strip())
     stock_code = _apply_stock_normalizer(normalizer, golden.stock_code) if golden_stock_valid else ""
     guarded_stock = golden.expected_guarded_stock
-    guarded_stock_valid = isinstance(guarded_stock, str) and bool(guarded_stock.strip())
-    guarded_stock = _apply_stock_normalizer(normalizer, guarded_stock) if guarded_stock_valid else guarded_stock
+    guarded_stock_nonempty = isinstance(guarded_stock, str) and bool(guarded_stock.strip())
+    # A pinned stock only takes effect for the coherent pairing
+    # validate_golden_sample() enforces: expected_guarded_stock must be
+    # declared together with guarded_retry in expected_outcomes.  An
+    # unpaired pin is malformed — it is reported below and must not reshape
+    # scoring (no wrong-stock exemption, no pinned seeding).
+    guarded_stock_valid = guarded_stock_nonempty and (
+        isinstance(golden.expected_outcomes, list) and "guarded_retry" in golden.expected_outcomes
+    )
+    guarded_stock = _apply_stock_normalizer(normalizer, guarded_stock) if guarded_stock_nonempty else guarded_stock
     # Extract the expected tool list before scanning entries so per-entry
-    # wrong-stock reporting can consult it during the loop.
+    # wrong-stock reporting can consult it during the loop.  Malformed
+    # elements are not silently dropped: they are reported as a violation
+    # below (mirroring validate_golden_sample, which rejects them at load
+    # time) and only the valid names take part in scoring.
     if isinstance(golden.expected_tools, list):
+        expected_tools_malformed = [t for t in golden.expected_tools if not isinstance(t, str) or not t]
         expected = [t for t in golden.expected_tools if isinstance(t, str) and t]
     else:
         # Defend against hand-edited samples passing a bare string:
         # validation rejects it at load time, but scoring must not misparse
         # it into per-character tool names either.
+        expected_tools_malformed = []
         expected = []
     # A hand-edited sample may repeat a tool name; normalize to first
     # occurrences before scoring so the hit rate cannot be inflated
@@ -660,6 +691,8 @@ def compute_trajectory_metrics(
 
     if expected_dupes:
         violations.append("expected_tools contains duplicate names")
+    if expected_tools_malformed:
+        violations.append("expected_tools must contain only non-empty strings")
     if normalizer_invalid:
         violations.append("stock_code_normalizer is not callable")
     if not stock_code:
@@ -697,6 +730,12 @@ def compute_trajectory_metrics(
         violations.append("expected_outcomes must be a list of outcome tags")
         outcomes: List[str] = []
     else:
+        malformed_outcomes = [t for t in golden.expected_outcomes if not isinstance(t, str) or not t]
+        # Malformed outcome elements are reported (same wording as
+        # validate_golden_sample) instead of silently dropping the
+        # requirement they tried to declare.
+        if malformed_outcomes:
+            violations.append("expected_outcomes must contain only non-empty strings")
         outcomes = [t for t in golden.expected_outcomes if isinstance(t, str) and t]
         if len(set(outcomes)) != len(outcomes):
             violations.append("expected_outcomes contains duplicate tags")
@@ -705,9 +744,19 @@ def compute_trajectory_metrics(
         if unknown:
             violations.append(f"unknown expected outcome tags: {', '.join(unknown)}")
     # A pinned but malformed guarded stock must not silently disable the
-    # stock binding for guarded_retry.
-    if golden.expected_guarded_stock is not None and not guarded_stock_valid:
+    # stock binding for guarded_retry — nor silently keep it: mirror the
+    # structure contract validate_golden_sample() enforces at load time, so
+    # the direct-construction path reports the same violations instead of
+    # drifting from the loader semantics.
+    if golden.expected_guarded_stock is not None and not guarded_stock_nonempty:
         violations.append("expected_guarded_stock must be a non-empty string")
+    elif guarded_stock_nonempty and guarded_stock == stock_code:
+        violations.append(
+            "expected_guarded_stock must name a different stock than stock_code "
+            "after canonicalization (it names the out-of-scope call)"
+        )
+    elif guarded_stock_nonempty and not guarded_stock_valid:
+        violations.append("expected_guarded_stock requires guarded_retry in expected_outcomes")
     # Codex App Server entries carry no guarded / cached metadata (the
     # backend records only step / tool / arguments_summary / success /
     # duration), so guard-dependent outcome tags can never be observed from a

--- a/evals/agent_trajectory/metrics.py
+++ b/evals/agent_trajectory/metrics.py
@@ -1,0 +1,277 @@
+# -*- coding: utf-8 -*-
+"""Pure-function trajectory metrics for agent evaluation (Issue #1956).
+
+This module computes quality metrics for an agent execution trajectory from its
+``tool_calls_log`` (see ``src/agent/runner.py`` for the producer contract):
+
+* each entry carries ``step / tool / arguments / success / duration /
+  result_length / cached`` and optionally ``timeout`` or ``guarded`` fields;
+* entries with missing optional fields are tolerated with defaults (e.g. the
+  Codex App Server backend emits ``arguments_summary`` instead of
+  ``arguments``).
+
+All functions in this module are pure: they consume plain data (a log list and
+a ``GoldenSample``) and never touch the filesystem, network, or LLM.  This keeps
+the metrics layer deterministic, unit-testable without an API key, and free of
+``src/`` imports — it can score trajectories from any source.
+
+Idempotency key contract
+------------------------
+Two log entries are considered "the same call" when their ``tool`` names are
+equal and their serialized ``arguments`` are equal.  Arguments may contain
+unhashable values (dict / list), so the key is built with
+``json.dumps(arguments, sort_keys=True, default=str)`` — a *stable string*,
+not a hash.  Do not replace this with ``tuple(arguments)`` or ``repr()``:
+insertion order or collection type would then change call identity and corrupt
+redundancy / retry counts.
+
+Metric semantics
+----------------
+* ``redundant_calls``: every occurrence of a (tool, args-key) pair beyond its
+  first — regardless of success.
+* ``retries``: occurrences that follow a *failed* occurrence of the same pair
+  (i.e. "tried again after a failure").  ``retries`` is a subset of
+  ``redundant_calls``; repeats after success count as redundant but not retry.
+* ``cached_calls``: entries with ``cached=True`` (runner semantics: reuse of a
+  non-retriable failure result).
+* ``max_steps_touched``: the log does not carry ``max_steps`` itself, so this
+  is the conservative heuristic ``max(step) >= golden.allowed_max_steps`` —
+  a proxy for "the run reached the step budget", not proof of the loop
+  exhausting it.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field, fields
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Optional
+
+
+@dataclass
+class GoldenSample:
+    """Expected trajectory for one evaluation task.
+
+    ``expected_tools`` are the tool names the agent should call; tools outside
+    this set are tolerated only when ``allow_optional_tools`` is true.
+    """
+
+    id: str
+    task_description: str
+    stock_code: str
+    expected_tools: List[str]
+    skills: List[str] = field(default_factory=list)
+    allowed_max_steps: int = 10
+    allow_optional_tools: bool = True
+
+
+@dataclass
+class TrajectoryMetrics:
+    """All metrics computed for one trajectory against one golden sample."""
+
+    expected_hit_rate: float
+    expected_total: int
+    missing_expected: List[str]
+    optional_tools_used: List[str]
+    redundant_calls: int
+    cached_calls: int
+    failed_calls: int
+    retries: int
+    distinct_steps: int
+    max_steps_touched: bool
+    violations: List[str]
+
+
+def _args_key(arguments: Any) -> str:
+    """Return a stable idempotency key for tool-call arguments (see module docstring)."""
+    if arguments is None:
+        arguments = {}
+    return json.dumps(arguments, sort_keys=True, default=str)
+
+
+def _entry_arguments(entry: Dict[str, Any]) -> Any:
+    """Extract the idempotent argument payload from a log entry.
+
+    Runner entries carry ``arguments`` (a dict); Codex App Server entries carry
+    ``arguments_summary`` (a string) instead.  Falling back to ``{}`` for
+    non-dict ``arguments`` would merge every summary-only entry into one key,
+    so the summary is wrapped to keep call identity distinct.
+    """
+    arguments = entry.get("arguments")
+    if isinstance(arguments, dict):
+        return arguments
+    summary = entry.get("arguments_summary")
+    if summary:
+        return {"arguments_summary": summary}
+    return arguments
+
+
+def _coerce_step(value: Any) -> int:
+    """Coerce a log entry's ``step`` to a non-negative int (missing/odd -> 0)."""
+    try:
+        step = int(value)
+    except (TypeError, ValueError):
+        return 0
+    return step if step > 0 else 0
+
+
+def compute_trajectory_metrics(log: List[Dict[str, Any]], golden: GoldenSample) -> TrajectoryMetrics:
+    """Compute all trajectory metrics from a ``tool_calls_log`` and a golden sample."""
+    used_tools: List[str] = []
+    key_counts: Dict[tuple, int] = {}
+    key_failed_seen: Dict[tuple, bool] = {}
+    key_retries: Dict[tuple, int] = {}
+    failed_calls = 0
+    cached_calls = 0
+    redundant_calls = 0
+    distinct_steps = 0
+    max_step = 0
+    seen_steps: set = set()
+
+    for entry in log:
+        if not isinstance(entry, dict):
+            continue
+        tool = entry.get("tool") or ""
+        if tool and tool not in used_tools:
+            used_tools.append(tool)
+        step = _coerce_step(entry.get("step"))
+        if step and step not in seen_steps:
+            seen_steps.add(step)
+            distinct_steps += 1
+            max_step = max(max_step, step)
+        success = bool(entry.get("success", True))
+        if not success:
+            failed_calls += 1
+        if entry.get("cached"):
+            cached_calls += 1
+
+        key = (tool, _args_key(_entry_arguments(entry)))
+        if key_counts.get(key, 0):
+            redundant_calls += 1
+        key_counts[key] = key_counts.get(key, 0) + 1
+        # An occurrence is a retry only when the same call already failed
+        # before it (see module docstring for the precise contract).
+        if key_failed_seen.get(key):
+            key_retries[key] = key_retries.get(key, 0) + 1
+        if not success:
+            key_failed_seen[key] = True
+
+    expected = [t for t in (golden.expected_tools or []) if isinstance(t, str) and t]
+    missing_expected = [t for t in expected if t not in used_tools]
+    expected_hit_rate = (len(expected) - len(missing_expected)) / len(expected) if expected else 0.0
+    optional_tools_used = [t for t in used_tools if t not in expected]
+    max_steps_touched = bool(max_step and max_step >= golden.allowed_max_steps)
+
+    violations: List[str] = []
+    if not expected:
+        violations.append("golden sample has no expected_tools")
+    if optional_tools_used and not golden.allow_optional_tools:
+        violations.append(f"optional tools used but not allowed: {', '.join(optional_tools_used)}")
+    if max_steps_touched:
+        violations.append(f"trajectory reached allowed_max_steps ({golden.allowed_max_steps})")
+
+    return TrajectoryMetrics(
+        expected_hit_rate=expected_hit_rate,
+        expected_total=len(expected),
+        missing_expected=missing_expected,
+        optional_tools_used=optional_tools_used,
+        redundant_calls=redundant_calls,
+        cached_calls=cached_calls,
+        failed_calls=failed_calls,
+        retries=sum(key_retries.values()),
+        distinct_steps=distinct_steps,
+        max_steps_touched=max_steps_touched,
+        violations=violations,
+    )
+
+
+def format_text_report(m: TrajectoryMetrics) -> str:
+    """Render metrics as a deterministic, human-readable text report."""
+    hit_count = max(0, m.expected_total - len(m.missing_expected))
+    hit_percent = f"{m.expected_hit_rate * 100:.1f}%"
+    missing = ", ".join(m.missing_expected) if m.missing_expected else "无"
+    optional = ", ".join(m.optional_tools_used) if m.optional_tools_used else "无"
+    violations = "; ".join(m.violations) if m.violations else "无"
+    max_steps_label = "是" if m.max_steps_touched else "否"
+    return (
+        "============================================\n"
+        "Agent Trajectory 评估报告\n"
+        "============================================\n"
+        f"- 期望工具命中: {hit_count}/{m.expected_total} ({hit_percent})\n"
+        f"- 缺失期望工具: {missing}\n"
+        f"- 期望外工具: {optional}\n"
+        f"- 冗余调用: {m.redundant_calls} | 缓存调用: {m.cached_calls} | "
+        f"失败调用: {m.failed_calls} | 重试: {m.retries}\n"
+        f"- 消耗步数: {m.distinct_steps} (触碰 max_steps: {max_steps_label})\n"
+        f"- 违规项: {violations}\n"
+    )
+
+
+def load_golden_samples(
+    path: Optional[str] = None,
+    known_tool_names: Optional[Iterable[str]] = None,
+) -> List[GoldenSample]:
+    """Load golden samples from ``path`` (default: ``golden_samples.json`` next to this module).
+
+    Raises ``FileNotFoundError`` when the file is missing and ``ValueError`` on
+    malformed JSON or structural issues (see :func:`validate_golden_sample`).
+    Unknown extra JSON keys are ignored so the file can carry forward-looking
+    metadata without breaking the loader.
+    """
+    if path is None:
+        path = str(Path(__file__).with_name("golden_samples.json"))
+    data = json.loads(Path(path).read_text(encoding="utf-8"))
+    if not isinstance(data, list):
+        raise ValueError(f"golden samples file must contain a JSON list, got {type(data).__name__}")
+
+    known = set(known_tool_names) if known_tool_names is not None else None
+    golden_fields = {f.name for f in fields(GoldenSample)}
+    samples: List[GoldenSample] = []
+    seen_ids: set = set()
+    for index, item in enumerate(data):
+        if not isinstance(item, dict):
+            raise ValueError(f"sample #{index} must be a JSON object, got {type(item).__name__}")
+        try:
+            sample = GoldenSample(**{k: v for k, v in item.items() if k in golden_fields})
+        except TypeError as exc:
+            raise ValueError(f"sample #{index} has invalid fields: {exc}") from exc
+        if sample.id in seen_ids:
+            raise ValueError(f"duplicate sample id: {sample.id}")
+        seen_ids.add(sample.id)
+        issues = validate_golden_sample(sample, known)
+        if issues:
+            raise ValueError(f"sample '{sample.id}': " + "; ".join(issues))
+        samples.append(sample)
+    return samples
+
+
+def validate_golden_sample(
+    sample: GoldenSample,
+    known_tool_names: Optional[Iterable[str]] = None,
+) -> List[str]:
+    """Return a list of structural issues for ``sample``; empty list means valid.
+
+    When ``known_tool_names`` is provided, ``expected_tools`` must be a subset
+    of it; the caller supplies the authoritative registry names (this module
+    deliberately does not import ``src/``).
+    """
+    issues: List[str] = []
+    if not sample.id or not sample.id.strip():
+        issues.append("id must be a non-empty string")
+    if not sample.task_description or not sample.task_description.strip():
+        issues.append("task_description must be a non-empty string")
+    if not sample.stock_code or not sample.stock_code.strip():
+        issues.append("stock_code must be a non-empty string")
+    if not sample.expected_tools:
+        issues.append("expected_tools must be a non-empty list")
+    elif any(not isinstance(t, str) or not t.strip() for t in sample.expected_tools):
+        issues.append("expected_tools must contain only non-empty strings")
+    if known_tool_names is not None:
+        unknown = [t for t in sample.expected_tools if isinstance(t, str) and t.strip() and t not in known_tool_names]
+        if unknown:
+            issues.append(f"unknown expected_tools: {', '.join(unknown)}")
+    if sample.allowed_max_steps < 1:
+        issues.append("allowed_max_steps must be >= 1")
+    if any(not isinstance(s, str) or not s.strip() for s in sample.skills):
+        issues.append("skills must contain only non-empty strings")
+    return issues

--- a/evals/agent_trajectory/metrics.py
+++ b/evals/agent_trajectory/metrics.py
@@ -70,9 +70,10 @@ Metric semantics
   retry of an unrelated call does not satisfy it.  When the sample sets
   ``expected_guarded_stock``, the guarded occurrence of ``guarded_retry``
   must additionally target that stock (the task's required out-of-scope
-  call), and every *later* occurrence of the pair must remain blocked
-  (``cached`` / ``guarded`` / failed): a clean success after the guard is an
-  escape — the scope guard was bypassed — and does not satisfy it.  A
+  call), and every occurrence of the pair must remain blocked
+  (``cached`` / ``guarded`` / failed): a clean success at *any* point — before
+  or after the first guarded occurrence — is an escape (the scope guard was
+  bypassed, or the call provably gets through it) and does not satisfy it.  A
   required outcome that is not observed is reported as a violation, so a
   golden sample that declares guard / cache / retry expectations cannot be
   passed by a trajectory that skips the behaviour it describes.
@@ -81,7 +82,9 @@ Metric semantics
   exactly against the dedicated ``stock_code`` argument field of runner
   entries (never a substring scan, so e.g. ``"1600519"`` cannot satisfy
   ``600519``), the guard metadata ``requested_stock_code``, or the Codex
-  ``arguments_summary`` preview (substring match, best-effort).  Both sides
+  ``arguments_summary`` preview (structured ``stock_code`` recovered from a
+  well-formed preview is compared exactly; otherwise a substring scan,
+  best-effort).  Both sides
   of each comparison are canonicalized first with the runtime-equivalent
   stock-code normalization (see below), so production-accepted forms such as
   ``SH600519`` / ``600519.SH`` / ``SZ.000001`` / ``hk700`` resolve to the
@@ -307,8 +310,11 @@ def _entry_matches_stock(
     is canonicalized and compared for equality, never scanned as a substring,
     so ``"1600519"`` cannot satisfy a ``600519`` golden while
     ``"SH600519"`` can.  Codex App Server entries carry only the redacted
-    ``arguments_summary`` preview, which has no structured field and is
-    matched by substring.  Entries with no stock evidence at all (or
+    ``arguments_summary`` preview: when that preview parses back to a JSON
+    object with a ``stock_code`` field, the recovered value is canonicalized
+    and compared exactly like a runner argument (so ``hk700`` matches an
+    ``HK00700`` golden); otherwise the preview is scanned by substring as a
+    best-effort fallback.  Entries with no stock evidence at all (or
     unresolvable values) keep the name-only tolerance so malformed or minimal
     entries still count as before.
     """
@@ -325,8 +331,38 @@ def _entry_matches_stock(
         return _apply_stock_normalizer(normalizer, value) == stock_code
     summary = entry.get("arguments_summary")
     if isinstance(summary, str) and summary:
-        return stock_code in summary
+        value = _summary_stock_code(summary)
+        if value is _SUMMARY_NO_EVIDENCE:
+            return stock_code in summary
+        if not isinstance(value, (str, int)) or isinstance(value, bool):
+            return True
+        return _apply_stock_normalizer(normalizer, value) == stock_code
     return True
+
+
+# Sentinel distinguishing "the summary holds no structured stock_code" from a
+# legitimate ``None`` value.
+_SUMMARY_NO_EVIDENCE = object()
+
+
+def _summary_stock_code(summary: str) -> Any:
+    """Recover the structured ``stock_code`` value from a Codex ``arguments_summary``.
+
+    ``src/agent/codex_agent_backend`` stores
+    ``redact_diagnostic_value(record.arguments)`` — the JSON-serialized
+    arguments dict — so a well-formed (untruncated, unredacted) preview
+    parses back to the original payload.  Returns ``_SUMMARY_NO_EVIDENCE``
+    when the preview is not a JSON object with a ``stock_code`` key
+    (truncated / redacted / non-object previews), leaving callers to their
+    documented no-evidence tolerance or substring fallback.
+    """
+    try:
+        parsed = json.loads(summary)
+    except (TypeError, ValueError):
+        return _SUMMARY_NO_EVIDENCE
+    if isinstance(parsed, dict) and "stock_code" in parsed:
+        return parsed["stock_code"]
+    return _SUMMARY_NO_EVIDENCE
 
 
 def _entry_mismatches_stock(
@@ -337,10 +373,12 @@ def _entry_mismatches_stock(
     """True when the entry's stock resolves to a *different* code.
 
     Only evidence that resolves to a concrete code can mismatch: guard
-    metadata, or the ``stock_code`` argument field of runner entries.
-    Unresolvable evidence (Codex summary previews, malformed values) is
-    treated as "no evidence" — it can neither match nor mismatch, so it never
-    produces a wrong-stock violation on its own.
+    metadata, the ``stock_code`` argument field of runner entries, or a
+    ``stock_code`` value recovered from a well-formed Codex
+    ``arguments_summary``.  Unresolvable evidence (truncated / redacted
+    previews, malformed values) is treated as "no evidence" — it can neither
+    match nor mismatch, so it never produces a wrong-stock violation on its
+    own.
     """
     requested = entry.get("requested_stock_code")
     if requested:
@@ -350,6 +388,14 @@ def _entry_mismatches_stock(
     args = entry.get("arguments")
     if isinstance(args, dict):
         value = args.get("stock_code")
+        if not isinstance(value, (str, int)) or isinstance(value, bool):
+            return False
+        return _apply_stock_normalizer(normalizer, value) != stock_code
+    summary = entry.get("arguments_summary")
+    if isinstance(summary, str) and summary:
+        value = _summary_stock_code(summary)
+        if value is _SUMMARY_NO_EVIDENCE:
+            return False
         if not isinstance(value, (str, int)) or isinstance(value, bool):
             return False
         return _apply_stock_normalizer(normalizer, value) != stock_code
@@ -457,10 +503,13 @@ def compute_trajectory_metrics(
         if key_counts.get(key, 0):
             redundant_calls += 1
         key_counts[key] = key_counts.get(key, 0) + 1
-        # Every occurrence after a guarded call must remain blocked (cached
-        # / guarded / failed): a clean success escapes the scope guard and
-        # disqualifies the key from the "guarded_retry" outcome.
-        if key in key_guarded_at and not (entry.get("cached") or entry.get("guarded") or not success):
+        # A clean success bypasses the stock-scope guard: the call escaped.
+        # The key is disqualified from the "guarded_retry" outcome whether
+        # the success happened before or after the first guarded occurrence —
+        # the golden contract requires every out-of-scope call to stay
+        # blocked at all times, and a pre-guard success proves the call can
+        # get through the guard.
+        if not (entry.get("cached") or entry.get("guarded") or not success):
             key_guarded_escaped.add(key)
         # Record the occurrence index of the (first) guarded call so the
         # "guarded_retry" outcome can require a *later* occurrence of the

--- a/evals/agent_trajectory/metrics.py
+++ b/evals/agent_trajectory/metrics.py
@@ -92,7 +92,12 @@ Metric semantics
   Every occurrence of the pair must remain blocked
   (``cached`` / ``guarded`` / failed): a clean success at *any* point — before
   or after the first guarded occurrence — is an escape (the scope guard was
-  bypassed, or the call provably gets through it) and does not satisfy it.  A
+  bypassed, or the call provably gets through it) and does not satisfy it.
+  ``success`` is authoritative over the markers: the runner never emits a
+  successful guarded / cached entry (guard interception and cache reuse both
+  record ``success=False``), so a synthetic entry combining ``success=True``
+  with either marker counts as an escape and not as an observed guard or
+  cache event.  A
   required outcome that is not observed is reported as a violation, so a
   golden sample that declares guard / cache / retry expectations cannot be
   passed by a trajectory that skips the behaviour it describes.  Codex-shaped
@@ -487,15 +492,18 @@ def _entry_mismatches_stock(
     return False
 
 
-def _entry_stayed_blocked(entry: Dict[str, Any], success: bool) -> bool:
+def _entry_stayed_blocked(success: bool) -> bool:
     """True when the call did not execute cleanly (guarded / cached / failed).
 
-    A blocked call proves nothing about whether the scope guard can be
-    bypassed, while a clean success of an out-of-scope call does — the same
-    predicate drives the ``guarded_retry`` escape tracking and the
-    wrong-stock exemption for pinned out-of-scope probes.
+    ``success`` is authoritative: the runner never emits a successful
+    guarded / cached entry (guard interception and cache reuse both record
+    ``success=False``), so a synthetic entry that combines ``success=True``
+    with either marker describes a call that *did* execute cleanly — per the
+    module contract, a clean success at any point is an escape, never a
+    blocked probe.  The same predicate drives the ``guarded_retry`` escape
+    tracking and the wrong-stock exemption for pinned out-of-scope probes.
     """
-    return bool(entry.get("cached") or entry.get("guarded") or not success)
+    return not success
 
 
 def compute_trajectory_metrics(
@@ -619,7 +627,7 @@ def compute_trajectory_metrics(
         pinned_probe_blocked = (
             guarded_stock_valid
             and _entry_matches_stock(entry, guarded_stock, normalizer, require_evidence=True)
-            and _entry_stayed_blocked(entry, success)
+            and _entry_stayed_blocked(success)
         )
         if (
             stock_code
@@ -635,9 +643,12 @@ def compute_trajectory_metrics(
             max_step = max(max_step, step)
         if not success:
             failed_calls += 1
-        if entry.get("cached"):
+        # success is authoritative for the guarded / cached markers too: a
+        # successful entry with either marker did not stay blocked, so it
+        # must not count as an observed guard interception or cache reuse.
+        if entry.get("cached") and not success:
             cached_calls += 1
-        if entry.get("guarded"):
+        if entry.get("guarded") and not success:
             guarded_calls += 1
         if not isinstance(entry.get("arguments"), dict) and entry.get("arguments_summary"):
             codex_shaped = True
@@ -652,7 +663,7 @@ def compute_trajectory_metrics(
         # the golden contract requires every out-of-scope call to stay
         # blocked at all times, and a pre-guard success proves the call can
         # get through the guard.
-        if not _entry_stayed_blocked(entry, success):
+        if not _entry_stayed_blocked(success):
             key_guarded_escaped.add(key)
         # Record the occurrence index of the (first) guarded call so the
         # "guarded_retry" outcome can require a *later* occurrence of the
@@ -661,7 +672,7 @@ def compute_trajectory_metrics(
         # carrying actual stock evidence for that stock can seed the
         # outcome — a blocked call that never identifies a stock cannot
         # prove the pinned out-of-scope probe (no name-only tolerance here).
-        if entry.get("guarded") and key not in key_guarded_at:
+        if entry.get("guarded") and not success and key not in key_guarded_at:
             if not guarded_stock_valid or _entry_matches_stock(entry, guarded_stock, normalizer, require_evidence=True):
                 key_guarded_at[key] = key_counts[key]
         # An occurrence is a retry only when the same call already failed

--- a/evals/agent_trajectory/metrics.py
+++ b/evals/agent_trajectory/metrics.py
@@ -10,10 +10,13 @@ This module computes quality metrics for an agent execution trajectory from its
   Codex App Server backend emits ``arguments_summary`` instead of
   ``arguments``).
 
-All functions in this module are pure: they consume plain data (a log list and
-a ``GoldenSample``) and never touch the filesystem, network, or LLM.  This keeps
-the metrics layer deterministic, unit-testable without an API key, and free of
-``src/`` imports — it can score trajectories from any source.
+The scoring functions in this module are pure: ``compute_trajectory_metrics``,
+``format_text_report`` and ``validate_golden_sample`` consume plain data (a log
+list and a ``GoldenSample``) and never touch the filesystem, network, or LLM.
+The one exception is the loader ``load_golden_samples``, which reads the golden
+JSON file from disk.  This keeps the metrics layer deterministic, unit-testable
+without an API key, and free of ``src/`` imports — it can score trajectories
+from any source.
 
 Idempotency key contract
 ------------------------
@@ -24,6 +27,13 @@ unhashable values (dict / list), so the key is built with
 not a hash.  Do not replace this with ``tuple(arguments)`` or ``repr()``:
 insertion order or collection type would then change call identity and corrupt
 redundancy / retry counts.
+
+Codex App Server entries carry only ``arguments_summary`` — the redacted and
+truncated preview produced by ``redact_diagnostic_value`` — so their identity
+is best-effort: distinct calls whose summaries collide after redaction or
+truncation may be over-counted as redundant.  A stable argument fingerprint
+requires a producer-side change in ``src/agent/codex_agent_backend.py``, which
+is out of scope for this metrics layer.
 
 Metric semantics
 ----------------
@@ -273,6 +283,9 @@ def load_golden_samples(
     if not isinstance(data, list):
         raise ValueError(f"golden samples file must contain a JSON list, got {type(data).__name__}")
 
+    # Materialize once before the loop: a one-shot generator must survive the
+    # validation of every sample, not just the first.
+    known = set(known_tool_names) if known_tool_names is not None else None
     golden_fields = {f.name for f in fields(GoldenSample)}
     samples: List[GoldenSample] = []
     seen_ids: set = set()
@@ -283,12 +296,15 @@ def load_golden_samples(
             sample = GoldenSample(**{k: v for k, v in item.items() if k in golden_fields})
         except TypeError as exc:
             raise ValueError(f"sample #{index} has invalid fields: {exc}") from exc
+        # Structural validation runs before duplicate detection so that a
+        # mistyped (possibly unhashable) id is rejected as a ValueError here
+        # instead of crashing the membership check below.
+        issues = validate_golden_sample(sample, known)
+        if issues:
+            raise ValueError(f"sample '{sample.id}': " + "; ".join(issues))
         if sample.id in seen_ids:
             raise ValueError(f"duplicate sample id: {sample.id}")
         seen_ids.add(sample.id)
-        issues = validate_golden_sample(sample, known_tool_names)
-        if issues:
-            raise ValueError(f"sample '{sample.id}': " + "; ".join(issues))
         samples.append(sample)
     return samples
 

--- a/evals/agent_trajectory/metrics.py
+++ b/evals/agent_trajectory/metrics.py
@@ -273,7 +273,6 @@ def load_golden_samples(
     if not isinstance(data, list):
         raise ValueError(f"golden samples file must contain a JSON list, got {type(data).__name__}")
 
-    known = set(known_tool_names) if known_tool_names is not None else None
     golden_fields = {f.name for f in fields(GoldenSample)}
     samples: List[GoldenSample] = []
     seen_ids: set = set()
@@ -287,7 +286,7 @@ def load_golden_samples(
         if sample.id in seen_ids:
             raise ValueError(f"duplicate sample id: {sample.id}")
         seen_ids.add(sample.id)
-        issues = validate_golden_sample(sample, known)
+        issues = validate_golden_sample(sample, known_tool_names)
         if issues:
             raise ValueError(f"sample '{sample.id}': " + "; ".join(issues))
         samples.append(sample)
@@ -302,7 +301,9 @@ def validate_golden_sample(
 
     When ``known_tool_names`` is provided, ``expected_tools`` must be a subset
     of it; the caller supplies the authoritative registry names (this module
-    deliberately does not import ``src/``).
+    deliberately does not import ``src/``).  Any ``Iterable[str]`` is accepted
+    — including one-shot generators — and materialized once internally, so
+    membership checks never consume the caller's iterable.
 
     Field *types* are part of the structural contract — hand-edited golden
     JSON must fail with a clear message instead of crashing or silently
@@ -311,6 +312,7 @@ def validate_golden_sample(
     boolean.
     """
     issues: List[str] = []
+    known = set(known_tool_names) if known_tool_names is not None else None
     if not isinstance(sample.id, str) or not sample.id.strip():
         issues.append("id must be a non-empty string")
     if not isinstance(sample.task_description, str) or not sample.task_description.strip():
@@ -323,8 +325,10 @@ def validate_golden_sample(
         issues.append("expected_tools must be a non-empty list")
     elif any(not isinstance(t, str) or not t.strip() for t in sample.expected_tools):
         issues.append("expected_tools must contain only non-empty strings")
-    if known_tool_names is not None:
-        unknown = [t for t in sample.expected_tools if isinstance(t, str) and t.strip() and t not in known_tool_names]
+    elif known is not None:
+        # Only reachable when expected_tools is a non-empty list of non-empty
+        # strings, so malformed values can never crash the membership check.
+        unknown = [t for t in sample.expected_tools if t not in known]
         if unknown:
             issues.append(f"unknown expected_tools: {', '.join(unknown)}")
     if not isinstance(sample.skills, list):

--- a/evals/agent_trajectory/metrics.py
+++ b/evals/agent_trajectory/metrics.py
@@ -89,6 +89,13 @@ Metric semantics
   call) with *actual stock evidence* — the name-only tolerance does not
   apply to the pinned check, so a blocked call that never identifies a
   stock (empty or missing arguments payload) cannot prove the pinned probe.
+  A pin that fails the structural contract (unpaired, or naming the golden
+  stock itself after canonicalization) is reported as a violation and
+  disabled — no wrong-stock exemption, no escape tracking, no pin-name
+  seeding.  ``guarded_retry`` then binds to the out-of-scope requirement it
+  declares: a guarded call carrying evidence for a stock other than the
+  golden's seeds the pair, so an in-scope blocked retry never satisfies it
+  and a genuine out-of-scope probe still does.
   Every occurrence of the pair must remain blocked
   (``cached`` / ``guarded`` / failed): a clean success at *any* point — before
   or after the first guarded occurrence — is an escape (the scope guard was
@@ -197,7 +204,11 @@ class GoldenSample:
     intercept (the task's out-of-scope call): when set, ``guarded_retry`` is
     only observed for guarded calls targeting that stock, and blocked calls
     (guarded / cached / failed) targeting it are exempt from wrong-stock
-    reporting — the sample itself requires the probe.
+    reporting — the sample itself requires the probe.  A pin rejected by the
+    structural contract (unpaired, or the golden stock itself after
+    canonicalization) is reported as a violation and disabled; see
+    :func:`compute_trajectory_metrics` for the degraded ``guarded_retry``
+    requirement.
     """
 
     id: str
@@ -582,8 +593,12 @@ def compute_trajectory_metrics(
     disabled), and a pinned ``expected_guarded_stock`` is only honoured for
     the coherent pairing the validator requires (``guarded_retry`` declared,
     and a stock different from ``golden.stock_code`` after
-    canonicalization) — an unpaired pin is reported and disabled rather than
-    silently erasing wrong-stock reporting.
+    canonicalization) — an unpaired or same-stock pin is reported and
+    disabled: no wrong-stock exemption, no escape tracking, no pin-name
+    seeding.  A same-stock pin still keeps ``guarded_retry`` bound to the
+    out-of-scope probe it declares: with the pin disabled, a guarded call
+    carrying actual evidence for a *different* stock seeds the pair, and an
+    in-scope blocked retry can never pass as the required probe.
     """
     used_tools: List[str] = []
     key_counts: Dict[tuple, int] = {}
@@ -609,15 +624,17 @@ def compute_trajectory_metrics(
     stock_code = _apply_stock_normalizer(normalizer, golden.stock_code) if golden_stock_valid else ""
     guarded_stock = golden.expected_guarded_stock
     guarded_stock_nonempty = isinstance(guarded_stock, str) and bool(guarded_stock.strip())
+    guarded_stock = _apply_stock_normalizer(normalizer, guarded_stock) if guarded_stock_nonempty else guarded_stock
     # A pinned stock only takes effect for the coherent pairing
     # validate_golden_sample() enforces: expected_guarded_stock must be
-    # declared together with guarded_retry in expected_outcomes.  An
-    # unpaired pin is malformed — it is reported below and must not reshape
-    # scoring (no wrong-stock exemption, no pinned seeding).
-    guarded_stock_valid = guarded_stock_nonempty and (
-        isinstance(golden.expected_outcomes, list) and "guarded_retry" in golden.expected_outcomes
-    )
-    guarded_stock = _apply_stock_normalizer(normalizer, guarded_stock) if guarded_stock_nonempty else guarded_stock
+    # declared together with guarded_retry in expected_outcomes, and it
+    # must name a stock different from golden.stock_code after
+    # canonicalization.  An unpaired or same-stock pin is malformed — it is
+    # reported below and must not reshape scoring (no wrong-stock
+    # exemption, no escape tracking, no pin-name seeding; the degraded
+    # guarded_retry requirement is handled at the seeding site below).
+    guarded_retry_declared = isinstance(golden.expected_outcomes, list) and "guarded_retry" in golden.expected_outcomes
+    guarded_stock_valid = guarded_stock_nonempty and guarded_retry_declared and guarded_stock != stock_code
     # Extract the expected tool list before scanning entries so per-entry
     # wrong-stock reporting can consult it during the loop.  Malformed
     # elements are not silently dropped: they are reported as a violation
@@ -730,7 +747,26 @@ def compute_trajectory_metrics(
         # outcome — a blocked call that never identifies a stock cannot
         # prove the pinned out-of-scope probe (no name-only tolerance here).
         if entry.get("guarded") and not success and key not in key_guarded_at:
-            if not guarded_stock_valid or _entry_matches_stock(entry, guarded_stock, normalizer, require_evidence=True):
+            if not guarded_stock_nonempty:
+                # No pin declared: the legacy pin-less requirement — any
+                # guarded occurrence seeds the pair.
+                key_guarded_at[key] = key_counts[key]
+            elif guarded_stock_valid and _entry_matches_stock(entry, guarded_stock, normalizer, require_evidence=True):
+                # Coherent pin: only a probe carrying actual evidence for
+                # the pinned stock proves the required out-of-scope call.
+                key_guarded_at[key] = key_counts[key]
+            elif (
+                not guarded_stock_valid
+                and guarded_retry_declared
+                and stock_code
+                and _entry_mismatches_stock(entry, stock_code, normalizer)
+            ):
+                # Malformed pin (same stock after canonicalization): the pin
+                # is disabled, but the declared guarded_retry still binds to
+                # the out-of-scope probe it declares — the pin merely names
+                # it.  A guarded call carrying evidence for a *different*
+                # stock seeds the pair; an in-scope call never does, so an
+                # in-scope blocked retry cannot pass as the required probe.
                 key_guarded_at[key] = key_counts[key]
         # An occurrence is a retry only when the same call already failed
         # before it (see module docstring for the precise contract).

--- a/evals/agent_trajectory/metrics.py
+++ b/evals/agent_trajectory/metrics.py
@@ -196,13 +196,26 @@ def compute_trajectory_metrics(
     missing_expected = [t for t in expected if t not in used_tools]
     expected_hit_rate = (len(expected) - len(missing_expected)) / len(expected) if expected else 0.0
     optional_tools_used = [t for t in used_tools if t not in expected]
-    max_steps_touched = bool(max_step and max_step >= golden.allowed_max_steps)
 
     violations: List[str] = []
     if not expected:
         violations.append("golden sample has no expected_tools")
-    if optional_tools_used and not golden.allow_optional_tools:
+
+    # Malformed golden samples must not crash scoring nor flip semantics:
+    # a truthy string like "false" must not silently turn a strict sample
+    # permissive, and a non-integer step limit must not crash the comparison.
+    optional_allowed = golden.allow_optional_tools
+    if not isinstance(optional_allowed, bool):
+        violations.append("allow_optional_tools is not a boolean")
+        optional_allowed = False
+    if optional_tools_used and not optional_allowed:
         violations.append(f"optional tools used but not allowed: {', '.join(optional_tools_used)}")
+
+    limit = golden.allowed_max_steps
+    if isinstance(limit, bool) or not isinstance(limit, int):
+        violations.append("allowed_max_steps is not an integer")
+        limit = 0
+    max_steps_touched = bool(max_step and limit > 0 and max_step >= limit)
     if max_steps_touched:
         violations.append(f"trajectory reached allowed_max_steps ({golden.allowed_max_steps})")
 
@@ -290,13 +303,19 @@ def validate_golden_sample(
     When ``known_tool_names`` is provided, ``expected_tools`` must be a subset
     of it; the caller supplies the authoritative registry names (this module
     deliberately does not import ``src/``).
+
+    Field *types* are part of the structural contract — hand-edited golden
+    JSON must fail with a clear message instead of crashing or silently
+    passing: text fields must be strings, ``expected_tools``/``skills`` must
+    be lists, ``allowed_max_steps`` an integer and ``allow_optional_tools`` a
+    boolean.
     """
     issues: List[str] = []
-    if not sample.id or not sample.id.strip():
+    if not isinstance(sample.id, str) or not sample.id.strip():
         issues.append("id must be a non-empty string")
-    if not sample.task_description or not sample.task_description.strip():
+    if not isinstance(sample.task_description, str) or not sample.task_description.strip():
         issues.append("task_description must be a non-empty string")
-    if not sample.stock_code or not sample.stock_code.strip():
+    if not isinstance(sample.stock_code, str) or not sample.stock_code.strip():
         issues.append("stock_code must be a non-empty string")
     if not isinstance(sample.expected_tools, list):
         issues.append("expected_tools must be a list of tool names")
@@ -308,8 +327,14 @@ def validate_golden_sample(
         unknown = [t for t in sample.expected_tools if isinstance(t, str) and t.strip() and t not in known_tool_names]
         if unknown:
             issues.append(f"unknown expected_tools: {', '.join(unknown)}")
-    if sample.allowed_max_steps < 1:
-        issues.append("allowed_max_steps must be >= 1")
-    if any(not isinstance(s, str) or not s.strip() for s in sample.skills):
+    if not isinstance(sample.skills, list):
+        issues.append("skills must be a list of strings")
+    elif any(not isinstance(s, str) or not s.strip() for s in sample.skills):
         issues.append("skills must contain only non-empty strings")
+    if isinstance(sample.allowed_max_steps, bool) or not isinstance(sample.allowed_max_steps, int):
+        issues.append("allowed_max_steps must be an integer")
+    elif sample.allowed_max_steps < 1:
+        issues.append("allowed_max_steps must be >= 1")
+    if not isinstance(sample.allow_optional_tools, bool):
+        issues.append("allow_optional_tools must be a boolean")
     return issues

--- a/tests/test_agent_trajectory_metrics.py
+++ b/tests/test_agent_trajectory_metrics.py
@@ -173,13 +173,13 @@ class TestComputeMetricsHitRate:
     def test_empty_expected_tools_yields_zero_hit_and_violation(self):
         m = compute_trajectory_metrics([_entry()], _golden(expected_tools=[]))
         assert m.expected_hit_rate == 0.0
-        assert "golden sample has no expected_tools" in m.violations
+        assert "expected_tools must be a non-empty list" in m.violations
 
     def test_string_expected_tools_scored_as_empty_not_as_characters(self):
         m = compute_trajectory_metrics([_entry()], _golden(expected_tools="get_realtime_quote"))
         assert m.expected_hit_rate == 0.0
         assert m.expected_total == 0
-        assert "golden sample has no expected_tools" in m.violations
+        assert "expected_tools must be a list of tool names" in m.violations
 
     def test_non_bool_allow_optional_tools_scores_strictly(self):
         log = [
@@ -207,7 +207,7 @@ class TestComputeMetricsHitRate:
         assert m.expected_total == 2
         assert m.expected_hit_rate == pytest.approx(0.5)
         assert m.missing_expected == ["get_daily_history"]
-        assert "expected_tools contains duplicate names" in m.violations
+        assert "expected_tools must not contain duplicate names" in m.violations
 
 
 # ---------------------------------------------------------------------------
@@ -251,7 +251,7 @@ class TestDirectConstructionContract:
         log = [_entry(tool="get_realtime_quote", arguments={"stock_code": "600519"})]
         m = compute_trajectory_metrics(log, _golden(expected_outcomes=["   "]))
         assert "expected_outcomes must contain only non-empty strings" in m.violations
-        assert not any("unknown expected outcome tags" in v for v in m.violations)
+        assert not any("unknown expected_outcomes" in v for v in m.violations)
 
     def test_non_positive_allowed_max_steps_reported_in_direct_score(self):
         # Review counter-example: allowed_max_steps=0 / -3 must report the
@@ -277,6 +277,10 @@ class TestDirectConstructionContract:
             (dict(allowed_max_steps=0), "allowed_max_steps must be >= 1"),
             (dict(allowed_max_steps=-3), "allowed_max_steps must be >= 1"),
             (dict(allow_optional_tools="false"), "allow_optional_tools must be a boolean"),
+            (dict(id=[]), "id must be a non-empty string"),
+            (dict(task_description=None), "task_description must be a non-empty string"),
+            (dict(skills="trading"), "skills must be a list of strings"),
+            (dict(skills=["", "trading"]), "skills must contain only non-empty strings"),
             (
                 dict(expected_guarded_stock="600036"),
                 "expected_guarded_stock requires guarded_retry in expected_outcomes",
@@ -297,6 +301,31 @@ class TestDirectConstructionContract:
             assert any(issue in i for i in validator_issues), (issue, overrides, validator_issues)
             m = compute_trajectory_metrics(log, golden)
             assert any(issue in v for v in m.violations), (issue, overrides, m.violations)
+
+    def test_every_validator_issue_surfaces_in_direct_score(self):
+        # Structural lock: the direct-score path surfaces the validator's
+        # COMPLETE issue list verbatim (this is how id / task_description /
+        # skills and any future validator check apply to direct scoring
+        # automatically).  A thoroughly malformed sample must yield every
+        # validator issue in compute violations, with no duplicates from the
+        # inline scoring checks.
+        log = [_entry(tool="get_realtime_quote", arguments={"stock_code": "600519"})]
+        golden = GoldenSample(
+            id=[],
+            task_description=None,
+            stock_code=None,
+            expected_tools=["", "   "],
+            skills=["", "trading"],
+            allowed_max_steps=0,
+            allow_optional_tools="false",
+            expected_outcomes=[1],
+        )
+        validator_issues = validate_golden_sample(golden)
+        assert validator_issues, "the sample is thoroughly malformed"
+        m = compute_trajectory_metrics(log, golden)
+        for issue in validator_issues:
+            assert any(issue in v for v in m.violations), (issue, m.violations)
+            assert m.violations.count(issue) == 1, (issue, m.violations)
 
     def test_unpaired_guarded_stock_reported_and_exemption_disabled(self):
         # Review counter-example: expected_guarded_stock without guarded_retry
@@ -1042,7 +1071,7 @@ class TestExpectedOutcomes:
             self._faithful_log(),
             self._guarded_sample(expected_outcomes=["guarded", "warp"]),
         )
-        assert "unknown expected outcome tags: warp" in m.violations
+        assert "unknown expected_outcomes: warp" in m.violations
         assert not any("not observed" in v for v in m.violations)
 
     def test_non_list_expected_outcomes_surfaces_violation(self):
@@ -1057,7 +1086,7 @@ class TestExpectedOutcomes:
             self._faithful_log(),
             self._guarded_sample(expected_outcomes=["guarded_retry", "guarded_retry"]),
         )
-        assert "expected_outcomes contains duplicate tags" in m.violations
+        assert "expected_outcomes must not contain duplicate tags" in m.violations
         assert "expected outcomes not observed" not in m.violations
 
 
@@ -1314,7 +1343,7 @@ class TestStockCodeScoping:
             [_entry(tool="get_realtime_quote")],
             _golden(expected_tools=["get_realtime_quote"], stock_code=None),
         )
-        assert "golden.stock_code is not a non-empty string" in m.violations
+        assert "stock_code must be a non-empty string" in m.violations
         assert m.expected_hit_rate == 1.0
 
 
@@ -1540,7 +1569,7 @@ class TestMaxStepsTouched:
         log = [_entry(step=i) for i in range(1, 6)]
         m = compute_trajectory_metrics(log, _golden(allowed_max_steps="5"))
         assert m.max_steps_touched is False
-        assert "allowed_max_steps is not an integer" in m.violations
+        assert "allowed_max_steps must be an integer" in m.violations
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_agent_trajectory_metrics.py
+++ b/tests/test_agent_trajectory_metrics.py
@@ -350,6 +350,85 @@ class TestExpectedOutcomes:
         assert m.expected_hit_rate == 1.0
         assert "expected outcomes not observed: guarded_retry" in m.violations
 
+    def test_clean_success_after_guard_is_an_escape(self):
+        # Review counter-example: the guarded call is retried and the retry
+        # succeeds without cache — the guard was bypassed, so guarded_retry
+        # must not be observed.
+        log = [
+            _entry(tool="get_stock_info", arguments={"stock_code": "600036"}, step=1),
+            _entry(tool="get_daily_history", arguments={"stock_code": "600036"}, step=2),
+            _entry(
+                tool="get_realtime_quote",
+                arguments={"stock_code": "600519"},
+                step=3,
+                success=False,
+                guarded=True,
+            ),
+            _entry(
+                tool="get_realtime_quote",
+                arguments={"stock_code": "600519"},
+                step=4,
+                success=True,
+            ),
+        ]
+        m = compute_trajectory_metrics(log, self._guarded_sample())
+        assert m.expected_hit_rate == 1.0
+        assert m.retries == 1
+        assert "expected outcomes not observed: guarded_retry" in m.violations
+
+    def test_blocked_retry_variants_stay_satisfied(self):
+        # The retry may fail again or hit the non-retriable cache — both are
+        # blocked outcomes and satisfy the sample.
+        for extra in ({"success": False}, {"cached": True, "success": False}):
+            log = [
+                _entry(tool="get_stock_info", arguments={"stock_code": "600036"}, step=1),
+                _entry(tool="get_daily_history", arguments={"stock_code": "600036"}, step=2),
+                _entry(
+                    tool="get_realtime_quote",
+                    arguments={"stock_code": "600519"},
+                    step=3,
+                    success=False,
+                    guarded=True,
+                ),
+                _entry(
+                    tool="get_realtime_quote",
+                    arguments={"stock_code": "600519"},
+                    step=4,
+                    **extra,
+                ),
+            ]
+            m = compute_trajectory_metrics(log, self._guarded_sample())
+            assert "expected outcomes not observed" not in m.violations, extra
+
+    def test_escape_after_a_blocked_retry_still_violates(self):
+        # guard -> blocked retry -> clean success: the guard boundary was
+        # breached eventually, so the outcome must not be observed.
+        log = [
+            _entry(tool="get_stock_info", arguments={"stock_code": "600036"}, step=1),
+            _entry(tool="get_daily_history", arguments={"stock_code": "600036"}, step=2),
+            _entry(
+                tool="get_realtime_quote",
+                arguments={"stock_code": "600519"},
+                step=3,
+                success=False,
+                guarded=True,
+            ),
+            _entry(
+                tool="get_realtime_quote",
+                arguments={"stock_code": "600519"},
+                step=4,
+                success=False,
+            ),
+            _entry(
+                tool="get_realtime_quote",
+                arguments={"stock_code": "600519"},
+                step=5,
+                success=True,
+            ),
+        ]
+        m = compute_trajectory_metrics(log, self._guarded_sample())
+        assert "expected outcomes not observed: guarded_retry" in m.violations
+
     def test_unrelated_retry_does_not_satisfy_guarded_retry(self):
         # Review counter-example: a guard on the out-of-scope quote plus a
         # retry of an unrelated news call must not satisfy the bound outcome.
@@ -490,6 +569,39 @@ class TestStockCodeScoping:
         assert m.expected_hit_rate == 1.0
         assert m.missing_expected == []
 
+    def test_equivalent_stock_code_forms_count_as_hit(self):
+        # Review counter-example (inverse): production accepts SH600519 /
+        # 600519.SH / lowercase etc. as the same stock, so the metrics layer
+        # must too — via runtime-equivalent canonicalization, not raw
+        # equality.
+        for form in ("SH600519", "sh600519", "600519.SH", "SS600519", "SH.600519", " 600519 "):
+            m = compute_trajectory_metrics(
+                [_entry(tool="get_realtime_quote", arguments={"stock_code": form}, step=1)],
+                _golden(expected_tools=["get_realtime_quote"]),
+            )
+            assert m.expected_hit_rate == 1.0, form
+            assert m.violations == [], form
+
+    def test_hk_variant_forms_share_one_identity(self):
+        golden = _golden(stock_code="HK00700", expected_tools=["get_realtime_quote"])
+        for form in ("HK00700", "hk700", "700.HK", "00700"):
+            m = compute_trajectory_metrics(
+                [_entry(tool="get_realtime_quote", arguments={"stock_code": form}, step=1)],
+                golden,
+            )
+            assert m.expected_hit_rate == 1.0, form
+            assert m.violations == [], form
+
+    def test_sz_prefix_and_suffix_forms_match_their_golden(self):
+        golden = _golden(stock_code="000001", expected_tools=["get_realtime_quote"])
+        for form in ("SZ000001", "000001.SZ", "SZ.000001", "sz000001"):
+            m = compute_trajectory_metrics(
+                [_entry(tool="get_realtime_quote", arguments={"stock_code": form}, step=1)],
+                golden,
+            )
+            assert m.expected_hit_rate == 1.0, form
+            assert m.violations == [], form
+
     def test_each_wrong_stock_call_of_an_expected_tool_is_reported(self):
         # Review counter-example: the correct call used to set
         # stock_hit[tool], which legitimized every other call of the same
@@ -531,6 +643,70 @@ class TestStockCodeScoping:
         )
         assert "golden.stock_code is not a non-empty string" in m.violations
         assert m.expected_hit_rate == 1.0
+
+
+# ---------------------------------------------------------------------------
+# 2c. Stock-code canonicalization (runtime-equivalent mirror)
+# ---------------------------------------------------------------------------
+class TestStockCanonicalization:
+    def test_mirror_matches_production_normalization(self):
+        # The mirror must track the runtime chain exactly; if production
+        # changes and this parity test fails, update the mirror.
+        from src.agent.tools.execution import _normalize_tool_stock_code
+
+        from evals.agent_trajectory.metrics import _canonicalize_stock_code
+
+        forms = [
+            "600519",
+            "sh600519",
+            "SH600519",
+            "SH.600519",
+            "600519.SH",
+            "600519.SS",
+            "SS600519",
+            "SZ000001",
+            "sz000001",
+            "000001.SZ",
+            "SZ.000001",
+            "BJ920748",
+            "920748.BJ",
+            "HK00700",
+            "hk700",
+            "700.HK",
+            "1810.HK",
+            "00700",
+            "7203.T",
+            "005930.KS",
+            "035720.KQ",
+            "2330.TW",
+            "6505.TWO",
+            "AAPL",
+            "aapl",
+            " 600519 ",
+            "1600519",
+            "000001",
+            "HK.700",
+            "600519.SH ",
+        ]
+        for form in forms:
+            assert _canonicalize_stock_code(form) == _normalize_tool_stock_code(form), form
+
+    def test_injected_normalizer_overrides_the_mirror(self):
+        golden = _golden(expected_tools=["get_realtime_quote"])
+        log = [_entry(tool="get_realtime_quote", arguments={"stock_code": "SH600519"}, step=1)]
+        # A strict identity normalizer must see SH600519 as a different
+        # stock, while the default mirror resolves it to 600519.
+        strict = compute_trajectory_metrics(log, golden, stock_code_normalizer=lambda v: str(v))
+        assert strict.expected_hit_rate == 0.0
+        assert strict.missing_expected == ["get_realtime_quote"]
+        default = compute_trajectory_metrics(log, golden)
+        assert default.expected_hit_rate == 1.0
+        assert default.violations == []
+
+    def test_non_callable_normalizer_surfaces_violation(self):
+        m = compute_trajectory_metrics([_entry()], _golden(), stock_code_normalizer="nope")
+        assert "stock_code_normalizer is not callable" in m.violations
+        assert m.expected_hit_rate == pytest.approx(1 / 3)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_agent_trajectory_metrics.py
+++ b/tests/test_agent_trajectory_metrics.py
@@ -149,6 +149,18 @@ class TestComputeMetricsHitRate:
         assert m.expected_total == 0
         assert "golden sample has no expected_tools" in m.violations
 
+    def test_non_bool_allow_optional_tools_scores_strictly(self):
+        log = [
+            _entry(tool="get_realtime_quote", step=1),
+            _entry(tool="search_stock_news", step=2),
+        ]
+        m = compute_trajectory_metrics(
+            log,
+            _golden(expected_tools=["get_realtime_quote"], allow_optional_tools="false"),
+        )
+        assert "allow_optional_tools is not a boolean" in m.violations
+        assert "optional tools used but not allowed: search_stock_news" in m.violations
+
 
 # ---------------------------------------------------------------------------
 # 3. Retries, caching, failure counting
@@ -240,6 +252,12 @@ class TestMaxStepsTouched:
     def test_empty_log_not_touched(self):
         m = compute_trajectory_metrics([], _golden(allowed_max_steps=5))
         assert m.max_steps_touched is False
+
+    def test_non_integer_limit_surfaces_violation_without_crash(self):
+        log = [_entry(step=i) for i in range(1, 6)]
+        m = compute_trajectory_metrics(log, _golden(allowed_max_steps="5"))
+        assert m.max_steps_touched is False
+        assert "allowed_max_steps is not an integer" in m.violations
 
 
 # ---------------------------------------------------------------------------
@@ -380,6 +398,36 @@ class TestGoldenSamplesFile:
         issues = validate_golden_sample(sample)
         assert any("must be a list" in i for i in issues)
 
+    def test_non_bool_allow_optional_tools_fails_validation(self):
+        sample = GoldenSample(
+            id="x",
+            task_description="t",
+            stock_code="600519",
+            expected_tools=["get_realtime_quote"],
+            allow_optional_tools="false",
+        )
+        issues = validate_golden_sample(sample)
+        assert any("allow_optional_tools must be a boolean" in i for i in issues)
+
+    def test_mistyped_fields_fail_validation_not_crash(self):
+        # Same defect class as the string expected_tools bug: hand-edited JSON
+        # with mistyped fields must be rejected cleanly, never crash or pass.
+        bad = GoldenSample(
+            id=5,
+            task_description=None,
+            stock_code="600519",
+            expected_tools=["get_realtime_quote"],
+            skills="trading",
+            allowed_max_steps="5",
+            allow_optional_tools=1,
+        )
+        issues = validate_golden_sample(bad)
+        assert any("id must be a non-empty string" in i for i in issues)
+        assert any("task_description must be a non-empty string" in i for i in issues)
+        assert any("skills must be a list" in i for i in issues)
+        assert any("allowed_max_steps must be an integer" in i for i in issues)
+        assert any("allow_optional_tools must be a boolean" in i for i in issues)
+
 
 class TestLoadGoldenSamplesErrors:
     @staticmethod
@@ -467,4 +515,16 @@ class TestLoadGoldenSamplesErrors:
         }
         path = self._write_sample(tmp_path, [sample])
         with pytest.raises(ValueError, match="expected_tools must be a list"):
+            load_golden_samples(path=path)
+
+    def test_non_bool_allow_optional_tools_raises(self, tmp_path):
+        sample = {
+            "id": "x",
+            "task_description": "t",
+            "stock_code": "600519",
+            "expected_tools": ["get_realtime_quote"],
+            "allow_optional_tools": "false",
+        }
+        path = self._write_sample(tmp_path, [sample])
+        with pytest.raises(ValueError, match="allow_optional_tools must be a boolean"):
             load_golden_samples(path=path)

--- a/tests/test_agent_trajectory_metrics.py
+++ b/tests/test_agent_trajectory_metrics.py
@@ -89,6 +89,19 @@ class TestArgsKey:
     def test_non_dict_arguments_serialized(self):
         assert _args_key(["600519"]) == '["600519"]'
 
+    def test_stock_code_aliases_share_a_key(self):
+        # Mirroring _build_tool_cache_key: the stock_code field is
+        # canonicalized before serialization, so runtime-equivalent alias
+        # forms share one call identity.
+        assert _args_key({"stock_code": "SH600519"}) == _args_key({"stock_code": "600519"})
+        assert _args_key({"stock_code": "600519.SH"}) == _args_key({"stock_code": "sh600519"})
+        assert _args_key({"stock_code": "HK00700"}) == _args_key({"stock_code": "700.HK"})
+
+    def test_other_arguments_stay_raw_in_the_key(self):
+        assert _args_key({"stock_code": "SH600519", "period": "daily"}) != _args_key(
+            {"stock_code": "600519", "period": "weekly"}
+        )
+
 
 # ---------------------------------------------------------------------------
 # 2. Hit rate / expected & optional tools
@@ -349,6 +362,99 @@ class TestExpectedOutcomes:
         m = compute_trajectory_metrics(log, self._guarded_sample())
         assert m.expected_hit_rate == 1.0
         assert "expected outcomes not observed: guarded_retry" in m.violations
+
+    def test_alias_guard_and_retry_share_one_call_identity(self):
+        # Review counter-example: the runtime cache key normalizes the
+        # stock_code argument, so a guarded SH600519 call retried as 600519
+        # is the same (tool, args-key) pair and must count as a retry —
+        # previously the raw-argument key split it into two fresh calls and
+        # reported guarded_retry as missing.
+        log = [
+            _entry(tool="get_stock_info", arguments={"stock_code": "600036"}, step=1),
+            _entry(tool="get_daily_history", arguments={"stock_code": "600036"}, step=2),
+            _entry(
+                tool="get_realtime_quote",
+                arguments={"stock_code": "SH600519"},
+                step=3,
+                success=False,
+                guarded=True,
+            ),
+            _entry(
+                tool="get_realtime_quote",
+                arguments={"stock_code": "600519"},
+                step=4,
+                success=False,
+                cached=True,
+            ),
+        ]
+        m = compute_trajectory_metrics(log, self._guarded_sample())
+        assert "expected outcomes not observed" not in m.violations
+        assert m.retries == 1
+        assert m.redundant_calls == 1
+
+    def test_alias_retry_counts_toward_retry_and_redundancy(self):
+        # A failed 600519.SH call retried as 600519 is one identity: the
+        # second occurrence is both redundant and a retry.
+        log = [
+            _entry(
+                tool="get_realtime_quote",
+                arguments={"stock_code": "600519.SH"},
+                step=1,
+                success=False,
+            ),
+            _entry(
+                tool="get_realtime_quote",
+                arguments={"stock_code": "600519"},
+                step=2,
+                success=True,
+            ),
+        ]
+        m = compute_trajectory_metrics(log, _golden())
+        assert m.retries == 1
+        assert m.redundant_calls == 1
+
+    def test_identity_normalization_only_touches_the_stock_code_field(self):
+        # Mirroring _build_tool_cache_key: other arguments stay raw, so a
+        # different period still splits the identity even when the stock
+        # codes are aliases of each other.
+        log = [
+            _entry(
+                tool="get_realtime_quote",
+                arguments={"stock_code": "SH600519", "period": "daily"},
+                step=1,
+                success=False,
+            ),
+            _entry(
+                tool="get_realtime_quote",
+                arguments={"stock_code": "600519", "period": "weekly"},
+                step=2,
+                success=True,
+            ),
+        ]
+        m = compute_trajectory_metrics(log, _golden())
+        assert m.retries == 0
+        assert m.redundant_calls == 0
+
+    def test_injected_normalizer_drives_call_identity(self):
+        # Call identity follows the injected normalizer, not the mirror: a
+        # constant normalizer merges every stock code into one identity.
+        log = [
+            _entry(
+                tool="get_realtime_quote",
+                arguments={"stock_code": "600519"},
+                step=1,
+                success=False,
+            ),
+            _entry(
+                tool="get_realtime_quote",
+                arguments={"stock_code": "000001"},
+                step=2,
+                success=True,
+            ),
+        ]
+        m = compute_trajectory_metrics(log, _golden(), stock_code_normalizer=lambda v: "SAME")
+        assert m.retries == 1
+        assert m.redundant_calls == 1
 
     def test_clean_success_after_guard_is_an_escape(self):
         # Review counter-example: the guarded call is retried and the retry
@@ -992,7 +1098,14 @@ class TestGoldenSamplesFile:
         mistyped = GoldenSample(**base, expected_guarded_stock=600519)
         assert any("expected_guarded_stock must be a non-empty string" in i for i in validate_golden_sample(mistyped))
         same_stock = GoldenSample(**base, expected_guarded_stock="600036")
-        assert any("must differ from stock_code" in i for i in validate_golden_sample(same_stock))
+        assert any("must name a different stock than stock_code" in i for i in validate_golden_sample(same_stock))
+        # Review counter-example: canonicalization must catch alias spellings
+        # of the in-scope stock, not just identical strings.
+        for alias in ("SH600036", "600036.SH", "SS600036", " 600036 "):
+            alias_sample = GoldenSample(**base, expected_guarded_stock=alias)
+            assert any(
+                "must name a different stock than stock_code" in i for i in validate_golden_sample(alias_sample)
+            ), alias
         no_outcome = GoldenSample(
             id="x",
             task_description="t",
@@ -1003,6 +1116,10 @@ class TestGoldenSamplesFile:
         assert any("requires guarded_retry in expected_outcomes" in i for i in validate_golden_sample(no_outcome))
         pinned = GoldenSample(**base, expected_guarded_stock="600519")
         assert validate_golden_sample(pinned) == []
+        # A guarded stock that canonicalizes to a different code stays valid,
+        # alias spelling or not.
+        alias_other = GoldenSample(**base, expected_guarded_stock="SH600519")
+        assert validate_golden_sample(alias_other) == []
 
     def test_unknown_expected_outcome_fails_validation(self):
         sample = GoldenSample(

--- a/tests/test_agent_trajectory_metrics.py
+++ b/tests/test_agent_trajectory_metrics.py
@@ -211,6 +211,83 @@ class TestComputeMetricsHitRate:
 
 
 # ---------------------------------------------------------------------------
+# 2b. Direct-construction path: same structure contract as the loader
+# ---------------------------------------------------------------------------
+class TestDirectConstructionContract:
+    def test_malformed_expected_tools_elements_are_reported(self):
+        # Review counter-example: ['get_realtime_quote', ''] must not
+        # silently collapse into a one-tool golden — the malformed element
+        # is reported, only valid names take part in scoring.
+        log = [_entry(tool="get_realtime_quote", arguments={"stock_code": "600519"})]
+        for malformed in (["get_realtime_quote", ""], ["get_realtime_quote", 1]):
+            m = compute_trajectory_metrics(log, _golden(expected_tools=malformed))
+            assert m.expected_hit_rate == 1.0
+            assert "expected_tools must contain only non-empty strings" in m.violations
+
+    def test_malformed_expected_outcomes_elements_are_reported(self):
+        # Review counter-example: expected_outcomes=[1, ''] must not
+        # silently drop the requirement — the malformed elements are
+        # reported instead of vanishing from the required set.
+        log = [_entry(tool="get_realtime_quote", arguments={"stock_code": "600519"})]
+        for malformed in ([1, ""], [1], [""]):
+            m = compute_trajectory_metrics(log, _golden(expected_outcomes=malformed))
+            assert "expected_outcomes must contain only non-empty strings" in m.violations
+            assert "expected outcomes not observed" not in " ".join(m.violations)
+
+    def test_unpaired_guarded_stock_reported_and_exemption_disabled(self):
+        # Review counter-example: expected_guarded_stock without guarded_retry
+        # is a malformed sample; it must be reported and must not erase the
+        # wrong-stock violation for the blocked out-of-scope probe.
+        golden = GoldenSample(
+            id="x",
+            task_description="t",
+            stock_code="600036",
+            expected_tools=["get_stock_info"],
+            skills=[],
+            expected_outcomes=[],
+            expected_guarded_stock="600519",
+        )
+        log = [
+            _entry(tool="get_stock_info", arguments={"stock_code": "600036"}, step=1),
+            _entry(
+                tool="get_stock_info",
+                arguments={"stock_code": "600519"},
+                step=2,
+                success=False,
+                guarded=True,
+            ),
+        ]
+        m = compute_trajectory_metrics(log, golden)
+        assert m.expected_hit_rate == 1.0
+        assert "expected_guarded_stock requires guarded_retry in expected_outcomes" in m.violations
+        assert any("different stock than 600036: get_stock_info" in v for v in m.violations)
+
+    def test_same_stock_pinned_guard_reported_in_direct_score(self):
+        # A pinned stock that canonicalizes back to golden.stock_code is a
+        # dead configuration the validator rejects; the direct-score path
+        # reports it too (canonicalized comparison, so 'SH600036' counts).
+        golden = _golden(
+            stock_code="600036",
+            expected_tools=["get_stock_info"],
+            expected_outcomes=["guarded_retry"],
+            expected_guarded_stock="SH600036",
+        )
+        log = [
+            _entry(tool="get_stock_info", arguments={"stock_code": "600036"}, step=1),
+            _entry(
+                tool="get_stock_info",
+                arguments={"stock_code": "600519"},
+                step=2,
+                success=False,
+                guarded=True,
+            ),
+        ]
+        m = compute_trajectory_metrics(log, golden)
+        assert any("expected_guarded_stock must name a different stock than stock_code" in v for v in m.violations)
+        assert any("different stock than 600036: get_stock_info" in v for v in m.violations)
+
+
+# ---------------------------------------------------------------------------
 # 3. Retries, caching, failure counting
 # ---------------------------------------------------------------------------
 class TestRetryAndCaching:

--- a/tests/test_agent_trajectory_metrics.py
+++ b/tests/test_agent_trajectory_metrics.py
@@ -265,6 +265,7 @@ class TestExpectedOutcomes:
             allowed_max_steps=10,
             allow_optional_tools=True,
             expected_outcomes=["guarded_retry"],
+            expected_guarded_stock="600519",
         )
         values.update(overrides)
         return GoldenSample(**values)
@@ -321,6 +322,32 @@ class TestExpectedOutcomes:
             ),
         ]
         m = compute_trajectory_metrics(log, self._guarded_sample())
+        assert "expected outcomes not observed: guarded_retry" in m.violations
+
+    def test_guarded_retry_of_a_different_stock_does_not_satisfy(self):
+        # Review counter-example: two guarded calls for 000001 form a
+        # repeated key, which the bound outcome used to accept even though
+        # the task requires attempting the pinned out-of-scope stock 600519.
+        log = [
+            _entry(tool="get_stock_info", arguments={"stock_code": "600036"}, step=1),
+            _entry(tool="get_daily_history", arguments={"stock_code": "600036"}, step=2),
+            _entry(
+                tool="get_realtime_quote",
+                arguments={"stock_code": "000001"},
+                step=3,
+                success=False,
+                guarded=True,
+            ),
+            _entry(
+                tool="get_realtime_quote",
+                arguments={"stock_code": "000001"},
+                step=4,
+                success=False,
+                guarded=True,
+            ),
+        ]
+        m = compute_trajectory_metrics(log, self._guarded_sample())
+        assert m.expected_hit_rate == 1.0
         assert "expected outcomes not observed: guarded_retry" in m.violations
 
     def test_unrelated_retry_does_not_satisfy_guarded_retry(self):
@@ -437,6 +464,53 @@ class TestStockCodeScoping:
         m = compute_trajectory_metrics(log, _golden(expected_tools=["get_realtime_quote"]))
         assert m.expected_hit_rate == 0.0
         assert m.missing_expected == ["get_realtime_quote"]
+
+    def test_stock_code_field_matched_exactly_not_substring(self):
+        # Review counter-example: {"stock_code": "1600519"} contains the
+        # golden code as a substring but must not satisfy the 600519 golden.
+        m = compute_trajectory_metrics(
+            [
+                _entry(
+                    tool="get_realtime_quote",
+                    arguments={"stock_code": "1600519"},
+                    step=1,
+                )
+            ],
+            _golden(expected_tools=["get_realtime_quote"]),
+        )
+        assert m.expected_hit_rate == 0.0
+        assert m.missing_expected == ["get_realtime_quote"]
+        assert any("different stock than 600519: get_realtime_quote" in v for v in m.violations)
+
+    def test_integer_stock_code_argument_counts_after_normalization(self):
+        m = compute_trajectory_metrics(
+            [_entry(tool="get_realtime_quote", arguments={"stock_code": 600519}, step=1)],
+            _golden(expected_tools=["get_realtime_quote"]),
+        )
+        assert m.expected_hit_rate == 1.0
+        assert m.missing_expected == []
+
+    def test_each_wrong_stock_call_of_an_expected_tool_is_reported(self):
+        # Review counter-example: the correct call used to set
+        # stock_hit[tool], which legitimized every other call of the same
+        # tool — the mismatching call must now surface in a violation.
+        log = [
+            _entry(tool="get_realtime_quote", arguments={"stock_code": "600519"}, step=1),
+            _entry(tool="get_realtime_quote", arguments={"stock_code": "000001"}, step=2),
+        ]
+        m = compute_trajectory_metrics(log, _golden(expected_tools=["get_realtime_quote"]))
+        assert m.expected_hit_rate == 1.0
+        assert any("different stock than 600519: get_realtime_quote" in v for v in m.violations)
+
+    def test_arguments_without_stock_field_keep_name_only_tolerance(self):
+        # No stock evidence at all: the entry still counts (documented
+        # tolerance) and never produces a wrong-stock violation.
+        m = compute_trajectory_metrics(
+            [_entry(tool="get_realtime_quote", arguments={"days": 60}, step=1)],
+            _golden(expected_tools=["get_realtime_quote"]),
+        )
+        assert m.expected_hit_rate == 1.0
+        assert m.violations == []
 
     def test_requested_stock_code_guard_metadata_counts(self):
         entry = {
@@ -729,6 +803,30 @@ class TestGoldenSamplesFile:
     def test_guarded_retry_sample_declares_bound_guard_retry_outcome(self):
         sample = next(s for s in load_golden_samples() if s.id == "600036_guarded_retry")
         assert sample.expected_outcomes == ["guarded_retry"]
+        assert sample.expected_guarded_stock == "600519"
+
+    def test_expected_guarded_stock_validation(self):
+        base = dict(
+            id="x",
+            task_description="t",
+            stock_code="600036",
+            expected_tools=["get_stock_info"],
+            expected_outcomes=["guarded_retry"],
+        )
+        mistyped = GoldenSample(**base, expected_guarded_stock=600519)
+        assert any("expected_guarded_stock must be a non-empty string" in i for i in validate_golden_sample(mistyped))
+        same_stock = GoldenSample(**base, expected_guarded_stock="600036")
+        assert any("must differ from stock_code" in i for i in validate_golden_sample(same_stock))
+        no_outcome = GoldenSample(
+            id="x",
+            task_description="t",
+            stock_code="600036",
+            expected_tools=["get_stock_info"],
+            expected_guarded_stock="600519",
+        )
+        assert any("requires guarded_retry in expected_outcomes" in i for i in validate_golden_sample(no_outcome))
+        pinned = GoldenSample(**base, expected_guarded_stock="600519")
+        assert validate_golden_sample(pinned) == []
 
     def test_unknown_expected_outcome_fails_validation(self):
         sample = GoldenSample(

--- a/tests/test_agent_trajectory_metrics.py
+++ b/tests/test_agent_trajectory_metrics.py
@@ -190,7 +190,7 @@ class TestComputeMetricsHitRate:
             log,
             _golden(expected_tools=["get_realtime_quote"], allow_optional_tools="false"),
         )
-        assert "allow_optional_tools is not a boolean" in m.violations
+        assert "allow_optional_tools must be a boolean" in m.violations
         assert "optional tools used but not allowed: search_stock_news" in m.violations
 
     def test_duplicate_expected_tools_scored_as_unique_names(self):
@@ -217,12 +217,23 @@ class TestDirectConstructionContract:
     def test_malformed_expected_tools_elements_are_reported(self):
         # Review counter-example: ['get_realtime_quote', ''] must not
         # silently collapse into a one-tool golden — the malformed element
-        # is reported, only valid names take part in scoring.
+        # is reported, only valid names take part in scoring.  Whitespace-
+        # only elements follow the validator's predicate (t.strip()).
         log = [_entry(tool="get_realtime_quote", arguments={"stock_code": "600519"})]
         for malformed in (["get_realtime_quote", ""], ["get_realtime_quote", 1]):
             m = compute_trajectory_metrics(log, _golden(expected_tools=malformed))
             assert m.expected_hit_rate == 1.0
             assert "expected_tools must contain only non-empty strings" in m.violations
+
+    def test_whitespace_only_expected_tool_does_not_pollute_scoring(self):
+        # Review counter-example: '   ' must not enter the hit-rate
+        # denominator nor show up as a missing tool — it is malformed.
+        log = [_entry(tool="get_realtime_quote", arguments={"stock_code": "600519"})]
+        m = compute_trajectory_metrics(log, _golden(expected_tools=["get_realtime_quote", "   "]))
+        assert m.expected_total == 1
+        assert m.expected_hit_rate == 1.0
+        assert m.missing_expected == []
+        assert "expected_tools must contain only non-empty strings" in m.violations
 
     def test_malformed_expected_outcomes_elements_are_reported(self):
         # Review counter-example: expected_outcomes=[1, ''] must not
@@ -233,6 +244,59 @@ class TestDirectConstructionContract:
             m = compute_trajectory_metrics(log, _golden(expected_outcomes=malformed))
             assert "expected_outcomes must contain only non-empty strings" in m.violations
             assert "expected outcomes not observed" not in " ".join(m.violations)
+
+    def test_whitespace_only_outcome_gets_structural_violation(self):
+        # Review counter-example: '   ' must be reported as a malformed
+        # element, not misrouted into the unknown-tag violation type.
+        log = [_entry(tool="get_realtime_quote", arguments={"stock_code": "600519"})]
+        m = compute_trajectory_metrics(log, _golden(expected_outcomes=["   "]))
+        assert "expected_outcomes must contain only non-empty strings" in m.violations
+        assert not any("unknown expected outcome tags" in v for v in m.violations)
+
+    def test_non_positive_allowed_max_steps_reported_in_direct_score(self):
+        # Review counter-example: allowed_max_steps=0 / -3 must report the
+        # validator's wording instead of silently disabling the budget
+        # assertion, no matter how many steps the trajectory takes.
+        log = [_entry(tool="get_realtime_quote", arguments={"stock_code": "600519"}, step=s) for s in range(1, 100)]
+        for limit in (0, -3):
+            m = compute_trajectory_metrics(log, _golden(allowed_max_steps=limit))
+            assert "allowed_max_steps must be >= 1" in m.violations
+            assert m.max_steps_touched is False
+
+    def test_direct_score_mirrors_validator_structure_contract(self):
+        # The owner-requested parity: for each malformed golden shape the
+        # validator rejects, the direct-score path must surface the same
+        # issue wording in its violations.
+        log = [_entry(tool="get_realtime_quote", arguments={"stock_code": "600519"})]
+        cases = [
+            (dict(expected_tools=["get_realtime_quote", "   "]), "expected_tools must contain only non-empty strings"),
+            (dict(expected_tools=["get_realtime_quote", ""]), "expected_tools must contain only non-empty strings"),
+            (dict(expected_outcomes=["   "]), "expected_outcomes must contain only non-empty strings"),
+            (dict(expected_outcomes=[1, ""]), "expected_outcomes must contain only non-empty strings"),
+            (dict(expected_outcomes="guarded"), "expected_outcomes must be a list of outcome tags"),
+            (dict(allowed_max_steps=0), "allowed_max_steps must be >= 1"),
+            (dict(allowed_max_steps=-3), "allowed_max_steps must be >= 1"),
+            (dict(allow_optional_tools="false"), "allow_optional_tools must be a boolean"),
+            (
+                dict(expected_guarded_stock="600036"),
+                "expected_guarded_stock requires guarded_retry in expected_outcomes",
+            ),
+            (
+                dict(
+                    stock_code="600036",
+                    expected_tools=["get_stock_info"],
+                    expected_outcomes=["guarded_retry"],
+                    expected_guarded_stock="SH600036",
+                ),
+                "expected_guarded_stock must name a different stock than stock_code after canonicalization (it names the out-of-scope call)",
+            ),
+        ]
+        for overrides, issue in cases:
+            golden = _golden(**overrides)
+            validator_issues = validate_golden_sample(golden)
+            assert any(issue in i for i in validator_issues), (issue, overrides, validator_issues)
+            m = compute_trajectory_metrics(log, golden)
+            assert any(issue in v for v in m.violations), (issue, overrides, m.violations)
 
     def test_unpaired_guarded_stock_reported_and_exemption_disabled(self):
         # Review counter-example: expected_guarded_stock without guarded_retry

--- a/tests/test_agent_trajectory_metrics.py
+++ b/tests/test_agent_trajectory_metrics.py
@@ -704,6 +704,68 @@ class TestExpectedOutcomes:
         m = compute_trajectory_metrics(log, self._guarded_sample())
         assert "expected outcomes not observed: guarded_retry" in m.violations
 
+    def test_guarded_probe_without_stock_evidence_does_not_satisfy(self):
+        # Review counter-example: a blocked call with no stock evidence at
+        # all (arguments={}) cannot prove the pinned 600519 probe, so the
+        # name-only tolerance must not seed a stock-pinned guarded_retry.
+        log = [
+            _entry(tool="get_stock_info", arguments={"stock_code": "600036"}, step=1),
+            _entry(tool="get_daily_history", arguments={"stock_code": "600036"}, step=2),
+            _entry(
+                tool="get_realtime_quote",
+                arguments={},
+                step=3,
+                success=False,
+                guarded=True,
+            ),
+            _entry(
+                tool="get_realtime_quote",
+                arguments={},
+                step=4,
+                success=False,
+                cached=True,
+            ),
+        ]
+        m = compute_trajectory_metrics(log, self._guarded_sample())
+        assert m.expected_hit_rate == 1.0
+        assert "expected outcomes not observed: guarded_retry" in m.violations
+
+    def test_guarded_probe_without_any_arguments_does_not_satisfy(self):
+        # Minimal entries with no arguments payload at all must not seed the
+        # pinned outcome through the trailing name-only tolerance either.
+        log = [
+            _entry(tool="get_stock_info", arguments={"stock_code": "600036"}, step=1),
+            _entry(tool="get_daily_history", arguments={"stock_code": "600036"}, step=2),
+            {"step": 3, "tool": "get_realtime_quote", "success": False, "guarded": True},
+            {"step": 4, "tool": "get_realtime_quote", "success": False, "cached": True},
+        ]
+        m = compute_trajectory_metrics(log, self._guarded_sample())
+        assert "expected outcomes not observed: guarded_retry" in m.violations
+
+    def test_guarded_probe_without_stock_field_does_not_satisfy(self):
+        # A structured payload without a stock_code field ({"days": 30})
+        # carries no stock evidence either and must not satisfy the pin.
+        log = [
+            _entry(tool="get_stock_info", arguments={"stock_code": "600036"}, step=1),
+            _entry(tool="get_daily_history", arguments={"stock_code": "600036"}, step=2),
+            _entry(
+                tool="get_realtime_quote",
+                arguments={"days": 30},
+                step=3,
+                success=False,
+                guarded=True,
+            ),
+            _entry(
+                tool="get_realtime_quote",
+                arguments={"days": 30},
+                step=4,
+                success=False,
+                cached=True,
+            ),
+        ]
+        m = compute_trajectory_metrics(log, self._guarded_sample())
+        assert "expected outcomes not observed: guarded_retry" in m.violations
+
     def test_injected_normalizer_drives_call_identity(self):
         # Call identity follows the injected normalizer, not the mirror: a
         # constant normalizer merges every stock code into one identity.

--- a/tests/test_agent_trajectory_metrics.py
+++ b/tests/test_agent_trajectory_metrics.py
@@ -450,6 +450,12 @@ class TestGoldenSamplesFile:
         known = (name for name in ["a", "b"])
         assert validate_golden_sample(sample, known) == []
 
+    def test_loader_materializes_registry_once_for_multiple_samples(self):
+        # A one-shot generator must survive loading the whole checked-in file:
+        # the first sample must not exhaust it for the remaining samples.
+        samples = load_golden_samples(known_tool_names=(name for name in _repo_tool_names()))
+        assert len(samples) == 3
+
 
 class TestLoadGoldenSamplesErrors:
     @staticmethod
@@ -551,6 +557,20 @@ class TestLoadGoldenSamplesErrors:
         path = self._write_sample(tmp_path, [sample])
         with pytest.raises(ValueError, match="expected_tools must be a list"):
             load_golden_samples(path=path, known_tool_names={"get_realtime_quote"})
+
+    def test_unhashable_id_raises_valueerror(self, tmp_path):
+        # Structural validation must run before duplicate detection: an
+        # unhashable id would otherwise crash the seen_ids membership check
+        # with a TypeError instead of the documented ValueError.
+        sample = {
+            "id": ["x"],
+            "task_description": "t",
+            "stock_code": "600519",
+            "expected_tools": ["get_realtime_quote"],
+        }
+        path = self._write_sample(tmp_path, [sample])
+        with pytest.raises(ValueError, match="id must be a non-empty string"):
+            load_golden_samples(path=path)
 
     def test_non_bool_allow_optional_tools_raises(self, tmp_path):
         sample = {

--- a/tests/test_agent_trajectory_metrics.py
+++ b/tests/test_agent_trajectory_metrics.py
@@ -102,6 +102,12 @@ class TestArgsKey:
             {"stock_code": "600519", "period": "weekly"}
         )
 
+    def test_numeric_stock_code_stays_distinct_from_string(self):
+        # The production normalizer returns non-string values unchanged, so a
+        # JSON number and a string must remain two different call identities.
+        assert _args_key({"stock_code": 600519}) != _args_key({"stock_code": "600519"})
+        assert _args_key({"stock_code": 600519}) == json.dumps({"stock_code": 600519}, sort_keys=True)
+
 
 # ---------------------------------------------------------------------------
 # 2. Hit rate / expected & optional tools
@@ -432,6 +438,55 @@ class TestExpectedOutcomes:
             ),
         ]
         m = compute_trajectory_metrics(log, _golden())
+        assert m.retries == 0
+        assert m.redundant_calls == 0
+
+    def test_number_and_string_stock_codes_do_not_merge_identity(self):
+        # The runtime cache key preserves the JSON number type, so a failed
+        # number call followed by a string call is not "the same call" — no
+        # retry, no redundancy.
+        log = [
+            _entry(
+                tool="get_realtime_quote",
+                arguments={"stock_code": 600519},
+                step=1,
+                success=False,
+            ),
+            _entry(
+                tool="get_realtime_quote",
+                arguments={"stock_code": "600519"},
+                step=2,
+                success=True,
+            ),
+        ]
+        m = compute_trajectory_metrics(log, _golden())
+        assert m.retries == 0
+        assert m.redundant_calls == 0
+
+    def test_number_then_string_guard_retry_stays_distinct(self):
+        # A guarded number call followed by a cached string call is not the
+        # same (tool, args-key) in the runtime cache, so guarded_retry must
+        # not be observed from that pair.
+        log = [
+            _entry(tool="get_stock_info", arguments={"stock_code": "600036"}, step=1),
+            _entry(tool="get_daily_history", arguments={"stock_code": "600036"}, step=2),
+            _entry(
+                tool="get_realtime_quote",
+                arguments={"stock_code": 600519},
+                step=3,
+                success=False,
+                guarded=True,
+            ),
+            _entry(
+                tool="get_realtime_quote",
+                arguments={"stock_code": "600519"},
+                step=4,
+                success=False,
+                cached=True,
+            ),
+        ]
+        m = compute_trajectory_metrics(log, self._guarded_sample())
+        assert "expected outcomes not observed: guarded_retry" in m.violations
         assert m.retries == 0
         assert m.redundant_calls == 0
 
@@ -808,6 +863,31 @@ class TestStockCanonicalization:
         default = compute_trajectory_metrics(log, golden)
         assert default.expected_hit_rate == 1.0
         assert default.violations == []
+
+    def test_identity_key_matches_production_cache_key_payload(self):
+        # The identity payload must mirror src/agent/tools/execution.
+        # _build_tool_cache_key byte for byte — alias folding for strings,
+        # type preservation for JSON numbers.
+        from src.agent.tools.execution import _build_tool_cache_key
+
+        from evals.agent_trajectory.metrics import _args_key
+
+        forms = [
+            600519,
+            "600519",
+            "SH600519",
+            "600519.SH",
+            "sh600519",
+            "HK00700",
+            "700.HK",
+            "00700",
+            "SZ000001",
+            " 600519 ",
+        ]
+        for form in forms:
+            production = _build_tool_cache_key("get_realtime_quote", {"stock_code": form})
+            mirrored = "get_realtime_quote:" + _args_key({"stock_code": form})
+            assert mirrored == production, form
 
     def test_non_callable_normalizer_surfaces_violation(self):
         m = compute_trajectory_metrics([_entry()], _golden(), stock_code_normalizer="nope")

--- a/tests/test_agent_trajectory_metrics.py
+++ b/tests/test_agent_trajectory_metrics.py
@@ -379,6 +379,118 @@ class TestDirectConstructionContract:
         assert any("expected_guarded_stock must name a different stock than stock_code" in v for v in m.violations)
         assert any("different stock than 600036: get_stock_info" in v for v in m.violations)
 
+    def test_same_stock_pin_does_not_score_in_scope_retry_as_probe(self):
+        # A pin that canonicalizes back to golden.stock_code is a dead
+        # configuration: the direct-score path reports it AND disables the
+        # pin, so an in-scope blocked guard-retry must not pass as the
+        # required out-of-scope probe — guarded_retry reads not observed
+        # next to the structural violation.
+        golden = _golden(
+            stock_code="600036",
+            expected_tools=["get_stock_info"],
+            expected_outcomes=["guarded_retry"],
+            expected_guarded_stock="SH600036",
+        )
+        log = [
+            _entry(
+                tool="get_stock_info",
+                arguments={"stock_code": "600036"},
+                step=1,
+                success=False,
+                guarded=True,
+            ),
+            _entry(
+                tool="get_stock_info",
+                arguments={"stock_code": "600036"},
+                step=2,
+                success=False,
+                cached=True,
+            ),
+        ]
+        m = compute_trajectory_metrics(log, golden)
+        assert any("expected_guarded_stock must name a different stock than stock_code" in v for v in m.violations)
+        assert "expected outcomes not observed: guarded_retry" in m.violations
+
+    def test_same_stock_pin_disabled_tracks_no_escape_for_optional_tool_success(self):
+        # A disabled pin must not reshape scoring: an optional tool reaching
+        # the (invalid) pinned stock cleanly is not a guard bypass, because
+        # the pin names the in-scope stock, not an out-of-scope one.
+        golden = _golden(
+            stock_code="600036",
+            expected_tools=["get_stock_info"],
+            expected_outcomes=["guarded_retry"],
+            expected_guarded_stock="SH600036",
+        )
+        log = [
+            _entry(
+                tool="get_realtime_quote",
+                arguments={"stock_code": "600036"},
+                step=1,
+                success=True,
+            ),
+        ]
+        m = compute_trajectory_metrics(log, golden)
+        assert not any("escaped the guarded stock" in v for v in m.violations)
+
+    def test_same_stock_pin_keeps_out_of_scope_probe_satisfying_guarded_retry(self):
+        # The pin names the out-of-scope call; a broken (same-stock) pin is
+        # disabled, but the declared guarded_retry still binds to the
+        # out-of-scope requirement — a genuine 600519 blocked guard-retry
+        # satisfies it (no misleading "not observed"), while the structural
+        # violation for the broken pin is still reported.
+        golden = _golden(
+            stock_code="600036",
+            expected_tools=["get_stock_info"],
+            expected_outcomes=["guarded_retry"],
+            expected_guarded_stock="SH600036",
+        )
+        log = [
+            _entry(
+                tool="get_stock_info",
+                arguments={"stock_code": "600519"},
+                step=1,
+                success=False,
+                guarded=True,
+            ),
+            _entry(
+                tool="get_stock_info",
+                arguments={"stock_code": "600519"},
+                step=2,
+                success=False,
+                cached=True,
+            ),
+        ]
+        m = compute_trajectory_metrics(log, golden)
+        assert any("expected_guarded_stock must name a different stock than stock_code" in v for v in m.violations)
+        assert not any("expected outcomes not observed" in v for v in m.violations)
+
+    def test_unpinned_guarded_retry_legacy_seeding_unchanged(self):
+        # No pin declared: the legacy pin-less guarded_retry still seeds
+        # from any guarded occurrence, in-scope included.
+        golden = _golden(
+            stock_code="600036",
+            expected_tools=["get_stock_info"],
+            expected_outcomes=["guarded_retry"],
+        )
+        log = [
+            _entry(
+                tool="get_stock_info",
+                arguments={"stock_code": "600036"},
+                step=1,
+                success=False,
+                guarded=True,
+            ),
+            _entry(
+                tool="get_stock_info",
+                arguments={"stock_code": "600036"},
+                step=2,
+                success=False,
+                cached=True,
+            ),
+        ]
+        m = compute_trajectory_metrics(log, golden)
+        assert m.violations == []
+
 
 # ---------------------------------------------------------------------------
 # 3. Retries, caching, failure counting

--- a/tests/test_agent_trajectory_metrics.py
+++ b/tests/test_agent_trajectory_metrics.py
@@ -677,6 +677,33 @@ class TestExpectedOutcomes:
         assert m.expected_hit_rate == 0.0
         assert any("different stock than 600519: get_realtime_quote" in v for v in m.violations)
 
+    def test_malformed_guarded_probe_does_not_satisfy_guarded_retry(self):
+        # Review counter-example: a guarded call whose stock evidence is
+        # explicitly malformed (stock_code=None, empty requested_stock_code)
+        # never proves the required 600519 probe, so it must not seed the
+        # pinned guard outcome — not even when a cached repeat follows.
+        log = [
+            _entry(tool="get_stock_info", arguments={"stock_code": "600036"}, step=1),
+            _entry(tool="get_daily_history", arguments={"stock_code": "600036"}, step=2),
+            _entry(
+                tool="get_realtime_quote",
+                arguments={"stock_code": None},
+                step=3,
+                success=False,
+                guarded=True,
+                requested_stock_code="",
+            ),
+            _entry(
+                tool="get_realtime_quote",
+                arguments={"stock_code": None},
+                step=4,
+                success=False,
+                cached=True,
+            ),
+        ]
+        m = compute_trajectory_metrics(log, self._guarded_sample())
+        assert "expected outcomes not observed: guarded_retry" in m.violations
+
     def test_injected_normalizer_drives_call_identity(self):
         # Call identity follows the injected normalizer, not the mirror: a
         # constant normalizer merges every stock code into one identity.
@@ -1032,6 +1059,52 @@ class TestStockCodeScoping:
         }
         m = compute_trajectory_metrics([entry], _golden(expected_tools=["get_realtime_quote"]))
         assert m.expected_hit_rate == 1.0
+
+    def test_explicit_malformed_stock_evidence_does_not_hit(self):
+        # Review counter-example: an explicitly present but invalid
+        # stock_code (null / boolean / non-scalar) proves nothing about the
+        # call's target, so it must not earn name-only hit credit — the
+        # tolerance is reserved for entries with no stock evidence at all.
+        for bad in (None, False, [], {}):
+            m = compute_trajectory_metrics(
+                [_entry(tool="get_realtime_quote", arguments={"stock_code": bad}, step=1)],
+                _golden(expected_tools=["get_realtime_quote"]),
+            )
+            assert m.expected_hit_rate == 0.0, bad
+            assert m.missing_expected == ["get_realtime_quote"], bad
+            assert not any("different stock" in v for v in m.violations), bad
+
+    def test_malformed_requested_stock_code_does_not_hit(self):
+        # Guard metadata is authoritative: a present but invalid (or empty)
+        # requested_stock_code is a non-match, not name-only tolerance.
+        for bad in (None, "", [], True):
+            entry = {
+                "step": 1,
+                "tool": "get_realtime_quote",
+                "success": False,
+                "guarded": True,
+                "requested_stock_code": bad,
+            }
+            m = compute_trajectory_metrics([entry], _golden(expected_tools=["get_realtime_quote"]))
+            assert m.expected_hit_rate == 0.0, bad
+            assert m.missing_expected == ["get_realtime_quote"], bad
+
+    def test_codex_summary_malformed_stock_evidence_does_not_hit(self):
+        # A well-formed summary whose stock_code recovers to JSON null /
+        # false / an array is explicit invalid evidence: a non-match, not
+        # name-only tolerance.
+        for bad in (None, False, []):
+            log = [
+                _codex_entry(
+                    tool="get_realtime_quote",
+                    summary=json.dumps({"stock_code": bad}),
+                    step=1,
+                ),
+            ]
+            m = compute_trajectory_metrics(log, _golden(expected_tools=["get_realtime_quote"]))
+            assert m.expected_hit_rate == 0.0, bad
+            assert m.missing_expected == ["get_realtime_quote"], bad
+            assert not any("different stock" in v for v in m.violations), bad
 
     def test_invalid_golden_stock_code_falls_back_to_name_only(self):
         m = compute_trajectory_metrics(

--- a/tests/test_agent_trajectory_metrics.py
+++ b/tests/test_agent_trajectory_metrics.py
@@ -490,6 +490,71 @@ class TestExpectedOutcomes:
         assert m.retries == 0
         assert m.redundant_calls == 0
 
+    def test_clean_success_before_guard_still_escapes(self):
+        # Review counter-example: the out-of-scope key succeeded before ever
+        # being guarded — the call provably gets through the scope guard, so
+        # a later guarded occurrence plus a blocked repeat must not satisfy
+        # the golden contract.
+        log = [
+            _entry(tool="get_stock_info", arguments={"stock_code": "600036"}, step=1),
+            _entry(tool="get_daily_history", arguments={"stock_code": "600036"}, step=2),
+            _entry(
+                tool="get_realtime_quote",
+                arguments={"stock_code": "600519"},
+                step=3,
+                success=True,
+            ),
+            _entry(
+                tool="get_realtime_quote",
+                arguments={"stock_code": "600519"},
+                step=4,
+                success=False,
+                guarded=True,
+            ),
+            _entry(
+                tool="get_realtime_quote",
+                arguments={"stock_code": "600519"},
+                step=5,
+                success=False,
+                cached=True,
+            ),
+        ]
+        m = compute_trajectory_metrics(log, self._guarded_sample())
+        assert "expected outcomes not observed: guarded_retry" in m.violations
+        assert m.retries == 1
+        assert m.cached_calls == 1
+
+    def test_success_on_a_different_key_does_not_escape(self):
+        # Escape tracking is per (tool, args-key): a clean success of an
+        # unrelated out-of-scope key leaves the pinned 600519 guard/retry
+        # sequence intact.
+        log = [
+            _entry(tool="get_stock_info", arguments={"stock_code": "600036"}, step=1),
+            _entry(tool="get_daily_history", arguments={"stock_code": "600036"}, step=2),
+            _entry(
+                tool="get_realtime_quote",
+                arguments={"stock_code": "000001"},
+                step=3,
+                success=True,
+            ),
+            _entry(
+                tool="get_realtime_quote",
+                arguments={"stock_code": "600519"},
+                step=4,
+                success=False,
+                guarded=True,
+            ),
+            _entry(
+                tool="get_realtime_quote",
+                arguments={"stock_code": "600519"},
+                step=5,
+                success=False,
+                cached=True,
+            ),
+        ]
+        m = compute_trajectory_metrics(log, self._guarded_sample())
+        assert "expected outcomes not observed" not in m.violations
+
     def test_injected_normalizer_drives_call_identity(self):
         # Call identity follows the injected normalizer, not the mirror: a
         # constant normalizer merges every stock code into one identity.
@@ -704,6 +769,55 @@ class TestStockCodeScoping:
         m = compute_trajectory_metrics(log, _golden(expected_tools=["get_realtime_quote"]))
         assert m.expected_hit_rate == 0.0
         assert m.missing_expected == ["get_realtime_quote"]
+
+    def test_codex_summary_alias_resolves_to_canonical_golden(self):
+        # Review counter-example: the backend keeps the original spelling in
+        # arguments_summary, so the structured value must be recovered and
+        # canonicalized — hk700 matches an HK00700 golden, aapl matches AAPL.
+        for summary_code, golden_code in (("hk700", "HK00700"), ("aapl", "AAPL")):
+            log = [
+                {
+                    "step": 1,
+                    "tool": "get_realtime_quote",
+                    "arguments_summary": json.dumps({"stock_code": summary_code}),
+                    "success": True,
+                },
+            ]
+            m = compute_trajectory_metrics(log, _golden(stock_code=golden_code, expected_tools=["get_realtime_quote"]))
+            assert m.expected_hit_rate == 1.0, (summary_code, golden_code)
+            assert m.missing_expected == []
+
+    def test_codex_summary_structured_different_stock_reports_wrong_stock(self):
+        # A well-formed summary recovers to concrete evidence, so it must be
+        # treated like a runner argument: a different code is a wrong-stock
+        # call, not silent tolerance.
+        log = [
+            {
+                "step": 1,
+                "tool": "get_realtime_quote",
+                "arguments_summary": json.dumps({"stock_code": "000001"}),
+                "success": True,
+            },
+        ]
+        m = compute_trajectory_metrics(log, _golden(expected_tools=["get_realtime_quote"]))
+        assert m.expected_hit_rate == 0.0
+        assert any("different stock than 600519: get_realtime_quote" in v for v in m.violations)
+
+    def test_unparsable_summary_falls_back_to_substring_no_evidence(self):
+        # Truncated previews cannot recover a structured value: they fall
+        # back to the substring scan for matching and stay "no evidence" for
+        # wrong-stock reporting.
+        log = [
+            {
+                "step": 1,
+                "tool": "get_realtime_quote",
+                "arguments_summary": '{"stock_code": "6005...<truncated 12 chars>',
+                "success": True,
+            },
+        ]
+        m = compute_trajectory_metrics(log, _golden(expected_tools=["get_realtime_quote"]))
+        assert m.expected_hit_rate == 0.0
+        assert not any("different stock" in v for v in m.violations)
 
     def test_stock_code_field_matched_exactly_not_substring(self):
         # Review counter-example: {"stock_code": "1600519"} contains the

--- a/tests/test_agent_trajectory_metrics.py
+++ b/tests/test_agent_trajectory_metrics.py
@@ -1155,6 +1155,23 @@ class TestExpectedOutcomes:
         assert "optional tools escaped the guarded stock 600519: get_realtime_quote" in m.violations
         assert "expected outcomes not observed: guarded_retry" in m.violations
 
+    def test_integral_float_clean_success_on_guarded_stock_reports_escape(self):
+        # Review counter-example: get_realtime_quote(stock_code=600519.0,
+        # success=True) is a clean success on the pinned stock even though
+        # the argument is a JSON float — the escape and the guarded_retry
+        # break must both be reported, not silently missed as invalid
+        # evidence.
+        log = [
+            _entry(tool="get_stock_info", arguments={"stock_code": "600036"}, step=1),
+            _entry(tool="get_daily_history", arguments={"stock_code": "600036"}, step=2),
+            _entry(tool="get_stock_info", arguments={"stock_code": "600519"}, step=3, success=False, guarded=True),
+            _entry(tool="get_stock_info", arguments={"stock_code": "600519"}, step=4, success=False, cached=True),
+            _entry(tool="get_realtime_quote", arguments={"stock_code": 600519.0}, step=5),
+        ]
+        m = compute_trajectory_metrics(log, self._guarded_sample())
+        assert "optional tools escaped the guarded stock 600519: get_realtime_quote" in m.violations
+        assert "expected outcomes not observed: guarded_retry" in m.violations
+
     def test_blocked_optional_probe_on_guarded_stock_stays_clean(self):
         # The deliberate-probe exemption spans tools: a blocked optional
         # probe of the pinned stock is as legitimate as an expected one and
@@ -1219,6 +1236,46 @@ class TestStockCodeScoping:
         assert m.expected_hit_rate == pytest.approx(2 / 3)
         assert m.missing_expected == ["get_daily_history"]
         assert any("different stock than 600519: get_daily_history" in v for v in m.violations)
+
+    def test_integral_float_stock_argument_counts_as_hit(self):
+        # Review counter-example: the runner records arguments verbatim, so a
+        # JSON-parsed code can arrive as 600519.0; the guard chain coerces
+        # integral floats to int before normalization
+        # (_normalize_guard_stock_code), so the metrics layer must read it
+        # as 600519 instead of rejecting the evidence.
+        golden = _golden(expected_tools=["get_realtime_quote"])
+        log = [_entry(tool="get_realtime_quote", arguments={"stock_code": 600519.0}, step=1)]
+        m = compute_trajectory_metrics(log, golden)
+        assert m.expected_hit_rate == 1.0
+        assert m.missing_expected == []
+        assert m.violations == []
+
+    def test_integral_float_wrong_stock_is_reported(self):
+        # The coercion must reach the mismatch side too: 600000.0 reads as
+        # 600000, a different code, so analyze_trend scores no hit and
+        # reports a wrong-stock violation even though its argument is a
+        # float.
+        log = [
+            _entry(tool="get_realtime_quote", arguments={"stock_code": 600519.0}, step=1),
+            _entry(tool="get_daily_history", arguments={"stock_code": "600519"}, step=2),
+            _entry(tool="analyze_trend", arguments={"stock_code": 600000.0}, step=3),
+        ]
+        m = compute_trajectory_metrics(log, _golden())
+        assert m.expected_hit_rate == pytest.approx(2 / 3)
+        assert m.missing_expected == ["analyze_trend"]
+        assert any("different stock than 600519: analyze_trend" in v for v in m.violations)
+
+    def test_non_integral_float_stock_is_a_distinct_code(self):
+        # Guard-chain parity for the non-integral branch: the guard compares
+        # str(600519.5) = "600519.5", which never canonicalizes to 600519 —
+        # it is evidence of a different code, so no hit and a wrong-stock
+        # violation.
+        golden = _golden(expected_tools=["get_realtime_quote"])
+        log = [_entry(tool="get_realtime_quote", arguments={"stock_code": 600519.5}, step=1)]
+        m = compute_trajectory_metrics(log, golden)
+        assert m.expected_hit_rate == 0.0
+        assert m.missing_expected == ["get_realtime_quote"]
+        assert any("different stock than 600519: get_realtime_quote" in v for v in m.violations)
 
     def test_codex_summary_matching_the_stock_counts(self):
         log = [
@@ -1595,6 +1652,21 @@ class TestStockCanonicalization:
         ]
         for form in forms:
             assert _canonicalize_stock_code(form) == _normalize_tool_stock_code(form), form
+
+    def test_float_evidence_matches_production_guard_coercion(self):
+        # Guard-chain parity for float-shaped stock evidence: the coercion
+        # step plus the mirror must agree with
+        # execution._normalize_guard_stock_code on both branches (integral
+        # float -> int, any other float -> str), so a value the runtime
+        # guard reads as a code scores identically here.
+        from src.agent.tools.execution import _normalize_guard_stock_code
+
+        from evals.agent_trajectory.metrics import _canonicalize_stock_code, _coerce_guard_float
+
+        for value in [600519.0, 600036.0, 600519.5, 600036.5]:
+            coerced = _coerce_guard_float(value)
+            assert _canonicalize_stock_code(coerced) == _normalize_guard_stock_code(coerced), value
+            assert _normalize_guard_stock_code(value) == _normalize_guard_stock_code(coerced), value
 
     def test_injected_normalizer_overrides_the_mirror(self):
         golden = _golden(expected_tools=["get_realtime_quote"])

--- a/tests/test_agent_trajectory_metrics.py
+++ b/tests/test_agent_trajectory_metrics.py
@@ -143,6 +143,12 @@ class TestComputeMetricsHitRate:
         assert m.expected_hit_rate == 0.0
         assert "golden sample has no expected_tools" in m.violations
 
+    def test_string_expected_tools_scored_as_empty_not_as_characters(self):
+        m = compute_trajectory_metrics([_entry()], _golden(expected_tools="get_realtime_quote"))
+        assert m.expected_hit_rate == 0.0
+        assert m.expected_total == 0
+        assert "golden sample has no expected_tools" in m.violations
+
 
 # ---------------------------------------------------------------------------
 # 3. Retries, caching, failure counting
@@ -185,6 +191,19 @@ class TestRetryAndCaching:
         assert m.redundant_calls == 2
         assert m.failed_calls == 2
 
+    def test_recovery_clears_failure_state(self):
+        # fail -> success -> success: only the recovery attempt is a retry;
+        # the repeat after success counts as redundant only.
+        log = [
+            _entry(step=1, success=False),
+            _entry(step=2, success=True),
+            _entry(step=3, success=True),
+        ]
+        m = compute_trajectory_metrics(log, _golden())
+        assert m.retries == 1
+        assert m.redundant_calls == 2
+        assert m.failed_calls == 1
+
     def test_cached_entry_counted(self):
         m = compute_trajectory_metrics([_entry(cached=True, success=False)], _golden())
         assert m.cached_calls == 1
@@ -221,6 +240,37 @@ class TestMaxStepsTouched:
     def test_empty_log_not_touched(self):
         m = compute_trajectory_metrics([], _golden(allowed_max_steps=5))
         assert m.max_steps_touched is False
+
+
+# ---------------------------------------------------------------------------
+# 4b. total_steps input (final answer round)
+# ---------------------------------------------------------------------------
+class TestTotalStepsInput:
+    def test_total_steps_extends_step_metrics_beyond_log(self):
+        log = [_entry(step=1), _entry(step=2)]
+        m = compute_trajectory_metrics(log, _golden(allowed_max_steps=5), total_steps=4)
+        assert m.distinct_steps == 4
+        assert m.max_steps_touched is False
+
+    def test_total_steps_can_touch_the_limit(self):
+        log = [_entry(step=1), _entry(step=2)]
+        m = compute_trajectory_metrics(log, _golden(allowed_max_steps=3), total_steps=3)
+        assert m.max_steps_touched is True
+        assert m.distinct_steps == 3
+
+    def test_log_wins_when_it_reaches_further(self):
+        log = [_entry(step=i) for i in range(1, 5)]
+        m = compute_trajectory_metrics(log, _golden(allowed_max_steps=5), total_steps=2)
+        assert m.distinct_steps == 4
+        assert m.max_steps_touched is False
+
+    def test_none_keeps_log_only_behaviour(self):
+        m = compute_trajectory_metrics([_entry(step=1)], _golden())
+        assert m.distinct_steps == 1
+
+    def test_non_numeric_total_steps_ignored(self):
+        m = compute_trajectory_metrics([_entry(step=1)], _golden(), total_steps="not-a-number")
+        assert m.distinct_steps == 1
 
 
 # ---------------------------------------------------------------------------
@@ -320,6 +370,16 @@ class TestGoldenSamplesFile:
             assert sample.stock_code.strip()
             assert sample.allowed_max_steps >= 1
 
+    def test_string_expected_tools_fails_validation(self):
+        sample = GoldenSample(
+            id="x",
+            task_description="t",
+            stock_code="600519",
+            expected_tools="get_realtime_quote",
+        )
+        issues = validate_golden_sample(sample)
+        assert any("must be a list" in i for i in issues)
+
 
 class TestLoadGoldenSamplesErrors:
     @staticmethod
@@ -396,4 +456,15 @@ class TestLoadGoldenSamplesErrors:
         }
         path = self._write_sample(tmp_path, [sample])
         with pytest.raises(ValueError, match="allowed_max_steps must be >= 1"):
+            load_golden_samples(path=path)
+
+    def test_string_expected_tools_raises(self, tmp_path):
+        sample = {
+            "id": "x",
+            "task_description": "t",
+            "stock_code": "600519",
+            "expected_tools": "get_realtime_quote",
+        }
+        path = self._write_sample(tmp_path, [sample])
+        with pytest.raises(ValueError, match="expected_tools must be a list"):
             load_golden_samples(path=path)

--- a/tests/test_agent_trajectory_metrics.py
+++ b/tests/test_agent_trajectory_metrics.py
@@ -428,6 +428,28 @@ class TestGoldenSamplesFile:
         assert any("allowed_max_steps must be an integer" in i for i in issues)
         assert any("allow_optional_tools must be a boolean" in i for i in issues)
 
+    def test_non_iterable_expected_tools_with_known_names_does_not_crash(self):
+        sample = GoldenSample(
+            id="x",
+            task_description="t",
+            stock_code="600519",
+            expected_tools=1,
+        )
+        issues = validate_golden_sample(sample, {"get_realtime_quote"})
+        assert any("expected_tools must be a list" in i for i in issues)
+
+    def test_registry_membership_with_one_shot_generator(self):
+        # The helper accepts any Iterable[str]; a one-shot generator must be
+        # materialized internally so membership checks never consume it.
+        sample = GoldenSample(
+            id="x",
+            task_description="t",
+            stock_code="600519",
+            expected_tools=["b", "a"],
+        )
+        known = (name for name in ["a", "b"])
+        assert validate_golden_sample(sample, known) == []
+
 
 class TestLoadGoldenSamplesErrors:
     @staticmethod
@@ -516,6 +538,19 @@ class TestLoadGoldenSamplesErrors:
         path = self._write_sample(tmp_path, [sample])
         with pytest.raises(ValueError, match="expected_tools must be a list"):
             load_golden_samples(path=path)
+
+    def test_non_list_expected_tools_with_known_names_raises_valueerror(self, tmp_path):
+        # Regression for OR-COR-4e0e3cf1: the registry membership check must
+        # not iterate a rejected non-list value and leak a TypeError.
+        sample = {
+            "id": "x",
+            "task_description": "t",
+            "stock_code": "600519",
+            "expected_tools": 1,
+        }
+        path = self._write_sample(tmp_path, [sample])
+        with pytest.raises(ValueError, match="expected_tools must be a list"):
+            load_golden_samples(path=path, known_tool_names={"get_realtime_quote"})
 
     def test_non_bool_allow_optional_tools_raises(self, tmp_path):
         sample = {

--- a/tests/test_agent_trajectory_metrics.py
+++ b/tests/test_agent_trajectory_metrics.py
@@ -264,7 +264,7 @@ class TestExpectedOutcomes:
             skills=[],
             allowed_max_steps=10,
             allow_optional_tools=True,
-            expected_outcomes=["guarded", "retry"],
+            expected_outcomes=["guarded_retry"],
         )
         values.update(overrides)
         return GoldenSample(**values)
@@ -308,9 +308,9 @@ class TestExpectedOutcomes:
         ]
         m = compute_trajectory_metrics(log, self._guarded_sample())
         assert m.expected_hit_rate == 1.0
-        assert "expected outcomes not observed: guarded, retry" in m.violations
+        assert "expected outcomes not observed: guarded_retry" in m.violations
 
-    def test_guarded_without_retry_reports_missing_retry(self):
+    def test_guarded_without_follow_up_reports_missing_guarded_retry(self):
         log = [
             _entry(
                 tool="get_realtime_quote",
@@ -321,8 +321,37 @@ class TestExpectedOutcomes:
             ),
         ]
         m = compute_trajectory_metrics(log, self._guarded_sample())
-        assert "expected outcomes not observed: retry" in m.violations
-        assert not any("guarded" in v for v in m.violations)
+        assert "expected outcomes not observed: guarded_retry" in m.violations
+
+    def test_unrelated_retry_does_not_satisfy_guarded_retry(self):
+        # Review counter-example: a guard on the out-of-scope quote plus a
+        # retry of an unrelated news call must not satisfy the bound outcome.
+        log = [
+            _entry(tool="get_stock_info", arguments={"stock_code": "600036"}, step=1),
+            _entry(tool="get_daily_history", arguments={"stock_code": "600036"}, step=2),
+            _entry(
+                tool="get_realtime_quote",
+                arguments={"stock_code": "600519"},
+                step=3,
+                success=False,
+                guarded=True,
+            ),
+            _entry(
+                tool="search_stock_news",
+                arguments={"query": "招商银行"},
+                step=4,
+                success=False,
+            ),
+            _entry(
+                tool="search_stock_news",
+                arguments={"query": "招商银行"},
+                step=5,
+                success=True,
+            ),
+        ]
+        m = compute_trajectory_metrics(log, self._guarded_sample())
+        assert m.retries == 1
+        assert "expected outcomes not observed: guarded_retry" in m.violations
 
     def test_unknown_outcome_tag_flagged_once(self):
         m = compute_trajectory_metrics(
@@ -342,10 +371,92 @@ class TestExpectedOutcomes:
     def test_duplicate_outcome_tags_normalized_with_violation(self):
         m = compute_trajectory_metrics(
             self._faithful_log(),
-            self._guarded_sample(expected_outcomes=["guarded", "guarded"]),
+            self._guarded_sample(expected_outcomes=["guarded_retry", "guarded_retry"]),
         )
         assert "expected_outcomes contains duplicate tags" in m.violations
         assert "expected outcomes not observed" not in m.violations
+
+
+# ---------------------------------------------------------------------------
+# 2b. Stock-scoped hit semantics (golden.stock_code)
+# ---------------------------------------------------------------------------
+class TestStockCodeScoping:
+    @staticmethod
+    def _wrong_stock_log():
+        return [
+            _entry(tool="get_realtime_quote", arguments={"stock_code": "000001"}, step=1),
+            _entry(tool="get_daily_history", arguments={"stock_code": "000001"}, step=2),
+            _entry(tool="analyze_trend", arguments={"stock_code": "000001"}, step=3),
+        ]
+
+    def test_expected_tools_called_for_wrong_stock_score_zero(self):
+        # Review counter-example: tool names all correct but every call
+        # targets 000001, so the 600519_technical sample must not score a
+        # full hit.
+        m = compute_trajectory_metrics(self._wrong_stock_log(), _golden())
+        assert m.expected_hit_rate == 0.0
+        assert m.missing_expected == [
+            "get_realtime_quote",
+            "get_daily_history",
+            "analyze_trend",
+        ]
+        assert any("called for a different stock than 600519" in v for v in m.violations)
+
+    def test_mixed_stock_calls_score_partial(self):
+        log = [
+            _entry(tool="get_realtime_quote", arguments={"stock_code": "600519"}, step=1),
+            _entry(tool="get_daily_history", arguments={"stock_code": "000001"}, step=2),
+            _entry(tool="analyze_trend", arguments={"stock_code": "600519"}, step=3),
+        ]
+        m = compute_trajectory_metrics(log, _golden())
+        assert m.expected_hit_rate == pytest.approx(2 / 3)
+        assert m.missing_expected == ["get_daily_history"]
+        assert any("different stock than 600519: get_daily_history" in v for v in m.violations)
+
+    def test_codex_summary_matching_the_stock_counts(self):
+        log = [
+            {
+                "step": 1,
+                "tool": "get_realtime_quote",
+                "arguments_summary": "600519",
+                "success": True,
+            },
+        ]
+        m = compute_trajectory_metrics(log, _golden(expected_tools=["get_realtime_quote"]))
+        assert m.expected_hit_rate == 1.0
+
+    def test_codex_summary_without_the_stock_does_not_count(self):
+        log = [
+            {
+                "step": 1,
+                "tool": "get_realtime_quote",
+                "arguments_summary": "000001",
+                "success": True,
+            },
+        ]
+        m = compute_trajectory_metrics(log, _golden(expected_tools=["get_realtime_quote"]))
+        assert m.expected_hit_rate == 0.0
+        assert m.missing_expected == ["get_realtime_quote"]
+
+    def test_requested_stock_code_guard_metadata_counts(self):
+        entry = {
+            "step": 1,
+            "tool": "get_realtime_quote",
+            "success": False,
+            "guarded": True,
+            "requested_stock_code": "600519",
+            "expected_stock_code": "600519",
+        }
+        m = compute_trajectory_metrics([entry], _golden(expected_tools=["get_realtime_quote"]))
+        assert m.expected_hit_rate == 1.0
+
+    def test_invalid_golden_stock_code_falls_back_to_name_only(self):
+        m = compute_trajectory_metrics(
+            [_entry(tool="get_realtime_quote")],
+            _golden(expected_tools=["get_realtime_quote"], stock_code=None),
+        )
+        assert "golden.stock_code is not a non-empty string" in m.violations
+        assert m.expected_hit_rate == 1.0
 
 
 # ---------------------------------------------------------------------------
@@ -404,6 +515,46 @@ class TestTotalStepsInput:
     def test_non_numeric_total_steps_ignored(self):
         m = compute_trajectory_metrics([_entry(step=1)], _golden(), total_steps="not-a-number")
         assert m.distinct_steps == 1
+
+
+# ---------------------------------------------------------------------------
+# 4c. Codex App Server step accounting
+# ---------------------------------------------------------------------------
+class TestCodexStepMetrics:
+    @staticmethod
+    def _codex_entries(n):
+        return [
+            {"step": 1, "tool": "get_realtime_quote", "arguments_summary": "600519", "success": True} for _ in range(n)
+        ]
+
+    def test_codex_shaped_log_suppresses_step_metrics(self):
+        # The Codex backend records step=1 for every call in a turn and
+        # total_steps=1 on success; feeding 8 such entries must not silently
+        # read as a normal one-step run below the budget.
+        m = compute_trajectory_metrics(
+            self._codex_entries(8),
+            _golden(expected_tools=["get_realtime_quote"], allowed_max_steps=8),
+            total_steps=1,
+        )
+        assert m.distinct_steps == 0
+        assert m.max_steps_touched is False
+        assert any("step metrics are unsupported for Codex App Server logs" in v for v in m.violations)
+
+    def test_runner_shaped_log_keeps_step_metrics(self):
+        log = [_entry(step=i) for i in range(1, 9)]
+        m = compute_trajectory_metrics(
+            log,
+            _golden(expected_tools=["get_realtime_quote"], allowed_max_steps=8),
+        )
+        assert m.distinct_steps == 8
+        assert m.max_steps_touched is True
+        assert not any("unsupported for Codex" in v for v in m.violations)
+
+    def test_entries_without_any_arguments_are_not_codex_shaped(self):
+        # Missing-argument tolerance must not trip the Codex detection.
+        m = compute_trajectory_metrics([{"step": 3, "tool": "get_realtime_quote"}], _golden())
+        assert m.distinct_steps == 1
+        assert not any("unsupported for Codex" in v for v in m.violations)
 
 
 # ---------------------------------------------------------------------------
@@ -575,9 +726,9 @@ class TestGoldenSamplesFile:
         issues = validate_golden_sample(sample)
         assert any("must not contain duplicate names" in i for i in issues)
 
-    def test_guarded_retry_sample_declares_guard_and_retry_outcomes(self):
+    def test_guarded_retry_sample_declares_bound_guard_retry_outcome(self):
         sample = next(s for s in load_golden_samples() if s.id == "600036_guarded_retry")
-        assert sample.expected_outcomes == ["guarded", "retry"]
+        assert sample.expected_outcomes == ["guarded_retry"]
 
     def test_unknown_expected_outcome_fails_validation(self):
         sample = GoldenSample(

--- a/tests/test_agent_trajectory_metrics.py
+++ b/tests/test_agent_trajectory_metrics.py
@@ -38,6 +38,18 @@ def _entry(tool="get_realtime_quote", arguments=None, step=1, success=True, **ex
     return entry
 
 
+def _codex_entry(tool="get_realtime_quote", summary="600519", step=1, success=True, **extra):
+    """Build a Codex App Server-shaped entry (``arguments_summary`` only)."""
+    entry = {
+        "step": step,
+        "tool": tool,
+        "arguments_summary": summary,
+        "success": success,
+    }
+    entry.update(extra)
+    return entry
+
+
 def _golden(**overrides):
     values = dict(
         id="600519_technical",
@@ -555,6 +567,116 @@ class TestExpectedOutcomes:
         m = compute_trajectory_metrics(log, self._guarded_sample())
         assert "expected outcomes not observed" not in m.violations
 
+    def test_expected_tool_blocked_probe_of_pinned_stock_is_exempt(self):
+        # Review counter-example: the sample pins only the out-of-scope
+        # stock, not a tool — the deliberate 600519 probe may use any
+        # expected tool, and while it stays blocked (guarded / cached) it
+        # must not surface as a wrong-stock violation.
+        log = [
+            _entry(tool="get_stock_info", arguments={"stock_code": "600036"}, step=1),
+            _entry(tool="get_daily_history", arguments={"stock_code": "600036"}, step=2),
+            _entry(
+                tool="get_stock_info",
+                arguments={"stock_code": "600519"},
+                step=3,
+                success=False,
+                guarded=True,
+            ),
+            _entry(
+                tool="get_stock_info",
+                arguments={"stock_code": "600519"},
+                step=4,
+                success=False,
+                cached=True,
+            ),
+        ]
+        m = compute_trajectory_metrics(log, self._guarded_sample())
+        assert m.expected_hit_rate == 1.0
+        assert m.retries == 1
+        assert m.cached_calls == 1
+        assert not any("different stock" in v for v in m.violations)
+        assert m.violations == []
+
+    def test_alias_pinned_stock_probe_is_exempt(self):
+        # The exemption compares canonicalized identities like every other
+        # stock comparison: an SH600519 probe of the 600519-pinned sample is
+        # the required out-of-scope call, not a wrong-stock call.
+        log = [
+            _entry(tool="get_stock_info", arguments={"stock_code": "600036"}, step=1),
+            _entry(tool="get_daily_history", arguments={"stock_code": "600036"}, step=2),
+            _entry(
+                tool="get_stock_info",
+                arguments={"stock_code": "SH600519"},
+                step=3,
+                success=False,
+                guarded=True,
+            ),
+            _entry(
+                tool="get_stock_info",
+                arguments={"stock_code": "600519"},
+                step=4,
+                success=False,
+                cached=True,
+            ),
+        ]
+        m = compute_trajectory_metrics(log, self._guarded_sample())
+        assert m.expected_hit_rate == 1.0
+        assert not any("different stock" in v for v in m.violations)
+        assert m.violations == []
+
+    def test_clean_success_on_pinned_stock_is_still_wrong_stock(self):
+        # The exemption covers blocked probes only: an expected-tool call
+        # that cleanly succeeds on the pinned stock is still a wrong-stock
+        # call, and with no guarded occurrence at all the sample's
+        # guarded_retry stays unobserved.
+        log = [
+            _entry(tool="get_stock_info", arguments={"stock_code": "600036"}, step=1),
+            _entry(tool="get_daily_history", arguments={"stock_code": "600036"}, step=2),
+            _entry(
+                tool="get_stock_info",
+                arguments={"stock_code": "600519"},
+                step=3,
+                success=True,
+            ),
+        ]
+        m = compute_trajectory_metrics(log, self._guarded_sample())
+        assert m.expected_hit_rate == 1.0
+        assert any("different stock than 600036: get_stock_info" in v for v in m.violations)
+        assert "expected outcomes not observed: guarded_retry" in m.violations
+
+    def test_blocked_probe_of_another_stock_is_still_wrong_stock(self):
+        # Only the pinned stock is exempt: an expected-tool probe of a third
+        # stock stays a wrong-stock call even while guarded.
+        log = [
+            _entry(tool="get_stock_info", arguments={"stock_code": "600036"}, step=1),
+            _entry(tool="get_daily_history", arguments={"stock_code": "600036"}, step=2),
+            _entry(
+                tool="get_stock_info",
+                arguments={"stock_code": "000001"},
+                step=3,
+                success=False,
+                guarded=True,
+            ),
+        ]
+        m = compute_trajectory_metrics(log, self._guarded_sample())
+        assert any("different stock than 600036: get_stock_info" in v for v in m.violations)
+
+    def test_without_pinned_stock_blocked_probes_stay_wrong_stock(self):
+        # No expected_guarded_stock means no exemption: a blocked call to
+        # another stock is wrong-stock exactly like before.
+        log = [
+            _entry(
+                tool="get_realtime_quote",
+                arguments={"stock_code": "000001"},
+                step=1,
+                success=False,
+                guarded=True,
+            ),
+        ]
+        m = compute_trajectory_metrics(log, _golden(expected_tools=["get_realtime_quote"]))
+        assert m.expected_hit_rate == 0.0
+        assert any("different stock than 600519: get_realtime_quote" in v for v in m.violations)
+
     def test_injected_normalizer_drives_call_identity(self):
         # Call identity follows the injected normalizer, not the mirror: a
         # constant normalizer merges every stock code into one identity.
@@ -921,6 +1043,115 @@ class TestStockCodeScoping:
 
 
 # ---------------------------------------------------------------------------
+# 2d. Codex arguments_summary call identity (recovered structured payloads)
+# ---------------------------------------------------------------------------
+class TestCodexSummaryIdentity:
+    def test_alias_summaries_share_one_call_identity(self):
+        # Review counter-example: a failed call summarized with the alias
+        # hk700 followed by the same call summarized as HK00700 is one
+        # (tool, args-key) — the recovered dict goes through the same
+        # stock_code canonicalization as a runner payload.
+        log = [
+            _codex_entry(
+                tool="get_realtime_quote",
+                summary=json.dumps({"stock_code": "hk700"}),
+                step=1,
+                success=False,
+            ),
+            _codex_entry(
+                tool="get_realtime_quote",
+                summary=json.dumps({"stock_code": "HK00700"}),
+                step=2,
+            ),
+        ]
+        m = compute_trajectory_metrics(log, _golden(expected_tools=["get_realtime_quote"]))
+        assert m.retries == 1
+        assert m.redundant_calls == 1
+
+    def test_key_order_summaries_share_one_call_identity(self):
+        # Review counter-example: the recovered dict is serialized with
+        # sort_keys=True, so argument insertion order must not split call
+        # identity.
+        log = [
+            _codex_entry(
+                tool="get_realtime_quote",
+                summary=json.dumps({"stock_code": "600519", "days": 30}),
+                step=1,
+                success=False,
+            ),
+            _codex_entry(
+                tool="get_realtime_quote",
+                summary=json.dumps({"days": 30, "stock_code": "600519"}),
+                step=2,
+            ),
+        ]
+        m = compute_trajectory_metrics(log, _golden(expected_tools=["get_realtime_quote"]))
+        assert m.retries == 1
+        assert m.redundant_calls == 1
+
+    def test_number_and_string_summaries_do_not_merge_identity(self):
+        # The recovered payload preserves the JSON number type exactly like
+        # the runtime cache key: 600519 and "600519" stay two identities.
+        log = [
+            _codex_entry(
+                tool="get_realtime_quote",
+                summary=json.dumps({"stock_code": 600519}),
+                step=1,
+                success=False,
+            ),
+            _codex_entry(
+                tool="get_realtime_quote",
+                summary=json.dumps({"stock_code": "600519"}),
+                step=2,
+            ),
+        ]
+        m = compute_trajectory_metrics(log, _golden(expected_tools=["get_realtime_quote"]))
+        assert m.retries == 0
+        assert m.redundant_calls == 0
+
+    def test_other_summary_arguments_stay_raw_in_the_identity(self):
+        # Only the string stock_code field is canonicalized — a different
+        # period still splits the identity even for alias spellings.
+        log = [
+            _codex_entry(
+                tool="get_realtime_quote",
+                summary=json.dumps({"stock_code": "SH600519", "period": "daily"}),
+                step=1,
+                success=False,
+            ),
+            _codex_entry(
+                tool="get_realtime_quote",
+                summary=json.dumps({"stock_code": "600519", "period": "weekly"}),
+                step=2,
+            ),
+        ]
+        m = compute_trajectory_metrics(log, _golden(expected_tools=["get_realtime_quote"]))
+        assert m.retries == 0
+        assert m.redundant_calls == 0
+
+    def test_truncated_previews_keep_the_raw_preview_identity(self):
+        # A preview that no longer parses to an object falls back to the
+        # raw-preview wrapper, so it never merges with an intact summary of
+        # the same call (documented best-effort limit).
+        log = [
+            _codex_entry(
+                tool="get_realtime_quote",
+                summary='{"stock_code": "6005...<truncated 12 chars>',
+                step=1,
+                success=False,
+            ),
+            _codex_entry(
+                tool="get_realtime_quote",
+                summary=json.dumps({"stock_code": "600519"}),
+                step=2,
+            ),
+        ]
+        m = compute_trajectory_metrics(log, _golden(expected_tools=["get_realtime_quote"]))
+        assert m.retries == 0
+        assert m.redundant_calls == 0
+
+
+# ---------------------------------------------------------------------------
 # 2c. Stock-code canonicalization (runtime-equivalent mirror)
 # ---------------------------------------------------------------------------
 class TestStockCanonicalization:
@@ -1105,6 +1336,69 @@ class TestCodexStepMetrics:
         m = compute_trajectory_metrics([{"step": 3, "tool": "get_realtime_quote"}], _golden())
         assert m.distinct_steps == 1
         assert not any("unsupported for Codex" in v for v in m.violations)
+
+
+# ---------------------------------------------------------------------------
+# 4d. Codex outcome support (guard-dependent tags are unobservable)
+# ---------------------------------------------------------------------------
+class TestCodexOutcomeSupport:
+    def test_guard_dependent_outcomes_marked_unsupported_for_codex_logs(self):
+        # The Codex backend drops guarded/cached metadata, so a Codex-shaped
+        # log can never observe guard-dependent tags; declaring them must
+        # surface an explicit unsupported violation instead of a false
+        # "expected outcomes not observed" regression.
+        for tag in ("guarded", "cached", "guarded_retry"):
+            log = [_codex_entry(tool="get_realtime_quote", step=1)]
+            m = compute_trajectory_metrics(log, _golden(expected_tools=["get_realtime_quote"], expected_outcomes=[tag]))
+            assert not any("not observed" in v for v in m.violations), tag
+            assert any("unsupported for Codex App Server logs" in v and tag in v for v in m.violations), tag
+
+    def test_retry_stays_scoreable_for_codex_logs(self):
+        # retry derives from (tool, args-key) repeats, which Codex entries
+        # do carry: a failed call retried as the same recovered payload must
+        # still satisfy the sample.
+        log = [
+            _codex_entry(
+                tool="get_realtime_quote",
+                summary=json.dumps({"stock_code": "600519"}),
+                step=1,
+                success=False,
+            ),
+            _codex_entry(
+                tool="get_realtime_quote",
+                summary=json.dumps({"stock_code": "600519"}),
+                step=2,
+            ),
+        ]
+        m = compute_trajectory_metrics(log, _golden(expected_tools=["get_realtime_quote"], expected_outcomes=["retry"]))
+        assert m.retries == 1
+        assert "expected outcomes not observed" not in m.violations
+        assert not any("expected outcomes unsupported" in v for v in m.violations)
+
+    def test_missing_retry_still_reported_for_codex_logs(self):
+        # An observable outcome that is genuinely absent stays a real
+        # regression for Codex logs too.
+        log = [_codex_entry(tool="get_realtime_quote", step=1)]
+        m = compute_trajectory_metrics(log, _golden(expected_tools=["get_realtime_quote"], expected_outcomes=["retry"]))
+        assert "expected outcomes not observed: retry" in m.violations
+
+    def test_runner_logs_keep_guard_outcome_scoring(self):
+        # Runner-shaped logs carry the metadata, so guard-dependent tags are
+        # scored normally and never marked unsupported.
+        log = [
+            _entry(
+                tool="get_realtime_quote",
+                arguments={"stock_code": "600519"},
+                step=1,
+                success=False,
+                guarded=True,
+            ),
+        ]
+        m = compute_trajectory_metrics(
+            log, _golden(expected_tools=["get_realtime_quote"], expected_outcomes=["guarded"])
+        )
+        assert "expected outcomes not observed" not in m.violations
+        assert not any("expected outcomes unsupported" in v for v in m.violations)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_agent_trajectory_metrics.py
+++ b/tests/test_agent_trajectory_metrics.py
@@ -1138,6 +1138,51 @@ class TestExpectedOutcomes:
         assert m.cached_calls == 0
         assert "expected outcomes not observed: cached" in m.violations
 
+    def test_optional_tool_clean_success_on_guarded_stock_reports_escape(self):
+        # Review counter-example: the runtime guard intercepts every
+        # stock-scoped tool alike, so an OPTIONAL tool that cleanly reaches
+        # the pinned out-of-scope stock is a scope escape too — it must be
+        # reported and must break guarded_retry even though the guarded pair
+        # itself stayed blocked.
+        log = [
+            _entry(tool="get_stock_info", arguments={"stock_code": "600036"}, step=1),
+            _entry(tool="get_daily_history", arguments={"stock_code": "600036"}, step=2),
+            _entry(tool="get_stock_info", arguments={"stock_code": "600519"}, step=3, success=False, guarded=True),
+            _entry(tool="get_stock_info", arguments={"stock_code": "600519"}, step=4, success=False, cached=True),
+            _entry(tool="get_realtime_quote", arguments={"stock_code": "600519"}, step=5),
+        ]
+        m = compute_trajectory_metrics(log, self._guarded_sample())
+        assert "optional tools escaped the guarded stock 600519: get_realtime_quote" in m.violations
+        assert "expected outcomes not observed: guarded_retry" in m.violations
+
+    def test_blocked_optional_probe_on_guarded_stock_stays_clean(self):
+        # The deliberate-probe exemption spans tools: a blocked optional
+        # probe of the pinned stock is as legitimate as an expected one and
+        # must not be reported as an escape.
+        log = [
+            _entry(tool="get_stock_info", arguments={"stock_code": "600036"}, step=1),
+            _entry(tool="get_daily_history", arguments={"stock_code": "600036"}, step=2),
+            _entry(tool="get_stock_info", arguments={"stock_code": "600519"}, step=3, success=False, guarded=True),
+            _entry(tool="get_stock_info", arguments={"stock_code": "600519"}, step=4, success=False, cached=True),
+            _entry(tool="get_realtime_quote", arguments={"stock_code": "600519"}, step=5, success=False, cached=True),
+        ]
+        m = compute_trajectory_metrics(log, self._guarded_sample())
+        assert not any("escaped the guarded stock" in v for v in m.violations)
+        assert "expected outcomes not observed" not in m.violations
+
+    def test_optional_escape_and_tool_disallowance_are_independent(self):
+        # A disallowed optional tool that also escapes the guarded stock
+        # violates two contracts at once; both must be reported.
+        golden = self._guarded_sample(allow_optional_tools=False)
+        log = [
+            _entry(tool="get_stock_info", arguments={"stock_code": "600036"}, step=1),
+            _entry(tool="get_daily_history", arguments={"stock_code": "600036"}, step=2),
+            _entry(tool="get_realtime_quote", arguments={"stock_code": "600519"}, step=3),
+        ]
+        m = compute_trajectory_metrics(log, golden)
+        assert "optional tools used but not allowed: get_realtime_quote" in m.violations
+        assert "optional tools escaped the guarded stock 600519: get_realtime_quote" in m.violations
+
 
 # ---------------------------------------------------------------------------
 # 2b. Stock-scoped hit semantics (golden.stock_code)

--- a/tests/test_agent_trajectory_metrics.py
+++ b/tests/test_agent_trajectory_metrics.py
@@ -47,6 +47,7 @@ def _golden(**overrides):
         skills=[],
         allowed_max_steps=8,
         allow_optional_tools=True,
+        expected_outcomes=[],
     )
     values.update(overrides)
     return GoldenSample(**values)
@@ -161,6 +162,22 @@ class TestComputeMetricsHitRate:
         assert "allow_optional_tools is not a boolean" in m.violations
         assert "optional tools used but not allowed: search_stock_news" in m.violations
 
+    def test_duplicate_expected_tools_scored_as_unique_names(self):
+        # Regression: ["quote", "quote", "history"] with a single quote call
+        # must read 1/2, not 2/3.
+        golden = _golden(
+            expected_tools=[
+                "get_realtime_quote",
+                "get_realtime_quote",
+                "get_daily_history",
+            ],
+        )
+        m = compute_trajectory_metrics([_entry(tool="get_realtime_quote")], golden)
+        assert m.expected_total == 2
+        assert m.expected_hit_rate == pytest.approx(0.5)
+        assert m.missing_expected == ["get_daily_history"]
+        assert "expected_tools contains duplicate names" in m.violations
+
 
 # ---------------------------------------------------------------------------
 # 3. Retries, caching, failure counting
@@ -231,6 +248,104 @@ class TestRetryAndCaching:
         )
         m = compute_trajectory_metrics([entry], _golden())
         assert m.failed_calls == 1
+
+
+# ---------------------------------------------------------------------------
+# 3b. Expected outcomes (guarded / cached / retry contract)
+# ---------------------------------------------------------------------------
+class TestExpectedOutcomes:
+    @staticmethod
+    def _guarded_sample(**overrides):
+        values = dict(
+            id="600036_guarded_retry",
+            task_description="guard / cached retry boundary",
+            stock_code="600036",
+            expected_tools=["get_stock_info", "get_daily_history"],
+            skills=[],
+            allowed_max_steps=10,
+            allow_optional_tools=True,
+            expected_outcomes=["guarded", "retry"],
+        )
+        values.update(overrides)
+        return GoldenSample(**values)
+
+    @staticmethod
+    def _faithful_log():
+        """In-scope calls succeed; the out-of-scope call is guarded and its
+        same-args retry hits the non-retriable cache."""
+        return [
+            _entry(tool="get_stock_info", arguments={"stock_code": "600036"}, step=1),
+            _entry(tool="get_daily_history", arguments={"stock_code": "600036"}, step=2),
+            _entry(
+                tool="get_realtime_quote",
+                arguments={"stock_code": "600519"},
+                step=3,
+                success=False,
+                guarded=True,
+            ),
+            _entry(
+                tool="get_realtime_quote",
+                arguments={"stock_code": "600519"},
+                step=4,
+                success=False,
+                cached=True,
+            ),
+        ]
+
+    def test_faithful_guard_retry_log_satisfies_outcomes(self):
+        m = compute_trajectory_metrics(self._faithful_log(), self._guarded_sample())
+        assert "expected outcomes not observed" not in m.violations
+        assert m.retries == 1
+        assert m.cached_calls == 1
+        assert m.failed_calls == 2
+
+    def test_skipping_the_out_of_scope_call_violates_the_contract(self):
+        # Review counter-example: hitting every expected tool without ever
+        # attempting the out-of-scope call must not score clean.
+        log = [
+            _entry(tool="get_stock_info", arguments={"stock_code": "600036"}, step=1),
+            _entry(tool="get_daily_history", arguments={"stock_code": "600036"}, step=2),
+        ]
+        m = compute_trajectory_metrics(log, self._guarded_sample())
+        assert m.expected_hit_rate == 1.0
+        assert "expected outcomes not observed: guarded, retry" in m.violations
+
+    def test_guarded_without_retry_reports_missing_retry(self):
+        log = [
+            _entry(
+                tool="get_realtime_quote",
+                arguments={"stock_code": "600519"},
+                step=1,
+                success=False,
+                guarded=True,
+            ),
+        ]
+        m = compute_trajectory_metrics(log, self._guarded_sample())
+        assert "expected outcomes not observed: retry" in m.violations
+        assert not any("guarded" in v for v in m.violations)
+
+    def test_unknown_outcome_tag_flagged_once(self):
+        m = compute_trajectory_metrics(
+            self._faithful_log(),
+            self._guarded_sample(expected_outcomes=["guarded", "warp"]),
+        )
+        assert "unknown expected outcome tags: warp" in m.violations
+        assert not any("not observed" in v for v in m.violations)
+
+    def test_non_list_expected_outcomes_surfaces_violation(self):
+        m = compute_trajectory_metrics(
+            self._faithful_log(),
+            self._guarded_sample(expected_outcomes="guarded"),
+        )
+        assert "expected_outcomes must be a list of outcome tags" in m.violations
+
+    def test_duplicate_outcome_tags_normalized_with_violation(self):
+        m = compute_trajectory_metrics(
+            self._faithful_log(),
+            self._guarded_sample(expected_outcomes=["guarded", "guarded"]),
+        )
+        assert "expected_outcomes contains duplicate tags" in m.violations
+        assert "expected outcomes not observed" not in m.violations
 
 
 # ---------------------------------------------------------------------------
@@ -450,6 +565,49 @@ class TestGoldenSamplesFile:
         known = (name for name in ["a", "b"])
         assert validate_golden_sample(sample, known) == []
 
+    def test_duplicate_expected_tools_fail_validation(self):
+        sample = GoldenSample(
+            id="x",
+            task_description="t",
+            stock_code="600519",
+            expected_tools=["get_realtime_quote", "get_realtime_quote"],
+        )
+        issues = validate_golden_sample(sample)
+        assert any("must not contain duplicate names" in i for i in issues)
+
+    def test_guarded_retry_sample_declares_guard_and_retry_outcomes(self):
+        sample = next(s for s in load_golden_samples() if s.id == "600036_guarded_retry")
+        assert sample.expected_outcomes == ["guarded", "retry"]
+
+    def test_unknown_expected_outcome_fails_validation(self):
+        sample = GoldenSample(
+            id="x",
+            task_description="t",
+            stock_code="600519",
+            expected_tools=["get_realtime_quote"],
+            expected_outcomes=["warp"],
+        )
+        issues = validate_golden_sample(sample)
+        assert any("unknown expected_outcomes: warp" in i for i in issues)
+
+    def test_duplicate_or_mistyped_expected_outcomes_fail_validation(self):
+        dup = GoldenSample(
+            id="x",
+            task_description="t",
+            stock_code="600519",
+            expected_tools=["get_realtime_quote"],
+            expected_outcomes=["guarded", "guarded"],
+        )
+        assert any("must not contain duplicate tags" in i for i in validate_golden_sample(dup))
+        mistyped = GoldenSample(
+            id="x",
+            task_description="t",
+            stock_code="600519",
+            expected_tools=["get_realtime_quote"],
+            expected_outcomes="guarded",
+        )
+        assert any("must be a list of outcome tags" in i for i in validate_golden_sample(mistyped))
+
     def test_loader_materializes_registry_once_for_multiple_samples(self):
         # A one-shot generator must survive loading the whole checked-in file:
         # the first sample must not exhaust it for the remaining samples.
@@ -582,4 +740,27 @@ class TestLoadGoldenSamplesErrors:
         }
         path = self._write_sample(tmp_path, [sample])
         with pytest.raises(ValueError, match="allow_optional_tools must be a boolean"):
+            load_golden_samples(path=path)
+
+    def test_duplicate_expected_tools_raise(self, tmp_path):
+        sample = {
+            "id": "x",
+            "task_description": "t",
+            "stock_code": "600519",
+            "expected_tools": ["get_realtime_quote", "get_realtime_quote"],
+        }
+        path = self._write_sample(tmp_path, [sample])
+        with pytest.raises(ValueError, match="expected_tools must not contain duplicate names"):
+            load_golden_samples(path=path)
+
+    def test_unknown_expected_outcome_raises(self, tmp_path):
+        sample = {
+            "id": "x",
+            "task_description": "t",
+            "stock_code": "600519",
+            "expected_tools": ["get_realtime_quote"],
+            "expected_outcomes": ["warp"],
+        }
+        path = self._write_sample(tmp_path, [sample])
+        with pytest.raises(ValueError, match="unknown expected_outcomes: warp"):
             load_golden_samples(path=path)

--- a/tests/test_agent_trajectory_metrics.py
+++ b/tests/test_agent_trajectory_metrics.py
@@ -1278,11 +1278,13 @@ class TestStockCodeScoping:
         assert any("different stock than 600519: get_realtime_quote" in v for v in m.violations)
 
     def test_codex_summary_matching_the_stock_counts(self):
+        # Only the structured value recovered from a well-formed preview
+        # earns the hit — raw preview text never gets substring credit.
         log = [
             {
                 "step": 1,
                 "tool": "get_realtime_quote",
-                "arguments_summary": "600519",
+                "arguments_summary": json.dumps({"stock_code": "600519"}),
                 "success": True,
             },
         ]
@@ -1335,21 +1337,45 @@ class TestStockCodeScoping:
         assert m.expected_hit_rate == 0.0
         assert any("different stock than 600519: get_realtime_quote" in v for v in m.violations)
 
-    def test_unparsable_summary_falls_back_to_substring_no_evidence(self):
-        # Truncated previews cannot recover a structured value: they fall
-        # back to the substring scan for matching and stay "no evidence" for
-        # wrong-stock reporting.
-        log = [
-            {
-                "step": 1,
-                "tool": "get_realtime_quote",
-                "arguments_summary": '{"stock_code": "6005...<truncated 12 chars>',
-                "success": True,
-            },
-        ]
-        m = compute_trajectory_metrics(log, _golden(expected_tools=["get_realtime_quote"]))
-        assert m.expected_hit_rate == 0.0
-        assert not any("different stock" in v for v in m.violations)
+    def test_truncated_summary_never_grants_substring_hit(self):
+        # Review counter-example: a truncated preview cannot be parsed back
+        # to structured evidence, and its raw text must never grant stock
+        # credit — a truncated {"stock_code": "1600519", ...} contains
+        # 600519 as a substring, and 600519 sitting in another field while
+        # stock_code names a different stock is no evidence for the golden.
+        for summary in (
+            '{"stock_code": "1600519", "padding": "...<truncated>',
+            '{"stock_code": "000001", "note": "600519 ref...<truncated>',
+        ):
+            log = [
+                {
+                    "step": 1,
+                    "tool": "get_realtime_quote",
+                    "arguments_summary": summary,
+                    "success": True,
+                },
+            ]
+            m = compute_trajectory_metrics(log, _golden(expected_tools=["get_realtime_quote"]))
+            assert m.expected_hit_rate == 0.0, summary
+            assert m.missing_expected == ["get_realtime_quote"], summary
+            assert not any("different stock" in v for v in m.violations), summary
+
+    def test_raw_summary_text_never_grants_substring_hit(self):
+        # A preview that is not intact JSON of an object (raw text such as
+        # "600519", or a JSON scalar / array) carries unreadable evidence:
+        # no substring credit, no hit.
+        for summary in ("600519", json.dumps("600519"), json.dumps(["600519"])):
+            log = [
+                {
+                    "step": 1,
+                    "tool": "get_realtime_quote",
+                    "arguments_summary": summary,
+                    "success": True,
+                },
+            ]
+            m = compute_trajectory_metrics(log, _golden(expected_tools=["get_realtime_quote"]))
+            assert m.expected_hit_rate == 0.0, summary
+            assert m.missing_expected == ["get_realtime_quote"], summary
 
     def test_stock_code_field_matched_exactly_not_substring(self):
         # Review counter-example: {"stock_code": "1600519"} contains the

--- a/tests/test_agent_trajectory_metrics.py
+++ b/tests/test_agent_trajectory_metrics.py
@@ -1,0 +1,399 @@
+# -*- coding: utf-8 -*-
+"""Unit tests for the agent trajectory evaluation metrics (Issue #1956).
+
+All trajectories are synthetic ``tool_calls_log`` lists — no LLM, no network.
+The golden-samples-file tests verify that the checked-in ``golden_samples.json``
+stays structurally valid and that every ``expected_tools`` entry exists in the
+repository's real tool registry (imported lazily so the metrics-only sections
+run even without ``src/`` importable).
+"""
+
+import json
+
+import pytest
+
+from evals.agent_trajectory.metrics import (
+    GoldenSample,
+    TrajectoryMetrics,
+    _args_key,
+    compute_trajectory_metrics,
+    format_text_report,
+    load_golden_samples,
+    validate_golden_sample,
+)
+
+
+def _entry(tool="get_realtime_quote", arguments=None, step=1, success=True, **extra):
+    """Build a runner-shaped ``tool_calls_log`` entry with sensible defaults."""
+    entry = {
+        "step": step,
+        "tool": tool,
+        "arguments": arguments if arguments is not None else {"stock_code": "600519"},
+        "success": success,
+        "duration": 0.5,
+        "result_length": 100,
+        "cached": False,
+    }
+    entry.update(extra)
+    return entry
+
+
+def _golden(**overrides):
+    values = dict(
+        id="600519_technical",
+        task_description="分析贵州茅台近期技术面走势",
+        stock_code="600519",
+        expected_tools=["get_realtime_quote", "get_daily_history", "analyze_trend"],
+        skills=[],
+        allowed_max_steps=8,
+        allow_optional_tools=True,
+    )
+    values.update(overrides)
+    return GoldenSample(**values)
+
+
+def _metrics(**overrides):
+    values = dict(
+        expected_hit_rate=2 / 3,
+        expected_total=3,
+        missing_expected=["analyze_trend"],
+        optional_tools_used=[],
+        redundant_calls=0,
+        cached_calls=0,
+        failed_calls=0,
+        retries=0,
+        distinct_steps=3,
+        max_steps_touched=False,
+        violations=[],
+    )
+    values.update(overrides)
+    return TrajectoryMetrics(**values)
+
+
+# ---------------------------------------------------------------------------
+# 1. Args-key stability
+# ---------------------------------------------------------------------------
+class TestArgsKey:
+    def test_key_stable_across_key_order_and_nested_unhashable(self):
+        a = {"b": [1, 2], "a": {"x": {"y": 1}}}
+        b = {"a": {"x": {"y": 1}}, "b": [1, 2]}
+        assert _args_key(a) == _args_key(b)
+
+    def test_key_differs_for_different_arguments(self):
+        assert _args_key({"stock_code": "600519"}) != _args_key({"stock_code": "000001"})
+
+    def test_none_arguments_use_empty_object(self):
+        assert _args_key(None) == json.dumps({})
+
+    def test_non_dict_arguments_serialized(self):
+        assert _args_key(["600519"]) == '["600519"]'
+
+
+# ---------------------------------------------------------------------------
+# 2. Hit rate / expected & optional tools
+# ---------------------------------------------------------------------------
+class TestComputeMetricsHitRate:
+    @staticmethod
+    def _two_of_three_log():
+        return [
+            _entry(tool="get_realtime_quote", step=1),
+            _entry(tool="get_daily_history", step=2),
+            _entry(tool="search_stock_news", step=3),
+        ]
+
+    def test_hit_rate_missing_and_optional(self):
+        m = compute_trajectory_metrics(self._two_of_three_log(), _golden())
+        assert m.expected_hit_rate == pytest.approx(2 / 3)
+        assert m.missing_expected == ["analyze_trend"]
+        assert m.optional_tools_used == ["search_stock_news"]
+        assert m.violations == []
+
+    def test_optional_tools_not_allowed_produces_violation(self):
+        m = compute_trajectory_metrics(self._two_of_three_log(), _golden(allow_optional_tools=False))
+        assert m.violations == ["optional tools used but not allowed: search_stock_news"]
+        assert m.expected_hit_rate == pytest.approx(2 / 3)
+
+    def test_duplicate_tool_calls_still_full_hit(self):
+        log = [
+            _entry(tool="get_realtime_quote", arguments={"stock_code": "600519"}, step=1),
+            _entry(tool="get_realtime_quote", arguments={"stock_code": "000001"}, step=2),
+        ]
+        m = compute_trajectory_metrics(log, _golden(expected_tools=["get_realtime_quote"]))
+        assert m.expected_hit_rate == 1.0
+        assert m.missing_expected == []
+
+    def test_empty_log_yields_zero_metrics(self):
+        m = compute_trajectory_metrics([], _golden())
+        assert m.expected_hit_rate == 0.0
+        assert m.expected_total == 3
+        assert m.missing_expected == ["get_realtime_quote", "get_daily_history", "analyze_trend"]
+        assert m.redundant_calls == 0 and m.cached_calls == 0 and m.failed_calls == 0
+        assert m.retries == 0 and m.distinct_steps == 0
+        assert m.max_steps_touched is False
+        assert m.violations == []
+
+    def test_non_dict_entries_ignored(self):
+        log = ["garbage", None, _entry(tool="get_realtime_quote", step=1)]
+        m = compute_trajectory_metrics(log, _golden(expected_tools=["get_realtime_quote"]))
+        assert m.expected_hit_rate == 1.0
+        assert m.distinct_steps == 1
+
+    def test_empty_expected_tools_yields_zero_hit_and_violation(self):
+        m = compute_trajectory_metrics([_entry()], _golden(expected_tools=[]))
+        assert m.expected_hit_rate == 0.0
+        assert "golden sample has no expected_tools" in m.violations
+
+
+# ---------------------------------------------------------------------------
+# 3. Retries, caching, failure counting
+# ---------------------------------------------------------------------------
+class TestRetryAndCaching:
+    def test_fail_then_retry_success_counts_one_retry(self):
+        log = [
+            _entry(step=1, success=False),
+            _entry(step=2, success=True),
+        ]
+        m = compute_trajectory_metrics(log, _golden())
+        assert m.retries == 1
+        assert m.redundant_calls == 1
+        assert m.failed_calls == 1
+
+    def test_same_tool_different_args_not_redundant(self):
+        log = [
+            _entry(arguments={"stock_code": "600519"}, step=1),
+            _entry(arguments={"stock_code": "000001"}, step=2),
+        ]
+        m = compute_trajectory_metrics(log, _golden())
+        assert m.redundant_calls == 0
+        assert m.retries == 0
+
+    def test_repeat_after_success_is_redundant_but_not_retry(self):
+        log = [_entry(step=1, success=True), _entry(step=2, success=True)]
+        m = compute_trajectory_metrics(log, _golden())
+        assert m.redundant_calls == 1
+        assert m.retries == 0
+        assert m.failed_calls == 0
+
+    def test_fail_fail_success_counts_two_retries(self):
+        log = [
+            _entry(step=1, success=False),
+            _entry(step=2, success=False),
+            _entry(step=3, success=True),
+        ]
+        m = compute_trajectory_metrics(log, _golden())
+        assert m.retries == 2
+        assert m.redundant_calls == 2
+        assert m.failed_calls == 2
+
+    def test_cached_entry_counted(self):
+        m = compute_trajectory_metrics([_entry(cached=True, success=False)], _golden())
+        assert m.cached_calls == 1
+        assert m.failed_calls == 1
+
+    def test_guarded_entry_counts_as_failed(self):
+        entry = _entry(
+            success=False,
+            guarded=True,
+            expected_stock_code="600519",
+            requested_stock_code="000001",
+            allowed_stock_codes=["600519"],
+        )
+        m = compute_trajectory_metrics([entry], _golden())
+        assert m.failed_calls == 1
+
+
+# ---------------------------------------------------------------------------
+# 4. max_steps touching
+# ---------------------------------------------------------------------------
+class TestMaxStepsTouched:
+    def test_steps_reaching_allowed_max_touched(self):
+        log = [_entry(step=i) for i in range(1, 6)]
+        m = compute_trajectory_metrics(log, _golden(allowed_max_steps=5))
+        assert m.max_steps_touched is True
+        assert "trajectory reached allowed_max_steps (5)" in m.violations
+
+    def test_steps_below_limit_not_touched(self):
+        log = [_entry(step=i) for i in range(1, 5)]
+        m = compute_trajectory_metrics(log, _golden(allowed_max_steps=5))
+        assert m.max_steps_touched is False
+        assert m.violations == []
+
+    def test_empty_log_not_touched(self):
+        m = compute_trajectory_metrics([], _golden(allowed_max_steps=5))
+        assert m.max_steps_touched is False
+
+
+# ---------------------------------------------------------------------------
+# 5. Tolerant entry shapes (Codex backend / missing fields)
+# ---------------------------------------------------------------------------
+class TestTolerantEntries:
+    def test_missing_optional_fields_defaulted(self):
+        m = compute_trajectory_metrics([{"step": 1, "tool": "get_realtime_quote"}], _golden())
+        assert m.failed_calls == 0
+        assert m.cached_calls == 0
+        assert m.expected_hit_rate == pytest.approx(1 / 3)
+
+    def test_codex_style_entries_keyed_by_arguments_summary(self):
+        entry = {"step": 1, "tool": "get_stock_info", "arguments_summary": "600519", "success": True}
+        m = compute_trajectory_metrics([entry, dict(entry, step=2)], _golden())
+        assert m.redundant_calls == 1
+        other = compute_trajectory_metrics(
+            [entry, {**entry, "arguments_summary": "000001", "step": 2}],
+            _golden(),
+        )
+        assert other.redundant_calls == 0
+
+    def test_invalid_step_coerced_to_zero(self):
+        m = compute_trajectory_metrics([_entry(step="not-a-number")], _golden())
+        assert m.distinct_steps == 0
+
+
+# ---------------------------------------------------------------------------
+# 6. Text report rendering
+# ---------------------------------------------------------------------------
+class TestFormatTextReport:
+    def test_contains_hit_fraction_and_percent(self):
+        text = format_text_report(_metrics())
+        assert "2/3" in text
+        assert "66.7%" in text
+
+    def test_empties_render_placeholder(self):
+        m = _metrics(
+            expected_hit_rate=0.0,
+            expected_total=3,
+            missing_expected=["get_realtime_quote", "get_daily_history", "analyze_trend"],
+        )
+        text = format_text_report(m)
+        assert "缺失期望工具: get_realtime_quote, get_daily_history, analyze_trend" in text
+        assert "期望外工具: 无" in text
+        assert "违规项: 无" in text
+        assert "触碰 max_steps: 否" in text
+
+    def test_violations_rendered(self):
+        text = format_text_report(_metrics(violations=["trajectory reached allowed_max_steps (5)"]))
+        assert "违规项: trajectory reached allowed_max_steps (5)" in text
+
+    def test_deterministic(self):
+        m = _metrics(redundant_calls=2, retries=1, max_steps_touched=True)
+        assert format_text_report(m) == format_text_report(m)
+
+
+# ---------------------------------------------------------------------------
+# 7. Golden samples file (schema + registry membership)
+# ---------------------------------------------------------------------------
+def _repo_tool_names():
+    """Authoritative tool names from the five tool modules (lazy import)."""
+    from src.agent.tools.analysis_tools import ALL_ANALYSIS_TOOLS
+    from src.agent.tools.backtest_tools import ALL_BACKTEST_TOOLS
+    from src.agent.tools.data_tools import ALL_DATA_TOOLS
+    from src.agent.tools.market_tools import ALL_MARKET_TOOLS
+    from src.agent.tools.search_tools import ALL_SEARCH_TOOLS
+
+    all_tools = ALL_DATA_TOOLS + ALL_ANALYSIS_TOOLS + ALL_SEARCH_TOOLS + ALL_MARKET_TOOLS + ALL_BACKTEST_TOOLS
+    return {tool_def.name for tool_def in all_tools}
+
+
+class TestGoldenSamplesFile:
+    def test_samples_load_clean_with_registry_names(self):
+        samples = load_golden_samples(known_tool_names=_repo_tool_names())
+        assert len(samples) == 3
+        assert [s.id for s in samples] == ["600519_technical", "000001_core_data_strict", "600036_guarded_retry"]
+
+    def test_each_sample_passes_structural_validation(self):
+        for sample in load_golden_samples():
+            assert validate_golden_sample(sample, _repo_tool_names()) == []
+
+    def test_expected_tools_exist_in_repo_registry(self):
+        known = _repo_tool_names()
+        for sample in load_golden_samples():
+            unknown = [t for t in sample.expected_tools if t not in known]
+            assert unknown == [], f"sample '{sample.id}' expects unknown tools: {unknown}"
+
+    def test_contains_strict_sample_without_optional_tools(self):
+        samples = load_golden_samples()
+        assert any(not s.allow_optional_tools for s in samples)
+
+    def test_samples_have_required_text_fields(self):
+        for sample in load_golden_samples():
+            assert sample.id.strip()
+            assert sample.task_description.strip()
+            assert sample.stock_code.strip()
+            assert sample.allowed_max_steps >= 1
+
+
+class TestLoadGoldenSamplesErrors:
+    @staticmethod
+    def _write_sample(tmp_path, payload, name="golden.json"):
+        target = tmp_path / name
+        target.write_text(json.dumps(payload, ensure_ascii=False), encoding="utf-8")
+        return str(target)
+
+    def test_missing_file_raises(self):
+        with pytest.raises(FileNotFoundError):
+            load_golden_samples(path="no/such/golden_samples.json")
+
+    def test_non_list_root_raises(self, tmp_path):
+        path = self._write_sample(tmp_path, {"id": "x"})
+        with pytest.raises(ValueError, match="JSON list"):
+            load_golden_samples(path=path)
+
+    def test_malformed_json_raises(self, tmp_path):
+        target = tmp_path / "golden.json"
+        target.write_text("{not json", encoding="utf-8")
+        with pytest.raises(ValueError):
+            load_golden_samples(path=str(target))
+
+    def test_duplicate_ids_raise(self, tmp_path):
+        sample = {
+            "id": "dup",
+            "task_description": "t",
+            "stock_code": "600519",
+            "expected_tools": ["get_realtime_quote"],
+        }
+        path = self._write_sample(tmp_path, [sample, sample])
+        with pytest.raises(ValueError, match="duplicate sample id: dup"):
+            load_golden_samples(path=path)
+
+    def test_unknown_expected_tool_flagged_when_names_given(self, tmp_path):
+        sample = {
+            "id": "x",
+            "task_description": "t",
+            "stock_code": "600519",
+            "expected_tools": ["not_a_real_tool"],
+        }
+        path = self._write_sample(tmp_path, [sample])
+        with pytest.raises(ValueError, match="unknown expected_tools: not_a_real_tool"):
+            load_golden_samples(path=path, known_tool_names=_repo_tool_names())
+
+    def test_unknown_expected_tool_allowed_without_names(self, tmp_path):
+        sample = {
+            "id": "x",
+            "task_description": "t",
+            "stock_code": "600519",
+            "expected_tools": ["not_a_real_tool"],
+        }
+        path = self._write_sample(tmp_path, [sample])
+        assert [s.id for s in load_golden_samples(path=path)] == ["x"]
+
+    def test_extra_json_keys_ignored(self, tmp_path):
+        sample = {
+            "id": "x",
+            "task_description": "t",
+            "stock_code": "600519",
+            "expected_tools": ["get_realtime_quote"],
+            "notes": "forward-looking metadata",
+        }
+        path = self._write_sample(tmp_path, [sample])
+        assert load_golden_samples(path=path)[0].id == "x"
+
+    def test_invalid_max_steps_flagged(self, tmp_path):
+        sample = {
+            "id": "x",
+            "task_description": "t",
+            "stock_code": "600519",
+            "expected_tools": ["get_realtime_quote"],
+            "allowed_max_steps": 0,
+        }
+        path = self._write_sample(tmp_path, [sample])
+        with pytest.raises(ValueError, match="allowed_max_steps must be >= 1"):
+            load_golden_samples(path=path)

--- a/tests/test_agent_trajectory_metrics.py
+++ b/tests/test_agent_trajectory_metrics.py
@@ -1089,6 +1089,55 @@ class TestExpectedOutcomes:
         assert "expected_outcomes must not contain duplicate tags" in m.violations
         assert "expected outcomes not observed" not in m.violations
 
+    def test_successful_guarded_entry_escapes_and_reports_wrong_stock(self):
+        # Review counter-example (success is authoritative): a success=True
+        # entry carrying guarded=True did NOT stay blocked — it must keep its
+        # wrong-stock violation on the pinned stock and must not satisfy
+        # guarded_retry, even when the same-args retry is a blocked cache hit.
+        log = [
+            _entry(tool="get_stock_info", arguments={"stock_code": "600036"}, step=1),
+            _entry(tool="get_daily_history", arguments={"stock_code": "600036"}, step=2),
+            _entry(tool="get_stock_info", arguments={"stock_code": "600519"}, step=3, guarded=True),
+            _entry(tool="get_stock_info", arguments={"stock_code": "600519"}, step=4, success=False, cached=True),
+        ]
+        m = compute_trajectory_metrics(log, self._guarded_sample())
+        assert "expected tools called for a different stock than 600036: get_stock_info" in m.violations
+        assert "expected outcomes not observed: guarded_retry" in m.violations
+
+    def test_successful_cached_retry_is_an_escape(self):
+        # A cache-hit retry marked success=True executed cleanly, so the pair
+        # escaped: guarded_retry must not be observed.
+        log = [
+            _entry(
+                tool="get_stock_info",
+                arguments={"stock_code": "600519"},
+                step=1,
+                success=False,
+                guarded=True,
+            ),
+            _entry(tool="get_stock_info", arguments={"stock_code": "600519"}, step=2, cached=True),
+        ]
+        m = compute_trajectory_metrics(log, self._guarded_sample())
+        assert "expected outcomes not observed: guarded_retry" in m.violations
+
+    def test_successful_guarded_entry_does_not_count_as_interception(self):
+        # success is authoritative for the observed-outcome counters too: a
+        # successful guarded entry neither counts as a guard interception nor
+        # observes the guarded outcome.
+        golden = _golden(expected_outcomes=["guarded"])
+        log = [_entry(tool="get_realtime_quote", arguments={"stock_code": "600519"}, guarded=True)]
+        m = compute_trajectory_metrics(log, golden)
+        assert "expected outcomes not observed: guarded" in m.violations
+
+    def test_successful_cached_entry_does_not_count_as_cache_reuse(self):
+        # Same authority for the cached marker: a successful cached entry
+        # neither counts as cache reuse nor observes the cached outcome.
+        golden = _golden(expected_outcomes=["cached"])
+        log = [_entry(tool="get_realtime_quote", arguments={"stock_code": "600519"}, cached=True)]
+        m = compute_trajectory_metrics(log, golden)
+        assert m.cached_calls == 0
+        assert "expected outcomes not observed: cached" in m.violations
+
 
 # ---------------------------------------------------------------------------
 # 2b. Stock-scoped hit semantics (golden.stock_code)


### PR DESCRIPTION
## Problem

Issue #1956 提出为 agent 执行轨迹建立评估能力：目前缺少对 `tool_calls_log` 的标准化度量，无法量化回答「agent 是否调用了期望的工具」「存在多少冗余 / 失败 / 重试调用」「是否耗尽步数预算」等问题，prompt / 工具描述类改动只能靠人工观察回归效果。

## Solution

新增纯函数指标层 `evals/agent_trajectory/`，直接消费 runner 产出的 `tool_calls_log`（契约见 `src/agent/runner.py`），以 golden sample（期望轨迹描述）为基准计算：

- 期望工具命中率 / 缺失期望工具（stock-scoped：golden 与参数值先经运行时等价 canonicalization 再精确匹配 `stock_code` 参数字段 / `requested_stock_code` / Codex summary 还原出的结构化 `stock_code`（无法解析时判 non-match，绝不子串匹配）才计命中，错误股票调用逐条记违规）
- 期望外工具调用（`allow_optional_tools` 开关）
- 冗余 / 缓存 / 失败 / 重试调用（基于 `(tool, args-key)` 幂等键派生；键内 `stock_code` 字段按生产 `_build_tool_cache_key` 语义先 canonicalize，等价别名共享同一调用身份）
- 步数效率与 max_steps 触碰（启发式，支持传入 `RunLoopResult.total_steps` 纳入最终回答轮；Codex 形态日志显式标记 unsupported 而非输出失真步数）
- 违规项清单

选择纯函数方案的原因：**不修改 `src/` 执行语义、不接入 CI 阻断门、不新增运行时配置**；指标层零 `src/` 导入、纯标准库，可离线单测、输出确定性，为后续 live-run 脚本（PR-2）与 prompt / 工具改动提供可量化的回归手段。

## Changes

- 新增 `evals/agent_trajectory/__init__.py`（包标记）
- 新增 `evals/agent_trajectory/metrics.py`：`GoldenSample` / `TrajectoryMetrics` 数据类，`compute_trajectory_metrics` / `format_text_report` / `load_golden_samples` / `validate_golden_sample` 纯函数；`expected_tools` 拒绝重名（load 时报错、计分时归一化），`expected_outcomes` 轨迹特征断言强制校验；命中率 stock-scoped（runner 条目精确匹配专用 `stock_code` 参数字段——非子串扫描——/ `requested_stock_code` / Codex summary 还原出的结构化 `stock_code`，错误股票的期望工具调用逐条记违规，**显式存在但类型非法的股票证据（null / boolean / 非标量 / 空 guard 记录）判 non-match 不计命中；float 形态证据走 guard 链转换——整数值 float（`600519.0`）先转 int、其余按 `str` 形态（`600519.5`）比较，与生产 `_normalize_guard_stock_code` 同口径，runner 按原样记录的 JSON 数字不再漏判**；**截断 / 不可解析的 Codex summary 判 non-match——绝不子串匹配（截断的 `1600519` 含 `600519` 子串、非 `stock_code` 字段里的码都不计命中）**——name-only tolerance 仅保留给完全没有股票证据的条目），比较前 golden 与参数值均经运行时等价 canonicalization 镜像归一（`SH600519`/`600519.SH`/HK 变体同一身份），支持注入 `stock_code_normalizer` 传入生产归一函数（非 callable 值记违规）；幂等键同样镜像生产 `_build_tool_cache_key`（dict 参数的**字符串** `stock_code` 字段序列化前先归一、非字符串值如 JSON number 原样保留——`600519` 与 `"600519"` 保持两个身份、其余参数保持原样），`validate_golden_sample` 对 `expected_guarded_stock` 与 `stock_code` 的异股校验也在 canonicalization 后进行；Codex `arguments_summary` 可解析回参数 dict 时按**还原后的 dict** 参与幂等键（`stock_code` 字段同路径 canonicalize、键序 sort_keys 归一——alias 与键序变体共享同一调用身份），不可解析（截断/脱敏）的 preview 保持 raw wrapper fallback；`expected_guarded_stock` 的 blocked 探测（guarded / cached / 失败）免于 wrong-stock 违规——样例本身要求该越界探测，对锁定股票干净成功仍记违规；两处股票锁定断言（豁免 + `guarded_retry` 种子）均要求**实际股票证据**（`_entry_matches_stock` 新增 `require_evidence` 严格模式：`arguments={}`、缺失 `arguments`、不含 `stock_code` 的结构化 payload 判 non-match，普通命中率计分保留 name-only tolerance）；Codex 形态日志声明 guard 依赖 outcome（guarded / cached / guarded_retry）时显式标记 unsupported 而非输出假 "not observed" 回归（`retry` 仍可评分，由 (tool, args-key) 重复推导）；Codex 形态日志的步数指标显式抑制并记违规；`compute_trajectory_metrics()` 对**直接构造**的 malformed golden 与 `validate_golden_sample()` 共享同一结构契约且**按构造对齐**——返回前调用 validator 并把其完整 issue 列表逐字并入 violations（与内联计分违规去重），`id` / `task_description` / `skills` 及今后任何新增 validator 检查自动作用于 direct-score，malformed golden 不可能静默按合法评分；剩余计分内联文案全部对齐 validator 逐字（`expected_tools` 非列表 / 空列表 / 重名、`stock_code`、`expected_outcomes` 重名 / 未知 tag、`allowed_max_steps` 非整数），每个畸形字段恰好一条违规、两入口零文案漂移；畸形元素谓词为 validator 精确谓词 `t.strip()`（非字符串 / 空串 / **纯空白**报违规并从评分排除）、`allowed_max_steps <= 0` 报 validator 同文案且预算断言仅伴随显式违规时关闭、未配对（未声明 `guarded_retry`）或 canonicalization 后同股的 `expected_guarded_stock` 报违规且 pin 语义全禁用——不豁免 wrong-stock、不追踪 escape（in-scope 干净成功不再误记 pinned escape）、不按 pin 名 seed；`guarded_retry` 仍绑定其声明的越界探测（pin 禁用后携带**异股证据**的 guarded 调用才 seed 该键，in-scope blocked retry 永不满足、真实异股探测仍满足），direct-score 路径不再静默放宽评分语义；表驱动 parity 测试将 validator 拒绝的每一类 malformed golden 同时跑两条入口并断言同一违规文案（已锁死 14 类场景），属性测试断言 validator 的每一条 issue 都出现在 direct-score violations 中且不重复（新漂移本地即红）
- 新增 `evals/agent_trajectory/golden_samples.json`：3 个 golden 样例（技术面命中、严格模式禁期望外工具、guard 拦截 / 缓存重试边界）；golden 契约支持 `expected_outcomes`（guarded / cached / retry / guarded_retry，声明特征未在轨迹中观察到即记为违规；`guarded_retry` 为绑定语义——被 guard 的同键调用后续再次出现**且每一次后续同键调用都保持 blocked**（guarded / cached / 失败）才算，同键调用在任何时刻（guard 之前或之后）干净成功都视为逃逸、不满足；**success 对 guarded / cached 标记权威**——生产 guard 拦截与 cache 复用都记 success=False，合成条目 success=True 与标记并存判 escape：保留 wrong-stock、不满足 guarded_retry、不观察 guarded / cached outcome、不 seed 守卫位置索引；pinned 股票（`expected_guarded_stock`）的干净成功逃逸按**任意工具**追踪——可选工具对越界股票的干净成功报 `optional tools escaped the guarded stock` 违规并使 guarded_retry 不满足（blocked 的可选探测仍豁免），与运行时 guard 统一拦截所有 stock-scoped 工具的语义一致），`expected_guarded_stock` 可将 guard 拦截目标锁定到具体股票（600036 样例固定 600519，其他股票的 guard 重试不算；锁定股票的 blocked 探测免于 wrong-stock 违规，且无任何股票证据的 blocked 调用——空 / 缺失 arguments 等——不豁免、不 seed 绑定 outcome）
- 新增 `tests/test_agent_trajectory_metrics.py`：158 个单元测试（合成轨迹，无 LLM / 网络依赖）
- 修改 `docs/CHANGELOG.md`：`[Unreleased]` 段追加 1 条扁平条目

修复范围仅限以上新增 / 修改；`src/`、`api/`、`apps/` 零改动，无新增第三方依赖。

## Testing

本地验证环境：Windows 11 / Python 3.12.2 / `PYTHONUTF8=1`（GBK 终端会读炸 setup.cfg 的 UTF-8 中文注释，故显式设置）。

```bash
# 单元测试：158/158 通过（单独运行 + 完整套件内复跑均通过）
D:/Python/python3.12.2/python.exe -m pytest tests/test_agent_trajectory_metrics.py -v

# 完整离线套件：新增文件 158/158 通过；约 115 个失败全部为既有文件在 Windows 上的
# 平台差异（os.killpg / getpgid POSIX-only、WinError 10038、Codex platform_unsupported），
# 与本次改动无关，CI 为 Linux 不受影响
D:/Python/python3.12.2/python.exe -m pytest -m "not network" -q   # 6400+ passed

# ci_gate 阶段
bash scripts/ci_gate.sh syntax          # 通过
bash scripts/ci_gate.sh deterministic   # 通过
# flake8：新增文件 critical + full 均 0 问题；black --check 通过
```

Head CI（2026-09-01，commit 843e5dd）：`backend-tests (1/3)`、`backend-tests (2/3)` 通过；`backend-tests (3/3)` 与 `backend-gate` 失败——根因是**仓库级 litellm 1.99.0 依赖漂移**（2026-09-01 00:42 UTC 发布；`requirements.txt` 只锁 `litellm>=1.80.10,!=1.82.7,!=1.82.8,<2.0.0`），失败测试对真实 `litellm.completion()` 断言 `prompt_cache_key` 不透传 provider，1.99.0 起开始透传；本 PR 与 `tests/test_provider_cache.py`、`src/provider/` 零 diff，失败与本 PR 逻辑无关（维护者评审已确认该结论）。待仓库锁定 litellm 或适配后重跑即绿。

测试覆盖场景：args-key 稳定性（键序无关 / 嵌套 unhashable 参数、`stock_code` 别名共享同一 key、JSON number 与字符串保持不同 key、非 `stock_code` 参数保持原始）、期望工具命中与缺失、stock-scoped 命中（错误股票反例、精确字段匹配反例 `1600519`、整数参数归一化、整数值 float 参数 guard 链 coercion（`600519.0` 命中 / wrong-stock / pinned 逃逸三条路径、非积分 float 异码分支、与生产 `_normalize_guard_stock_code` 的 parity 锁）、按条目报告同工具错误股票调用、无股票字段容忍、显式畸形股票证据判 non-match——runner null/boolean/list/dict、空/非法 `requested_stock_code`、Codex summary 还原出 JSON null/false/数组均不计命中、summary 含码 / 不含码、summary 结构化别名还原命中（`hk700`→`HK00700`、`aapl`→`AAPL`）、summary 结构化异股记 wrong-stock、不可解析 / 截断 summary 判 non-match（截断 `1600519` 含 `600519` 子串不计命中、非 `stock_code` 字段里的码不计命中、raw 文本 / JSON 标量不计命中、结构化缺 `stock_code` 字段不计命中）、guard 元数据匹配）、Codex summary 身份（alias 共享 key（`hk700`/`HK00700`）、键序变体共享 key、JSON number/string 不并身份、非 `stock_code` 参数保持原始、截断 preview raw fallback 不并）、股票 canonicalization（`SH600519` / `sh600519` / `600519.SH` / `SS600519` / `SH.600519` / 带空格等形态同一身份、HK 变体 `HK00700`/`hk700`/`700.HK`/`00700` 归一、镜像与生产 `_normalize_tool_stock_code` 的 parity 表（~31 形态惰性导入比对）、注入 normalizer 覆盖镜像、非 callable normalizer 报违规、身份 payload 与生产 `_build_tool_cache_key` 逐字节 parity（字符串别名折叠 + 数字类型保留一张表锁死））、重试与缓存语义（失败后重试 vs 成功后重复、别名间重试共享身份计数、number→string 不并身份、注入 normalizer 驱动调用身份、仅字符串 `stock_code` 字段参与归一）、`total_steps` 最终回答轮、max_steps 触碰边界、Codex 形态日志步数抑制（8 条 step=1 条目不再输出失真 1 步）、Codex outcome 支持（guarded/cached/guarded_retry 三个 guard 依赖 tag 显式 unsupported、retry 可评分且缺失仍报、runner 形态正常评分）、容错条目（缺失可选字段 / Codex `arguments_summary` 变体 / 非法 step）、文本报告渲染确定性、golden 文件 schema 与真实工具 registry 成员校验（含一次性 generator、误类型字段的拒绝路径）、重复工具名拒绝与计分归一化、`expected_outcomes` 特征断言（guard 拦截 / 缓存 / 重试 / 绑定 guarded_retry，含反例：跳过越界调用必违规、guard 来自 A retry 来自 B 必违规、guard 重试目标股票不匹配必违规、guard 后同键直接成功逃逸必违规、guard 之前先成功再 guard/cached 仍必违规、异 key 干净成功不影响 pinned guard/retry、blocked 变体重试 cached / 失败保持满足、guard→失败→成功逃逸必违规、alias guard→alias 重试共享身份满足、success 权威——成功 guarded 条目逃逸且保留 pinned stock 的 wrong-stock 违规（owner 复现：success=True+guarded=True 后接 blocked cache 重试仍报两条违规）、成功 cached 重试逃逸、成功 guarded / cached 条目不观察对应 outcome、可选工具对 pinned 越界股票的干净成功报逃逸违规并破坏 guarded_retry（owner 复现）、blocked 可选探测仍豁免、逃逸与被禁止工具两条违规独立）、锁定股票 blocked 探测豁免（guarded/cached 两分支、别名拼写豁免、干净成功仍违规、第三方股票仍违规、无锁定 baseline）、畸形 guarded 探测不满足 guarded_retry（`stock_code=None` + 空 `requested_stock_code` 不 seed 绑定 outcome）、无股票证据 guarded 探测不满足 pinned guarded_retry（`arguments={}` / 缺失 `arguments` / 不含 `stock_code` 的结构化 payload 均不 seed，命中率 name-only tolerance 不受影响）、`expected_guarded_stock` 校验（同字符串拒绝、`SH600036`/`600036.SH`/`SS600036`/空白变体 canonicalization 后同股拒绝、canonicalize 后不同股票的别名合法）、direct-score 结构契约（畸形 `expected_tools`/`expected_outcomes` 元素含纯空白报 validator 同文案违规、纯空白 tool 不污染命中率分母、`allowed_max_steps` 0/负数报 `must be >= 1` 且 99 步轨迹预算断言仍关闭、未配对 `expected_guarded_stock` 报违规且禁用 wrong-stock 豁免与 pinned seeding、canonicalization 后同股 pin 报违规且 pin 语义全禁用——in-scope blocked retry 报「结构违规 + not observed」双违规（owner 复现）、optional 工具 in-scope 成功不记 escape、真实异股探测仍满足 guarded_retry、无 pin 遗法 seed 锁、malformed outcome 不误报 "not observed"、表驱动 parity 测试锁死两入口同文案 14 类场景、属性测试断言 validator 每条 issue 均出现在 direct-score violations 且不重复、`id` / `task_description` / `skills` 畸形值（含 owner 复现）与其余内联文案对齐后每个畸形字段恰好一条违规）、加载错误路径（缺文件 / 非列表 / 坏 JSON / 重复 id / 未知工具名 / unhashable id / 未知 outcome tag）。

## Notes for Reviewer

1. **有意不接 CI、不改 `src/`**：本 PR 只交付可复用指标层；live-run 脚本（PR-2）将复用 `factory.build_agent_executor` 对真实轨迹落盘打分，CI 阻断门是否接入届时另行讨论，避免影响现有流程。
2. **`max_steps_touched` 为保守启发式**：`tool_calls_log` 不携带 `max_steps` 字段，故定义为 `max(step, total_steps) >= allowed_max_steps`，模块 docstring 已写明该近似契约。Codex App Server 日志（`arguments_summary` 条目）步数记账固定 `step=1`，检测到即抑制步数指标并记显式违规，避免输出失真结果；同口径预算字段需 producer 侧改动（见 Note 7）。
3. **工具名校验不硬编码**：`load_golden_samples(known_tool_names=...)` 由调用方注入 registry 名（测试传 5 个 `ALL_*_TOOLS` 列表），指标层自身不 import `src/`，避免与工具 registry 漂移。
4. **幂等键契约**：`(tool, json.dumps(arguments, sort_keys=True, default=str))` 稳定字符串（非 hash），兼容 dict / list 等 unhashable 参数；dict 参数的**字符串** `stock_code` 字段在序列化前按生产 `_build_tool_cache_key` 语义 canonicalize（`SH600519`/`600519.SH`/`600519` 共享同一调用身份），非字符串值（`json.loads` 产出的 JSON number）原样保留——`600519` 与 `"600519"` 在运行时 cache key 里就是两个键，评估层保持一致；其余参数保持原始；Codex backend 的 `arguments_summary` 若可解析回参数 dict（`redact_diagnostic_value(record.arguments)` 的序列化产物）则按**还原后的 dict** 参与同一幂等键——`stock_code` 字段同路径 canonicalize、键序 sort_keys 归一，别名与键序变体共享身份；无法解析（截断 / 脱敏）的 preview 按 raw 字符串保持调用身份（best-effort，模块 docstring 已写明脱敏 / 截断碰撞限制）。
5. 本 PR 关联 Issue #1956，请 review 时重点看 `metrics.py` 的指标语义（模块 docstring 中的契约部分）与 golden 样例的覆盖设计。
6. golden 契约新增 `expected_outcomes`（词汇表 guarded / cached / retry / guarded_retry）：600036 样例声明 `["guarded_retry"]` —— 绑定语义：同一 (tool, args-key) 上出现 guarded 调用**且其后每一次同键后续调用都保持 blocked**（guarded / cached / 失败）才算观察到；guard 来自 A、retry 来自 B 的轨迹不通过，同键调用在**任何时刻**（guard 之前或之后）干净成功（逃逸）都不通过——先成功本身就证明该越界调用能穿透 guard。并新增 `expected_guarded_stock=600519` 将 guard 拦截目标锁定到任务要求的越界股票——guarded 调用本身必须针对该股票**且携带实际股票证据**（空 / 缺失 arguments 等无证据 blocked 调用不 seed、不豁免），其他股票的 guard 重试不算（validate 会拒绝畸形值 / 与 `stock_code` 相同 / 未声明 `guarded_retry` 的配置；`compute_trajectory_metrics()` 的 direct-score 路径对同一组 malformed 配置以 validator 逐字文案报违规，未配对或同股 pin 被禁用——不豁免 wrong-stock、不追踪 escape、不按 pin 名 seed；同股 pin 下 `guarded_retry` 仍绑越界探测（携带异股证据的 guarded 调用才 seed，in-scope blocked retry 永不满足）——与 loader 语义不再漂移）。其 task_description 允许"命中非可重试缓存**或**再次失败"两个分支，故不强制 `cached`。声明特征未在轨迹中观察到即记为违规，保证 guard / 缓存 / 重试行为回归可被机器检测（此前跳过越界调用或无关调用拼 outcome 的轨迹会通过）。锁定股票的 blocked 探测（guarded / cached / 失败，且带实际股票证据）免于 wrong-stock 违规——样例本身要求该越界探测、且只锁股票不锁工具，任何 expected tool 的 blocked 探测都是合规行为；对锁定股票干净成功仍记 wrong-stock。另：Codex 形态日志（`arguments_summary` 条目）无法携带 guarded / cached 元数据，声明 guard 依赖 outcome（guarded / cached / guarded_retry）时显式标记 unsupported（与 step 指标抑制同模式），不输出假 "not observed" 回归；`retry` 仍可评分。
7. **Codex 步数口径（已由维护者定案）**：维护者 ledger 已关闭 `OR-COR-codex-step-metrics-miscount`，本 PR 的 metrics 层检测 + 步数抑制 + 显式违规即为已接受的最小方案；producer 侧同口径预算字段留作独立 follow-up（需改 `src/agent/codex_agent_backend.py`，超出本 PR「零 src/ 改动」边界）。
8. **股票 canonicalization 不直接 import 生产函数**：`data_provider/base.py` 会引入 pandas / akshare 运行时依赖，破坏指标层「零 src/ 导入、纯标准库、可离线」契约，故指标层内置与 `_normalize_tool_stock_code` 运行时等价的镜像实现，并用 parity 测试（惰性 import 生产函数、~31 种形态逐一比对）防止镜像漂移；live-run 可通过 `stock_code_normalizer` 注入真实生产函数，两侧语义一致。

## Issue Link

Refs #1956
