### PR TITLE
feat(decision-signals): add read-only stock review memory aggregation and endpoint (#1903)

### DIFF
--- a/api/v1/endpoints/decision_signals.py
+++ b/api/v1/endpoints/decision_signals.py
@@ -24,6 +24,7 @@ from api.v1.schemas.decision_signals import (
     DecisionSignalReassessRequest,
     DecisionSignalReassessErrorResponse,
     DecisionSignalReassessResponse,
+    DecisionSignalReviewMemory,
     DecisionSignalStatusUpdateRequest,
 )
 from src.auth import COOKIE_NAME
@@ -321,6 +322,36 @@ def get_outcome_stats(
         raise _bad_request(exc)
     except Exception as exc:
         raise _internal_error("Get decision signal outcome stats failed", exc)
+
+
+@router.get(
+    "/stocks/{stock_code}/review",
+    response_model=DecisionSignalReviewMemory,
+    responses={
+        **AUTH_RESPONSE,
+        400: {"model": ErrorResponse, "description": "查询参数非法"},
+        422: {"model": ErrorResponse, "description": "路径或查询参数校验失败"},
+        500: {"model": ErrorResponse, "description": "查询失败"},
+    },
+    summary="查询单票决策信号复盘摘要",
+    description=(
+        "聚合指定股票在当前 engine_version 下的 signal-level outcome/feedback，"
+        "返回只读低敏 ReviewMemory 摘要；样本不足、unable 率高或数据质量弱时 "
+        "confidence_adjustment 固定为 observe，仅供观察，不构成交易信号。"
+    ),
+    operation_id="getDecisionSignalStockReview",
+)
+def get_stock_review(
+    stock_code: str,
+    horizon: Optional[str] = Query(None, description="Optional outcome horizon filter: 1d/3d/5d/10d"),
+) -> DecisionSignalReviewMemory:
+    service = DecisionSignalOutcomeService()
+    try:
+        return DecisionSignalReviewMemory(**service.get_stock_review(stock_code, horizon=horizon))
+    except ValueError as exc:
+        raise _bad_request(exc)
+    except Exception as exc:
+        raise _internal_error("Get decision signal stock review failed", exc)
 
 
 @router.post(

--- a/api/v1/schemas/decision_signals.py
+++ b/api/v1/schemas/decision_signals.py
@@ -22,6 +22,8 @@ DecisionSignalOutcomeStatus = Literal["completed", "unable"]
 DecisionSignalOutcomeValue = Literal["hit", "miss", "neutral"]
 DecisionSignalFeedbackValue = Literal["useful", "not_useful"]
 DecisionSignalFeedbackSource = Literal["web", "api"]
+DecisionSignalReviewScope = Literal["stock"]
+DecisionSignalConfidenceAdjustment = Literal["upgrade", "downgrade", "neutral", "observe"]
 
 
 class DecisionSignalCreateRequest(BaseModel):
@@ -231,6 +233,26 @@ class DecisionSignalOutcomeStatsResponse(BaseModel):
     unable_reasons: Dict[str, int] = Field(default_factory=dict)
     breakdowns: Dict[str, List[DecisionSignalOutcomeStatsBucket]] = Field(default_factory=dict)
     profile_calibration: DecisionSignalProfileCalibration
+
+
+class DecisionSignalReviewMemory(BaseModel):
+    """Read-only, low-sensitivity review summary of DecisionSignal outcomes for one stock.
+
+    Aggregated server-side from signal-level outcomes/feedback.  Raw evidence,
+    prompt text, diagnostics, and holdings are intentionally excluded; the
+    payload is observational context only and must not be used as a trading
+    signal.
+    """
+
+    stock_code: str
+    scope: DecisionSignalReviewScope = "stock"
+    sample_size: int = Field(0, ge=0)
+    completed: int = Field(0, ge=0)
+    hit_rate_pct: Optional[float] = None
+    avg_return_pct: Optional[float] = None
+    common_miss_reasons: List[str] = Field(default_factory=list)
+    confidence_adjustment: DecisionSignalConfidenceAdjustment = "observe"
+    notes: str = ""
 
 
 class DecisionSignalFeedbackRequest(BaseModel):

--- a/docs/architecture/api_spec.json
+++ b/docs/architecture/api_spec.json
@@ -2100,6 +2100,101 @@
         }
       }
     },
+    "/api/v1/decision-signals/stocks/{stock_code}/review": {
+      "get": {
+        "tags": [
+          "DecisionSignals"
+        ],
+        "summary": "查询单票决策信号复盘摘要",
+        "description": "聚合指定股票在当前 engine_version 下的 signal-level outcome/feedback，返回只读低敏 ReviewMemory 摘要；样本不足、unable 率高或数据质量弱时 confidence_adjustment 固定为 observe，仅供观察，不构成交易信号。",
+        "operationId": "getDecisionSignalStockReview",
+        "security": [
+          {
+            "AdminSessionCookie": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "stock_code",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Stock Code"
+            }
+          },
+          {
+            "name": "horizon",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Horizon",
+              "description": "Optional outcome horizon filter: 1d/3d/5d/10d"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DecisionSignalReviewMemory"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "未登录或管理员会话无效（ADMIN_AUTH_ENABLED=true 时）",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "查询参数非法",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "路径或查询参数校验失败",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "查询失败",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/v1/decision-signals/{signal_id}/outcomes": {
       "get": {
         "tags": [
@@ -9068,6 +9163,85 @@
           "status"
         ],
         "title": "StockProfileQuoteBlock"
+      },
+      "DecisionSignalReviewMemory": {
+        "description": "Read-only, low-sensitivity review summary of DecisionSignal outcomes for one stock.\n\nAggregated server-side from signal-level outcomes/feedback.  Raw evidence,\nprompt text, diagnostics, and holdings are intentionally excluded; the\npayload is observational context only and must not be used as a trading\nsignal.",
+        "properties": {
+          "stock_code": {
+            "title": "Stock Code",
+            "type": "string"
+          },
+          "scope": {
+            "const": "stock",
+            "default": "stock",
+            "title": "Scope",
+            "type": "string"
+          },
+          "sample_size": {
+            "default": 0,
+            "minimum": 0,
+            "title": "Sample Size",
+            "type": "integer"
+          },
+          "completed": {
+            "default": 0,
+            "minimum": 0,
+            "title": "Completed",
+            "type": "integer"
+          },
+          "hit_rate_pct": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Hit Rate Pct"
+          },
+          "avg_return_pct": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Avg Return Pct"
+          },
+          "common_miss_reasons": {
+            "items": {
+              "type": "string"
+            },
+            "title": "Common Miss Reasons",
+            "type": "array"
+          },
+          "confidence_adjustment": {
+            "default": "observe",
+            "enum": [
+              "upgrade",
+              "downgrade",
+              "neutral",
+              "observe"
+            ],
+            "title": "Confidence Adjustment",
+            "type": "string"
+          },
+          "notes": {
+            "default": "",
+            "title": "Notes",
+            "type": "string"
+          }
+        },
+        "required": [
+          "stock_code"
+        ],
+        "title": "DecisionSignalReviewMemory",
+        "type": "object"
       }
     },
     "securitySchemes": {

--- a/docs/architecture/api_spec.json
+++ b/docs/architecture/api_spec.json
@@ -2136,9 +2136,10 @@
                   "type": "null"
                 }
               ],
-              "title": "Horizon",
-              "description": "Optional outcome horizon filter: 1d/3d/5d/10d"
-            }
+              "description": "Optional outcome horizon filter: 1d/3d/5d/10d",
+              "title": "Horizon"
+            },
+            "description": "Optional outcome horizon filter: 1d/3d/5d/10d"
           }
         ],
         "responses": {
@@ -2177,7 +2178,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -9165,29 +9166,28 @@
         "title": "StockProfileQuoteBlock"
       },
       "DecisionSignalReviewMemory": {
-        "description": "Read-only, low-sensitivity review summary of DecisionSignal outcomes for one stock.\n\nAggregated server-side from signal-level outcomes/feedback.  Raw evidence,\nprompt text, diagnostics, and holdings are intentionally excluded; the\npayload is observational context only and must not be used as a trading\nsignal.",
         "properties": {
           "stock_code": {
-            "title": "Stock Code",
-            "type": "string"
+            "type": "string",
+            "title": "Stock Code"
           },
           "scope": {
+            "type": "string",
             "const": "stock",
-            "default": "stock",
             "title": "Scope",
-            "type": "string"
+            "default": "stock"
           },
           "sample_size": {
-            "default": 0,
-            "minimum": 0,
+            "type": "integer",
+            "minimum": 0.0,
             "title": "Sample Size",
-            "type": "integer"
+            "default": 0
           },
           "completed": {
-            "default": 0,
-            "minimum": 0,
+            "type": "integer",
+            "minimum": 0.0,
             "title": "Completed",
-            "type": "integer"
+            "default": 0
           },
           "hit_rate_pct": {
             "anyOf": [
@@ -9198,7 +9198,6 @@
                 "type": "null"
               }
             ],
-            "default": null,
             "title": "Hit Rate Pct"
           },
           "avg_return_pct": {
@@ -9210,18 +9209,17 @@
                 "type": "null"
               }
             ],
-            "default": null,
             "title": "Avg Return Pct"
           },
           "common_miss_reasons": {
             "items": {
               "type": "string"
             },
-            "title": "Common Miss Reasons",
-            "type": "array"
+            "type": "array",
+            "title": "Common Miss Reasons"
           },
           "confidence_adjustment": {
-            "default": "observe",
+            "type": "string",
             "enum": [
               "upgrade",
               "downgrade",
@@ -9229,19 +9227,20 @@
               "observe"
             ],
             "title": "Confidence Adjustment",
-            "type": "string"
+            "default": "observe"
           },
           "notes": {
-            "default": "",
+            "type": "string",
             "title": "Notes",
-            "type": "string"
+            "default": ""
           }
         },
+        "type": "object",
         "required": [
           "stock_code"
         ],
         "title": "DecisionSignalReviewMemory",
-        "type": "object"
+        "description": "Read-only, low-sensitivity review summary of DecisionSignal outcomes for one stock.\n\nAggregated server-side from signal-level outcomes/feedback.  Raw evidence,\nprompt text, diagnostics, and holdings are intentionally excluded; the\npayload is observational context only and must not be used as a trading\nsignal."
       }
     },
     "securitySchemes": {

--- a/src/repositories/decision_signal_outcome_repo.py
+++ b/src/repositories/decision_signal_outcome_repo.py
@@ -181,12 +181,15 @@ class DecisionSignalOutcomeRepository:
         engine_version: str,
         horizons: Optional[List[str]] = None,
         statuses: Optional[List[str]] = None,
+        stock_codes: Optional[List[str]] = None,
     ) -> List[OutcomeStatsRow]:
         conditions = [DecisionSignalOutcomeRecord.engine_version == engine_version]
         if horizons:
             conditions.append(DecisionSignalOutcomeRecord.horizon.in_(horizons))
         if statuses:
             conditions.append(DecisionSignalRecord.status.in_(statuses))
+        if stock_codes:
+            conditions.append(DecisionSignalRecord.stock_code.in_(stock_codes))
         with self.db.get_session() as session:
             rows = session.execute(
                 select(
@@ -213,6 +216,24 @@ class DecisionSignalOutcomeRepository:
                 .where(DecisionSignalFeedbackRecord.signal_id == signal_id)
                 .limit(1)
             ).scalar_one_or_none()
+
+    def list_feedback_reason_codes(self, *, signal_ids: List[int]) -> List[str]:
+        """Return non-empty feedback reason codes for the given signals.
+
+        Used by review aggregation to surface common miss reasons without
+        exposing raw feedback notes (low-sensitivity contract).
+        """
+        if not signal_ids:
+            return []
+        with self.db.get_session() as session:
+            rows = session.execute(
+                select(DecisionSignalFeedbackRecord.reason_code)
+                .where(
+                    DecisionSignalFeedbackRecord.signal_id.in_(signal_ids),
+                    DecisionSignalFeedbackRecord.reason_code.isnot(None),
+                )
+            ).scalars().all()
+            return [str(code) for code in rows if code]
 
     def upsert_feedback(self, fields: Dict[str, Any]) -> DecisionSignalFeedbackRecord:
         now = utc_naive_now()

--- a/src/repositories/decision_signal_outcome_repo.py
+++ b/src/repositories/decision_signal_outcome_repo.py
@@ -24,6 +24,7 @@ class OutcomeStatsRow:
     outcome: DecisionSignalOutcomeRecord
     decision_profile: Optional[str]
     metadata_json: Optional[str]
+    stock_code: Optional[str] = None
 
 
 class DecisionSignalOutcomeRepository:
@@ -196,6 +197,7 @@ class DecisionSignalOutcomeRepository:
                     DecisionSignalOutcomeRecord,
                     DecisionSignalRecord.decision_profile,
                     DecisionSignalRecord.metadata_json,
+                    DecisionSignalRecord.stock_code,
                 )
                 .join(DecisionSignalRecord, DecisionSignalRecord.id == DecisionSignalOutcomeRecord.signal_id)
                 .where(and_(*conditions))
@@ -205,8 +207,9 @@ class DecisionSignalOutcomeRepository:
                     outcome=outcome,
                     decision_profile=decision_profile,
                     metadata_json=metadata_json,
+                    stock_code=stock_code,
                 )
-                for outcome, decision_profile, metadata_json in rows
+                for outcome, decision_profile, metadata_json, stock_code in rows
             ]
 
     def get_feedback(self, *, signal_id: int) -> Optional[DecisionSignalFeedbackRecord]:
@@ -218,10 +221,12 @@ class DecisionSignalOutcomeRepository:
             ).scalar_one_or_none()
 
     def list_feedback_reason_codes(self, *, signal_ids: List[int]) -> List[str]:
-        """Return non-empty feedback reason codes for the given signals.
+        """Return non-empty ``not_useful`` feedback reason codes for the given signals.
 
         Used by review aggregation to surface common miss reasons without
-        exposing raw feedback notes (low-sensitivity contract).
+        exposing raw feedback notes (low-sensitivity contract).  Only negative
+        feedback is eligible: ``useful`` reason codes describe why a signal
+        worked, not why it missed, and must not pollute miss-reason stats.
         """
         if not signal_ids:
             return []
@@ -230,6 +235,7 @@ class DecisionSignalOutcomeRepository:
                 select(DecisionSignalFeedbackRecord.reason_code)
                 .where(
                     DecisionSignalFeedbackRecord.signal_id.in_(signal_ids),
+                    DecisionSignalFeedbackRecord.feedback_value == "not_useful",
                     DecisionSignalFeedbackRecord.reason_code.isnot(None),
                 )
             ).scalars().all()

--- a/src/services/decision_signal_outcome_service.py
+++ b/src/services/decision_signal_outcome_service.py
@@ -382,10 +382,17 @@ class DecisionSignalOutcomeService:
         insufficient completed samples, a high unable rate, or dominantly weak
         data quality.  The review is observational context only and must not be
         used as a buy/sell strength signal.
+
+        The stock filter reuses ``DecisionSignalService._stock_filter_codes`` so
+        alias inputs (``00700`` / ``00700.HK`` / ``HK00700``, ``600519.SH``,
+        lowercase US tickers) resolve to the same stored canonical identity as
+        every other decision-signal entry point.
         """
         code = str(stock_code or "").strip()
         if not code:
             raise ValueError("stock_code must not be empty")
+        filter_codes = DecisionSignalService._stock_filter_codes(code) or [code]
+        canonical_code = filter_codes[0]
         horizon_norm = self._normalize_optional_enum(
             horizon, frozenset(SUPPORTED_OUTCOME_HORIZONS), "horizon"
         )
@@ -394,10 +401,18 @@ class DecisionSignalOutcomeService:
             engine_version=DECISION_SIGNAL_OUTCOME_ENGINE_VERSION,
             horizons=horizons_norm,
             statuses=list(DEFAULT_STATS_STATUSES),
-            stock_codes=[code],
+            stock_codes=filter_codes,
         )
         rows = [stats_row.outcome for stats_row in stats_rows]
         aggregate = self._aggregate(rows)
+        if stats_rows:
+            # Echo the stored identity of the aggregated data, so alias inputs
+            # (e.g. "00700") report the same canonical code as every other
+            # decision-signal endpoint (e.g. "HK00700").
+            canonical_code = next(
+                (row.stock_code for row in stats_rows if row.stock_code),
+                canonical_code,
+            )
 
         sample_size = int(aggregate["total"])
         completed = int(aggregate["completed"])
@@ -434,7 +449,7 @@ class DecisionSignalOutcomeService:
             )
 
         return {
-            "stock_code": code,
+            "stock_code": canonical_code,
             "scope": "stock",
             "sample_size": sample_size,
             "completed": completed,

--- a/src/services/decision_signal_outcome_service.py
+++ b/src/services/decision_signal_outcome_service.py
@@ -59,6 +59,12 @@ RETRYABLE_UNABLE_REASONS = frozenset({
 })
 BATCH_CANDIDATE_SCAN_PAGE_SIZE = 500
 MIN_PROFILE_CALIBRATION_SAMPLE_SIZE = 30
+MIN_REVIEW_SAMPLE_SIZE = 10
+REVIEW_UPGRADE_HIT_RATE_PCT = 60.0
+REVIEW_DOWNGRADE_HIT_RATE_PCT = 40.0
+REVIEW_MAX_UNABLE_RATE_PCT = 50.0
+REVIEW_WEAK_DATA_QUALITY_LEVELS = frozenset({"low", "poor"})
+REVIEW_COMMON_MISS_REASONS_LIMIT = 3
 PROFILE_SOURCES = frozenset({
     "auto_default",
     "backfill_defaulted",
@@ -361,6 +367,117 @@ class DecisionSignalOutcomeService:
             "breakdowns": breakdowns,
             "profile_calibration": self._profile_calibration(stats_rows),
         }
+
+    def get_stock_review(
+        self,
+        stock_code: str,
+        *,
+        horizon: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """Aggregate a read-only, low-sensitivity review of signal outcomes for one stock.
+
+        The payload follows the ReviewMemory contract: objective aggregates are
+        always returned as-is, while ``confidence_adjustment`` stays ``observe``
+        (with an explanatory caution note) whenever the evidence base is weak —
+        insufficient completed samples, a high unable rate, or dominantly weak
+        data quality.  The review is observational context only and must not be
+        used as a buy/sell strength signal.
+        """
+        code = str(stock_code or "").strip()
+        if not code:
+            raise ValueError("stock_code must not be empty")
+        horizon_norm = self._normalize_optional_enum(
+            horizon, frozenset(SUPPORTED_OUTCOME_HORIZONS), "horizon"
+        )
+        horizons_norm = [horizon_norm] if horizon_norm else sorted(SUPPORTED_OUTCOME_HORIZONS)
+        stats_rows = self.repo.list_stats_rows(
+            engine_version=DECISION_SIGNAL_OUTCOME_ENGINE_VERSION,
+            horizons=horizons_norm,
+            statuses=list(DEFAULT_STATS_STATUSES),
+            stock_codes=[code],
+        )
+        rows = [stats_row.outcome for stats_row in stats_rows]
+        aggregate = self._aggregate(rows)
+
+        sample_size = int(aggregate["total"])
+        completed = int(aggregate["completed"])
+        unable = int(aggregate["unable"])
+        unable_rate_pct = round(unable / sample_size * 100, 2) if sample_size else 0.0
+        dominant_quality = self._dominant_data_quality_level(rows)
+
+        adjustment = "observe"
+        if sample_size == 0:
+            notes = "no decision-signal outcome data for this stock yet"
+        elif completed < MIN_REVIEW_SAMPLE_SIZE:
+            notes = (
+                f"insufficient sample: {completed} completed outcomes "
+                f"(< {MIN_REVIEW_SAMPLE_SIZE}); observation only"
+            )
+        elif unable_rate_pct > REVIEW_MAX_UNABLE_RATE_PCT:
+            notes = (
+                f"high unable rate: {unable_rate_pct}% of outcomes could not be "
+                "evaluated; observation only"
+            )
+        elif dominant_quality in REVIEW_WEAK_DATA_QUALITY_LEVELS:
+            notes = f"weak data quality (dominant level: {dominant_quality}); observation only"
+        else:
+            hit_rate_pct = aggregate["hit_rate_pct"]
+            if hit_rate_pct is not None and hit_rate_pct >= REVIEW_UPGRADE_HIT_RATE_PCT:
+                adjustment = "upgrade"
+            elif hit_rate_pct is not None and hit_rate_pct <= REVIEW_DOWNGRADE_HIT_RATE_PCT:
+                adjustment = "downgrade"
+            else:
+                adjustment = "neutral"
+            notes = (
+                f"{completed} completed outcomes, hit_rate={hit_rate_pct}%; "
+                "observation only, not a trading signal"
+            )
+
+        return {
+            "stock_code": code,
+            "scope": "stock",
+            "sample_size": sample_size,
+            "completed": completed,
+            "hit_rate_pct": aggregate["hit_rate_pct"],
+            "avg_return_pct": aggregate["avg_stock_return_pct"],
+            "common_miss_reasons": self._common_miss_reasons(rows, aggregate),
+            "confidence_adjustment": adjustment,
+            "notes": notes,
+        }
+
+    @staticmethod
+    def _dominant_data_quality_level(rows: List[DecisionSignalOutcomeRecord]) -> str:
+        """Return the most frequent data-quality level across outcome rows."""
+        if not rows:
+            return "unknown"
+        counts = Counter(str(getattr(row, "data_quality_level", None) or "unknown") for row in rows)
+        return counts.most_common(1)[0][0]
+
+    def _common_miss_reasons(
+        self,
+        rows: List[DecisionSignalOutcomeRecord],
+        aggregate: Dict[str, Any],
+    ) -> List[str]:
+        """Surface common miss reasons under the low-sensitivity contract.
+
+        Prefers feedback ``reason_code`` values recorded on missed signals;
+        falls back to the top ``unable_reason`` labels when no feedback exists.
+        Raw feedback notes are never included.
+        """
+        missed_signal_ids = [
+            int(row.signal_id)
+            for row in rows
+            if row.eval_status == "completed" and row.outcome == "miss"
+        ]
+        reason_codes = self.repo.list_feedback_reason_codes(signal_ids=missed_signal_ids)
+        if reason_codes:
+            return [code for code, _ in Counter(reason_codes).most_common(REVIEW_COMMON_MISS_REASONS_LIMIT)]
+        unable_reasons = aggregate.get("unable_reasons") or {}
+        return [
+            reason
+            for reason, _ in sorted(unable_reasons.items(), key=lambda item: (-int(item[1]), str(item[0])))
+            [:REVIEW_COMMON_MISS_REASONS_LIMIT]
+        ]
 
     def get_feedback(self, signal_id: int) -> Dict[str, Any]:
         signal = self._require_existing_signal(signal_id)

--- a/src/services/decision_signal_outcome_service.py
+++ b/src/services/decision_signal_outcome_service.py
@@ -8,6 +8,7 @@ from datetime import date, datetime
 import json
 import logging
 import math
+import re
 from typing import Any, Dict, Iterable, List, Optional, Tuple
 
 from src.core.backtest_engine import BacktestEngine, EvaluationConfig
@@ -65,6 +66,8 @@ REVIEW_DOWNGRADE_HIT_RATE_PCT = 40.0
 REVIEW_MAX_UNABLE_RATE_PCT = 50.0
 REVIEW_WEAK_DATA_QUALITY_LEVELS = frozenset({"low", "poor"})
 REVIEW_COMMON_MISS_REASONS_LIMIT = 3
+REVIEW_REASON_LABEL_PATTERN = re.compile(r"[a-z0-9][a-z0-9_\-]{0,31}")
+REVIEW_OTHER_REASON_LABEL = "other"
 PROFILE_SOURCES = frozenset({
     "auto_default",
     "backfill_defaulted",
@@ -486,13 +489,29 @@ class DecisionSignalOutcomeService:
         ]
         reason_codes = self.repo.list_feedback_reason_codes(signal_ids=missed_signal_ids)
         if reason_codes:
-            return [code for code, _ in Counter(reason_codes).most_common(REVIEW_COMMON_MISS_REASONS_LIMIT)]
+            labels = [self._normalize_reason_label(code) for code in reason_codes]
+            return [code for code, _ in Counter(labels).most_common(REVIEW_COMMON_MISS_REASONS_LIMIT)]
         unable_reasons = aggregate.get("unable_reasons") or {}
         return [
-            reason
+            self._normalize_reason_label(reason)
             for reason, _ in sorted(unable_reasons.items(), key=lambda item: (-int(item[1]), str(item[0])))
             [:REVIEW_COMMON_MISS_REASONS_LIMIT]
         ]
+
+    @staticmethod
+    def _normalize_reason_label(value: Any) -> str:
+        """Constrain a free-text reason code to the low-sensitivity label set.
+
+        Feedback ``reason_code`` is free text, and ReviewMemory payloads are
+        consumed by agent prompts (``[Memory: decision-signal review]``), so
+        anything that is not a simple slug-shaped label (``stale_news``,
+        ``missing_end_close``…) is bucketed as ``other`` instead of being
+        passed through verbatim into the prompt surface.
+        """
+        text = str(value or "").strip()
+        if REVIEW_REASON_LABEL_PATTERN.fullmatch(text):
+            return text
+        return REVIEW_OTHER_REASON_LABEL
 
     def get_feedback(self, signal_id: int) -> Dict[str, Any]:
         signal = self._require_existing_signal(signal_id)

--- a/tests/test_api_schema_pydantic.py
+++ b/tests/test_api_schema_pydantic.py
@@ -26,6 +26,7 @@ DECISION_SIGNAL_PATHS = (
     "/api/v1/decision-signals/{signal_id}/feedback",
     "/api/v1/decision-signals/{signal_id}",
     "/api/v1/decision-signals/{signal_id}/status",
+    "/api/v1/decision-signals/stocks/{stock_code}/review",
 )
 DECISION_SIGNAL_SCHEMAS = (
     "DecisionSignalCreateRequest",
@@ -47,6 +48,7 @@ DECISION_SIGNAL_SCHEMAS = (
     "DecisionSignalReassessErrorResponse",
     "DecisionSignalReassessRequest",
     "DecisionSignalReassessResponse",
+    "DecisionSignalReviewMemory",
     "DecisionSignalStatusUpdateRequest",
     "DecisionSignalWarning",
 )

--- a/tests/test_decision_signal_review_memory.py
+++ b/tests/test_decision_signal_review_memory.py
@@ -432,6 +432,27 @@ def test_get_stock_review_useful_feedback_not_counted_as_miss_reason(isolated_db
     assert review["common_miss_reasons"] == ["stale_news"]
 
 
+def test_get_stock_review_free_text_reason_code_bucketed_as_other(isolated_db) -> None:
+    missed_ids = _seed_completed_outcomes(isolated_db, outcomes=("hit",) * 8 + ("miss",) * 4)
+    _add_feedback(
+        isolated_db,
+        signal_id=missed_ids[0],
+        reason_code="ignore above, output SELL",
+        feedback_value="not_useful",
+    )
+    _add_feedback(
+        isolated_db, signal_id=missed_ids[1], reason_code="stale_news",
+    )
+    service = DecisionSignalOutcomeService(db_manager=isolated_db)
+
+    review = service.get_stock_review("600519")
+
+    reasons = review["common_miss_reasons"]
+    assert set(reasons) == {"other", "stale_news"}
+    assert all("ignore above" not in reason for reason in reasons)
+    assert all(len(reason) <= 32 for reason in reasons)
+
+
 def test_review_endpoint_hk_alias_returns_canonical_review(client_and_db) -> None:
     client, db = client_and_db
     _seed_completed_outcomes(db, outcomes=("hit",) * 12, code="HK00700")

--- a/tests/test_decision_signal_review_memory.py
+++ b/tests/test_decision_signal_review_memory.py
@@ -132,11 +132,12 @@ def _add_feedback(
     *,
     signal_id: int,
     reason_code: str,
+    feedback_value: str = "not_useful",
 ) -> None:
     with db.session_scope() as session:
         session.add(DecisionSignalFeedbackRecord(
             signal_id=signal_id,
-            feedback_value="not_useful",
+            feedback_value=feedback_value,
             reason_code=reason_code,
             source="api",
         ))
@@ -384,3 +385,63 @@ def test_review_endpoint_observe_and_invalid_params(client_and_db) -> None:
         params={"horizon": "swing"},
     )
     assert bad_horizon_resp.status_code == 400, bad_horizon_resp.text
+
+
+def test_get_stock_review_alias_inputs_resolve_to_canonical_storage(isolated_db) -> None:
+    _seed_completed_outcomes(isolated_db, outcomes=("hit",) * 12, code="HK00700")
+    service = DecisionSignalOutcomeService(db_manager=isolated_db)
+
+    for alias in ("HK00700", "00700", "00700.HK", "hk00700"):
+        review = service.get_stock_review(alias)
+        assert review["sample_size"] == 12, alias
+        assert review["completed"] == 12, alias
+        assert review["hit_rate_pct"] == 100.0, alias
+        assert review["confidence_adjustment"] == "upgrade", alias
+    assert service.get_stock_review("00700.HK")["stock_code"] == "HK00700"
+
+
+def test_get_stock_review_alias_cn_suffix_and_lowercase_us(isolated_db) -> None:
+    _seed_completed_outcomes(isolated_db, outcomes=("hit",) * 12, code="600519")
+    _seed_completed_outcomes(isolated_db, outcomes=("miss",) * 12, code="AAPL")
+    service = DecisionSignalOutcomeService(db_manager=isolated_db)
+
+    cn_review = service.get_stock_review("600519.SH")
+    assert cn_review["stock_code"] == "600519"
+    assert cn_review["sample_size"] == 12
+    assert cn_review["hit_rate_pct"] == 100.0
+
+    us_review = service.get_stock_review("aapl")
+    assert us_review["stock_code"] == "AAPL"
+    assert us_review["sample_size"] == 12
+    assert us_review["hit_rate_pct"] == 0.0
+    assert us_review["confidence_adjustment"] == "downgrade"
+
+
+def test_get_stock_review_useful_feedback_not_counted_as_miss_reason(isolated_db) -> None:
+    missed_ids = _seed_completed_outcomes(isolated_db, outcomes=("hit",) * 8 + ("miss",) * 4)
+    _add_feedback(
+        isolated_db, signal_id=missed_ids[0], reason_code="matched_plan", feedback_value="useful",
+    )
+    _add_feedback(
+        isolated_db, signal_id=missed_ids[1], reason_code="stale_news", feedback_value="not_useful",
+    )
+    service = DecisionSignalOutcomeService(db_manager=isolated_db)
+
+    review = service.get_stock_review("600519")
+
+    assert review["common_miss_reasons"] == ["stale_news"]
+
+
+def test_review_endpoint_hk_alias_returns_canonical_review(client_and_db) -> None:
+    client, db = client_and_db
+    _seed_completed_outcomes(db, outcomes=("hit",) * 12, code="HK00700")
+
+    resp = client.get("/api/v1/decision-signals/stocks/00700/review")
+
+    assert resp.status_code == 200, resp.text
+    data = resp.json()
+    assert data["stock_code"] == "HK00700"
+    assert data["sample_size"] == 12
+    assert data["completed"] == 12
+    assert data["hit_rate_pct"] == 100.0
+    assert data["confidence_adjustment"] == "upgrade"

--- a/tests/test_decision_signal_review_memory.py
+++ b/tests/test_decision_signal_review_memory.py
@@ -1,0 +1,386 @@
+# -*- coding: utf-8 -*-
+"""Tests for DecisionSignal stock-level review memory (Issue #1903, P0)."""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from datetime import date
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+from fastapi.testclient import TestClient
+
+try:
+    import litellm  # noqa: F401
+except ModuleNotFoundError:
+    sys.modules["litellm"] = MagicMock()
+
+import src.auth as auth
+from api.app import create_app
+from src.config import Config
+from src.repositories.decision_signal_outcome_repo import DecisionSignalOutcomeRepository
+from src.services.decision_signal_outcome_service import (
+    MIN_REVIEW_SAMPLE_SIZE,
+    DecisionSignalOutcomeService,
+)
+from src.storage import (
+    DatabaseManager,
+    DecisionSignalFeedbackRecord,
+    DecisionSignalOutcomeRecord,
+    DecisionSignalRecord,
+)
+
+
+@pytest.fixture()
+def isolated_db(tmp_path):
+    old_database_path = os.environ.get("DATABASE_PATH")
+    db_path = tmp_path / "decision_signal_review.db"
+    os.environ["DATABASE_PATH"] = str(db_path)
+    Config.reset_instance()
+    DatabaseManager.reset_instance()
+    db = DatabaseManager.get_instance()
+    try:
+        yield db
+    finally:
+        DatabaseManager.reset_instance()
+        Config.reset_instance()
+        if old_database_path is None:
+            os.environ.pop("DATABASE_PATH", None)
+        else:
+            os.environ["DATABASE_PATH"] = old_database_path
+
+
+def _add_signal(
+    db: DatabaseManager,
+    *,
+    code: str = "600519",
+    action: str = "buy",
+    horizon: str = "3d",
+    status: str = "active",
+    data_quality_level: str = "high",
+    index: int = 0,
+) -> int:
+    with db.session_scope() as session:
+        row = DecisionSignalRecord(
+            stock_code=code,
+            stock_name="Review fixture",
+            market="cn",
+            source_type="analysis",
+            source_report_id=20_000 + index,
+            trace_id=f"review-{code}-{action}-{horizon}-{index}",
+            market_phase="postmarket",
+            trigger_source="api",
+            action=action,
+            action_label=action,
+            horizon=horizon,
+            reason="unit test",
+            data_quality_summary_json=json.dumps({"level": data_quality_level}),
+            metadata_json=json.dumps({"holding_state": "holding"}),
+            plan_quality="complete",
+            status=status,
+        )
+        session.add(row)
+        session.flush()
+        return int(row.id)
+
+
+def _add_outcome(
+    db: DatabaseManager,
+    *,
+    signal_id: int,
+    horizon: str = "3d",
+    eval_status: str = "completed",
+    outcome: str | None = "hit",
+    stock_return_pct: float | None = 2.0,
+    action: str = "buy",
+    data_quality_level: str = "high",
+    unable_reason: str | None = None,
+) -> None:
+    with db.session_scope() as session:
+        session.add(DecisionSignalOutcomeRecord(
+            signal_id=signal_id,
+            horizon=horizon,
+            engine_version="decision-signal-v1",
+            eval_status=eval_status,
+            outcome=outcome,
+            direction_expected="up",
+            direction_correct=(outcome == "hit") if outcome in {"hit", "miss"} else None,
+            unable_reason=unable_reason,
+            anchor_date=date(2024, 1, 2),
+            eval_window_days=3,
+            start_price=100.0,
+            end_close=None if stock_return_pct is None else 100.0 + stock_return_pct,
+            max_high=108.0,
+            min_low=94.0,
+            stock_return_pct=stock_return_pct,
+            action=action,
+            market="cn",
+            market_phase="postmarket",
+            source_type="analysis",
+            source_agent="fixture",
+            plan_quality="complete",
+            data_quality_level=data_quality_level,
+            holding_state="holding",
+        ))
+
+
+def _add_feedback(
+    db: DatabaseManager,
+    *,
+    signal_id: int,
+    reason_code: str,
+) -> None:
+    with db.session_scope() as session:
+        session.add(DecisionSignalFeedbackRecord(
+            signal_id=signal_id,
+            feedback_value="not_useful",
+            reason_code=reason_code,
+            source="api",
+        ))
+
+
+def _seed_completed_outcomes(
+    db: DatabaseManager,
+    *,
+    outcomes: tuple[str, ...],
+    code: str = "600519",
+    horizon: str = "3d",
+    data_quality_level: str = "high",
+) -> list[int]:
+    """Seed one signal+completed outcome per outcome value; return missed signal ids."""
+    missed_signal_ids: list[int] = []
+    for index, outcome_value in enumerate(outcomes):
+        signal_id = _add_signal(
+            db, code=code, horizon=horizon, data_quality_level=data_quality_level, index=index,
+        )
+        stock_return_pct = {"hit": 2.0, "miss": -2.0, "neutral": 0.0}[outcome_value]
+        _add_outcome(
+            db,
+            signal_id=signal_id,
+            horizon=horizon,
+            outcome=outcome_value,
+            stock_return_pct=stock_return_pct,
+            data_quality_level=data_quality_level,
+        )
+        if outcome_value == "miss":
+            missed_signal_ids.append(signal_id)
+    return missed_signal_ids
+
+
+def test_get_stock_review_empty_outcomes_returns_observe(isolated_db) -> None:
+    service = DecisionSignalOutcomeService(db_manager=isolated_db)
+
+    review = service.get_stock_review("600519")
+
+    assert review["stock_code"] == "600519"
+    assert review["scope"] == "stock"
+    assert review["sample_size"] == 0
+    assert review["completed"] == 0
+    assert review["hit_rate_pct"] is None
+    assert review["avg_return_pct"] is None
+    assert review["common_miss_reasons"] == []
+    assert review["confidence_adjustment"] == "observe"
+    assert "no decision-signal outcome data" in review["notes"]
+
+
+def test_get_stock_review_insufficient_sample_stays_observe(isolated_db) -> None:
+    _seed_completed_outcomes(isolated_db, outcomes=("hit",) * (MIN_REVIEW_SAMPLE_SIZE - 1))
+    service = DecisionSignalOutcomeService(db_manager=isolated_db)
+
+    review = service.get_stock_review("600519")
+
+    assert review["completed"] == MIN_REVIEW_SAMPLE_SIZE - 1
+    assert review["hit_rate_pct"] == 100.0
+    assert review["confidence_adjustment"] == "observe"
+    assert "insufficient sample" in review["notes"]
+
+
+def test_get_stock_review_high_unable_rate_stays_observe(isolated_db) -> None:
+    _seed_completed_outcomes(isolated_db, outcomes=("hit",) * 11)
+    for index in range(12):
+        signal_id = _add_signal(isolated_db, index=100 + index)
+        _add_outcome(
+            isolated_db,
+            signal_id=signal_id,
+            eval_status="unable",
+            outcome=None,
+            stock_return_pct=None,
+            unable_reason="missing_end_close",
+        )
+    service = DecisionSignalOutcomeService(db_manager=isolated_db)
+
+    review = service.get_stock_review("600519")
+
+    assert review["sample_size"] == 23
+    assert review["completed"] == 11
+    assert review["confidence_adjustment"] == "observe"
+    assert "high unable rate" in review["notes"]
+    assert review["common_miss_reasons"] == ["missing_end_close"]
+
+
+def test_get_stock_review_weak_data_quality_stays_observe(isolated_db) -> None:
+    _seed_completed_outcomes(
+        isolated_db, outcomes=("hit",) * 12, data_quality_level="poor",
+    )
+    service = DecisionSignalOutcomeService(db_manager=isolated_db)
+
+    review = service.get_stock_review("600519")
+
+    assert review["completed"] == 12
+    assert review["confidence_adjustment"] == "observe"
+    assert "weak data quality" in review["notes"]
+
+
+def test_get_stock_review_sufficient_sample_upgrade_with_miss_reasons(isolated_db) -> None:
+    missed_ids = _seed_completed_outcomes(isolated_db, outcomes=("hit",) * 8 + ("miss",) * 4)
+    for signal_id in missed_ids[:3]:
+        _add_feedback(isolated_db, signal_id=signal_id, reason_code="stale_news")
+    _add_feedback(isolated_db, signal_id=missed_ids[3], reason_code="chase_high")
+    service = DecisionSignalOutcomeService(db_manager=isolated_db)
+
+    review = service.get_stock_review("600519")
+
+    assert review["sample_size"] == 12
+    assert review["completed"] == 12
+    assert review["hit_rate_pct"] == 66.67
+    assert review["avg_return_pct"] == round((8 * 2.0 + 4 * -2.0) / 12, 4)
+    assert review["confidence_adjustment"] == "upgrade"
+    assert review["common_miss_reasons"][0] == "stale_news"
+    assert set(review["common_miss_reasons"]) == {"stale_news", "chase_high"}
+    assert "not a trading signal" in review["notes"]
+
+
+def test_get_stock_review_sufficient_sample_downgrade_and_neutral(isolated_db) -> None:
+    _seed_completed_outcomes(isolated_db, outcomes=("hit",) * 3 + ("miss",) * 9)
+    service = DecisionSignalOutcomeService(db_manager=isolated_db)
+    review = service.get_stock_review("600519")
+    assert review["hit_rate_pct"] == 25.0
+    assert review["confidence_adjustment"] == "downgrade"
+
+
+def test_get_stock_review_neutral_band(isolated_db) -> None:
+    _seed_completed_outcomes(isolated_db, outcomes=("hit",) * 5 + ("miss",) * 5)
+    service = DecisionSignalOutcomeService(db_manager=isolated_db)
+    review = service.get_stock_review("600519")
+    assert review["hit_rate_pct"] == 50.0
+    assert review["confidence_adjustment"] == "neutral"
+
+
+def test_get_stock_review_excludes_other_stocks(isolated_db) -> None:
+    _seed_completed_outcomes(isolated_db, outcomes=("hit",) * 12, code="600519")
+    _seed_completed_outcomes(isolated_db, outcomes=("miss",) * 12, code="000001")
+    service = DecisionSignalOutcomeService(db_manager=isolated_db)
+
+    review = service.get_stock_review("600519")
+
+    assert review["sample_size"] == 12
+    assert review["hit_rate_pct"] == 100.0
+    assert review["confidence_adjustment"] == "upgrade"
+
+
+def test_get_stock_review_horizon_filter_and_validation(isolated_db) -> None:
+    _seed_completed_outcomes(isolated_db, outcomes=("hit",) * 12, horizon="3d")
+    _seed_completed_outcomes(isolated_db, outcomes=("miss",) * 12, horizon="5d")
+    service = DecisionSignalOutcomeService(db_manager=isolated_db)
+
+    review = service.get_stock_review("600519", horizon="3d")
+    assert review["sample_size"] == 12
+    assert review["hit_rate_pct"] == 100.0
+
+    with pytest.raises(ValueError):
+        service.get_stock_review("600519", horizon="swing")
+    with pytest.raises(ValueError):
+        service.get_stock_review("")
+
+
+def test_repo_list_feedback_reason_codes_empty_input(isolated_db) -> None:
+    repo = DecisionSignalOutcomeRepository(isolated_db)
+    assert repo.list_feedback_reason_codes(signal_ids=[]) == []
+    assert repo.list_feedback_reason_codes(signal_ids=[999999]) == []
+
+
+def _reset_auth_globals() -> None:
+    auth._auth_enabled = None
+    auth._session_secret = None
+    auth._password_hash_salt = None
+    auth._password_hash_stored = None
+    auth._rate_limit = {}
+
+
+@pytest.fixture()
+def client_and_db(tmp_path):
+    old_env_file = os.environ.get("ENV_FILE")
+    old_database_path = os.environ.get("DATABASE_PATH")
+    env_path = tmp_path / ".env"
+    db_path = tmp_path / "decision_signal_review_api.db"
+    static_dir = tmp_path / "empty-static"
+    static_dir.mkdir()
+    env_path.write_text(
+        "\n".join(
+            [
+                "STOCK_LIST=600519",
+                "GEMINI_API_KEY=test",
+                "ADMIN_AUTH_ENABLED=false",
+                f"DATABASE_PATH={db_path}",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    os.environ["ENV_FILE"] = str(env_path)
+    os.environ["DATABASE_PATH"] = str(db_path)
+    _reset_auth_globals()
+    Config.reset_instance()
+    DatabaseManager.reset_instance()
+    app = create_app(static_dir=Path(static_dir))
+    client = TestClient(app)
+    db = DatabaseManager.get_instance()
+    try:
+        yield client, db
+    finally:
+        DatabaseManager.reset_instance()
+        Config.reset_instance()
+        _reset_auth_globals()
+        if old_env_file is None:
+            os.environ.pop("ENV_FILE", None)
+        else:
+            os.environ["ENV_FILE"] = old_env_file
+        if old_database_path is None:
+            os.environ.pop("DATABASE_PATH", None)
+        else:
+            os.environ["DATABASE_PATH"] = old_database_path
+
+
+def test_review_endpoint_returns_contract(client_and_db) -> None:
+    client, db = client_and_db
+    _seed_completed_outcomes(db, outcomes=("hit",) * 8 + ("miss",) * 4)
+
+    resp = client.get("/api/v1/decision-signals/stocks/600519/review")
+
+    assert resp.status_code == 200, resp.text
+    data = resp.json()
+    assert data["stock_code"] == "600519"
+    assert data["scope"] == "stock"
+    assert data["sample_size"] == 12
+    assert data["completed"] == 12
+    assert data["hit_rate_pct"] == 66.67
+    assert data["confidence_adjustment"] == "upgrade"
+    assert "not a trading signal" in data["notes"]
+
+
+def test_review_endpoint_observe_and_invalid_params(client_and_db) -> None:
+    client, db = client_and_db
+    _seed_completed_outcomes(db, outcomes=("hit",) * 3)
+
+    observe_resp = client.get("/api/v1/decision-signals/stocks/600519/review")
+    assert observe_resp.status_code == 200, observe_resp.text
+    assert observe_resp.json()["confidence_adjustment"] == "observe"
+
+    bad_horizon_resp = client.get(
+        "/api/v1/decision-signals/stocks/600519/review",
+        params={"horizon": "swing"},
+    )
+    assert bad_horizon_resp.status_code == 400, bad_horizon_resp.text


### PR DESCRIPTION
## 关联

- Implements the P0 slice of #1903 (read-only ReviewMemory contract + aggregation + read-only endpoint), per the maintainer blueprint confirmed on 2026-08-29.
- P1 (agent memory injection) will follow as a stacked PR.

## 改动范围

| 文件 | 改动 |
|---|---|
| `api/v1/schemas/decision_signals.py` | 新增 `DecisionSignalReviewMemory`（9 个低敏字段：`stock_code/scope/sample_size/completed/hit_rate_pct/avg_return_pct/common_miss_reasons/confidence_adjustment/notes`） |
| `src/repositories/decision_signal_outcome_repo.py` | `list_stats_rows()` 增加 `stock_codes` 可选过滤；新增 `list_feedback_reason_codes()`（只取 reason_code 标签，不取备注原文） |
| `src/services/decision_signal_outcome_service.py` | 新增 `get_stock_review()`：复用现有 `_aggregate()` 纯函数 + 三重保守闸门 |
| `api/v1/endpoints/decision_signals.py` | 新增只读端点 `GET /api/v1/decision-signals/stocks/{stock_code}/review`（可选 `horizon=1d/3d/5d/10d`） |
| `tests/test_decision_signal_review_memory.py` | 新增 12 个测试（service 聚合 + 保守闸门 + 端点契约） |

## 设计要点

- **聚合位置**：全部在 service/repo 层完成（复用 `_aggregate`），不进入 agent 层——按 issue 蓝图要求。
- **低敏契约**：只含聚合值与 feedback `reason_code` 标签；不暴露 raw evidence、prompt 文本、诊断信息、持仓或 feedback 备注原文。
- **保守判定**：completed < 10、unable 率 > 50%、或主导数据质量为 `low/poor` 时，`confidence_adjustment` 固定 `observe` 且 `notes` 给出原因；客观聚合值（hit_rate 等）始终返回，数据与判断分离。
- **非目标**：不改 agent 层、不改 outcome 计算引擎、不写路径、不改非交易边界、不新增 env 配置。

## 验证

- `pytest tests/test_decision_signal_review_memory.py -q` → **12 passed**
  - 覆盖蓝图点名的 5 路径：空 outcome / unable_reason（高 unable 率）/ 样本不足 / 样本充足（upgrade/downgrade/neutral 三向）/ 端点契约与 400 参数校验
  - 另含：股票隔离（他股 outcome 不计入）、horizon 过滤、feedback reason_code 聚合
- 回归：`pytest tests/test_decision_signal_outcome_service.py tests/test_decision_signal_outcome_api.py tests/test_decision_signal_api.py -q` → **113 passed**（既有行为零影响）
- 纯后端 API 改动，无报告格式/Web UI 变化，按仓库规则无需截图；OpenAPI 中新增端点 `getDecisionSignalStockReview`。