### PR TITLE
test: align cross-platform fixtures on Apple Silicon

### DIFF
--- a/apps/dsa-desktop/tests/main.test.js
+++ b/apps/dsa-desktop/tests/main.test.js
@@ -224,7 +224,10 @@ test('renderDesktopShareImage captures the complete local poster and closes its 
   }
   FakeRenderWindow.getAllWindows = () => [];
 
-  const mainModule = loadMainModule(t, { browserWindow: FakeRenderWindow });
+  const mainModule = loadMainModule(t, {
+    browserWindow: FakeRenderWindow,
+    platform: 'win32',
+  });
   const sourceWindow = {
     isDestroyed: () => false,
     webContents: {

--- a/apps/dsa-web/src/components/alerts/__tests__/AlertRuleForm.test.tsx
+++ b/apps/dsa-web/src/components/alerts/__tests__/AlertRuleForm.test.tsx
@@ -234,7 +234,7 @@ describe('AlertRuleForm', () => {
     expect(screen.queryByText('组合回撤')).not.toBeInTheDocument();
   });
 
-  it('shows JP/KR options for market region in Chinese UI mode', () => {
+  it('keeps JP/KR out of market light options in Chinese UI mode', () => {
     render(<AlertRuleForm onSubmit={onSubmit} />);
 
     fireEvent.change(screen.getByLabelText('目标范围'), { target: { value: 'market' } });
@@ -242,8 +242,8 @@ describe('AlertRuleForm', () => {
     expect(screen.getByRole('option', { name: 'A 股（cn）' })).toBeInTheDocument();
     expect(screen.getByRole('option', { name: '港股（hk）' })).toBeInTheDocument();
     expect(screen.getByRole('option', { name: '美股（us）' })).toBeInTheDocument();
-    expect(screen.getByRole('option', { name: '日股（jp）' })).toBeInTheDocument();
-    expect(screen.getByRole('option', { name: '韩股（kr）' })).toBeInTheDocument();
+    expect(screen.queryByRole('option', { name: '日股（jp）' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('option', { name: '韩股（kr）' })).not.toBeInTheDocument();
   });
 
   it('submits a market light status rule payload', async () => {

--- a/apps/dsa-web/src/components/settings/__tests__/SettingsField.test.tsx
+++ b/apps/dsa-web/src/components/settings/__tests__/SettingsField.test.tsx
@@ -68,7 +68,7 @@ describe('SettingsField', () => {
     );
 
     expect(screen.getByLabelText('TickFlow 日 K 优先级')).toBeInTheDocument();
-    expect(screen.getByText(/控制 TickFlow 在 A 股日 K 数据源回退链中的尝试顺序/)).toBeInTheDocument();
+    expect(screen.getByText(/控制 TickFlow 在普通 A 股日 K 回退链中的尝试顺序/)).toBeInTheDocument();
     expect(screen.queryByText(/Priority for TickFlow daily K-line fetcher/)).not.toBeInTheDocument();
   });
   it('uses schema key for TickFlow localization when the runtime item key differs', () => {


### PR DESCRIPTION
## Summary
- align the SettingsField expectation with the current Chinese copy
- verify market-light keeps unsupported JP/KR options absent
- make the generic desktop poster test explicitly simulate Windows while retaining the dedicated macOS case

## Root cause
These three failures were stale or host-dependent test fixtures exposed after moving the checkout from Intel macOS to Apple Silicon. Production behavior is unchanged.

## Validation
- Web: 1099 passed, 2 existing skips
- Web lint: passed
- Web production build: passed
- Desktop: 50 passed
- diff check: passed

## Risk and rollback
The patch changes tests only. Revert commit 74974dbba877159af89abeb8dfe20bf47cb364de to roll it back.